### PR TITLE
Reader Recent Feed Overhaul: Temporarily "disable" page selection in middle column

### DIFF
--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -187,15 +187,10 @@ body.is-reader-full-post {
 		// This is a temporary fix to disable the pagination page selector because of this issue: Automattic/loop#247
 		// Once that issue is fixed, this code should be removed.
 		.dataviews-pagination__page-select {
-			.components-input-control__suffix {
-				display: none;
-			}
-			.components-input-control__container {
-				cursor: text;
-			}
-			.components-select-control__input {
-				pointer-events: none;
-				padding: 0;
+			display: none;
+
+			& + div {
+				margin-left: auto;
 			}
 		}
 	}

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -1,8 +1,8 @@
-@import "@wordpress/base-styles/variables";
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/mixins";
-@import "@wordpress/dataviews/build-style/style.css";
-@import "calypso/assets/stylesheets/shared/mixins/hide-content-accessibly";
+@import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/dataviews/build-style/style.css';
+@import 'calypso/assets/stylesheets/shared/mixins/hide-content-accessibly';
 
 body.is-reader-full-post {
 	overflow: hidden;
@@ -11,7 +11,11 @@ body.is-reader-full-post {
 .is-section-reader .recent-feed {
 	$recent-feed-spacing: 12px;
 	$feed-card-border-radius: 8px; /* stylelint-disable-line scales/radii */
-	$feed-content-height: calc( 100vh - var( --masterbar-height ) - var( --content-padding-top ) - var( --content-padding-bottom ) );
+	$feed-content-height: calc(
+		100vh - var( --masterbar-height ) - var( --content-padding-top ) - var(
+				--content-padding-bottom
+			)
+	);
 
 	height: $feed-content-height !important; // Using !important here to avoid having a lengthy selector.
 
@@ -77,7 +81,10 @@ body.is-reader-full-post {
 		}
 
 		.dataviews-view-list {
-			height: calc( 100vh - var( --masterbar-height ) - var( --content-padding-top ) - $feed-list-header-height - $feed-list-actions-height - $feed-list-footer-height - var( --content-padding-bottom ) );
+			height: calc(
+				100vh - var( --masterbar-height ) - var( --content-padding-top ) - $feed-list-header-height -
+					$feed-list-actions-height - $feed-list-footer-height - var( --content-padding-bottom )
+			);
 			overflow-y: auto;
 			@include custom-scrollbars-on-hover( transparent, $gray-600 );
 			scrollbar-gutter: auto;
@@ -98,7 +105,7 @@ body.is-reader-full-post {
 
 			li {
 				border-top: 1px solid var( --studio-gray-0 );
-				
+
 				&.is-selected + li {
 					border-top: 1px solid var( --studio-gray-0 );
 				}
@@ -140,30 +147,30 @@ body.is-reader-full-post {
 					width: 100%;
 					min-height: fit-content;
 					gap: $recent-feed-spacing;
-		
+
 					%text-shared {
 						white-space: nowrap;
 						text-overflow: ellipsis;
 						overflow: hidden;
 					}
-		
+
 					&__title {
 						min-width: 0;
 					}
-		
+
 					&__title-text {
 						font-weight: 700;
-						font-size: rem(13px);
+						font-size: rem( 13px );
 						@extend %text-shared;
 					}
-		
+
 					&__site-name {
 						font-weight: 400;
 						font-size: rem( 11px );
 						line-height: 1;
 						@extend %text-shared;
 					}
-		
+
 					&__featured-image {
 						max-width: 38px;
 						align-self: flex-end;
@@ -174,6 +181,18 @@ body.is-reader-full-post {
 
 			.dataviews-view-list__item {
 				padding: $recent-feed-spacing;
+			}
+		}
+
+		// This is a temporary fix to disable the pagination page selector because of this issue: Automattic/loop#247
+		// Once that issue is fixed, this code should be removed.
+		.dataviews-pagination__page-select {
+			.components-input-control__suffix {
+				display: none;
+			}
+			.components-select-control__input {
+				pointer-events: none;
+				padding: 0;
 			}
 		}
 	}

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -190,6 +190,9 @@ body.is-reader-full-post {
 			.components-input-control__suffix {
 				display: none;
 			}
+			.components-input-control__container {
+				cursor: text;
+			}
 			.components-select-control__input {
 				pointer-events: none;
 				padding: 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/loop#247

## Proposed Changes

* Prevent the user from being able to select an arbitrary page in the middle posts column to prevent the issue described in Automattic/loop#247

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To move the Recent Feed Overhaul project forward.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/read?flags="reader/recent-feed-overhaul"
* Choose new "three column" view
* Attempt to select a page in the middle column

**Note:** We can't style the cursor of the `<select/>` element so it will look like its interactive if hovered. I think this is a better tradeoff over hiding the page number altogether because this doesn't hide information from the user.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
