### PR TITLE
Enable stats/paid-wpcom-v3 upsell feature flag in production config

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -195,6 +195,7 @@
 		"stats/empty-module-v2": true,
 		"stats/new-date-filtering": true,
 		"stats/paid-wpcom-v2": true,
+		"stats/paid-wpcom-v3": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,


### PR DESCRIPTION
Related to https://github.com/Automattic/red-team/issues/297

## Proposed Changes

* Enables the `stats/paid-wpcom-v3` feature flag

## Testing Instructions

The feature flag is already enabled on staging, wpcalypso, and dev environments.

- [ ] Apply the diff D167647-code
- [ ] Confirm free sites with registration dates in the future see the new upsell
- [ ] Confirm free sites with registration dates in the past see the v2 upsells
- [ ] Confirm Personal sites see some v2 upsells for utm/device stats but clicks/referrers are unlocked
- [ ] Confirm Premium sites see utm/device stats unlocked.

![Screenshot 2024-12-11 at 13-17-36 Jetpack Stats ‹ Site test — WordPress com](https://github.com/user-attachments/assets/30bd060b-290d-44fa-9225-7bb912d1b9c1)
![Screenshot 2024-12-11 at 13-17-41 Jetpack Stats ‹ Site test — WordPress com](https://github.com/user-attachments/assets/533ba5ff-cd6e-4b69-9c56-9f8334d39c98)


