### PR TITLE
Purchases: Highlight Upgrades Owned by Other Administrators

### DIFF
--- a/client/me/purchases/purchases-list/index.tsx
+++ b/client/me/purchases/purchases-list/index.tsx
@@ -14,6 +14,7 @@ import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
+import Notice from 'calypso/components/notice';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { getPurchasesBySite, getSubscriptionsBySite } from 'calypso/lib/purchases';
@@ -68,6 +69,55 @@ class PurchasesList extends Component<
 		}
 
 		return ! this.props.sites.length && ! this.props.subscriptions.length;
+	}
+
+	renderPurchasesByOtherAdminsNotice() {
+		const { sites, translate } = this.props;
+
+		/*
+		 * Because this is only rendered when the user has no purchases,
+		 * we don't need to check each site to ensure the purchases aren't
+		 * linked with the user (they can't be, since they don't have any).
+		 */
+		const affectedSites = sites
+			.filter(
+				( site ) =>
+					( ! site?.plan.is_free || site?.products.length > 0 ) && site.capabilities.manage_options
+			)
+			.map( ( site ) => site.slug );
+
+		if ( ! affectedSites.length ) {
+			return;
+		}
+
+		let affectedSitesString = '';
+
+		if ( affectedSites.length === 1 ) {
+			affectedSitesString = affectedSites[ 0 ];
+		} else {
+			const allButLast = affectedSites.slice( 0, -1 ).join( ', ' );
+			const translatedAnd = translate( 'and', {
+				comment: 'last conjunction in a list of blognames: (blog1, blog2,) blog3 _and_ blog4',
+			} );
+			const last = affectedSites[ affectedSites.length - 1 ];
+
+			affectedSitesString = allButLast + ' ' + translatedAnd + ' ' + last;
+		}
+
+		return (
+			<Notice status="is-info" showDismiss={ false }>
+				{ translate(
+					'The upgrades for {{strong}}%(affectedSitesString)s{{/strong}} are owned by another site administrator. ' +
+						'These can only be managed by the purchase owners.',
+					{
+						components: { strong: <strong /> },
+						args: {
+							affectedSitesString,
+						},
+					}
+				) }
+			</Notice>
+		);
 	}
 
 	renderConciergeBanner() {
@@ -143,6 +193,7 @@ class PurchasesList extends Component<
 								eventName="calypso_no_purchases_upgrade_nudge_impression"
 								eventProperties={ commonEventProps }
 							/>
+							{ this.renderPurchasesByOtherAdminsNotice() }
 							<EmptyContent
 								title={ translate( 'Looking to upgrade?' ) }
 								line={ translate(

--- a/client/me/purchases/purchases-list/index.tsx
+++ b/client/me/purchases/purchases-list/index.tsx
@@ -14,7 +14,6 @@ import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import Notice from 'calypso/components/notice';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { getPurchasesBySite, getSubscriptionsBySite } from 'calypso/lib/purchases';
@@ -69,55 +68,6 @@ class PurchasesList extends Component<
 		}
 
 		return ! this.props.sites.length && ! this.props.subscriptions.length;
-	}
-
-	renderPurchasesByOtherAdminsNotice() {
-		const { sites, translate } = this.props;
-
-		/*
-		 * Because this is only rendered when the user has no purchases,
-		 * we don't need to check each site to ensure the purchases aren't
-		 * linked with the user (they can't be, since they don't have any).
-		 */
-		const affectedSites = sites
-			.filter(
-				( site ) =>
-					( ! site.plan.is_free || site.products.length > 0 ) && site.capabilities.manage_options
-			)
-			.map( ( site ) => site.slug );
-
-		if ( ! affectedSites.length ) {
-			return;
-		}
-
-		let affectedSitesString = '';
-
-		if ( affectedSites.length === 1 ) {
-			affectedSitesString = affectedSites[ 0 ];
-		} else {
-			const allButLast = affectedSites.slice( 0, -1 ).join( ', ' );
-			const translatedAnd = translate( 'and', {
-				comment: 'last conjunction in a list of blognames: (blog1, blog2,) blog3 _and_ blog4',
-			} );
-			const last = affectedSites[ affectedSites.length - 1 ];
-
-			affectedSitesString = allButLast + ' ' + translatedAnd + ' ' + last;
-		}
-
-		return (
-			<Notice status="is-info" showDismiss={ false }>
-				{ translate(
-					'The upgrades for {{strong}}%(affectedSitesString)s{{/strong}} are owned by another site administrator. ' +
-						'These can only be managed by the purchase owner.',
-					{
-						components: { strong: <strong /> },
-						args: {
-							affectedSitesString,
-						},
-					}
-				) }
-			</Notice>
-		);
 	}
 
 	renderConciergeBanner() {
@@ -193,7 +143,6 @@ class PurchasesList extends Component<
 								eventName="calypso_no_purchases_upgrade_nudge_impression"
 								eventProperties={ commonEventProps }
 							/>
-							{ this.renderPurchasesByOtherAdminsNotice() }
 							<EmptyContent
 								title={ translate( 'Looking to upgrade?' ) }
 								line={ translate(

--- a/client/me/purchases/purchases-list/index.tsx
+++ b/client/me/purchases/purchases-list/index.tsx
@@ -80,10 +80,15 @@ class PurchasesList extends Component<
 		 * linked with the user (they can't be, since they don't have any).
 		 */
 		const affectedSites = sites
-			.filter(
-				( site ) =>
-					( ! site?.plan.is_free || site?.products.length > 0 ) && site.capabilities.manage_options
-			)
+			.filter( ( site ) => {
+				if ( ! site?.plan?.is_free ) {
+					return site.capabilities.manage_options;
+				}
+				if ( site?.products && site?.products?.length > 0 ) {
+					return site.capabilities.manage_options;
+				}
+				return false;
+			} )
 			.map( ( site ) => site.slug );
 
 		if ( ! affectedSites.length ) {

--- a/client/me/purchases/purchases-list/index.tsx
+++ b/client/me/purchases/purchases-list/index.tsx
@@ -14,6 +14,7 @@ import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
+import Notice from 'calypso/components/notice';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { getPurchasesBySite, getSubscriptionsBySite } from 'calypso/lib/purchases';
@@ -68,6 +69,55 @@ class PurchasesList extends Component<
 		}
 
 		return ! this.props.sites.length && ! this.props.subscriptions.length;
+	}
+
+	renderPurchasesByOtherAdminsNotice() {
+		const { sites, translate } = this.props;
+
+		/*
+		 * Because this is only rendered when the user has no purchases,
+		 * we don't need to check each site to ensure the purchases aren't
+		 * linked with the user (they can't be, since they don't have any).
+		 */
+		const affectedSites = sites
+			.filter(
+				( site ) =>
+					( ! site.plan.is_free || site.products.length > 0 ) && site.capabilities.manage_options
+			)
+			.map( ( site ) => site.slug );
+
+		if ( ! affectedSites ) {
+			return;
+		}
+
+		let affectedSitesString = '';
+
+		if ( affectedSites.length === 1 ) {
+			affectedSitesString = affectedSites[ 0 ];
+		} else {
+			const allButLast = affectedSites.slice( 0, -1 ).join( ', ' );
+			const translatedAnd = translate( 'and', {
+				comment: 'last conjunction in a list of blognames: (blog1, blog2,) blog3 _and_ blog4',
+			} );
+			const last = affectedSites[ affectedSites.length - 1 ];
+
+			affectedSitesString = allButLast + ' ' + translatedAnd + ' ' + last;
+		}
+
+		return (
+			<Notice status="is-info" showDismiss={ false }>
+				{ translate(
+					'The upgrades for {{strong}}%(affectedSitesString)s{{/strong}} are owned by another site administrator. ' +
+						'These can only be managed by the purchase owner.',
+					{
+						components: { strong: <strong /> },
+						args: {
+							affectedSitesString,
+						},
+					}
+				) }
+			</Notice>
+		);
 	}
 
 	renderConciergeBanner() {
@@ -143,6 +193,7 @@ class PurchasesList extends Component<
 								eventName="calypso_no_purchases_upgrade_nudge_impression"
 								eventProperties={ commonEventProps }
 							/>
+							{ this.renderPurchasesByOtherAdminsNotice() }
 							<EmptyContent
 								title={ translate( 'Looking to upgrade?' ) }
 								line={ translate(

--- a/client/me/purchases/purchases-list/index.tsx
+++ b/client/me/purchases/purchases-list/index.tsx
@@ -86,7 +86,7 @@ class PurchasesList extends Component<
 			)
 			.map( ( site ) => site.slug );
 
-		if ( ! affectedSites ) {
+		if ( ! affectedSites.length ) {
 			return;
 		}
 


### PR DESCRIPTION
Addresses #96328
## Proposed Changes

Provides an informational notice when the user goes to manage their upgrades, and sees the "no purchases `EmptyContent`" because the subscriptions on the sites for which they are an admin are managed by somebody else.  

**NOTE:** this only works when the user has no purchases (as opposed to having their own sites with purchases). I imagine that would capture most the use cases in practice, but the problem is that when the user has their own sites, we need to check whether they own that specific purchase. This would require checking the individual site purchases (as opposed to the general `getSites` data), but without owning the purchase, they don't have the authorisation to do so. I think that might, therefore, require an endpoint change. As such, this only implements one of the two designs in the original issue.  

## Why are these changes being made?

See original issue - lots of users apparently face confusion over why they can't manage an upgrade. 

## Testing Instructions

1. Create a site with a purchase
2. Add another user to that site **as an administrator**
3. Confirm that on that user's account, you see the correct notice under Me > Purchases
4. Verify that the notice shows all the sites for which that applies, and it doesn't show any sites which the user is not an administrator on 

<img width="1085" alt="Screenshot 2024-12-06 at 21 42 53" src="https://github.com/user-attachments/assets/ad572f7b-0378-4a62-ac95-46ca8b4c50df">

cc @sirbrillig, @DavidRothstein