### PR TITLE
Add Calypso onboarding A/A test

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -217,7 +217,7 @@ export default {
 
 		const isOnboardingFlow = flowName === 'onboarding';
 		if ( isOnboardingFlow ) {
-			await loadExperimentAssignment( 'calypso_onboarding_aa_test' );
+			loadExperimentAssignment( 'calypso_onboarding_aa_test' );
 			const stepperOnboardingExperimentAssignment = await loadExperimentAssignment(
 				'calypso_signup_onboarding_stepper_flow_2'
 			);

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -217,24 +217,24 @@ export default {
 
 		const isOnboardingFlow = flowName === 'onboarding';
 		if ( isOnboardingFlow ) {
-			loadExperimentAssignment( 'calypso_signup_onboarding_aa_test' );
-			const stepperOnboardingExperimentAssignment = await loadExperimentAssignment(
-				'calypso_signup_onboarding_stepper_flow_2'
-			);
-			if ( stepperOnboardingExperimentAssignment.variationName === 'stepper' ) {
-				window.location =
-					getStepUrl(
-						flowName,
-						getStepName( context.params ),
-						getStepSectionName( context.params ),
-						localeFromParams ?? localeFromStore,
-						null,
-						'/setup'
-					) +
-					( context.querystring ? '?' + context.querystring : '' ) +
-					( context.hashstring ? '#' + context.hashstring : '' );
-				return;
-			}
+			await loadExperimentAssignment( 'calypso_signup_onboarding_aa_test' );
+			// const stepperOnboardingExperimentAssignment = await loadExperimentAssignment(
+			// 	'calypso_signup_onboarding_stepper_flow_2'
+			// );
+			// if ( stepperOnboardingExperimentAssignment.variationName === 'stepper' ) {
+			// 	window.location =
+			// 		getStepUrl(
+			// 			flowName,
+			// 			getStepName( context.params ),
+			// 			getStepSectionName( context.params ),
+			// 			localeFromParams ?? localeFromStore,
+			// 			null,
+			// 			'/setup'
+			// 		) +
+			// 		( context.querystring ? '?' + context.querystring : '' ) +
+			// 		( context.hashstring ? '#' + context.hashstring : '' );
+			// 	return;
+			// }
 		}
 
 		// const isOnboardingFlow = flowName === 'onboarding';

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -217,6 +217,7 @@ export default {
 
 		const isOnboardingFlow = flowName === 'onboarding';
 		if ( isOnboardingFlow ) {
+			await loadExperimentAssignment( 'calypso_onboarding_aa_test' );
 			const stepperOnboardingExperimentAssignment = await loadExperimentAssignment(
 				'calypso_signup_onboarding_stepper_flow_2'
 			);

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -217,7 +217,7 @@ export default {
 
 		const isOnboardingFlow = flowName === 'onboarding';
 		if ( isOnboardingFlow ) {
-			loadExperimentAssignment( 'calypso_onboarding_aa_test' );
+			loadExperimentAssignment( 'calypso_signup_onboarding_aa_test' );
 			const stepperOnboardingExperimentAssignment = await loadExperimentAssignment(
 				'calypso_signup_onboarding_stepper_flow_2'
 			);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See this experiment: 22123-explat-experiment
Related Stepper experiment: 22056-explat-experiment

## Proposed Changes

Runs an A/A test on the Onboarding flow to test for assignment and metric bias using the Stepper experiment metrics.

Because this is an A/A test, both `control` and `treatment` will have the same experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using the bookmarklet, assign yourself to `control` and experience the default onboarding flow.
- Using the bookmarklet, assign yourself to `treatment` and experience the default onboarding flow.
- Both assignments should have the same experience.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?