### PR TITLE
Reader: Update Reader Conversations copy

### DIFF
--- a/client/blocks/conversations/empty.jsx
+++ b/client/blocks/conversations/empty.jsx
@@ -37,7 +37,7 @@ class ConversationsEmptyContent extends Component {
 				title={ this.props.translate( 'Welcome to Conversations' ) }
 				line={ this.props.translate(
 					"When WordPress posts spark lively conversations, they'll appear here. " +
-						'To get started, Follow or comment on some posts.'
+						'To get started, follow or comment on some posts.'
 				) }
 				action={ action }
 				secondaryAction={ secondaryAction }

--- a/client/blocks/conversations/empty.jsx
+++ b/client/blocks/conversations/empty.jsx
@@ -37,7 +37,7 @@ class ConversationsEmptyContent extends Component {
 				title={ this.props.translate( 'Welcome to Conversations' ) }
 				line={ this.props.translate(
 					"When WordPress posts spark lively conversations, they'll appear here. " +
-						'To get started, like or comment on some posts.'
+						'To get started, Follow or comment on some posts.'
 				) }
 				action={ action }
 				secondaryAction={ secondaryAction }

--- a/client/reader/conversations/controller.js
+++ b/client/reader/conversations/controller.js
@@ -60,6 +60,7 @@ export function conversationsA8c( context, next ) {
 			key="conversations"
 			title="Conversations @ Automattic"
 			streamKey={ streamKey }
+			store={ { id: streamKey } }
 			trackScrollPage={ scrollTracker }
 		/>
 	);

--- a/client/reader/conversations/intro.jsx
+++ b/client/reader/conversations/intro.jsx
@@ -61,11 +61,10 @@ class ConversationsIntro extends Component {
 						<span>
 							{ isInternal
 								? translate(
-										'{{strong}}Welcome to A8C Conversations{{/strong}}, where you can read ' +
-											'and reply to all your P2 conversations in one place. ' +
-											"Automattic P2 posts you've liked or commented on " +
-											'will appear when they have new comments. ' +
-											'{{a}}More info. {{/a}}',
+										`{{strong}}Welcome to A8C Conversations.{{/strong}} ` +
+											`Automattic P2 posts you've written, Followed, or commented on will appear here when they have new comments. ` +
+											`Posts with the most recent comments appear on top. ` +
+											`{{a}}More info.{{/a}}`,
 										{
 											components: {
 												strong: <strong />,
@@ -74,10 +73,9 @@ class ConversationsIntro extends Component {
 										}
 								  )
 								: translate(
-										'{{strong}}Welcome to Conversations.{{/strong}} You can read ' +
-											'and reply to all your conversations in one place. ' +
-											"WordPress posts you've liked or commented on " +
-											'will appear when they have new comments.',
+										`{{strong}}Welcome to Conversations{{/strong}} ` +
+											`WordPress posts you've written, Followed, or commented on will appear here when they have new comments. ` +
+											`Posts with the most recent comments appear on top.`,
 										{
 											components: {
 												strong: <strong />,

--- a/client/reader/conversations/intro.jsx
+++ b/client/reader/conversations/intro.jsx
@@ -62,7 +62,7 @@ class ConversationsIntro extends Component {
 							{ isInternal
 								? translate(
 										`{{strong}}Welcome to A8C Conversations.{{/strong}} ` +
-											`Automattic P2 posts you've written, Followed, or commented on will appear here when they have new comments. ` +
+											`Automattic P2 posts you've written, followed, or commented on will appear here when they have new comments. ` +
 											`Posts with the most recent comments appear on top. ` +
 											`{{a}}More info.{{/a}}`,
 										{
@@ -74,7 +74,7 @@ class ConversationsIntro extends Component {
 								  )
 								: translate(
 										`{{strong}}Welcome to Conversations{{/strong}} ` +
-											`WordPress posts you've written, Followed, or commented on will appear here when they have new comments. ` +
+											`WordPress posts you've written, followed, or commented on will appear here when they have new comments. ` +
 											`Posts with the most recent comments appear on top.`,
 										{
 											components: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/258 and D168390-code

## Proposed Changes

* This PR updates the copy of the Conversations sections to be more informative and removes the mention of Likes since they're removed in D168390-code
* It also fixes an issue so that the specialized intro copy for /read/conversations/a8c appears as initially intended.


Before | After
--|--
<img width="1722" alt="Screenshot 2024-12-11 at 1 51 42 PM" src="https://github.com/user-attachments/assets/2fb1a079-35b4-4d20-947d-a5a096ba8c7f" />  |  <img width="1724" alt="Screenshot 2024-12-11 at 1 50 34 PM" src="https://github.com/user-attachments/assets/819e9fc7-04dd-417c-92c4-d1149730f4b0" />


Before | After
--|--
<img width="1724" alt="Screenshot 2024-12-11 at 1 51 53 PM" src="https://github.com/user-attachments/assets/86863140-4c8f-4e95-a9f7-c5165a6f74e7" /> | <img width="1725" alt="Screenshot 2024-12-11 at 1 50 49 PM" src="https://github.com/user-attachments/assets/1d60fe2a-be55-429b-8e59-169f22be8bbc" />


Before | After
--|--
<img width="1725" alt="Screenshot 2024-12-11 at 1 52 12 PM" src="https://github.com/user-attachments/assets/33c0a4ca-327f-42d5-9134-d74375363aa2" /> | <img width="1724" alt="Screenshot 2024-12-11 at 1 52 31 PM" src="https://github.com/user-attachments/assets/f31b1611-8798-49d9-890b-4d12c1b95b72" />





## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Create clarity around the functionality of the Conversations section.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /read/conversations/a8c and /read/conversations
* Ensure the copy makes sense

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?