### PR TITLE
Domain management: Match component design in the case where user has Mailboxes

### DIFF
--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -209,6 +209,7 @@ export default {
 
 				<EmailHome
 					source={ pageContext.query.source }
+					context={ pageContext.section.name }
 					selectedDomainName={ pageContext.params.domain }
 					selectedEmailProviderSlug={ pageContext.query.provider }
 					selectedIntervalLength={ castIntervalLength( pageContext.query.interval ) }

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -32,8 +32,13 @@ import './style.scss';
 
 const ContentWithHeader = ( props: { children: ReactNode } ) => {
 	const translate = useTranslate();
+	const isAllDomainManagementEnabled = isEnabled( 'calypso/all-domain-management' );
+
 	return (
-		<Main wideLayout>
+		<Main
+			wideLayout
+			className={ clsx( { 'context-all-domain-management': isAllDomainManagementEnabled } ) }
+		>
 			<DocumentHead title={ translate( 'Emails', { textOnly: true } ) } />
 
 			<EmailHeader />
@@ -154,7 +159,9 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 					// `/email/:site_slug` page to `/email/:domain/manage/:site_slug`. That's why
 					// we also hide the back button, to avoid scenarios where clicking "Back"
 					// redirects users to the same page as they are currently on.
-					hideHeaderCake={ isSingleDomainThatHasEmail }
+					hideHeaderCake={ isAllDomainManagementEnabled || isSingleDomainThatHasEmail }
+					hideHeader={ isAllDomainManagementEnabled }
+					hidePlanActions={ isAllDomainManagementEnabled }
 					selectedSite={ selectedSite }
 					source={ source }
 				/>

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -2,6 +2,7 @@ import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import React, { ReactNode } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
@@ -26,14 +27,12 @@ import { createSiteDomainObject } from 'calypso/state/sites/domains/assembler';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { TranslateResult } from 'i18n-calypso';
-import type { ReactNode } from 'react';
 
 import './style.scss';
 
-interface ContentWithHeaderProps {
-	children: ReactNode;
+type ContentWithHeaderProps = React.PropsWithChildren< {
 	className?: string;
-}
+} >;
 const ContentWithHeader = ( { children, className }: ContentWithHeaderProps ) => {
 	const translate = useTranslate();
 

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -164,6 +164,7 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 					hideHeaderCake={ isAllDomainManagementContext || isSingleDomainThatHasEmail }
 					hideHeader={ isAllDomainManagementContext }
 					hidePlanActions={ isAllDomainManagementContext }
+					hideMailPoetUpsell={ isAllDomainManagementContext }
 					selectedSite={ selectedSite }
 					source={ source }
 				/>

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
 import clsx from 'clsx';
@@ -73,6 +72,7 @@ interface EmailManagementHomeProps {
 	selectedIntervalLength?: IntervalLength;
 	showActiveDomainList?: boolean;
 	source: string;
+	context?: 'domains' | 'email' | string;
 }
 
 const domainHasEmail = ( domain: ResponseDomain ) =>
@@ -87,6 +87,7 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 		selectedIntervalLength,
 		sectionHeaderLabel,
 		source,
+		context,
 	} = props;
 
 	const selectedSite = useSelector( getSelectedSite );
@@ -98,7 +99,7 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 		return canCurrentUser( state, selectedSite.ID, 'manage_options' );
 	} );
 	const hasSitesLoaded = useSelector( hasLoadedSites );
-	const isAllDomainManagementEnabled = isEnabled( 'calypso/all-domain-management' );
+	const isAllDomainManagementEnabled = context === 'domains';
 
 	const addEmailForwardMutationActive = useAddEmailForwardMutationIsLoading();
 

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -30,20 +30,21 @@ import type { ReactNode } from 'react';
 
 import './style.scss';
 
-const ContentWithHeader = ( props: { children: ReactNode } ) => {
+interface ContentWithHeaderProps {
+	children: ReactNode;
+	className?: string;
+}
+const ContentWithHeader = ( props: ContentWithHeaderProps ) => {
 	const translate = useTranslate();
-	const isAllDomainManagementEnabled = isEnabled( 'calypso/all-domain-management' );
+	const { children, className } = props;
 
 	return (
-		<Main
-			wideLayout
-			className={ clsx( { 'context-all-domain-management': isAllDomainManagementEnabled } ) }
-		>
+		<Main wideLayout className={ className }>
 			<DocumentHead title={ translate( 'Emails', { textOnly: true } ) } />
 
 			<EmailHeader />
 
-			{ props.children }
+			{ children }
 		</Main>
 	);
 };
@@ -152,7 +153,9 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 		}
 
 		return (
-			<ContentWithHeader>
+			<ContentWithHeader
+				className={ clsx( { 'context-all-domain-management': isAllDomainManagementEnabled } ) }
+			>
 				<EmailPlan
 					domain={ selectedDomain }
 					// When users have a single domain with email, they are auto-redirected from the

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -99,7 +99,7 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 		return canCurrentUser( state, selectedSite.ID, 'manage_options' );
 	} );
 	const hasSitesLoaded = useSelector( hasLoadedSites );
