### PR TITLE
useStatsPurchases: make it rely on features instead of plan checks

### DIFF
--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -1,5 +1,6 @@
 import {
 	FEATURE_STATS_FREE,
+	FEATURE_STATS_PAID,
 	FEATURE_STATS_COMMERCIAL,
 	JETPACK_COMPLETE_PLANS,
 	JETPACK_GROWTH_PLANS,
@@ -127,20 +128,22 @@ export default function useStatsPurchases( siteId: number | null ) {
 		return siteHasFeature( state, siteId, FEATURE_STATS_FREE );
 	} );
 
-	const isCommercialOwned = useMemo(
-		() => isCommercialPurchaseOwned( sitePurchases ),
-		[ sitePurchases ]
-	);
+	const isPaidOwned = useSelector( ( state ) => {
+		return siteHasFeature( state, siteId, FEATURE_STATS_PAID );
+	} );
+
+	const isCommercialOwned = useSelector( ( state ) => {
+		return siteHasFeature( state, siteId, FEATURE_STATS_COMMERCIAL );
+	} );
 
 	// Pay what you want
 	const isPWYWOwned = useMemo( () => {
 		return isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_PWYW_YEARLY );
 	}, [ sitePurchases ] );
 
-	const supportCommercialUse = useSelector( ( state ) => {
-		return siteHasFeature( state, siteId, FEATURE_STATS_COMMERCIAL );
-	} );
+	const supportCommercialUse = isCommercialOwned;
 
+	// TODO: can this be removed now?
 	const isLegacyCommercialLicense = useMemo( () => {
 		const purchases = filterPurchasesByProducts( sitePurchases, [
 			PRODUCT_JETPACK_STATS_MONTHLY,
@@ -158,6 +161,7 @@ export default function useStatsPurchases( siteId: number | null ) {
 		isRequestingSitePurchases,
 		isFreeOwned,
 		isPWYWOwned,
+		isPaidOwned,
 		isCommercialOwned,
 		supportCommercialUse,
 		isLegacyCommercialLicense,

--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -1,6 +1,6 @@
 import {
+	FEATURE_STATS_COMMERCIAL,
 	JETPACK_COMPLETE_PLANS,
-	JETPACK_GROWTH_PLANS,
 	JETPACK_SECURITY_PLANS,
 	JETPACK_VIDEOPRESS_PRODUCTS,
 	PLAN_JETPACK_BUSINESS,
@@ -20,6 +20,7 @@ import {
 	hasLoadedSitePurchasesFromServer,
 	getPurchases,
 } from 'calypso/state/purchases/selectors';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import {
 	getShouldShowPaywallNotice,
 	getShouldShowPaywallAfterGracePeriod,
@@ -135,9 +136,8 @@ export default function useStatsPurchases( siteId: number | null ) {
 		return isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_PWYW_YEARLY );
 	}, [ sitePurchases ] );
 
-	const supportCommercialUse = useMemo(
-		() => supportCommercialPurchaseUse( sitePurchases ),
-		[ sitePurchases ]
+	const supportCommercialUse = useSelector( ( state ) =>
+		siteHasFeature( state, siteId, FEATURE_STATS_COMMERCIAL )
 	);
 
 	const isLegacyCommercialLicense = useMemo( () => {

--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -1,12 +1,13 @@
 import {
+	FEATURE_STATS_FREE,
 	FEATURE_STATS_COMMERCIAL,
 	JETPACK_COMPLETE_PLANS,
+	JETPACK_GROWTH_PLANS,
 	JETPACK_SECURITY_PLANS,
 	JETPACK_VIDEOPRESS_PRODUCTS,
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 	PRODUCT_JETPACK_STATS_BI_YEARLY,
-	PRODUCT_JETPACK_STATS_FREE,
 	PRODUCT_JETPACK_STATS_MONTHLY,
 	PRODUCT_JETPACK_STATS_PWYW_YEARLY,
 	PRODUCT_JETPACK_STATS_YEARLY,
@@ -122,23 +123,23 @@ export default function useStatsPurchases( siteId: number | null ) {
 	const hasLoadedSitePurchases = useSelector( hasLoadedSitePurchasesFromServer );
 
 	// Determine whether a product is owned.
-	// TODO we need to do plan check as well, because Stats products would be built into other plans.
-	const isFreeOwned = useMemo( () => {
-		return isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_FREE );
-	}, [ sitePurchases ] );
+	const isFreeOwned = useSelector( ( state ) => {
+		return siteHasFeature( state, siteId, FEATURE_STATS_FREE );
+	} );
 
 	const isCommercialOwned = useMemo(
 		() => isCommercialPurchaseOwned( sitePurchases ),
 		[ sitePurchases ]
 	);
 
+	// Pay what you want
 	const isPWYWOwned = useMemo( () => {
 		return isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_PWYW_YEARLY );
 	}, [ sitePurchases ] );
 
-	const supportCommercialUse = useSelector( ( state ) =>
-		siteHasFeature( state, siteId, FEATURE_STATS_COMMERCIAL )
-	);
+	const supportCommercialUse = useSelector( ( state ) => {
+		return siteHasFeature( state, siteId, FEATURE_STATS_COMMERCIAL );
+	} );
 
 	const isLegacyCommercialLicense = useMemo( () => {
 		const purchases = filterPurchasesByProducts( sitePurchases, [


### PR DESCRIPTION
Related to #97041 that introduced stats-related features constants.

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
