### PR TITLE
Fix WCCOM account creation flow UI

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -884,14 +884,16 @@ class Login extends Component {
 		if ( action === 'lostpassword' && isReactLostPasswordScreenEnabled() ) {
 			return (
 				<Fragment>
-					<AsyncLoad
-						require="calypso/blocks/login/lost-password-form"
-						redirectToAfterLoginUrl={ this.props.redirectTo }
-						oauth2ClientId={ this.props.oauth2Client && this.props.oauth2Client.id }
-						locale={ locale }
-						isWooPasswordlessJPC={ isWooPasswordlessJPC }
-						from={ get( currentQuery, 'from' ) }
-					/>
+					<div className="login__lost-password-form-wrapper">
+						<AsyncLoad
+							require="calypso/blocks/login/lost-password-form"
+							redirectToAfterLoginUrl={ this.props.redirectTo }
+							oauth2ClientId={ this.props.oauth2Client && this.props.oauth2Client.id }
+							locale={ locale }
+							isWooPasswordlessJPC={ isWooPasswordlessJPC }
+							from={ get( currentQuery, 'from' ) }
+						/>
+					</div>
 					{ ! isWooPasswordlessJPC && ! isBlazePro && (
 						<div className="login__lost-password-footer">
 							<p className="login__lost-password-no-account">

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -797,7 +797,7 @@ $breakpoint-mobile: 660px;
 	}
 
 	.login__lost-password-form-wrapper {
-		// Loading lost password form module is very fast, so we don't need to show a visual placeholder, just need to have the space reserved.  Otherwise we will see a flash of content.
+		// Loading lost password form module is very fast, so we don't need to show a visual placeholder, just need to have the space reserved. Otherwise we will see a flash of content.
 		.async-load__placeholder {
 			visibility: hidden;
 			height: 185px;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -796,6 +796,14 @@ $breakpoint-mobile: 660px;
 		}
 	}
 
+	.login__lost-password-form-wrapper {
+		.async-load__placeholder {
+			visibility: hidden;
+			height: 185px;
+			margin: 48px auto 0;
+		}
+	}
+
 	.login .login__form-forgot-password {
 		text-align: start;
 		color: $gray-50;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -797,6 +797,7 @@ $breakpoint-mobile: 660px;
 	}
 
 	.login__lost-password-form-wrapper {
+		// Loading lost password form module is very fast, so we don't need to show a visual placeholder, just need to have the space reserved.  Otherwise we will see a flash of content.
 		.async-load__placeholder {
 			visibility: hidden;
 			height: 185px;

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -94,7 +94,7 @@ export default {
 		if ( isReskinnedFlow( currentFlowName ) ) {
 			next();
 		} else if ( isWoo ) {
-			// Do nothing, we don't want to remove the white background for Woo
+			// Do nothing, Woo flow background should keep white.
 			next();
 		} else if (
 			context.pathname.indexOf( 'domain' ) >= 0 ||

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -6,10 +6,12 @@ import store from 'store';
 import { notFound } from 'calypso/controller';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
 import { loadExperimentAssignment } from 'calypso/lib/explat';
+import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import { sectionify } from 'calypso/lib/route';
 import flows from 'calypso/signup/config/flows';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import { updateDependencies } from 'calypso/state/signup/actions';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import { setCurrentFlowName, setPreviousFlowName } from 'calypso/state/signup/flow/actions';
@@ -87,7 +89,12 @@ export default {
 	redirectTests( context, next ) {
 		const isLoggedIn = isUserLoggedIn( context.store.getState() );
 		const currentFlowName = getFlowName( context.params, isLoggedIn );
+		const isWoo = isWooOAuth2Client( getCurrentOAuth2Client( context.store.getState() ) );
+
 		if ( isReskinnedFlow( currentFlowName ) ) {
+			next();
+		} else if ( isWoo ) {
+			// Do nothing, we don't want to remove the white background for Woo
 			next();
 		} else if (
 			context.pathname.indexOf( 'domain' ) >= 0 ||

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -202,13 +202,14 @@ export class UserStep extends Component {
 			wccomFrom,
 			isReskinned,
 			isOnboardingAffiliateFlow,
+			isWoo,
 		} = this.props;
 
 		let subHeaderText = this.props.subHeaderText;
 		const loginUrl = this.getLoginUrl();
 
 		if ( [ 'wpcc', 'crowdsignal' ].includes( flowName ) && oauth2Client ) {
-			if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
+			if ( isWoo && wccomFrom ) {
 				switch ( wccomFrom ) {
 					case 'cart':
 						subHeaderText = translate(
@@ -241,7 +242,7 @@ export class UserStep extends Component {
 							}
 						);
 				}
-			} else if ( isWooOAuth2Client( oauth2Client ) && ! wccomFrom ) {
+			} else if ( isWoo && ! wccomFrom ) {
 				subHeaderText = translate(
 					'Please create an account to continue. Already registered? {{a}}Log in{{/a}}',
 					{
@@ -491,6 +492,7 @@ export class UserStep extends Component {
 			isSocialFirst,
 			userLoggedIn,
 			isBlazePro,
+			isWoo,
 		} = this.props;
 
 		if ( userLoggedIn ) {
@@ -504,7 +506,7 @@ export class UserStep extends Component {
 			return translate( 'Sign up for Crowdsignal' );
 		}
 
-		if ( isWooOAuth2Client( oauth2Client ) ) {
+		if ( isWoo ) {
 			if ( 'cart' === wccomFrom ) {
 				return <WooCommerceConnectCartHeader />;
 			}
@@ -565,7 +567,7 @@ export class UserStep extends Component {
 	}
 
 	submitButtonText() {
-		const { translate, flowName } = this.props;
+		const { translate, flowName, isWoo } = this.props;
 
 		if ( isP2Flow( flowName ) ) {
 			return translate( 'Continue' );
@@ -575,7 +577,7 @@ export class UserStep extends Component {
 			return translate( 'Continue' );
 		}
 
-		if ( isWooOAuth2Client( this.props.oauth2Client ) ) {
+		if ( isWoo ) {
 			return translate( 'Get started' );
 		}
 
@@ -587,7 +589,7 @@ export class UserStep extends Component {
 	}
 
 	renderSignupForm() {
-		const { oauth2Client, isReskinned } = this.props;
+		const { oauth2Client, isReskinned, isWoo } = this.props;
 		const isPasswordless =
 			isMobile() ||
 			this.props.isPasswordless ||
@@ -597,7 +599,7 @@ export class UserStep extends Component {
 		let socialServiceResponse;
 		let isSocialSignupEnabled = this.props.isSocialSignupEnabled;
 
-		if ( isWooOAuth2Client( oauth2Client ) ) {
+		if ( isWoo ) {
 			isSocialSignupEnabled = true;
 		}
 
@@ -635,9 +637,7 @@ export class UserStep extends Component {
 					recaptchaClientId={ this.state.recaptchaClientId }
 					horizontal={ isReskinned }
 					isReskinned={ isReskinned }
-					shouldDisplayUserExistsError={
-						! isWooOAuth2Client( oauth2Client ) && ! isBlazeProOAuth2Client( oauth2Client )
-					}
+					shouldDisplayUserExistsError={ ! isWoo && ! isBlazeProOAuth2Client( oauth2Client ) }
 					isSocialFirst={ this.props.isSocialFirst }
 					labelText={ this.props.isWooPasswordless ? this.props.translate( 'Your email' ) : null }
 				/>
@@ -732,8 +732,8 @@ export class UserStep extends Component {
 	}
 
 	render() {
-		if ( this.userCreationComplete() ) {
-			return null; // return nothing so that we don't see the completed signup form flash.
+		if ( this.userCreationComplete() && ! this.props.isWoo ) {
+			return null; // return nothing so that we don't see the completed signup form flash but skip for Woo because it need to keep the form until the user is redirected back to original page (e.g. WooCommerce.com).
 		}
 
 		if ( isP2Flow( this.props.flowName ) ) {
@@ -748,7 +748,7 @@ export class UserStep extends Component {
 			return this.renderGravatarSignupStep();
 		}
 
-		if ( isWooOAuth2Client( this.props.oauth2Client ) && this.props.userLoggedIn ) {
+		if ( this.props.isWoo && this.props.userLoggedIn ) {
 			page( this.getLoginUrl() );
 			return null;
 		}
@@ -772,10 +772,12 @@ export class UserStep extends Component {
 
 const ConnectedUser = connect(
 	( state ) => {
+		const oauth2Client = getCurrentOAuth2Client( state );
 		return {
-			oauth2Client: getCurrentOAuth2Client( state ),
+			oauth2Client: oauth2Client,
 			suggestedUsername: getSuggestedUsername( state ),
 			wccomFrom: getWccomFrom( state ),
+			isWoo: isWooOAuth2Client( oauth2Client ),
 			isWooPasswordless: getIsWooPasswordless( state ),
 			isBlazePro: getIsBlazePro( state ),
 			from: get( getCurrentQueryArguments( state ), 'from' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1733370435079849-slack-C01SFMVEYAK



## Proposed Changes

Fix the following issues:

- Login textbox & button unintentionally re-enabled when logging in
- Blue flash on login screen
- Placeholder flash on Lost password screen

![Screenshot 2024-12-11 at 11 56 42](https://github.com/user-attachments/assets/84a6861c-09d4-4f46-aaed-6ea382f7f155)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bad UI experience

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up Woo Start environment
* Go to WooCommerce.com in a incognito window
* Click on "Log in"
* Click on "Lost password?" and confirm it doesn't show placeholder flash before the form is filled
* Go back to the login page and click on "Sign up"
* Observe that background is white and doesn't show a blue flash
* Create a new account and confirm the Login text button not re-enabled when logging in



https://github.com/user-attachments/assets/528ba180-1ec4-4df5-a779-8819ec93997b


https://github.com/user-attachments/assets/a8d7ab0a-5219-4319-bcd5-592c97a96553


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?