### PR TITLE
Sites dashboard: redirect to My Home without flashing preview pane

### DIFF
--- a/client/layout/global-sidebar/menu-items/menu-item.tsx
+++ b/client/layout/global-sidebar/menu-items/menu-item.tsx
@@ -49,8 +49,7 @@ const SidebarMenuItem = forwardRef< HTMLButtonElement | HTMLAnchorElement, Props
 			return getShouldShowCollapsedGlobalSidebar(
 				state,
 				selectedSiteId,
-				currentSection !== false ? currentSection?.group ?? '' : '',
-				currentSection !== false ? currentSection?.name ?? '' : ''
+				currentSection !== false ? currentSection?.group ?? '' : ''
 			);
 		} );
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -455,17 +455,11 @@ export default withCurrentRoute(
 		const isWooPasswordlessJPC =
 			[ 'jetpack-connect', 'login' ].includes( sectionName ) && isWooPasswordlessJPCFlow( state );
 		const isBlazePro = getIsBlazePro( state );
-		const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
-			state,
-			siteId,
-			sectionGroup,
-			sectionName
-		);
+		const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
 		const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(
 			state,
 			siteId,
-			sectionGroup,
-			sectionName
+			sectionGroup
 		);
 		const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
 			state,

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -251,14 +251,8 @@ export default withCurrentRoute(
 	connect(
 		( state, { currentSection } ) => {
 			const sectionGroup = currentSection?.group ?? null;
-			const sectionName = currentSection?.name ?? null;
 			const siteId = getSelectedSiteId( state );
-			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
-				state,
-				siteId,
-				sectionGroup,
-				sectionName
-			);
+			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
 			return {
 				currentUser: getCurrentUser( state ),
 				shouldShowGlobalSidebar,

--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -112,17 +112,11 @@ export default withCurrentRoute(
 			const sectionName = currentSection?.name ?? null;
 			const siteId = getSelectedSiteId( state );
 			const siteDomain = getSiteDomain( state, siteId );
-			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
-				state,
-				siteId,
-				sectionGroup,
-				sectionName
-			);
+			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
 			const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(
 				state,
 				siteId,
-				sectionGroup,
-				sectionName
+				sectionGroup
 			);
 			const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
 				state,

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -403,8 +403,7 @@ export function renderPluginsSidebar( context, next ) {
 				isCollapsed={ getShouldShowCollapsedGlobalSidebar(
 					state,
 					undefined,
-					context.section.group,
-					context.section.name
+					context.section.group
 				) }
 			/>
 		);

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -37,12 +37,7 @@ const useSiteMenuItems = () => {
 	const isAllDomainsView = '/domains/manage' === currentRoute;
 	const { currentSection } = useCurrentRoute();
 	const shouldShowGlobalSidebar = useSelector( ( state ) => {
-		return getShouldShowGlobalSidebar(
-			state,
-			selectedSiteId,
-			currentSection?.group,
-			currentSection?.name
-		);
+		return getShouldShowGlobalSidebar( state, selectedSiteId, currentSection?.group );
 	} );
 	useEffect( () => {
 		if ( selectedSiteId && siteDomain ) {

--- a/client/reader/notifications/controller.jsx
+++ b/client/reader/notifications/controller.jsx
@@ -13,12 +13,7 @@ export function notifications( context, next ) {
 	const basePath = sectionify( context.path );
 	const mcKey = 'notifications';
 	const state = context.store.getState();
-	const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
-		state,
-		null,
-		'reader',
-		'notifications'
-	);
+	const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, null, 'reader' );
 	const isGlobalNotificationsOpen = getIsNotificationsOpen( state );
 
 	// Close the global notifications panel if it's already open.

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -346,14 +346,8 @@ export default withCurrentRoute(
 	connect(
 		( state, { currentSection } ) => {
 			const sectionGroup = currentSection?.group ?? null;
-			const sectionName = currentSection?.name ?? null;
 			const siteId = getSelectedSiteId( state );
-			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
-				state,
-				siteId,
-				sectionGroup,
-				sectionName
-			);
+			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
 
 			return {
 				isListsOpen: isListsOpen( state ),

--- a/client/sites/components/sites-dashboard.tsx
+++ b/client/sites/components/sites-dashboard.tsx
@@ -32,6 +32,7 @@ import {
 	handleQueryParamChange,
 } from 'calypso/sites-dashboard/components/sites-content-controls';
 import { useSelector } from 'calypso/state';
+import { shouldShowSiteDashboard } from 'calypso/state/global-sidebar/selectors';
 import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { useInitializeDataViewsPage } from '../hooks/use-initialize-dataviews-page';
@@ -349,6 +350,13 @@ const SitesDashboard = ( {
 			openSitePreviewPane( targetSite, 'environment_switcher' );
 		}
 	};
+
+	const showSiteDashboard = useSelector( ( state ) =>
+		shouldShowSiteDashboard( state, selectedSite?.ID ?? null )
+	);
+	if ( !! selectedSite && ! showSiteDashboard ) {
+		return null;
+	}
 
 	// todo: temporary mock data
 	const hideListing = false;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/97109

## Proposed Changes

After we removed JS overrides from sites dashboard (pbxlJb-6DF-p2), many logic around it are not necessary anymore. However, we have a regression where we show a flashing preview pane when a row click leads to My Home.

This is due to a [different implementation](https://github.com/Automattic/wp-calypso/pull/96326/files#diff-666054b1e2a6f78aeb37afc6a89df6cd13092428043dfb620572824d2c6d15c3R402) of how we tell DataViews which site is currently selected. Previously we maintain a `dataViewsState.selectedItem`; now we use Calypso's `selectedSite` directly, which is ultimately derived from the URL. When the URL is redirected `/home/:site`, we're already too late in stopping the preview pane from opening.

This PR cleans up the logic and fixes the regression, by returning null in `SitesDashboard` when a site is selected but the route is not matching a valid site dashboard route.

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/6a3f7981-fa27-457b-ba99-24955f3c9f66">|<video src="https://github.com/user-attachments/assets/558b9a48-b65c-4f16-9132-ce11faba0710">|

## Testing Instructions

It's hard to log in as different user in Calypso live URLs in other browser, so we can use P2s instead:

1. Go to /p2s.
2. Click on a P2.
3. Verify you are redirected to My Home without a flashing content.

Regression testing: click around on /sites and verify that nothing related to opening/closing preview panes breaks.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?