### PR TITLE
AP: Launches the Application Password flow

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -13,7 +13,7 @@
 		"100-year-plan/vip": true,
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
-		"automated-migration/application-password": false,
+		"automated-migration/application-password": true,
 		"automated-migration/collect-credentials": true,
 		"automated-migration/pending-status": true,
 		"calypso/ai-blogging-prompts": false,

--- a/config/production.json
+++ b/config/production.json
@@ -24,7 +24,7 @@
 		"ad-tracking": true,
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
-		"automated-migration/application-password": false,
+		"automated-migration/application-password": true,
 		"automated-migration/collect-credentials": true,
 		"automated-migration/pending-status": true,
 		"bulk-plugin-management": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -23,7 +23,7 @@
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
-		"automated-migration/application-password": false,
+		"automated-migration/application-password": true,
 		"automated-migration/collect-credentials": true,
 		"automated-migration/pending-status": true,
 		"bulk-plugin-management": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -22,7 +22,7 @@
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
-		"automated-migration/application-password": false,
+		"automated-migration/application-password": true,
 		"automated-migration/collect-credentials": true,
 		"automated-migration/pending-status": true,
 		"bulk-plugin-management": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

More context: 
* paYKcK-5B6-p2
* pdtkmj-3bR-p2

## Proposed Changes

* Enables the feature flag for the Application Passwords flow to all users.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?