### PR TITLE
Tooltip left alignment

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -109,7 +109,6 @@ export enum ChartSourceOptions {
 
 // Define the available date range options
 enum ChartSourceDateRanges {
-	TODAY = 'today',
 	YESTERDAY = 'yesterday',
 	LAST_7_DAYS = 'last_7_days',
 	LAST_14_DAYS = 'last_14_days',
@@ -119,7 +118,6 @@ enum ChartSourceDateRanges {
 
 // User facing strings for date ranges
 const ChartSourceDateRangeLabels = {
-	[ ChartSourceDateRanges.TODAY ]: __( 'Today' ),
 	[ ChartSourceDateRanges.YESTERDAY ]: __( 'Yesterday' ),
 	[ ChartSourceDateRanges.LAST_7_DAYS ]: __( 'Last 7 days' ),
 	[ ChartSourceDateRanges.LAST_14_DAYS ]: __( 'Last 14 days' ),
@@ -321,8 +319,7 @@ export default function CampaignItemDetails( props: Props ) {
 	const updateChartParams = ( newDateRange: ChartSourceDateRanges ) => {
 		// These shorter time frames can show hourly data, we can show up to 30 days of hourly data (max days stored in Druid)
 		const newResolution =
-			[ ChartSourceDateRanges.TODAY, ChartSourceDateRanges.YESTERDAY ].includes( newDateRange ) ||
-			activeDays < 3
+			newDateRange === ChartSourceDateRanges.YESTERDAY || activeDays < 3
 				? ChartResolution.Hour
 				: ChartResolution.Day;
 
@@ -453,16 +450,11 @@ export default function CampaignItemDetails( props: Props ) {
 	const chartControls = [];
 
 	// Some controls are conditional, depending on how long the campaign has been active, or if the campaign is in the past
-	// It would be pointless showing "today" to a finished campaign, or 30 days to a 7-day campaign
+	// It would be pointless showing "yesterday" to a finished campaign, or 30 days to a 7-day campaign
 	const conditionalControls = [
 		{
 			condition: ! campaignIsFinished,
 			controls: [
-				{
-					onClick: () => updateChartParams( ChartSourceDateRanges.TODAY ),
-					title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.TODAY ],
-					isDisabled: selectedDateRange === ChartSourceDateRanges.TODAY,
-				},
 				{
 					onClick: () => updateChartParams( ChartSourceDateRanges.YESTERDAY ),
 					title: ChartSourceDateRangeLabels[ ChartSourceDateRanges.YESTERDAY ],

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -1305,7 +1305,6 @@ $break-huge-collapsed-menu: $break-huge - 222px;
 		padding: 8px 10px;
 		border-radius: 4px;
 		display: none;
-		text-align: center;
 		min-width: 60px;
 	}
 


### PR DESCRIPTION
## Proposed Changes

* Makes the tooltip text left aligned, request from Bart.
* Remove today, it is often the case that it doesn't have enough data


<img width="415" alt="Screenshot 2024-12-09 at 11 09 14" src="https://github.com/user-attachments/assets/f916775c-5bb9-42b0-8c87-a2c0bb822980">

![Screenshot 2024-12-09 at 16 06 28](https://github.com/user-attachments/assets/91ceda1f-3eea-491c-a549-0c5655724ade)


## Testing Instructions

Load a campaign using the calypso live link in the comments,  go to view the campaign details
- tooltip should have text left aligned
- Today should not be an option for the chart date filters

![Screenshot 2024-12-09 at 11 08 09](https://github.com/user-attachments/assets/31c4e454-9b00-4329-a4c4-1860d55eda63)



https://github.com/user-attachments/assets/d7225f46-e07c-4f00-bbcd-df2f60202a40



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
