### PR TITLE
Domain management revamp: update domain list column styles in sidebar

### DIFF
--- a/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
@@ -12,6 +12,7 @@ import type {
 	ItemData,
 	FeaturePreviewInterface,
 } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane/types';
+import './style.scss';
 
 interface Props {
 	selectedDomainPreview: React.ReactNode;

--- a/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
@@ -1,5 +1,8 @@
-@media (max-width: 960px) {
-    .a4a-layout.domains-overview .domains-overview__details .item-preview__content {
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.a4a-layout.domains-overview .domains-overview__details .item-preview__content {
+    @include break-large {
         padding-top: 24px;
         padding-left: 24px;
         padding-right: 24px;

--- a/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
@@ -1,0 +1,7 @@
+@media (max-width: 960px) {
+    .a4a-layout.domains-overview .domains-overview__details .item-preview__content {
+        padding-top: 24px;
+        padding-left: 24px;
+        padding-right: 24px;
+    }
+}

--- a/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
@@ -8,3 +8,8 @@
         padding-right: 24px;
     }
 }
+
+.a4a-layout.domains-overview .domains-overview__details .section-nav-tabs__list {
+    box-sizing: border-box;
+    overflow-x: auto;
+}

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -239,6 +239,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 			.a4a-layout-column.domains-overview__list.main .a4a-layout-column__container .main {
 				display: flex;
 				flex-direction: column;
+				padding-bottom: 0;
 
 				.domains-table {
 					flex-grow: 1;

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -246,6 +246,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					margin-top: 0;
 					overflow: auto;
 					padding-bottom: 0;
+					width: 100%;
 
 					table {
 						max-height: unset;

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -230,6 +230,32 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				}
 			}
 
+			.domains-overview__list.a4a-layout-column,
+			.domains-overview__list .a4a-layout-column__container,
+			.a4a-layout-column.domains-overview__list.main .a4a-layout-column__container .main {
+				height: 100%;
+			}
+
+			.a4a-layout-column.domains-overview__list.main .a4a-layout-column__container .main {
+				display: flex;
+				flex-direction: column;
+
+				.domains-table {
+					flex-grow: 1;
+					margin-top: 0;
+					overflow: auto;
+					padding-bottom: 0;
+
+					table {
+						max-height: unset;
+					}
+				}
+			}
+
+			.domains-overview__list .gridicons-ellipsis {
+				rotate: 90deg;
+			}
+
 			@media only screen and ( min-width: 782px ) {
 				.is-global-sidebar-visible {
 					header.navigation-header {
@@ -269,6 +295,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				.domains-overview__list .domains-table {
 					table {
 						grid-template-columns: 4fr auto;
+						max-height: 100%;
 
 						.domains-table__domain-name {
 							overflow-wrap: anywhere;

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -252,8 +252,19 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				}
 			}
 
-			.domains-overview__list .gridicons-ellipsis {
-				rotate: 90deg;
+			.domains-overview__list {
+				.domains-table__row {
+					.gridicons-ellipsis {
+						rotate: 90deg;
+						visibility: hidden;
+					}
+
+					&:hover {
+						.gridicons-ellipsis {
+							visibility: visible;
+						}
+					}
+				}
 			}
 
 			@media only screen and ( min-width: 782px ) {

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -360,7 +360,13 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 
 	const isDomainsEmpty = isFetched && domains.length === 0;
 	const buttons = ! isDomainsEmpty
-		? [ <OptionsDomainButton key="breadcrumb_button_1" allDomainsList /> ]
+		? [
+				<OptionsDomainButton
+					key="breadcrumb_button_1"
+					allDomainsList
+					sidebarMode={ props.sidebarMode }
+				/>,
+		  ]
 		: [];
 	const purchaseActions = usePurchaseActions();
 

--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -20,10 +20,12 @@ class AddDomainButton extends Component {
 	static propTypes = {
 		selectedSiteSlug: PropTypes.string,
 		allDomainsList: PropTypes.bool,
+		sidebarMode: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		allDomainsList: false,
+		sidebarMode: false,
 	};
 
 	constructor( props ) {
@@ -87,8 +89,8 @@ class AddDomainButton extends Component {
 		return (
 			<SplitButton
 				className="options-domain-button"
-				primary
-				whiteSeparator
+				primary={ ! this.props.sidebarMode }
+				whiteSeparator={ ! this.props.sidebarMode }
 				label={ isBreakpointActive ? undefined : translate( 'Add new domain' ) }
 				toggleIcon={ isBreakpointActive ? 'plus' : undefined }
 				href={ this.getAddNewDomainUrl() }

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -328,3 +328,67 @@
 .domains-overview .main.domains-overview__list {
 	max-width: 400px;
 }
+
+main.domains-overview main.domains-overview__list .a4a-layout-column__container {
+	// Header navigation styles
+	.navigation-header {
+		padding: 0;
+
+		.navigation-header__main {
+			padding-inline: 0;
+			padding: 12px 24px;
+			margin: 0;
+		}
+	}
+
+	// Header title styles
+	.formatted-header__title {
+		display: flex;
+		align-items: center;
+		min-width: 40px;
+		font-size: 1.25rem;
+		font-weight: 500;
+		letter-spacing: normal;
+	}
+
+	// Split button styles
+	.navigation-header__main .options-domain-button {
+		&.split-button {
+			--white-separator-color: rgba(255, 255, 255, 0.3);
+			display: inline-block;
+			white-space: nowrap;
+		}
+
+		.split-button__main,
+		.split-button__toggle {
+			display: inline-flex;
+			align-items: center;
+			height: 28px;
+			padding: 0 12px;
+			font-size: 0.75rem;
+			line-height: 14px;
+		}
+
+		.split-button__main {
+			font-weight: 400;
+			border-radius: 2px 0 0 2px;
+			-webkit-font-smoothing: antialiased;
+		}
+
+		.split-button__toggle.button svg.gridicon {
+			position: relative;
+			top: 2px;
+			width: 18px;
+			height: 18px;
+			margin-top: -2px;
+		}
+	}
+}
+
+// Similar to the sites-overview, hide the domains-overview list on the left on smaller screens.
+@media (max-width: 1280px) {
+	main.domains-overview main.domains-overview__list {
+		display: none;
+		width: unset;
+	}
+}

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -336,7 +336,7 @@ main.domains-overview main.domains-overview__list .a4a-layout-column__container 
 
 		.navigation-header__main {
 			padding-inline: 0;
-			padding: 12px 24px;
+			padding: 16px 24px;
 			margin: 0;
 		}
 	}
@@ -345,7 +345,7 @@ main.domains-overview main.domains-overview__list .a4a-layout-column__container 
 	.formatted-header__title {
 		display: flex;
 		align-items: center;
-		min-width: 40px;
+		min-height: 40px;
 		font-size: 1.25rem;
 		font-weight: 500;
 		letter-spacing: normal;

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -384,11 +384,3 @@ main.domains-overview main.domains-overview__list .a4a-layout-column__container 
 		}
 	}
 }
-
-// Similar to the sites-overview, hide the domains-overview list on the left on smaller screens.
-@media (max-width: 1280px) {
-	main.domains-overview main.domains-overview__list {
-		display: none;
-		width: unset;
-	}
-}

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -335,7 +335,6 @@ main.domains-overview main.domains-overview__list .a4a-layout-column__container 
 		padding: 0;
 
 		.navigation-header__main {
-			padding-inline: 0;
 			padding: 16px 24px;
 			margin: 0;
 		}

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -18,6 +18,13 @@ import {
 } from './domain-management/domain-overview-pane/constants';
 import * as paths from './paths';
 
+/**
+ * Registers a multi-page route.
+ *
+ * @param {Object} options - The options object.
+ * @param {Array} options.paths - The paths to register.
+ * @param {Array} options.handlers - The handlers to register. These will be applied to each path.
+ */
 function registerMultiPage( { paths: givenPaths, handlers } ) {
 	givenPaths.forEach( ( path ) => page( path, ...handlers ) );
 }

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -21,7 +21,7 @@ export function DomainsTable( props: DomainsTableProps & { footer?: ReactNode } 
 
 	const state = useGenerateDomainsTableState( allProps );
 
-	const { isAllSitesView, domains } = props;
+	const { isAllSitesView, domains, sidebarMode } = props;
 
 	const showDomainsToolbar =
 		isAllSitesView ||
@@ -43,7 +43,7 @@ export function DomainsTable( props: DomainsTableProps & { footer?: ReactNode } 
 							'has-checkbox': state.canSelectAnyDomains && ! hideCheckbox,
 						} ) }
 					>
-						<DomainsTableHeader />
+						{ ! sidebarMode && <DomainsTableHeader /> }
 						<DomainsTableBody />
 					</table>
 				) }

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -424,3 +424,38 @@ a.domains-table-view-email-button {
 		color: var(--color-link);
 	}
 }
+
+main.domains-overview main.domains-overview__list .a4a-layout-column__container {
+	.domains-table {
+		margin-top: 0;
+	}
+
+	.domains-table .domains-table-toolbar {
+		padding-inline: 0;
+		padding: 12px 24px;
+		margin: 0;
+	}
+
+	.domains-table-search {
+		width: 100%;
+	}
+
+	.domains-table-search .components-base-control__field {
+		margin-bottom: 0;
+	}
+
+	.domains-table-search .components-input-base {
+		max-width: 100%;
+		width: 100%;
+	}
+
+	.domains-table-toolbar {
+		border-block-end: 1px solid var(--color-border-secondary);
+	}
+
+	.domains-table__row td.domains-table-row__domain,
+	.domains-table__row td.domains-table-row__actions {
+		padding: 16px 24px;
+		margin-inline-start: 0;
+	}
+}

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -431,7 +431,6 @@ main.domains-overview main.domains-overview__list .a4a-layout-column__container 
 	}
 
 	.domains-table .domains-table-toolbar {
-		padding-inline: 0;
 		padding: 12px 24px;
 		margin: 0;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/96554

## Proposed Changes
Updates the looks of the left side of the Domains preview

* Fix the font size, spacing and styling of the Tab title ("Domains")
* Fix the look and style of the button to add domains
* Fix search bar
* Fix spacings
* Remove column names when showing domains only in sidebar
* Fix hiding left column if size of tab view and smaller
* Fix paddings of preview pane in mobile view
* Fixes scrollbar showing up in tab

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To revamp domain management

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to wordpress.com/domains/manage
- Browse around, check inner functionalities, make sure you see no issues in how the table looks and works
- Open a site's wp-admin area, go to Upgrades -> Emails, browse around and make sure everything works as before
- Also click on a few domains to make sure everything is working as before.
- Now enable the feature flag by entering window.sessionStorage.setItem('flags', 'calypso/all-domain-management') in the - browser console. Reload the page
- Now click on different domains. They should open in the new layout now.
- Check that the left side of the new layout (the domains list) matches the design.
- When you open wordpress.com/sites and click a site, the left side panel opens. The domains side panel should also match the sites side panel

| Before | After |
|--------|--------|
| <img width="1545" alt="Screenshot 2024-12-07 at 1 50 39 AM" src="https://github.com/user-attachments/assets/2e59600d-e2d3-4242-9997-62124c360e44"> | <img width="1619" alt="Screenshot 2024-12-07 at 3 06 44 AM" src="https://github.com/user-attachments/assets/7eb3a716-49e0-48fd-b79a-87cc9044dff5"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
