### PR TITLE
Fix: Add the goals step back to `site-setup` on staging

### DIFF
--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { OnboardSelect, Onboard } from '@automattic/data-stores';
 import { ONBOARDING_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -94,6 +93,8 @@ const onboarding: Flow = {
 		const [ redirectedToUseMyDomain, setRedirectedToUseMyDomain ] = useState( false );
 		const [ useMyDomainQueryParams, setUseMyDomainQueryParams ] = useState( {} );
 		const [ useMyDomainTracksEventProps, setUseMyDomainTracksEventProps ] = useState( {} );
+
+		const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 
 		clearUseMyDomainsQueryParams( currentStepSlug );
 
@@ -204,7 +205,7 @@ const onboarding: Flow = {
 				case 'processing': {
 					const destination = addQueryArgs( '/setup/site-setup', {
 						siteSlug: providedDependencies.siteSlug,
-						...( isEnabled( 'onboarding/goals-first' ) && { flags: 'onboarding/goals-first' } ),
+						...( isGoalsAtFrontExperiment && { 'goals-at-front-experiment': true } ),
 					} );
 					persistSignupDestination( destination );
 					setSignupCompleteFlowName( flowName );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -12,6 +12,7 @@ import { ImporterMainPlatform } from 'calypso/lib/importer/types';
 import { addQueryArgs } from 'calypso/lib/route';
 import { useDispatch as reduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getInitialQueryArguments } from 'calypso/state/selectors/get-initial-query-arguments';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { WRITE_INTENT_DEFAULT_DESIGN } from '../constants';
 import { useIsGoalsHoldout } from '../hooks/use-is-goals-holdout';
@@ -20,7 +21,6 @@ import { useSiteData } from '../hooks/use-site-data';
 import { useCanUserManageOptions } from '../hooks/use-user-can-manage-options';
 import { ONBOARD_STORE, SITE_STORE, USER_STORE, STEPPER_INTERNAL_STORE } from '../stores';
 import { shouldRedirectToSiteMigration } from './helpers';
-import { useGoalsFirstExperiment } from './helpers/use-goals-first-experiment';
 import { useLaunchpadDecider } from './internals/hooks/use-launchpad-decider';
 import { STEPS } from './internals/steps';
 import { redirect } from './internals/steps-repository/import/util';
@@ -67,8 +67,9 @@ const siteSetupFlow: Flow = {
 	},
 
 	useSteps() {
-		// We have already checked the value has loaded in useAssertConditions
-		const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
+		const isGoalsAtFrontExperiment = Boolean(
+			useSelector( getInitialQueryArguments )?.[ 'goals-at-front-experiment' ]
+		);
 
 		const steps = [
 			STEPS.GOALS,
@@ -728,13 +729,6 @@ const siteSetupFlow: Flow = {
 				state: AssertConditionState.FAILURE,
 				message:
 					'site-setup the user needs to have the manage_options capability to go through the flow.',
-			};
-		}
-
-		const [ isLoadingGoalsFirstExp ] = useGoalsFirstExperiment();
-		if ( isLoadingGoalsFirstExp ) {
-			result = {
-				state: AssertConditionState.CHECKING,
 			};
 		}
 

--- a/client/landing/stepper/declarative-flow/test/site-setup-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-setup-flow.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { renderHook } from '@testing-library/react';
+import { renderHookWithProvider } from '../../../../test-helpers/testing-library';
 import { STEPS } from '../internals/steps';
 import siteSetupFlow from '../site-setup-flow';
 import { getFlowLocation, renderFlow } from './helpers';
@@ -28,7 +28,7 @@ describe( 'Site Setup Flow', () => {
 	 * It's totally fine to change this test if the flow changes. But please make sure to update and test the site-setup-wg accordingly.
 	 */
 	describe( 'First steps should be goals and intent capture', () => {
-		const { result } = renderHook( () => siteSetupFlow.useSteps() );
+		const { result } = renderHookWithProvider( () => siteSetupFlow.useSteps() );
 		const firstStep = result.current[ 0 ];
 		const secondStep = result.current[ 1 ];
 


### PR DESCRIPTION
The goals step was unintentionally removed from all flows on staging in #96866. But we only want it removed when the user began on the `onboarding` flow.

Another approach from @arthur791004 was https://github.com/Automattic/wp-calypso/pull/97219 which simply disabled the feature flag on staging. This would be good too, but we want internal stakeholders to be able to see the `onboarding` changes as easily as possible.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
