### PR TITLE
Paid stats: add Stats reference on Personal checkout

### DIFF
--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -1876,7 +1876,7 @@ const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_STATS_COMMERCIAL ]: {
 		getSlug: () => FEATURE_STATS_COMMERCIAL,
-		getTitle: () => i18n.translate( 'In-depth site analytics dashboard.' ),
+		getTitle: () => i18n.translate( 'In-depth site analytics dashboard' ),
 		getDescription: () =>
 			i18n.translate(
 				'Deep-dive analytics and conversion data to help you make decisions to grow your site.'

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -292,6 +292,7 @@ import {
 	FEATURE_COMMISSION_FEE_STANDARD_FEATURES,
 	FEATURE_COMMISSION_FEE_WOO_FEATURES,
 	FEATURE_STATS_PAID,
+	FEATURE_STATS_COMMERCIAL,
 	FEATURE_SENSEI_SUPPORT,
 	FEATURE_SENSEI_UNLIMITED,
 	FEATURE_SENSEI_INTERACTIVE,
@@ -1863,7 +1864,19 @@ const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_STATS_PAID ]: {
 		getSlug: () => FEATURE_STATS_PAID,
-		getTitle: () => i18n.translate( 'In-depth site analytics dashboard' ),
+		getTitle: () => {
+			return isEnabled( 'stats/paid-wpcom-v3' )
+				? i18n.translate( 'Stats beyond last 7 days. Detailed traffic stats and site insights.' )
+				: i18n.translate( 'In-depth site analytics dashboard.' );
+		},
+		getDescription: () =>
+			i18n.translate(
+				'Deep-dive analytics and conversion data to help you make decisions to grow your site.'
+			),
+	},
+	[ FEATURE_STATS_COMMERCIAL ]: {
+		getSlug: () => FEATURE_STATS_COMMERCIAL,
+		getTitle: () => i18n.translate( 'In-depth site analytics dashboard.' ),
 		getDescription: () =>
 			i18n.translate(
 				'Deep-dive analytics and conversion data to help you make decisions to grow your site.'

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -1866,8 +1866,8 @@ const FEATURES_LIST: FeatureList = {
 		getSlug: () => FEATURE_STATS_PAID,
 		getTitle: () => {
 			return isEnabled( 'stats/paid-wpcom-v3' )
-				? i18n.translate( 'Stats beyond last 7 days. Detailed traffic stats and site insights.' )
-				: i18n.translate( 'In-depth site analytics dashboard.' );
+				? i18n.translate( 'Stats beyond the last 7 days' )
+				: i18n.translate( 'In-depth site analytics dashboard' );
 		},
 		getDescription: () =>
 			i18n.translate(

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -399,6 +399,7 @@ import {
 	PRODUCT_JETPACK_STATS_YEARLY,
 	TERM_CENTENNIALLY,
 	FEATURE_STATS_PAID,
+	FEATURE_STATS_COMMERCIAL,
 	PRODUCT_JETPACK_SCAN_BI_YEARLY,
 	PRODUCT_JETPACK_ANTI_SPAM_BI_YEARLY,
 	PRODUCT_JETPACK_VIDEOPRESS_BI_YEARLY,
@@ -850,12 +851,18 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_PREMIUM_CONTENT_JP,
 		FEATURE_PAID_SUBSCRIBERS_JP,
 	],
-	getCheckoutFeatures: () => [
-		FEATURE_CUSTOM_DOMAIN,
-		FEATURE_AD_FREE_EXPERIENCE,
-		FEATURE_FAST_DNS,
-		FEATURE_PAID_SUBSCRIBERS_JP,
-	],
+	getCheckoutFeatures: () => {
+		const baseFeatures = [
+			FEATURE_CUSTOM_DOMAIN,
+			FEATURE_AD_FREE_EXPERIENCE,
+			FEATURE_FAST_DNS,
+			FEATURE_PAID_SUBSCRIBERS_JP,
+		];
+
+		return isEnabled( 'stats/paid-wpcom-v3' )
+			? [ ...baseFeatures, FEATURE_STATS_PAID ]
+			: baseFeatures;
+	},
 	// Features not displayed but used for checking plan abilities
 	getIncludedFeatures: () => [ FEATURE_AUDIO_UPLOADS ],
 	getInferiorFeatures: () => [],
@@ -1287,7 +1294,7 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
 		FEATURE_UNLTD_SOCIAL_MEDIA_JP,
 		FEATURE_VIDEOPRESS_JP,
-		FEATURE_STATS_PAID,
+		isEnabled( 'stats/paid-wpcom-v3' ) ? FEATURE_STATS_COMMERCIAL : FEATURE_STATS_PAID,
 		FEATURE_PAYMENT_TRANSACTION_FEES_4,
 	],
 	getNewsletterHighlightedFeatures: () => [
@@ -1307,7 +1314,7 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_VIDEOPRESS_JP,
 		FEATURE_UNLTD_SOCIAL_MEDIA_JP,
 		FEATURE_WORDADS,
-		FEATURE_STATS_PAID,
+		isEnabled( 'stats/paid-wpcom-v3' ) ? FEATURE_STATS_COMMERCIAL : FEATURE_STATS_PAID,
 	],
 	getLinkInBioHighlightedFeatures: () => [ FEATURE_CUSTOM_DOMAIN ],
 	getBlogOnboardingSignupFeatures: () => [
@@ -1323,7 +1330,7 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_VIDEOPRESS_JP,
 		FEATURE_UNLTD_SOCIAL_MEDIA_JP,
 		FEATURE_SITE_ACTIVITY_LOG_JP,
-		FEATURE_STATS_PAID,
+		isEnabled( 'stats/paid-wpcom-v3' ) ? FEATURE_STATS_COMMERCIAL : FEATURE_STATS_PAID,
 	],
 	getBlogSignupFeatures: () =>
 		[
@@ -1376,7 +1383,7 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
 		FEATURE_WORDADS,
 		FEATURE_STYLE_CUSTOMIZATION,
-		FEATURE_STATS_PAID,
+		isEnabled( 'stats/paid-wpcom-v3' ) ? FEATURE_STATS_COMMERCIAL : FEATURE_STATS_PAID,
 		FEATURE_VIDEOPRESS_JP,
 		FEATURE_UNLTD_SOCIAL_MEDIA_JP,
 		FEATURE_SITE_ACTIVITY_LOG_JP,
@@ -1391,7 +1398,11 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		[ FEATURE_COMMISSION_FEE_STANDARD_FEATURES ]: i18n.translate( '4%' ),
 	} ),
 	get2023PlanComparisonJetpackFeatureOverride: () => {
-		return [ FEATURE_PAYPAL_JP, FEATURE_VIDEOPRESS_JP, FEATURE_STATS_PAID ];
+		return [
+			FEATURE_PAYPAL_JP,
+			FEATURE_VIDEOPRESS_JP,
+			isEnabled( 'stats/paid-wpcom-v3' ) ? FEATURE_STATS_COMMERCIAL : FEATURE_STATS_PAID,
+		];
 	},
 	// Features not displayed but used for checking plan abilities
 	getIncludedFeatures: () => [
@@ -1968,7 +1979,7 @@ const getJetpackBusinessDetails = (): IncompleteJetpackPlan => ( {
 			WPCOM_FEATURES_SCAN,
 			WPCOM_FEATURES_ANTISPAM,
 			WPCOM_FEATURES_BACKUPS,
-			FEATURE_STATS_PAID,
+			isEnabled( 'stats/paid-wpcom-v3' ) ? FEATURE_STATS_COMMERCIAL : FEATURE_STATS_PAID,
 		] ),
 	getInferiorFeatures: () => [ FEATURE_JETPACK_BACKUP_DAILY, FEATURE_JETPACK_BACKUP_DAILY_MONTHLY ],
 } );
@@ -2244,7 +2255,7 @@ const getPlanJetpackCompleteDetails = (): IncompleteJetpackPlan => ( {
 			WPCOM_FEATURES_SCAN,
 			WPCOM_FEATURES_ANTISPAM,
 			WPCOM_FEATURES_BACKUPS,
-			FEATURE_STATS_PAID,
+			isEnabled( 'stats/paid-wpcom-v3' ) ? FEATURE_STATS_COMMERCIAL : FEATURE_STATS_PAID,
 		] ),
 	getInferiorFeatures: () => [
 		FEATURE_JETPACK_BACKUP_DAILY,
@@ -2357,7 +2368,10 @@ const getPlanJetpackGrowthDetails = (): IncompleteJetpackPlan => ( {
 		translate(
 			'Essential tools to help you grow your audience, track visitor engagement, and turn leads into loyal customers and advocates.'
 		),
-	getPlanCardFeatures: () => [ FEATURE_JETPACK_SOCIAL_V1_MONTHLY, FEATURE_STATS_PAID ],
+	getPlanCardFeatures: () => [
+		FEATURE_JETPACK_SOCIAL_V1_MONTHLY,
+		isEnabled( 'stats/paid-wpcom-v3' ) ? FEATURE_STATS_COMMERCIAL : FEATURE_STATS_PAID,
+	],
 	getIncludedFeatures: () => [
 		FEATURE_EARN_AD,
 		FEATURE_UNLIMITED_SUBSCRIBERS,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/red-team/issues/305

We want to include Stats features on the checkout page while purchasing a WordPress.com Personal plan.

To achieve this, we need to replace the existing feature texts from `FEATURE_STATS_PAID` with `FEATURE_STATS_COMMERCIAL` and add the new feature message for `FEATURE_STATS_PAID` on the checkout page.

To ensure a smooth transition, these changes are being made conditionally under the `stats/paid-wpcom-v3` feature flag to ensure everything works as expected.

![CleanShot 2024-12-10 at 20 18 00@2x](https://github.com/user-attachments/assets/c317d37d-6ebd-46ad-9d3e-126e8cfcb14d)

> [!NOTE]
> Due to restrictions on how the features list is presented, I am merging both lines into a single line while we gather feedback from the design team. I believe it is safe to proceed with this PR and iterate if needed.
> | Expected | Proposal |
> |---|---|
> | ![CleanShot 2024-12-10 at 20 20 23@2x](https://github.com/user-attachments/assets/9c3fa1c1-4000-4b51-91d0-9c90122e702c) | ![CleanShot 2024-12-10 at 20 20 45@2x](https://github.com/user-attachments/assets/f7c349f3-b6df-489a-a91e-bca7a5d8da5d) |

## Proposed Changes

* Add `FEATURE_STATS_COMMERCIAL` feature details using the existing `FEATURE_STATS_PAID`.
* Update `FEATURE_STATS_PAID` title/description with the new texts under the `stats/paid-wpcom-v3` feature flag.
* Replace `FEATURE_STATS_PAID` with conditional logic to use `FEATURE_STATS_COMMERCIAL` under the `stats/paid-wpcom-v3` feature flag in the Calypso plans list configuration.
  * This ensures that any references to `FEATURE_STATS_PAID` will continue working as usual and will switch to `FEATURE_STATS_COMMERCIAL` when the feature flag is enabled.

| Before | After |
|---|---|
| ![CleanShot 2024-12-10 at 19 47 04@2x](https://github.com/user-attachments/assets/07ca26bc-6f22-420e-a8c3-fbcd5ae1e367) | ![CleanShot 2024-12-10 at 19 47 32@2x](https://github.com/user-attachments/assets/f95410a7-d127-4af1-82f5-609f84c85921) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://github.com/Automattic/red-team/issues/305

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Calypso Live Branch

### Validate Personal checkout has the new message under `stats/paid-wpcom-v3` flag

* Try upgrading to Personal plan. You can click on `Upgrade plan` on `Clicks` module.
* Ensure you see the `Stats beyond last 7 days` message in the features list (the feature flag is enabled by default in live branch environment).
  ![CleanShot 2024-12-10 at 20 01 56@2x](https://github.com/user-attachments/assets/8930c427-f161-428a-9e6f-f8fde19f3694)
* Now disable the feature flag by appending `?flags=-stats/paid-wpcom-v3` to the checkout page.
* Ensure you don't see any Stats message in the features list.
  ![CleanShot 2024-12-10 at 19 59 55@2x](https://github.com/user-attachments/assets/99f758a0-7197-4d76-b287-be6d7ceeb928)
 
### Validate Premium checkout is not affected
* Try upgrading to Premium plan, you can click on `Upgrade plan` on the UTM or Devices module.
* In the checkout page, ensure you see  `In-depth site analytics dashboard.` in the features list, with and without the `stats/paid-wpcom-v3` flag.
  ![CleanShot 2024-12-10 at 19 54 17@2x](https://github.com/user-attachments/assets/f5bc3218-07ca-4d20-94c7-6e0bc24133e6)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
