### PR TITLE
Stats: improve tooltips consistency

### DIFF
--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -84,6 +84,8 @@ function SubscriberHighlightsStandard( {
 	highlights,
 	isLoading,
 }: SubscriberHighlightsRenderProps ) {
+	const translate = useTranslate();
+
 	return (
 		<div className="highlight-cards-list">
 			{ highlights.map( ( highlight ) => (
@@ -91,6 +93,7 @@ function SubscriberHighlightsStandard( {
 					heading={ isLoading ? '-' : highlight.heading }
 					key={ highlight.heading }
 					showValueTooltip
+					label={ translate( 'subscribers' ) }
 					note={ highlight.note }
 					value={ isLoading ? null : highlight.count }
 				/>

--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -1,4 +1,5 @@
 import { CountCard } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import useSubscribersOverview from 'calypso/my-sites/stats/hooks/use-subscribers-overview';
 
@@ -8,16 +9,25 @@ interface SubscribersOverviewProps {
 
 const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } ) => {
 	const { isLoading, isError, overviewData } = useSubscribersOverview( siteId );
+	const translate = useTranslate();
 
 	return (
 		<div className="subscribers-overview highlight-cards">
 			<div className="highlight-cards-list">
 				{ overviewData.map( ( { count, heading }, index ) => {
+					let note = translate( 'As of today' );
+					if ( heading !== 'Today' ) {
+						const prefix = translate( 'Since' );
+						note = `${ prefix } ${ heading }`;
+					}
+
 					return (
 						// TODO: Communicate loading vs error state to the user.
 						<CountCard
 							key={ index }
 							heading={ heading }
+							label={ translate( 'subscribers' ) }
+							note={ note }
 							value={ isLoading || isError ? null : count }
 							showValueTooltip
 						/>

--- a/packages/components/src/highlight-cards/annual-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/annual-highlight-cards.tsx
@@ -48,6 +48,7 @@ function AnnualHighlightsStandard( { counts }: AnnualHighlightsProps ) {
 				<CountCard
 					key={ index }
 					heading={ heading }
+					label={ heading.toLocaleLowerCase() }
 					value={ count }
 					icon={ <Icon icon={ icon } /> }
 					showValueTooltip

--- a/packages/components/src/highlight-cards/count-card.tsx
+++ b/packages/components/src/highlight-cards/count-card.tsx
@@ -7,17 +7,20 @@ import { formatNumber } from './lib/numbers';
 interface CountCardProps {
 	heading?: React.ReactNode;
 	icon?: JSX.Element;
+	label?: string;
 	note?: string;
 	showValueTooltip?: boolean;
 	value: number | string | null;
 }
 
-function TooltipContent( { value }: CountCardProps ) {
+function TooltipContent( { value, label, note }: CountCardProps ) {
 	return (
 		<div className="highlight-card-tooltip-content">
 			<span className="highlight-card-tooltip-counts">
 				{ formatNumber( value as number, false ) }
+				{ label && ` ${ label }` }
 			</span>
+			{ note && <div className="highlight-card-tooltip-note">{ note }</div> }
 		</div>
 	);
 }
@@ -25,6 +28,7 @@ function TooltipContent( { value }: CountCardProps ) {
 export default function CountCard( {
 	heading,
 	icon,
+	label,
 	note,
 	value,
 	showValueTooltip,
@@ -58,8 +62,7 @@ export default function CountCard( {
 					position="bottom right"
 					context={ textRef.current }
 				>
-					<TooltipContent value={ value } />
-					{ note && <div className="highlight-card-tooltip-note">{ note }</div> }
+					<TooltipContent value={ value } label={ label } note={ note } />
 				</Popover>
 			) }
 		</Card>

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -342,7 +342,7 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 }
 
 .highlight-card-tooltip-content {
-	display: flex;
+	display: block;
 	align-items: center;
 	justify-content: space-between;
 	font-size: $font-body-small;
@@ -397,8 +397,8 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 }
 
 .highlight-card-tooltip-note {
-	font-size: $font-body-extra-small;
-	padding-top: 8px;
+	color: var(--studio-gray-30);
+	font-size: $font-body-small;
 }
 .highlight-card__settings-tooltip {
 	.highlight-card-tooltip-content {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of Automattic/red-team#193.

## Proposed Changes

Improve tooltips consistency in the `Insights` and `Subscribers` page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is part of the efforts started by Design (p1HpG7-unJ-p2) to increase consistency between different Stats tooltips.

## Testing Instructions

- Go to the `Stats` page of any website that has meaningful data.
  - I've used `cicerosletters.wordpress.com` in these tests: `/stats/day/cicerosletters.wordpress.com`
- Check the tooltips by hovering over the different stats in the `Insights` and `Subscribers` tabs, as shown in the screenshots below.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Insights

| Before | After |
| :-: | :-: |
| <img width="582" alt="image" src="https://github.com/user-attachments/assets/eccc916a-c4db-476b-b152-f61cbdf2561f"> | <img width="585" alt="image" src="https://github.com/user-attachments/assets/6ab72e85-229b-4337-88e9-039a0e61fe84"> |

### Subscribers

| Before | After |
| :-: | :-: |
| <img width="495" alt="image" src="https://github.com/user-attachments/assets/d6dfcdc6-24ae-4b56-bc76-ffb3555c9695"> | <img width="494" alt="image" src="https://github.com/user-attachments/assets/0be4bf06-93c1-4515-854e-04871161405b"> |
| <img width="627" alt="image" src="https://github.com/user-attachments/assets/aa663d0f-6e1d-4431-a56f-511e06b72144"> | <img width="640" alt="image" src="https://github.com/user-attachments/assets/021caaa9-b3f8-49ff-bfd5-ee8e625542f5"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
