### PR TITLE
Notifications: Restore viewbox for Reblog icon

### DIFF
--- a/apps/notifications/src/panel/templates/gridicons.jsx
+++ b/apps/notifications/src/panel/templates/gridicons.jsx
@@ -159,7 +159,7 @@ export default class extends Component {
 
 			case 'gridicons-reblog':
 				return (
-					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 						<title>Reblog</title>
 						<g>
 							<path d="M22.086 9.914L20 7.828V18c0 1.105-.895 2-2 2h-7v-2h7V7.828l-2.086 2.086L14.5 8.5 19 4l4.5 4.5-1.414 1.414zM6 16.172V6h7V4H6c-1.105 0-2 .895-2 2v10.172l-2.086-2.086L.5 15.5 5 20l4.5-4.5-1.414-1.414L6 16.172z" />


### PR DESCRIPTION
Fixes the display of Reblog gridicons in Notifications.

From what I can tell, the sharing icons referenced in #79932 are no longer in use. @davemart-in could you confirm?

Introduced in #79932.

## Proposed Changes

* Restore viewbox attribute for Reblog icon to 24px.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/d53c6c01-8ea1-4875-ac49-bf6e5e4da2cc) | <img alt="image" src="https://github.com/user-attachments/assets/14067034-00b6-48df-8275-74ceb9ebba04" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Activate Activitypub on a Simple test site, Tools -> Marketing -> Connections.
* Publish a new post.
* Find the Fediverse account for the test site on your favorite server (E.g. mastodon.live)
* Reblog (Boost) the post you published.
* Double check your notifications!

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
