### PR TITLE
A4A: fix overdue invoice banner typo

### DIFF
--- a/client/a8c-for-agencies/components/pending-payment-notification/index.tsx
+++ b/client/a8c-for-agencies/components/pending-payment-notification/index.tsx
@@ -72,7 +72,7 @@ export default function PendingPaymentNotification() {
 		);
 	} else {
 		description = translate(
-			'Your product licenses have now been revoked. If you want to continue using the plaform, please pay your outstanding invoices.'
+			'Your product licenses have now been revoked. If you want to continue using the platform, please pay your outstanding invoices.'
 		);
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1561

## Proposed Changes

A tiny typo in the banner: `plaform` instead of `platform`

<img width="1190" alt="Screenshot 2024-12-10 at 3 18 55 PM" src="https://github.com/user-attachments/assets/48c455db-71ac-4aac-934f-e15d500178b5">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout branch locally
- Open `client/a8c-for-agencies/components/pending-payment-notification/index.tsx` in the branch
- Modify line 26 to `return 28` . Also comment line 31.
- Start client: `yarn start-a8c-for-agencies`
- Navigate to `http://agencies.localhost:3000/overview`
- Check that banner has no typo

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
