### PR TITLE
Design Picker: Track the selection of the categories

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
@@ -44,7 +44,9 @@ export const useFlowNavigation = (): FlowNavigation => {
 	const customNavigate = useCallback< Navigate< StepperStep[] > >(
 		( nextStep: string, extraData = {}, replace = false ) => {
 			const hasQueryParams = nextStep.includes( '?' );
-			const queryParams = ! hasQueryParams ? currentSearchParams : null;
+
+			// Get the latest search params from the current location
+			const queryParams = ! hasQueryParams ? new URLSearchParams( window.location.search ) : null;
 
 			setStepData( {
 				path: nextStep,
@@ -61,7 +63,7 @@ export const useFlowNavigation = (): FlowNavigation => {
 
 			navigate( addQueryParams( newPath, queryParams ), { replace } );
 		},
-		[ currentSearchParams, flow, intent, lang, navigate, setStepData, currentStepSlug ]
+		[ flow, intent, lang, navigate, setStepData, currentStepSlug ]
 	);
 
 	return {

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/test/index.tsx
@@ -34,6 +34,7 @@ const Wrapper =
 	);
 
 const render = ( { initialEntry = '/setup/some-flow/some-step' } = {} ) => {
+	window.history.replaceState( null, '', initialEntry );
 	return renderHookWithProvider( () => useFlowNavigation(), {
 		wrapper: Wrapper( initialEntry ),
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -1,28 +1,6 @@
 import { Onboard } from '@automattic/data-stores';
-import { Category } from '@automattic/design-picker';
-
-const FEATURE_CATEGORIES = {
-	BLOG: 'blog',
-	NEWSLETTER: 'newsletter',
-	PORTFOLIO: 'portfolio',
-	PODCAST: 'podcast',
-	STORE: 'store',
-};
-
-const SUBJECT_CATEGORIES = {
-	BUSINESS: 'business',
-	COMMUNITY_NON_PROFIT: 'community-non-profit',
-	AUTHORS_WRITERS: 'authors-writers',
-	EDUCATION: 'education',
-	ENTERTAINMENT: 'entertainment',
-	EVENTS: 'events',
-	LINK_IN_BIO: 'link-in-bio',
-};
-
-const CATEGORIES = {
-	...FEATURE_CATEGORIES,
-	...SUBJECT_CATEGORIES,
-};
+import { CATEGORIES } from '@automattic/design-picker';
+import type { Category } from '@automattic/design-picker';
 
 const GOALS_TO_CATEGORIES: { [ key in Onboard.SiteGoal ]: string[] } = {
 	[ Onboard.SiteGoal.Write ]: [ CATEGORIES.BLOG, CATEGORIES.NEWSLETTER ],

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -80,12 +80,3 @@ export function getCategorizationOptions(
 function getGoalsPreferredCategories( goal: Onboard.SiteGoal ): string[] {
 	return GOALS_TO_CATEGORIES[ goal ] || [];
 }
-
-export function getCategoryType( categorySlug: string ) {
-	const featuresSet = new Set( Object.values( FEATURE_CATEGORIES ) );
-	if ( featuresSet.has( categorySlug ) ) {
-		return 'feature';
-	}
-
-	return 'subject';
-}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -80,3 +80,12 @@ export function getCategorizationOptions(
 function getGoalsPreferredCategories( goal: Onboard.SiteGoal ): string[] {
 	return GOALS_TO_CATEGORIES[ goal ] || [];
 }
+
+export function getCategoryType( categorySlug: string ) {
+	const featuresSet = new Set( Object.values( FEATURE_CATEGORIES ) );
+	if ( featuresSet.has( categorySlug ) ) {
+		return 'feature';
+	}
+
+	return 'subject';
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -1,19 +1,15 @@
 import { Onboard } from '@automattic/data-stores';
 import { Category } from '@automattic/design-picker';
 
-const CATEGORIES = {
-	/**
-	 * Features
-	 */
+const FEATURE_CATEGORIES = {
 	BLOG: 'blog',
 	NEWSLETTER: 'newsletter',
 	PORTFOLIO: 'portfolio',
 	PODCAST: 'podcast',
 	STORE: 'store',
+};
 
-	/**
-	 * Subjects
-	 */
+const SUBJECT_CATEGORIES = {
 	BUSINESS: 'business',
 	COMMUNITY_NON_PROFIT: 'community-non-profit',
 	AUTHORS_WRITERS: 'authors-writers',
@@ -21,6 +17,11 @@ const CATEGORIES = {
 	ENTERTAINMENT: 'entertainment',
 	EVENTS: 'events',
 	LINK_IN_BIO: 'link-in-bio',
+};
+
+const CATEGORIES = {
+	...FEATURE_CATEGORIES,
+	...SUBJECT_CATEGORIES,
 };
 
 const GOALS_TO_CATEGORIES: { [ key in Onboard.SiteGoal ]: string[] } = {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
@@ -12,6 +12,12 @@ import type { GlobalStyles, OnboardSelect, StarterDesigns } from '@automattic/da
 import type { Design, StyleVariation } from '@automattic/design-picker';
 import type { GlobalStylesObject } from '@automattic/global-styles';
 
+// The `currentSearchParams` parameter from the callback of the `setSearchParams` function
+// might not have the latest query parameter on multiple calls at the same time.
+const makeSearchParams = (
+	callback: ( currentSearchParams: URLSearchParams ) => URLSearchParams
+) => callback( new URLSearchParams( window.location.search ) );
+
 const useRecipe = (
 	siteId = 0,
 	allDesigns: StarterDesigns | undefined,
@@ -92,22 +98,24 @@ const useRecipe = (
 		}
 
 		if ( theme !== searchParams.get( 'theme' ) ) {
-			setSearchParams( ( currentSearchParams ) => {
-				if ( theme ) {
-					currentSearchParams.set( 'theme', theme );
-				} else {
-					currentSearchParams.delete( 'theme' );
-				}
+			setSearchParams(
+				makeSearchParams( ( currentSearchParams ) => {
+					if ( theme ) {
+						currentSearchParams.set( 'theme', theme );
+					} else {
+						currentSearchParams.delete( 'theme' );
+					}
 
-				return currentSearchParams;
-			} );
+					return currentSearchParams;
+				} )
+			);
 		}
 	};
 
 	const handleSelectedStyleVariationChange = ( variation?: StyleVariation ) => {
 		setSelectedStyleVariation( variation );
 		setSearchParams(
-			( currentSearchParams ) => {
+			makeSearchParams( ( currentSearchParams ) => {
 				if ( variation ) {
 					currentSearchParams.set( 'style_variation', variation.slug );
 				} else {
@@ -115,7 +123,7 @@ const useRecipe = (
 				}
 
 				return currentSearchParams;
-			},
+			} ),
 			{ replace: true }
 		);
 	};
@@ -123,7 +131,7 @@ const useRecipe = (
 	const handleSelectedColorVariationChange = ( variation: GlobalStyles | null ) => {
 		setSelectedColorVariation( variation );
 		setSearchParams(
-			( currentSearchParams ) => {
+			makeSearchParams( ( currentSearchParams ) => {
 				if ( variation && variation.title ) {
 					currentSearchParams.set( 'color_variation_title', variation.title );
 				} else {
@@ -131,7 +139,7 @@ const useRecipe = (
 				}
 
 				return currentSearchParams;
-			},
+			} ),
 			{ replace: true }
 		);
 	};
@@ -139,7 +147,7 @@ const useRecipe = (
 	const handleSelectedFontVariationChange = ( variation: GlobalStyles | null ) => {
 		setSelectedFontVariation( variation );
 		setSearchParams(
-			( currentSearchParams ) => {
+			makeSearchParams( ( currentSearchParams ) => {
 				if ( variation && variation.title ) {
 					currentSearchParams.set( 'font_variation_title', variation.title );
 				} else {
@@ -147,7 +155,7 @@ const useRecipe = (
 				}
 
 				return currentSearchParams;
-			},
+			} ),
 			{ replace: true }
 		);
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-track-filters.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-track-filters.ts
@@ -1,0 +1,67 @@
+import { useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getCategoryType } from '../categories';
+
+interface Props {
+	preselectedFilters: string[];
+	isBigSkyEligible: boolean;
+	isMultiSelection: boolean;
+}
+
+const useTrackFilters = ( { preselectedFilters, isBigSkyEligible, isMultiSelection }: Props ) => {
+	const [ searchParams ] = useSearchParams();
+
+	const selectedFilters = searchParams.get( 'categories' )?.split( ',' ) || [];
+
+	const isIncludedWithPlan = searchParams.get( 'tier' ) === 'free';
+
+	const filters = useMemo( () => {
+		return selectedFilters.reduce(
+			( result, filterSlug, index ) => ( {
+				...result,
+				[ `filters_${ filterSlug }` ]: `${ getCategoryType( filterSlug ) }:${ index }`,
+			} ),
+			{}
+		);
+	}, [ selectedFilters ] );
+
+	const commonFilterProperties = {
+		is_filter_included_with_plan_enabled: isIncludedWithPlan,
+		is_big_sky_eligible: isBigSkyEligible,
+		preselected_filters: preselectedFilters.join( ',' ),
+		selected_filters: selectedFilters.join( ',' ),
+		...filters,
+	};
+
+	const handleSelectFilter = ( term: string, type?: string ) => {
+		if ( ! isMultiSelection ) {
+			recordTracksEvent( 'calypso_signup_unified_design_select_category', {
+				category: term,
+			} );
+			return;
+		}
+
+		recordTracksEvent( 'calypso_design_picker_select_filter', {
+			...commonFilterProperties,
+			filter_type: type || getCategoryType( term ),
+			filter_term: term,
+		} );
+	};
+
+	const handleDeselectFilter = ( term: string, type?: string ) => {
+		recordTracksEvent( 'calypso_design_picker_deselect_filter', {
+			...commonFilterProperties,
+			filter_type: type || getCategoryType( term ),
+			filter_term: term,
+		} );
+	};
+
+	return {
+		commonFilterProperties,
+		handleSelectFilter,
+		handleDeselectFilter,
+	};
+};
+
+export default useTrackFilters;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-track-filters.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-track-filters.ts
@@ -1,7 +1,7 @@
+import { getCategoryType } from '@automattic/design-picker';
 import { useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { getCategoryType } from '../categories';
 
 interface Props {
 	preselectedFilters: string[];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-track-filters.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-track-filters.ts
@@ -20,7 +20,10 @@ const useTrackFilters = ( { preselectedFilters, isBigSkyEligible, isMultiSelecti
 		return selectedFilters.reduce(
 			( result, filterSlug, index ) => ( {
 				...result,
-				[ `filters_${ filterSlug }` ]: `${ getCategoryType( filterSlug ) }:${ index }`,
+				// The property cannot contain `-` character.
+				[ `filters_${ filterSlug.replace( '-', '_' ) }` ]: `${ getCategoryType(
+					filterSlug
+				) }:${ index }`,
 			} ),
 			{}
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -88,6 +88,7 @@ import { STEP_NAME } from './constants';
 import DesignPickerDesignTitle from './design-picker-design-title';
 import { EligibilityWarningsModal } from './eligibility-warnings-modal';
 import useRecipe from './hooks/use-recipe';
+import useTrackFilters from './hooks/use-track-filters';
 import getThemeIdFromDesign from './utils/get-theme-id-from-design';
 import type { Step, ProvidedDependencies } from '../../types';
 import './style.scss';
@@ -117,6 +118,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const isGoalsHoldout = useIsGoalsHoldout( stepName );
 
 	const isGoalCentricFeature = isEnabled( 'design-picker/goal-centric' ) && ! isGoalsHoldout;
+
+	const { isEligible } = useIsBigSkyEligible();
+	const isBigSkyEligible = isEligible && isGoalCentricFeature;
 
 	const queryParams = useQuery();
 	const { goBack, submit, exitFlow } = navigation;
@@ -227,10 +231,27 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const categorizationOptions = getCategorizationOptions( goals, {
 		isMultiSelection: isGoalCentricFeature,
 	} );
+
+	const { commonFilterProperties, handleSelectFilter, handleDeselectFilter } = useTrackFilters( {
+		preselectedFilters: categorizationOptions.defaultSelections,
+		isBigSkyEligible,
+		isMultiSelection: isGoalCentricFeature,
+	} );
+
 	const categorization = useCategorization( allDesigns?.filters?.subject || EMPTY_OBJECT, {
 		...categorizationOptions,
 		isMultiSelection: isGoalCentricFeature,
+		handleSelect: handleSelectFilter,
+		handleDeselect: handleDeselectFilter,
 	} );
+
+	const handleChangeTier = ( value: boolean ) => {
+		if ( value ) {
+			handleSelectFilter( 'free', 'included_with_plan' );
+		} else {
+			handleDeselectFilter( 'free', 'included_with_plan' );
+		}
+	};
 
 	// ********** Logic for selecting a design and style variation
 	const {
@@ -452,9 +473,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const [ showUpgradeModal, setShowUpgradeModal ] = useState( false );
 
 	const eligibility = useSelector( ( state ) => site && getEligibility( state, site.ID ) );
-
-	const { isEligible } = useIsBigSkyEligible();
-	const isBigSkyEligible = isEligible && isGoalCentricFeature;
 
 	const hasEligibilityMessages =
 		! isAtomic &&
@@ -921,16 +939,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			showActiveThemeBadge={ intent !== 'build' }
 			isTierFilterEnabled={ isGoalCentricFeature }
 			isMultiFilterEnabled={ isGoalCentricFeature }
+			onChangeTier={ handleChangeTier }
 		/>
 	);
 
-	const bigSkyButtonEventProperties = {
-		is_big_sky_eligible: isBigSkyEligible,
-		// is_filter_included_with_plan_enabled: true/false,
-		// preselected_filters: ??,
-		// selected_filters: ??,
-		// {filter} ??
-	};
 	const bigSkyButtons = (
 		<>
 			{ isBigSkyEligible && (
@@ -941,7 +953,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 						);
 						recordTracksEvent(
 							'calypso_design_picker_big_sky_button_click',
-							bigSkyButtonEventProperties
+							commonFilterProperties
 						);
 					} }
 				>
@@ -950,7 +962,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			) }
 			<TrackComponentView
 				eventName="calypso_design_picker_big_sky_button_impression"
-				eventProperties={ bigSkyButtonEventProperties }
+				eventProperties={ commonFilterProperties }
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -18,6 +18,7 @@ import {
 import {
 	UnifiedDesignPicker,
 	useCategorization,
+	useDesignPickerFilters,
 	getDesignPreviewUrl,
 	isAssemblerDesign,
 	PERSONAL_THEME,
@@ -244,6 +245,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		handleSelect: handleSelectFilter,
 		handleDeselect: handleDeselectFilter,
 	} );
+
+	const designPickerFilters = useDesignPickerFilters();
 
 	const handleChangeTier = ( value: boolean ) => {
 		if ( value ) {
@@ -736,6 +739,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			return;
 		}
 
+		designPickerFilters.resetFilters();
 		goBack?.();
 	}
 

--- a/packages/design-picker/src/components/design-picker-category-filter/index.tsx
+++ b/packages/design-picker/src/components/design-picker-category-filter/index.tsx
@@ -1,5 +1,4 @@
 import { ResponsiveToolbarGroup } from '@automattic/components';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks'; // eslint-disable-line no-restricted-imports
 import type { Category } from '../../types';
 import './style.scss';
 
@@ -23,10 +22,6 @@ export default function DesignPickerCategoryFilter( {
 	const onClick = ( index: number ) => {
 		const category = categories[ index ];
 		if ( category?.slug ) {
-			recordTracksEvent( 'calypso_signup_unified_design_select_category', {
-				category: category?.slug,
-			} );
-
 			onSelect( category.slug );
 		}
 	};

--- a/packages/design-picker/src/components/design-picker-tier-filter/index.tsx
+++ b/packages/design-picker/src/components/design-picker-tier-filter/index.tsx
@@ -1,6 +1,6 @@
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useSearchParams } from 'react-router-dom';
+import { useDesignPickerFilters } from '../../hooks/use-design-picker-filters';
 import './style.scss';
 
 interface Props {
@@ -9,21 +9,13 @@ interface Props {
 
 const DesignPickerTierFilter = ( { onChange }: Props ) => {
 	const translate = useTranslate();
-	const [ searchParams, setSearchParams ] = useSearchParams();
 
-	const isFreeOnly = searchParams.get( 'tier' ) === 'free';
+	const { selectedDesignTier, setSelectedDesignTier } = useDesignPickerFilters();
+
+	const isFreeOnly = selectedDesignTier === 'free';
 
 	const handleChange = ( value: boolean ) => {
-		setSearchParams( ( currentSearchParams: any ) => {
-			if ( value ) {
-				currentSearchParams.set( 'tier', 'free' );
-			} else {
-				currentSearchParams.delete( 'tier' );
-			}
-
-			return currentSearchParams;
-		} );
-
+		setSelectedDesignTier( value ? 'free' : '' );
 		onChange?.( value );
 	};
 

--- a/packages/design-picker/src/components/design-picker-tier-filter/index.tsx
+++ b/packages/design-picker/src/components/design-picker-tier-filter/index.tsx
@@ -3,7 +3,11 @@ import { useTranslate } from 'i18n-calypso';
 import { useSearchParams } from 'react-router-dom';
 import './style.scss';
 
-const DesignPickerTierFilter = () => {
+interface Props {
+	onChange?: ( value: boolean ) => void;
+}
+
+const DesignPickerTierFilter = ( { onChange }: Props ) => {
 	const translate = useTranslate();
 	const [ searchParams, setSearchParams ] = useSearchParams();
 
@@ -19,6 +23,8 @@ const DesignPickerTierFilter = () => {
 
 			return currentSearchParams;
 		} );
+
+		onChange?.( value );
 	};
 
 	return (

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -222,7 +222,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	isMultiFilterEnabled = false,
 	onChangeTier,
 } ) => {
-	const filteredDesigns = useFilteredDesigns( designs, categorization );
+	const filteredDesigns = useFilteredDesigns( designs );
 	const categoryTypes = useMemo(
 		() => ( categorization?.categories || [] ).filter( ( { slug } ) => isFeatureCategory( slug ) ),
 		[ categorization?.categories ]

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -203,6 +203,7 @@ interface DesignPickerProps {
 	showActiveThemeBadge?: boolean;
 	isTierFilterEnabled?: boolean;
 	isMultiFilterEnabled?: boolean;
+	onChangeTier?: ( value: boolean ) => void;
 }
 
 const DesignPicker: React.FC< DesignPickerProps > = ( {
@@ -219,6 +220,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	showActiveThemeBadge = false,
 	isTierFilterEnabled = false,
 	isMultiFilterEnabled = false,
+	onChangeTier,
 } ) => {
 	const filteredDesigns = useFilteredDesigns( designs, categorization );
 	const categoryTypes = useMemo(
@@ -261,7 +263,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 				) }
 				{ isTierFilterEnabled && (
 					<DesignPickerFilterGroup>
-						<DesignPickerTierFilter />
+						<DesignPickerTierFilter onChange={ onChangeTier } />
 					</DesignPickerFilterGroup>
 				) }
 			</div>
@@ -306,6 +308,7 @@ export interface UnifiedDesignPickerProps {
 	showActiveThemeBadge?: boolean;
 	isTierFilterEnabled?: boolean;
 	isMultiFilterEnabled?: boolean;
+	onChangeTier?: ( value: boolean ) => void;
 }
 
 const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
@@ -324,6 +327,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	showActiveThemeBadge = false,
 	isTierFilterEnabled = false,
 	isMultiFilterEnabled = false,
+	onChangeTier,
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 
@@ -359,6 +363,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					showActiveThemeBadge={ showActiveThemeBadge }
 					isTierFilterEnabled={ isTierFilterEnabled }
 					isMultiFilterEnabled={ isMultiFilterEnabled }
+					onChangeTier={ onChangeTier }
 				/>
 				{ bottomAnchorContent }
 			</div>

--- a/packages/design-picker/src/constants.ts
+++ b/packages/design-picker/src/constants.ts
@@ -44,3 +44,18 @@ export const FEATURE_CATEGORIES = {
 	PODCAST: 'podcast',
 	STORE: 'store',
 };
+
+export const SUBJECT_CATEGORIES = {
+	BUSINESS: 'business',
+	COMMUNITY_NON_PROFIT: 'community-non-profit',
+	AUTHORS_WRITERS: 'authors-writers',
+	EDUCATION: 'education',
+	ENTERTAINMENT: 'entertainment',
+	EVENTS: 'events',
+	LINK_IN_BIO: 'link-in-bio',
+};
+
+export const CATEGORIES = {
+	...FEATURE_CATEGORIES,
+	...SUBJECT_CATEGORIES,
+};

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState, useCallback } from 'react';
+import { useEffect, useMemo, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Category } from '../types';
 
 export interface Categorization {
@@ -11,12 +12,22 @@ interface UseCategorizationOptions {
 	defaultSelections: string[];
 	isMultiSelection?: boolean;
 	sort?: ( a: Category, b: Category ) => number;
+	handleSelect?: ( slug: string ) => void;
+	handleDeselect?: ( slug: string ) => void;
 }
 
 export function useCategorization(
 	categoryMap: Record< string, Category >,
-	{ defaultSelections, isMultiSelection, sort }: UseCategorizationOptions
+	{
+		defaultSelections,
+		isMultiSelection,
+		sort,
+		handleSelect,
+		handleDeselect,
+	}: UseCategorizationOptions
 ): Categorization {
+	const [ searchParams, setSearchParams ] = useSearchParams();
+
 	const categories = useMemo( () => {
 		const categoryMapKeys = Object.keys( categoryMap ) || [];
 		const result = categoryMapKeys.map( ( slug ) => ( {
@@ -27,62 +38,57 @@ export function useCategorization(
 		return result.sort( sort );
 	}, [ categoryMap, sort ] );
 
-	const [ selections, setSelections ] = useState< string[] >(
-		chooseDefaultSelections( categories, defaultSelections )
-	);
+	const selections = searchParams.get( 'categories' )?.split( ',' ) || [];
+
+	const setSelections = ( values: string[] ) => {
+		setSearchParams( ( currentSearchParams ) => {
+			if ( values.length > 0 ) {
+				currentSearchParams.set( 'categories', values.join( ',' ) );
+			} else {
+				currentSearchParams.delete( 'categories' );
+			}
+			return currentSearchParams;
+		} );
+	};
 
 	const onSelect = useCallback(
 		( value: string ) => {
-			setSelections( ( currentSelections: string[] ) => {
-				if ( ! isMultiSelection ) {
-					return [ value ];
-				}
+			if ( ! isMultiSelection ) {
+				handleSelect?.( value );
+				setSelections( [ value ] );
+				return;
+			}
 
-				const index = currentSelections.findIndex( ( selection ) => selection === value );
-				if ( index === -1 ) {
-					return [ ...currentSelections, value ];
-				}
+			const currentSelections = searchParams.get( 'categories' )?.split( ',' ) || [];
+			const index = currentSelections.findIndex( ( selection ) => selection === value );
+			if ( index === -1 ) {
+				handleSelect?.( value );
+				return setSelections( [ ...currentSelections, value ] );
+			}
 
-				// The selections should at least have one.
-				return currentSelections.length > 1
-					? [ ...currentSelections.slice( 0, index ), ...currentSelections.slice( index + 1 ) ]
-					: currentSelections;
-			} );
+			// The selections should at least have one.
+			if ( currentSelections.length > 1 ) {
+				handleDeselect?.( value );
+				return setSelections( [
+					...currentSelections.slice( 0, index ),
+					...currentSelections.slice( index + 1 ),
+				] );
+			}
 		},
-		[ isMultiSelection, setSelections ]
+		[ searchParams, isMultiSelection, setSelections, handleSelect, handleDeselect ]
 	);
 
 	useEffect( () => {
-		if ( shouldSetToDefaultSelections( categories, selections ) ) {
+		if ( selections.length === 0 ) {
 			setSelections( chooseDefaultSelections( categories, defaultSelections ) );
 		}
-	}, [ categories, defaultSelections, selections ] );
+	}, [] );
 
 	return {
 		categories,
 		selections,
 		onSelect,
 	};
-}
-
-/**
- *	Check that the current selections still match one of the category slugs,
- *	and if it doesn't reset the current selections to the default selections.
- *	@param categories the list of available categories
- *	@param currentSelections the slugs of the current selected category
- *	@returns whether the current selections should be set to the default selections
- */
-function shouldSetToDefaultSelections(
-	categories: Category[],
-	currentSelections: string[]
-): boolean {
-	// For an empty list, the empty selections is the only correct one.
-	if ( categories.length === 0 && currentSelections.length === 0 ) {
-		return false;
-	}
-
-	const currentSelectionsSet = new Set( currentSelections );
-	return ! categories.some( ( { slug } ) => currentSelectionsSet.has( slug ) );
 }
 
 /**

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -1,11 +1,11 @@
 import { useEffect, useMemo, useCallback } from 'react';
-import { useSearchParams } from 'react-router-dom';
-import { Category } from '../types';
+import { useDesignPickerFilters } from './use-design-picker-filters';
+import type { Category } from '../types';
 
 export interface Categorization {
+	categories: Category[];
 	selections: string[];
 	onSelect: ( selectedSlug: string ) => void;
-	categories: Category[];
 }
 
 interface UseCategorizationOptions {
@@ -26,8 +26,6 @@ export function useCategorization(
 		handleDeselect,
 	}: UseCategorizationOptions
 ): Categorization {
-	const [ searchParams, setSearchParams ] = useSearchParams();
-
 	const categories = useMemo( () => {
 		const categoryMapKeys = Object.keys( categoryMap ) || [];
 		const result = categoryMapKeys.map( ( slug ) => ( {
@@ -38,55 +36,43 @@ export function useCategorization(
 		return result.sort( sort );
 	}, [ categoryMap, sort ] );
 
-	const selections = searchParams.get( 'categories' )?.split( ',' ) || [];
-
-	const setSelections = ( values: string[] ) => {
-		setSearchParams( ( currentSearchParams ) => {
-			if ( values.length > 0 ) {
-				currentSearchParams.set( 'categories', values.join( ',' ) );
-			} else {
-				currentSearchParams.delete( 'categories' );
-			}
-			return currentSearchParams;
-		} );
-	};
+	const { selectedCategories, setSelectedCategories } = useDesignPickerFilters();
 
 	const onSelect = useCallback(
 		( value: string ) => {
 			if ( ! isMultiSelection ) {
 				handleSelect?.( value );
-				setSelections( [ value ] );
+				setSelectedCategories( [ value ] );
 				return;
 			}
 
-			const currentSelections = searchParams.get( 'categories' )?.split( ',' ) || [];
-			const index = currentSelections.findIndex( ( selection ) => selection === value );
+			const index = selectedCategories.findIndex( ( selection ) => selection === value );
 			if ( index === -1 ) {
 				handleSelect?.( value );
-				return setSelections( [ ...currentSelections, value ] );
+				return setSelectedCategories( [ ...selectedCategories, value ] );
 			}
 
 			// The selections should at least have one.
-			if ( currentSelections.length > 1 ) {
+			if ( selectedCategories.length > 1 ) {
 				handleDeselect?.( value );
-				return setSelections( [
-					...currentSelections.slice( 0, index ),
-					...currentSelections.slice( index + 1 ),
+				return setSelectedCategories( [
+					...selectedCategories.slice( 0, index ),
+					...selectedCategories.slice( index + 1 ),
 				] );
 			}
 		},
-		[ searchParams, isMultiSelection, setSelections, handleSelect, handleDeselect ]
+		[ selectedCategories, isMultiSelection, setSelectedCategories, handleSelect, handleDeselect ]
 	);
 
 	useEffect( () => {
-		if ( selections.length === 0 ) {
-			setSelections( chooseDefaultSelections( categories, defaultSelections ) );
+		if ( selectedCategories.length === 0 ) {
+			setSelectedCategories( chooseDefaultSelections( categories, defaultSelections ) );
 		}
 	}, [] );
 
 	return {
 		categories,
-		selections,
+		selections: selectedCategories,
 		onSelect,
 	};
 }

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -65,10 +65,10 @@ export function useCategorization(
 	);
 
 	useEffect( () => {
-		if ( selectedCategories.length === 0 ) {
+		if ( categories.length > 0 && selectedCategories.length === 0 ) {
 			setSelectedCategories( chooseDefaultSelections( categories, defaultSelections ) );
 		}
-	}, [] );
+	}, [ categories ] );
 
 	return {
 		categories,

--- a/packages/design-picker/src/hooks/use-design-picker-filters.ts
+++ b/packages/design-picker/src/hooks/use-design-picker-filters.ts
@@ -1,0 +1,69 @@
+import { useSearchParams } from 'react-router-dom';
+
+// The `currentSearchParams` parameter from the callback of the `setSearchParams` function
+// might not have the latest query parameter on multiple calls at the same time.
+const makeSearchParams = (
+	callback: ( currentSearchParams: URLSearchParams ) => URLSearchParams
+) => callback( new URLSearchParams( window.location.search ) );
+
+const useCategoriesFilter = () => {
+	const [ searchParams, setSearchParams ] = useSearchParams();
+	const selectedCategories = searchParams.get( 'categories' )?.split( ',' ) || [];
+	const setSelectedCategories = ( values: string[] ) => {
+		setSearchParams(
+			makeSearchParams( ( currentSearchParams ) => {
+				if ( values.length > 0 ) {
+					currentSearchParams.set( 'categories', values.join( ',' ) );
+				} else {
+					currentSearchParams.delete( 'categories' );
+				}
+				return currentSearchParams;
+			} ),
+			{ replace: true }
+		);
+	};
+
+	return { selectedCategories, setSelectedCategories };
+};
+
+const useDesignTierFilter = () => {
+	const [ searchParams, setSearchParams ] = useSearchParams();
+
+	const selectedDesignTier = searchParams.get( 'tier' ) ?? '';
+
+	const setSelectedDesignTier = ( value: string ) => {
+		setSearchParams(
+			makeSearchParams( ( currentSearchParams: any ) => {
+				if ( value ) {
+					currentSearchParams.set( 'tier', value );
+				} else {
+					currentSearchParams.delete( 'tier' );
+				}
+
+				return currentSearchParams;
+			} ),
+			{ replace: true }
+		);
+	};
+
+	return {
+		selectedDesignTier,
+		setSelectedDesignTier,
+	};
+};
+
+export const useDesignPickerFilters = () => {
+	const { selectedCategories, setSelectedCategories } = useCategoriesFilter();
+	const { selectedDesignTier, setSelectedDesignTier } = useDesignTierFilter();
+
+	return {
+		selectedCategories,
+		selectedDesignTier,
+		setSelectedCategories,
+		setSelectedDesignTier,
+		resetFilters: () => {
+			setSelectedCategories( [] );
+			setSelectedDesignTier( '' );
+		},
+	};
+};

--- a/packages/design-picker/src/hooks/use-filtered-designs.ts
+++ b/packages/design-picker/src/hooks/use-filtered-designs.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
 import { isBlankCanvasDesign } from '../utils/available-designs';
-import type { Categorization } from './use-categorization';
+import { useDesignPickerFilters } from './use-design-picker-filters';
 import type { Design } from '../types';
 
 const getDesignSlug = ( design: Design ) => design.recipe?.slug ?? design.slug;
@@ -51,18 +50,16 @@ export const filterDesigns = (
 	return filteredDesigns;
 };
 
-export const useFilteredDesigns = ( designs: Design[], categorization?: Categorization ) => {
-	const [ searchParams ] = useSearchParams();
-
-	const selectedDesignTier = searchParams.get( 'tier' ) ?? '';
+export const useFilteredDesigns = ( designs: Design[] ) => {
+	const { selectedCategories, selectedDesignTier } = useDesignPickerFilters();
 
 	const filteredDesigns = useMemo( () => {
-		if ( categorization?.selections || selectedDesignTier ) {
-			return filterDesigns( designs, categorization?.selections, selectedDesignTier );
+		if ( selectedCategories.length > 0 || selectedDesignTier ) {
+			return filterDesigns( designs, selectedCategories, selectedDesignTier );
 		}
 
 		return designs;
-	}, [ designs, categorization?.selections, selectedDesignTier ] );
+	}, [ designs, selectedCategories, selectedDesignTier ] );
 
 	return filteredDesigns;
 };

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -22,6 +22,7 @@ export {
 	BUNDLED_THEME,
 	MARKETPLACE_THEME,
 	SHOW_ALL_SLUG,
+	CATEGORIES,
 } from './constants';
 export type {
 	Design,

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -33,4 +33,5 @@ export type {
 	StyleVariationStylesColor,
 } from './types';
 export { useCategorization } from './hooks/use-categorization';
+export { useDesignPickerFilters } from './hooks/use-design-picker-filters';
 export { useThemeDesignsQuery } from './hooks/use-theme-designs-query';

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -8,6 +8,7 @@ export {
 	getMShotOptions,
 	isAssemblerSupported,
 	isLockedStyleVariation,
+	getCategoryType,
 } from './utils';
 export {
 	DEFAULT_GLOBAL_STYLES_VARIATION_SLUG,

--- a/packages/design-picker/src/utils/categories.ts
+++ b/packages/design-picker/src/utils/categories.ts
@@ -3,3 +3,11 @@ import { FEATURE_CATEGORIES } from '../constants';
 const featureCategorySet = new Set( Object.values( FEATURE_CATEGORIES ) );
 
 export const isFeatureCategory = ( categorySlug: string ) => featureCategorySet.has( categorySlug );
+
+export const getCategoryType = ( categorySlug: string ) => {
+	if ( featureCategorySet.has( categorySlug ) ) {
+		return 'feature';
+	}
+
+	return 'subject';
+}

--- a/packages/design-picker/src/utils/categories.ts
+++ b/packages/design-picker/src/utils/categories.ts
@@ -10,4 +10,4 @@ export const getCategoryType = ( categorySlug: string ) => {
 	}
 
 	return 'subject';
-}
+};

--- a/packages/design-picker/src/utils/index.ts
+++ b/packages/design-picker/src/utils/index.ts
@@ -1,5 +1,5 @@
 export * from './available-designs';
+export * from './categories';
 export * from './designs';
 export * from './global-styles';
-export * from './is-feature-category';
 export * from './is-locked-style-variation';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pbxlJb-6Hz-p2

## Proposed Changes

* Use the query string parameter for the selected categories
* Track the `Free only` toggle
* Track the selection of categories
* Add the common properies to the event of the big sky button

**Filters**

| Select | Deselect |
| - | - |
| ![image](https://github.com/user-attachments/assets/6c8723d1-4a2c-4bcb-836f-ec1cf4c16cc8) | ![image](https://github.com/user-attachments/assets/d31b0f26-e768-41c7-913f-cfff17273c26) |
| ![image](https://github.com/user-attachments/assets/9b629a26-8733-4fbd-81a7-548b8cd0f6b7) | ![image](https://github.com/user-attachments/assets/90bb37d0-d1c3-4c4c-a598-68cd8be2292a) |

**Free Only Filter**

| Select | Deselect |
| - | - |
| ![image](https://github.com/user-attachments/assets/d1d95e9d-bcec-42f1-8622-6242a6e2f5c4) | ![image](https://github.com/user-attachments/assets/f51486a2-a128-47f7-9760-f6140b0627c4) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to track the behavior of the category selection

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* On the Goals screen, select any goals
* On the Design Picker screen
  * Select any features
  * Select any subjects
  * Toggle the free-only filter
  * Ensure the track event is sent with the correct properties

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?