### PR TITLE
Checkout: Make PayPal PPCP available to everyone if server allows it

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -66,8 +66,7 @@ export function useCreatePayPalExpress( {
 }
 
 export function useCreatePayPalPPCP(): PaymentMethod | null {
-	const shouldUsePayPalPPCP = isEnabled( 'checkout/paypal-ppcp' );
-	return useMemo( () => ( shouldUsePayPalPPCP ? createPayPal() : null ), [ shouldUsePayPalPPCP ] );
+	return useMemo( () => createPayPal(), [] );
 }
 
 export function useCreateCreditCard( {

--- a/client/my-sites/checkout/src/lib/filter-appropriate-payment-methods.ts
+++ b/client/my-sites/checkout/src/lib/filter-appropriate-payment-methods.ts
@@ -10,11 +10,29 @@ export default function filterAppropriatePaymentMethods( {
 	paymentMethodObjects: PaymentMethod[];
 	allowedPaymentMethods: CheckoutPaymentMethodSlug[];
 } ): PaymentMethod[] {
-	return paymentMethodObjects.filter( ( methodObject ) => {
-		const slug = readCheckoutPaymentMethodSlug( methodObject.id );
-		if ( ! slug ) {
-			return false;
-		}
-		return isPaymentMethodEnabled( slug, allowedPaymentMethods );
-	} );
+	let isPayPalPPCPEnabled = false;
+	return paymentMethodObjects
+		.filter( ( methodObject ) => {
+			const slug = readCheckoutPaymentMethodSlug( methodObject.id );
+			if ( ! slug ) {
+				return false;
+			}
+			if ( slug === 'paypal-js' ) {
+				isPayPalPPCPEnabled = true;
+			}
+			return isPaymentMethodEnabled( slug, allowedPaymentMethods );
+		} )
+		.filter( ( methodObject ) => {
+			// Only allow one of 'paypal-express' or 'paypal-js' in checkout. We
+			// don't want to confuse users with both options, even if they are both
+			// available. 'paypal-js' takes precedence.
+			const slug = readCheckoutPaymentMethodSlug( methodObject.id );
+			if ( ! slug ) {
+				return false;
+			}
+			if ( isPayPalPPCPEnabled && slug === 'paypal-express' ) {
+				return false;
+			}
+			return true;
+		} );
 }

--- a/client/my-sites/checkout/src/lib/filter-appropriate-payment-methods.ts
+++ b/client/my-sites/checkout/src/lib/filter-appropriate-payment-methods.ts
@@ -17,10 +17,13 @@ export default function filterAppropriatePaymentMethods( {
 			if ( ! slug ) {
 				return false;
 			}
+			if ( ! isPaymentMethodEnabled( slug, allowedPaymentMethods ) ) {
+				return false;
+			}
 			if ( slug === 'paypal-js' ) {
 				isPayPalPPCPEnabled = true;
 			}
-			return isPaymentMethodEnabled( slug, allowedPaymentMethods );
+			return true;
 		} )
 		.filter( ( methodObject ) => {
 			// Only allow one of 'paypal-express' or 'paypal-js' in checkout. We

--- a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
+++ b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
@@ -34,7 +34,7 @@ function PayPalLabel() {
 	return (
 		<>
 			<div>
-				<span>PayPal (A8C-only)</span>
+				<span>PayPal</span>
 			</div>
 			<PaymentMethodLogos className="paypal__logo payment-logos">
 				<PayPalLogo />

--- a/config/development.json
+++ b/config/development.json
@@ -48,7 +48,6 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
-		"checkout/paypal-ppcp": true,
 		"checkout/checkout-version": true,
 		"checkout/razorpay": true,
 		"cloudflare": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -27,7 +27,6 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
-		"checkout/paypal-ppcp": true,
 		"checkout/checkout-version": false,
 		"checkout/razorpay": false,
 		"cloudflare": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -34,7 +34,6 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": false,
 		"checkout/vat-form": true,
-		"checkout/paypal-ppcp": true,
 		"checkout/checkout-version": false,
 		"checkout/razorpay": false,
 		"current-site/domain-warning": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -31,7 +31,6 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
-		"checkout/paypal-ppcp": true,
 		"checkout/checkout-version": false,
 		"checkout/razorpay": false,
 		"current-site/domain-warning": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -33,7 +33,6 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": false,
 		"checkout/vat-form": true,
-		"checkout/paypal-ppcp": false,
 		"checkout/checkout-version": false,
 		"checkout/razorpay": false,
 		"current-site/domain-warning": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -33,7 +33,6 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": false,
 		"checkout/vat-form": true,
-		"checkout/paypal-ppcp": true,
 		"checkout/checkout-version": false,
 		"checkout/razorpay": false,
 		"current-site/domain-warning": false,

--- a/config/production.json
+++ b/config/production.json
@@ -40,7 +40,6 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
-		"checkout/paypal-ppcp": false,
 		"checkout/checkout-version": false,
 		"checkout/razorpay": false,
 		"cloudflare": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -37,7 +37,6 @@
 		"catch-js-errors": true,
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
-		"checkout/paypal-ppcp": true,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": true,
 		"checkout/razorpay": false,

--- a/config/test.json
+++ b/config/test.json
@@ -35,7 +35,6 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
-		"checkout/paypal-ppcp": false,
 		"checkout/checkout-version": false,
 		"checkout/razorpay": true,
 		"cloudflare": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -37,7 +37,6 @@
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
-		"checkout/paypal-ppcp": true,
 		"checkout/checkout-version": true,
 		"checkout/razorpay": false,
 		"cloudflare": true,


### PR DESCRIPTION
## Proposed Changes

This PR removes the config flag that gated the new PayPal PPCP payment method so it will be available to everyone, if the server reports it as available (controlled by a flag on the backend).

Currently we only have support for PPCP in checkout. The "Change Payment Method" form will still use the NVP system.

## Why are these changes being made?

We are launching PayPal PPCP as a replacement for PayPal Express. See pfOicC-cP-p2

## Testing Instructions

- Add something to your cart and visit checkout. Edit the payment method and make sure you only see one "PayPal" option. Select it and submit checkout to make sure it's PPCP; you can tell because it will open a new window for the PayPal confirmation but checkout will remain visible. You do not need to complete the transaction.
- Manually alter the allowed payment methods coming from the shopping cart endpoint (see `WPCOM_Allowed_Payment_Methods`) and remove PPCP. Then reload checkout and repeat the above step but verify that you are using PayPal NVP; you can tell because the full page redirects to PayPal. Then revert the server changes.
- Use an account with at least one active subscription. Visit `/me/purchases` and click on the subscription. Click "Change Payment Method" and verify you see only one "PayPal" option. Select it and submit the form to make sure it's NVP; you can tell because the full page will redirect to PayPal. You do not need to confirm the assignment.