### PR TITLE
Stats: Avoid overlapped chart period dropdown list

### DIFF
--- a/client/components/stats-interval-dropdown/index.jsx
+++ b/client/components/stats-interval-dropdown/index.jsx
@@ -5,9 +5,20 @@ import { check, Icon, chevronDown, lock } from '@wordpress/icons';
 import clsx from 'clsx';
 import { capitalize } from 'lodash';
 import qs from 'qs';
+import { useRef } from 'react';
 import './style.scss';
+import useOutsideClickCallback from 'calypso/lib/use-outside-click-callback';
 
-const StatsIntervalDropdownListing = ( { selected, onSelection, intervals, onGatedHandler } ) => {
+const StatsIntervalDropdownListing = ( {
+	selected,
+	onSelection,
+	intervals,
+	onGatedHandler,
+	onClickOutside,
+} ) => {
+	const ref = useRef( null );
+	useOutsideClickCallback( ref, onClickOutside );
+
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
 	const isSelectedItem = ( interval ) => {
@@ -33,7 +44,7 @@ const StatsIntervalDropdownListing = ( { selected, onSelection, intervals, onGat
 	};
 
 	return (
-		<div className="stats-interval-dropdown-listing">
+		<div className="stats-interval-dropdown-listing" ref={ ref }>
 			<ul className="stats-interval-dropdown-listing__list" role="radiogroup">
 				{ Object.keys( intervals ).map( ( intervalKey ) => {
 					const interval = intervals[ intervalKey ];
@@ -105,13 +116,14 @@ const IntervalDropdown = ( { slug, period, queryParams, intervals, onGatedHandle
 					<Icon className="gridicon" icon={ chevronDown } />
 				</Button>
 			) }
-			renderContent={ () => (
+			renderContent={ ( { onClose } ) => (
 				<div className="stats-interval-dropdown__container">
 					<StatsIntervalDropdownListing
 						selected={ period }
 						onSelection={ onSelectionHandler }
 						intervals={ intervals }
 						onGatedHandler={ onGatedHandler }
+						onClickOutside={ onClose }
 					/>
 				</div>
 			) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Dismiss the chart period dropdown list when clicking outside to avoid it being concurrent with the date range picker, as they are overlapped.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve the user experience, we must prevent showing the overlapped Popover components.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Click on the chart period dropdown.
* Ensure it works as previously.
* Click on the date range picker directly.
* Ensure the chart period dropdown list is dismissed.

|Before|After|
|-|-|
|<img width="834" alt="截圖 2024-12-11 凌晨1 15 47" src="https://github.com/user-attachments/assets/61972dc5-2584-478e-84d8-1302020efd3a">|<img width="830" alt="截圖 2024-12-11 凌晨1 16 29" src="https://github.com/user-attachments/assets/48797d48-1f13-4f98-80b3-c4024537224c">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
