### PR TITLE
Design Picker: Dedupe the themes

### DIFF
--- a/packages/design-picker/src/hooks/use-filtered-designs.ts
+++ b/packages/design-picker/src/hooks/use-filtered-designs.ts
@@ -30,14 +30,17 @@ export const getFilteredDesignsByCategory = (
 	// Get designs by the selected category.
 	// Note that we don't want to show a theme in multiple sections.
 	// See https://github.com/Automattic/dotcom-forge/issues/10110.
-	const categorySlugsSet = new Set( categorySlugs );
 	for ( let i = 0; i < filteredDesigns.length; i++ ) {
 		const design = filteredDesigns[ i ];
-		const matchedCategories = design.categories.filter( ( category ) =>
-			categorySlugsSet.has( category.slug )
+		const designCategorySlugsSet = new Set(
+			design.categories.map( ( category ) => category.slug )
 		);
 
-		const matchedCount = matchedCategories.length;
+		const matchedCategorySlugs = categorySlugs.filter( ( categorySlug ) =>
+			designCategorySlugsSet.has( categorySlug )
+		);
+
+		const matchedCount = matchedCategorySlugs.length;
 
 		// For designs that match all selected categories.
 		// Limit the best matches to at least 2 selected categories.
@@ -49,9 +52,9 @@ export const getFilteredDesignsByCategory = (
 		// We show the designs for the last selected category on top first
 		// so it would be better to put the design into the last matched category
 		// if it doesn't match all selected categories.
-		const lastMatchedCategory = matchedCategories[ matchedCategories.length - 1 ];
-		if ( lastMatchedCategory ) {
-			filteredDesignsByCategory[ lastMatchedCategory.slug ].push( design );
+		const lastMatchedCategorySlug = matchedCategorySlugs[ matchedCategorySlugs.length - 1 ];
+		if ( lastMatchedCategorySlug ) {
+			filteredDesignsByCategory[ lastMatchedCategorySlug ].push( design );
 		}
 	}
 

--- a/packages/design-picker/src/hooks/use-filtered-designs.ts
+++ b/packages/design-picker/src/hooks/use-filtered-designs.ts
@@ -33,18 +33,11 @@ export const getFilteredDesignsByCategory = (
 	const categorySlugsSet = new Set( categorySlugs );
 	for ( let i = 0; i < filteredDesigns.length; i++ ) {
 		const design = filteredDesigns[ i ];
-		let lastMatchedCategory = null;
-		let matchedCount = 0;
-		for ( let j = 0; j < design.categories.length; j++ ) {
-			const category = design.categories[ j ];
-			if ( categorySlugsSet.has( category.slug ) ) {
-				// We show the designs for the last selected category on top first
-				// so it would be better to put the design into the last matched category
-				// if it doesn't match all selected categories.
-				lastMatchedCategory = category.slug;
-				matchedCount++;
-			}
-		}
+		const matchedCategories = design.categories.filter( ( category ) =>
+			categorySlugsSet.has( category.slug )
+		);
+
+		const matchedCount = matchedCategories.length;
 
 		// For designs that match all selected categories.
 		// Limit the best matches to at least 2 selected categories.
@@ -53,8 +46,12 @@ export const getFilteredDesignsByCategory = (
 			continue;
 		}
 
+		// We show the designs for the last selected category on top first
+		// so it would be better to put the design into the last matched category
+		// if it doesn't match all selected categories.
+		const lastMatchedCategory = matchedCategories[ matchedCategories.length - 1 ];
 		if ( lastMatchedCategory ) {
-			filteredDesignsByCategory[ lastMatchedCategory ].push( design );
+			filteredDesignsByCategory[ lastMatchedCategory.slug ].push( design );
 		}
 	}
 

--- a/packages/design-picker/src/hooks/use-filtered-designs.ts
+++ b/packages/design-picker/src/hooks/use-filtered-designs.ts
@@ -28,21 +28,33 @@ export const getFilteredDesignsByCategory = (
 	}
 
 	// Get designs by the selected category.
+	// Note that we don't want to show a theme in multiple sections.
+	// See https://github.com/Automattic/dotcom-forge/issues/10110.
 	const categorySlugsSet = new Set( categorySlugs );
 	for ( let i = 0; i < filteredDesigns.length; i++ ) {
 		const design = filteredDesigns[ i ];
-		let count = 0;
+		let lastMatchedCategory = null;
+		let matchedCount = 0;
 		for ( let j = 0; j < design.categories.length; j++ ) {
 			const category = design.categories[ j ];
 			if ( categorySlugsSet.has( category.slug ) ) {
-				filteredDesignsByCategory[ category.slug ].push( design );
-				count++;
+				// We show the designs for the last selected category on top first
+				// so it would be better to put the design into the last matched category
+				// if it doesn't match all selected categories.
+				lastMatchedCategory = category.slug;
+				matchedCount++;
 			}
 		}
 
 		// For designs that match all selected categories.
-		if ( count === categorySlugs.length ) {
+		// Limit the best matches to at least 2 selected categories.
+		if ( categorySlugs.length > 1 && matchedCount === categorySlugs.length ) {
 			filteredDesignsByCategory.best.push( design );
+			continue;
+		}
+
+		if ( lastMatchedCategory ) {
+			filteredDesignsByCategory[ lastMatchedCategory ].push( design );
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10110

## Proposed Changes

* Demo of https://github.com/Automattic/dotcom-forge/issues/10110

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* On the Goals screen, select any goals
* On the Design Picker screen
  * Select any categories
  * Ensure a design won't be shown on multiple categories
  * Ensure a design is shown on the top matched category

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
