### PR TITLE
Plugins: allow VideoPress standalone installation

### DIFF
--- a/client/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin/index.ts
+++ b/client/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin/index.ts
@@ -1,7 +1,6 @@
 import {
 	WPCOM_FEATURES_REAL_TIME_BACKUPS,
 	WPCOM_FEATURES_SCAN,
-	// WPCOM_FEATURES_VIDEOPRESS,
 	FEATURE_REPUBLICIZE,
 	WPCOM_FEATURES_CLASSIC_SEARCH,
 } from '@automattic/calypso-products';
@@ -25,7 +24,6 @@ export default function useAtomicSiteHasEquivalentFeatureToPlugin( pluginSlug: s
 	const atomicFeaturesIncludedInPluginsMap = {
 		'jetpack-backup': WPCOM_FEATURES_REAL_TIME_BACKUPS,
 		'jetpack-protect': WPCOM_FEATURES_SCAN,
-		// 'jetpack-videopress': WPCOM_FEATURES_VIDEOPRESS,
 		'jetpack-social': FEATURE_REPUBLICIZE,
 		'jetpack-search': WPCOM_FEATURES_CLASSIC_SEARCH,
 	};

--- a/client/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin/index.ts
+++ b/client/my-sites/plugins/use-atomic-site-has-equivalent-feature-to-plugin/index.ts
@@ -1,7 +1,7 @@
 import {
 	WPCOM_FEATURES_REAL_TIME_BACKUPS,
 	WPCOM_FEATURES_SCAN,
-	WPCOM_FEATURES_VIDEOPRESS,
+	// WPCOM_FEATURES_VIDEOPRESS,
 	FEATURE_REPUBLICIZE,
 	WPCOM_FEATURES_CLASSIC_SEARCH,
 } from '@automattic/calypso-products';
@@ -25,7 +25,7 @@ export default function useAtomicSiteHasEquivalentFeatureToPlugin( pluginSlug: s
 	const atomicFeaturesIncludedInPluginsMap = {
 		'jetpack-backup': WPCOM_FEATURES_REAL_TIME_BACKUPS,
 		'jetpack-protect': WPCOM_FEATURES_SCAN,
-		'jetpack-videopress': WPCOM_FEATURES_VIDEOPRESS,
+		// 'jetpack-videopress': WPCOM_FEATURES_VIDEOPRESS,
 		'jetpack-social': FEATURE_REPUBLICIZE,
 		'jetpack-search': WPCOM_FEATURES_CLASSIC_SEARCH,
 	};


### PR DESCRIPTION
Related to p1HpG7-v3V-p2

## Proposed Changes
Remove feature-to-plugin mapping for VideoPress.

## Why are these changes being made?
The assumption that the plugin should not be installed due to the feature being available for the user is not correct in the case of VideoPress. VideoPress standalone implements the VideoPress dashboard, which can't be found anywhere else.

p1HpG7-v3V-p2

p1733765449709419-slack-C02LK1W8T4Z

## Testing Instructions
Have some AT site ready, use the calypso.live link below.

Visit the plugins section on your AT site and search for VideoPress. Access the plugin details and see the CTA "Install and activate" button is enabled. Install the plugin and confirm the process succeeds.

Look for the VideoPress entry under the Jetpack sidebar menu, click it to see the VideoPress dashboard.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?