### PR TITLE
Design Picker: Group results by the best matching and categories (2nd try)

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/index.tsx
@@ -1,3 +1,4 @@
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import UnifiedDesignPicker from './unified-design-picker';
@@ -8,8 +9,11 @@ import type { Step } from '../../types';
  */
 const DesignSetup: Step = ( props ) => {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 
-	const headerText = translate( 'Pick a design' );
+	const headerText = hasEnTranslation( 'Pick a theme' )
+		? translate( 'Pick a theme' )
+		: translate( 'Pick a design' );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
@@ -182,7 +182,7 @@ describe( 'UnifiedDesignPickerStep', () => {
 			);
 
 			await waitFor( () => {
-				expect( screen.getByText( 'Pick a design' ) ).toBeInTheDocument();
+				expect( screen.getByText( 'Pick a theme' ) ).toBeInTheDocument();
 				expect( container.getElementsByClassName( 'unified-design-picker__designs' ) ).toHaveLength(
 					1
 				);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -23,7 +23,7 @@ import {
 	isAssemblerDesign,
 	PERSONAL_THEME,
 } from '@automattic/design-picker';
-import { useLocale } from '@automattic/i18n-utils';
+import { useLocale, useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer, DESIGN_FIRST_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -130,6 +130,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	const translate = useTranslate();
 	const locale = useLocale();
+	const hasEnTranslation = useHasEnTranslation();
 
 	const { intent, goals } = useSelect( ( select ) => {
 		const onboardStore = select( ONBOARD_STORE ) as OnboardSelect;
@@ -914,7 +915,11 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const heading = (
 		<FormattedHeader
 			id="step-header"
-			headerText={ translate( 'Pick a design' ) }
+			headerText={
+				hasEnTranslation( 'Pick a theme' )
+					? translate( 'Pick a theme' )
+					: translate( 'Pick a design' )
+			}
 			subHeaderText={ translate(
 				'One of these homepage options could be great to start with. You can always change later.'
 			) }

--- a/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
@@ -167,6 +167,6 @@ export class StartSiteFlow {
 	 * @param {string} themeName Name of theme, e.g. "Zoologist".
 	 */
 	async selectTheme( themeName: string ): Promise< void > {
-		await this.page.getByRole( 'link', { name: themeName } ).click();
+		await this.page.getByRole( 'link', { name: themeName } ).first().click();
 	}
 }

--- a/packages/design-picker/src/components/no-results/index.tsx
+++ b/packages/design-picker/src/components/no-results/index.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 const NoResults = () => {
 	const translate = useTranslate();
 
-	return <span>{ translate( 'No designs matched.' ) }</span>;
+	return <span>{ translate( 'No themes matched.' ) }</span>;
 };
 
 export default NoResults;

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -78,12 +78,17 @@
 
 	.design-picker__design-card-group {
 		.design-picker__design-card-title {
-			margin-bottom: 8px;
+			position: sticky;
+			top: 0;
+			padding: 16px 12px;
+			margin: 0 -12px 8px;
 			color: var(--studio-black);
+			background-color: var(--color-body-background);
 			font-size: $font-body;
 			font-style: normal;
 			font-weight: 500;
 			line-height: 24px;
+			z-index: 10;
 		}
 
 		.design-picker__grid {

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -76,16 +76,23 @@
 		}
 	}
 
-	.design-picker__grid,
-	.design-picker__grid-minimal {
-		flex: 5;
+	.design-picker__design-card-group {
+		.design-picker__design-card-title {
+			margin-bottom: 8px;
+			color: var(--studio-black);
+			font-size: $font-body;
+			font-style: normal;
+			font-weight: 500;
+			line-height: 24px;
+		}
+
+		.design-picker__grid {
+			margin-bottom: 24px;
+		}
 	}
 
 	.design-picker__grid {
-		margin: 0 -12px 30px;
-	}
-
-	.design-picker__grid-minimal {
+		flex: 5;
 		margin: 0 -12px 30px;
 	}
 
@@ -141,23 +148,6 @@
 				grid-template-columns: 1fr 1fr;
 				column-gap: 24px;
 				row-gap: 28px;
-			}
-		}
-
-		.design-picker__grid-minimal {
-			display: grid;
-			grid-template-columns: 1fr;
-			row-gap: 36px;
-			margin: 0 0 30px;
-
-			@include break-medium {
-				grid-template-columns: 1fr 1fr;
-				column-gap: 24px;
-			}
-
-			@include break-xlarge {
-				grid-template-columns: 1fr 1fr 1fr;
-				column-gap: 32px;
 			}
 		}
 
@@ -425,7 +415,7 @@
 
 	.design-picker__grid {
 		@supports ( display: grid ) {
-			row-gap: 32px;
+			row-gap: 24px;
 
 			@include break-medium {
 				grid-template-columns: 1fr 1fr 1fr;

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -171,7 +171,7 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 };
 
 interface DesignCardGroup {
-	title?: string;
+	title?: string | React.ReactNode;
 	designs: Design[];
 	locale: string;
 	category?: string | null;
@@ -309,6 +309,10 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	);
 
 	const translate = useTranslate();
+
+	const getCategoryName = ( value: string ) =>
+		( categorization?.categories || [] ).find( ( { slug } ) => slug === value )?.name || '';
+
 	const designCardProps = {
 		locale,
 		isPremiumThemeAvailable,
@@ -369,9 +373,10 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						{ ...designCardProps }
 						title={
 							isMultiFilterEnabled
-								? `${ ( categorization?.categories || [] ).find(
-										( { slug } ) => slug === categorySlug
-								  )?.name } themes`
+								? translate( '%s themes', {
+										args: getCategoryName( categorySlug ),
+										comment: '%s will be a name of the theme category. e.g. Blog.',
+								  } )
 								: ''
 						}
 						category={ categorySlug }

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -2,7 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useRef, useState } from 'react';
-import { useInView } from 'react-intersection-observer';
+import { InView } from 'react-intersection-observer';
 import { SHOW_ALL_SLUG } from '../constants';
 import { useFilteredDesignsByGroup } from '../hooks/use-filtered-designs';
 import {
@@ -428,16 +428,6 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 
-	const { ref } = useInView( {
-		onChange: ( inView ) => {
-			if ( inView ) {
-				onViewAllDesigns();
-			}
-		},
-	} );
-	// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-	const bottomAnchorContent = <div className="design-picker__bottom_anchor" ref={ ref }></div>;
-
 	return (
 		<div
 			className={ clsx( 'design-picker', `design-picker--theme-light`, 'design-picker__unified', {
@@ -462,7 +452,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					isMultiFilterEnabled={ isMultiFilterEnabled }
 					onChangeTier={ onChangeTier }
 				/>
-				{ bottomAnchorContent }
+				<InView onChange={ ( inView ) => inView && onViewAllDesigns() } />
 			</div>
 		</div>
 	);

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -354,7 +354,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 				) }
 			</div>
 
-			{ isMultiFilterEnabled && (
+			{ isMultiFilterEnabled && categorization && categorization.selections.length > 1 && (
 				<DesignCardGroup
 					{ ...designCardProps }
 					title={ translate( 'Best matching themes' ) }

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -294,24 +294,23 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	isMultiFilterEnabled = false,
 	onChangeTier,
 } ) => {
+	const translate = useTranslate();
 	const { all, best, ...designsByGroup } = useFilteredDesignsByGroup( designs );
+	const categories = categorization?.categories || [];
 	const isNoResults = Object.values( designsByGroup ).every(
 		( categoryDesigns ) => categoryDesigns.length === 0
 	);
 	const categoryTypes = useMemo(
-		() => ( categorization?.categories || [] ).filter( ( { slug } ) => isFeatureCategory( slug ) ),
+		() => categories.filter( ( { slug } ) => isFeatureCategory( slug ) ),
 		[ categorization?.categories ]
 	);
 	const categoryTopics = useMemo(
-		() =>
-			( categorization?.categories || [] ).filter( ( { slug } ) => ! isFeatureCategory( slug ) ),
+		() => categories.filter( ( { slug } ) => ! isFeatureCategory( slug ) ),
 		[ categorization?.categories ]
 	);
 
-	const translate = useTranslate();
-
 	const getCategoryName = ( value: string ) =>
-		( categorization?.categories || [] ).find( ( { slug } ) => slug === value )?.name || '';
+		categories.find( ( { slug } ) => slug === value )?.name || '';
 
 	const designCardProps = {
 		locale,
@@ -366,8 +365,10 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 					designs={ best }
 				/>
 			) }
-			{ Object.entries( designsByGroup ).map(
-				( [ categorySlug, categoryDesigns ], index, array ) => (
+			{ /* We want to show the last one on top first. */ }
+			{ Object.entries( designsByGroup )
+				.reverse()
+				.map( ( [ categorySlug, categoryDesigns ], index, array ) => (
 					<DesignCardGroup
 						key={ categorySlug }
 						{ ...designCardProps }
@@ -383,8 +384,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						designs={ categoryDesigns }
 						showNoResults={ index === array.length - 1 && isNoResults }
 					/>
-				)
-			) }
+				) ) }
 		</div>
 	);
 };

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -180,6 +180,7 @@ interface DesignCardGroup {
 	oldHighResImageLoading?: boolean; // Temporary for A/B test.
 	showActiveThemeBadge?: boolean;
 	siteActiveTheme?: string | null;
+	showNoResults?: boolean;
 	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
 	getBadge: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
@@ -192,12 +193,13 @@ const DesignCardGroup = ( {
 	locale,
 	isPremiumThemeAvailable,
 	shouldLimitGlobalStyles,
-	onChangeVariation,
-	onPreview,
-	getBadge,
 	oldHighResImageLoading,
 	showActiveThemeBadge,
 	siteActiveTheme,
+	showNoResults,
+	onChangeVariation,
+	onPreview,
+	getBadge,
 }: DesignCardGroup ) => {
 	const content = (
 		<div className="design-picker__grid">
@@ -218,11 +220,15 @@ const DesignCardGroup = ( {
 					/>
 				);
 			} ) }
-			{ designs.length === 0 && <NoResults /> }
+			{ showNoResults && designs.length === 0 && <NoResults /> }
 		</div>
 	);
 
-	if ( ! title ) {
+	if ( ! showNoResults && designs.length === 0 ) {
+		return null;
+	}
+
+	if ( ! title || designs.length === 0 ) {
 		return content;
 	}
 
@@ -289,6 +295,9 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	onChangeTier,
 } ) => {
 	const { all, best, ...designsByGroup } = useFilteredDesignsByGroup( designs );
+	const isNoResults = Object.values( designsByGroup ).every(
+		( categoryDesigns ) => categoryDesigns.length === 0
+	);
 	const categoryTypes = useMemo(
 		() => ( categorization?.categories || [] ).filter( ( { slug } ) => isFeatureCategory( slug ) ),
 		[ categorization?.categories ]
@@ -345,32 +354,31 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 				) }
 			</div>
 
-			{ isMultiFilterEnabled ? (
-				<>
-					<DesignCardGroup
-						{ ...designCardProps }
-						title={ translate( 'Best matching themes' ) }
-						category="best"
-						designs={ best }
-					/>
-					{ Object.entries( designsByGroup ).map( ( [ categorySlug, categoryDesigns ] ) => (
-						<DesignCardGroup
-							key={ categorySlug }
-							{ ...designCardProps }
-							title={ `${ ( categorization?.categories || [] ).find(
-								( { slug } ) => slug === categorySlug
-							)?.name } themes` }
-							category={ categorySlug }
-							designs={ categoryDesigns }
-						/>
-					) ) }
-				</>
-			) : (
+			{ isMultiFilterEnabled && (
 				<DesignCardGroup
 					{ ...designCardProps }
-					category={ categorization?.selections.join( ',' ) }
-					designs={ all }
+					title={ translate( 'Best matching themes' ) }
+					category="best"
+					designs={ best }
 				/>
+			) }
+			{ Object.entries( designsByGroup ).map(
+				( [ categorySlug, categoryDesigns ], index, array ) => (
+					<DesignCardGroup
+						key={ categorySlug }
+						{ ...designCardProps }
+						title={
+							isMultiFilterEnabled
+								? `${ ( categorization?.categories || [] ).find(
+										( { slug } ) => slug === categorySlug
+								  )?.name } themes`
+								: ''
+						}
+						category={ categorySlug }
+						designs={ categoryDesigns }
+						showNoResults={ index === array.length - 1 && isNoResults }
+					/>
+				)
 			) }
 		</div>
 	);

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -4,7 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { SHOW_ALL_SLUG } from '../constants';
-import { useFilteredDesigns } from '../hooks/use-filtered-designs';
+import { useFilteredDesignsByGroup } from '../hooks/use-filtered-designs';
 import {
 	isDefaultGlobalStylesVariationSlug,
 	isFeatureCategory,
@@ -170,6 +170,72 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 	);
 };
 
+interface DesignCardGroup {
+	title?: string;
+	designs: Design;
+	locale: string;
+	category?: string | null;
+	isPremiumThemeAvailable?: boolean;
+	shouldLimitGlobalStyles?: boolean;
+	oldHighResImageLoading?: boolean; // Temporary for A/B test.
+	showActiveThemeBadge?: boolean;
+	siteActiveTheme?: string | null;
+	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;
+	onPreview: ( design: Design, variation?: StyleVariation ) => void;
+	getBadge: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
+}
+
+const DesignCardGroup = ( {
+	title,
+	designs,
+	category,
+	locale,
+	isPremiumThemeAvailable,
+	shouldLimitGlobalStyles,
+	onChangeVariation,
+	onPreview,
+	getBadge,
+	oldHighResImageLoading,
+	showActiveThemeBadge,
+	siteActiveTheme,
+}: DesignCardGroup ) => {
+	const content = (
+		<div className="design-picker__grid">
+			{ designs.map( ( design, index ) => {
+				return (
+					<DesignCard
+						key={ design.recipe?.slug ?? design.slug ?? index }
+						category={ category }
+						design={ design }
+						locale={ locale }
+						isPremiumThemeAvailable={ isPremiumThemeAvailable }
+						shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
+						onChangeVariation={ onChangeVariation }
+						onPreview={ onPreview }
+						getBadge={ getBadge }
+						oldHighResImageLoading={ oldHighResImageLoading }
+						isActive={ showActiveThemeBadge && design.recipe?.stylesheet === siteActiveTheme }
+					/>
+				);
+			} ) }
+			{ designs.length === 0 && <NoResults /> }
+		</div>
+	);
+
+	if ( ! title ) {
+		return content;
+	}
+
+	return (
+		<div className="design-picker__design-card-group">
+			<div className="design-picker__design-card-title">
+				{ title } ({ designs.length })
+			</div>
+			{ content }
+		</div>
+	);
+};
+
 interface DesignPickerFilterGroupProps {
 	title?: string;
 	grow?: boolean;
@@ -222,7 +288,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	isMultiFilterEnabled = false,
 	onChangeTier,
 } ) => {
-	const filteredDesigns = useFilteredDesigns( designs );
+	const { all, best, ...designsByGroup } = useFilteredDesignsByGroup( designs );
 	const categoryTypes = useMemo(
 		() => ( categorization?.categories || [] ).filter( ( { slug } ) => isFeatureCategory( slug ) ),
 		[ categorization?.categories ]
@@ -234,6 +300,17 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	);
 
 	const translate = useTranslate();
+	const designCardProps = {
+		locale,
+		isPremiumThemeAvailable,
+		shouldLimitGlobalStyles,
+		onChangeVariation,
+		onPreview,
+		getBadge,
+		oldHighResImageLoading,
+		showActiveThemeBadge,
+		siteActiveTheme,
+	};
 
 	return (
 		<div>
@@ -268,26 +345,33 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 				) }
 			</div>
 
-			<div className="design-picker__grid">
-				{ filteredDesigns.map( ( design, index ) => {
-					return (
-						<DesignCard
-							key={ design.recipe?.slug ?? design.slug ?? index }
-							category={ categorization?.selections.join( ',' ) }
-							design={ design }
-							locale={ locale }
-							isPremiumThemeAvailable={ isPremiumThemeAvailable }
-							shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
-							onChangeVariation={ onChangeVariation }
-							onPreview={ onPreview }
-							getBadge={ getBadge }
-							oldHighResImageLoading={ oldHighResImageLoading }
-							isActive={ showActiveThemeBadge && design.recipe?.stylesheet === siteActiveTheme }
+			{ isMultiFilterEnabled ? (
+				<>
+					<DesignCardGroup
+						{ ...designCardProps }
+						title={ translate( 'Best matching themes' ) }
+						category="best"
+						designs={ best }
+					/>
+					{ Object.entries( designsByGroup ).map( ( [ categorySlug, categoryDesigns ] ) => (
+						<DesignCardGroup
+							key={ categorySlug }
+							{ ...designCardProps }
+							title={ `${ ( categorization?.categories || [] ).find(
+								( { slug } ) => slug === categorySlug
+							)?.name } themes` }
+							category={ categorySlug }
+							designs={ categoryDesigns }
 						/>
-					);
-				} ) }
-				{ filteredDesigns.length === 0 && <NoResults /> }
-			</div>
+					) ) }
+				</>
+			) : (
+				<DesignCardGroup
+					{ ...designCardProps }
+					category={ categorization?.selections.join( ',' ) }
+					designs={ all }
+				/>
+			) }
 		</div>
 	);
 };

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -172,7 +172,7 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 
 interface DesignCardGroup {
 	title?: string;
-	designs: Design;
+	designs: Design[];
 	locale: string;
 	category?: string | null;
 	isPremiumThemeAvailable?: boolean;
@@ -194,7 +194,7 @@ const DesignCardGroup = ( {
 	isPremiumThemeAvailable,
 	shouldLimitGlobalStyles,
 	oldHighResImageLoading,
-	showActiveThemeBadge,
+	showActiveThemeBadge = false,
 	siteActiveTheme,
 	showNoResults,
 	onChangeVariation,

--- a/packages/design-picker/src/hooks/use-filtered-designs.ts
+++ b/packages/design-picker/src/hooks/use-filtered-designs.ts
@@ -3,62 +3,69 @@ import { isBlankCanvasDesign } from '../utils/available-designs';
 import { useDesignPickerFilters } from './use-design-picker-filters';
 import type { Design } from '../types';
 
-const getDesignSlug = ( design: Design ) => design.recipe?.slug ?? design.slug;
-
 // Returns designs that match the features, subjects and tiers.
 // Designs with `showFirst` are always included regardless of the selected features and subjects.
-export const filterDesigns = (
+export const getFilteredDesignsByCategory = (
 	designs: Design[],
 	categorySlugs: string[] | null | undefined,
 	selectedDesignTier: string = ''
-): Design[] => {
-	const categorySlugsSet = new Set( categorySlugs || [] );
+) => {
 	const filteredDesigns = designs.filter(
 		( design ) =>
-			( design.showFirst ||
-				categorySlugsSet.size === 0 ||
-				design.categories.find( ( { slug } ) => categorySlugsSet.has( slug ) ) ) &&
 			( ! selectedDesignTier || design.design_tier === selectedDesignTier ) &&
 			! isBlankCanvasDesign( design )
 	);
 
-	if ( categorySlugsSet.size > 1 ) {
-		const scores: { [ key: string ]: number } = filteredDesigns.reduce(
-			( result, design ) => ( {
-				...result,
-				[ getDesignSlug( design ) ]: design.categories.reduce(
-					( sum, { slug } ) => sum + ( categorySlugsSet.has( slug ) ? 1 : 0 ),
-					0
-				),
-			} ),
-			{}
-		);
+	const filteredDesignsByCategory: { [ key: string ]: Design[] } = {
+		all: filteredDesigns,
+		best: [],
+		...Object.fromEntries( ( categorySlugs || [] ).map( ( slug ) => [ slug, [] ] ) ),
+	};
 
-		filteredDesigns.sort( ( a: Design, b: Design ) => {
-			const aScore = scores[ getDesignSlug( a ) ];
-			const bScore = scores[ getDesignSlug( b ) ];
-
-			if ( aScore > bScore ) {
-				return -1;
-			} else if ( aScore < bScore ) {
-				return 1;
-			}
-			return 0;
-		} );
+	// Return early if none of the category is selected.
+	if ( ! categorySlugs || categorySlugs.length === 0 ) {
+		return filteredDesignsByCategory;
 	}
 
-	return filteredDesigns;
+	// Get designs by the selected category.
+	const categorySlugsSet = new Set( categorySlugs );
+	for ( let i = 0; i < filteredDesigns.length; i++ ) {
+		const design = filteredDesigns[ i ];
+		let count = 0;
+		for ( let j = 0; j < design.categories.length; j++ ) {
+			const category = design.categories[ j ];
+			if ( categorySlugsSet.has( category.slug ) ) {
+				filteredDesignsByCategory[ category.slug ].push( design );
+				count++;
+			}
+		}
+
+		// For designs that match all selected categories.
+		if ( count === categorySlugs.length ) {
+			filteredDesignsByCategory.best.push( design );
+		}
+	}
+
+	return filteredDesignsByCategory;
 };
 
-export const useFilteredDesigns = ( designs: Design[] ) => {
+export const useFilteredDesignsByGroup = (
+	designs: Design[]
+): { [ key: string ]: Design[] } => {
 	const { selectedCategories, selectedDesignTier } = useDesignPickerFilters();
 
 	const filteredDesigns = useMemo( () => {
 		if ( selectedCategories.length > 0 || selectedDesignTier ) {
-			return filterDesigns( designs, selectedCategories, selectedDesignTier );
+			return getFilteredDesignsByCategory(
+				designs,
+				selectedCategories,
+				selectedDesignTier
+			);
 		}
 
-		return designs;
+		return {
+			all: designs,
+		};
 	}, [ designs, selectedCategories, selectedDesignTier ] );
 
 	return filteredDesigns;

--- a/packages/design-picker/src/hooks/use-filtered-designs.ts
+++ b/packages/design-picker/src/hooks/use-filtered-designs.ts
@@ -49,18 +49,12 @@ export const getFilteredDesignsByCategory = (
 	return filteredDesignsByCategory;
 };
 
-export const useFilteredDesignsByGroup = (
-	designs: Design[]
-): { [ key: string ]: Design[] } => {
+export const useFilteredDesignsByGroup = ( designs: Design[] ): { [ key: string ]: Design[] } => {
 	const { selectedCategories, selectedDesignTier } = useDesignPickerFilters();
 
 	const filteredDesigns = useMemo( () => {
 		if ( selectedCategories.length > 0 || selectedDesignTier ) {
-			return getFilteredDesignsByCategory(
-				designs,
-				selectedCategories,
-				selectedDesignTier
-			);
+			return getFilteredDesignsByCategory( designs, selectedCategories, selectedDesignTier );
 		}
 
 		return {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/97263

## Proposed Changes

* Second try of https://github.com/Automattic/wp-calypso/pull/97263 because of failing e2e tests

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
