### PR TITLE
Dotcom Paid Stats: Fixes for Odyssey on Simple and Atomic

### DIFF
--- a/apps/odyssey-stats/src/lib/create-odyssey-config.ts
+++ b/apps/odyssey-stats/src/lib/create-odyssey-config.ts
@@ -119,6 +119,9 @@ export class ConfigApi extends Function {
 		// Note: configData is hydrated in https://github.com/Automattic/jetpack/blob/d4d0f987cbf63a864b03b542b7813aabe87e0ed3/projects/packages/stats-admin/src/class-dashboard.php#L214
 		this.configData.features = productionConfig.features;
 
+		// Set a flag to identify if the app is running in WP Admin becuase `is_running_in_jetpack_site` now means whether the app calls public-api directly or use the Jetpack ones.
+		this.configData.features.is_odyssey = true;
+
 		// Sets the Blaze Dashboard path prefix.
 		this.configData.advertising_dashboard_path_prefix = '/advertising';
 	}

--- a/apps/odyssey-stats/src/lib/create-odyssey-config.ts
+++ b/apps/odyssey-stats/src/lib/create-odyssey-config.ts
@@ -119,7 +119,9 @@ export class ConfigApi extends Function {
 		// Note: configData is hydrated in https://github.com/Automattic/jetpack/blob/d4d0f987cbf63a864b03b542b7813aabe87e0ed3/projects/packages/stats-admin/src/class-dashboard.php#L214
 		this.configData.features = productionConfig.features;
 
-		// Set a flag to identify if the app is running in WP Admin becuase `is_running_in_jetpack_site` now means whether the app calls public-api directly or use the Jetpack ones.
+		// Set a flag to identify if the app is running in WP Admin.
+		// `is_running_in_jetpack_site` now means whether the app calls public-api directly or use the Jetpack ones.
+		// For Simple sites running Odyssey Stats, `is_running_in_jetpack_site` is true and `is_odyssey` is false.
 		this.configData.features.is_odyssey = true;
 
 		// Sets the Blaze Dashboard path prefix.

--- a/client/my-sites/stats/const.js
+++ b/client/my-sites/stats/const.js
@@ -27,3 +27,6 @@ export const JETPACK_SUPPORT_VIDEOPRESS_URL = 'https://jetpack.com/support/jetpa
 export const JETPACK_SUPPORT_VIDEOPRESS_URL_STATS =
 	'https://jetpack.com/support/jetpack-videopress/add-video-block-editor/video-stats/';
 export const JETPACK_VIDEOPRESS_LANDING_PAGE_URL = 'https://jetpack.com/videopress/';
+export const WPCOM_PERSONAL_PLAN_SUPPORT =
+	// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
+	'https://wordpress.com/support/plan-features/personal-plan/';

--- a/client/my-sites/stats/stats-upsell/index.tsx
+++ b/client/my-sites/stats/stats-upsell/index.tsx
@@ -43,7 +43,7 @@ export default function StatsUpsell( { title, features, image, statType }: Props
 	} )?.[ planKey ];
 	const planSlug = plan?.pathSlug ?? planKey;
 	const isLoading = plans.isLoading || ! pricing;
-	const isOdysseyStats = isEnabled( 'is_running_in_jetpack_site' );
+	const isOdysseyStats = isEnabled( 'is_odyssey' );
 	const eventPrefix = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 	const { setShowHelpCenter, setShowSupportDoc } = useDataStoreDispatch( HELP_CENTER_STORE );
 	const localizeUrl = useLocalizeUrl();
