### PR TITLE
A4A: Fix the bug with bundle licenses not showing on the licenses page correctly.

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
@@ -85,6 +85,7 @@ export default function LicenseList() {
 						<LicenseTransition key={ license.licenseKey }>
 							<LicensePreview
 								license={ license }
+								parentLicenseId={ license.licenseId }
 								productName={ getProductName( license.product ) }
 								licenseType={
 									license.ownerType === LicenseType.Standard


### PR DESCRIPTION
This PR addresses a regression on the licenses page that prevents the rendering of the bundle license preview for bundle licenses.

Context: p1733478916071639-slack-C06JY8QL0TU

## Proposed Changes

* Make sure we always pass the license ID as the parent license ID in the root of our list.

## Why are these changes being made?

* User is unable to view the bundle licenses correctly in the Licenses page.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace` page.
* Purchase any bundle licenses.
* Go to the `/licenses` page
* Confirm the bundle license is rendered correctly.
<img width="1532" alt="Screenshot 2024-12-06 at 6 36 47 PM" src="https://github.com/user-attachments/assets/9b719563-b89f-4e33-b07d-0175a9039ff0">

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?