### PR TITLE
Add arrows to switch dates for the post details page

### DIFF
--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -112,7 +112,12 @@ class StatsPeriodNavigation extends PureComponent {
 		const previousDayQuery = qs.stringify( Object.assign( {}, queryParams, newQueryParams ), {
 			addQueryPrefix: true,
 		} );
-		const href = `${ url }${ previousDayQuery }`;
+
+		let href = null;
+		if ( url ) {
+			href = `${ url }${ previousDayQuery }`;
+		}
+
 		this.handleArrowEvent( 'previous', href );
 	};
 
@@ -125,7 +130,12 @@ class StatsPeriodNavigation extends PureComponent {
 		const nextDayQuery = qs.stringify( Object.assign( {}, queryParams, newQueryParams ), {
 			addQueryPrefix: true,
 		} );
-		const href = `${ url }${ nextDayQuery }`;
+
+		let href = null;
+		if ( url ) {
+			href = `${ url }${ nextDayQuery }`;
+		}
+
 		this.handleArrowEvent( 'next', href );
 	};
 

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -213,7 +213,6 @@ class StatsPostDetail extends Component {
 								siteId={ siteId }
 								postId={ postId }
 								supportsUTMStats={ supportsUTMStats }
-								siteSlug={ siteSlug }
 							/>
 							<PostDetailTableSection siteId={ siteId } postId={ postId } />
 						</>

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -213,6 +213,7 @@ class StatsPostDetail extends Component {
 								siteId={ siteId }
 								postId={ postId }
 								supportsUTMStats={ supportsUTMStats }
+								siteSlug={ siteSlug }
 							/>
 							<PostDetailTableSection siteId={ siteId } postId={ postId } />
 						</>

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -35,7 +35,6 @@ class StatsPostSummary extends Component {
 		siteId: PropTypes.number,
 		translate: PropTypes.func,
 		supportsUTMStats: PropTypes.bool,
-		siteSlug: PropTypes.string,
 	};
 
 	static MAX_RECORDS_PER_DAY = 10;
@@ -69,9 +68,7 @@ class StatsPostSummary extends Component {
 			selectedRecord = chartData[ chartData.length - 1 ];
 		}
 
-		const recordIndex = chartData.findIndex(
-			( item ) => item.startDate === selectedRecord.startDate
-		);
+		const recordIndex = chartData.findIndex( ( item ) => item.period === selectedRecord.period );
 
 		if ( 'previous' === direction ) {
 			if ( recordIndex > 0 ) {
@@ -221,7 +218,7 @@ class StatsPostSummary extends Component {
 	}
 
 	render() {
-		const { isRequesting, postId, siteId, translate, siteSlug, stats } = this.props;
+		const { isRequesting, postId, siteId, translate, stats } = this.props;
 		const periods = [
 			{ id: 'day', label: translate( 'Days' ) },
 			{ id: 'week', label: translate( 'Weeks' ) },
@@ -234,13 +231,18 @@ class StatsPostSummary extends Component {
 			selectedRecord = chartData[ chartData.length - 1 ];
 		}
 
-		const maxPages = Math.ceil( stats.data.length / StatsPostSummary.MAX_RECORDS_PER_DAY );
 		let disablePreviousArrow = false;
-		if ( this.state.page >= maxPages ) {
-			const selectedRecordIndex = chartData.findIndex(
-				( item ) => item.startDate === selectedRecord.startDate
-			);
+		let disableNextArrow = false;
+		const selectedRecordIndex = chartData.findIndex(
+			( item ) => item.period === selectedRecord.period
+		);
+		if ( 'day' === this.state.period ) {
+			const maxPages = Math.ceil( stats.data.length / StatsPostSummary.MAX_RECORDS_PER_DAY );
+			disablePreviousArrow = this.state.page >= maxPages && selectedRecordIndex === 0;
+			disableNextArrow = 1 === this.state.page && selectedRecordIndex === chartData.length - 1;
+		} else {
 			disablePreviousArrow = selectedRecordIndex === 0;
+			disableNextArrow = selectedRecordIndex === chartData.length - 1;
 		}
 
 		const summaryWrapperClass = clsx( 'stats-post-summary', 'is-chart-tabs', {
@@ -256,10 +258,10 @@ class StatsPostSummary extends Component {
 						<StatsPeriodNavigation
 							showArrows
 							onPeriodChange={ this.onPeriodChange }
-							url={ `/stats/post/${ postId }/${ siteSlug }` }
-							date={ selectedRecord?.startDate }
-							period={ this.state.period }
 							disablePreviousArrow={ disablePreviousArrow }
+							disableNextArrow={ disableNextArrow }
+							date={ null }
+							period={ this.state.period }
 						>
 							<DatePicker period={ this.state.period } date={ selectedRecord?.startDate } isShort />
 						</StatsPeriodNavigation>

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -38,9 +38,12 @@ class StatsPostSummary extends Component {
 		siteSlug: PropTypes.string,
 	};
 
+	static MAX_RECORDS_PER_DAY = 10;
+
 	state = {
 		selectedRecord: null,
 		period: 'day',
+		page: 1,
 	};
 
 	selectPeriod( period ) {
@@ -56,7 +59,7 @@ class StatsPostSummary extends Component {
 	};
 
 	onPeriodChange = ( { direction } ) => {
-		const chartData = this.getChartData();
+		let chartData = this.getChartData();
 		if ( ! chartData.length ) {
 			return;
 		}
@@ -70,17 +73,37 @@ class StatsPostSummary extends Component {
 			( item ) => item.startDate === selectedRecord.startDate
 		);
 
-		if ( 'previous' === direction && recordIndex > 0 ) {
-			this.setState( { selectedRecord: chartData[ recordIndex - 1 ] } );
-		} else if ( 'next' === direction && recordIndex < chartData.length - 1 ) {
-			this.setState( { selectedRecord: chartData[ recordIndex + 1 ] } );
+		if ( 'previous' === direction ) {
+			if ( recordIndex > 0 ) {
+				this.setState( { selectedRecord: chartData[ recordIndex - 1 ] } );
+			} else {
+				const nextPage = this.state.page + 1;
+				chartData = this.getChartData( nextPage );
+				if ( chartData ) {
+					this.setState( { selectedRecord: chartData[ chartData.length - 1 ] } );
+				}
+			}
+		} else if ( 'next' === direction ) {
+			if ( recordIndex < chartData.length - 1 ) {
+				this.setState( { selectedRecord: chartData[ recordIndex + 1 ] } );
+			} else {
+				const nextPage = this.state.page - 1;
+				chartData = this.getChartData( nextPage );
+				this.setState( { selectedRecord: chartData[ 0 ] } );
+			}
 		}
 	};
 
-	getChartData() {
+	getChartData( newPage = 0 ) {
 		const { moment, stats } = this.props;
 		if ( ! stats ) {
 			return [];
+		}
+
+		let page = this.state.page;
+		if ( newPage ) {
+			page = newPage;
+			this.setState( { page: newPage } );
 		}
 
 		switch ( this.state.period ) {
@@ -90,7 +113,10 @@ class StatsPostSummary extends Component {
 				}
 
 				return stats.data
-					.slice( Math.max( stats.data.length - 10, 0 ) )
+					.slice(
+						Math.max( stats.data.length - StatsPostSummary.MAX_RECORDS_PER_DAY * page, 0 ),
+						stats.data.length - StatsPostSummary.MAX_RECORDS_PER_DAY * ( page - 1 )
+					)
 					.map( ( [ date, value ] ) => {
 						const momentDate = moment( date );
 						return {
@@ -191,7 +217,7 @@ class StatsPostSummary extends Component {
 	}
 
 	render() {
-		const { isRequesting, postId, siteId, translate, siteSlug } = this.props;
+		const { isRequesting, postId, siteId, translate, siteSlug, stats } = this.props;
 		const periods = [
 			{ id: 'day', label: translate( 'Days' ) },
 			{ id: 'week', label: translate( 'Weeks' ) },
@@ -203,9 +229,15 @@ class StatsPostSummary extends Component {
 		if ( ! this.state.selectedRecord && chartData.length ) {
 			selectedRecord = chartData[ chartData.length - 1 ];
 		}
-		const selectedRecordIndex = chartData.findIndex(
-			( item ) => item.startDate === selectedRecord.startDate
-		);
+
+		const maxPages = Math.ceil( stats.data.length / StatsPostSummary.MAX_RECORDS_PER_DAY );
+		let disablePreviousArrow = false;
+		if ( this.state.page >= maxPages - 1 ) {
+			const selectedRecordIndex = chartData.findIndex(
+				( item ) => item.startDate === selectedRecord.startDate
+			);
+			disablePreviousArrow = selectedRecordIndex === 0;
+		}
 
 		const summaryWrapperClass = clsx( 'stats-post-summary', 'is-chart-tabs', {
 			'is-period-year': this.state.period === 'year',
@@ -223,7 +255,7 @@ class StatsPostSummary extends Component {
 							url={ `/stats/post/${ postId }/${ siteSlug }` }
 							date={ selectedRecord?.startDate }
 							period={ this.state.period }
-							disablePreviousArrow={ selectedRecordIndex === 0 }
+							disablePreviousArrow={ disablePreviousArrow }
 						>
 							<DatePicker period={ this.state.period } date={ selectedRecord?.startDate } isShort />
 						</StatsPeriodNavigation>

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -261,7 +261,6 @@ class StatsPostSummary extends Component {
 							disablePreviousArrow={ disablePreviousArrow }
 							disableNextArrow={ disableNextArrow }
 							date={ null }
-							period={ this.state.period }
 						>
 							<DatePicker period={ this.state.period } date={ selectedRecord?.startDate } isShort />
 						</StatsPeriodNavigation>

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -107,25 +107,29 @@ class StatsPostSummary extends Component {
 		}
 
 		switch ( this.state.period ) {
-			case 'day':
+			case 'day': {
 				if ( ! stats.data ) {
 					return [];
 				}
 
-				return stats.data
-					.slice(
-						Math.max( stats.data.length - StatsPostSummary.MAX_RECORDS_PER_DAY * page, 0 ),
-						stats.data.length - StatsPostSummary.MAX_RECORDS_PER_DAY * ( page - 1 )
-					)
-					.map( ( [ date, value ] ) => {
-						const momentDate = moment( date );
-						return {
-							period: momentDate.format( 'MMM D' ),
-							periodLabel: momentDate.format( 'LL' ),
-							startDate: date,
-							value,
-						};
-					} );
+				const dataStart = Math.max(
+					stats.data.length - StatsPostSummary.MAX_RECORDS_PER_DAY * page,
+					0
+				);
+				const dataEnd = Math.max(
+					stats.data.length - StatsPostSummary.MAX_RECORDS_PER_DAY * ( page - 1 ),
+					0
+				);
+				return stats.data.slice( dataStart, dataEnd ).map( ( [ date, value ] ) => {
+					const momentDate = moment( date );
+					return {
+						period: momentDate.format( 'MMM D' ),
+						periodLabel: momentDate.format( 'LL' ),
+						startDate: date,
+						value,
+					};
+				} );
+			}
 			case 'year':
 				if ( ! stats.years ) {
 					return [];
@@ -232,7 +236,7 @@ class StatsPostSummary extends Component {
 
 		const maxPages = Math.ceil( stats.data.length / StatsPostSummary.MAX_RECORDS_PER_DAY );
 		let disablePreviousArrow = false;
-		if ( this.state.page >= maxPages - 1 ) {
+		if ( this.state.page >= maxPages ) {
 			const selectedRecordIndex = chartData.findIndex(
 				( item ) => item.startDate === selectedRecord.startDate
 			);

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -35,6 +35,7 @@ class StatsPostSummary extends Component {
 		siteId: PropTypes.number,
 		translate: PropTypes.func,
 		supportsUTMStats: PropTypes.bool,
+		siteSlug: PropTypes.string,
 	};
 
 	state = {
@@ -52,6 +53,28 @@ class StatsPostSummary extends Component {
 
 	selectRecord = ( record ) => {
 		this.setState( { selectedRecord: record } );
+	};
+
+	onPeriodChange = ( { direction } ) => {
+		const chartData = this.getChartData();
+		if ( ! chartData.length ) {
+			return;
+		}
+
+		let selectedRecord = this.state.selectedRecord;
+		if ( ! selectedRecord ) {
+			selectedRecord = chartData[ chartData.length - 1 ];
+		}
+
+		const recordIndex = chartData.findIndex(
+			( item ) => item.startDate === selectedRecord.startDate
+		);
+
+		if ( 'previous' === direction && recordIndex > 0 ) {
+			this.setState( { selectedRecord: chartData[ recordIndex - 1 ] } );
+		} else if ( 'next' === direction && recordIndex < chartData.length - 1 ) {
+			this.setState( { selectedRecord: chartData[ recordIndex + 1 ] } );
+		}
 	};
 
 	getChartData() {
@@ -168,7 +191,7 @@ class StatsPostSummary extends Component {
 	}
 
 	render() {
-		const { isRequesting, postId, siteId, translate } = this.props;
+		const { isRequesting, postId, siteId, translate, siteSlug } = this.props;
 		const periods = [
 			{ id: 'day', label: translate( 'Days' ) },
 			{ id: 'week', label: translate( 'Weeks' ) },
@@ -180,6 +203,9 @@ class StatsPostSummary extends Component {
 		if ( ! this.state.selectedRecord && chartData.length ) {
 			selectedRecord = chartData[ chartData.length - 1 ];
 		}
+		const selectedRecordIndex = chartData.findIndex(
+			( item ) => item.startDate === selectedRecord.startDate
+		);
 
 		const summaryWrapperClass = clsx( 'stats-post-summary', 'is-chart-tabs', {
 			'is-period-year': this.state.period === 'year',
@@ -191,7 +217,14 @@ class StatsPostSummary extends Component {
 					<QueryPostStats siteId={ siteId } postId={ postId } />
 
 					<StatsPeriodHeader>
-						<StatsPeriodNavigation showArrows={ false }>
+						<StatsPeriodNavigation
+							showArrows
+							onPeriodChange={ this.onPeriodChange }
+							url={ `/stats/post/${ postId }/${ siteSlug }` }
+							date={ selectedRecord?.startDate }
+							period={ this.state.period }
+							disablePreviousArrow={ selectedRecordIndex === 0 }
+						>
 							<DatePicker period={ this.state.period } date={ selectedRecord?.startDate } isShort />
 						</StatsPeriodNavigation>
 						<SegmentedControl primary>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/red-team/issues/257

## Proposed Changes

* Add arrows to switch dates for the post details page
* For the period `days`, there are more dates that can be shown, so logic was added to navigate over them using the current data.

https://github.com/user-attachments/assets/ee3da205-5c61-450d-9235-cba0c473ca2d


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Consistency with the design

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the arrows to navigate the data
* For the period `days` you can go to older data

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
