### PR TITLE
Reader Onboarding: Fix selection scroll position

### DIFF
--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -209,9 +209,21 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		}
 	}, [ displayedRecommendations, selectedSite ] );
 
-	const handleItemClick = useCallback( ( site: CardData ) => {
-		setSelectedSite( site );
-	}, [] );
+	const handleItemClick = useCallback(
+		( site: CardData ) => {
+			// Only reset scroll position if selecting a different site.
+			if ( site.feed_ID !== selectedSite?.feed_ID ) {
+				const previewContainer = document.querySelector(
+					'.subscribe-modal__preview-stream-container'
+				);
+				if ( previewContainer ) {
+					previewContainer.scrollTop = 0;
+				}
+			}
+			setSelectedSite( site );
+		},
+		[ selectedSite ]
+	);
 
 	const follows = useSelector( getReaderFollows );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10089

## Proposed Changes

* This PR fixes the scroll position in Reader Onboarding so that it resets to the top when you select a new blog.






Before | After
--|--
<video src="https://github.com/user-attachments/assets/05cc9535-fc18-4f20-a5b6-5f85740395ab" /> | <video src="https://github.com/user-attachments/assets/39a5900e-84cc-4c60-97c5-cc64b068dd5c" /> 



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improved user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /read?flags=reader/force-onboarding and select the "Scrolling Feed" view. The `reader/force-onboarding` flag will force the onboarding box visible.
* Select "Discover and subscribe to sites you'll love"
* Select some blogs on the left and see that the scroll position resets to the top when you select a new blog.
* If you click the already selected blog, the scroll position will NOT reset.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
