### PR TITLE
Help Center: Show a spinner instead of "nothing found"

### DIFF
--- a/packages/help-center/src/components/help-center-chat-history.tsx
+++ b/packages/help-center/src/components/help-center-chat-history.tsx
@@ -36,7 +36,7 @@ const Conversations = ( {
 	isLoadingInteractions,
 }: {
 	conversations: ZendeskConversation[];
-	isLoadingInteractions: boolean;
+	isLoadingInteractions?: boolean;
 } ) => {
 	const { __ } = useI18n();
 

--- a/packages/help-center/src/components/help-center-chat-history.tsx
+++ b/packages/help-center/src/components/help-center-chat-history.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-imports */
 import { HelpCenterSelect } from '@automattic/data-stores';
 import { useGetSupportInteractions } from '@automattic/odie-client/src/data/use-get-support-interactions';
-import { Card, CardHeader, CardBody } from '@wordpress/components';
+import { Card, CardHeader, CardBody, Spinner } from '@wordpress/components';
 import { useSelect, useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { comment, Icon } from '@wordpress/icons';
@@ -31,8 +31,22 @@ const TAB_STATES = {
 	archived: 'archived',
 };
 
-const Conversations = ( { conversations }: { conversations: ZendeskConversation[] } ) => {
+const Conversations = ( {
+	conversations,
+	isLoadingInteractions,
+}: {
+	conversations: ZendeskConversation[];
+	isLoadingInteractions: boolean;
+} ) => {
 	const { __ } = useI18n();
+
+	if ( isLoadingInteractions ) {
+		return (
+			<div className="help-center-chat-history__no-results">
+				<Spinner />
+			</div>
+		);
+	}
 
 	if ( ! conversations || ! conversations.length ) {
 		return (
@@ -88,10 +102,10 @@ export const HelpCenterChatHistory = () => {
 	} );
 	const { setUnreadCount } = useDataStoreDispatch( HELP_CENTER_STORE );
 
-	useEffect( () => {
-		const isLoadingInteractions =
-			isLoadingResolvedInteractions || isLoadingClosedInteractions || isLoadingOpenInteractions;
+	const isLoadingInteractions =
+		isLoadingResolvedInteractions || isLoadingClosedInteractions || isLoadingOpenInteractions;
 
+	useEffect( () => {
 		if ( isChatLoaded && getZendeskConversations && ! isLoadingInteractions ) {
 			const allConversations = getZendeskConversations();
 			const supportInteractions = [
@@ -107,13 +121,11 @@ export const HelpCenterChatHistory = () => {
 			setConversations( filteredConversations );
 		}
 	}, [
+		isLoadingInteractions,
 		supportInteractionsResolved,
 		supportInteractionsOpen,
 		isChatLoaded,
 		setUnreadCount,
-		isLoadingResolvedInteractions,
-		isLoadingClosedInteractions,
-		isLoadingOpenInteractions,
 		supportInteractionsClosed,
 	] );
 
@@ -143,7 +155,12 @@ export const HelpCenterChatHistory = () => {
 
 	// Temporarily simplified version
 	if ( simplifiedHistoryChat ) {
-		return <Conversations conversations={ recentConversations } />;
+		return (
+			<Conversations
+				conversations={ recentConversations }
+				isLoadingInteractions={ isLoadingInteractions }
+			/>
+		);
 	}
 
 	return (


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/97170

## Proposed Changes

https://github.com/user-attachments/assets/475db7c3-860a-4490-804b-e51f2c02223f


## Why are these changes being made?
The UX was jarring. 

## Testing Instructions
1. Start a chat (with flag enabled = `flags=help-center-experience`).
2. Delete Calypso index DB in DevTools.
3. Refresh the page.
4. Open the Help Center.
5. In DevTools > Network, simulate Slow 3G.
6. Click "History"
7. A spinner should show. 