### PR TITLE
Application passwords: small UI improvements.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/access-method-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/access-method-picker.tsx
@@ -1,4 +1,7 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { FormLabel } from '@automattic/components';
+import { useLocale } from '@automattic/i18n-utils';
+import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
 import { Controller } from 'react-hook-form';
@@ -7,6 +10,16 @@ import { CredentialsFormFieldProps } from '../types';
 
 export const AccessMethodPicker: FC< CredentialsFormFieldProps > = ( { control } ) => {
 	const translate = useTranslate();
+	const locale = useLocale();
+
+	const applicationPasswordEnabled = isEnabled( 'automated-migration/application-password' );
+	const hasLabelTranslation =
+		locale.startsWith( 'en' ) || hasTranslation( 'WordPress site credentials' );
+
+	const credentialsLabel =
+		applicationPasswordEnabled && hasLabelTranslation
+			? translate( 'WordPress site credentials' )
+			: translate( 'WordPress credentials' );
 
 	return (
 		<div>
@@ -20,7 +33,7 @@ export const AccessMethodPicker: FC< CredentialsFormFieldProps > = ( { control }
 						<FormRadio
 							id="site-migration-credentials__radio-credentials"
 							htmlFor="site-migration-credentials__radio-credentials"
-							label={ translate( 'WordPress credentials' ) }
+							label={ credentialsLabel }
 							checked={ value === 'credentials' }
 							{ ...props }
 							value="credentials"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -51,7 +51,10 @@ const siteAddressInput = () =>
 const usernameInput = () => getByLabelText( 'WordPress admin username' );
 const passwordInput = () => getByLabelText( 'Password' );
 const backupOption = () => getByRole( 'radio', { name: 'Backup file' } );
-const credentialsOption = () => getByRole( 'radio', { name: 'WordPress credentials' } );
+const credentialsOption = () =>
+	isEnabled( 'automated-migration/application-password' )
+		? getByRole( 'radio', { name: 'WordPress site credentials' } )
+		: getByRole( 'radio', { name: 'WordPress credentials' } );
 const backupFileInput = () => getByLabelText( 'Backup file location' );
 //TODO: it requires a testid because there is no accessible name, it is an issue with the component
 const specialInstructionsInput = () => getByTestId( 'special-instructions-textarea' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/style.scss
@@ -55,8 +55,8 @@ $blueberry-color: #3858e9;
 			margin-top: 1em;
 			flex: 1;
 		}
-		.site-migration-credentials__form-field--notes {
-			margin-top: 5px;
+		.site-migration-credentials__form-field:nth-of-type(1) {
+			margin-top: 0;
 		}
 
 		.site-migration-credentials__form-note {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/style.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 $blueberry-color: #3858e9;
 
-.site-migration-credentials {
+.site-migration-fallback-credentials {
 	#site-migration-credentials-header {
 		.formatted-header__subtitle {
 			text-align: center;
@@ -30,6 +30,9 @@ $blueberry-color: #3858e9;
 		@media (min-width: $break-mobile) {
 			margin-bottom: 16px;
 		}
+
+		max-width: 400px;
+		margin: auto;
 
 		hr {
 			margin-top: 1em;


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/97241

## Proposed Changes

During call for testing, we got suggested a couple improvements on the UI. Including:
#### How we can access your site label
![Image](https://github.com/user-attachments/assets/e01f8808-e1ff-4ad4-b346-3a66a7c3efe8)

The label reads “WordPress credentials” and should be updated to “WordPress site address”.

#### Credentials
The credential fields and button look really long. Typically, you want the fields to represent the type of content that will be entered into it.
![Image](https://github.com/user-attachments/assets/b3baa9b2-9d69-4865-bff6-e29662935686)


Can we update the max width to 400px?

## Testing Instructions

Go through the new application passwords flow.
Check that on the credentials step, the label on radio button reads `WordPress site credentials`.
Check that on the fallback credentials step, the one triggered when application password is not available, the form has a 400px max width.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
