### PR TITLE
Fix spacing issue with billing timeframe on cloud backup upsell

### DIFF
--- a/client/components/backup-storage-space/usage-warning/upsell.tsx
+++ b/client/components/backup-storage-space/usage-warning/upsell.tsx
@@ -39,7 +39,7 @@ export const UpsellPrice: React.FC< UpsellPriceProps > = ( {
 	const billingTerm = upsellSlug?.displayTerm || upsellSlug?.term || 'TERM_MONTHLY';
 	return (
 		<span className={ priceClass }>
-			<PlanPrice displayFlatPrice rawPrice={ originalPrice } currencyCode={ currencyCode } />
+			<PlanPrice displayFlatPrice rawPrice={ originalPrice } currencyCode={ currencyCode } />{ ' ' }
 			<TimeFrame billingTerm={ billingTerm } />
 		</span>
 	);


### PR DESCRIPTION
## Proposed Changes
* Fix the spacing issue present on the cloud backups upsell when displaying the price of additional storage.

NOTE: I audited all other uses of the `<TimeFrame />` component and this issue doesn't seem to be present anywhere else as all other uses I could find use the `<TimeFrame />` component separate from the price itself and apply spacing via CSS. This seem to be the only case where it is inserted into a translated string in this way. Therefore this issue shouldn't be present anywhere else

## Why are these changes being made?

There is a space missing between the price and timeframe in this upsell
![image](https://github.com/user-attachments/assets/3401d70d-e869-43ec-a8c6-c982697b7d48)


## Testing Instructions

1. Checkout this branch locally
2. Start up Jetpack cloud with `yarn start-jetpack-cloud`
3. Connect your site with a site and user connection
4. Create a testing JN site and, in whatever way you'd like, add a paid Jetpack Backup plan to it.
5. Go to `client/components/backup-storage-space/usage-warning/use-storage-status-text.ts`
Update line 29 to
```ts
default:
```
6. Go to `client/components/backup-storage-space/index.tsx`
Update line 56 to 
```tsx
const showUpsell = true;
```
7. Now go to `http://jetpack.cloud.localhost:3001/backup/{your-test-site}`
8. You should see the upsell with the space present
 
![image](https://github.com/user-attachments/assets/b162c721-2262-46ed-91cf-d288f4c77f47)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