-	const isAllDomainManagementEnabled = context === 'domains';
+	const isAllDomainManagementContext = context === 'domains';
 
 	const addEmailForwardMutationActive = useAddEmailForwardMutationIsLoading();
 
@@ -135,13 +135,13 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 		if ( ! domainHasEmail( selectedDomain ) ) {
 			return (
 				<EmailProvidersStackedComparisonPage
-					className={ clsx( { 'context-all-domain-management': isAllDomainManagementEnabled } ) }
+					className={ clsx( { 'context-all-domain-management': isAllDomainManagementContext } ) }
 					comparisonContext="email-home-selected-domain"
 					selectedDomainName={ selectedDomainName }
 					selectedEmailProviderSlug={ selectedEmailProviderSlug }
 					selectedIntervalLength={ selectedIntervalLength }
 					source={ source }
-					hideNavigation={ isAllDomainManagementEnabled }
+					hideNavigation={ isAllDomainManagementContext }
 				/>
 			);
 		}

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -34,9 +34,8 @@ interface ContentWithHeaderProps {
 	children: ReactNode;
 	className?: string;
 }
-const ContentWithHeader = ( props: ContentWithHeaderProps ) => {
+const ContentWithHeader = ( { children, className }: ContentWithHeaderProps ) => {
 	const translate = useTranslate();
-	const { children, className } = props;
 
 	return (
 		<Main wideLayout className={ className }>

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -1,5 +1,7 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
@@ -96,6 +98,7 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 		return canCurrentUser( state, selectedSite.ID, 'manage_options' );
 	} );
 	const hasSitesLoaded = useSelector( hasLoadedSites );
+	const isAllDomainManagementEnabled = isEnabled( 'calypso/all-domain-management' );
 
 	const addEmailForwardMutationActive = useAddEmailForwardMutationIsLoading();
 
@@ -131,11 +134,13 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 		if ( ! domainHasEmail( selectedDomain ) ) {
 			return (
 				<EmailProvidersStackedComparisonPage
+					className={ clsx( { 'context-all-domain-management': isAllDomainManagementEnabled } ) }
 					comparisonContext="email-home-selected-domain"
 					selectedDomainName={ selectedDomainName }
 					selectedEmailProviderSlug={ selectedEmailProviderSlug }
 					selectedIntervalLength={ selectedIntervalLength }
 					source={ source }
+					hideNavigation={ isAllDomainManagementEnabled }
 				/>
 			);
 		}

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -154,7 +154,7 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 
 		return (
 			<ContentWithHeader
-				className={ clsx( { 'context-all-domain-management': isAllDomainManagementEnabled } ) }
+				className={ clsx( { 'context-all-domain-management': isAllDomainManagementContext } ) }
 			>
 				<EmailPlan
 					domain={ selectedDomain }
@@ -162,9 +162,9 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 					// `/email/:site_slug` page to `/email/:domain/manage/:site_slug`. That's why
 					// we also hide the back button, to avoid scenarios where clicking "Back"
 					// redirects users to the same page as they are currently on.
-					hideHeaderCake={ isAllDomainManagementEnabled || isSingleDomainThatHasEmail }
-					hideHeader={ isAllDomainManagementEnabled }
-					hidePlanActions={ isAllDomainManagementEnabled }
+					hideHeaderCake={ isAllDomainManagementContext || isSingleDomainThatHasEmail }
+					hideHeader={ isAllDomainManagementContext }
+					hidePlanActions={ isAllDomainManagementContext }
 					selectedSite={ selectedSite }
 					source={ source }
 				/>

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -46,19 +46,20 @@ const MailboxListHeader = ( {
 	const translate = useTranslate();
 	const isGoogle = isGoogleEmailAccount( { accountType } );
 
+	const HeaderIcon = () => (
+		<div className="email-plan-mailboxes-list__mailbox-header-icon">
+			{ isGoogle && <GoogleIcon /> }
+			{ ! isGoogle && <Icon icon={ wordpress } /> }
+		</div>
+	);
+
 	return (
 		<div className="email-plan-mailboxes-list__mailbox-list">
 			<SectionHeader
 				isPlaceholder={ isPlaceholder }
 				label={
 					<>
-						{ !! showIcon && (
-							<>
-								{ isGoogle && <GoogleIcon /> }
-								{ ! isGoogle && <Icon icon={ wordpress } /> }
-								&nbsp;
-							</>
-						) }
+						{ !! showIcon && <HeaderIcon /> }
 						{ getListHeaderTextForAccountType( accountType, translate ) }
 					</>
 				}

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -6,6 +6,7 @@ import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import ExternalLink from 'calypso/components/external-link';
 import SectionHeader from 'calypso/components/section-header';
+import GoogleIcon from 'calypso/components/social-icons/google';
 import { isRecentlyRegistered } from 'calypso/lib/domains/utils';
 import {
 	getEmailAddress,
@@ -14,6 +15,7 @@ import {
 	isEmailForwardAccount,
 	isEmailUserAdmin,
 	isTitanMailAccount,
+	isGoogleEmailAccount,
 } from 'calypso/lib/emails';
 import { EMAIL_ACCOUNT_TYPE_FORWARD } from 'calypso/lib/emails/email-provider-constants';
 import { getGSuiteSubscriptionStatus, getGmailUrl } from 'calypso/lib/gsuite';
@@ -39,8 +41,10 @@ const MailboxListHeader = ( {
 	children,
 	isPlaceholder = false,
 	addMailboxPath,
+	showIcon,
 } ) => {
 	const translate = useTranslate();
+	const isGoogle = isGoogleEmailAccount( { accountType } );
 
 	return (
 		<div className="email-plan-mailboxes-list__mailbox-list">
@@ -48,8 +52,13 @@ const MailboxListHeader = ( {
 				isPlaceholder={ isPlaceholder }
 				label={
 					<>
-						<Icon icon={ wordpress } />
-						&nbsp;
+						{ !! showIcon && (
+							<>
+								{ isGoogle && <GoogleIcon /> }
+								{ ! isGoogle && <Icon icon={ wordpress } /> }
+								&nbsp;
+							</>
+						) }
 						{ getListHeaderTextForAccountType( accountType, translate ) }
 					</>
 				}

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -1,4 +1,6 @@
 import { Badge, CompactCard, Gridicon, MaterialIcon } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { Icon, wordpress } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -32,15 +34,32 @@ const getListHeaderTextForAccountType = ( accountType, translate ) => {
 	} );
 };
 
-const MailboxListHeader = ( { accountType = null, children, isPlaceholder = false } ) => {
+const MailboxListHeader = ( {
+	accountType = null,
+	children,
+	isPlaceholder = false,
+	addMailboxPath,
+} ) => {
 	const translate = useTranslate();
 
 	return (
 		<div className="email-plan-mailboxes-list__mailbox-list">
 			<SectionHeader
 				isPlaceholder={ isPlaceholder }
-				label={ getListHeaderTextForAccountType( accountType, translate ) }
-			/>
+				label={
+					<>
+						<Icon icon={ wordpress } />
+						&nbsp;
+						{ getListHeaderTextForAccountType( accountType, translate ) }
+					</>
+				}
+			>
+				{ addMailboxPath && (
+					<Button isLink="link" href={ addMailboxPath }>
+						{ translate( 'Add mailbox' ) }
+					</Button>
+				) }
+			</SectionHeader>
 			{ children }
 		</div>
 	);
@@ -107,7 +126,7 @@ function MailboxLink( { account, mailbox } ) {
 	);
 }
 
-function EmailPlanMailboxesList( { account, domain, isLoadingEmails, mailboxes } ) {
+function EmailPlanMailboxesList( { account, domain, isLoadingEmails, mailboxes, addMailboxPath } ) {
 	const translate = useTranslate();
 	const accountType = account?.account_type;
 
@@ -170,7 +189,11 @@ function EmailPlanMailboxesList( { account, domain, isLoadingEmails, mailboxes }
 		);
 	} );
 
-	return <MailboxListHeader accountType={ accountType }>{ mailboxItems }</MailboxListHeader>;
+	return (
+		<MailboxListHeader accountType={ accountType } addMailboxPath={ addMailboxPath }>
+			{ mailboxItems }
+		</MailboxListHeader>
+	);
 }
 
 EmailPlanMailboxesList.propTypes = {
@@ -178,6 +201,7 @@ EmailPlanMailboxesList.propTypes = {
 	domain: PropTypes.object,
 	isLoadingEmails: PropTypes.bool,
 	mailboxes: PropTypes.array,
+	addMailboxPath: PropTypes.string,
 };
 
 export default EmailPlanMailboxesList;

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -199,7 +199,11 @@ function EmailPlanMailboxesList( { account, domain, isLoadingEmails, mailboxes, 
 	} );
 
 	return (
-		<MailboxListHeader accountType={ accountType } addMailboxPath={ addMailboxPath }>
+		<MailboxListHeader
+			accountType={ accountType }
+			addMailboxPath={ addMailboxPath }
+			showIcon={ !! addMailboxPath }
+		>
 			{ mailboxItems }
 		</MailboxListHeader>
 	);

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -1,12 +1,10 @@
 import { Badge, CompactCard, Gridicon, MaterialIcon } from '@automattic/components';
 import { Button } from '@wordpress/components';
-import { Icon, wordpress } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import ExternalLink from 'calypso/components/external-link';
 import SectionHeader from 'calypso/components/section-header';
-import GoogleIcon from 'calypso/components/social-icons/google';
 import { isRecentlyRegistered } from 'calypso/lib/domains/utils';
 import {
 	getEmailAddress,
@@ -15,13 +13,13 @@ import {
 	isEmailForwardAccount,
 	isEmailUserAdmin,
 	isTitanMailAccount,
-	isGoogleEmailAccount,
 } from 'calypso/lib/emails';
 import { EMAIL_ACCOUNT_TYPE_FORWARD } from 'calypso/lib/emails/email-provider-constants';
 import { getGSuiteSubscriptionStatus, getGmailUrl } from 'calypso/lib/gsuite';
 import { getTitanEmailUrl, useTitanAppsUrlPrefix } from 'calypso/lib/titan';
 import EmailMailboxActionMenu from 'calypso/my-sites/email/email-management/home/email-mailbox-action-menu';
 import EmailMailboxWarnings from 'calypso/my-sites/email/email-management/home/email-mailbox-warnings';
+import EmailTypeIcon from 'calypso/my-sites/email/email-management/home/email-type-icon';
 import { recordEmailAppLaunchEvent } from './utils';
 
 const getListHeaderTextForAccountType = ( accountType, translate ) => {
@@ -41,15 +39,14 @@ const MailboxListHeader = ( {
 	children,
 	isPlaceholder = false,
 	addMailboxPath,
+	domain,
 	showIcon,
 } ) => {
 	const translate = useTranslate();
-	const isGoogle = isGoogleEmailAccount( { accountType } );
 
 	const HeaderIcon = () => (
 		<div className="email-plan-mailboxes-list__mailbox-header-icon">
-			{ isGoogle && <GoogleIcon /> }
-			{ ! isGoogle && <Icon icon={ wordpress } /> }
+			<EmailTypeIcon domain={ domain } />
 		</div>
 	);
 
@@ -59,7 +56,7 @@ const MailboxListHeader = ( {
 				isPlaceholder={ isPlaceholder }
 				label={
 					<>
-						{ !! showIcon && <HeaderIcon /> }
+						{ !! showIcon && domain && <HeaderIcon /> }
 						{ getListHeaderTextForAccountType( accountType, translate ) }
 					</>
 				}
@@ -142,7 +139,7 @@ function EmailPlanMailboxesList( { account, domain, isLoadingEmails, mailboxes, 
 
 	if ( isLoadingEmails ) {
 		return (
-			<MailboxListHeader isPlaceholder accountType={ accountType }>
+			<MailboxListHeader isPlaceholder accountType={ accountType } domain={ domain }>
 				<MailboxListItem isPlaceholder>
 					<MaterialIcon icon="email" />
 					<span />
@@ -204,6 +201,7 @@ function EmailPlanMailboxesList( { account, domain, isLoadingEmails, mailboxes, 
 			accountType={ accountType }
 			addMailboxPath={ addMailboxPath }
 			showIcon={ !! addMailboxPath }
+			domain={ domain }
 		>
 			{ mailboxItems }
 		</MailboxListHeader>

--- a/client/my-sites/email/email-management/home/email-plan/index.jsx
+++ b/client/my-sites/email/email-management/home/email-plan/index.jsx
@@ -97,7 +97,14 @@ function getMailboxes( data ) {
 	return account?.emails ?? [];
 }
 
-function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
+function EmailPlan( {
+	domain,
+	selectedSite,
+	source,
+	hideHeader = false,
+	hideHeaderCake = false,
+	hidePlanActions = false,
+} ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -340,33 +347,38 @@ function EmailPlan( { domain, hideHeaderCake = false, selectedSite, source } ) {
 			<DocumentHead title={ titleCase( getHeaderText() ) } />
 			<MailPoetUpsell />
 			{ ! hideHeaderCake && <HeaderCake onClick={ handleBack }>{ getHeaderText() }</HeaderCake> }
-			<EmailPlanHeader
-				domain={ domain }
-				hasEmailSubscription={ hasSubscription }
-				isLoadingEmails={ isLoading }
-				isLoadingPurchase={ isLoadingPurchase }
-				purchase={ purchase }
-				selectedSite={ selectedSite }
-				emailAccount={ getAccount( emailAccounts ) }
-			/>
+			{ ! hideHeader && (
+				<EmailPlanHeader
+					domain={ domain }
+					hasEmailSubscription={ hasSubscription }
+					isLoadingEmails={ isLoading }
+					isLoadingPurchase={ isLoadingPurchase }
+					purchase={ purchase }
+					selectedSite={ selectedSite }
+					emailAccount={ getAccount( emailAccounts ) }
+				/>
+			) }
 			<EmailPlanMailboxesList
 				account={ getAccount( emailAccounts ) }
 				domain={ domain }
 				mailboxes={ getMailboxes( emailAccounts ) }
 				isLoadingEmails={ isLoading }
+				addMailboxPath={ hidePlanActions && getAddMailboxProps()?.path }
 			/>
-			<div className="email-plan__actions">
-				<VerticalNav>
-					{ renderAddNewMailboxesOrRenewNavItem( getMailboxes( emailAccounts ) ) }
-					<UpgradeNavItem
-						currentRoute={ currentRoute }
-						domain={ domain }
-						selectedSiteSlug={ selectedSite.slug }
-					/>
-					{ renderManageAllMailboxesNavItem() }
-					{ renderViewBillingAndPaymentSettingsNavItem() }
-				</VerticalNav>
-			</div>
+			{ ! hidePlanActions && (
+				<div className="email-plan__actions">
+					<VerticalNav>
+						{ renderAddNewMailboxesOrRenewNavItem( getMailboxes( emailAccounts ) ) }
+						<UpgradeNavItem
+							currentRoute={ currentRoute }
+							domain={ domain }
+							selectedSiteSlug={ selectedSite.slug }
+						/>
+						{ renderManageAllMailboxesNavItem() }
+						{ renderViewBillingAndPaymentSettingsNavItem() }
+					</VerticalNav>
+				</div>
+			) }
 		</>
 	);
 }

--- a/client/my-sites/email/email-management/home/email-plan/index.jsx
+++ b/client/my-sites/email/email-management/home/email-plan/index.jsx
@@ -104,6 +104,7 @@ function EmailPlan( {
 	hideHeader = false,
 	hideHeaderCake = false,
 	hidePlanActions = false,
+	hideMailPoetUpsell = false,
 } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -345,7 +346,7 @@ function EmailPlan( {
 		<>
 			{ selectedSite && hasSubscription && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 			<DocumentHead title={ titleCase( getHeaderText() ) } />
-			<MailPoetUpsell />
+			{ ! hideMailPoetUpsell && <MailPoetUpsell /> }
 			{ ! hideHeaderCake && <HeaderCake onClick={ handleBack }>{ getHeaderText() }</HeaderCake> }
 			{ ! hideHeader && (
 				<EmailPlanHeader
@@ -385,9 +386,12 @@ function EmailPlan( {
 
 EmailPlan.propTypes = {
 	domain: PropTypes.object.isRequired,
-	hideHeaderCake: PropTypes.bool,
 	selectedSite: PropTypes.object.isRequired,
 	source: PropTypes.string,
+	hideHeader: PropTypes.bool,
+	hideHeaderCake: PropTypes.bool,
+	hidePlanActions: PropTypes.bool,
+	hideMailPoetUpsell: PropTypes.bool,
 };
 
 export default EmailPlan;

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -507,4 +507,8 @@
 			fill: var(--color-accent);
 		}
 	}
+
+	.email-plan-mailboxes-list__mailbox-list-item > div {
+		flex-grow: initial;
+	}
 }

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -481,8 +481,7 @@
 		}
 
 		.section-header__actions {
-			display: flex;
-			flex-direction: row-reverse;
+			flex: none;
 
 			.components-button {
 				font-size: 0.875rem;
@@ -497,13 +496,15 @@
 	.email-plan-mailboxes-list__mailbox-header-icon {
 		display: flex;
 		margin-inline-end: 0.5rem;
+		width: 24px;
 
-		svg {
-			fill: var(--color-accent);
+		img {
+			height: 24px;
 		}
 
-		.social-icons__google {
-			margin-top: 2px;
+		svg {
+			height: 24px;
+			fill: var(--color-accent);
 		}
 	}
 }

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -499,7 +499,7 @@
 		margin-inline-end: 0.5rem;
 
 		svg {
-			fill: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+			fill: var(--color-accent);
 		}
 
 		.social-icons__google {

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -444,17 +444,17 @@
 .context-all-domain-management {
 	&.main {
 		width: 100%;
-	}
 
-	.navigation-header {
-		border-block-end: none !important;
-	}
+		.email-header .navigation-header {
+			border-block-end: none;
 
-	.navigation-header__main {
-		padding-inline: 0 !important;
+			.navigation-header__main {
+				padding-inline: 0 !important;
 
-		.navigation-header__actions {
-			flex-grow: 0;
+				.navigation-header__actions {
+					flex-grow: 0;
+				}
+			}
 		}
 	}
 

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -440,3 +440,54 @@
 		}
 	}
 }
+
+.context-all-domain-management {
+	&.main {
+		width: 100%;
+	}
+
+	.navigation-header {
+		border-block-end: none !important;
+	}
+
+	.navigation-header__main {
+		padding-inline: 0 !important;
+
+		.navigation-header__actions {
+			flex-grow: 0;
+		}
+	}
+
+	.email-plan-mailboxes-list__mailbox-list {
+		border: solid 1px var(--color-border-subtle);
+		border-radius: 4px;
+
+		.card {
+			box-shadow: none;
+			background: none;
+		}
+
+		.card.section-header {
+			padding: 1.5rem 0 1rem 0;
+			margin: 0 1.5rem;
+			border-bottom: solid 1px var(--color-border-subtle);
+		}
+
+		.section-header__label-text {
+			display: flex;
+
+			svg {
+				fill: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+			}
+		}
+
+		.section-header__actions {
+			display: flex;
+			flex-direction: row-reverse;
+
+			.components-button.is-link {
+				text-decoration: none;
+			}
+		}
+	}
+}

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -475,6 +475,7 @@
 
 		.section-header__label-text {
 			display: flex;
+			align-items: center;
 		}
 
 		.section-header__actions {

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -479,6 +479,10 @@
 			svg {
 				fill: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
 			}
+
+			.social-icons__google {
+				margin-top: 2px;
+			}
 		}
 
 		.section-header__actions {

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -475,14 +475,6 @@
 
 		.section-header__label-text {
 			display: flex;
-
-			svg {
-				fill: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
-			}
-
-			.social-icons__google {
-				margin-top: 2px;
-			}
 		}
 
 		.section-header__actions {
@@ -492,6 +484,19 @@
 			.components-button.is-link {
 				text-decoration: none;
 			}
+		}
+	}
+
+	.email-plan-mailboxes-list__mailbox-header-icon {
+		display: flex;
+		margin-inline-end: 0.5rem;
+
+		svg {
+			fill: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+		}
+
+		.social-icons__google {
+			margin-top: 2px;
 		}
 	}
 }

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -476,11 +476,17 @@
 		.section-header__label-text {
 			display: flex;
 			align-items: center;
+			font-size: 1rem;
+			color: var(--studio-gray-100);
 		}
 
 		.section-header__actions {
 			display: flex;
 			flex-direction: row-reverse;
+
+			.components-button {
+				font-size: 0.875rem;
+			}
 
 			.components-button.is-link {
 				text-decoration: none;

--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -52,6 +52,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import './style.scss';
 
 export type EmailProvidersStackedComparisonProps = {
+	className?: string;
 	cartDomainName?: string;
 	comparisonContext: string;
 	hideNavigation?: boolean;
@@ -63,6 +64,7 @@ export type EmailProvidersStackedComparisonProps = {
 };
 
 const EmailProvidersStackedComparison = ( {
+	className = '',
 	comparisonContext,
 	hideNavigation = false,
 	isDomainInCart = false,
@@ -240,7 +242,7 @@ const EmailProvidersStackedComparison = ( {
 
 	return (
 		<Main
-			className={ clsx( {
+			className={ clsx( className, {
 				'email-providers-stacked-comparison__main--domain-upsell': isDomainInCart,
 			} ) }
 			wideLayout

--- a/client/my-sites/email/email-providers-comparison/stacked/style.scss
+++ b/client/my-sites/email/email-providers-comparison/stacked/style.scss
@@ -55,3 +55,14 @@
 .email-providers-stacked-comparison__notice {
 	margin-top: 24px;
 }
+
+.context-all-domain-management {
+
+	.card.action-panel {
+		border-radius: 4px;
+	}
+
+	.form-text-input-with-affixes input {
+		border-radius: 2px 0 0 2px !important;
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/96820

## Proposed Changes

* Extend existing Email Management components to support different variations. Every extended part is behind the property flag, so the existing screens in production are not changed and behave the same.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To support all domains management context

## Testing Instructions

* Go to `/domains/manage?flags=calypso/all-domain-management`
* Make sure you have your domain (you can purchase a .blog)
* Select "Email" tab
* Check the screen and compare with ePfz53j71KKDLWtuSm567A-fi-4949_49822
* Also, go to the current experience on route `/email/{DOMAIN}/manage/{DOMAIN}` and check if everything is the same as before


All domains management context:
<img width="995" alt="Screenshot 2024-12-10 at 12 12 28" src="https://github.com/user-attachments/assets/19dd8ed9-c29e-4dde-89c4-33a4fef015ff">

The current regular email management screen:
<img width="1114" alt="Screenshot 2024-12-10 at 12 12 43" src="https://github.com/user-attachments/assets/ad1e2ae1-dbfb-46b2-97c2-f60edf28812b">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?