### PR TITLE
Move big sky button from nav-container to filters container

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -24,6 +24,10 @@ $container-padding-large: 48px;
 			position: absolute;
 			top: $container-padding-small;
 			right: $container-padding-small;
+
+			@include break-small {
+				display: none;
+			}
 		}
 
 		.step-container__content {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -6,20 +6,28 @@
 $gray-100: #101517;
 $gray-60: #50575e;
 $design-button-primary-color: rgb(17, 122, 201);
+$container-padding-small: 20px;
+$container-padding-large: 48px;
 
 .design-setup {
 	.step-container {
-		padding-inline-start: 20px;
-		padding-inline-end: 20px;
+		padding-inline-start: $container-padding-small;
+		padding-inline-end: $container-padding-small;
 		max-width: 1440px;
+
+		@include break-small {
+			padding-inline-start: $container-padding-large;
+			padding-inline-end: $container-padding-large;
+		}
+
+		.setup-container__big-sky-container {
+			position: absolute;
+			top: $container-padding-small;
+			right: $container-padding-small;
+		}
 
 		.step-container__content {
 			margin-top: 32px;
-		}
-
-		@include break-small {
-			padding-inline-start: 48px;
-			padding-inline-end: 48px;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -926,14 +926,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		categorization.selections = [ 'blog' ];
 	}
 
-	const bigSkyButtonEventProperties = {
-		is_big_sky_eligible: isBigSkyEligible,
-		// is_filter_included_with_plan_enabled: true/false,
-		// preselected_filters: ??,
-		// selected_filters: ??,
-		// {filter} ??
-	};
-
 	function onDesignWithAI() {
 		recordTracksEvent( 'calypso_design_picker_big_sky_button_click', commonFilterProperties );
 		navigate( `/setup/site-setup/launch-big-sky?siteSlug=${ siteSlug }&siteId=${ site?.ID }` );
@@ -941,13 +933,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	const bigSkyButton = isBigSkyEligible && (
 		<>
-			<Button
-				onClick={ () => {
-					onDesignWithAI && onDesignWithAI();
-				} }
-			>
-				{ translate( 'Design with AI' ) }
-			</Button>
+			<Button onClick={ onDesignWithAI }>{ translate( 'Design with AI' ) }</Button>
 			<TrackComponentView
 				eventName="calypso_design_picker_big_sky_button_impression"
 				eventProperties={ commonFilterProperties }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -933,32 +933,37 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		// selected_filters: ??,
 		// {filter} ??
 	};
-	const bigSkyButtons = isBigSkyEligible && (
-		<Button
-			onClick={ () => {
-				navigate( `/setup/site-setup/launch-big-sky?siteSlug=${ siteSlug }&siteId=${ site.ID }` );
-				recordTracksEvent(
-					'calypso_design_picker_big_sky_button_click',
-					commonFilterProperties
-				);
-			} }
-		>
-			{ translate( 'Create yours with AI' ) }
-		</Button>
+
+	function onDesignWithAI() {
+		recordTracksEvent( 'calypso_design_picker_big_sky_button_click', commonFilterProperties );
+		navigate( `/setup/site-setup/launch-big-sky?siteSlug=${ siteSlug }&siteId=${ site?.ID }` );
+	}
+
+	const bigSkyButtons = (
+		<>
+			<TrackComponentView
+				eventName="calypso_design_picker_big_sky_button_impression"
+				eventProperties={ commonFilterProperties }
+			/>
+			{ isBigSkyEligible && (
+				<Button
+					onClick={ () => {
+						onDesignWithAI && onDesignWithAI()
+					} }
+				>
+					{ translate( 'Design with AI' ) }
+				</Button>
+			) }
+		</>
 	);
 
 	const stepContent = (
 		<>
-			<div className="setup-container__big-sky-container">
-				{ bigSkyButtons }
-				<TrackComponentView
-					eventName="calypso_design_picker_big_sky_button_impression"
-					eventProperties={ commonFilterProperties }
-				/>
-			</div>
+			<div className="setup-container__big-sky-container">{ bigSkyButtons }</div>
 			<UnifiedDesignPicker
 				designs={ designs }
 				locale={ locale }
+				onDesignWithAI={ onDesignWithAI }
 				onPreview={ previewDesign }
 				onChangeVariation={ onChangeVariation }
 				onViewAllDesigns={ trackAllDesignsView }
@@ -973,6 +978,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				isTierFilterEnabled={ isGoalCentricFeature }
 				isMultiFilterEnabled={ isGoalCentricFeature }
 				onChangeTier={ handleChangeTier }
+				isBigSkyEligible={ isBigSkyEligible }
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -926,47 +926,53 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		categorization.selections = [ 'blog' ];
 	}
 
-	const stepContent = (
-		<UnifiedDesignPicker
-			designs={ designs }
-			locale={ locale }
-			onPreview={ previewDesign }
-			onChangeVariation={ onChangeVariation }
-			onViewAllDesigns={ trackAllDesignsView }
-			heading={ heading }
-			categorization={ categorization }
-			isPremiumThemeAvailable={ isPremiumThemeAvailable }
-			shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
-			getBadge={ getBadge }
-			oldHighResImageLoading={ oldHighResImageLoading }
-			siteActiveTheme={ siteActiveTheme?.[ 0 ]?.stylesheet ?? null }
-			showActiveThemeBadge={ intent !== 'build' }
-			isTierFilterEnabled={ isGoalCentricFeature }
-			isMultiFilterEnabled={ isGoalCentricFeature }
-			onChangeTier={ handleChangeTier }
-		/>
+	const bigSkyButtonEventProperties = {
+		is_big_sky_eligible: isBigSkyEligible,
+		// is_filter_included_with_plan_enabled: true/false,
+		// preselected_filters: ??,
+		// selected_filters: ??,
+		// {filter} ??
+	};
+	const bigSkyButtons = isBigSkyEligible && (
+		<Button
+			onClick={ () => {
+				navigate( `/setup/site-setup/launch-big-sky?siteSlug=${ siteSlug }&siteId=${ site.ID }` );
+				recordTracksEvent(
+					'calypso_design_picker_big_sky_button_click',
+					commonFilterProperties
+				);
+			} }
+		>
+			{ translate( 'Create yours with AI' ) }
+		</Button>
 	);
 
-	const bigSkyButtons = (
+	const stepContent = (
 		<>
-			{ isBigSkyEligible && (
-				<Button
-					onClick={ () => {
-						navigate(
-							`/setup/site-setup/launch-big-sky?siteSlug=${ siteSlug }&siteId=${ site.ID }`
-						);
-						recordTracksEvent(
-							'calypso_design_picker_big_sky_button_click',
-							commonFilterProperties
-						);
-					} }
-				>
-					{ translate( 'Create yours with AI' ) }
-				</Button>
-			) }
-			<TrackComponentView
-				eventName="calypso_design_picker_big_sky_button_impression"
-				eventProperties={ commonFilterProperties }
+			<div className="setup-container__big-sky-container">
+				{ bigSkyButtons }
+				<TrackComponentView
+					eventName="calypso_design_picker_big_sky_button_impression"
+					eventProperties={ commonFilterProperties }
+				/>
+			</div>
+			<UnifiedDesignPicker
+				designs={ designs }
+				locale={ locale }
+				onPreview={ previewDesign }
+				onChangeVariation={ onChangeVariation }
+				onViewAllDesigns={ trackAllDesignsView }
+				heading={ heading }
+				categorization={ categorization }
+				isPremiumThemeAvailable={ isPremiumThemeAvailable }
+				shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
+				getBadge={ getBadge }
+				oldHighResImageLoading={ oldHighResImageLoading }
+				siteActiveTheme={ siteActiveTheme?.[ 0 ]?.stylesheet ?? null }
+				showActiveThemeBadge={ intent !== 'build' }
+				isTierFilterEnabled={ isGoalCentricFeature }
+				isMultiFilterEnabled={ isGoalCentricFeature }
+				onChangeTier={ handleChangeTier }
 			/>
 		</>
 	);
@@ -979,7 +985,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			hideFormattedHeader
 			hideSkip
 			backLabelText={ translate( 'Back' ) }
-			customizedActionButtons={ bigSkyButtons }
 			stepContent={ stepContent }
 			recordTracksEvent={ recordStepContainerTracksEvent }
 			goNext={ handleSubmit }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -939,27 +939,25 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		navigate( `/setup/site-setup/launch-big-sky?siteSlug=${ siteSlug }&siteId=${ site?.ID }` );
 	}
 
-	const bigSkyButtons = (
+	const bigSkyButton = isBigSkyEligible && (
 		<>
+			<Button
+				onClick={ () => {
+					onDesignWithAI && onDesignWithAI();
+				} }
+			>
+				{ translate( 'Design with AI' ) }
+			</Button>
 			<TrackComponentView
 				eventName="calypso_design_picker_big_sky_button_impression"
 				eventProperties={ commonFilterProperties }
 			/>
-			{ isBigSkyEligible && (
-				<Button
-					onClick={ () => {
-						onDesignWithAI && onDesignWithAI()
-					} }
-				>
-					{ translate( 'Design with AI' ) }
-				</Button>
-			) }
 		</>
 	);
 
 	const stepContent = (
 		<>
-			<div className="setup-container__big-sky-container">{ bigSkyButtons }</div>
+			<div className="setup-container__big-sky-container">{ bigSkyButton }</div>
 			<UnifiedDesignPicker
 				designs={ designs }
 				locale={ locale }

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -44,8 +44,9 @@
 
 			.design-picker__category-group-content {
 				display: flex;
+				align-items: center;
 				flex-wrap: wrap;
-				gap: 16px;
+				gap: 8px 16px;
 			}
 		}
 
@@ -55,24 +56,22 @@
 			font-weight: 500;
 		}
 
-		.design-picker__design-your-own-button {
-			flex-shrink: 0;
-			height: 32px;
-			line-height: 14px;
-			margin-top: 8px;
-			margin-bottom: 8px;
-
-			&.design-picker__design-with-ai {
-				display: none;
-				
-				@include break-small {
-					display: block;
-				}
-			}
+		.design-picker__tier-filter {
+			height: 40px; // match button height
+			margin-bottom: 6px;
 		}
 
-		.design-picker__tier-filter {
-			height: 48px; // match button height
+		.design-picker__design-your-own-button {
+			flex-shrink: 0;
+			margin-bottom: 6px;
+		}
+
+		.design-picker__design-with-ai {
+			display: none;
+			
+			@include break-small {
+				display: block;
+			}
 		}
 
 		.design-picker__design-your-own-button-without-categories {

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -41,6 +41,12 @@
 			&.grow {
 				flex-grow: 1;
 			}
+
+			.design-picker__category-group-content {
+				display: flex;
+				flex-wrap: wrap;
+				gap: 16px;
+			}
 		}
 
 		.design-picker__category-group-label {
@@ -55,6 +61,14 @@
 			line-height: 14px;
 			margin-top: 8px;
 			margin-bottom: 8px;
+
+			&.design-picker__design-with-ai {
+				display: none;
+				
+				@include break-small {
+					display: block;
+				}
+			}
 		}
 
 		.design-picker__tier-filter {

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -267,7 +267,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 					</DesignPickerFilterGroup>
 				) }
 				<DesignPickerFilterGroup>
-					{ isTierFilterEnabled && <DesignPickerTierFilter /> }
+					{ isTierFilterEnabled && <DesignPickerTierFilter onChange={ onChangeTier } /> }
 					{ isBigSkyEligible && (
 						<Button
 							className={ clsx(

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Button } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useRef, useState } from 'react';
@@ -184,13 +185,14 @@ const DesignPickerFilterGroup: React.FC< DesignPickerFilterGroupProps > = ( {
 	return (
 		<div className={ clsx( 'design-picker__category-group', { grow } ) }>
 			<div className="design-picker__category-group-label">{ title }</div>
-			{ children }
+			<div className="design-picker__category-group-content">{ children }</div>
 		</div>
 	);
 };
 
 interface DesignPickerProps {
 	locale: string;
+	onDesignWithAI?: () => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
 	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;
 	designs: Design[];
@@ -204,10 +206,12 @@ interface DesignPickerProps {
 	isTierFilterEnabled?: boolean;
 	isMultiFilterEnabled?: boolean;
 	onChangeTier?: ( value: boolean ) => void;
+	isBigSkyEligible?: boolean;
 }
 
 const DesignPicker: React.FC< DesignPickerProps > = ( {
 	locale,
+	onDesignWithAI,
 	onPreview,
 	onChangeVariation,
 	designs,
@@ -221,6 +225,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	isTierFilterEnabled = false,
 	isMultiFilterEnabled = false,
 	onChangeTier,
+	isBigSkyEligible = false,
 } ) => {
 	const filteredDesigns = useFilteredDesigns( designs );
 	const categoryTypes = useMemo(
@@ -261,11 +266,22 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						/>
 					</DesignPickerFilterGroup>
 				) }
-				{ isTierFilterEnabled && (
-					<DesignPickerFilterGroup>
-						<DesignPickerTierFilter onChange={ onChangeTier } />
-					</DesignPickerFilterGroup>
-				) }
+				<DesignPickerFilterGroup>
+					{ isTierFilterEnabled && <DesignPickerTierFilter /> }
+					{ isBigSkyEligible && (
+						<Button
+							className={ clsx(
+								'design-picker__design-your-own-button',
+								'design-picker__design-with-ai'
+							) }
+							onClick={ () => {
+								onDesignWithAI && onDesignWithAI();
+							} }
+						>
+							{ translate( 'Design with AI' ) }
+						</Button>
+					) }
+				</DesignPickerFilterGroup>
 			</div>
 
 			<div className="design-picker__grid">
@@ -294,6 +310,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 
 export interface UnifiedDesignPickerProps {
 	locale: string;
+	onDesignWithAI?: () => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
 	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;
 	onViewAllDesigns: () => void;
@@ -309,10 +326,12 @@ export interface UnifiedDesignPickerProps {
 	isTierFilterEnabled?: boolean;
 	isMultiFilterEnabled?: boolean;
 	onChangeTier?: ( value: boolean ) => void;
+	isBigSkyEligible?: boolean;
 }
 
 const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	locale,
+	onDesignWithAI,
 	onPreview,
 	onChangeVariation,
 	onViewAllDesigns,
@@ -328,6 +347,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	isTierFilterEnabled = false,
 	isMultiFilterEnabled = false,
 	onChangeTier,
+	isBigSkyEligible = false,
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 
@@ -351,6 +371,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 			<div className="unified-design-picker__designs">
 				<DesignPicker
 					locale={ locale }
+					onDesignWithAI={ onDesignWithAI }
 					onPreview={ onPreview }
 					onChangeVariation={ onChangeVariation }
 					designs={ designs }
@@ -364,6 +385,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					isTierFilterEnabled={ isTierFilterEnabled }
 					isMultiFilterEnabled={ isMultiFilterEnabled }
 					onChangeTier={ onChangeTier }
+					isBigSkyEligible={ isBigSkyEligible }
 				/>
 				{ bottomAnchorContent }
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/10093

## Proposed Changes

* Updated label of the button `Create yours with AI` to `Design with AI`
* Moved the button from header navigation to filters area
* Button is visible in the header area in small screens instead of in filters.

<img width="1145" alt="image" src="https://github.com/user-attachments/assets/7d26cd67-8448-4705-a677-a16bf633a1cb">

<img width="368" alt="image" src="https://github.com/user-attachments/assets/edf16ae9-a0af-47fa-80ab-452e434bb675">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To match new designs

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify the design picker UI in large and small screens

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
