### PR TITLE
Invert the option on the UI for easier understanding

### DIFF
--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -250,7 +250,7 @@ class NotificationSubscriptions extends Component {
 										name="p2_disable_autofollow_on_comment"
 										onChange={ this.props.toggleSetting }
 										onClick={ this.handleCheckboxEvent(
-											'Enable auto-follow P2 Upon Comment',
+											'Enable auto-follow P2 upon comment',
 											true
 										) }
 									/>

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -34,12 +34,10 @@ class NotificationSubscriptions extends Component {
 		return () => this.props.recordGoogleEvent( 'Me', 'Focused on ' + action );
 	}
 
-	handleCheckboxEvent( action ) {
+	handleCheckboxEvent( action, invert = false ) {
 		return ( event ) => {
-			const eventAction = 'Clicked ' + action + ' checkbox';
-			const optionValue = event.target.checked ? 1 : 0;
-
-			this.props.recordGoogleEvent( 'Me', eventAction, 'checked', optionValue );
+			const optionValue = invert ? ! event.target.checked : event.target.checked;
+			this.props.recordGoogleEvent( 'Me', `Clicked ${ action } checkbox`, 'checked', +optionValue );
 		};
 	}
 
@@ -243,21 +241,21 @@ class NotificationSubscriptions extends Component {
 
 						{ isAutomattician && (
 							<FormFieldset>
-								<FormLegend>
-									Disable auto-follow P2 posts upon commenting (Automatticians only)
-								</FormLegend>
+								<FormLegend>Auto-follow P2 posts (Automatticians only)</FormLegend>
 								<FormLabel>
 									<FormCheckbox
-										checked={ this.props.getSetting( 'p2_disable_autofollow_on_comment' ) }
+										checked={ ! this.props.getSetting( 'p2_disable_autofollow_on_comment' ) }
 										disabled={ this.props.getDisabledState() }
 										id="p2_disable_autofollow_on_comment"
 										name="p2_disable_autofollow_on_comment"
 										onChange={ this.props.toggleSetting }
-										onClick={ this.handleCheckboxEvent( 'Disable auto-follow P2 Upon Comment' ) }
+										onClick={ this.handleCheckboxEvent(
+											'Enable auto-follow P2 Upon Comment',
+											true
+										) }
 									/>
 									<span>
-										Don't automatically subscribe to notifications for a P2 post whenever you leave
-										a comment on it.
+										Automatically subscribe to P2 post notifications when you leave a comment.
 									</span>
 								</FormLabel>
 							</FormFieldset>


### PR DESCRIPTION
Related to #95663

## Proposed Changes

* Use a positive instead of a negative checkbox value. This makes it more straightforward.
    - The default behaviour is unaffected - it will be still on for A12s, unless toggled off.

## Why are these changes being made?

* See p1733332909946169-slack-C024FN1V8

## Testing Instructions

* Open https://wordpress.com/me/notifications/subscriptions and http://calypso.localhost:3000/me/notifications/subscriptions in another tab
* Ensure that the checkbox on the first tab is inverted on the second tab
* Change the value from the second tab. Save.
* Refresh first tab.
* Ensure that the checkbox on the first tab is inverted on the second tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
