### PR TITLE
Removed strictly typed checkbox labels

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
@@ -6,7 +6,6 @@ import { Page } from 'playwright';
  * @see client/landing/stepper/declarative-flow/site-setup-flow.ts for all step names
  */
 export type StepName = 'goals' | 'vertical' | 'intent' | 'designSetup' | 'options';
-type Goals = 'Write' | 'Promote' | 'Import Site' | 'Sell' | 'DIFM' | 'Other';
 type WriteActions = 'Start writing' | 'Start learning' | 'View designs';
 
 const selectors = {
@@ -86,7 +85,7 @@ export class StartSiteFlow {
 	 *
 	 * @param {string} goal The goal to select
 	 */
-	async selectGoal( goal: Goals ): Promise< void > {
+	async selectGoal( goal: string ): Promise< void > {
 		await this.page.click( selectors.goalButton( goal ) );
 		await this.page.waitForSelector( selectors.selectedGoalButton( goal ) );
 	}

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -143,9 +143,9 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 			page.waitForURL( /setup\/site-setup\/goals\?/, { timeout: 30 * 1000 } );
 		} );
 
-		it( 'Select "Sell" goal', async function () {
-			await startSiteFlow.selectGoal( 'Sell' );
-			await startSiteFlow.clickButton( 'Continue' );
+		it( 'Select "Sell services or digital goods" goal', async function () {
+			await startSiteFlow.selectGoal( 'Sell services or digital goods' );
+			await startSiteFlow.clickButton( 'Next' );
 		} );
 	} );
 

--- a/test/e2e/specs/onboarding/onboarding__write.ts
+++ b/test/e2e/specs/onboarding/onboarding__write.ts
@@ -79,9 +79,9 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 			expect( page.url() ).toContain( selectedFreeDomain );
 		} );
 
-		it( 'Select "Write" goal', async function () {
-			await startSiteFlow.selectGoal( 'Write' );
-			await startSiteFlow.clickButton( 'Continue' );
+		it( 'Select "Publish a blog" goal', async function () {
+			await startSiteFlow.selectGoal( 'Publish a blog' );
+			await startSiteFlow.clickButton( 'Next' );
 		} );
 
 		it( 'Select theme', async function () {


### PR DESCRIPTION
Fixes e2e tests that broke when https://github.com/Automattic/wp-calypso/pull/97203 was merged. I don't know why these tests ran during canary but not during CI ...

https://github.com/Automattic/wp-calypso/pull/97203 changes the goal checkbox labels, so the e2e selectors were no longer correct.