@@ -53,6 +53,7 @@ export default function StatsUpsell( { title, features, image, statType }: Props
 		recordTracksEvent( `${ eventPrefix }_stats_upsell_submit`, {
 			stat_type: statType,
 		} );
+		// TODO: add redirect_to param so that we can redirect back to the stats page after checkout.
 		if ( isOdysseyStats ) {
 			const checkoutProductUrl = new URL(
 				`https://wordpress.com/checkout/${ siteSlug }/${ planSlug }`
@@ -67,8 +68,12 @@ export default function StatsUpsell( { title, features, image, statType }: Props
 
 	const onLearnMoreClick = ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => {
 		event.preventDefault();
-		setShowHelpCenter( true );
-		setShowSupportDoc( learnMoreLink );
+		if ( ! isOdysseyStats ) {
+			setShowHelpCenter( true );
+			setShowSupportDoc( learnMoreLink );
+		} else {
+			window.open( learnMoreLink, '_blank' );
+		}
 
 		recordTracksEvent( `${ eventPrefix }_stats_upsell_learn_more`, {
 			stat_type: statType,

--- a/client/my-sites/stats/stats-upsell/index.tsx
+++ b/client/my-sites/stats/stats-upsell/index.tsx
@@ -53,7 +53,6 @@ export default function StatsUpsell( { title, features, image, statType }: Props
 		recordTracksEvent( `${ eventPrefix }_stats_upsell_submit`, {
 			stat_type: statType,
 		} );
-		// TODO: add redirect_to param so that we can redirect back to the stats page after checkout.
 		if ( isOdysseyStats ) {
 			const checkoutProductUrl = new URL(
 				`https://wordpress.com/checkout/${ siteSlug }/${ planSlug }`

--- a/client/my-sites/stats/stats-upsell/insights-upsell.tsx
+++ b/client/my-sites/stats/stats-upsell/insights-upsell.tsx
@@ -1,11 +1,16 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import statsFeaturesPNG from 'calypso/assets/images/stats/paid-features-2.png';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { WPCOM_PERSONAL_PLAN_SUPPORT } from '../const';
 import { STATS_FEATURE_PAGE_INSIGHTS } from '../constants';
 import StatsUpsell from './index';
 
 const InsightsUpsell: React.FC = () => {
 	const translate = useTranslate();
+	const isOdysseyStats = isEnabled( 'is_odyssey' );
 
 	return (
 		<StatsUpsell
@@ -14,8 +19,15 @@ const InsightsUpsell: React.FC = () => {
 			features={ [
 				translate( '{{personalFeaturesLink}}All personal plan features{{/personalFeaturesLink}}', {
 					components: {
-						personalFeaturesLink: (
+						personalFeaturesLink: ! isOdysseyStats ? (
 							<InlineSupportLink supportContext="personal_plan" showIcon={ false } />
+						) : (
+							<Button
+								href={ localizeUrl( WPCOM_PERSONAL_PLAN_SUPPORT ) }
+								target="_blank"
+								rel="norefferer nooppener"
+								variant="link"
+							/>
 						),
 					},
 				} ),

--- a/client/my-sites/stats/stats-upsell/traffic-upsell.tsx
+++ b/client/my-sites/stats/stats-upsell/traffic-upsell.tsx
@@ -1,11 +1,16 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import statsFeaturesPNG from 'calypso/assets/images/stats/paid-features.png';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { WPCOM_PERSONAL_PLAN_SUPPORT } from '../const';
 import { STATS_FEATURE_PAGE_TRAFFIC } from '../constants';
 import StatsUpsell from './index';
 
 const TrafficUpsell: React.FC = () => {
 	const translate = useTranslate();
+	const isOdysseyStats = isEnabled( 'is_odyssey' );
 
 	return (
 		<StatsUpsell
@@ -14,8 +19,15 @@ const TrafficUpsell: React.FC = () => {
 			features={ [
 				translate( '{{personalFeaturesLink}}All personal plan features{{/personalFeaturesLink}}', {
 					components: {
-						personalFeaturesLink: (
+						personalFeaturesLink: ! isOdysseyStats ? (
 							<InlineSupportLink supportContext="personal_plan" showIcon={ false } />
+						) : (
+							<Button
+								href={ localizeUrl( WPCOM_PERSONAL_PLAN_SUPPORT ) }
+								target="_blank"
+								rel="norefferer"
+								variant="link"
+							/>
 						),
 					},
 				} ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Add `is_odyssey` flag, which identifies Stats is running in WP Admin as `is_running_in_jetpack_site` return false for Simple sites yet it is still running Odyssey Stats. 
* `is_running_in_jetpack_site` now only means Stats calls public-api directly
* Fix purchase link and support links

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Ensure upsell works for Odyssey sites

## Testing Instructions

### Simple

* Open your local Calypso dev env
* Run `NODE_ENV=production yarn dev --sync` to sync to your sandbox
* Sandbox `widgets.wp.com`
* Open a Free Simple site, which has Classic admin interface (You can enable it in general settings)
* Open `/wp-admin/admin.php?page=stats#!/stats/day/:siteSlug?flags=stats%2Fpaid-wpcom-v3`
* Ensure you see the v3 upsell
* Click Insight page
* Ensure you see the v3 upsell
* Ensure both upsell directs you to checkout
* Checkout personal
* Ensure upsell for Personal goes away
* Ensure you can upgrade to Premium
* Ensure no blocked modules after upgrading to Premium


<img width="1510" alt="image" src="https://github.com/user-attachments/assets/1d189798-7a1b-4f85-88fa-e8014155e9a1">


### WoA

* Open an Atomic site `/wp-admin/admin.php?page=stats#!/stats/day/:siteSlug?flags=stats%2Fpaid-wpcom-v3`
* Ensure nothing is paywalled


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
