### PR TITLE
(PoC) Extend the storage add-on line-up.

### DIFF
--- a/packages/data-stores/src/add-ons/constants.ts
+++ b/packages/data-stores/src/add-ons/constants.ts
@@ -1,10 +1,15 @@
-export const STORAGE_LIMIT = 203;
+export const STORAGE_LIMIT = 410;
 
 export const ADD_ON_JETPACK_AI_MONTHLY = 'jetpack_ai_monthly-add-on';
 export const ADD_ON_UNLIMITED_THEMES = 'unlimited_themes-add-on';
 export const ADD_ON_CUSTOM_DESIGN = 'custom_design-add-on';
 export const ADD_ON_50GB_STORAGE = '50gb-storage-add-on';
 export const ADD_ON_100GB_STORAGE = '100gb-storage-add-on';
+export const ADD_ON_150GB_STORAGE = '150gb-storage-add-on';
+export const ADD_ON_200GB_STORAGE = '200gb-storage-add-on';
+export const ADD_ON_250GB_STORAGE = '250gb-storage-add-on';
+export const ADD_ON_300GB_STORAGE = '300gb-storage-add-on';
+export const ADD_ON_350GB_STORAGE = '350gb-storage-add-on';
 
 export const ADD_ONS = < const >[
 	ADD_ON_JETPACK_AI_MONTHLY,
@@ -12,6 +17,19 @@ export const ADD_ONS = < const >[
 	ADD_ON_CUSTOM_DESIGN,
 	ADD_ON_50GB_STORAGE,
 	ADD_ON_100GB_STORAGE,
+	ADD_ON_150GB_STORAGE,
+	ADD_ON_200GB_STORAGE,
+	ADD_ON_250GB_STORAGE,
+	ADD_ON_300GB_STORAGE,
+	ADD_ON_350GB_STORAGE,
 ];
 
-export const STORAGE_ADD_ONS = < const >[ ADD_ON_50GB_STORAGE, ADD_ON_100GB_STORAGE ];
+export const STORAGE_ADD_ONS = < const >[
+	ADD_ON_50GB_STORAGE,
+	ADD_ON_100GB_STORAGE,
+	ADD_ON_150GB_STORAGE,
+	ADD_ON_200GB_STORAGE,
+	ADD_ON_250GB_STORAGE,
+	ADD_ON_300GB_STORAGE,
+	ADD_ON_350GB_STORAGE,
+];

--- a/packages/data-stores/src/add-ons/hooks/use-add-ons.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-add-ons.ts
@@ -11,8 +11,13 @@ import * as ProductsList from '../../products-list';
 import * as Purchases from '../../purchases';
 import * as Site from '../../site';
 import {
-	ADD_ON_100GB_STORAGE,
 	ADD_ON_50GB_STORAGE,
+	ADD_ON_100GB_STORAGE,
+	ADD_ON_150GB_STORAGE,
+	ADD_ON_200GB_STORAGE,
+	ADD_ON_250GB_STORAGE,
+	ADD_ON_300GB_STORAGE,
+	ADD_ON_350GB_STORAGE,
 	ADD_ON_CUSTOM_DESIGN,
 	ADD_ON_UNLIMITED_THEMES,
 	STORAGE_LIMIT,
@@ -37,12 +42,22 @@ const useActiveAddOnsDefs = ( selectedSiteId: Props[ 'selectedSiteId' ] ) => {
 	const displayCostCustomDesign = useAddOnDisplayCost( PRODUCT_WPCOM_CUSTOM_DESIGN );
 	const displayCost1GBSpace50 = useAddOnDisplayCost( PRODUCT_1GB_SPACE, 50 );
 	const displayCost1GBSpace100 = useAddOnDisplayCost( PRODUCT_1GB_SPACE, 100 );
+	const displayCost1GBSpace150 = useAddOnDisplayCost( PRODUCT_1GB_SPACE, 150 );
+	const displayCost1GBSpace200 = useAddOnDisplayCost( PRODUCT_1GB_SPACE, 200 );
+	const displayCost1GBSpace250 = useAddOnDisplayCost( PRODUCT_1GB_SPACE, 250 );
+	const displayCost1GBSpace300 = useAddOnDisplayCost( PRODUCT_1GB_SPACE, 300 );
+	const displayCost1GBSpace350 = useAddOnDisplayCost( PRODUCT_1GB_SPACE, 350 );
 
 	/*
 	 * TODO: `useAddOnPrices` be refactored instead to return an index of `{ [ slug ]: AddOnPrice }`
 	 */
 	const addOnPrices1GBSpace50 = useAddOnPrices( PRODUCT_1GB_SPACE, 50 );
 	const addOnPrices1GBSpace100 = useAddOnPrices( PRODUCT_1GB_SPACE, 100 );
+	const addOnPrices1GBSpace150 = useAddOnPrices( PRODUCT_1GB_SPACE, 150 );
+	const addOnPrices1GBSpace200 = useAddOnPrices( PRODUCT_1GB_SPACE, 200 );
+	const addOnPrices1GBSpace250 = useAddOnPrices( PRODUCT_1GB_SPACE, 250 );
+	const addOnPrices1GBSpace300 = useAddOnPrices( PRODUCT_1GB_SPACE, 300 );
+	const addOnPrices1GBSpace350 = useAddOnPrices( PRODUCT_1GB_SPACE, 350 );
 
 	return useMemo(
 		() =>
@@ -100,6 +115,86 @@ const useActiveAddOnsDefs = ( selectedSiteId: Props[ 'selectedSiteId' ] ) => {
 					featured: false,
 					purchased: false,
 					checkoutLink: checkoutLink( selectedSiteId ?? null, PRODUCT_1GB_SPACE, 100 ),
+				},
+				{
+					addOnSlug: ADD_ON_150GB_STORAGE,
+					productSlug: PRODUCT_1GB_SPACE,
+					featureSlugs: null,
+					icon: spaceUpgradeIcon,
+					quantity: 150,
+					name: translate( '150 GB Storage' ),
+					displayCost: displayCost1GBSpace150,
+					prices: addOnPrices1GBSpace150,
+					description: translate(
+						'Take your site to the next level. Store all your media in one place without worrying about running out of space.'
+					),
+					featured: false,
+					purchased: false,
+					checkoutLink: checkoutLink( selectedSiteId ?? null, PRODUCT_1GB_SPACE, 150 ),
+				},
+				{
+					addOnSlug: ADD_ON_200GB_STORAGE,
+					productSlug: PRODUCT_1GB_SPACE,
+					featureSlugs: null,
+					icon: spaceUpgradeIcon,
+					quantity: 200,
+					name: translate( '200 GB Storage' ),
+					displayCost: displayCost1GBSpace200,
+					prices: addOnPrices1GBSpace200,
+					description: translate(
+						'Take your site to the next level. Store all your media in one place without worrying about running out of space.'
+					),
+					featured: false,
+					purchased: false,
+					checkoutLink: checkoutLink( selectedSiteId ?? null, PRODUCT_1GB_SPACE, 200 ),
+				},
+				{
+					addOnSlug: ADD_ON_250GB_STORAGE,
+					productSlug: PRODUCT_1GB_SPACE,
+					featureSlugs: null,
+					icon: spaceUpgradeIcon,
+					quantity: 250,
+					name: translate( '250 GB Storage' ),
+					displayCost: displayCost1GBSpace250,
+					prices: addOnPrices1GBSpace250,
+					description: translate(
+						'Take your site to the next level. Store all your media in one place without worrying about running out of space.'
+					),
+					featured: false,
+					purchased: false,
+					checkoutLink: checkoutLink( selectedSiteId ?? null, PRODUCT_1GB_SPACE, 250 ),
+				},
+				{
+					addOnSlug: ADD_ON_300GB_STORAGE,
+					productSlug: PRODUCT_1GB_SPACE,
+					featureSlugs: null,
+					icon: spaceUpgradeIcon,
+					quantity: 300,
+					name: translate( '300 GB Storage' ),
+					displayCost: displayCost1GBSpace300,
+					prices: addOnPrices1GBSpace300,
+					description: translate(
+						'Take your site to the next level. Store all your media in one place without worrying about running out of space.'
+					),
+					featured: false,
+					purchased: false,
+					checkoutLink: checkoutLink( selectedSiteId ?? null, PRODUCT_1GB_SPACE, 300 ),
+				},
+				{
+					addOnSlug: ADD_ON_350GB_STORAGE,
+					productSlug: PRODUCT_1GB_SPACE,
+					featureSlugs: null,
+					icon: spaceUpgradeIcon,
+					quantity: 350,
+					name: translate( '350 GB Storage' ),
+					displayCost: displayCost1GBSpace350,
+					prices: addOnPrices1GBSpace350,
+					description: translate(
+						'Take your site to the next level. Store all your media in one place without worrying about running out of space.'
+					),
+					featured: false,
+					purchased: false,
+					checkoutLink: checkoutLink( selectedSiteId ?? null, PRODUCT_1GB_SPACE, 350 ),
 				},
 			] as const,
 		[


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#3551

## Proposed Changes

This PR is just a quick PoC for exploring what needs to be done for the project of allowing up to 400G space using add-ons. The accompanying diff is code-D167999.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
