### PR TITLE
Plans: Disable longer plan term default in logged-in plans page

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -12,8 +12,6 @@ import {
 	PLAN_WOOEXPRESS_MEDIUM_MONTHLY,
 	PLAN_WOOEXPRESS_SMALL,
 	PLAN_WOOEXPRESS_SMALL_MONTHLY,
-	getBillingMonthsForTerm,
-	URL_FRIENDLY_TERMS_MAPPING,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { WpcomPlansUI, Plans } from '@automattic/data-stores';
@@ -41,7 +39,6 @@ import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
 import P2PlansMain from 'calypso/my-sites/plans/p2-plans-main';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
-import useLongerPlanTermDefaultExperiment from 'calypso/my-sites/plans-features-main/hooks/experiments/use-longer-plan-term-default-experiment';
 import { useSelector } from 'calypso/state';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -557,22 +554,14 @@ export default function PlansWrapper( props ) {
 	const { intervalType: intervalTypeFromProps } = props;
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const currentPlan = Plans.useCurrentPlan( { siteId: selectedSiteId } );
-	const longerPlanTermDefaultExperiment = useLongerPlanTermDefaultExperiment();
 	/**
 	 * For WP.com plans page, if intervalType is not explicitly specified in the URL,
 	 * we want to show plans of the same term as plan that is currently active
 	 * We want to show the highest term between the current plan and the longer plan term default experiment
 	 */
-	const currentPlanTerm = useSelector( ( state ) =>
+	const intervalTypeForCurrentPlanTerm = useSelector( ( state ) =>
 		getIntervalTypeForTerm( getCurrentPlanTerm( state, selectedSiteId ) )
 	);
-	const intervalType =
-		longerPlanTermDefaultExperiment.term &&
-		currentPlanTerm &&
-		getBillingMonthsForTerm( URL_FRIENDLY_TERMS_MAPPING[ currentPlanTerm ] ) >
-			getBillingMonthsForTerm( URL_FRIENDLY_TERMS_MAPPING[ longerPlanTermDefaultExperiment.term ] )
-			? currentPlanTerm
-			: longerPlanTermDefaultExperiment.term;
 
 	return (
 		<CalypsoShoppingCartProvider>
@@ -580,7 +569,7 @@ export default function PlansWrapper( props ) {
 				{ ...props }
 				currentPlan={ currentPlan }
 				selectedSiteId={ selectedSiteId }
-				intervalType={ intervalTypeFromProps ?? intervalType ?? currentPlanTerm }
+				intervalType={ intervalTypeFromProps ?? intervalTypeForCurrentPlanTerm }
 			/>
 		</CalypsoShoppingCartProvider>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/96816, https://github.com/Automattic/martech/issues/3403
Related to p1732646141389969-slack-CV2TX2PAN and p1732648406144139-slack-CV2TX2PAN

## Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/96816 where we disabled the term savings display for the logged-in plans page. That was only a part of the upcoming experiment. We disable the longer plan term default here as that's the main/core of the upcoming experiment, not the term savings display.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The same reasoning with https://github.com/Automattic/wp-calypso/pull/96816

> Defaulting to longer term plans leads to a subpar UX experience in the logged in plans page. See this comment specifically p1732652464476219/1732648406.144139-slack-CV2TX2PAN.
> It would also interfere with the Hide Lower Tiers Experiment pbxNRc-4gN-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Assign a treatment variation from pbxNRc-4tx-p2
- Visit `/plans/:site` and ensure it doesn't default to a longer plan term, like 2-yearly or 3-yearly depending on variation

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?