### PR TITLE
Fix coupons in Stepper

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -31,7 +31,7 @@ export default function PlansStepAdaptor( props: StepProps ) {
 		[]
 	);
 	const username = useSelector( getCurrentUserName );
-	const coupon = undefined;
+	const coupon = useQuery().get( 'coupon' ) ?? undefined;
 
 	const { setDomainCartItem, setDomainCartItems, setSiteUrl } = useWPDispatch( ONBOARD_STORE );
 

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -11,6 +11,7 @@ import {
 	setSignupCompleteSlug,
 } from 'calypso/signup/storageUtils';
 import { STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT } from '../constants';
+import { useQuery } from '../hooks/use-query';
 import { ONBOARD_STORE } from '../stores';
 import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 import { useGoalsFirstExperiment } from './helpers/use-goals-first-experiment';
@@ -90,6 +91,7 @@ const onboarding: Flow = {
 			} ),
 			[]
 		);
+		const coupon = useQuery().get( 'coupon' );
 
 		const [ redirectedToUseMyDomain, setRedirectedToUseMyDomain ] = useState( false );
 		const [ useMyDomainQueryParams, setUseMyDomainQueryParams ] = useState( {} );
@@ -221,6 +223,7 @@ const onboarding: Flow = {
 								redirect_to: destination,
 								signup: 1,
 								checkoutBackUrl: pathToUrl( addQueryArgs( destination, { skippedCheckout: 1 } ) ),
+								coupon,
 							} )
 						);
 					} else {


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/97355

## Proposed Changes

Handle `coupon` query param and forward it to checkout.

## Why are these changes being made?
To bring parity to Stepper (vs /start).

## Testing Instructions
1. Go to /setup/onboarding?coupon=federate25
2. Business plan should get a discount.
3. Pick a business plan.
4. Checkout should acknowledge the discount. 


