### PR TITLE
Enable logged out for /me/account/closed

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -134,6 +134,11 @@ export const redirectInvalidLanguage = ( context, next ) => {
 
 export function redirectLoggedOut( context, next ) {
 	const state = context.store.getState();
+	// Allow logged-out users to access account deleted page for self-restore.
+	// This is an exception because /me should not allow enableLoggedOut.
+	if ( context.pathname === '/me/account/closed' ) {
+		return next();
+	}
 
 	if ( isUserLoggedIn( state ) ) {
 		next();

--- a/client/sections.js
+++ b/client/sections.js
@@ -39,6 +39,9 @@ const sections = [
 	},
 	{
 		name: 'account-close',
+		// /me/account/closed enables account restoration for logged-out users
+		// Parent route is private so enableLoggedOut flag won't work here
+		// Redirection is handled in redirectLoggedOut
 		paths: [ '/me/account/close', '/me/account/closed' ],
 		module: 'calypso/me/account-close',
 		group: 'me',


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9909

## Proposed Changes

* Enable logged out for /me/account/closed
* This should not change any existing behavior other than `/me/account/closed` page

Note that `/me/account/closed` currently defaults to the "Account is deleting" state but it's not doing anything. This is also the current production behavior if you are logged in and access `/me/account/closed` directly.
To be focused on enabling logged out for `/me/account/closed`, this will not be addressed in this PR.

![expected@2x](https://github.com/user-attachments/assets/7bd3c6eb-8ca3-4692-b883-aeb856279bb1)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Allow users to self-restore accounts pet6gk-1Em-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You are logged out
* Go to `calypso.localhost:3000/me/account/closed` and it should be accessible
* The other /me routes and will redirect to `/log-in?redirect_to=<where you wanted to go>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
