### PR TITLE
Design Picker: Display the recommended themes

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-track-filters.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-track-filters.ts
@@ -21,7 +21,7 @@ const useTrackFilters = ( { preselectedFilters, isBigSkyEligible, isMultiSelecti
 			( result, filterSlug, index ) => ( {
 				...result,
 				// The property cannot contain `-` character.
-				[ `filters_${ filterSlug.replace( '-', '_' ) }` ]: `${ getCategoryType(
+				[ `filters_${ filterSlug.replaceAll( '-', '_' ) }` ]: `${ getCategoryType(
 					filterSlug
 				) }:${ index }`,
 			} ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -213,6 +213,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const { data: allDesigns, isLoading: isLoadingDesigns } = useStarterDesignsQuery(
 		{
 			seed: siteSlugOrId ? String( siteSlugOrId ) : undefined,
+			goals: goals.length > 0 ? goals : [ 'none' ],
 			_locale: locale,
 		},
 		{
@@ -968,6 +969,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				isMultiFilterEnabled={ isGoalCentricFeature }
 				onChangeTier={ handleChangeTier }
 				isBigSkyEligible={ isBigSkyEligible }
+				recommendedDesignSlugs={ allDesigns.recommendation || [] }
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -969,7 +969,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				isMultiFilterEnabled={ isGoalCentricFeature }
 				onChangeTier={ handleChangeTier }
 				isBigSkyEligible={ isBigSkyEligible }
-				recommendedDesignSlugs={ allDesigns.recommendation || [] }
+				recommendedDesignSlugs={ allDesigns?.recommendation || [] }
 			/>
 		</>
 	);

--- a/packages/data-stores/src/starter-designs-queries/types.ts
+++ b/packages/data-stores/src/starter-designs-queries/types.ts
@@ -1,17 +1,7 @@
-import type { Category, DesignRecipe, Design } from '@automattic/design-picker/src/types';
-
-export interface StarterDesignsGeneratedQueryParams {
-	seed?: string;
-	_locale: string;
-}
-
-export interface StarterDesignsGenerated {
-	slug: string;
-	title: string;
-	recipe: DesignRecipe;
-}
+import type { Category, Design } from '@automattic/design-picker/src/types';
 
 export interface StarterDesigns {
 	filters: { subject: Record< string, Category > };
 	designs: Design[];
+	recommendation: string[];
 }

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -14,6 +14,7 @@ import type {
 
 interface StarterDesignsQueryParams {
 	seed?: string;
+	goals?: string[];
 	_locale: string;
 }
 
@@ -25,6 +26,7 @@ interface Options extends QueryOptions< StarterDesignsResponse > {
 interface StarterDesignsResponse {
 	filters: { subject: Record< string, Category > };
 	static: { designs: StarterDesign[] };
+	recommendation: string[];
 }
 
 export type ThemeTier = {
@@ -63,6 +65,7 @@ export function useStarterDesignsQuery(
 					subject: response.filters?.subject || {},
 				},
 				designs: response.static?.designs?.map( apiStarterDesignsToDesign ),
+				recommendation: response.recommendation,
 			};
 
 			return select ? select( allDesigns ) : allDesigns;

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -279,6 +279,7 @@ interface DesignPickerProps {
 	isMultiFilterEnabled?: boolean;
 	onChangeTier?: ( value: boolean ) => void;
 	isBigSkyEligible?: boolean;
+	recommendedDesignSlugs?: string[];
 }
 
 const DesignPicker: React.FC< DesignPickerProps > = ( {
@@ -298,6 +299,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	isMultiFilterEnabled = false,
 	onChangeTier,
 	isBigSkyEligible = false,
+	recommendedDesignSlugs = [],
 } ) => {
 	const translate = useTranslate();
 	const { all, best, ...designsByGroup } = useFilteredDesignsByGroup( designs );
@@ -313,6 +315,15 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 		() => categories.filter( ( { slug } ) => ! isFeatureCategory( slug ) ),
 		[ categorization?.categories ]
 	);
+
+	const recommendedDesigns = useMemo( () => {
+		const recommendedDesignSlugsSet = new Set( recommendedDesignSlugs );
+
+		// The number should be a multiple of 3 but no more than 5
+		return designs
+			.filter( ( design ) => recommendedDesignSlugsSet.has( design.recipe?.stylesheet || '' ) )
+			.slice( 0, 3 );
+	}, [ designs, recommendedDesignSlugs ] );
 
 	const getCategoryName = ( value: string ) =>
 		categories.find( ( { slug } ) => slug === value )?.name || '';
@@ -373,6 +384,15 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 				</DesignPickerFilterGroup>
 			</div>
 
+			{ isMultiFilterEnabled && recommendedDesigns.length === 3 && (
+				<DesignCardGroup
+					{ ...designCardProps }
+					title={ translate( 'Recommended themes' ) }
+					category="recommended"
+					designs={ recommendedDesigns }
+				/>
+			) }
+
 			{ isMultiFilterEnabled && categorization && categorization.selections.length > 1 && (
 				<DesignCardGroup
 					{ ...designCardProps }
@@ -427,6 +447,7 @@ export interface UnifiedDesignPickerProps {
 	isMultiFilterEnabled?: boolean;
 	onChangeTier?: ( value: boolean ) => void;
 	isBigSkyEligible?: boolean;
+	recommendedDesignSlugs?: string[];
 }
 
 const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
@@ -448,6 +469,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	isMultiFilterEnabled = false,
 	onChangeTier,
 	isBigSkyEligible = false,
+	recommendedDesignSlugs = [],
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 
@@ -476,6 +498,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					isMultiFilterEnabled={ isMultiFilterEnabled }
 					onChangeTier={ onChangeTier }
 					isBigSkyEligible={ isBigSkyEligible }
+					recommendedDesignSlugs={ recommendedDesignSlugs }
 				/>
 				<InView onChange={ ( inView ) => inView && onViewAllDesigns() } />
 			</div>

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -384,14 +384,17 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 				</DesignPickerFilterGroup>
 			</div>
 
-			{ isMultiFilterEnabled && recommendedDesigns.length === 3 && (
-				<DesignCardGroup
-					{ ...designCardProps }
-					title={ translate( 'Recommended themes' ) }
-					category="recommended"
-					designs={ recommendedDesigns }
-				/>
-			) }
+			{ /* Show recommended themes only when the selected categories are never changed. */ }
+			{ isMultiFilterEnabled &&
+				! categorization?.isSelectionsChanged &&
+				recommendedDesigns.length === 3 && (
+					<DesignCardGroup
+						{ ...designCardProps }
+						title={ translate( 'Recommended themes' ) }
+						category="recommended"
+						designs={ recommendedDesigns }
+					/>
+				) }
 
 			{ isMultiFilterEnabled && categorization && categorization.selections.length > 1 && (
 				<DesignCardGroup
@@ -471,7 +474,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	isBigSkyEligible = false,
 	recommendedDesignSlugs = [],
 } ) => {
-	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
+	const hasCategories = !! ( categorization?.categories || [] ).length;
 
 	return (
 		<div

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -304,9 +304,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	const translate = useTranslate();
 	const { all, best, ...designsByGroup } = useFilteredDesignsByGroup( designs );
 	const categories = categorization?.categories || [];
-	const isNoResults = Object.values( designsByGroup ).every(
-		( categoryDesigns ) => categoryDesigns.length === 0
-	);
+
 	const categoryTypes = useMemo(
 		() => categories.filter( ( { slug } ) => isFeatureCategory( slug ) ),
 		[ categorization?.categories ]
@@ -324,6 +322,17 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 			.filter( ( design ) => recommendedDesignSlugsSet.has( design.recipe?.stylesheet || '' ) )
 			.slice( 0, 3 );
 	}, [ designs, recommendedDesignSlugs ] );
+
+	// Show recommended themes only when the selected categories are never changed.
+	const showRecommendedDesigns =
+		isMultiFilterEnabled &&
+		! categorization?.isSelectionsChanged &&
+		recommendedDesigns.length === 3;
+
+	// Show no results only when the recommended themes is hidden and no design matches the selected categories and tiers.
+	const showNoResults =
+		! showRecommendedDesigns &&
+		Object.values( designsByGroup ).every( ( categoryDesigns ) => categoryDesigns.length === 0 );
 
 	const getCategoryName = ( value: string ) =>
 		categories.find( ( { slug } ) => slug === value )?.name || '';
@@ -384,17 +393,14 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 				</DesignPickerFilterGroup>
 			</div>
 
-			{ /* Show recommended themes only when the selected categories are never changed. */ }
-			{ isMultiFilterEnabled &&
-				! categorization?.isSelectionsChanged &&
-				recommendedDesigns.length === 3 && (
-					<DesignCardGroup
-						{ ...designCardProps }
-						title={ translate( 'Recommended themes' ) }
-						category="recommended"
-						designs={ recommendedDesigns }
-					/>
-				) }
+			{ showRecommendedDesigns && (
+				<DesignCardGroup
+					{ ...designCardProps }
+					title={ translate( 'Recommended themes' ) }
+					category="recommended"
+					designs={ recommendedDesigns }
+				/>
+			) }
 
 			{ isMultiFilterEnabled && categorization && categorization.selections.length > 1 && (
 				<DesignCardGroup
@@ -424,7 +430,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						}
 						category={ categorySlug }
 						designs={ categoryDesigns }
-						showNoResults={ index === array.length - 1 && isNoResults }
+						showNoResults={ index === array.length - 1 && showNoResults }
 					/>
 				) ) }
 		</div>

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -1,10 +1,11 @@
-import { useEffect, useMemo, useCallback, useRef } from 'react';
+import { useEffect, useMemo, useCallback, useRef, useState } from 'react';
 import { useDesignPickerFilters } from './use-design-picker-filters';
 import type { Category } from '../types';
 
 export interface Categorization {
 	categories: Category[];
 	selections: string[];
+	isSelectionsChanged: boolean;
 	onSelect: ( selectedSlug: string ) => void;
 }
 
@@ -27,6 +28,7 @@ export function useCategorization(
 	}: UseCategorizationOptions
 ): Categorization {
 	const isInitRef = useRef( false );
+	const [ isSelectionsChanged, setIsSelectionsChanged ] = useState( false );
 	const categories = useMemo( () => {
 		const categoryMapKeys = Object.keys( categoryMap ) || [];
 		const result = categoryMapKeys.map( ( slug ) => ( {
@@ -47,6 +49,10 @@ export function useCategorization(
 				return;
 			}
 
+			if ( ! isSelectionsChanged ) {
+				setIsSelectionsChanged( true );
+			}
+
 			const index = selectedCategories.findIndex( ( selection ) => selection === value );
 			if ( index === -1 ) {
 				handleSelect?.( value );
@@ -59,7 +65,15 @@ export function useCategorization(
 				...selectedCategories.slice( index + 1 ),
 			] );
 		},
-		[ selectedCategories, isMultiSelection, setSelectedCategories, handleSelect, handleDeselect ]
+		[
+			selectedCategories,
+			isMultiSelection,
+			isSelectionsChanged,
+			setSelectedCategories,
+			handleSelect,
+			handleDeselect,
+			setIsSelectionsChanged,
+		]
 	);
 
 	useEffect( () => {
@@ -72,6 +86,7 @@ export function useCategorization(
 	return {
 		categories,
 		selections: selectedCategories,
+		isSelectionsChanged,
 		onSelect,
 	};
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10030

## Proposed Changes

* Display the `Recommended themes` section on the Design Picker screen only when the number is a multiple of 3 but no more than 5
* Don't show the `Recommended themes` section if the selected categories have been changed

![image](https://github.com/user-attachments/assets/96a1cec6-e5ba-4713-b6a1-788a17f6087e)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* ~Apply D168342-code to your sandbox and sandbox your endpoint~
* Create a new site
* On the Goals screen, select any goals
* On the Design Picker screen,
  * Ensure you can see the `Recommended themes` section
  * Change the selected categories
  * Ensure the section is gone even if the selected categories go back to the preselected ones

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?