### PR TITLE
Help Center Support Experience: Up to 75%

### DIFF
--- a/packages/help-center/src/components/utils.tsx
+++ b/packages/help-center/src/components/utils.tsx
@@ -141,7 +141,7 @@ export const matchSupportInteractionId = (
 };
 
 export const isUseHelpCenterExperienceEnabled = ( userId: number ): boolean => {
-	if ( ! userId || userId % 100 > 50 ) {
+	if ( ! userId || userId % 100 < 75 ) {
 		return false;
 	}
 	return true;


### PR DESCRIPTION
Following what has been done [here](https://github.com/Automattic/wp-calypso/pull/97119), PR that released the new Help Center Experience to 50% of users.

 APIs usage has been stable.

This PR ships the new experience to 75% of users.