### PR TITLE
Use the default version of Odie specified in the backend

### DIFF
--- a/packages/help-center/src/components/help-center-chat.tsx
+++ b/packages/help-center/src/components/help-center-chat.tsx
@@ -37,7 +37,7 @@ export function HelpCenterChat( {
 		}
 	}, [] );
 
-	const odieVersion = shouldUseHelpCenterExperience ? '14.0.3' : null;
+	const odieVersion = null; // Use the default version specified on the back-end
 
 	return (
 		<OdieAssistantProvider


### PR DESCRIPTION
Now that we have decided to go ahead with the new help center experience, we would like to stop specifying the version in the client, and instead use the version specified in the backend, which is what we normally do. This will allow us to start our next A/B test. The only difference between 14.0.3 and 13.1.1 was the greeting, that 13.1.1 introduced itself as Wapuu. Even though we haven't totally moved to the new help center yet, using this small difference in the greeting for the old version should not degrade the user experience at all. 

Thus with this change, for both the old Wapuu and the new help center experience, the user will be greeted by:
> Howdy, I'm WordPress.com's  support assistant

![image](https://github.com/user-attachments/assets/60583e1a-1aae-462a-ab54-43760b5b2110)



## Testing Instructions

Try asking a question to the virtual assistant in the help center and ensure that it still works.