### PR TITLE
Change Calypso Logo generator prompts

### DIFF
--- a/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.scss
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.scss
@@ -17,13 +17,11 @@
 		}
 	}
 
-	.components-button {
-		&:focus:not(:disabled):not(.is-primary) {
-			box-shadow: 0 0 0 2px var(--color-link, #3858e9);
-		}
+	.components-button.is-link {
+		padding: 0 4px;
+		text-decoration: none;
 
-		&.is-link {
-			text-decoration: none;
+		&:not(:disabled) {
 			color: var(--color-link, #3858e9);
 		}
 	}

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.scss
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.scss
@@ -19,9 +19,15 @@
 		display: flex;
 		font-size: $font-body-extra-small;
 		line-height: 20px;
+		gap: 16px;
 
 		.jetpack-ai-logo-generator-icon {
 			margin-right: 4px;
+
+			// tricky SVG
+			path {
+				fill: currentColor
+			};
 		}
 	}
 }

--- a/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
@@ -191,11 +191,39 @@ For example: user's prompt: A logo for an ice cream shop. Returned prompt: A log
 		prompt,
 	}: {
 		prompt: string;
-	} ): Promise< { data: Array< { url: string } > } > {
+	} ): Promise< { data: Array< { url?: string; b64_json?: string; revised_prompt?: string } > } > {
 		setLogoFetchError( null );
 
 		try {
 			const tokenData = await requestJwt( { siteDetails } );
+
+			let style;
+			// get URL hash
+			const urlHash = window.location.hash.split( '#' )?.[ 1 ];
+			if (
+				[
+					'none',
+					'enhance',
+					'anime',
+					'photographic',
+					'digital-art',
+					'comicbook',
+					'fantasy-art',
+					'analog-film',
+					'neonpunk',
+					'isometric',
+					'lowpoly',
+					'origami',
+					'line-art',
+					'craft-clay',
+					'cinematic',
+					'3d-model',
+					'pixel-art',
+					'texture',
+				].includes( urlHash )
+			) {
+				style = urlHash;
+			}
 
 			if ( ! tokenData || ! tokenData.token ) {
 				throw new Error( 'No token provided' );
@@ -213,11 +241,33 @@ The image should contain a single icon, without variations, color palettes or di
 
 User request:${ prompt }`;
 
-			const body = {
+			const body: {
+				prompt: string;
+				feature: string;
+				response_format: string;
+				style?: string;
+				messages?: Array< { role: string; context: Record< string, unknown > } >;
+			} = {
 				prompt: imageGenerationPrompt,
 				feature: 'jetpack-ai-logo-generator',
 				response_format: 'url',
 			};
+
+			if ( style ) {
+				body[ 'response_format' ] = 'b64_json';
+				body[ 'style' ] = style;
+				body[ 'messages' ] = [
+					{
+						role: 'jetpack-ai',
+						context: {
+							type: 'ai-assistant-generate-logo',
+							request: prompt,
+							name,
+							description,
+						},
+					},
+				];
+			}
 
 			const data = await wpcomLimitedRequest( {
 				apiNamespace: 'wpcom/v2',
@@ -226,6 +276,10 @@ User request:${ prompt }`;
 				token: tokenData.token,
 				body,
 			} );
+
+			if ( style ) {
+				return data as { data: { url?: string; b64_json?: string }[] };
+			}
 
 			return data as { data: { url: string }[] };
 		} catch ( error ) {
@@ -262,6 +316,7 @@ User request:${ prompt }`;
 				const { ID: mediaId, URL: mediaURL } = await saveToMediaLibrary( {
 					siteId,
 					url: logo.url,
+					logo,
 					attrs: {
 						caption: logo.description,
 						description: logo.description,
@@ -356,8 +411,11 @@ User request:${ prompt }`;
 
 			// response_format=url returns object with url, otherwise b64_json
 			const logo: Logo = {
-				url: image.data[ 0 ].url,
+				url: image.data[ 0 ].b64_json
+					? 'data:image/png;base64,' + image.data[ 0 ].b64_json
+					: image.data[ 0 ].url || '',
 				description: prompt,
+				revisedPrompt: image.data[ 0 ].revised_prompt,
 			};
 
 			try {

--- a/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
@@ -189,8 +189,10 @@ For example: user's prompt: A logo for an ice cream shop. Returned prompt: A log
 
 	const generateImage = async function ( {
 		prompt,
+		style = 'none',
 	}: {
 		prompt: string;
+		style?: string;
 	} ): Promise< { data: Array< { url?: string; b64_json?: string; revised_prompt?: string } > } > {
 		setLogoFetchError( null );
 
@@ -349,7 +351,13 @@ User request:${ prompt }`;
 		[ siteId, addLogoToHistory ]
 	);
 
-	const generateLogo = async function ( { prompt }: { prompt: string } ): Promise< void > {
+	const generateLogo = async function ( {
+		prompt,
+		style = 'none',
+	}: {
+		prompt: string;
+		style?: string;
+	} ): Promise< void > {
 		debug( 'Generating logo for site', siteId );
 
 		setIsRequestingImage( true );
@@ -371,7 +379,7 @@ User request:${ prompt }`;
 			let image;
 
 			try {
-				image = await generateImage( { prompt } );
+				image = await generateImage( { prompt, style } );
 
 				if ( ! image || ! image.data.length ) {
 					throw new Error( 'No image returned' );

--- a/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
@@ -197,34 +197,6 @@ For example: user's prompt: A logo for an ice cream shop. Returned prompt: A log
 		try {
 			const tokenData = await requestJwt( { siteDetails } );
 
-			let style;
-			// get URL hash
-			const urlHash = window.location.hash.split( '#' )?.[ 1 ];
-			if (
-				[
-					'none',
-					'enhance',
-					'anime',
-					'photographic',
-					'digital-art',
-					'comicbook',
-					'fantasy-art',
-					'analog-film',
-					'neonpunk',
-					'isometric',
-					'lowpoly',
-					'origami',
-					'line-art',
-					'craft-clay',
-					'cinematic',
-					'3d-model',
-					'pixel-art',
-					'texture',
-				].includes( urlHash )
-			) {
-				style = urlHash;
-			}
-
 			if ( ! tokenData || ! tokenData.token ) {
 				throw new Error( 'No token provided' );
 			}

--- a/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
@@ -97,17 +97,23 @@ const useLogoGenerator = () => {
 			const langName =
 				languages.find( ( language ) => language.langSlug === locale )?.name ?? 'English';
 
-			const firstPromptGenerationPrompt = `Generate a simple and short prompt asking for a logo based on the site's name and description. The prompt should be in ${ langName } (${ locale }).
-Example for a site named "The minimalist fashion blog", described as "Daily inspiration for all things fashion": A logo for a minimalist fashion site focused on daily sartorial inspiration with a clean and modern aesthetic that is sleek and sophisticated.
-Another example, now for a site called "El observatorio de aves", described as "Un sitio dedicado a nuestros compañeros y compañeras entusiastas de la observación de aves.": Un logo para un sitio web dedicado a la observación de aves,  capturando la esencia de la naturaleza y la pasión por la avifauna en un diseño elegante y representativo, reflejando una estética natural y apasionada por la vida silvestre.
-
-Site name: ${ name }
-Site description: ${ description }`;
+			const messages = [
+				{
+					role: 'jetpack-ai',
+					context: {
+						type: 'jetpack-ai-generate-logo-prompt',
+						name,
+						description,
+						language: langName,
+						locale,
+					},
+				},
+			];
 
 			const body = {
-				question: firstPromptGenerationPrompt,
 				feature: 'jetpack-ai-logo-generator',
 				stream: false,
+				messages,
 			};
 
 			const data = await wpcomLimitedRequest< {

--- a/packages/jetpack-ai-calypso/src/logo-generator/lib/save-to-media-library.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/lib/save-to-media-library.ts
@@ -1,5 +1,5 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
 import wpcomLimitedRequest from './wpcom-limited-request';
 /**
@@ -7,7 +7,33 @@ import wpcomLimitedRequest from './wpcom-limited-request';
  */
 import type { SaveToMediaLibraryProps, SaveToMediaLibraryResponseProps } from '../../types';
 
-export async function saveToMediaLibrary( { siteId, url, attrs = {} }: SaveToMediaLibraryProps ) {
+export async function saveToMediaLibrary( {
+	siteId,
+	url,
+	logo = { url: '', description: '' },
+	attrs = {},
+}: SaveToMediaLibraryProps ) {
+	// if the logo has a URL and it's a base64 string, use formData as expected by the API
+	if ( logo.url && logo.url.includes( 'data:image/png;base64,' ) ) {
+		// new FLUX response should send the logo object with a b64_json string
+		const fileResponse = await fetch( logo.url );
+		const blob = await fileResponse.blob();
+		const file = new File( [ blob ], 'site-logo.png', { type: 'image/png' } );
+
+		const formData: ( string | File )[][] = [
+			[ 'media[]', file ],
+			[ 'attrs[]', JSON.stringify( attrs ) ],
+		];
+
+		const response = await wpcomLimitedRequest< SaveToMediaLibraryResponseProps >( {
+			path: `/sites/${ String( siteId ) }/media/new`,
+			apiVersion: '1.1',
+			method: 'POST',
+			formData,
+		} );
+		return response.media[ 0 ];
+	}
+
 	const body = {
 		media_urls: [ url ],
 		attrs: [ attrs ],

--- a/packages/jetpack-ai-calypso/src/logo-generator/store/actions.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/store/actions.ts
@@ -64,6 +64,7 @@ export function mapAiFeatureResponseToAiFeatureProps(
 		nextTier: response[ 'next-tier' ],
 		tierPlansEnabled: !! response[ 'tier-plans-enabled' ],
 		costs: response.costs,
+		featuresControl: response[ 'features-control' ],
 	};
 }
 

--- a/packages/jetpack-ai-calypso/src/logo-generator/store/constants.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/store/constants.ts
@@ -47,3 +47,25 @@ export const ACTION_SET_ENHANCE_PROMPT_FETCH_ERROR = 'SET_ENHANCE_PROMPT_FETCH_E
 export const ACTION_SET_LOGO_FETCH_ERROR = 'SET_LOGO_FETCH_ERROR';
 export const ACTION_SET_SAVE_TO_LIBRARY_ERROR = 'SET_SAVE_TO_LIBRARY_ERROR';
 export const ACTION_SET_LOGO_UPDATE_ERROR = 'SET_LOGO_UPDATE_ERROR';
+
+// image styles
+export const IMAGE_STYLE_ENHANCE = 'enhance';
+export const IMAGE_STYLE_ANIME = 'anime';
+export const IMAGE_STYLE_PHOTOGRAPHIC = 'photographic';
+export const IMAGE_STYLE_DIGITAL_ART = 'digital-art';
+export const IMAGE_STYLE_COMICBOOK = 'comicbook';
+export const IMAGE_STYLE_FANTASY_ART = 'fantasy-art';
+export const IMAGE_STYLE_ANALOG_FILM = 'analog-film';
+export const IMAGE_STYLE_NEONPUNK = 'neonpunk';
+export const IMAGE_STYLE_ISOMETRIC = 'isometric';
+export const IMAGE_STYLE_LOWPOLY = 'lowpoly';
+export const IMAGE_STYLE_ORIGAMI = 'origami';
+export const IMAGE_STYLE_LINE_ART = 'line-art';
+export const IMAGE_STYLE_CRAFT_CLAY = 'craft-clay';
+export const IMAGE_STYLE_CINEMATIC = 'cinematic';
+export const IMAGE_STYLE_3D_MODEL = '3d-model';
+export const IMAGE_STYLE_PIXEL_ART = 'pixel-art';
+export const IMAGE_STYLE_TEXTURE = 'texture';
+export const IMAGE_STYLE_MONTY_PYTHON = 'monty-python';
+export const IMAGE_STYLE_AUTO = 'auto';
+export const IMAGE_STYLE_NONE = 'none';

--- a/packages/jetpack-ai-calypso/src/logo-generator/store/initial-state.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/store/initial-state.ts
@@ -34,6 +34,7 @@ const INITIAL_STATE: LogoGeneratorStateProp = {
 				asyncRequestTimerId: 0,
 				isRequestingImage: false,
 			},
+			featuresControl: {},
 		},
 	},
 	history: [],

--- a/packages/jetpack-ai-calypso/src/logo-generator/store/types.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/store/types.ts
@@ -126,6 +126,7 @@ export type Logo = {
 	url: string;
 	description: string;
 	mediaId?: number;
+	revisedPrompt?: string;
 };
 
 export type RequestError = string | Error | null;

--- a/packages/jetpack-ai-calypso/src/logo-generator/store/types.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/store/types.ts
@@ -1,3 +1,25 @@
+import {
+	IMAGE_STYLE_ENHANCE,
+	IMAGE_STYLE_ANIME,
+	IMAGE_STYLE_PHOTOGRAPHIC,
+	IMAGE_STYLE_DIGITAL_ART,
+	IMAGE_STYLE_COMICBOOK,
+	IMAGE_STYLE_FANTASY_ART,
+	IMAGE_STYLE_ANALOG_FILM,
+	IMAGE_STYLE_NEONPUNK,
+	IMAGE_STYLE_ISOMETRIC,
+	IMAGE_STYLE_LOWPOLY,
+	IMAGE_STYLE_ORIGAMI,
+	IMAGE_STYLE_LINE_ART,
+	IMAGE_STYLE_CRAFT_CLAY,
+	IMAGE_STYLE_CINEMATIC,
+	IMAGE_STYLE_3D_MODEL,
+	IMAGE_STYLE_PIXEL_ART,
+	IMAGE_STYLE_TEXTURE,
+	IMAGE_STYLE_MONTY_PYTHON,
+	IMAGE_STYLE_AUTO,
+	IMAGE_STYLE_NONE,
+} from './constants';
 import type { SiteDetails } from '@automattic/data-stores';
 
 /**
@@ -110,6 +132,7 @@ export type AiFeatureProps = {
 			logo: number;
 		};
 	};
+	featuresControl: FeaturesControl;
 };
 
 // Type used in the `wordpress-com/plans` store.
@@ -173,6 +196,19 @@ export type Selectors = {
 	getSaveToLibraryError(): RequestError;
 	getLogoUpdateError(): RequestError;
 	getContext(): string;
+	getFeatureControl( feature: string ): FeatureControl;
+};
+
+export type LogoGeneratorFeatureControl = FeatureControl & {
+	styles: Array< ImageStyleObject > | [];
+};
+
+export type FeatureControl = {
+	enabled: boolean;
+};
+
+export type FeaturesControl = {
+	[ key: string ]: FeatureControl | LogoGeneratorFeatureControl;
 };
 
 /*
@@ -203,4 +239,32 @@ export type AiAssistantFeatureEndpointResponseProps = {
 			logo: number;
 		};
 	};
+	'features-control': FeaturesControl;
+};
+
+export type ImageStyle =
+	| typeof IMAGE_STYLE_ENHANCE
+	| typeof IMAGE_STYLE_ANIME
+	| typeof IMAGE_STYLE_PHOTOGRAPHIC
+	| typeof IMAGE_STYLE_DIGITAL_ART
+	| typeof IMAGE_STYLE_COMICBOOK
+	| typeof IMAGE_STYLE_FANTASY_ART
+	| typeof IMAGE_STYLE_ANALOG_FILM
+	| typeof IMAGE_STYLE_NEONPUNK
+	| typeof IMAGE_STYLE_ISOMETRIC
+	| typeof IMAGE_STYLE_LOWPOLY
+	| typeof IMAGE_STYLE_ORIGAMI
+	| typeof IMAGE_STYLE_LINE_ART
+	| typeof IMAGE_STYLE_CRAFT_CLAY
+	| typeof IMAGE_STYLE_CINEMATIC
+	| typeof IMAGE_STYLE_3D_MODEL
+	| typeof IMAGE_STYLE_PIXEL_ART
+	| typeof IMAGE_STYLE_TEXTURE
+	| typeof IMAGE_STYLE_MONTY_PYTHON
+	| typeof IMAGE_STYLE_AUTO
+	| typeof IMAGE_STYLE_NONE;
+
+export type ImageStyleObject = {
+	label: string;
+	value: ImageStyle;
 };

--- a/packages/jetpack-ai-calypso/src/types.ts
+++ b/packages/jetpack-ai-calypso/src/types.ts
@@ -22,6 +22,7 @@ export interface LogoPresenterProps {
 export type SaveToMediaLibraryProps = {
 	siteId: string | number;
 	url: string;
+	logo?: Logo;
 	attrs?: {
 		caption?: string;
 		description?: string;


### PR DESCRIPTION
## Proposed Changes
- move first logo prompt to backend, we now only send a `role: jetpack-ai` message
- change save-to-library hook so it can handle both remote and base64 URLs, perform the API request accordingly
- as a first step to the transition, use the URL hash to allow switching to new FLUX requests by using a style

This will give us an important step where we can verify improvement, refine the prompt processing on backend, test/decide on a default generation style or just leave it as "none" (completely depending on the user prompt)

## Why are these changes being made?
Because we're moving away from using Dall-E as FLUX is giving better results.

## Testing Instructions
Depends on D167959-code being patched and sandboxing public-api.

Go to the home section `/home/some.site.url` and look for the Logo Generator among the quick links.

- on first open, the logo generator modal will perform an AI request to build a prompt and generate the first logo
- [ ] see the style selector is shown above the prompt input, to the right of "Enhance prompt" button
- [ ] see the style selector and "Enhance prompt" button are nicely spaced
- [ ] see the "Enhance prompt" button icon now has the same color as the button text, and this turns gray when disabled
- use the generated prompt to generate a logo, select any style or leave "Select style" to just use the prompt
- [ ] see the change in style compared to Dall-e results
- logo should be saved to library
- [ ] use the same prompt with different styles

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?