### PR TITLE
Site settings: introduce new selector to detect wpcom

### DIFF
--- a/client/sites/settings/site/form.jsx
+++ b/client/sites/settings/site/form.jsx
@@ -12,6 +12,7 @@ import LaunchSite from './visibility';
 export default function SiteSettingsForm( {
 	site,
 	siteIsJetpack,
+	siteIsWpcom,
 	isUnlaunchedSite,
 	isAtomicAndEditingToolkitDeactivated,
 	isWpcomStagingSite,
@@ -72,7 +73,7 @@ export default function SiteSettingsForm( {
 				urlRef="unlaunched-settings"
 			/>
 
-			{ ! siteIsJetpack && ! isWPForTeamsSite && (
+			{ siteIsWpcom && ! isWPForTeamsSite && (
 				<HolidaySnow
 					fields={ fields }
 					handleToggle={ handleToggle }

--- a/client/sites/settings/site/index.tsx
+++ b/client/sites/settings/site/index.tsx
@@ -8,7 +8,7 @@ import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import getIsUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { useSelectedSiteSelector } from 'calypso/state/sites/hooks';
-import { getSiteOption, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteOption, isJetpackSite, isWpcomSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import SiteSettingsForm from './form';
 
@@ -26,12 +26,14 @@ export function SiteSettings( props: any ) {
 	);
 	const isAtomic = useSelectedSiteSelector( isAtomicSite );
 	const isAtomicAndEditingToolkitDeactivated = isAtomic && editingToolkitIsActive === false;
+	const siteIsWpcom = useSelectedSiteSelector( isWpcomSite );
 	const isWpcomStagingSite = useSelectedSiteSelector( isSiteWpcomStaging );
 	const isWPForTeamsSite = useSelectedSiteSelector( isSiteWPForTeams );
 
 	const additionalProps = {
 		site,
 		siteIsJetpack,
+		siteIsWpcom,
 		isUnlaunchedSite,
 		isAtomicAndEditingToolkitDeactivated,
 		isWpcomStagingSite,

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -64,6 +64,7 @@ export { default as isSingleUserSite } from './is-single-user-site';
 export { default as isSiteConflicting } from './is-site-conflicting';
 export { default as isSitePreviewable } from './is-site-previewable';
 export { default as isSSOEnabled } from './is-sso-enabled';
+export { default as isWpcomSite } from './is-wpcom-site';
 export { default as verifyJetpackModulesActive } from './verify-jetpack-modules-active';
 export { default as getSelectedSiteWithFallback } from './get-site-with-fallback';
 export { default as getSiteThemeInstallUrl } from './get-site-theme-install-url';

--- a/client/state/sites/selectors/is-wpcom-site.ts
+++ b/client/state/sites/selectors/is-wpcom-site.ts
@@ -1,0 +1,18 @@
+import { createSelector } from '@automattic/state-utils';
+import { getSite } from 'calypso/state/sites/selectors';
+import isSimpleSite from 'calypso/state/sites/selectors/is-simple-site';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { AppState } from 'calypso/types';
+
+/**
+ * Returns true if the current site is a WordPress.com site (simple or WoA)
+ * @param  {Object}   state         Global state tree
+ * @returns {?boolean}               Whether the current site is a WordPress.com site or not
+ */
+export default createSelector(
+	( state: AppState, siteId = getSelectedSiteId( state ) ): boolean | null => {
+		const site = getSite( state, siteId );
+		return !! site && ( ( isSimpleSite( state, siteId ) || site?.is_wpcom_atomic ) ?? false );
+	},
+	( state: AppState, siteId = getSelectedSiteId( state ) ) => [ isSimpleSite( state, siteId ) ]
+);


### PR DESCRIPTION
Fixes https://github.com/Automattic/at-help/issues/897

## Proposed Changes

This commit introduces a new site selector that will return true when we're interested in a WordPress.com Site (simple OR atomic), and starts using it.

## Why are these changes being made?

Before this commit, we relied on the isJetpackSite selector to detect whether we should display the Holiday Snow settings or not (we want to display them on Wordress.com sites only (simple OR Atomic).

Epic: https://github.com/Automattic/dotcom-forge/issues/10082

## Testing Instructions

* Check out this branch
* Load `http://calypso.localhost:3000/settings/general/yoursite.wordpress.com?flags=-untangling/hosting-menu` for a WordPress.com site
* Load `http://calypso.localhost:3000/sites/settings/site/yoursite.wordpress.com` for the same site
* Load `http://calypso.localhost:3000/settings/general/atomicsite.com?flags=-untangling/hosting-menu` for a WoA site of yours
* Load `http://calypso.localhost:3000/sites/settings/site/atomicsite.com` for the same site

=> You should see the Holiday snow checklist.

* Load `http://calypso.localhost:3000/settings/general/yourjetpacksite.com?flags=-untangling/hosting-menu` for a Jetpack site.
* Load `http://calypso.localhost:3000/sites/settings/site/yourjetpacksite.com` for the same site

=> You should not see the Holiday snow checklist.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
