### PR TITLE
Hide back to sites on mobile

### DIFF
--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -264,6 +264,12 @@ body.is-section-stepper .domains__step-content,
 						margin: 48px 0 40px;
 					}
 				}
+
+				.action-buttons.step-container__navigation {
+					@media (max-width: $break-mobile) {
+						display: none;
+					}
+				}
 			}
 			.formatted-header__title {
 				font-size: 2rem;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
| Before  | After |
| ------------- | ------------- |
| <img width="375" alt="Screenshot 2024-12-09 at 16 14 11" src="https://github.com/user-attachments/assets/96cafe70-ad9c-4e06-832e-070b12024653">  | <img width="377" alt="Screenshot 2024-12-09 at 16 13 54" src="https://github.com/user-attachments/assets/765036c9-7c6b-4677-8d41-be3d1f2a5160">  |


Fixes https://github.com/Automattic/wp-calypso/issues/97179

## Proposed Changes

* Hide back to sites on mobile

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The onboarding flow should behave exactly like /start

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/setup/onboarding/domains` with mobile viewport
* Check if "Back to sites" is hidden

