### PR TITLE
Design Picker: Update the feature categories

### DIFF
--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -6,8 +6,12 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { SHOW_ALL_SLUG } from '../constants';
 import { useFilteredDesigns } from '../hooks/use-filtered-designs';
-import { getAssemblerDesign, isDefaultGlobalStylesVariationSlug } from '../utils';
-import { isLockedStyleVariation } from '../utils/is-locked-style-variation';
+import {
+	getAssemblerDesign,
+	isDefaultGlobalStylesVariationSlug,
+	isFeatureCategory,
+	isLockedStyleVariation,
+} from '../utils';
 import DesignPickerCategoryFilter from './design-picker-category-filter';
 import DesignPickerTierFilter from './design-picker-tier-filter';
 import DesignPreviewImage from './design-preview-image';
@@ -227,14 +231,13 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 	const filteredDesigns = useFilteredDesigns( designs, categorization );
-	const features = [ 'blog', 'portfolio', 'podcast', 'store' ];
 	const featureCategories = useMemo(
-		() => ( categorization?.categories || [] ).filter( ( { slug } ) => features.includes( slug ) ),
+		() => ( categorization?.categories || [] ).filter( ( { slug } ) => isFeatureCategory( slug ) ),
 		[ categorization?.categories ]
 	);
 	const subjectCategories = useMemo(
 		() =>
-			( categorization?.categories || [] ).filter( ( { slug } ) => ! features.includes( slug ) ),
+			( categorization?.categories || [] ).filter( ( { slug } ) => ! isFeatureCategory( slug ) ),
 		[ categorization?.categories ]
 	);
 

--- a/packages/design-picker/src/constants.ts
+++ b/packages/design-picker/src/constants.ts
@@ -42,3 +42,14 @@ export const PREMIUM_THEME = 'premium';
 export const DOT_ORG_THEME = 'dot-org';
 export const BUNDLED_THEME = 'bundled';
 export const MARKETPLACE_THEME = 'marketplace';
+
+/**
+ * Categories
+ */
+export const FEATURE_CATEGORIES = {
+	BLOG: 'blog',
+	NEWSLETTER: 'newsletter',
+	PORTFOLIO: 'portfolio',
+	PODCAST: 'podcast',
+	STORE: 'store',
+};

--- a/packages/design-picker/src/utils/index.ts
+++ b/packages/design-picker/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './available-designs';
 export * from './designs';
 export * from './global-styles';
+export * from './is-feature-category';
 export * from './is-locked-style-variation';

--- a/packages/design-picker/src/utils/is-feature-category.ts
+++ b/packages/design-picker/src/utils/is-feature-category.ts
@@ -1,0 +1,5 @@
+import { FEATURE_CATEGORIES } from '../constants';
+
+const featureCategorySet = new Set( Object.values( FEATURE_CATEGORIES ) );
+
+export const isFeatureCategory = ( categorySlug: string ) => featureCategorySet.has( categorySlug );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10014

## Proposed Changes

* Make the `newsletter` as a feature category

![image](https://github.com/user-attachments/assets/6713004a-1c32-4122-9481-ea2060ad7bfb)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* On the Goals screen, select goals
* On the Design Picker screen, ensure the `newsletter` category is shown on the `subjects` list

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
