### PR TITLE
Update copy on old modal for personal/premium upsell features

### DIFF
--- a/client/my-sites/stats/stats-upsell-modal/index.tsx
+++ b/client/my-sites/stats/stats-upsell-modal/index.tsx
@@ -1,8 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isEnabled } from '@automattic/calypso-config';
+import { PLAN_PREMIUM } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Gridicon, PlanPrice } from '@automattic/components';
-import { Plans } from '@automattic/data-stores';
+import { Plans, PlanNext } from '@automattic/data-stores';
 import formatCurrency from '@automattic/format-currency';
 import { Button, Modal } from '@wordpress/components';
 import { close } from '@wordpress/icons';
@@ -133,44 +134,94 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 									},
 							  } ) }
 					</div>
-					<div className="stats-upsell-modal__features">
-						<div className="stats-upsell-modal__feature">
-							<Gridicon icon="checkmark" size={ 18 } />
-							<div className="stats-upsell-modal__feature-text">
-								{ translate(
-									'All stats available: traffic trends, sources, optimal time to post…'
-								) }
-							</div>
-						</div>
-						<div className="stats-upsell-modal__feature">
-							<Gridicon icon="checkmark" size={ 18 } />
-							<div className="stats-upsell-modal__feature-text">
-								{ translate( 'Download data as CSV' ) }
-							</div>
-						</div>
-						<div className="stats-upsell-modal__feature">
-							<Gridicon icon="checkmark" size={ 18 } />
-							<div className="stats-upsell-modal__feature-text">
-								{ translate( 'Instant access to upcoming features' ) }
-							</div>
-						</div>
-						<div className="stats-upsell-modal__feature">
-							<Gridicon icon="checkmark" size={ 18 } />
-							<div className="stats-upsell-modal__feature-text">
-								{ translate( '14-day money-back guarantee' ) }
-							</div>
-						</div>
-						<div className="stats-upsell-modal__feature">
-							<Gridicon icon="checkmark" size={ 18 } />
-							<div className="stats-upsell-modal__feature-text">
-								{ translate( 'All %(planName)s plan features', {
-									args: { planName: plan?.productNameShort ?? '' },
-								} ) }
-							</div>
-						</div>
-					</div>
+					{ plan?.planSlug === PLAN_PREMIUM ? (
+						<PremiumFeatures plan={ plan } />
+					) : (
+						<PersonalFeatures plan={ plan } />
+					) }
 				</div>
 			</div>
 		</Modal>
+	);
+}
+
+function PremiumFeatures( { plan }: { plan: PlanNext | undefined } ) {
+	const translate = useTranslate();
+
+	return (
+		<div className="stats-upsell-modal__features">
+			<div className="stats-upsell-modal__feature">
+				<Gridicon icon="checkmark" size={ 18 } />
+				<div className="stats-upsell-modal__feature-text">
+					{ translate( 'All stats available: traffic trends, sources, optimal time to post…' ) }
+				</div>
+			</div>
+			<div className="stats-upsell-modal__feature">
+				<Gridicon icon="checkmark" size={ 18 } />
+				<div className="stats-upsell-modal__feature-text">
+					{ translate( 'Track campaign performance with UTM parameters' ) }
+				</div>
+			</div>
+			<div className="stats-upsell-modal__feature">
+				<Gridicon icon="checkmark" size={ 18 } />
+				<div className="stats-upsell-modal__feature-text">
+					{ translate( 'Instant access to upcoming features' ) }
+				</div>
+			</div>
+			<div className="stats-upsell-modal__feature">
+				<Gridicon icon="checkmark" size={ 18 } />
+				<div className="stats-upsell-modal__feature-text">
+					{ translate( '14-day money-back guarantee' ) }
+				</div>
+			</div>
+			<div className="stats-upsell-modal__feature">
+				<Gridicon icon="checkmark" size={ 18 } />
+				<div className="stats-upsell-modal__feature-text">
+					{ translate( 'All %(planName)s plan features', {
+						args: { planName: plan?.productNameShort ?? '' },
+					} ) }
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function PersonalFeatures( { plan }: { plan: PlanNext | undefined } ) {
+	const translate = useTranslate();
+	return (
+		<div className="stats-upsell-modal__features">
+			<div className="stats-upsell-modal__feature">
+				<Gridicon icon="checkmark" size={ 18 } />
+				<div className="stats-upsell-modal__feature-text">
+					{ translate( 'Stats beyond the last 7 days' ) }
+				</div>
+			</div>
+			<div className="stats-upsell-modal__feature">
+				<Gridicon icon="checkmark" size={ 18 } />
+				<div className="stats-upsell-modal__feature-text">
+					{ translate( 'Download data as CSV' ) }
+				</div>
+			</div>
+			<div className="stats-upsell-modal__feature">
+				<Gridicon icon="checkmark" size={ 18 } />
+				<div className="stats-upsell-modal__feature-text">
+					{ translate( 'Detailed traffic stats and site insights' ) }
+				</div>
+			</div>
+			<div className="stats-upsell-modal__feature">
+				<Gridicon icon="checkmark" size={ 18 } />
+				<div className="stats-upsell-modal__feature-text">
+					{ translate( '14-day money-back guarantee' ) }
+				</div>
+			</div>
+			<div className="stats-upsell-modal__feature">
+				<Gridicon icon="checkmark" size={ 18 } />
+				<div className="stats-upsell-modal__feature-text">
+					{ translate( 'All %(planName)s plan features', {
+						args: { planName: plan?.productNameShort ?? '' },
+					} ) }
+				</div>
+			</div>
+		</div>
 	);
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/red-team/issues/309

## Proposed Changes

Currently, the upsell modal has a feature list based around the upsell only ever upselling to the premium plan. Since we now handle upselling the the personal plan this modal needs updating to include features specific to the personal plan.

Before - only one feature list, shown for both premium and personal plan upsells

![Screenshot(165)](https://github.com/user-attachments/assets/29cc56dd-10d1-4aa2-8fc7-1c51f29aeccf)

After - specific feature lists for personal and premium

![Screenshot 2024-12-11 at 16-56-05 Jetpack Stats ‹ Site test — WordPress com](https://github.com/user-attachments/assets/f1904137-8b4a-43db-9a8d-16adecafcbf5)

![Screenshot 2024-12-11 at 16-55-38 Jetpack Stats ‹ Site test — WordPress com](https://github.com/user-attachments/assets/788006cd-9132-4a2b-abfd-5db7d043b7a7)

## Testing Instructions

The personal upsell modal is only shown when the feature flag enabled, without it, it only shows premium plans.

* View stats for a free site, click the upsell in the date picker, it should show the new feature list for the premium plans