### PR TITLE
Checkout: Do not wait for PayPal PPCP capture response

### DIFF
--- a/client/my-sites/checkout/src/lib/paypal-js-processor.ts
+++ b/client/my-sites/checkout/src/lib/paypal-js-processor.ts
@@ -138,7 +138,16 @@ export async function payPalJsProcessor(
 		// async but we don't need to wait for the response as it can be slow
 		// and the pending page should properly handle any errors on the WPCOM
 		// Order.
-		capturePayPalPayment( response.order_id.toString(), response.paypal_order_id );
+		capturePayPalPayment( response.order_id.toString(), response.paypal_order_id ).catch(
+			( error ) => {
+				// Do nothing. Errors with the capturing should be handled
+				// async and the user should be notified by the Pending page.
+				// Catching the error here just prevents an uncaught Promise
+				// failure.
+				// eslint-disable-next-line no-console
+				console.error( 'paypal confirmation error', error );
+			}
+		);
 		debug( 'paypal confirmation complete' );
 
 		return makeSuccessResponse( response );

--- a/client/my-sites/checkout/src/lib/paypal-js-processor.ts
+++ b/client/my-sites/checkout/src/lib/paypal-js-processor.ts
@@ -126,17 +126,20 @@ export async function payPalJsProcessor(
 			return makeErrorResponse( 'Transaction response did not include WordPress.com order ID' );
 		}
 
+		debug( 'paypal order created', response );
 		// Resolve the Promise which will trigger the PayPal button to display the confirmation dialog.
 		submitData.resolvePayPalOrderPromise( response.paypal_order_id );
 
 		// Wait for the PayPal dialog to complete before continuing.
 		await submitData.payPalApprovalPromise;
+		debug( 'paypal payment approved' );
 
 		// Capture PayPal order information after dialog approval.
 		const confirmResponse = await payPalJsApproval(
 			response.order_id.toString(),
 			response.paypal_order_id
 		);
+		debug( 'paypal confirmation complete' );
 		if ( 'error' in confirmResponse ) {
 			if (
 				confirmResponse.error === 'paypal_ppcp_payment_confirm_no_order' &&

--- a/client/my-sites/checkout/src/lib/paypal-js-processor.ts
+++ b/client/my-sites/checkout/src/lib/paypal-js-processor.ts
@@ -37,7 +37,7 @@ function isValidPayPalJsSubmitData( data: unknown ): data is PayPalSubmitData {
 	return false;
 }
 
-async function payPalJsApproval(
+async function capturePayPalPayment(
 	bdOrderId: string,
 	payPalOrderId: string
 ): Promise< PayPalConfirmResponse > {
@@ -134,27 +134,12 @@ export async function payPalJsProcessor(
 		await submitData.payPalApprovalPromise;
 		debug( 'paypal payment approved' );
 
-		// Capture PayPal order information after dialog approval.
-		const confirmResponse = await payPalJsApproval(
-			response.order_id.toString(),
-			response.paypal_order_id
-		);
+		// Capture PayPal order information after dialog approval. This is
+		// async but we don't need to wait for the response as it can be slow
+		// and the pending page should properly handle any errors on the WPCOM
+		// Order.
+		capturePayPalPayment( response.order_id.toString(), response.paypal_order_id );
 		debug( 'paypal confirmation complete' );
-		if ( 'error' in confirmResponse ) {
-			if (
-				confirmResponse.error === 'paypal_ppcp_payment_confirm_no_order' &&
-				confirmResponse.message
-			) {
-				return makeErrorResponse( confirmResponse.message );
-			}
-			if (
-				confirmResponse.error === 'paypal_ppcp_payment_confirm_status_wrong' &&
-				confirmResponse.message
-			) {
-				return makeErrorResponse( confirmResponse.message );
-			}
-			return makeErrorResponse( 'Transaction could not be completed' );
-		}
 
 		return makeSuccessResponse( response );
 	} catch ( error ) {


### PR DESCRIPTION
## Proposed Changes

This PR alters the PayPal PPCP purchase flow so that it does not wait for the capture response before considering the transaction complete.

> [!IMPORTANT]
> This requires a change to the capture endpoint to make it fail the WPCOM Order on an error.

Fixes https://github.com/Automattic/payments-shilling/issues/3290

## Why are these changes being made?

When the user has confirmed their payment with PayPal, we should show an active loading indicator to demonstrate that the transaction is in progress. The capturing step which happens at this point can sometimes be extremely slow and no loading indicator is shown until the user reaches the Pending page which happens when the payment processor is complete, leading to poor UX and user confusion about the status of the purchase.

By not waiting for the capture, we defer any error handling to the Pending page, which polls for the WPCOM Order status until it becomes complete or has an error. If an error is found, the Pending page will redirect back to checkout and display the error message. This way we operate more like the capture process of other payment methods which use a webhook to notify us when the payment is complete.

## Testing Instructions

1. Make sure you are using an environment where the PayPal PPCP payment method is available (see pdtkmj-3ar-p2).
2. Add a product to your cart and visit checkout.
3. Select "PayPal (A8C-only)" as the payment method.
4. Submit the checkout form.
5. When the PayPal window appears, confirm the purchase.
6. Verify that checkout redirects to the Pending page (with a full-screen loading indicator) almost instantly after the PayPal window disappears.
7. Verify that you are redirected to the post-checkout page after a few seconds.
8. Repeat this test again but break the `/me/paypal-ppcp-confirm-payment` endpoint so that it always fails.
9. Verify that the Pending page redirects back to checkout and that the error message is displayed.