### PR TITLE
Update busy state for self-restore account

### DIFF
--- a/client/me/account-close/closed.jsx
+++ b/client/me/account-close/closed.jsx
@@ -79,16 +79,23 @@ function AccountDeletedPage() {
 					<Button variant="secondary" onClick={ onCancelClick }>
 						{ translate( 'Return to WordPress.com' ) }
 					</Button>
-					{ config.isEnabled( 'me/account-restore' ) && (
-						<Button
-							variant="link"
-							className="account-deleted__button-link"
-							onClick={ onRestoreClick }
-							isBusy={ isRestoring }
-						>
-							{ translate( 'I made a mistake! Restore my account' ) }
-						</Button>
-					) }
+					{ config.isEnabled( 'me/account-restore' ) &&
+						( isRestoring ? (
+							<div className="account-deleted__restoring">
+								<Spinner />
+								<span className="account-deleted__restoring-text">
+									{ translate( 'Restoring your account' ) }
+								</span>
+							</div>
+						) : (
+							<Button
+								variant="link"
+								className="account-deleted__button-link"
+								onClick={ onRestoreClick }
+							>
+								{ translate( 'I made a mistake! Restore my account' ) }
+							</Button>
+						) ) }
 				</div>
 			</BlankCanvas.Content>
 		</BlankCanvas>

--- a/client/me/account-close/closed.scss
+++ b/client/me/account-close/closed.scss
@@ -43,4 +43,16 @@
 			align-items: center;
 		}
 	}
+	.account-deleted__restoring {
+		display: flex;
+		align-items: center;
+		.components-spinner {
+			margin-top: 0;
+			margin-left: 0;
+		}
+		&-text {
+			font-size: 0.875rem;
+			color: var( --studio-gray-60 );
+		}
+	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9460

## Proposed Changes

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/user-attachments/assets/13e6e084-da84-45e4-aaec-835d8b680a57">  | <img src="https://github.com/user-attachments/assets/61cdd81c-6878-487a-890c-e82e07ed2366">|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/dotcom-forge/issues/9460#issuecomment-2499984797

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

For quick testing you can change `isRestoring` to `true` and see the new spinner in action, as this is only a layout change

To fully test the flow:
* Go to `/me/account/close` with a non a11n account and delete the account.
* Next click on "I made a mistake! Restore my account"
* Spinner should be the new version
* Test on mobile/desktop

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
