### PR TITLE
Add BlueSky to feature copy on pricing page and features in checkout

### DIFF
--- a/client/my-sites/checkout/src/lib/get-jetpack-product-features.ts
+++ b/client/my-sites/checkout/src/lib/get-jetpack-product-features.ts
@@ -130,7 +130,7 @@ function getFeatureStrings(
 				translate( 'Posting to multiple channels at once' ),
 				translate( 'Scheduled posts' ),
 				translate(
-					'Sharing to Facebook, Instagram, Threads, BlueSky, LinkedIn, Mastodon, Tumblr, Nextdoor'
+					'Sharing to Facebook, Instagram, Threads, Bluesky, LinkedIn, Mastodon, Tumblr, Nextdoor'
 				),
 				translate( 'Content recycling' ),
 			];
@@ -141,7 +141,7 @@ function getFeatureStrings(
 				translate( 'Posting to multiple channels at once' ),
 				translate( 'Scheduled posts' ),
 				translate(
-					'Sharing to Facebook, Instagram, Threads, BlueSky, LinkedIn, Mastodon, Tumblr, Nextdoor'
+					'Sharing to Facebook, Instagram, Threads, Bluesky, LinkedIn, Mastodon, Tumblr, Nextdoor'
 				),
 				translate( 'Content recycling' ),
 			];

--- a/client/my-sites/checkout/src/lib/get-jetpack-product-features.ts
+++ b/client/my-sites/checkout/src/lib/get-jetpack-product-features.ts
@@ -129,7 +129,9 @@ function getFeatureStrings(
 				translate( 'Automatically share your posts' ),
 				translate( 'Posting to multiple channels at once' ),
 				translate( 'Scheduled posts' ),
-				translate( 'Sharing to Facebook, LinkedIn, and Tumblr' ),
+				translate(
+					'Sharing to Facebook, Instagram, Threads, BlueSky, LinkedIn, Mastodon, Tumblr, Nextdoor'
+				),
 				translate( 'Content recycling' ),
 			];
 		case 'social-v1':
@@ -138,7 +140,9 @@ function getFeatureStrings(
 				translate( 'Automatically share your posts' ),
 				translate( 'Posting to multiple channels at once' ),
 				translate( 'Scheduled posts' ),
-				translate( 'Sharing to Facebook, LinkedIn, and Tumblr' ),
+				translate(
+					'Sharing to Facebook, Instagram, Threads, BlueSky, LinkedIn, Mastodon, Tumblr, Nextdoor'
+				),
 				translate( 'Content recycling' ),
 			];
 		case 'stats-free':

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1375,6 +1375,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Facebook' ),
 		translate( 'Instagram' ),
 		translate( 'Threads' ),
+		translate( 'BlueSky' ),
 		translate( 'LinkedIn' ),
 		translate( 'Mastodon' ),
 		translate( 'Tumblr' ),

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1375,7 +1375,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Facebook' ),
 		translate( 'Instagram' ),
 		translate( 'Threads' ),
-		translate( 'BlueSky' ),
+		translate( 'Bluesky' ),
 		translate( 'LinkedIn' ),
 		translate( 'Mastodon' ),
 		translate( 'Tumblr' ),


### PR DESCRIPTION
## Proposed Changes

* Add BlueSky to list of social networks Social can share to in feature copy

## Why are these changes being made?

* BlueSky is currently missing

## Testing Instructions

1. Using the Calypso Green live link, go to `/pricing`
2. Open up the lightbox for Social and ensure "BlueSky" is listed
![Screenshot 2024-12-05 at 1 50 01 PM](https://github.com/user-attachments/assets/64e69f78-ae54-412e-9513-e040c0c5e791)

3. Next, using the Calypso Blue live link, go to `/checkout/jetpack/jetpack_social_v1_yearly` and ensure BlueSky is listed in the social sharing section

![Screenshot 2024-12-05 at 1 50 34 PM](https://github.com/user-attachments/assets/8b3024bc-0704-457f-b15b-3c84d22a4dfb)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
