### PR TITLE
Stepper: Show "your plan" when back from checkout

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -10,6 +10,7 @@ import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import { ProvidedDependencies, StepProps } from '../../types';
+import { useIsManagedSiteFlowProps } from '../unified-domains/use-is-managed-site-flow';
 import UnifiedPlansStep from './unified-plans-step';
 import { getIntervalType } from './util';
 
@@ -19,6 +20,7 @@ export default function PlansStepAdaptor( props: StepProps ) {
 	const [ stepState, setStepState ] = useStepPersistedState< ProvidedDependencies >( 'plans-step' );
 	const siteSlug = useSiteSlug();
 	const isMobile = useMobileBreakpoint();
+	const managedSiteFlowProps = useIsManagedSiteFlowProps();
 
 	const { siteTitle, domainItem, domainItems } = useSelect(
 		( select: ( key: string ) => OnboardSelect ) => {
@@ -44,7 +46,7 @@ export default function PlansStepAdaptor( props: StepProps ) {
 		domainCart: domainItems,
 	};
 
-	const site = useSite();
+	const site = useSite( managedSiteFlowProps.selectedSite?.slug );
 	const customerType = useQuery().get( 'customerType' ) ?? undefined;
 	const [ planInterval, setPlanInterval ] = useState< string | undefined >( undefined );
 

--- a/client/landing/stepper/hooks/use-site.ts
+++ b/client/landing/stepper/hooks/use-site.ts
@@ -8,11 +8,11 @@ import { useSiteIdParam } from './use-site-id-param';
 import { useSiteSlugParam } from './use-site-slug-param';
 import type { SiteSelect } from '@automattic/data-stores';
 
-export function useSite() {
+export function useSite( signupSlugParam?: string ) {
 	const dispatch = useDispatch();
 	const siteSlug = useSiteSlugParam();
 	const siteIdParam = useSiteIdParam();
-	const siteIdOrSlug = siteIdParam ?? siteSlug ?? '';
+	const siteIdOrSlug = siteIdParam ?? siteSlug ?? signupSlugParam ?? '';
 
 	const site = useSelect(
 		( select ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/97078

## Proposed Changes

Check the issue.



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/onboarding
* Free domain -> Paid plan -> Checkout -> Browser back to Plans page
* You should see the "Your plan" badge on the free plan
