### PR TITLE
Site Settings: add card to manage holiday snow settings

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -448,6 +448,7 @@ const getFormSettings = ( settings ) => {
 		lang_id: '',
 		timezone_string: '',
 		blog_public: '',
+		jetpack_holiday_snow_enabled: false,
 		wpcom_coming_soon: '',
 		wpcom_data_sharing_opt_out: false,
 		wpcom_legacy_contact: '',
@@ -471,6 +472,8 @@ const getFormSettings = ( settings ) => {
 		timezone_string: settings.timezone_string,
 
 		is_fully_managed_agency_site: settings.is_fully_managed_agency_site,
+
+		jetpack_holiday_snow_enabled: !! settings.jetpack_holiday_snow_enabled,
 
 		wpcom_coming_soon: settings.wpcom_coming_soon,
 		wpcom_data_sharing_opt_out: !! settings.wpcom_data_sharing_opt_out,

--- a/client/sites/settings/site/form.jsx
+++ b/client/sites/settings/site/form.jsx
@@ -3,6 +3,7 @@ import { DIFMUpsell } from '../components/difm-upsell-banner';
 import { A4AFullyManagedSiteForm } from './agency';
 import EnhancedOwnershipForm from './enhanced-ownership';
 import FooterCredit from './footer-credit';
+import HolidaySnow from './holiday-snow';
 import PrivacyForm from './privacy';
 import SubscriptionGiftingForm from './subscription-gifting';
 import ToolbarForm from './toolbar';
@@ -41,6 +42,16 @@ export default function SiteSettingsForm( {
 					updateFields={ updateFields }
 					isRequestingSettings={ isRequestingSettings }
 					isSavingSettings={ isSavingSettings }
+				/>
+			) }
+
+			{ ! siteIsJetpack && (
+				<HolidaySnow
+					fields={ fields }
+					handleToggle={ handleToggle }
+					isSaving={ isSavingSettings }
+					onSave={ handleSubmitForm }
+					disabled={ isRequestingSettings || isSavingSettings }
 				/>
 			) }
 

--- a/client/sites/settings/site/form.jsx
+++ b/client/sites/settings/site/form.jsx
@@ -45,16 +45,6 @@ export default function SiteSettingsForm( {
 				/>
 			) }
 
-			{ ! siteIsJetpack && (
-				<HolidaySnow
-					fields={ fields }
-					handleToggle={ handleToggle }
-					isSaving={ isSavingSettings }
-					onSave={ handleSubmitForm }
-					disabled={ isRequestingSettings || isSavingSettings }
-				/>
-			) }
-
 			<A4AFullyManagedSiteForm
 				site={ site }
 				isFullyManagedAgencySite={ fields.is_fully_managed_agency_site }
@@ -80,6 +70,16 @@ export default function SiteSettingsForm( {
 				isUnlaunchedSite={ isUnlaunchedSite }
 				urlRef="unlaunched-settings"
 			/>
+
+			{ ! siteIsJetpack && (
+				<HolidaySnow
+					fields={ fields }
+					handleToggle={ handleToggle }
+					isSaving={ isSavingSettings }
+					onSave={ handleSubmitForm }
+					disabled={ isRequestingSettings || isSavingSettings }
+				/>
+			) }
 
 			<SubscriptionGiftingForm
 				fields={ fields }

--- a/client/sites/settings/site/holiday-snow.jsx
+++ b/client/sites/settings/site/holiday-snow.jsx
@@ -1,0 +1,61 @@
+import { Button, CompactCard } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import { PanelCard, PanelCardHeading, PanelCardDescription } from 'calypso/components/panel';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { isHostingMenuUntangled } from '../utils';
+
+// Add settings for holiday snow: ability to enable snow on the site until January 4th.
+export default function HolidaySnow( { fields, handleToggle, isSaving, onSave, disabled } ) {
+	const translate = useTranslate();
+	const isUntangled = isHostingMenuUntangled();
+
+	const renderForm = () => {
+		return (
+			<>
+				<ToggleControl
+					disabled={ disabled }
+					className="site-settings__holiday-snow-toggle"
+					label={ translate( 'Enable snow' ) }
+					checked={ fields.jetpack_holiday_snow_enabled }
+					onChange={ handleToggle( 'jetpack_holiday_snow_enabled' ) }
+				/>
+				{ ! isUntangled && (
+					<FormSettingExplanation>
+						{ translate( 'Show falling snow on my site until January 4th.' ) }
+					</FormSettingExplanation>
+				) }
+			</>
+		);
+	};
+
+	if ( ! isUntangled ) {
+		return (
+			<div className="site-settings__holiday-snow-container">
+				<SettingsSectionHeader
+					title={ translate( 'Holiday snow' ) }
+					id="site-settings__holiday-snow-header"
+					disabled={ disabled }
+					isSaving={ isSaving }
+					onButtonClick={ onSave }
+					showButton
+				/>
+				<CompactCard className="site-settings__holiday-snow-content">{ renderForm() }</CompactCard>
+			</div>
+		);
+	}
+
+	return (
+		<PanelCard>
+			<PanelCardHeading>{ translate( 'Holiday snow' ) }</PanelCardHeading>
+			<PanelCardDescription>
+				{ translate( 'Show falling snow on my site until January 4th.' ) }
+			</PanelCardDescription>
+			{ renderForm() }
+			<Button busy={ isSaving } disabled={ disabled } onClick={ onSave }>
+				{ translate( 'Save' ) }
+			</Button>
+		</PanelCard>
+	);
+}

--- a/client/sites/settings/site/holiday-snow.jsx
+++ b/client/sites/settings/site/holiday-snow.jsx
@@ -1,4 +1,4 @@
-import { Button, CompactCard } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
@@ -41,7 +41,7 @@ export default function HolidaySnow( { fields, handleToggle, isSaving, onSave, d
 					onButtonClick={ onSave }
 					showButton
 				/>
-				<CompactCard className="site-settings__holiday-snow-content">{ renderForm() }</CompactCard>
+				<Card className="site-settings__holiday-snow-content">{ renderForm() }</Card>
 			</div>
 		);
 	}

--- a/client/sites/settings/site/holiday-snow.jsx
+++ b/client/sites/settings/site/holiday-snow.jsx
@@ -2,6 +2,7 @@ import { Button, Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { PanelCard, PanelCardHeading, PanelCardDescription } from 'calypso/components/panel';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { isHostingMenuUntangled } from '../utils';
@@ -10,6 +11,17 @@ import { isHostingMenuUntangled } from '../utils';
 export default function HolidaySnow( { fields, handleToggle, isSaving, onSave, disabled } ) {
 	const translate = useTranslate();
 	const isUntangled = isHostingMenuUntangled();
+	const moment = useLocalizedMoment();
+
+	// Only display the card between December 1st and January 4th.
+	const today = moment();
+	const currentYear = today.year();
+	const startDate = moment( { year: currentYear, month: 11, date: 1 } ); // moment months are 0-indexed
+	const endDate = moment( { year: currentYear, month: 0, date: 4 } ); // moment months are 0-indexed
+
+	if ( today.isBefore( startDate, 'day' ) && today.isAfter( endDate, 'day' ) ) {
+		return null;
+	}
 
 	const renderForm = () => {
 		return (

--- a/client/sites/settings/site/index.tsx
+++ b/client/sites/settings/site/index.tsx
@@ -50,6 +50,7 @@ export function SiteSettings( props: any ) {
 const getFormSettings = ( settings: any ) => {
 	const defaultSettings = {
 		blog_public: '',
+		jetpack_holiday_snow_enabled: false,
 		wpcom_coming_soon: '',
 		wpcom_data_sharing_opt_out: false,
 		wpcom_legacy_contact: '',
@@ -65,6 +66,7 @@ const getFormSettings = ( settings: any ) => {
 
 	const formSettings = {
 		blog_public: settings.blog_public,
+		jetpack_holiday_snow_enabled: !! settings.jetpack_holiday_snow_enabled,
 		wpcom_coming_soon: settings.wpcom_coming_soon,
 		wpcom_data_sharing_opt_out: !! settings.wpcom_data_sharing_opt_out,
 		wpcom_legacy_contact: settings.wpcom_legacy_contact,


### PR DESCRIPTION
## Proposed Changes

This PR brings a new card to site settings in Calypso, allowing one to toggle Holiday snow on and off on their site.

<img width="963" alt="image" src="https://github.com/user-attachments/assets/81cd743f-c1c7-482d-8dcb-cac82ba458cd">

<img width="869" alt="Screenshot 2024-12-06 at 14 47 24" src="https://github.com/user-attachments/assets/ff0d0ba9-ade0-48ae-9fc0-c89a87d3bd0f">

## Why are these changes being made?

See https://github.com/Automattic/dotcom-forge/issues/10082

## Testing Instructions

This can only be tested if you've added the functionality to your site, via this Jetpack PR:
https://github.com/Automattic/jetpack/pull/40478

When testing, you'll want to test both `/sites/settings/site/yoursite` and `settings/general/yoursite`, for a WordPress.com Simple and a WoA site.

1. Load `http://calypso.localhost:3000/settings/general/yoursite.wordpress.com?flags=-untangling/hosting-menu` for a WordPress.com site
2. Load `http://calypso.localhost:3000/sites/settings/site/yoursite.wordpress.com` for the same site

=> You should see the cards shown on the screenshots above.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
