### PR TITLE
Holiday Snow: do not display settings for P2s

### DIFF
--- a/client/sites/settings/site/form.jsx
+++ b/client/sites/settings/site/form.jsx
@@ -15,6 +15,7 @@ export default function SiteSettingsForm( {
 	isUnlaunchedSite,
 	isAtomicAndEditingToolkitDeactivated,
 	isWpcomStagingSite,
+	isWPForTeamsSite,
 	fields,
 	updateFields,
 	onChangeField,
@@ -71,7 +72,7 @@ export default function SiteSettingsForm( {
 				urlRef="unlaunched-settings"
 			/>
 
-			{ ! siteIsJetpack && (
+			{ ! siteIsJetpack && ! isWPForTeamsSite && (
 				<HolidaySnow
 					fields={ fields }
 					handleToggle={ handleToggle }

--- a/client/sites/settings/site/index.tsx
+++ b/client/sites/settings/site/index.tsx
@@ -5,6 +5,7 @@ import wrapSettingsForm from 'calypso/my-sites/site-settings/wrap-settings-form'
 import { useSelector } from 'calypso/state';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import getIsUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { useSelectedSiteSelector } from 'calypso/state/sites/hooks';
 import { getSiteOption, isJetpackSite } from 'calypso/state/sites/selectors';
@@ -26,6 +27,7 @@ export function SiteSettings( props: any ) {
 	const isAtomic = useSelectedSiteSelector( isAtomicSite );
 	const isAtomicAndEditingToolkitDeactivated = isAtomic && editingToolkitIsActive === false;
 	const isWpcomStagingSite = useSelectedSiteSelector( isSiteWpcomStaging );
+	const isWPForTeamsSite = useSelectedSiteSelector( isSiteWPForTeams );
 
 	const additionalProps = {
 		site,
@@ -33,6 +35,7 @@ export function SiteSettings( props: any ) {
 		isUnlaunchedSite,
 		isAtomicAndEditingToolkitDeactivated,
 		isWpcomStagingSite,
+		isWPForTeamsSite,
 	};
 
 	return (


### PR DESCRIPTION
Follow-up to #97127

## Proposed Changes

Holiday Snow does not currently work on p2s, so let's not show the toggle.

## Why are these changes being made?

The snowstorm library we use to display falling snow is not compatible with p2s. Let's consequently not offer the option to turn on snow on p2s.

## Testing Instructions

* Load this branch
* Go to `/settings/general/yourp2site.wordpress.com?flags=-untangling/hosting-menu`
    * You should not see the Holiday snow option
* Now switch to a different, not p2 site
    * You should see the option.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
