### PR TITLE
Domain management: Match component design for Google mailbox usecase

### DIFF
--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -166,6 +166,7 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 					hideMailPoetUpsell={ isAllDomainManagementContext }
 					selectedSite={ selectedSite }
 					source={ source }
+					context={ context }
 				/>
 			</ContentWithHeader>
 		);

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -83,7 +83,7 @@ function EmailPlanMailboxesList( {
 					) }
 
 					<EmailMailboxWarnings account={ account } mailbox={ mailbox } />
-					{ ! mailbox.temporary && (
+					{ ! mailbox.temporary && ! isGoogleConfiguring && (
 						<EmailMailboxActionMenu account={ account } domain={ domain } mailbox={ mailbox } />
 					) }
 				</MailboxListItem>

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -20,6 +20,7 @@ type Props = {
 	mailboxes: Mailbox[];
 	addMailboxPath: string;
 	isLoadingEmails: boolean;
+	configuringStateMode?: 'message' | 'notice';
 };
 function EmailPlanMailboxesList( {
 	domain,
@@ -27,6 +28,7 @@ function EmailPlanMailboxesList( {
 	mailboxes,
 	addMailboxPath,
 	isLoadingEmails,
+	configuringStateMode = 'message',
 }: Props ) {
 	const translate = useTranslate();
 	const accountType = account?.account_type;
@@ -46,7 +48,7 @@ function EmailPlanMailboxesList( {
 		);
 	}
 
-	if ( isGoogleConfiguring ) {
+	if ( isGoogleConfiguring && configuringStateMode === 'message' ) {
 		return (
 			<MailboxListHeader accountType={ accountType }>
 				<MailboxListItem hasNoEmails>
@@ -99,7 +101,7 @@ function EmailPlanMailboxesList( {
 
 	return (
 		<>
-			{ isGoogleConfiguring && (
+			{ isGoogleConfiguring && configuringStateMode === 'notice' && (
 				<Notice
 					className="email-plan-mailboxes-list__notice"
 					status="is-warning"

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -51,31 +51,50 @@ function EmailPlanMailboxesList( {
 	}
 
 	if ( isGoogleConfiguring && configuringStateMode === 'message' ) {
-		return (
-			<MailboxListHeader accountType={ accountType }>
-				<MailboxListItem hasNoEmails>
-					<span>
-						{ translate(
-							'We are configuring your mailboxes. You will receive an email shortly when they are ready to use.'
-						) }
-					</span>
-				</MailboxListItem>
-			</MailboxListHeader>
-		);
+		return <MailboxContent type="configuring" />;
 	}
 
 	if ( isNoMailboxes && configuringStateMode === 'message' ) {
+		return <MailboxContent type="no-mailboxes" />;
+	}
+
+	function MailboxItemsEmpty() {
+		return (
+			<MailboxListItem>
+				<div className="email-plan-mailboxes-list__mailbox-list-item-main">
+					<div className="email-plan-mailboxes-list__mailbox-list-link">
+						<span>{ domain.domain }</span>
+					</div>
+				</div>
+			</MailboxListItem>
+		);
+	}
+
+	function MailboxContent( { type }: { type: 'configuring' | 'no-mailboxes' } ) {
+		let message;
+
+		switch ( type ) {
+			case 'no-mailboxes':
+				message = translate( 'No mailboxes' );
+				break;
+			case 'configuring':
+				message = translate(
+					'We are configuring your mailboxes. You will receive an email shortly when they are ready to use.'
+				);
+				break;
+		}
+
 		return (
 			<MailboxListHeader accountType={ accountType }>
 				<MailboxListItem hasNoEmails>
-					<span>{ translate( 'No mailboxes' ) }</span>
+					<span>{ message }</span>
 				</MailboxListItem>
 			</MailboxListHeader>
 		);
 	}
 
-	const MailboxItems = () =>
-		mailboxes.map( ( mailbox ) => {
+	function MailboxItems() {
+		return mailboxes.map( ( mailbox ) => {
 			const mailboxHasWarnings = Boolean( mailbox?.warnings?.length );
 
 			return (
@@ -105,16 +124,7 @@ function EmailPlanMailboxesList( {
 				</>
 			);
 		} );
-
-	const MailboxItemsEmpty = () => (
-		<MailboxListItem>
-			<div className="email-plan-mailboxes-list__mailbox-list-item-main">
-				<div className="email-plan-mailboxes-list__mailbox-list-link">
-					<span>{ domain.domain }</span>
-				</div>
-			</div>
-		</MailboxListItem>
-	);
+	}
 
 	return (
 		<>

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -1,5 +1,7 @@
 import { Badge, MaterialIcon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
 import { isRecentlyRegistered } from 'calypso/lib/domains/utils';
 import { isEmailUserAdmin } from 'calypso/lib/emails';
 import { getGSuiteSubscriptionStatus } from 'calypso/lib/gsuite';
@@ -29,9 +31,13 @@ function EmailPlanMailboxesList( {
 	const translate = useTranslate();
 	const accountType = account?.account_type;
 
+	const isGoogleConfiguring =
+		isRecentlyRegistered( domain.registrationDate, 45 ) &&
+		getGSuiteSubscriptionStatus( domain ) === 'unknown';
+
 	if ( isLoadingEmails ) {
 		return (
-			<MailboxListHeader isPlaceholder accountType={ accountType } domain={ domain }>
+			<MailboxListHeader isPlaceholder>
 				<MailboxListItem isPlaceholder>
 					<MaterialIcon icon="email" />
 					<span />
@@ -43,10 +49,7 @@ function EmailPlanMailboxesList( {
 	if ( ! mailboxes || mailboxes.length < 1 ) {
 		let missingMailboxesText = translate( 'No mailboxes' );
 
-		if (
-			isRecentlyRegistered( domain.registrationDate, 45 ) &&
-			getGSuiteSubscriptionStatus( domain ) === 'unknown'
-		) {
+		if ( isGoogleConfiguring ) {
 			missingMailboxesText = translate(
 				'We are configuring your mailboxes. You will receive an email shortly when they are ready to use.'
 			);
@@ -65,38 +68,53 @@ function EmailPlanMailboxesList( {
 		const mailboxHasWarnings = Boolean( mailbox?.warnings?.length );
 
 		return (
-			<MailboxListItem key={ mailbox.mailbox } isError={ mailboxHasWarnings }>
-				<div className="email-plan-mailboxes-list__mailbox-list-item-main">
-					<MailboxLink account={ account } mailbox={ mailbox } />
-					<EmailForwardSecondaryDetails mailbox={ mailbox } />
-				</div>
+			<>
+				<MailboxListItem key={ mailbox.mailbox } isError={ mailboxHasWarnings }>
+					<div className="email-plan-mailboxes-list__mailbox-list-item-main">
+						<MailboxLink account={ account } mailbox={ mailbox } />
+						<EmailForwardSecondaryDetails mailbox={ mailbox } />
+					</div>
+					{ isEmailUserAdmin( mailbox ) && (
+						<Badge type="info">
+							{ translate( 'Admin', {
+								comment: 'Email user role displayed as a badge',
+							} ) }
+						</Badge>
+					) }
 
-				{ isEmailUserAdmin( mailbox ) && (
-					<Badge type="info">
-						{ translate( 'Admin', {
-							comment: 'Email user role displayed as a badge',
-						} ) }
-					</Badge>
-				) }
-
-				<EmailMailboxWarnings account={ account } mailbox={ mailbox } />
-
-				{ ! mailbox.temporary && (
-					<EmailMailboxActionMenu account={ account } domain={ domain } mailbox={ mailbox } />
-				) }
-			</MailboxListItem>
+					<EmailMailboxWarnings account={ account } mailbox={ mailbox } />
+					{ ! mailbox.temporary && (
+						<EmailMailboxActionMenu account={ account } domain={ domain } mailbox={ mailbox } />
+					) }
+				</MailboxListItem>
+			</>
 		);
 	} );
 
 	return (
-		<MailboxListHeader
-			accountType={ accountType }
-			addMailboxPath={ addMailboxPath }
-			showIcon={ !! addMailboxPath }
-			domain={ domain }
-		>
-			{ mailboxItems }
-		</MailboxListHeader>
+		<>
+			{ isGoogleConfiguring && (
+				<Notice
+					className="email-plan-mailboxes-list__notice"
+					status="is-warning"
+					showDismiss={ false }
+					text={ translate(
+						'We are configuring your mailboxes. You will receive an email shortly when they are ready to use.'
+					) }
+				>
+					<NoticeAction>{ translate( 'Finish setup' ) }</NoticeAction>
+				</Notice>
+			) }
+			<MailboxListHeader
+				accountType={ accountType }
+				addMailboxPath={ addMailboxPath }
+				showIcon={ !! addMailboxPath }
+				domain={ domain }
+				disableActions
+			>
+				{ mailboxItems }
+			</MailboxListHeader>
+		</>
 	);
 }
 

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -34,6 +34,7 @@ function EmailPlanMailboxesList( {
 	const accountType = account?.account_type;
 
 	const isNoMailboxes = ! mailboxes || mailboxes.length < 1;
+	const isAccountWarningPresent = !! account?.warnings.length;
 	const isGoogleConfiguring =
 		isRecentlyRegistered( domain.registrationDate, 45 ) &&
 		getGSuiteSubscriptionStatus( domain ) === 'unknown';
@@ -117,22 +118,22 @@ function EmailPlanMailboxesList( {
 
 	return (
 		<>
-			{ isGoogleConfiguring && configuringStateMode === 'notice' && (
+			{ ( isGoogleConfiguring || isAccountWarningPresent ) && configuringStateMode === 'notice' && (
 				<Notice
 					className="email-plan-mailboxes-list__notice"
 					status="is-warning"
 					showDismiss={ false }
 				>
-					{ ! account?.warnings.length ? (
-						translate(
-							'We are configuring your mailboxes. You will receive an email shortly when they are ready to use.'
-						)
-					) : (
+					{ isAccountWarningPresent ? (
 						<EmailPlanWarnings
 							domain={ domain }
 							emailAccount={ account }
 							ctaBtnProps={ { primary: false, plain: true } }
 						/>
+					) : (
+						translate(
+							'We are configuring your mailboxes. You will receive an email shortly when they are ready to use.'
+						)
 					) }
 				</Notice>
 			) }

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -117,17 +117,23 @@ function EmailPlanMailboxesList( {
 
 	return (
 		<>
-			{ configuringStateMode === 'notice' && !! account?.warnings.length && (
+			{ isGoogleConfiguring && configuringStateMode === 'notice' && (
 				<Notice
 					className="email-plan-mailboxes-list__notice"
 					status="is-warning"
 					showDismiss={ false }
 				>
-					<EmailPlanWarnings
-						domain={ domain }
-						emailAccount={ account }
-						ctaBtnProps={ { primary: false, plain: true } }
-					/>
+					{ ! account?.warnings.length ? (
+						translate(
+							'We are configuring your mailboxes. You will receive an email shortly when they are ready to use.'
+						)
+					) : (
+						<EmailPlanWarnings
+							domain={ domain }
+							emailAccount={ account }
+							ctaBtnProps={ { primary: false, plain: true } }
+						/>
+					) }
 				</Notice>
 			) }
 

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -71,7 +71,7 @@ function EmailPlanMailboxesList( {
 			<>
 				<MailboxListItem key={ mailbox.mailbox } isError={ mailboxHasWarnings }>
 					<div className="email-plan-mailboxes-list__mailbox-list-item-main">
-						<MailboxLink account={ account } mailbox={ mailbox } />
+						<MailboxLink account={ account } mailbox={ mailbox } readonly={ isGoogleConfiguring } />
 						<EmailForwardSecondaryDetails mailbox={ mailbox } />
 					</div>
 					{ isEmailUserAdmin( mailbox ) && (

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -46,19 +46,25 @@ function EmailPlanMailboxesList( {
 		);
 	}
 
-	if ( ! mailboxes || mailboxes.length < 1 ) {
-		let missingMailboxesText = translate( 'No mailboxes' );
-
-		if ( isGoogleConfiguring ) {
-			missingMailboxesText = translate(
-				'We are configuring your mailboxes. You will receive an email shortly when they are ready to use.'
-			);
-		}
-
+	if ( isGoogleConfiguring ) {
 		return (
 			<MailboxListHeader accountType={ accountType }>
 				<MailboxListItem hasNoEmails>
-					<span>{ missingMailboxesText }</span>
+					<span>
+						{ translate(
+							'We are configuring your mailboxes. You will receive an email shortly when they are ready to use.'
+						) }
+					</span>
+				</MailboxListItem>
+			</MailboxListHeader>
+		);
+	}
+
+	if ( isNoMailboxes ) {
+		return (
+			<MailboxListHeader accountType={ accountType }>
+				<MailboxListItem hasNoEmails>
+					<span>{ translate( 'No mailboxes' ) }</span>
 				</MailboxListItem>
 			</MailboxListHeader>
 		);

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -121,7 +121,7 @@ function EmailPlanMailboxesList( {
 				addMailboxPath={ addMailboxPath }
 				showIcon={ !! addMailboxPath }
 				domain={ domain }
-				disableActions
+				disableActions={ isGoogleConfiguring }
 			>
 				{ mailboxItems }
 			</MailboxListHeader>

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -1,12 +1,12 @@
 import { Badge, MaterialIcon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import Notice from 'calypso/components/notice';
-import NoticeAction from 'calypso/components/notice/notice-action';
 import { isRecentlyRegistered } from 'calypso/lib/domains/utils';
 import { isEmailUserAdmin } from 'calypso/lib/emails';
 import { getGSuiteSubscriptionStatus } from 'calypso/lib/gsuite';
 import EmailMailboxActionMenu from 'calypso/my-sites/email/email-management/home/email-mailbox-action-menu';
 import EmailMailboxWarnings from 'calypso/my-sites/email/email-management/home/email-mailbox-warnings';
+import EmailPlanWarnings from 'calypso/my-sites/email/email-management/home/email-plan-warnings';
 import EmailForwardSecondaryDetails from './email-plan-mailboxes/email-forward-secondary-details';
 import MailboxListHeader from './email-plan-mailboxes/list-header';
 import MailboxListItem from './email-plan-mailboxes/list-item';
@@ -33,6 +33,7 @@ function EmailPlanMailboxesList( {
 	const translate = useTranslate();
 	const accountType = account?.account_type;
 
+	const isNoMailboxes = ! mailboxes || mailboxes.length < 1;
 	const isGoogleConfiguring =
 		isRecentlyRegistered( domain.registrationDate, 45 ) &&
 		getGSuiteSubscriptionStatus( domain ) === 'unknown';
@@ -101,18 +102,20 @@ function EmailPlanMailboxesList( {
 
 	return (
 		<>
-			{ isGoogleConfiguring && configuringStateMode === 'notice' && (
+			{ configuringStateMode === 'notice' && account?.warnings.length && (
 				<Notice
 					className="email-plan-mailboxes-list__notice"
 					status="is-warning"
 					showDismiss={ false }
-					text={ translate(
-						'We are configuring your mailboxes. You will receive an email shortly when they are ready to use.'
-					) }
 				>
-					<NoticeAction>{ translate( 'Finish setup' ) }</NoticeAction>
+					<EmailPlanWarnings
+						domain={ domain }
+						emailAccount={ account }
+						ctaBtnProps={ { primary: false, plain: true } }
+					/>
 				</Notice>
 			) }
+
 			<MailboxListHeader
 				accountType={ accountType }
 				addMailboxPath={ addMailboxPath }

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -63,7 +63,7 @@ function EmailPlanMailboxesList( {
 		);
 	}
 
-	if ( isNoMailboxes ) {
+	if ( isNoMailboxes && configuringStateMode === 'message' ) {
 		return (
 			<MailboxListHeader accountType={ accountType }>
 				<MailboxListItem hasNoEmails>
@@ -73,36 +73,51 @@ function EmailPlanMailboxesList( {
 		);
 	}
 
-	const mailboxItems = mailboxes.map( ( mailbox ) => {
-		const mailboxHasWarnings = Boolean( mailbox?.warnings?.length );
+	const MailboxItems = () =>
+		mailboxes.map( ( mailbox ) => {
+			const mailboxHasWarnings = Boolean( mailbox?.warnings?.length );
 
-		return (
-			<>
-				<MailboxListItem key={ mailbox.mailbox } isError={ mailboxHasWarnings }>
-					<div className="email-plan-mailboxes-list__mailbox-list-item-main">
-						<MailboxLink account={ account } mailbox={ mailbox } readonly={ isGoogleConfiguring } />
-						<EmailForwardSecondaryDetails mailbox={ mailbox } />
-					</div>
-					{ isEmailUserAdmin( mailbox ) && (
-						<Badge type="info">
-							{ translate( 'Admin', {
-								comment: 'Email user role displayed as a badge',
-							} ) }
-						</Badge>
-					) }
+			return (
+				<>
+					<MailboxListItem key={ mailbox.mailbox } isError={ mailboxHasWarnings }>
+						<div className="email-plan-mailboxes-list__mailbox-list-item-main">
+							<MailboxLink
+								account={ account }
+								mailbox={ mailbox }
+								readonly={ isGoogleConfiguring }
+							/>
+							<EmailForwardSecondaryDetails mailbox={ mailbox } />
+						</div>
+						{ isEmailUserAdmin( mailbox ) && (
+							<Badge type="info">
+								{ translate( 'Admin', {
+									comment: 'Email user role displayed as a badge',
+								} ) }
+							</Badge>
+						) }
 
-					<EmailMailboxWarnings account={ account } mailbox={ mailbox } />
-					{ ! mailbox.temporary && ! isGoogleConfiguring && (
-						<EmailMailboxActionMenu account={ account } domain={ domain } mailbox={ mailbox } />
-					) }
-				</MailboxListItem>
-			</>
-		);
-	} );
+						<EmailMailboxWarnings account={ account } mailbox={ mailbox } />
+						{ ! mailbox.temporary && ! isGoogleConfiguring && (
+							<EmailMailboxActionMenu account={ account } domain={ domain } mailbox={ mailbox } />
+						) }
+					</MailboxListItem>
+				</>
+			);
+		} );
+
+	const MailboxItemsEmpty = () => (
+		<MailboxListItem>
+			<div className="email-plan-mailboxes-list__mailbox-list-item-main">
+				<div className="email-plan-mailboxes-list__mailbox-list-link">
+					<span>{ domain.domain }</span>
+				</div>
+			</div>
+		</MailboxListItem>
+	);
 
 	return (
 		<>
-			{ configuringStateMode === 'notice' && account?.warnings.length && (
+			{ configuringStateMode === 'notice' && !! account?.warnings.length && (
 				<Notice
 					className="email-plan-mailboxes-list__notice"
 					status="is-warning"
@@ -123,7 +138,7 @@ function EmailPlanMailboxesList( {
 				domain={ domain }
 				disableActions={ isGoogleConfiguring }
 			>
-				{ mailboxItems }
+				{ isNoMailboxes ? <MailboxItemsEmpty /> : <MailboxItems /> }
 			</MailboxListHeader>
 		</>
 	);

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/list-header.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/list-header.tsx
@@ -58,7 +58,9 @@ const MailboxListHeader = ( {
 				}
 			>
 				{ addMailboxPath && (
-					<Button href={ addMailboxPath } isLink disabled={ !! disableActions }>
+					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+					// @ts-expect-error
+					<Button href={ addMailboxPath } disabled={ !! disableActions }>
 						{ translate( 'Add mailbox' ) }
 					</Button>
 				) }

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/list-header.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/list-header.tsx
@@ -12,6 +12,7 @@ type Props = React.PropsWithChildren< {
 	addMailboxPath?: string;
 	domain?: ResponseDomain;
 	showIcon?: boolean;
+	disableActions?: boolean;
 } >;
 const MailboxListHeader = ( {
 	accountType = null,
@@ -20,6 +21,7 @@ const MailboxListHeader = ( {
 	addMailboxPath,
 	domain,
 	showIcon,
+	disableActions,
 }: Props ) => {
 	const translate = useTranslate();
 
@@ -56,7 +58,7 @@ const MailboxListHeader = ( {
 				}
 			>
 				{ addMailboxPath && (
-					<Button isLink href={ addMailboxPath }>
+					<Button href={ addMailboxPath } isLink disabled={ !! disableActions }>
 						{ translate( 'Add mailbox' ) }
 					</Button>
 				) }

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/list-header.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/list-header.tsx
@@ -60,7 +60,7 @@ const MailboxListHeader = ( {
 				{ addMailboxPath && (
 					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 					// @ts-expect-error
-					<Button href={ addMailboxPath } disabled={ !! disableActions }>
+					<Button href={ addMailboxPath } variant="link" disabled={ !! disableActions }>
 						{ translate( 'Add mailbox' ) }
 					</Button>
 				) }

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/list-item-link.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/list-item-link.tsx
@@ -9,12 +9,14 @@ import type { EmailAccount, Mailbox } from 'calypso/data/emails/types';
 type Props = {
 	account: EmailAccount;
 	mailbox: Mailbox;
+	readonly?: boolean;
 };
-function MailboxLink( { account, mailbox }: Props ) {
+function MailboxLink( { account, mailbox, readonly }: Props ) {
 	const titanAppsUrlPrefix = useTitanAppsUrlPrefix();
 	const emailAddress = getEmailAddress( mailbox );
+	const isReadonly = readonly || isEmailForwardAccount( account );
 
-	if ( isEmailForwardAccount( account ) ) {
+	if ( isReadonly ) {
 		return (
 			<div className="email-plan-mailboxes-list__mailbox-list-link">
 				<span>{ emailAddress }</span>

--- a/client/my-sites/email/email-management/home/email-plan-warnings.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-warnings.tsx
@@ -1,4 +1,4 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button, ButtonProps, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { canCurrentUserAddEmail, getCurrentUserCannotAddEmailReason } from 'calypso/lib/domains';
@@ -18,9 +18,10 @@ import type { ResponseDomain } from 'calypso/lib/domains/types';
 type EmailPlanWarningsProps = {
 	domain: ResponseDomain;
 	emailAccount: EmailAccount;
+	ctaBtnProps?: ButtonProps;
 };
 
-const EmailPlanWarnings = ( { domain, emailAccount }: EmailPlanWarningsProps ) => {
+const EmailPlanWarnings = ( { domain, emailAccount, ctaBtnProps }: EmailPlanWarningsProps ) => {
 	const translate = useTranslate();
 	const selectedSite = useSelector( getSelectedSite );
 	const selectedSiteSlug = selectedSite?.slug ?? '';
@@ -37,7 +38,12 @@ const EmailPlanWarnings = ( { domain, emailAccount }: EmailPlanWarningsProps ) =
 
 	if ( hasUnusedMailboxWarning( emailAccount ) && isTitanMailAccount( emailAccount ) ) {
 		cta = (
-			<Button compact primary href={ getTitanSetUpMailboxPath( selectedSiteSlug, domain.name ) }>
+			<Button
+				compact
+				primary
+				href={ getTitanSetUpMailboxPath( selectedSiteSlug, domain.name ) }
+				{ ...ctaBtnProps }
+			>
 				{ translate( 'Set up mailbox' ) }
 			</Button>
 		);
@@ -51,6 +57,7 @@ const EmailPlanWarnings = ( { domain, emailAccount }: EmailPlanWarningsProps ) =
 					recordTracksEvent( 'calypso_email_management_google_workspace_accept_tos_link_click' );
 				} }
 				target="_blank"
+				{ ...ctaBtnProps }
 			>
 				{ translate( 'Finish setup' ) }
 				<Gridicon icon="external" />

--- a/client/my-sites/email/email-management/home/email-plan/index.jsx
+++ b/client/my-sites/email/email-management/home/email-plan/index.jsx
@@ -101,6 +101,7 @@ function EmailPlan( {
 	domain,
 	selectedSite,
 	source,
+	context,
 	hideHeader = false,
 	hideHeaderCake = false,
 	hidePlanActions = false,
@@ -365,6 +366,7 @@ function EmailPlan( {
 				mailboxes={ getMailboxes( emailAccounts ) }
 				isLoadingEmails={ isLoading }
 				addMailboxPath={ hidePlanActions && getAddMailboxProps()?.path }
+				configuringStateMode={ context === 'domains' && 'notice' }
 			/>
 			{ ! hidePlanActions && (
 				<div className="email-plan__actions">
@@ -388,6 +390,7 @@ EmailPlan.propTypes = {
 	domain: PropTypes.object.isRequired,
 	selectedSite: PropTypes.object.isRequired,
 	source: PropTypes.string,
+	context: PropTypes.string,
 	hideHeader: PropTypes.bool,
 	hideHeaderCake: PropTypes.bool,
 	hidePlanActions: PropTypes.bool,

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -511,4 +511,9 @@
 	.email-plan-mailboxes-list__mailbox-list-item > div {
 		flex-grow: initial;
 	}
+
+	.email-plan-mailboxes-list__notice {
+		margin-top: 1rem;
+		margin-bottom: 2rem;
+	}
 }

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -512,8 +512,8 @@
 		flex-grow: initial;
 	}
 
-	.email-plan-mailboxes-list__mailbox-list-link span,
-	.section-header__actions button {
+	div.email-plan-mailboxes-list__mailbox-list-link span,
+	.section-header__actions button[disabled] {
 		color: var(--theme-highlight-color-50);
 		opacity: 0.5;
 	}

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -515,5 +515,45 @@
 	.email-plan-mailboxes-list__notice {
 		margin-top: 1rem;
 		margin-bottom: 2rem;
+
+		.email-plan-warnings__container {
+			margin: 0;
+		}
+
+		.email-plan-warnings__warning {
+			display: flex;
+			padding: 0;
+
+			.email-plan-warnings__message,
+			.email-plan-warnings__cta {
+				display: inline;
+			}
+
+			.email-plan-warnings__message {
+				flex-grow: 1;
+
+				span {
+					display: inline-block;
+					max-width: 700px;
+				}
+			}
+
+			.email-plan-warnings__cta {
+				margin: 0;
+				flex-grow: 0;
+				align-self: center;
+				white-space: nowrap;
+
+				svg {
+					height: 14px;
+					vertical-align: middle;
+				}
+
+				a {
+					color: var(--studio-gray-20);
+					text-decoration: none;
+				}
+			}
+		}
 	}
 }

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -512,6 +512,12 @@
 		flex-grow: initial;
 	}
 
+	.email-plan-mailboxes-list__mailbox-list-link span,
+	.section-header__actions button {
+		color: var(--theme-highlight-color-50);
+		opacity: 0.5;
+	}
+
 	.email-plan-mailboxes-list__notice {
 		margin-top: 1rem;
 		margin-bottom: 2rem;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/96823

## Proposed Changes

* Update `EmailPlanMailboxesList` matching Figma design proposals
* * Google configuring state: ePfz53j71KKDLWtuSm567A-fi-4951_11732
* * Finish setup state: ePfz53j71KKDLWtuSm567A-fi-4953_14100
* Adapt email-related components to support different states

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* All Domain Management

## Testing Instructions

* Go to: `/domains/manage?flags=calypso/all-domain-management`
* Select or create your domain
* Choose the Email tab
* Select the "Google Workspace" option
* Purchase it with you credits
* Manually go to `/domains/manage/all/email/{DOMAIN}/{DOMAIN}`
* Check transition screens when google is configuring the mailbox
* At the end, check the regular flow for regression

**NOTE:** This PR only handles UI matching FIGMA design; the UX and the flow with redirections will be handled in the separate PRs.

<img width="1260" alt="Screenshot 2024-12-13 at 19 24 14" src="https://github.com/user-attachments/assets/13ea1525-0ae1-4551-a891-903480bdfaf1" />

<img width="1260" alt="Screenshot 2024-12-13 at 19 35 29" src="https://github.com/user-attachments/assets/954342b1-2ef1-4701-891a-1cf042a490a3" />

<img width="1261" alt="Screenshot 2024-12-13 at 19 36 40" src="https://github.com/user-attachments/assets/2294a5c4-8732-4c0f-96e1-2adbe3b89d40" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?