### PR TITLE
Tooltip staying on charts

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -1306,6 +1306,7 @@ $break-huge-collapsed-menu: $break-huge - 222px;
 		border-radius: 4px;
 		display: none;
 		text-align: center;
+		min-width: 60px;
 	}
 
 	&__chart-tooltip-date {

--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
@@ -100,7 +100,7 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 					ticks: {
 						show: false,
 					},
-					gap: 12,
+					gap: 16,
 					values: ( u: uPlot, splits: number[] ) => {
 						// Filter the splits to show only non-overlapping labels
 						return splits.map( ( s, i ) =>
@@ -117,7 +117,7 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 					ticks: {
 						show: false,
 					},
-					gap: 12,
+					gap: 16,
 				},
 			],
 			cursor: {

--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/tooltip.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/tooltip.tsx
@@ -1,4 +1,3 @@
-import { debounce } from 'lodash';
 import React from 'react';
 import uPlot from 'uplot';
 
@@ -15,11 +14,12 @@ export function tooltip(
 				if ( ! tooltipRef.current ) {
 					tooltipRef.current = document.createElement( 'div' );
 					tooltipRef.current.className = 'campaign-item-details__chart-tooltip';
+					tooltipRef.current.style.display = 'none';
 					u.over.parentNode?.appendChild( tooltipRef.current );
 				}
 
 				// Wrap mouse move in a Debounce to reduce the number of updates
-				const handleMouseMove = debounce( ( e ) => {
+				const handleMouseMove = ( e: MouseEvent ) => {
 					if ( ! tooltipRef?.current ) {
 						return;
 					}
@@ -78,7 +78,7 @@ export function tooltip(
 					} else if ( tooltipRef.current ) {
 						tooltipRef.current.style.display = 'none';
 					}
-				}, 8 ); // 120mhz (1000/120 = 8.333ms)
+				};
 
 				u.over.addEventListener( 'mousemove', handleMouseMove );
 				u.over.addEventListener( 'mouseleave', () => {


### PR DESCRIPTION
## Proposed Changes

* Remove the debounce this was causing the tooltip to stay on


https://github.com/user-attachments/assets/a490d941-28f6-4c79-9ec6-22d1e05807fc



## Testing Instructions

- Code review please for quick ship

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
