### PR TITLE
Stats: improve tooltips positive/negative trends

### DIFF
--- a/client/my-sites/stats/hooks/use-subscribers-overview.ts
+++ b/client/my-sites/stats/hooks/use-subscribers-overview.ts
@@ -5,10 +5,13 @@ import { useSubscribersQueries } from './use-subscribers-query';
 const DATES_TO_QUERY = [ 0, 30, 60, 90 ];
 const DATES_TO_QUERY_EXCLUDE_TODAY = [ 30, 60, 90 ];
 
+// Used to allow comparisons between translated strings
+const TODAY_LABEL = translate( 'Today' );
+
 function getLabels( dateToQuery: number ) {
 	switch ( dateToQuery ) {
 		case 0:
-			return translate( 'Today' );
+			return TODAY_LABEL;
 		case 30:
 			return translate( '30 days ago' );
 		case 60:
@@ -22,7 +25,7 @@ function getLabels( dateToQuery: number ) {
 
 function getNote( heading: string ) {
 	let note = translate( 'As of today' );
-	if ( heading !== 'Today' ) {
+	if ( heading !== TODAY_LABEL ) {
 		const prefix = translate( 'Since' );
 		note = `${ prefix } ${ heading }`;
 	}

--- a/client/my-sites/stats/hooks/use-subscribers-overview.ts
+++ b/client/my-sites/stats/hooks/use-subscribers-overview.ts
@@ -20,6 +20,15 @@ function getLabels( dateToQuery: number ) {
 	}
 }
 
+function getNote( heading: string ) {
+	let note = translate( 'As of today' );
+	if ( heading !== 'Today' ) {
+		const prefix = translate( 'Since' );
+		note = `${ prefix } ${ heading }`;
+	}
+	return note;
+}
+
 // calculate the date to query for based on the number of days to subtract
 function calculateQueryDate( daysToSubtract: number ) {
 	const today = new Date();
@@ -43,9 +52,11 @@ export default function useSubscribersOverview( siteId: number | null, isTodayEx
 	const overviewData = subscribersData.map( ( data, index ) => {
 		const count = data?.data?.[ 0 ]?.subscribers || null;
 		const heading = getLabels( datesToQuery[ index ] );
+		const note = getNote( heading );
 		return {
 			count,
 			heading,
+			note,
 		};
 	} );
 

--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -14,13 +14,7 @@ const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } )
 	return (
 		<div className="subscribers-overview highlight-cards">
 			<div className="highlight-cards-list">
-				{ overviewData.map( ( { count, heading }, index ) => {
-					let note = translate( 'As of today' );
-					if ( heading !== 'Today' ) {
-						const prefix = translate( 'Since' );
-						note = `${ prefix } ${ heading }`;
-					}
-
+				{ overviewData.map( ( { count, heading, note }, index ) => {
 					return (
 						// TODO: Communicate loading vs error state to the user.
 						<CountCard

--- a/client/my-sites/stats/stats-tabs/tab.jsx
+++ b/client/my-sites/stats/stats-tabs/tab.jsx
@@ -1,7 +1,5 @@
-import {
-	TooltipContent,
-	TrendComparison,
-} from '@automattic/components/src/highlight-cards/count-comparison-card';
+import { TooltipContent } from '@automattic/components/src/highlight-cards/count-card';
+import { TrendComparison } from '@automattic/components/src/highlight-cards/count-comparison-card';
 import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import Popover from '@automattic/components/src/popover';
 import clsx from 'clsx';
@@ -111,7 +109,11 @@ class StatsTabsTab extends Component {
 								position="bottom right"
 								context={ this.tooltipRef.current }
 							>
-								<TooltipContent count={ value } previousCount={ previousValue } />
+								<TooltipContent
+									value={ value }
+									label={ label.toLocaleLowerCase() }
+									previousValue={ previousValue }
+								/>
 							</Popover>
 						</div>
 					) }

--- a/packages/components/src/highlight-cards/count-card.tsx
+++ b/packages/components/src/highlight-cards/count-card.tsx
@@ -1,8 +1,9 @@
+import { arrowDown, arrowUp, Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useRef, useState } from 'react';
 import { Card } from '../';
 import Popover from '../popover';
-import { formatNumber } from './lib/numbers';
+import { formatNumber, subtract } from './lib/numbers';
 
 interface CountCardProps {
 	heading?: React.ReactNode;
@@ -10,16 +11,32 @@ interface CountCardProps {
 	label?: string;
 	note?: string;
 	showValueTooltip?: boolean;
-	value: number | string | null;
+	value: number | null;
+	previousValue?: number | null;
 }
 
-function TooltipContent( { value, label, note }: CountCardProps ) {
+export function TooltipContent( { value, label, note, previousValue }: CountCardProps ) {
+	const difference = subtract( value, previousValue );
+
+	let trendClass = 'highlight-card-tooltip-count-difference-positive';
+	let trendIcon = arrowUp;
+	if ( difference !== null && difference < 0 ) {
+		trendClass = 'highlight-card-tooltip-count-difference-negative';
+		trendIcon = arrowDown;
+	}
+
 	return (
 		<div className="highlight-card-tooltip-content">
 			<span className="highlight-card-tooltip-counts">
-				{ formatNumber( value as number, false ) }
+				{ formatNumber( value, false ) }
 				{ label && ` ${ label }` }
 			</span>
+			{ difference !== null && difference !== 0 && (
+				<span className={ trendClass }>
+					<Icon size={ 18 } icon={ trendIcon } />
+					{ formatNumber( Math.abs( difference ), false ) }
+				</span>
+			) }
 			{ note && <div className="highlight-card-tooltip-note">{ note }</div> }
 		</div>
 	);

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -396,6 +396,21 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 	color: var(--studio-gray-10);
 }
 
+.highlight-card-tooltip-count-difference-positive {
+	color: var(--studio-green-10);
+}
+
+.highlight-card-tooltip-count-difference-negative {
+	color: var(--studio-red-10);
+}
+
+.highlight-card-tooltip-count-difference-positive svg,
+.highlight-card-tooltip-count-difference-negative svg {
+	fill: currentColor;
+	margin-left: 16px;
+	vertical-align: text-bottom;
+}
+
 .highlight-card-tooltip-note {
 	color: var(--studio-gray-30);
 	font-size: $font-body-small;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/red-team#193.

## Proposed Changes

Improve tooltips consistency in the Stats `Traffic` page.

I also took the opportunity to fix an inconsistency in the `Subscribers` page, where not having paid subscribers could result in tooltips without the optional description/note.

### Implementation details

> [!WARNING]
>
> I explicitly changed the `TooltipContent` implementation [within `count-card.tsx`][1], and NOT the one [that's part of `count-comparison-card.tsx`][1] to make sure we are using the same component, improving and ensuring consistency, as this is the goal of the design docs. If you think we are better served by separating concerns and making changes to the latter, please let me know and I'll update the PR.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is part of the efforts started by Design (p1HpG7-unJ-p2) to increase consistency between different Stats tooltips.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to the `Stats` page of a website that has meaningful traffic data.
  - The `Last 30 Days` of `jetpack.com` is a good example: `/stats/day/jetpack.com?chartStart=2024-11-12&chartEnd=2024-12-11`.
- Check the tooltips by hovering over the different stats in the `Traffic` and `Subscribers` tabs, as shown in the screenshots below.

### Traffic

| Before | After |
| :-: | :-: |
| <img width="228" alt="image" src="https://github.com/user-attachments/assets/58c53a52-e492-440c-9ee6-b06a5baba2f5" /> | <img width="271" alt="image" src="https://github.com/user-attachments/assets/389ab69f-b350-4ae5-855c-5eeb772d55e9" /> |
| <img width="223" alt="image" src="https://github.com/user-attachments/assets/5a879bb2-f386-42b7-b4a7-00908fca4eca" /> | <img width="231" alt="image" src="https://github.com/user-attachments/assets/68a7af95-0f9f-466b-83cc-3c1caf9e6c47" /> |

### Subscribers

| Before | After |
| :-: | :-: |
| <img width="527" alt="image" src="https://github.com/user-attachments/assets/8b09c261-8cab-4369-b30f-07723e687fa2" /> | <img width="527" alt="image" src="https://github.com/user-attachments/assets/0be8d4a7-81df-470f-a2c1-b5d1925e51ba" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://github.com/Automattic/wp-calypso/blob/0244a1ecae85bbe4e1bef053f4dc23543bbd8fe5/packages/components/src/highlight-cards/count-card.tsx#L16-L26
[2]: https://github.com/Automattic/wp-calypso/blob/0244a1ecae85bbe4e1bef053f4dc23543bbd8fe5/packages/components/src/highlight-cards/count-comparison-card.tsx#L55-L70