### PR TITLE
Reader Recent Feed Overhaul: Set height for loading container

### DIFF
--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -35,6 +35,10 @@ body.is-reader-full-post {
 		$feed-list-header-height: 70px;
 		$feed-list-actions-height: 65px;
 		$feed-list-footer-height: 57px;
+		$feed-list-height: calc(
+			100vh - var( --masterbar-height ) - var( --content-padding-top ) - $feed-list-header-height -
+				$feed-list-actions-height - $feed-list-footer-height - var( --content-padding-bottom )
+		);
 
 		@extend %column-shared;
 		flex: 1;
@@ -72,7 +76,7 @@ body.is-reader-full-post {
 		}
 
 		.dataviews-loading {
-			margin-top: 200px;
+			height: $feed-list-height;
 		}
 
 		.components-spinner {
@@ -81,10 +85,7 @@ body.is-reader-full-post {
 		}
 
 		.dataviews-view-list {
-			height: calc(
-				100vh - var( --masterbar-height ) - var( --content-padding-top ) - $feed-list-header-height -
-					$feed-list-actions-height - $feed-list-footer-height - var( --content-padding-bottom )
-			);
+			height: $feed-list-height;
 			overflow-y: auto;
 			@include custom-scrollbars-on-hover( transparent, $gray-600 );
 			scrollbar-gutter: auto;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Sets the height of the loading container so the pagination controls do not jump around when navigating.

### Before
https://github.com/user-attachments/assets/5bfd42f0-95ac-4e4c-80f1-dd40c7696aa9

### After
https://github.com/user-attachments/assets/2053ef6d-ca56-432d-8c1e-d51c73a258c1 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve the UX
* Polish the Recent Feed Overhaul

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/read?flags=reader/recent-feed-overhaul`
* Select a feed and navigate to the next pages
* When loading, the pagination controls should not change position on the screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
