### PR TITLE
Add events for opening interval dropdowns

### DIFF
--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -131,9 +131,9 @@ export function WPOrderReviewLineItems( {
 		);
 	}, [ responseCart.products ] );
 
-	const hasWPCOMPlanInCart = useMemo( () => {
-		return responseCart.products.some( ( product ) => isWpComPlan( product.product_slug ) );
-	}, [ responseCart.products ] );
+	const hasWPCOMPlanInCart = responseCart.products.some( ( product ) =>
+		isWpComPlan( product.product_slug )
+	);
 
 	const [ variantOpenId, setVariantOpenId ] = useState< string | null >( null );
 	const [ akQuantityOpenId, setAkQuantityOpenId ] = useState< string | null >( null );

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -3,6 +3,7 @@ import {
 	isAkismetProduct,
 	isJetpackPurchasableItem,
 	AKISMET_PRO_500_PRODUCTS,
+	isWpComPlan,
 } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { isCopySiteFlow } from '@automattic/onboarding';
@@ -130,6 +131,10 @@ export function WPOrderReviewLineItems( {
 		);
 	}, [ responseCart.products ] );
 
+	const hasWPCOMPlanInCart = useMemo( () => {
+		return responseCart.products.some( ( product ) => isWpComPlan( product.product_slug ) );
+	}, [ responseCart.products ] );
+
 	const [ variantOpenId, setVariantOpenId ] = useState< string | null >( null );
 	const [ akQuantityOpenId, setAkQuantityOpenId ] = useState< string | null >( null );
 
@@ -141,9 +146,21 @@ export function WPOrderReviewLineItems( {
 					setAkQuantityOpenId( null );
 				}
 			}
+
+			reduxDispatch(
+				recordTracksEvent( 'calypso_checkout_variant_dropdown_open', {
+					has_wpcom_plan_in_cart: hasWPCOMPlanInCart,
+				} )
+			);
 			setVariantOpenId( variantOpenId !== id ? id : null );
 		},
-		[ akQuantityOpenId, isAkismetProMultipleLicensesCart, variantOpenId ]
+		[
+			akQuantityOpenId,
+			hasWPCOMPlanInCart,
+			isAkismetProMultipleLicensesCart,
+			reduxDispatch,
+			variantOpenId,
+		]
 	);
 
 	const handleAkQuantityToggle = useCallback(

--- a/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -1,15 +1,24 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { CustomSelectControl } from '@wordpress/components';
+import { useRef } from 'react';
 import DropdownOption from '../../dropdown-option';
 import useIntervalOptions from '../hooks/use-interval-options';
 import type { IntervalTypeProps, SupportedUrlFriendlyTermType } from '../../../types';
 
 export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
-	const { hideDiscount, intent, intervalType, displayedIntervals, onPlanIntervalUpdate } = props;
+	const {
+		hideDiscount,
+		intent,
+		intervalType,
+		displayedIntervals,
+		onPlanIntervalUpdate,
+		isInSignup,
+	} = props;
 	const supportedIntervalType = (
 		displayedIntervals.includes( intervalType ) ? intervalType : 'yearly'
 	) as SupportedUrlFriendlyTermType;
 	const optionsList = useIntervalOptions( props );
+	const hasOpenedDropdown = useRef( false );
 
 	const selectOptionsList = Object.values( optionsList ).map( ( option ) => ( {
 		key: option.key,
@@ -28,6 +37,15 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 	return (
 		<div className="plan-type-selector__interval-type-dropdown-container">
 			<CustomSelectControl
+				onFocus={ () => {
+					if ( ! hasOpenedDropdown.current ) {
+						recordTracksEvent( 'calypso_plans_plan_type_selector_open', {
+							plans_intent: intent,
+							is_in_signup: isInSignup,
+						} );
+						hasOpenedDropdown.current = true;
+					}
+				} }
 				className="plan-type-selector__interval-type-dropdown"
 				label=""
 				options={ selectOptionsList }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1732151233100969-slack-CFFF01Q4V

## Proposed Changes

Adds 2 new events to track when a interval dropdown has opened.
* `calypso_checkout_variant_dropdown_open`: On the checkout page.
* `calypso_plans_plan_type_selector_open`: Dropdown used on the plans step in onboarding flows and on the /plans page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The data from these events will validate/invalidate the need for this experiment: p1732151233100969-slack-CFFF01Q4V

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans`.
* Open the network inspector.
* Click on the interval dropdown. Confirm that you see a request for `http://pixel.wp.com/t.gif` with the following data:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/350067c7-b7b4-4ec8-97bf-9eca9f88a15f">

* The event should be fired only once.
* Go to `/plans/<site slug>` and repeat the above steps.
* Go to checkout with any product in the cart and repeat the above steps. The event from checkout should have this data:
<img width="467" alt="image" src="https://github.com/user-attachments/assets/5ded6fc1-c3b7-4d88-a2e3-3e0b83334731">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?