### PR TITLE
Rename design picker filter category labels

### DIFF
--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -231,11 +231,11 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 	const filteredDesigns = useFilteredDesigns( designs, categorization );
-	const featureCategories = useMemo(
+	const categoryTypes = useMemo(
 		() => ( categorization?.categories || [] ).filter( ( { slug } ) => isFeatureCategory( slug ) ),
 		[ categorization?.categories ]
 	);
-	const subjectCategories = useMemo(
+	const categoryTopics = useMemo(
 		() =>
 			( categorization?.categories || [] ).filter( ( { slug } ) => ! isFeatureCategory( slug ) ),
 		[ categorization?.categories ]
@@ -248,11 +248,11 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	return (
 		<div>
 			<div className="design-picker__filters">
-				{ categorization && featureCategories.length && isMultiFilterEnabled && (
-					<DesignPickerFilterGroup title={ translate( 'Features' ) }>
+				{ categorization && categoryTypes.length && isMultiFilterEnabled && (
+					<DesignPickerFilterGroup title={ translate( 'Type' ) }>
 						<DesignPickerCategoryFilter
 							className="design-picker__category-filter"
-							categories={ featureCategories }
+							categories={ categoryTypes }
 							onSelect={ categorization.onSelect }
 							selectedSlugs={ categorization.selections }
 							isMultiSelection={ isMultiFilterEnabled }
@@ -260,14 +260,11 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						/>
 					</DesignPickerFilterGroup>
 				) }
-				{ categorization && subjectCategories.length && (
-					<DesignPickerFilterGroup
-						title={ isMultiFilterEnabled ? translate( 'Subjects' ) : '' }
-						grow
-					>
+				{ categorization && categoryTopics.length && (
+					<DesignPickerFilterGroup title={ isMultiFilterEnabled ? translate( 'Topic' ) : '' } grow>
 						<DesignPickerCategoryFilter
 							className="design-picker__category-filter"
-							categories={ isMultiFilterEnabled ? subjectCategories : categorization.categories }
+							categories={ isMultiFilterEnabled ? categoryTopics : categorization.categories }
 							onSelect={ categorization.onSelect }
 							selectedSlugs={ categorization.selections }
 							isMultiSelection={ isMultiFilterEnabled }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes: https://github.com/Automattic/dotcom-forge/issues/10092

## Proposed Changes

* Rename Filter label `Features` to `Type`
* Rename Filter label `Subjects` to `Topic`

<img width="826" alt="image" src="https://github.com/user-attachments/assets/1f759746-89c8-495f-9b27-14c575449a11">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit: `/setup/site-setup/designSetup?siteSlug=:slug&siteId=:id`
* Verify the design picker filters

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
