### PR TITLE
Remove `calypso_onboarding_goals_step_added_goals` experiment

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -73,62 +73,13 @@ function makeSortCategoryToTop( slugs: string[] ) {
 	};
 }
 
-const sortBlogToTop = makeSortCategoryToTop( [ CATEGORIES.BLOG ] );
-const sortStoreToTop = makeSortCategoryToTop( [ CATEGORIES.STORE ] );
-const sortBusinessToTop = makeSortCategoryToTop( [ CATEGORIES.BUSINESS ] );
+interface CategorizationOptions {
+	isMultiSelection?: boolean;
+}
 
 export function getCategorizationOptions(
-	intent: string,
 	goals: Onboard.SiteGoal[],
-	options: {
-		useGoals?: boolean;
-		isMultiSelection?: boolean;
-	} = {}
-) {
-	if ( options.useGoals ) {
-		return getCategorizationFromGoals( goals, options.isMultiSelection );
-	}
-	return getCategorizationFromIntent( intent );
-}
-
-function getCategorizationFromIntent( intent: string ) {
-	const result = {
-		defaultSelections: [] as string[],
-	} as {
-		defaultSelections: string[];
-		sort: ( a: Category, b: Category ) => 0 | 1 | -1;
-	};
-
-	switch ( intent ) {
-		case 'write':
-			return {
-				...result,
-				defaultSelections: [ CATEGORIES.BLOG ],
-				sort: sortBlogToTop,
-			};
-		case 'sell':
-			return {
-				...result,
-				defaultSelections: [ CATEGORIES.STORE ],
-				sort: sortStoreToTop,
-			};
-		case 'build':
-			return {
-				...result,
-				defaultSelections: [ CATEGORIES.BUSINESS ],
-				sort: sortBusinessToTop,
-			};
-		default:
-			return {
-				...result,
-				sort: sortBlogToTop,
-			};
-	}
-}
-
-function getCategorizationFromGoals(
-	goals: Onboard.SiteGoal[],
-	isMultiSelection: boolean = false
+	{ isMultiSelection = false }: CategorizationOptions = {}
 ) {
 	const defaultSelections = Array.from(
 		new Set(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -116,10 +116,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const variantName = experimentAssignment?.variationName;
 	const oldHighResImageLoading = ! isLoadingExperiment && variantName === 'treatment';
 
-	const [ isAddedGoalsExpLoading, addedGoalsExpAssignment ] = useExperiment(
-		'calypso_onboarding_goals_step_added_goals'
-	);
-
 	const isGoalsHoldout = useIsGoalsHoldout( stepName );
 
 	const isGoalCentricFeature = isEnabled( 'design-picker/goal-centric' ) && ! isGoalsHoldout;
@@ -232,8 +228,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		}
 	}, [ hasTrackedView, designs ] );
 
