### PR TITLE
Help Center: New Support Experience to 75% of users

### DIFF
--- a/packages/help-center/src/components/utils.tsx
+++ b/packages/help-center/src/components/utils.tsx
@@ -141,8 +141,11 @@ export const matchSupportInteractionId = (
 };
 
 export const isUseHelpCenterExperienceEnabled = ( userId: number ): boolean => {
-	if ( ! userId || userId % 100 >= 75 ) {
+	if ( ! userId ) {
 		return false;
 	}
-	return true;
+	if ( userId % 100 < 75 ) {
+		return true;
+	}
+	return false;
 };

--- a/packages/help-center/src/components/utils.tsx
+++ b/packages/help-center/src/components/utils.tsx
@@ -141,7 +141,7 @@ export const matchSupportInteractionId = (
 };
 
 export const isUseHelpCenterExperienceEnabled = ( userId: number ): boolean => {
-	if ( ! userId || userId % 100 < 75 ) {
+	if ( ! userId || userId % 100 >= 75 ) {
 		return false;
 	}
 	return true;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

75% of users on Calypso, wp-admin and the editor will see the new Support Experience.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test with a user whose 2 last digits of the user id end with a number < 75. You should be seeing the new experience.
* Otherwise you should be seeing the old one.

