### PR TITLE
Disable bloganuary

### DIFF
--- a/client/data/blogging-prompt/is-bloganuary.ts
+++ b/client/data/blogging-prompt/is-bloganuary.ts
@@ -4,5 +4,10 @@ import moment from 'moment';
  * @returns true if bloganuary mode is active
  */
 export default function isBloganuary() {
+	// Disable for January 2025 (see https://wp.me/p5uIfZ-gxX).
+	const BLOGANUARY_ENABLED = false;
+	if ( ! BLOGANUARY_ENABLED ) {
+		return false;
+	}
 	return moment().format( 'MM' ) === '01' || isEnabled( 'bloganuary' );
 }

--- a/client/data/blogging-prompt/is-bloganuary.ts
+++ b/client/data/blogging-prompt/is-bloganuary.ts
@@ -4,7 +4,9 @@ import moment from 'moment';
  * @returns true if bloganuary mode is active
  */
 export default function isBloganuary() {
-	// Disable for January 2025 (see https://wp.me/p5uIfZ-gxX).
+	// Disable for January 2025 and beyond (see https://wp.me/p5uIfZ-gxX).
+	// Intentionally redundant to make it easier to spot the disable condition,
+	// and avoid removing code we may re-enable in the future.
 	const BLOGANUARY_ENABLED = false;
 	if ( ! BLOGANUARY_ENABLED ) {
 		return false;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/242

## Proposed Changes

* Add an explicit disable for bloganuary.
* Related diff: D167949-code

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See p5uIfZ-gxX-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch locally.
* Change[ this line](https://github.com/Automattic/wp-calypso/blob/disable/bloganuary/client/data/blogging-prompt/is-bloganuary.ts#L12) to `return: true;`
* Verify that the regular writing prompt, not the Bloganuary writing prompt, shows on My Home.

Regular writing prompt | Bloganuary writing prompt
----- | ----
<img width="700" alt="Screen Shot 2024-12-05 at 2 46 07 PM" src="https://github.com/user-attachments/assets/9ffd538b-a71c-4954-8972-9a5d316c792f"> | <img width="698" alt="Screen Shot 2024-12-05 at 2 46 31 PM" src="https://github.com/user-attachments/assets/bfa643d4-94d4-49ef-8fec-652421bfd354">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?