### PR TITLE
Recent Feed Overhaul - Handful of CSS tweaks

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -42,8 +42,7 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	max-width: 1200px;
 	margin: 0 auto;
 
-	.comment-button__icon path,
-	.conversation-follow-button path {
+	.comment-button__icon path {
 		fill: var( --color-neutral-0 );
 	}
 }

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -13,7 +13,7 @@
 	}
 
 	@media (max-width: 600px) {
-		margin: 0 16px;
+		padding: 0 16px;
 		.navigation-header__main {
 			min-height: auto;
 		}

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -2,7 +2,6 @@
 
 .is-section-reader .navigation-header.following-stream-header {
 	margin: 0 auto;
-	max-width: 600px;
 	padding: 0;
 	&.reader-dual-column {
 		max-width: 968px; // Max width of dual column reader stream.

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -106,9 +106,6 @@ body.is-section-reader {
 		.navigation-header__main {
 			justify-content: normal;
 			align-items: center;
-			.formatted-header {
-				flex: none;
-			}
 		}
 	}
 

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -604,7 +604,7 @@
 	align-items: flex-start;
 	display: flex;
 	flex-wrap: nowrap;
-	gap: 80px;
+	gap: 40px;
 	justify-content: flex-start;
 }
 


### PR DESCRIPTION
## Description

I did one final review this morning and cleaned up 3 minor CSS issues. Head to `/read?flags=reader/recent-feed-overhaul`, then review:

### 1) Ghost SVG

When you pull up the full-page post and scroll to the bottom, if you're following the blog, you'll see an empty spot where the plus symbol should be:

**Before**
![svg-before](https://github.com/user-attachments/assets/c8b69c30-064a-4466-b07b-bb50a1cfc9ad)

**After**
![svg-after](https://github.com/user-attachments/assets/6bd12056-c569-4d58-a871-a722ab8e3d19)

### 2) Two column alignment

When you pull up the two column view, the second column is currently breaking out of the default layout width:

**Before**
![alignment-before](https://github.com/user-attachments/assets/0a8e1a9c-5d5d-4df9-a5a8-9b60a4aa5a21)

**After**
![alignment-after](https://github.com/user-attachments/assets/e01264f5-cd92-4152-ae89-58b2f735c517)

### 3) On mobile, the layout icons should be right aligned

**Before**
![icons-before](https://github.com/user-attachments/assets/fe8bf6a2-27e0-41df-ade7-2db7890813a9)

**After**
![icons-after](https://github.com/user-attachments/assets/408b39a6-878a-4d09-866c-3cb95ea576c9)
