### PR TITLE
Payment Methods: handle PPCP as PayPal method in list and receipts

### DIFF
--- a/client/lib/checkout/payment-methods.tsx
+++ b/client/lib/checkout/payment-methods.tsx
@@ -12,8 +12,13 @@ import payPalImage from 'calypso/assets/images/upgrades/paypal.svg';
 import razorpayImage from 'calypso/assets/images/upgrades/upi.svg';
 
 export const PARTNER_PAYPAL_EXPRESS = 'paypal_express';
+export const PARTNER_PAYPAL_PPCP = 'paypal_ppcp';
 export const PARTNER_RAZORPAY = 'razorpay';
-export const PAYMENT_AGREEMENTS_PARTNERS = [ PARTNER_PAYPAL_EXPRESS, PARTNER_RAZORPAY ];
+export const PAYMENT_AGREEMENTS_PARTNERS = [
+	PARTNER_PAYPAL_EXPRESS,
+	PARTNER_PAYPAL_PPCP,
+	PARTNER_RAZORPAY,
+];
 export const UPI_PARTNERS = [ PARTNER_RAZORPAY ];
 
 /**
@@ -53,7 +58,7 @@ export interface StoredPaymentMethodBase {
 }
 
 export interface StoredPaymentMethodPayPal extends StoredPaymentMethodBase {
-	payment_partner: 'paypal_express';
+	payment_partner: 'paypal_express' | 'paypal_ppcp';
 }
 
 export interface StoredPaymentMethodRazorpay extends StoredPaymentMethodBase {
@@ -125,8 +130,9 @@ const CREDIT_CARD_SELECTED_PATHS: ImagePathsMap = {
 	mastercard: creditCardMasterCardImage,
 	unionpay: creditCardUnionPayImage,
 	visa: creditCardVisaImage,
-	paypal_express: payPalImage,
 	paypal: payPalImage,
+	paypal_express: payPalImage,
+	paypal_ppcp: payPalImage,
 	razorpay: razorpayImage,
 };
 
@@ -148,7 +154,7 @@ export const PaymentMethodSummary = ( {
 	email?: string;
 } ) => {
 	const translate = useTranslate();
-	if ( type === PARTNER_PAYPAL_EXPRESS ) {
+	if ( type === PARTNER_PAYPAL_EXPRESS || type === PARTNER_PAYPAL_PPCP ) {
 		return <>{ email || '' }</>;
 	}
 	if ( type === PARTNER_RAZORPAY ) {

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -21,7 +21,7 @@ import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import TextareaAutosize from 'calypso/components/textarea-autosize';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { PARTNER_PAYPAL_EXPRESS } from 'calypso/lib/checkout/payment-methods';
+import { PARTNER_PAYPAL_EXPRESS, PARTNER_PAYPAL_PPCP } from 'calypso/lib/checkout/payment-methods';
 import { billingHistory, vatDetails as vatDetailsPath } from 'calypso/me/purchases/paths';
 import titles from 'calypso/me/purchases/titles';
 import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
@@ -207,7 +207,10 @@ function ReceiptPaymentMethod( { transaction }: { transaction: BillingTransactio
 	const translate = useTranslate();
 	let text;
 
-	if ( transaction.pay_part === PARTNER_PAYPAL_EXPRESS ) {
+	if (
+		transaction.pay_part === PARTNER_PAYPAL_EXPRESS ||
+		transaction.pay_part === PARTNER_PAYPAL_PPCP
+	) {
 		text = translate( 'PayPal' );
 	} else if ( 'XXXX' !== transaction.cc_num ) {
 		text = translate( '%(cardType)s ending in %(cardNum)s', {


### PR DESCRIPTION
As part of the PayPal API migration to the PPCP API, we need to handle PPCP stored payment methods in a similar manner to PayPal express methods. This includes the following:

- On the payment method list (from Me > Purchases > Payment Methods):
  - Using the PayPal email address to identify the method
  - Hiding the option to "use as backup"
  - Showing the PayPal icon
  - Fixing the list of associated subscriptions on the "delete this payment method" confirmation modal
- On the receipt view for a PPCP transaction (from Me > Purchases > Billing History):
  - Setting the payment method to "PayPal"

Ultimately, we just need to include the `paypal_ppcp` payment partner key anywhere that the `paypal_express` one is currently used.

![Screenshot 2024-12-09 at 11 01 55 AM](https://github.com/user-attachments/assets/d8c061bd-014b-4891-804d-4722c1cf7c3a)
![Screenshot 2024-12-09 at 11 02 21 AM](https://github.com/user-attachments/assets/429e6f1b-653d-41b1-9167-960eb0e753c9)
<img width="678" alt="Screenshot 2024-12-09 at 11 02 52 AM" src="https://github.com/user-attachments/assets/d871e09f-8be3-4ac6-b00a-45673fc0eab5">


**To test:**
- Make a PayPal PPCP purchase (or five) in Checkout using the `PayPal (A8C-only)` payment method option
- Visit the payment method list (from Me > Purchases > Payment Methods)
- Verify that the changes above have been made
- Click "delete this payment method"
- Verify that the associated subscriptions for the payment method are all listed
- Visit your billing history and select a receipt from the PPCP purchases
- Verify that "PayPal" is shown as the payment method