### PR TITLE
Stats: Fix StickyPanel header ID for Simple sites WP-Admin

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -434,6 +434,9 @@ class StatsSite extends Component {
 			'stats__flexible-grid-item--full--medium'
 		);
 
+		// TODO: Fix isOdysseyStats to include the environment running on WP-Admin of Simple sites.
+		const isRunningOnWPAdmin = document.getElementById( 'wpadminbar' );
+
 		return (
 			<div className="stats">
 				{ ! isOdysseyStats && (
@@ -472,7 +475,7 @@ class StatsSite extends Component {
 				) }
 				{ isNewDateFilteringEnabled && (
 					// moves date range block into new location
-					<StickyPanel headerId={ isOdysseyStats ? 'wpadminbar' : 'header' }>
+					<StickyPanel headerId={ isRunningOnWPAdmin ? 'wpadminbar' : 'header' }>
 						<StatsPeriodHeader>
 							<StatsPeriodNavigation
 								date={ date }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Detect the `#wpadminbar` DOM to set the header id for `StickyPanel` rather than relying on `isOdysseyStats`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Simple sites can visit `/wp-admin` for Jetpack Stats, whose `isOdysseyStats` flag has not been updated. The detection of `isOdysseyStats` to determine whether the `#wpadminbar` is available is unreliable.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
#### Calypso Stats
* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page for a Simple site.
* Ensure the date ranger header is stuck to the top of the window when scrolling down, which works as previously.

#### Odyssey Stats
* Run `cd apps/odyssey-stats && yarn dev --sync`.
* Sandbox `widgets.wp.com`.
* Navigate to a Simple site's `/wp-admin` page that has set the `Admin Interface Style` to `Classic style.`

<img width="638" alt="截圖 2024-12-09 下午3 17 00" src="https://github.com/user-attachments/assets/738f1013-d496-4348-8404-0cdf64ec175f">

* Click on the Jetpack > Stats item on the sidebar.
* Ensure the date ranger header of the Traffic page is stuck to the top of the window when scrolling down.

|Before|After|
|-|-|
|<img width="764" alt="截圖 2024-12-09 下午3 19 39" src="https://github.com/user-attachments/assets/d1a41629-f65e-44ca-8136-48b22c55d411">|<img width="926" alt="截圖 2024-12-09 下午3 19 10" src="https://github.com/user-attachments/assets/082046cc-7643-4ba4-be1f-899b5f1a7946">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
