### PR TITLE
A4A: improve check if pressable subscription exists

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type.ts
@@ -13,9 +13,8 @@ export default function usePressableOwnershipType() {
 			return 'none';
 		}
 
-		// If the agency has a regular Pressable plan (not brought through A4A marketplace), A4A id is null.
 		const hasRegularPressablePlan =
-			hasPressablePlan && activeAgency?.third_party?.pressable?.a4a_id === null;
+			activeAgency?.third_party?.pressable?.subscription?.status === 'active';
 
 		return hasRegularPressablePlan ? 'regular' : 'agency';
 	}, [ activeAgency ] );

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -24,6 +24,10 @@ export interface Agency {
 			email: string;
 			name: string;
 			pressable_id: number;
+			subscription?: null | {
+				id?: number;
+				status?: 'active' | 'canceled';
+			};
 			usage?: null | {
 				status: string;
 				storage_gb: number;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1422

## Proposed Changes

Current approach doesn't allow us to distinct users, who have Pressable account registered aside of A4A with and without active subscriptions. Thus, users, without active subscriptions still can't purchase plans through A4A.

We expanded existing endpoint to provide more data in this diff: D168068-code

We are now able to check if there's an existing subscription on Pressable side.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Patch branch from this Diff: D168068-code to your sandbox on proxy it, if not yet deployed.
- To test the functionality you would need 3 A4A accounts (you can reach out and I will share some account you could test on if needed)
- A4A account, without prior creation of Pressable account - should be able to purchase Pressable plans through `/marketplace/hosting/pressable`
- A4A account, with Pressable account but **without** active subscriptions - should be able to purchase Pressable plans through `/marketplace/hosting/pressable`
- A4A account, with Pressable account **with** active subscription - Manage in pressable button should be show on  `/marketplace/hosting/pressable`
<img width="439" alt="Screenshot 2024-12-06 at 3 03 10 PM" src="https://github.com/user-attachments/assets/4fbd92a8-45c7-446a-ad1d-2c47ff3df79d">

- Cancel subscription on Pressable for the last account. You should be able to purchase plan again.
- Try purchasing a plan.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?