### PR TITLE
Set SITE_MIGRATION_ASSISTED_MIGRATION as final step of application passwords flow.

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -555,8 +555,9 @@ const siteMigration: Flow = {
 				}
 
 				case STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_AUTHORIZATION.slug: {
-					const { action, authorizationUrl } = providedDependencies as {
+					const { action, authorizationUrl, from } = providedDependencies as {
 						action: string;
+						from: string;
 						authorizationUrl: string;
 					};
 
@@ -583,7 +584,10 @@ const siteMigration: Flow = {
 					}
 
 					return navigate(
-						addQueryArgs( { siteId, siteSlug }, STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug )
+						addQueryArgs(
+							{ siteId, from: from || fromQueryParam, siteSlug, preventTicketCreation: true },
+							STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug
+						)
 					);
 				}
 			}

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -582,10 +582,9 @@ const siteMigration: Flow = {
 						);
 					}
 
-					return navigate( STEPS.SITE_MIGRATION_STARTED.slug, {
-						siteId,
-						siteSlug,
-					} );
+					return navigate(
+						addQueryArgs( { siteId, siteSlug }, STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug )
+					);
 				}
 			}
 		}


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/97243

## Proposed Changes

After I approve the application access, user taken to the migration started screen. This is technically not right. We should be taking people to the “We’ll take it from here” screen (like we do with the credentials):

## Testing Instructions

- Use calypso live to avoid the SSL error when trying to authenticate.
- Go through the migration process using the application passwords flow.
- After authorizing Application passwords on origin site, you should be redirect to “We’ll take it from here” screen.

![image](https://github.com/user-attachments/assets/991f8c01-a272-4e0a-8482-d83e5c421428)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
