### PR TITLE
AP: Fix the loading state text for the Application Passwords check

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
@@ -1,5 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { useLocale } from '@automattic/i18n-utils';
 import { NextButton } from '@automattic/onboarding';
+import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
 import { UrlData } from 'calypso/blocks/import/types';
@@ -25,6 +27,8 @@ interface CredentialsFormProps {
 
 export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip } ) => {
 	const translate = useTranslate();
+	const locale = useLocale();
+
 	const { control, errors, accessMethod, isBusy, submitHandler, canBypassVerification } =
 		useCredentialsForm( onSubmit );
 
@@ -43,6 +47,10 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 
 	const getContinueButtonText = () => {
 		if ( isBusy && ! canBypassVerification ) {
+			const hasScanningTranslation = locale.startsWith( 'en' ) || hasTranslation( 'Scanning site' );
+			if ( applicationPasswordEnabled && hasScanningTranslation ) {
+				return translate( 'Scanning site' );
+			}
 			return translate( 'Verifying credentials' );
 		}
 		if ( canBypassVerification ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
@@ -1,7 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { useLocale } from '@automattic/i18n-utils';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { NextButton } from '@automattic/onboarding';
-import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
 import { UrlData } from 'calypso/blocks/import/types';
@@ -27,7 +26,7 @@ interface CredentialsFormProps {
 
 export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip } ) => {
 	const translate = useTranslate();
-	const locale = useLocale();
+	const hasEnTranslation = useHasEnTranslation();
 
 	const { control, errors, accessMethod, isBusy, submitHandler, canBypassVerification } =
 		useCredentialsForm( onSubmit );
@@ -47,7 +46,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 
 	const getContinueButtonText = () => {
 		if ( isBusy && ! canBypassVerification ) {
-			const hasScanningTranslation = locale.startsWith( 'en' ) || hasTranslation( 'Scanning site' );
+			const hasScanningTranslation = hasEnTranslation( 'Scanning site' );
 			if ( applicationPasswordEnabled && hasScanningTranslation ) {
 				return translate( 'Scanning site' );
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -435,7 +435,7 @@ describe( 'SiteMigrationCredentials', () => {
 		} );
 	} );
 
-	it( 'shows "Verifying credentials" on the Continue button during submission with application password', async () => {
+	it( 'shows "Scanning site" on the Continue button during submission with application password', async () => {
 		const submit = jest.fn();
 		render( { navigation: { submit } } );
 		const pendingPromise = new Promise( () => {} );
@@ -446,7 +446,7 @@ describe( 'SiteMigrationCredentials', () => {
 		userEvent.click( continueButton() );
 
 		await waitFor( () => {
-			expect( continueButton( /Verifying credentials/ ) ).toBeVisible();
+			expect( continueButton( /Scanning site/ ) ).toBeVisible();
 		} );
 	} );
 
@@ -605,7 +605,7 @@ describe( 'SiteMigrationCredentials', () => {
 		} );
 	} );
 
-	it( 'shows "Verifying credentials" on the Continue button during submission when fetching site info with application password', async () => {
+	it( 'shows "Scanning site" on the Continue button during submission when fetching site info with application password', async () => {
 		const submit = jest.fn();
 		render( { navigation: { submit } } );
 		const pendingPromise = new Promise( () => {} );
@@ -621,7 +621,7 @@ describe( 'SiteMigrationCredentials', () => {
 		await userEvent.click( continueButton() );
 
 		await waitFor( () => {
-			expect( continueButton( /Verifying credentials/ ) ).toBeVisible();
+			expect( continueButton( /Scanning site/ ) ).toBeVisible();
 		} );
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to paYKcK-5Ht-p2#comment-4342

## Proposed Changes

* Fix the text while verifying the Application Password availability to reflect the action.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The previous text displayed while verifying the Application Passwords availability didn't really reflect the action that was being executed.

![Captura de Tela 2024-12-11 às 12 23 30](https://github.com/user-attachments/assets/3ef63773-7ba1-4fa8-9e78-907bfaab8f92)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link below.
* Enable the feature flag by running the following code on your Dev console
```
sessionStorage.setItem('flags', 'automated-migration/application-password')
```
* Go through the migration DIFM flow until you reach the credentials step.
* Click on "Continue" to verify your site, you should see the `Scanning site` message in the button while it is loading.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?