### PR TITLE
Conditionally update UI on DIFM vs. DIY step of migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/diy-option/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/diy-option/index.tsx
@@ -5,7 +5,7 @@ import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
 import './style.scss';
 
 interface Props {
-	onClick: () => void;
+	onClick: ( option: string ) => void;
 }
 
 export const DIYOption: FC< Props > = ( { onClick } ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/diy-option/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/diy-option/index.tsx
@@ -1,0 +1,23 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import React, { FC } from 'react';
+import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
+import './style.scss';
+
+interface Props {
+	onClick: () => void;
+}
+
+export const DIYOption: FC< Props > = ( { onClick } ) => {
+	const translate = useTranslate();
+
+	return (
+		<Button
+			plain
+			className="how-to-migrate__experiment-diy"
+			onClick={ () => onClick( HOW_TO_MIGRATE_OPTIONS.DO_IT_MYSELF ) }
+		>
+			{ translate( "I'll do it myself" ) }
+		</Button>
+	);
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/diy-option/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/diy-option/style.scss
@@ -1,0 +1,5 @@
+.how-to-migrate__experiment-diy {
+	color: var(--studio-gray-90);
+	font-weight: 500;
+	text-decoration: underline;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/diy-option/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/diy-option/test/index.tsx
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment jsdom
+ */
+import config, { isEnabled } from '@automattic/calypso-config';
+import { render, screen } from '@testing-library/react';
+import { DIYOption } from '..';
+
+const isMigrationExperimentEnabled = isEnabled( 'migration-flow/experiment' );
+const onClick = jest.fn();
+
+const restoreIsMigrationExperimentEnabled = () => {
+	if ( isMigrationExperimentEnabled ) {
+		config.enable( 'migration-flow/experiment' );
+	} else {
+		config.disable( 'migration-flow/experiment' );
+	}
+};
+
+describe( 'DIYOption', () => {
+	afterEach( () => {
+		restoreIsMigrationExperimentEnabled();
+	} );
+
+	it( 'should render the DIY link', () => {
+		config.enable( 'migration-flow/experiment' );
+
+		render( <DIYOption onClick={ onClick } /> );
+
+		expect( screen.queryByText( /I'll do it myself/ ) ).toBeInTheDocument();
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -205,35 +205,6 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 		);
 	}
 
-	let stepContainerProps = {
-		stepName: stepName ?? 'site-migration-how-to-migrate',
-		className: 'how-to-migrate',
-		shouldHideNavButtons: false,
-		hideSkip: true,
-		formattedHeader: (
-			<FormattedHeader
-				id="how-to-migrate-header"
-				headerText={
-					headerText ?? isMigrationExperimentEnabled
-						? translate( 'Let us migrate your site' )
-						: translate( 'How do you want to migrate?' )
-				}
-				subHeaderText={ subHeaderText || renderSubHeaderText() }
-				align="center"
-			/>
-		),
-		stepContent: renderStepContent(),
-		recordTracksEvent: recordTracksEvent,
-		goBack: goBack,
-	};
-
-	if ( isMigrationExperimentEnabled ) {
-		stepContainerProps = {
-			...stepContainerProps,
-			customizedActionButtons: <DIYOption onClick={ handleClick } />,
-		};
-	}
-
 	return (
 		<>
 			<DocumentHead
@@ -243,7 +214,30 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 						: translate( 'How do you want to migrate?' )
 				}
 			/>
-			<StepContainer { ...stepContainerProps } />
+			<StepContainer
+				stepName={ stepName ?? 'site-migration-how-to-migrate' }
+				className="how-to-migrate"
+				shouldHideNavButtons={ false }
+				hideSkip
+				formattedHeader={
+					<FormattedHeader
+						id="how-to-migrate-header"
+						headerText={
+							headerText ?? isMigrationExperimentEnabled
+								? translate( 'Let us migrate your site' )
+								: translate( 'How do you want to migrate?' )
+						}
+						subHeaderText={ subHeaderText || renderSubHeaderText() }
+						align="center"
+					/>
+				}
+				stepContent={ renderStepContent() }
+				recordTracksEvent={ recordTracksEvent }
+				goBack={ goBack }
+				customizedActionButtons={
+					isMigrationExperimentEnabled ? <DIYOption onClick={ handleClick } /> : undefined
+				}
+			/>
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -16,6 +16,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { usePresalesChat } from 'calypso/lib/presales-chat';
 import useHostingProviderName from 'calypso/site-profiler/hooks/use-hosting-provider-name';
 import FlowCard from '../components/flow-card';
+import { DIYOption } from './diy-option';
 import type { StepProps } from '../../types';
 import './style.scss';
 
@@ -27,7 +28,7 @@ interface Props extends StepProps {
 const isMigrationExperimentEnabled = config.isEnabled( 'migration-flow/experiment' );
 
 const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
-	const { navigation, headerText } = props;
+	const { navigation, headerText, stepName, subHeaderText } = props;
 	const translate = useTranslate();
 	const importSiteQueryParam = useQuery().get( 'from' ) || '';
 	const site = useSite();
@@ -56,6 +57,8 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 		[ translate ]
 	);
 
+	// Extract the display of items to a separate component if we keep this version post-experiment,
+	// as this format is also used on the site identification page and further into the DIFM flow.
 	const experimentalOptions = useMemo(
 		() => [
 			{
@@ -202,6 +205,35 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 		);
 	}
 
+	let stepContainerProps = {
+		stepName: stepName ?? 'site-migration-how-to-migrate',
+		className: 'how-to-migrate',
+		shouldHideNavButtons: false,
+		hideSkip: true,
+		formattedHeader: (
+			<FormattedHeader
+				id="how-to-migrate-header"
+				headerText={
+					headerText ?? isMigrationExperimentEnabled
+						? translate( 'Let us migrate your site' )
+						: translate( 'How do you want to migrate?' )
+				}
+				subHeaderText={ subHeaderText || renderSubHeaderText() }
+				align="center"
+			/>
+		),
+		stepContent: renderStepContent(),
+		recordTracksEvent: recordTracksEvent,
+		goBack: goBack,
+	};
+
+	if ( isMigrationExperimentEnabled ) {
+		stepContainerProps = {
+			...stepContainerProps,
+			customizedActionButtons: <DIYOption onClick={ handleClick } />,
+		};
+	}
+
 	return (
 		<>
 			<DocumentHead
@@ -211,27 +243,7 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 						: translate( 'How do you want to migrate?' )
 				}
 			/>
-			<StepContainer
-				stepName={ props.stepName ?? 'site-migration-how-to-migrate' }
-				className="how-to-migrate"
-				shouldHideNavButtons={ false }
-				hideSkip
-				formattedHeader={
-					<FormattedHeader
-						id="how-to-migrate-header"
-						headerText={
-							headerText ?? isMigrationExperimentEnabled
-								? translate( 'Let us migrate your site' )
-								: translate( 'How do you want to migrate?' )
-						}
-						subHeaderText={ props.subHeaderText || renderSubHeaderText() }
-						align="center"
-					/>
-				}
-				stepContent={ renderStepContent() }
-				recordTracksEvent={ recordTracksEvent }
-				goBack={ goBack }
-			/>
+			<StepContainer { ...stepContainerProps } />
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -163,7 +163,7 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 	function renderStepContent() {
 		if ( isMigrationExperimentEnabled ) {
 			return (
-				<div className="how-to-migrate__experiment">
+				<div className="how-to-migrate__experiment-expectations">
 					<NextButton onClick={ () => handleClick( HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME ) }>
 						{ translate( 'Get started' ) }
 					</NextButton>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -1,4 +1,7 @@
-import { StepContainer } from '@automattic/onboarding';
+import config from '@automattic/calypso-config';
+import { PLAN_BUSINESS, getPlan, isWpComBusinessPlan } from '@automattic/calypso-products';
+import { NextButton, StepContainer } from '@automattic/onboarding';
+import { Icon, copy, globe, lockOutline, scheduled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { FC, useCallback, useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -21,9 +24,10 @@ interface Props extends StepProps {
 	subHeaderText?: string;
 }
 
+const isMigrationExperimentEnabled = config.isEnabled( 'migration-flow/experiment' );
+
 const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 	const { navigation, headerText } = props;
-
 	const translate = useTranslate();
 	const importSiteQueryParam = useQuery().get( 'from' ) || '';
 	const site = useSite();
@@ -36,7 +40,7 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 			{
 				label: translate( 'Do it for me' ),
 				description: translate(
-					"Share your site with us, and we'll review it and handle the migration if possible."
+					"Share your site with us. We'll review it and handle the migration if possible."
 				),
 				value: HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME,
 				selected: true,
@@ -47,6 +51,36 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 					'Install the plugin yourself, find the migration key and migrate the site.'
 				),
 				value: HOW_TO_MIGRATE_OPTIONS.DO_IT_MYSELF,
+			},
+		],
+		[ translate ]
+	);
+
+	const experimentalOptions = useMemo(
+		() => [
+			{
+				icon: lockOutline,
+				description: translate(
+					'Upgrade your site and securely share access to your current site.'
+				),
+			},
+			{
+				icon: copy,
+				description: translate(
+					"We'll bring over a copy of your site, without affecting the current live version."
+				),
+			},
+			{
+				icon: scheduled,
+				description: translate(
+					"You'll get an update on the progress of your migration within 2-3 business days."
+				),
+			},
+			{
+				icon: globe,
+				description: translate(
+					"We'll help you switch your domain over after the migration's completed."
+				),
 			},
 		],
 		[ translate ]
@@ -79,39 +113,104 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 		}
 	};
 
-	const hostingProviderSlug = hostingProviderData?.hosting_provider?.slug;
-	const shouldDisplayHostIdentificationMessage =
-		hostingProviderSlug &&
-		hostingProviderSlug !== 'unknown' &&
-		hostingProviderSlug !== 'automattic';
-
-	const stepContent = (
-		<div className="how-to-migrate__list">
-			{ options.map( ( option, i ) => (
-				<FlowCard
-					key={ i }
-					title={ option.label }
-					text={ option.description }
-					onClick={ () => handleClick( option.value ) }
-				/>
-			) ) }
-		</div>
-	);
-
-	const platformText = shouldDisplayHostIdentificationMessage
-		? translate( 'Your WordPress site is hosted with %(hostingProviderName)s.', {
-				args: { hostingProviderName },
-		  } )
-		: '';
-
 	const goBack = useCallback( () => {
 		cancelMigration();
 		navigation.goBack?.();
 	}, [ cancelMigration, navigation ] );
 
+	function renderSubHeaderText() {
+		if ( isMigrationExperimentEnabled ) {
+			const planName = getPlan( PLAN_BUSINESS )?.getTitle() ?? '';
+			const isBusinessPlan = site?.plan?.product_slug
+				? isWpComBusinessPlan( site?.plan?.product_slug )
+				: false;
+
+			return isBusinessPlan
+				? // translators: %(planName)s is the name of the Business plan.
+				  translate(
+						'Save yourself the headache of migrating. Our expert team takes care of everything without interrupting your current site. Plus it’s included in your %(planName)s plan.',
+						{
+							args: {
+								planName,
+							},
+						}
+				  )
+				: translate(
+						'Save yourself the headache of migrating. Our expert team takes care of everything without interrupting your current site. Plus you get 50% off our annual %(planName)s plan.',
+						{
+							args: {
+								planName,
+							},
+						}
+				  );
+		}
+
+		// Maybe extract this code to a separate component if we keep it post-experiment.
+		const hostingProviderSlug = hostingProviderData?.hosting_provider?.slug;
+		const shouldDisplayHostIdentificationMessage =
+			hostingProviderSlug &&
+			hostingProviderSlug !== 'unknown' &&
+			hostingProviderSlug !== 'automattic';
+
+		return shouldDisplayHostIdentificationMessage
+			? // translators: %(hostingProviderName)s is the name of the hosting provider.
+			  translate( 'Your WordPress site is hosted with %(hostingProviderName)s.', {
+					args: { hostingProviderName },
+			  } )
+			: '';
+	}
+
+	function renderStepContent() {
+		if ( isMigrationExperimentEnabled ) {
+			return (
+				<div className="how-to-migrate__experiment">
+					<NextButton onClick={ () => handleClick( HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME ) }>
+						{ translate( 'Get started' ) }
+					</NextButton>
+					<div className="how-to-migrate__process-details">
+						<p className="how-to-migrate__process-details-title">{ translate( 'How it works' ) }</p>
+						<ul className="how-to-migrate__process-details-list">
+							{ experimentalOptions.map( ( option, index ) => (
+								<li key={ index } className="how-to-migrate__process-details-list-item">
+									<Icon
+										className="how-to-migrate__process-details-icon"
+										icon={ option.icon }
+										size={ 24 }
+									/>
+									<p className="how-to-migrate__process-details-description">
+										{ option.description }
+									</p>
+								</li>
+							) ) }
+						</ul>
+					</div>
+				</div>
+			);
+		}
+
+		return (
+			<div className="how-to-migrate__list">
+				{ options.map( ( option, i ) => (
+					<FlowCard
+						key={ i }
+						title={ option.label }
+						text={ option.description }
+						onClick={ () => handleClick( option.value ) }
+					/>
+				) ) }
+			</div>
+		);
+	}
+
 	return (
 		<>
-			<DocumentHead title={ translate( 'How do you want to migrate?' ) } />
+			<DocumentHead
+				title={
+					isMigrationExperimentEnabled
+						? translate( 'Let us migrate your site' )
+						: translate( 'How do you want to migrate?' )
+				}
+			/>
 			<StepContainer
 				stepName={ props.stepName ?? 'site-migration-how-to-migrate' }
 				className="how-to-migrate"
@@ -120,12 +219,16 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 				formattedHeader={
 					<FormattedHeader
 						id="how-to-migrate-header"
-						headerText={ headerText ?? translate( 'How do you want to migrate?' ) }
-						subHeaderText={ props.subHeaderText || platformText }
+						headerText={
+							headerText ?? isMigrationExperimentEnabled
+								? translate( 'Let us migrate your site' )
+								: translate( 'How do you want to migrate?' )
+						}
+						subHeaderText={ props.subHeaderText || renderSubHeaderText() }
 						align="center"
 					/>
 				}
-				stepContent={ stepContent }
+				stepContent={ renderStepContent() }
 				recordTracksEvent={ recordTracksEvent }
 				goBack={ goBack }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -1,4 +1,3 @@
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { FC, useCallback, useMemo } from 'react';
@@ -32,21 +31,13 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 
 	usePresalesChat( 'wpcom' );
 
-	const hasEnTranslation = useHasEnTranslation();
-
 	const options = useMemo(
 		() => [
 			{
 				label: translate( 'Do it for me' ),
-				description: hasEnTranslation(
-					"Share your site with us. We'll review it and handle the migration if possible."
-				)
-					? translate(
-							"Share your site with us. We'll review it and handle the migration if possible."
-					  )
-					: translate(
-							"Share your site with us, and we'll review it and handle the migration if possible."
-					  ),
+				description: translate(
+					"Share your site with us, and we'll review it and handle the migration if possible."
+				),
 				value: HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME,
 				selected: true,
 			},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -121,7 +121,7 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 		navigation.goBack?.();
 	}, [ cancelMigration, navigation ] );
 
-	function renderSubHeaderText() {
+	const renderSubHeaderText = () => {
 		if ( isMigrationExperimentEnabled ) {
 			const planName = getPlan( PLAN_BUSINESS )?.getTitle() ?? '';
 			const isBusinessPlan = site?.plan?.product_slug
@@ -161,9 +161,9 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 					args: { hostingProviderName },
 			  } )
 			: '';
-	}
+	};
 
-	function renderStepContent() {
+	const renderStepContent = () => {
 		if ( isMigrationExperimentEnabled ) {
 			return (
 				<div className="how-to-migrate__experiment-expectations">
@@ -203,7 +203,7 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 				) ) }
 			</div>
 		);
-	}
+	};
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -25,10 +25,9 @@ interface Props extends StepProps {
 	subHeaderText?: string;
 }
 
-const isMigrationExperimentEnabled = config.isEnabled( 'migration-flow/experiment' );
-
 const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 	const { navigation, headerText, stepName, subHeaderText } = props;
+	const isMigrationExperimentEnabled = config.isEnabled( 'migration-flow/experiment' );
 	const translate = useTranslate();
 	const importSiteQueryParam = useQuery().get( 'from' ) || '';
 	const site = useSite();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/style.scss
@@ -49,3 +49,57 @@
 		margin: 0 auto;
 	}
 }
+
+.how-to-migrate__experiment {
+	.action-buttons__next {
+		display: block;
+		margin: auto;
+		width: 50%;
+	}
+
+	.how-to-migrate__process-details {
+		margin: 40px auto 0 auto;
+		max-width: 350px;
+
+		&-title {
+			color: var(--studio-gray-100);
+			font-size: 1.25rem;
+			font-weight: 500;
+			margin-bottom: 0.5rem;
+			text-align: center;
+		}
+
+		&-list {
+			background-color: #f6f7f7;
+			font-size: 0.75rem;
+			list-style: none;
+			margin: 0;
+			padding: 2rem;
+
+			&-item {
+				display: flex;
+				gap: 0.5rem;
+				margin-bottom: 1rem;
+
+				&:last-child {
+					margin-bottom: 0;
+				}
+			}
+		}
+
+		&-icon {
+			background-color: #dcdcde;
+			border: 2px solid #dcdcde;
+			border-radius: 4px;
+			display: flex;
+			fill: var(--studio-gray-70);
+			flex: 0 0 24px;
+			padding: 4px;
+		}
+
+		&-description {
+			color: var(--studio-black);
+			line-height: 1.66666667;
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/style.scss
@@ -50,7 +50,13 @@
 	}
 }
 
-.how-to-migrate__experiment {
+.how-to-migrate__experiment-expectations {
+	padding: 0 0 60px;
+
+	@include break-large {
+		padding: 0;
+	}
+
 	.action-buttons__next {
 		display: block;
 		margin: auto;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/test/index.tsx
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+import config, { isEnabled } from '@automattic/calypso-config';
+import { screen } from '@testing-library/react';
+import { ComponentProps } from 'react';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import SiteMigrationHowToMigrate from '../';
+import { defaultSiteDetails } from '../../launchpad/test/lib/fixtures';
+import { mockStepProps, renderStep, RenderStepOptions } from '../../test/helpers';
+
+const isMigrationExperimentEnabled = isEnabled( 'migration-flow/experiment' );
+const navigation = { submit: jest.fn() };
+
+type Props = ComponentProps< typeof SiteMigrationHowToMigrate >;
+
+const render = ( props?: Partial< Props >, renderOptions?: RenderStepOptions ) => {
+	const combinedProps = { ...mockStepProps( props ), stepName: 'site-migration-how-to-migrate' };
+
+	return renderStep( <SiteMigrationHowToMigrate { ...combinedProps } />, renderOptions );
+};
+
+jest.mock( 'calypso/landing/stepper/hooks/use-site', () => ( {
+	useSite: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/presales-chat', () => ( {
+	usePresalesChat: () => {},
+} ) );
+
+describe( 'SiteMigrationHowToMigrate', () => {
+	beforeAll( () => {
+		config.enable( 'migration-flow/experiment' );
+	} );
+
+	afterAll( () => {
+		if ( isMigrationExperimentEnabled ) {
+			config.enable( 'migration-flow/experiment' );
+		} else {
+			config.disable( 'migration-flow/experiment' );
+		}
+	} );
+
+	afterEach( () => {
+		jest.resetAllMocks();
+	} );
+
+	it( 'should render proper subheading for free plan', () => {
+		const mockSite = {
+			...defaultSiteDetails,
+		};
+
+		( useSite as jest.Mock ).mockReturnValue( mockSite );
+
+		render( { navigation } );
+
+		expect( screen.queryByText( /Plus you get 50% off our annual/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render proper subheading for Business plan', () => {
+		const mockSite = {
+			...defaultSiteDetails,
+			plan: {
+				...defaultSiteDetails.plan,
+				product_slug: 'business-bundle',
+			},
+		};
+
+		( useSite as jest.Mock ).mockReturnValue( mockSite );
+
+		render( { navigation } );
+
+		expect( screen.queryByText( /Plus it’s included in your/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render step content', () => {
+		render( { navigation } );
+
+		expect( screen.queryByText( /How it works/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render <DIYOption /> component', () => {
+		render( { navigation } );
+
+		expect( screen.queryByText( /I'll do it myself/ ) ).toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10025.

## Proposed Changes

Updates the UI on the DIFM vs. DIY step of the migration flow. These changes are currently behind a feature flag and will be launched as part of a future experiment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Browse to the DIFM vs. DIY step of the migration flow for a **free** site.
* Ensure the UI is the same as it was before:

![Screenshot 2024-12-10 at 1 49 26 PM](https://github.com/user-attachments/assets/b39c8592-5354-4b53-a8f1-11ad0505e80d)

* Enable the `migration-flow/experiment` feature flag in `config/development.json`.
* Ensure the UI matches the new design (ay0fZYgdXxPDbZbgPlz3hu-fi-1_3506). Note that I didn't use the same content width as in the design, instead opting to keep the width the same as it was before as it's closer to what other pages in the migration flow use. This is most noticeable in the subheading text:

![Screenshot 2024-12-10 at 1 53 02 PM](https://github.com/user-attachments/assets/323422d3-01aa-487b-94ac-52907944c08b)

* Click the _Get started_ button and ensure you are eventually taken to the credentials page.
* Click the _I'll do it myself_ link and ensure you are eventually taken to the migration instructions page.
* Browse to the DIFM vs. DIY step of the migration flow for a site on the **Business plan** (or replace `siteId` and `siteSlug` query params with appropriate values for a Business plan site).
* Ensure the subheading text is updated:

![Screenshot 2024-12-09 at 3 38 23 PM](https://github.com/user-attachments/assets/68a9a092-e49b-4be8-9226-e0ef1d6433e8)

* Check the layout on mobile and ensure it looks good.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?