-	const categorizationOptions = getCategorizationOptions( intent, goals, {
-		useGoals: addedGoalsExpAssignment?.variationName === 'treatment',
+	const categorizationOptions = getCategorizationOptions( goals, {
 		isMultiSelection: isGoalCentricFeature,
 	} );
 	const categorization = useCategorization( allDesigns?.filters?.subject || EMPTY_OBJECT, {
@@ -812,7 +807,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	// ********** Main render logic
 
 	// Don't render until we've done fetching all the data needed for initial render.
-	if ( ! site || isLoadingDesigns || isAddedGoalsExpLoading ) {
+	if ( ! site || isLoadingDesigns ) {
 		return <StepperLoader />;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -1,5 +1,4 @@
 import { Onboard } from '@automattic/data-stores';
-import { useLocale, isLocaleRtl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { loadExperimentAssignment } from 'calypso/lib/explat';
@@ -8,11 +7,10 @@ import type { Goal } from './types';
 
 const SiteGoal = Onboard.SiteGoal;
 
-export const useGoals = ( isAddedGoalsExp: boolean ): Goal[] => {
+export const useGoals = (): Goal[] => {
 	loadExperimentAssignment( 'calypso_design_picker_image_optimization_202406' ); // Temporary for A/B test.
 
 	const translate = useTranslate();
-	const locale = useLocale();
 
 	const addedGoalsExpResult = useMemo( () => {
 		const goals = [
@@ -77,47 +75,5 @@ export const useGoals = ( isAddedGoalsExp: boolean ): Goal[] => {
 		return shuffleArray( goals );
 	}, [ translate ] );
 
-	const goals = [
-		{
-			key: SiteGoal.Write,
-			title: translate( 'Write & Publish' ),
-		},
-		{
-			key: SiteGoal.Sell,
-			title: translate( 'Sell online' ),
-		},
-		{
-			key: SiteGoal.Promote,
-			title: translate( 'Promote myself or business' ),
-		},
-		{
-			key: SiteGoal.DIFM,
-			title: translate( 'Let us build your site in 4 days' ),
-			isPremium: true,
-		},
-		{
-			key: SiteGoal.Import,
-			title: translate( 'Import existing content or website' ),
-		},
-		{
-			key: SiteGoal.Other,
-			title: translate( 'Other' ),
-		},
-	];
-
-	/**
-	 * Hides the DIFM goal for RTL locales.
-	 */
-	const hideDIFMGoalForUnsupportedLocales = ( { key }: Goal ) => {
-		if ( key === SiteGoal.DIFM && isLocaleRtl( locale ) ) {
-			return false;
-		}
-		return true;
-	};
-
-	if ( isAddedGoalsExp ) {
-		return addedGoalsExpResult;
-	}
-
-	return goals.filter( hideDIFMGoalForUnsupportedLocales );
+	return addedGoalsExpResult;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -12,7 +12,7 @@ export const useGoals = (): Goal[] => {
 
 	const translate = useTranslate();
 
-	const addedGoalsExpResult = useMemo( () => {
+	return useMemo( () => {
 		const goals = [
 			{
 				key: SiteGoal.Write,
@@ -74,6 +74,4 @@ export const useGoals = (): Goal[] => {
 
 		return shuffleArray( goals );
 	}, [ translate ] );
-
-	return addedGoalsExpResult;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -8,7 +8,6 @@ import DocumentHead from 'calypso/components/data/document-head';
 import { isGoalsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-big-sky-eligible';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useExperiment } from 'calypso/lib/explat';
 import { getQueryArgs } from 'calypso/lib/query-args';
 import DashboardIcon from './dashboard-icon';
 import { GoalsCaptureContainer } from './goals-capture-container';
@@ -44,18 +43,11 @@ const refGoals: Record< string, Onboard.SiteGoal[] > = {
  * The goals capture step
  */
 const GoalsStep: Step = ( { navigation } ) => {
-	const [ isAddedGoalsExpLoading, addedGoalsExpAssignment ] = useExperiment(
-		'calypso_onboarding_goals_step_added_goals'
-	);
-	const isAddedGoalsExp = addedGoalsExpAssignment?.variationName === 'treatment';
-
 	const translate = useTranslate();
-	const whatAreYourGoalsText = isAddedGoalsExp
-		? translate( 'What would you like to do?' )
-		: translate( 'What are your goals?' );
-	const subHeaderText = isAddedGoalsExp
-		? translate( 'Pick one or more goals and we’ll tailor the setup experience for you.' )
-		: translate( 'Tell us what would you like to accomplish with your website.' );
+	const whatAreYourGoalsText = translate( 'What would you like to do?' );
+	const subHeaderText = translate(
+		'Pick one or more goals and we’ll tailor the setup experience for you.'
+	);
 
 	const goals = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getGoals(),
@@ -161,10 +153,6 @@ const GoalsStep: Step = ( { navigation } ) => {
 
 	const isMediumOrBiggerScreen = useViewportMatch( 'small', '>=' );
 
-	if ( isAddedGoalsExpLoading ) {
-		return null;
-	}
-
 	return (
 		<>
 			<DocumentHead title={ whatAreYourGoalsText } />
@@ -173,18 +161,14 @@ const GoalsStep: Step = ( { navigation } ) => {
 				whatAreYourGoalsText={ whatAreYourGoalsText }
 				subHeaderText={ subHeaderText }
 				stepName="goals-step"
-				onSkip={ isAddedGoalsExp ? handleSkip : handleDashboardClick }
+				onSkip={ handleSkip }
 				goNext={ handleNext }
 				nextLabelText={ translate( 'Next' ) }
-				skipLabelText={ isAddedGoalsExp ? translate( 'Skip' ) : translate( 'Skip to dashboard' ) }
+				skipLabelText={ translate( 'Skip' ) }
 				recordTracksEvent={ recordTracksEvent }
 				stepContent={
 					<>
-						<SelectGoals
-							selectedGoals={ goals }
-							onChange={ setGoals }
-							isAddedGoalsExp={ isAddedGoalsExp }
-						/>
+						<SelectGoals selectedGoals={ goals } onChange={ setGoals } />
 						{ isMediumOrBiggerScreen && (
 							<Button
 								__next40pxDefaultSize
@@ -192,28 +176,26 @@ const GoalsStep: Step = ( { navigation } ) => {
 								variant="primary"
 								onClick={ handleNext }
 							>
-								{ isAddedGoalsExp ? translate( 'Next' ) : translate( 'Continue' ) }
+								{ translate( 'Next' ) }
 							</Button>
 						) }
-						{ isAddedGoalsExp && (
-							<div className="select-goals__alternative-flows-container">
-								<Button variant="link" onClick={ handleImportClick } className="select-goals__link">
-									{ translate( 'Import or migrate an existing site' ) }
-								</Button>
-								<span className="select-goals__link-separator" />
-								<Button variant="link" onClick={ handleDIFMClick } className="select-goals__link">
-									{ translate( 'Let us build a custom site for you' ) }
-								</Button>
-								<Button
-									variant="link"
-									onClick={ handleDashboardClick }
-									className="select-goals__link select-goals__dashboard-button"
-								>
-									<DashboardIcon />
-									{ translate( 'Skip to dashboard' ) }
-								</Button>
-							</div>
-						) }
+						<div className="select-goals__alternative-flows-container">
+							<Button variant="link" onClick={ handleImportClick } className="select-goals__link">
+								{ translate( 'Import or migrate an existing site' ) }
+							</Button>
+							<span className="select-goals__link-separator" />
+							<Button variant="link" onClick={ handleDIFMClick } className="select-goals__link">
+								{ translate( 'Let us build a custom site for you' ) }
+							</Button>
+							<Button
+								variant="link"
+								onClick={ handleDashboardClick }
+								className="select-goals__link select-goals__dashboard-button"
+							>
+								<DashboardIcon />
+								{ translate( 'Skip to dashboard' ) }
+							</Button>
+						</div>
 					</>
 				}
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -2,13 +2,11 @@ import { PremiumBadge } from '@automattic/components';
 import { Onboard } from '@automattic/data-stores';
 import { SelectCardCheckbox } from '@automattic/onboarding';
 import styled from '@emotion/styled';
-import { useTranslate } from 'i18n-calypso';
 import { useGoals } from './goals';
 
 type SelectGoalsProps = {
 	onChange: ( selectedGoals: Onboard.SiteGoal[] ) => void;
 	selectedGoals: Onboard.SiteGoal[];
-	isAddedGoalsExp: boolean;
 };
 
 const Placeholder = styled.div`
@@ -33,9 +31,8 @@ const Placeholder = styled.div`
 
 const SiteGoal = Onboard.SiteGoal;
 
-export const SelectGoals = ( { onChange, selectedGoals, isAddedGoalsExp }: SelectGoalsProps ) => {
-	const translate = useTranslate();
-	const goalOptions = useGoals( isAddedGoalsExp );
+export const SelectGoals = ( { onChange, selectedGoals }: SelectGoalsProps ) => {
+	const goalOptions = useGoals();
 
 	// *******************************************************************************
 	// ****  Experiment skeleton left in for future BBE (Goal) copy change tests  ****
@@ -69,9 +66,6 @@ export const SelectGoals = ( { onChange, selectedGoals, isAddedGoalsExp }: Selec
 	return (
 		<>
 			<div className="select-goals__cards-container">
-				{ ! isAddedGoalsExp && (
-					<div className="select-goals__cards-hint">{ translate( 'Select all that apply' ) }</div>
-				) }
 				{ /* We only need to show the goal loader only if the BBE goal will be displayed */ }
 				{ hasBuiltByExpressGoal && isBuiltByExpressExperimentLoading
 					? goalOptions.map( ( { key } ) => (


### PR DESCRIPTION



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

Removes code for assigning experiment participants, and any code that used the old control variant.
* Removes `calypso_onboarding_goals_step_added_goals` assignment code
* Removes code used by the `control` variant, since it's now dead code

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We're wrapping up the experiment p1733606517185389-slack-C07H21B2W59

We've collected plenty of data on the difference between the two experiences, and having the extra variation is going to add too many permutations to deal with while working on https://github.com/Automattic/wp-calypso/issues/96905

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test the `site-setup` flow. There should be no changes from the existing treatment experience.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?