### PR TITLE
Help Center Experience: ramp to 75% of users 

### DIFF
--- a/packages/help-center/src/components/utils.tsx
+++ b/packages/help-center/src/components/utils.tsx
@@ -125,7 +125,7 @@ export const matchSupportInteractionId = (
 };
 
 export const isUseHelpCenterExperienceEnabled = ( userId: number ): boolean => {
-	if ( ! userId || userId % 100 < 75 ) {
+	if ( ! userId || userId % 100 > 75 ) {
 		return false;
 	}
 	return true;


### PR DESCRIPTION
This fixes the [previous commit,](https://github.com/Automattic/wp-calypso/pull/97228) which was intended to enable the new help center experience for 75% of users, but instead reduced to 25%.

To answer the question `isUseHelpCenterExperienceEnabled` we want to return false 25% of the time, which is what this does, as opposed to returning false 75% of the time, which is what the previous commit did.