### PR TITLE
Allow free users with flag to set dotblog as primary

### DIFF
--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
@@ -11,7 +11,7 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import { getTld } from 'calypso/lib/domains';
 import { useSelector } from 'calypso/state';
 import {
-	CAN_SET_DOTBLOG_AS_PRIMARY,
+	CAMPAIGN_PRIMARY_DOTBLOG_ON_FREE_2024,
 	NON_PRIMARY_DOMAINS_TO_FREE_USERS,
 } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
@@ -42,7 +42,7 @@ const PrimaryDomainSelector = ( {
 
 	const hasDotBlogDomainAndCanSetDotBlogAsPrimary = useSelector(
 		( state ) =>
-			currentUserHasFlag( state, CAN_SET_DOTBLOG_AS_PRIMARY ) &&
+			currentUserHasFlag( state, CAMPAIGN_PRIMARY_DOTBLOG_ON_FREE_2024 ) &&
 			domains?.some(
 				( domain ) => ! domain.wpcom_domain && 'blog'.startsWith( getTld( domain.domain ) )
 			)
@@ -68,7 +68,7 @@ const PrimaryDomainSelector = ( {
 			selectedDomain &&
 			( 'blog'.startsWith( getTld( selectedDomain ) )
 				? canUserSetPrimaryDomainOnThisSite ||
-				  currentUserHasFlag( state, CAN_SET_DOTBLOG_AS_PRIMARY )
+				  currentUserHasFlag( state, CAMPAIGN_PRIMARY_DOTBLOG_ON_FREE_2024 )
 				: canUserSetPrimaryDomainOnThisSite )
 	);
 

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
@@ -8,8 +8,12 @@ import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { getTld } from 'calypso/lib/domains';
 import { useSelector } from 'calypso/state';
-import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
+import {
+	CAN_SET_DOTBLOG_AS_PRIMARY,
+	NON_PRIMARY_DOMAINS_TO_FREE_USERS,
+} from 'calypso/state/current-user/constants';
 import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
 import type { DomainData, SiteDetails } from '@automattic/data-stores';
 
@@ -36,6 +40,14 @@ const PrimaryDomainSelector = ( {
 		currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
 	);
 
+	const hasDotBlogDomainAndCanSetDotBlogAsPrimary = useSelector(
+		( state ) =>
+			currentUserHasFlag( state, CAN_SET_DOTBLOG_AS_PRIMARY ) &&
+			domains?.some(
+				( domain ) => ! domain.wpcom_domain && 'blog'.startsWith( getTld( domain.domain ) )
+			)
+	);
+
 	useEffect( () => {
 		if ( domains?.length ) {
 			const primary = domains.find( ( domain ) => {
@@ -48,12 +60,21 @@ const PrimaryDomainSelector = ( {
 		}
 	}, [ domains ] );
 
+	const isOnFreePlan = site?.plan?.is_free ?? false;
+	const canUserSetPrimaryDomainOnThisSite = ! ( primaryWithPlanOnly && isOnFreePlan );
+
+	const canSetSelectedDomainAsPrimary = useSelector(
+		( state ) =>
+			selectedDomain &&
+			( 'blog'.startsWith( getTld( selectedDomain ) )
+				? canUserSetPrimaryDomainOnThisSite ||
+				  currentUserHasFlag( state, CAN_SET_DOTBLOG_AS_PRIMARY )
+				: canUserSetPrimaryDomainOnThisSite )
+	);
+
 	if ( ! domains || ! site ) {
 		return null;
 	}
-
-	const isOnFreePlan = site?.plan?.is_free ?? false;
-	const canUserSetPrimaryDomainOnThisSite = ! ( primaryWithPlanOnly && isOnFreePlan );
 
 	const shouldUpgradeToMakeDomainPrimary = ( domain: DomainData ): boolean => {
 		return (
@@ -119,7 +140,7 @@ const PrimaryDomainSelector = ( {
 
 	let message: Substitution;
 
-	if ( ! canUserSetPrimaryDomainOnThisSite ) {
+	if ( ! canUserSetPrimaryDomainOnThisSite && ! hasDotBlogDomainAndCanSetDotBlogAsPrimary ) {
 		// The user can't set a primary domain on this site because they need to upgrade their plan
 		message = translate(
 			"Your site plan doesn't allow to set a custom domain as a primary site address. {{planUpgradeLink}}Upgrade your plan{{/planUpgradeLink}} and get a free one-year domain registration or transfer with any annual paid plan. {{learnMoreLink}}Learn more{{/learnMoreLink}}.",
@@ -181,33 +202,55 @@ const PrimaryDomainSelector = ( {
 			</CardHeading>
 			<>
 				<p className="domains-set-primary-address__subtitle">{ message }</p>
-				{ otherValidPrimaryDomains.length > 0 && canUserSetPrimaryDomainOnThisSite && (
-					<FormFieldset className="domains-set-primary-address__fieldset">
-						<FormSelect
-							className="domains-set-primary-address__select"
-							disabled={ isSettingPrimaryDomain }
-							id="primary-domain-selector"
-							onChange={ onSelectChange }
-							value={ selectedDomain }
-						>
-							<option value="">{ translate( 'Select a domain' ) }</option>
-							{ otherValidPrimaryDomains.map( ( domain ) => (
-								<option key={ domain.domain } value={ domain.domain }>
-									{ domain.domain }
-								</option>
-							) ) }
-						</FormSelect>
-						<FormButton
-							className="domains-set-primary-address__submit"
-							primary
-							busy={ isSettingPrimaryDomain }
-							disabled={ isSettingPrimaryDomain || ! selectedDomain }
-							onClick={ onSubmit }
-						>
-							{ translate( 'Set as primary' ) }
-						</FormButton>
-					</FormFieldset>
-				) }
+				{ otherValidPrimaryDomains.length > 0 &&
+					( canUserSetPrimaryDomainOnThisSite || hasDotBlogDomainAndCanSetDotBlogAsPrimary ) && (
+						<>
+							<FormFieldset className="domains-set-primary-address__fieldset">
+								<FormSelect
+									className="domains-set-primary-address__select"
+									disabled={ isSettingPrimaryDomain }
+									id="primary-domain-selector"
+									onChange={ onSelectChange }
+									value={ selectedDomain }
+								>
+									<option value="">{ translate( 'Select a domain' ) }</option>
+									{ otherValidPrimaryDomains.map( ( domain ) => (
+										<option key={ domain.domain } value={ domain.domain }>
+											{ domain.domain }
+										</option>
+									) ) }
+								</FormSelect>
+								<FormButton
+									className="domains-set-primary-address__submit"
+									primary
+									busy={ isSettingPrimaryDomain }
+									disabled={
+										isSettingPrimaryDomain || ! selectedDomain || ! canSetSelectedDomainAsPrimary
+									}
+									onClick={ onSubmit }
+								>
+									{ translate( 'Set as primary' ) }
+								</FormButton>
+							</FormFieldset>
+							{ selectedDomain && ! canSetSelectedDomainAsPrimary && (
+								<p className="domains-set-primary-address__error">
+									{ translate(
+										"Your site plan doesn't allow to set this custom domain as a primary site address. {{planUpgradeLink}}Upgrade your plan{{/planUpgradeLink}} and get a free one-year domain registration or transfer with any annual paid plan.",
+										{
+											components: {
+												planUpgradeLink: (
+													<a
+														href={ '/plans/' + primaryDomain }
+														onClick={ () => trackUpgradeClick( true ) }
+													/>
+												),
+											},
+										}
+									) }
+								</p>
+							) }
+						</>
+					) }
 			</>
 		</Card>
 	);

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/style.scss
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/style.scss
@@ -9,6 +9,12 @@
 		margin-bottom: 0;
 		font-size: 0.875rem;
 	}
+	&__error {
+		color: var(--color-text-subtle);
+		margin-bottom: 0;
+		margin-top: 0.875rem;
+		font-size: 0.875rem;
+	}
 	&__fieldset.form-fieldset {
 		margin-top: 0.875rem;
 		margin-bottom: 0;

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/test/index.tsx
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/test/index.tsx
@@ -6,7 +6,10 @@ import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products'
 import { render, screen, fireEvent } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
-import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
+import {
+	NON_PRIMARY_DOMAINS_TO_FREE_USERS,
+	CAN_SET_DOTBLOG_AS_PRIMARY,
+} from 'calypso/state/current-user/constants';
 import PrimaryDomainSelector from '../index';
 
 // Mock dependencies
@@ -69,7 +72,7 @@ describe( 'PrimaryDomainSelector', () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'renders the primary domain message', () => {
+	test( 'renders the primary domain message', () => {
 		renderComponent();
 		expect(
 			screen.getByText( /The current primary address set for this site is:/i )
@@ -77,7 +80,7 @@ describe( 'PrimaryDomainSelector', () => {
 		expect( screen.getByText( 'primary.com' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders the domain selector with valid options', () => {
+	test( 'renders the domain selector with valid options', () => {
 		renderComponent();
 		const select = screen.getByRole( 'combobox' );
 		expect( select ).toBeInTheDocument();
@@ -85,7 +88,7 @@ describe( 'PrimaryDomainSelector', () => {
 		expect( screen.queryByText( 'cannot-be-primary.com' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'enables the submit button only when a domain is selected', () => {
+	test( 'enables the submit button only when a domain is selected', () => {
 		renderComponent();
 		const submitButton = screen.getByRole( 'button', { name: /set as primary/i } );
 		expect( submitButton ).toBeDisabled();
@@ -96,7 +99,7 @@ describe( 'PrimaryDomainSelector', () => {
 		expect( submitButton ).toBeEnabled();
 	} );
 
-	it( 'calls onSetPrimaryDomain when form is submitted', () => {
+	test( 'calls onSetPrimaryDomain when form is submitted', () => {
 		renderComponent();
 		const select = screen.getByRole( 'combobox' );
 		const submitButton = screen.getByRole( 'button', { name: /set as primary/i } );
@@ -111,7 +114,7 @@ describe( 'PrimaryDomainSelector', () => {
 		);
 	} );
 
-	it( 'shows upgrade message for free plan users', () => {
+	test( 'shows upgrade message for free plan users', () => {
 		renderComponent(
 			{
 				site: {
@@ -135,7 +138,7 @@ describe( 'PrimaryDomainSelector', () => {
 		expect( screen.queryByRole( 'combobox' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'shows add domain message when no valid domains are available', () => {
+	test( 'shows add domain message when no valid domains are available', () => {
 		renderComponent( {
 			domains: [
 				{
@@ -153,7 +156,7 @@ describe( 'PrimaryDomainSelector', () => {
 		expect( screen.queryByRole( 'combobox' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'tracks upgrade click events', () => {
+	test( 'tracks upgrade click events', () => {
 		renderComponent(
 			{
 				site: {
@@ -180,7 +183,7 @@ describe( 'PrimaryDomainSelector', () => {
 		);
 	} );
 
-	it( 'handles staging domains correctly', () => {
+	test( 'handles staging domains correctly', () => {
 		renderComponent( {
 			domains: [
 				{
@@ -207,11 +210,152 @@ describe( 'PrimaryDomainSelector', () => {
 			],
 		} );
 
-		const options = screen.getAllByRole( 'option' );
+		const select = screen.getByRole( 'combobox' );
 
 		// Should only show staging domain and custom domain, not regular wpcom domain
-		expect( options ).toHaveLength( 3 ); // Including the "Select a domain" option
+		expect( select ).toHaveLength( 3 ); // Including the "Select a domain" option
 		expect( screen.queryByText( 'regular.wordpress.com' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'custom.com' ) ).toBeInTheDocument();
+	} );
+
+	test( 'shows dropdown for free plan users with CAN_SET_DOTBLOG_AS_PRIMARY flag and .blog domain and allows selecting the .blog domain', () => {
+		renderComponent(
+			{
+				site: {
+					plan: {
+						is_free: true,
+					},
+				},
+				domains: [
+					...defaultProps.domains,
+					{
+						domain: 'test.blog',
+						primary_domain: false,
+						can_set_as_primary: true,
+						type: 'registered',
+					},
+				],
+			},
+			{
+				currentUser: {
+					flags: [ NON_PRIMARY_DOMAINS_TO_FREE_USERS, CAN_SET_DOTBLOG_AS_PRIMARY ],
+				},
+			}
+		);
+
+		const select = screen.getByRole( 'combobox' );
+
+		expect( select ).toHaveLength( 3 ); // Including the "Select a domain" option
+		expect( screen.getByText( 'secondary.com' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'test.blog' ) ).toBeInTheDocument();
+		fireEvent.change( select, { target: { value: 'test.blog' } } );
+		const submitButton = screen.getByRole( 'button', { name: /set as primary/i } );
+		expect( submitButton ).toBeEnabled();
+	} );
+
+	test( 'shows upgrade message for free plan users with CAN_SET_DOTBLOG_AS_PRIMARY flag and no .blog domain', () => {
+		renderComponent(
+			{
+				site: {
+					plan: {
+						is_free: true,
+					},
+				},
+				domains: [
+					...defaultProps.domains,
+					{
+						domain: 'test.notblog',
+						primary_domain: false,
+						can_set_as_primary: true,
+						type: 'registered',
+					},
+				],
+			},
+			{
+				currentUser: {
+					flags: [ NON_PRIMARY_DOMAINS_TO_FREE_USERS, CAN_SET_DOTBLOG_AS_PRIMARY ],
+				},
+			}
+		);
+
+		expect(
+			screen.getByText(
+				/Your site plan doesn't allow to set a custom domain as a primary site address/i
+			)
+		).toBeInTheDocument();
+		expect( screen.queryByRole( 'combobox' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'shows upgrade message for free plan users without CAN_SET_DOTBLOG_AS_PRIMARY flag and .blog domain', () => {
+		renderComponent(
+			{
+				site: {
+					plan: {
+						is_free: true,
+					},
+				},
+				domains: [
+					...defaultProps.domains,
+					{
+						domain: 'test.notblog',
+						primary_domain: false,
+						can_set_as_primary: true,
+						type: 'registered',
+					},
+				],
+			},
+			{
+				currentUser: {
+					flags: [ NON_PRIMARY_DOMAINS_TO_FREE_USERS ],
+				},
+			}
+		);
+
+		expect(
+			screen.getByText(
+				/Your site plan doesn't allow to set a custom domain as a primary site address/i
+			)
+		).toBeInTheDocument();
+		expect( screen.queryByRole( 'combobox' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'shows error and disables button for free plan users with CAN_SET_DOTBLOG_AS_PRIMARY flag and having a .blog domain, but a non .blog domain is selected', () => {
+		renderComponent(
+			{
+				site: {
+					plan: {
+						is_free: true,
+					},
+				},
+				domains: [
+					...defaultProps.domains,
+					{
+						domain: 'test.blog',
+						primary_domain: false,
+						can_set_as_primary: true,
+						type: 'registered',
+					},
+				],
+			},
+			{
+				currentUser: {
+					flags: [ NON_PRIMARY_DOMAINS_TO_FREE_USERS, CAN_SET_DOTBLOG_AS_PRIMARY ],
+				},
+			}
+		);
+
+		const select = screen.getByRole( 'combobox' );
+
+		expect( select ).toHaveLength( 3 ); // Including the "Select a domain" option
+		expect( screen.getByText( 'secondary.com' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'test.blog' ) ).toBeInTheDocument();
+		fireEvent.change( select, { target: { value: 'secondary.com' } } );
+		const submitButton = screen.getByRole( 'button', { name: /set as primary/i } );
+		expect( submitButton ).toBeDisabled();
+		expect(
+			screen.getByText(
+				/Your site plan doesn't allow to set this custom domain as a primary site address/i
+			)
+		).toBeInTheDocument();
 	} );
 } );

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/test/index.tsx
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/test/index.tsx
@@ -8,7 +8,7 @@ import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
 import {
 	NON_PRIMARY_DOMAINS_TO_FREE_USERS,
-	CAN_SET_DOTBLOG_AS_PRIMARY,
+	CAMPAIGN_PRIMARY_DOTBLOG_ON_FREE_2024,
 } from 'calypso/state/current-user/constants';
 import PrimaryDomainSelector from '../index';
 
@@ -218,7 +218,7 @@ describe( 'PrimaryDomainSelector', () => {
 		expect( screen.getByText( 'custom.com' ) ).toBeInTheDocument();
 	} );
 
-	test( 'shows dropdown for free plan users with CAN_SET_DOTBLOG_AS_PRIMARY flag and .blog domain and allows selecting the .blog domain', () => {
+	test( 'shows dropdown for free plan users with CAMPAIGN_PRIMARY_DOTBLOG_ON_FREE_2024 flag and .blog domain and allows selecting the .blog domain', () => {
 		renderComponent(
 			{
 				site: {
@@ -238,7 +238,7 @@ describe( 'PrimaryDomainSelector', () => {
 			},
 			{
 				currentUser: {
-					flags: [ NON_PRIMARY_DOMAINS_TO_FREE_USERS, CAN_SET_DOTBLOG_AS_PRIMARY ],
+					flags: [ NON_PRIMARY_DOMAINS_TO_FREE_USERS, CAMPAIGN_PRIMARY_DOTBLOG_ON_FREE_2024 ],
 				},
 			}
 		);
@@ -253,7 +253,7 @@ describe( 'PrimaryDomainSelector', () => {
 		expect( submitButton ).toBeEnabled();
 	} );
 
-	test( 'shows upgrade message for free plan users with CAN_SET_DOTBLOG_AS_PRIMARY flag and no .blog domain', () => {
+	test( 'shows upgrade message for free plan users with CAMPAIGN_PRIMARY_DOTBLOG_ON_FREE_2024 flag and no .blog domain', () => {
 		renderComponent(
 			{
 				site: {
@@ -273,7 +273,7 @@ describe( 'PrimaryDomainSelector', () => {
 			},
 			{
 				currentUser: {
-					flags: [ NON_PRIMARY_DOMAINS_TO_FREE_USERS, CAN_SET_DOTBLOG_AS_PRIMARY ],
+					flags: [ NON_PRIMARY_DOMAINS_TO_FREE_USERS, CAMPAIGN_PRIMARY_DOTBLOG_ON_FREE_2024 ],
 				},
 			}
 		);
@@ -286,7 +286,7 @@ describe( 'PrimaryDomainSelector', () => {
 		expect( screen.queryByRole( 'combobox' ) ).not.toBeInTheDocument();
 	} );
 
-	test( 'shows upgrade message for free plan users without CAN_SET_DOTBLOG_AS_PRIMARY flag and .blog domain', () => {
+	test( 'shows upgrade message for free plan users without CAMPAIGN_PRIMARY_DOTBLOG_ON_FREE_2024 flag and .blog domain', () => {
 		renderComponent(
 			{
 				site: {
@@ -319,7 +319,7 @@ describe( 'PrimaryDomainSelector', () => {
 		expect( screen.queryByRole( 'combobox' ) ).not.toBeInTheDocument();
 	} );
 
-	test( 'shows error and disables button for free plan users with CAN_SET_DOTBLOG_AS_PRIMARY flag and having a .blog domain, but a non .blog domain is selected', () => {
+	test( 'shows error and disables button for free plan users with CAMPAIGN_PRIMARY_DOTBLOG_ON_FREE_2024 flag and having a .blog domain, but a non .blog domain is selected', () => {
 		renderComponent(
 			{
 				site: {
@@ -339,7 +339,7 @@ describe( 'PrimaryDomainSelector', () => {
 			},
 			{
 				currentUser: {
-					flags: [ NON_PRIMARY_DOMAINS_TO_FREE_USERS, CAN_SET_DOTBLOG_AS_PRIMARY ],
+					flags: [ NON_PRIMARY_DOMAINS_TO_FREE_USERS, CAMPAIGN_PRIMARY_DOTBLOG_ON_FREE_2024 ],
 				},
 			}
 		);

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
@@ -9,6 +9,7 @@ import {
 } from '..';
 type Props = {
 	isCustomDomainAllowedOnFreePlan?: boolean | null;
+	isCustomDomainAllowedAsPrimaryOnFreePlan?: boolean | null;
 	flowName?: string | null;
 	paidDomainName?: string | null;
 	intent?: string | null;
@@ -19,6 +20,7 @@ type Props = {
  */
 export function useModalResolutionCallback( {
 	isCustomDomainAllowedOnFreePlan,
+	isCustomDomainAllowedAsPrimaryOnFreePlan,
 	flowName,
 	paidDomainName,
 	intent,
@@ -26,6 +28,10 @@ export function useModalResolutionCallback( {
 	return useCallback(
 		( currentSelectedPlan?: string | null ): ModalType | null => {
 			if ( currentSelectedPlan && isFreePlan( currentSelectedPlan ) ) {
+				if ( isCustomDomainAllowedAsPrimaryOnFreePlan ) {
+					return null;
+				}
+
 				if ( isCustomDomainAllowedOnFreePlan ) {
 					if ( paidDomainName ) {
 						return FREE_PLAN_PAID_DOMAIN_DIALOG;
@@ -46,6 +52,12 @@ export function useModalResolutionCallback( {
 			}
 			return null;
 		},
-		[ isCustomDomainAllowedOnFreePlan, flowName, paidDomainName, intent ]
+		[
+			isCustomDomainAllowedOnFreePlan,
+			isCustomDomainAllowedAsPrimaryOnFreePlan,
+			flowName,
+			paidDomainName,
+			intent,
+		]
 	);
 }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -53,13 +53,15 @@ import QuerySites from 'calypso/components/data/query-sites';
 import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
+import { getTld } from 'calypso/lib/domains';
 import { useExperiment } from 'calypso/lib/explat';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import PlanNotice from 'calypso/my-sites/plans-features-main/components/plan-notice';
 import { shouldForceDefaultPlansBasedOnIntent } from 'calypso/my-sites/plans-features-main/components/utils/utils';
 import { useFreeTrialPlanSlugs } from 'calypso/my-sites/plans-features-main/hooks/use-free-trial-plan-slugs';
 import usePlanTypeDestinationCallback from 'calypso/my-sites/plans-features-main/hooks/use-plan-type-destination-callback';
-import { getCurrentUserName } from 'calypso/state/current-user/selectors';
+import { CAN_SET_DOTBLOG_AS_PRIMARY } from 'calypso/state/current-user/constants';
+import { currentUserHasFlag, getCurrentUserName } from 'calypso/state/current-user/selectors';
 import canUpgradeToPlan from 'calypso/state/selectors/can-upgrade-to-plan';
 import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
@@ -246,8 +248,17 @@ const PlansFeaturesMain = ( {
 
 	const longerPlanTermDefaultExperiment = useLongerPlanTermDefaultExperiment();
 
+	const isCustomDomainAllowedAsPrimaryOnFreePlan = useSelector( ( state: IAppState ) =>
+		Boolean(
+			currentUserHasFlag( state, CAN_SET_DOTBLOG_AS_PRIMARY ) &&
+				paidDomainName &&
+				'blog'.startsWith( getTld( paidDomainName ) )
+		)
+	);
+
 	const resolveModal = useModalResolutionCallback( {
 		isCustomDomainAllowedOnFreePlan,
+		isCustomDomainAllowedAsPrimaryOnFreePlan,
 		flowName,
 		paidDomainName,
 		intent: intentFromProps,

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -60,7 +60,7 @@ import PlanNotice from 'calypso/my-sites/plans-features-main/components/plan-not
 import { shouldForceDefaultPlansBasedOnIntent } from 'calypso/my-sites/plans-features-main/components/utils/utils';
 import { useFreeTrialPlanSlugs } from 'calypso/my-sites/plans-features-main/hooks/use-free-trial-plan-slugs';
 import usePlanTypeDestinationCallback from 'calypso/my-sites/plans-features-main/hooks/use-plan-type-destination-callback';
-import { CAN_SET_DOTBLOG_AS_PRIMARY } from 'calypso/state/current-user/constants';
+import { CAMPAIGN_PRIMARY_DOTBLOG_ON_FREE_2024 } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag, getCurrentUserName } from 'calypso/state/current-user/selectors';
 import canUpgradeToPlan from 'calypso/state/selectors/can-upgrade-to-plan';
 import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
@@ -250,7 +250,7 @@ const PlansFeaturesMain = ( {
 
 	const isCustomDomainAllowedAsPrimaryOnFreePlan = useSelector( ( state: IAppState ) =>
 		Boolean(
-			currentUserHasFlag( state, CAN_SET_DOTBLOG_AS_PRIMARY ) &&
+			currentUserHasFlag( state, CAMPAIGN_PRIMARY_DOTBLOG_ON_FREE_2024 ) &&
 				paidDomainName &&
 				'blog'.startsWith( getTld( paidDomainName ) )
 		)

--- a/client/state/current-user/constants.js
+++ b/client/state/current-user/constants.js
@@ -1,5 +1,5 @@
 export const DOMAINS_WITH_PLANS_ONLY = 'calypso_domains_with_plans_only';
 export const NON_PRIMARY_DOMAINS_TO_FREE_USERS = 'calypso_allow_nonprimary_domains_without_plan';
-export const CAN_SET_DOTBLOG_AS_PRIMARY = 'can_set_dotblog_as_primary';
+export const CAMPAIGN_PRIMARY_DOTBLOG_ON_FREE_2024 = 'campaign_primary_dotblog_on_free_2024';
 
 export const MARKETING_PRICE_GROUP_2020_Q2_TEST_1 = 'price_2020_q2_test_1';

--- a/client/state/current-user/constants.js
+++ b/client/state/current-user/constants.js
@@ -1,4 +1,5 @@
 export const DOMAINS_WITH_PLANS_ONLY = 'calypso_domains_with_plans_only';
 export const NON_PRIMARY_DOMAINS_TO_FREE_USERS = 'calypso_allow_nonprimary_domains_without_plan';
+export const CAN_SET_DOTBLOG_AS_PRIMARY = 'can_set_dotblog_as_primary';
 
 export const MARKETING_PRICE_GROUP_2020_Q2_TEST_1 = 'price_2020_q2_test_1';


### PR DESCRIPTION
Related to https://github.com/Automattic/martech/issues/3561

## Proposed Changes

This PR contains 2 changes:
* When the `CAMPAIGN_PRIMARY_DOTBLOG_ON_FREE_2024` flag is set for a user, allow the user to select a .blog domain and a free plan in the onboarding flow, without showing any dialog.
* When the `CAMPAIGN_PRIMARY_DOTBLOG_ON_FREE_2024` flag is set for a user, allow the user to select a .blog domain as primary for a free site on the `/domains/manage/<site slug>` screen.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Please see p5uIfZ-gr1-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Testing the onboarding flow

* Apply 168070-ghe-Automattic/wpcom
* Set the flag for your user by following the instructions in 168070-ghe-Automattic/wpcom
* Go to `/start`.
* Select a .blog domain. For testing, it's best to select a domain with random characters.
* On the plans step, select the Free plan.
* Confirm that you are not shown any dialog and are taken directly to checkout.
* If you don't have a .blog domain on the site, purchase it using credits for the next step.

### Testing setting the .blog domain as primary

* Apply 168070-ghe-Automattic/wpcom
* Set the flag for your user by following the instructions in 168070-ghe-Automattic/wpcom
* Go to `/domains/manage/<site slug>` where <site slug> is for a site on the free plan with a .blog domain mapped to it.
* Confirm that you see the dropdown for selecting a primary domain.
* Confirm that you can set the .blog domain as primary by clicking on the CTA.

<img width="1495" alt="image" src="https://github.com/user-attachments/assets/f5ec2523-8950-4f03-9124-7a741712800f">


### Testing to confirm that non .blog domains cannot be set as primary.

* Map a non .blog domain to the same site.
* Go to `/domains/manage/<site slug>`.
* Confirm that you see the dropdown for selecting a primary domain and both the .blog and non-.blog domains are present in the list.
* Select the non .blog domain.
* Confirm that the CTA is disabled and a message is shown below it:

<img width="1133" alt="image" src="https://github.com/user-attachments/assets/52c2675f-0d85-403d-ba12-8ed4222c8a62">

### Testing for regressions

* Delete the flag by following the instructions in 168070-ghe-Automattic/wpcom
* Go to `/domains/manage/<site slug>` for the same site.
* Confirm that the dropdown is not visible and you see a message for a plan upgrade.

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/c9219519-ddd1-42a0-ae04-653d3346c749">

* Please see `client/my-sites/domains/domain-management/components/primary-domain-selector/test/index.tsx` for additional cases.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?