### PR TITLE
Stats: Enable tab switching for unsupported fields of hourly views

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { localize } from 'i18n-calypso';
+import { localize, translate } from 'i18n-calypso';
 import { flowRight } from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
@@ -151,7 +151,16 @@ class StatModuleChartTabs extends Component {
 
 				<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />
 				<Chart barClick={ this.props.barClick } data={ chartData } minBarWidth={ 35 }>
-					<StatsEmptyState />
+					<StatsEmptyState
+						headingText={
+							selectedPeriod === 'hour' ? translate( 'No hourly data available' ) : null
+						}
+						infoText={
+							selectedPeriod === 'hour'
+								? translate( 'Try selecting a different time frame.' )
+								: null
+						}
+					/>
 				</Chart>
 				<StatTabs
 					data={ this.props.counts }

--- a/client/my-sites/stats/stats-tabs/index.jsx
+++ b/client/my-sites/stats/stats-tabs/index.jsx
@@ -31,7 +31,8 @@ class StatsTabs extends Component {
 		} else {
 			data?.map( ( day ) =>
 				tabs.map( ( tab ) => {
-					if ( isFinite( day[ tab.attr ] ) ) {
+					// Exclude non-numeric values, e.g., NULL from unsupported stats fields.
+					if ( Number.isFinite( day[ tab.attr ] ) ) {
 						if ( ! ( tab.attr in activeData ) ) {
 							activeData[ tab.attr ] = 0;
 						}
@@ -68,7 +69,6 @@ class StatsTabs extends Component {
 			};
 
 			statsTabs = tabs.map( ( tab ) => {
-				const hasTrend = trendData?.[ tab.attr ] >= 0 && trendData[ tab.attr ] !== null;
 				const hasData = activeData?.[ tab.attr ] >= 0 && activeData[ tab.attr ] !== null;
 				const value = hasData ? activeData[ tab.attr ] : null;
 				const previousValue =
@@ -81,7 +81,7 @@ class StatsTabs extends Component {
 					label: tab.label,
 					loading: ! hasData,
 					selected: selectedTab === tab.attr,
-					tabClick: hasTrend ? switchTab : undefined,
+					tabClick: switchTab,
 					value,
 					previousValue,
 					format: tab.format,

--- a/client/state/data-layer/wpcom/sites/stats/visits/index.js
+++ b/client/state/data-layer/wpcom/sites/stats/visits/index.js
@@ -21,7 +21,7 @@ export const fetch = ( action ) => {
 					unit: period,
 					date: adjustedDate,
 					quantity,
-					stat_fields: 'views',
+					stat_fields: statFields,
 				},
 			},
 			action

--- a/client/state/data-layer/wpcom/sites/stats/visits/schema.js
+++ b/client/state/data-layer/wpcom/sites/stats/visits/schema.js
@@ -9,7 +9,8 @@ export default {
 			items: {
 				type: 'array',
 				items: {
-					type: [ 'integer', 'string', 'array' ],
+					// Valid for NULL from unsupported stats fields in hourly data
+					type: [ 'integer', 'string', 'array', null ],
 				},
 			},
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/301.

## Proposed Changes

* Restore chart tab switching for tab `Visitors`, `Likes`, and `Comments`.
* Use `NULL` to recognize unsupported Stats visits fields for hourly views to apply alternative data.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Making unsupported hourly views tabs clickable with dedicated text in an empty state would communicate better to users. Context: https://github.com/Automattic/wp-calypso/pull/97060#issuecomment-2518645225.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply Diff `D167991-code` and sandbox `public-api.wordpress.com`.
* Navigate to Stats > Traffic with the feature flag: `?flags=stats/new-date-filtering`.
* Click on any day on the chart to navigate to the hourly views.
* Ensure the `Views` tab works as previously.

<img width="1417" alt="截圖 2024-12-06 下午2 58 22" src="https://github.com/user-attachments/assets/428baf93-8532-4a04-937a-8ff799314c30">

* Ensure the `Visitors`, `Likes`, and `Comments` tabs are clickable.
* Click on the `Visitors` tab.
* Ensure the chart is showing empty state with hourly views dedicated texts.
* Ensure the chart tab still displays the cumulative number of visitors for a single day.

<img width="1416" alt="截圖 2024-12-06 下午2 58 05" src="https://github.com/user-attachments/assets/b5844982-d4d2-48f5-b93d-52718739ae32">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?