### PR TITLE
Reader Onboarding: Remove selected site background gradient

### DIFF
--- a/client/reader/onboarding/subscribe-modal/style.scss
+++ b/client/reader/onboarding/subscribe-modal/style.scss
@@ -80,6 +80,12 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 					border-radius: 6px; /* stylelint-disable-line scales/radii */
 				}
 			}
+
+			.reader-subscription-list-item__site-url-timestamp {
+				&:not( .is-placeholder )::after {
+					background: none;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Removes an out-of-place background gradient on the selected site in Reader Onboarding.

Before | After
--|--
<img width="491" alt="Screenshot 2024-12-10 at 4 05 02 PM" src="https://github.com/user-attachments/assets/81b05aec-9539-4d4f-84f7-bff712733121">  | <img width="483" alt="Screenshot 2024-12-10 at 4 04 53 PM" src="https://github.com/user-attachments/assets/053d8348-cbca-482c-9767-0762885e79ec">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve design.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /read?flags=reader/force-onboarding and select the "Scrolling Feed" view. The reader/force-onboarding flag will force the onboarding box visible.
* Select "Discover and subscribe to sites you'll love"
* Select some sites on the left and view that the out-of-place gradient is gone. (See pictures above for reference)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
