### PR TITLE
Checkout: Break cache of PayPal PPCP payment method button when cart changes or cancelling

### DIFF
--- a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
+++ b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
@@ -82,6 +82,8 @@ function PayPalSubmitButton( {
 	const translate = useTranslate();
 	const togglePaymentMethod = useTogglePaymentMethod();
 	const [ forceReRender, setForceReRender ] = useState< number >( 0 );
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
 
 	// Wait for PayPal.js to load before marking this payment method as active.
 	const [ { isResolved, isPending } ] = usePayPalScriptReducer();
@@ -90,6 +92,14 @@ function PayPalSubmitButton( {
 			togglePaymentMethod( 'paypal-js', true );
 		}
 	}, [ isResolved, togglePaymentMethod ] );
+
+	useEffect( () => {
+		debug( 'cart changed; rerendering PayPalSubmitButton' );
+		// The PayPalButtons component appears to cache certain data about the
+		// order process and in order to make sure it has the latest data, we
+		// have to use the `forceReRender` prop.
+		setForceReRender( ( val ) => val + 1 );
+	}, [ responseCart ] );
 
 	// We have to wait for the active payment method to switch because the
 	// contents of the `onClick` function will change when the active state

--- a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
+++ b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
@@ -13,7 +13,7 @@ import {
 } from '@paypal/react-paypal-js';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { PaymentMethodLogos } from '../components/payment-method-logos';
 
@@ -81,6 +81,7 @@ function PayPalSubmitButton( {
 } ) {
 	const translate = useTranslate();
 	const togglePaymentMethod = useTogglePaymentMethod();
+	const [ forceReRender, setForceReRender ] = useState< number >( 0 );
 
 	// Wait for PayPal.js to load before marking this payment method as active.
 	const [ { isResolved, isPending } ] = usePayPalScriptReducer();
@@ -139,6 +140,10 @@ function PayPalSubmitButton( {
 
 	const onCancel: PayPalButtonsComponentProps[ 'onCancel' ] = async () => {
 		debug( 'order cancelled' );
+		// The PayPalButtons component appears to cache certain data about the
+		// order process and in order to make sure it has the latest data, we
+		// have to use the `forceReRender` prop.
+		setForceReRender( ( val ) => val + 1 );
 		rejectPayPalApprovalPromise(
 			new Error( translate( 'The PayPal transaction was not approved.' ) )
 		);
@@ -176,6 +181,7 @@ function PayPalSubmitButton( {
 	// transaction system that the purchase is complete.
 	return (
 		<PayPalButtons
+			forceReRender={ [ forceReRender ] }
 			disabled={ disabled }
 			style={ { layout: 'horizontal' } }
 			fundingSource="paypal"


### PR DESCRIPTION
## Proposed Changes

This PR forces recreating the `PayPalButtons` component of the `@paypal/react-paypal-js` package when either the shopping cart changes or the user cancels their purchase. To do this we use the `forceReRender` prop of the component.

## Why are these changes being made?

I would have assumed that when clicking on the PayPal submit button, it would create a new PayPal order every time. However, that does not appear to be the case. If the button has already been clicked, it somehow caches the order information. This causes several bugs:

1. If the first order is cancelled after being started, no new orders can be completed.
2. If the first order is cancelled and the second order has a different price or term length, PayPal will still show information pertaining to the first order's price and term length.

It appears that the correct way to defeat this caching is to use the `forceReRender` prop of the component. (See https://stackoverflow.com/a/75634613/1877316)

## Testing Instructions

- Make sure you are testing in an environment where the PayPal PPCP payment method is allowed (see pdtkmj-3ar-p2).
- Add a new plan to your cart and visit checkout.
- Edit the payment method and select "PayPal (A8C-only)".
- Click to submit the purchase.
- If required, log into PayPal when the new window dialog appears.
- Note that the dialog should read something like "Your subscription will automatically renew each year" and that the price matches what was shown in checkout.
- Click "Cancel and return to WordPress.com" at the bottom.
- Verify that you see "The PayPal transaction was not approved."
- Change the billing term length of the cart item (eg: from one year to two years).
- Click to submit the purchase again.
- Verify that the dialog reads something like "Your subscription will automatically renew every 2 years" and that the price matches the new price shown in checkout. (Prior to this PR, it would still read "each year" and show the one year price.)
