### PR TITLE
Hosting dashboard: prevent flashing invalid intermediate content when switching from Atomic to Simple

### DIFF
--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -14,6 +14,7 @@ import { profilerVersion } from 'calypso/performance-profiler/utils/profiler-ver
 import { useDispatch, useSelector } from 'calypso/state';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getRequest from 'calypso/state/selectors/get-request';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { launchSite } from 'calypso/state/sites/launch/actions';
 import { requestSiteStats } from 'calypso/state/stats/lists/actions';
 import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
@@ -143,6 +144,7 @@ export const SitePerformance = () => {
 	const { getSiteSetting } = useSiteSettings( site?.slug );
 	const blog_public = getSiteSetting( 'blog_public' );
 	const isSitePublic = site && blog_public === 1;
+	const isSiteAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 
 	const stats = useSelector( ( state ) =>
 		getSiteStatsNormalizedData( state, siteId, statType, statsQuery )
@@ -371,6 +373,10 @@ export const SitePerformance = () => {
 						},
 					}
 			  );
+
+	if ( ! isSiteAtomic ) {
+		return null;
+	}
 
 	return (
 		<div className="site-performance">

--- a/client/hosting/server-settings/main.tsx
+++ b/client/hosting/server-settings/main.tsx
@@ -38,6 +38,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
 import { getAtomicHostingIsLoadingSftpData } from 'calypso/state/selectors/get-atomic-hosting-is-loading-sftp-data';
+import isRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
@@ -177,6 +178,10 @@ const ServerSettings = ( { fetchUpdatedData }: ServerSettingsProps ) => {
 		dispatch( recordTracksEvent( 'calypso_hosting_configuration_activate_click' ) );
 
 	const siteId = useSelector( getSelectedSiteId );
+
+	const requestingSiteFeatures = useSelector( ( state ) =>
+		isRequestingSiteFeatures( state, siteId )
+	);
 	const hasAtomicFeature = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_ATOMIC )
 	);
@@ -294,6 +299,10 @@ const ServerSettings = ( { fetchUpdatedData }: ServerSettingsProps ) => {
 		( ! isLoadingSftpData || isECommerceTrial ) &&
 		( ! hasAtomicFeature || ( ! hasTransfer && ! hasSftpFeature && ! isWpcomStagingSite ) );
 	const banner = shouldShowUpgradeBanner ? getUpgradeBanner() : getAtomicActivationNotice();
+
+	if ( requestingSiteFeatures ) {
+		return null;
+	}
 
 	return (
 		<Panel wide className="page-server-settings">

--- a/client/sites/tools/deployments/components/page-shell/index.tsx
+++ b/client/sites/tools/deployments/components/page-shell/index.tsx
@@ -60,6 +60,10 @@ export function PageShell( { topRightButton, pageTitle, children }: GitHubDeploy
 		}
 	};
 
+	if ( ! isSiteAtomic ) {
+		return null;
+	}
+
 	const WrapperComponent = ! isSiteAtomic ? FeatureExample : Fragment;
 	return (
 		<Panel wide className="github-deployments tools-deployments">

--- a/client/sites/tools/staging-site/components/staging-site/index.tsx
+++ b/client/sites/tools/staging-site/components/staging-site/index.tsx
@@ -1,6 +1,6 @@
 import { FEATURE_SITE_STAGING_SITES } from '@automattic/calypso-products';
 import { useSelector } from 'calypso/state';
-import getSiteFeatures from 'calypso/state/selectors/get-site-features';
+import isRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -11,13 +11,15 @@ import './style.scss';
 
 const StagingSite = () => {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) ) ?? 0;
-	const features = useSelector( ( state ) => getSiteFeatures( state, siteId ) );
+	const requestingSiteFeatures = useSelector( ( state ) =>
+		isRequestingSiteFeatures( state, siteId )
+	);
 	const hasStagingSitesFeature = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, FEATURE_SITE_STAGING_SITES )
 	);
 	const isWpcomStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
 
-	if ( ! features ) {
+	if ( requestingSiteFeatures ) {
 		return null;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/96050

## Proposed Changes

When we open a site in a hosting dashboard tab, and then switch to another site, the newly selected site will still have a chance to be rendered even though it's not valid.

For example, when we are in one of the hosting feature tabs in an Atomic site, then switch to a Simple site, we will first render the tab with the Simple site before we get redirected to the Hosting Features tab. This is problematic, especially when the tab shows different content for different kind of sites. In this case, users will see a flashing different content before viewing the Hosting Features tab content.

These are such tabs:

- Performance: shows a notice if a site is not yet launched
- Staging site: shows an upsell if a site plan has no Staging site support
- Deployments: shows a notice when the hosting activation is not yet completed
- Server Settings: shows a subset of the settings if the site plan has no SFTP support

In this PR, I propose that such tabs first check whether the site has valid requirements, and return null otherwise.

## Why are these changes being made?

Fixes a visual bug.

## Testing Instructions

1. Prepare a LAUNCHED Atomic site.
2. Go to /sites and click that Atomic site.
1. For each of the following tab:
   - Performance,
   - Staging Site,
   - Deployments,
   - Server Settings,
1. Open the tab.
3. Switch to a Simple site.
4. Verify you see the Hosting Features tab content without seeing a flashing invalid content.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
