### PR TITLE
Paid stats: update upsell copy in Stats modules

### DIFF
--- a/client/my-sites/stats/stats-card-upsell/index.tsx
+++ b/client/my-sites/stats/stats-card-upsell/index.tsx
@@ -1,6 +1,8 @@
-import { translate } from 'i18n-calypso';
+import { Plans } from '@automattic/data-stores';
+import { translate, TranslateResult } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { statTypeToPlan } from '../stat-type-to-plan';
 import StatsCardUpsellJetpack from './stats-card-upsell-jetpack';
 import StatsCardUpsellWPCOM from './stats-card-upsell-wpcom';
 
@@ -8,7 +10,7 @@ export interface Props {
 	className?: string;
 	statType: string;
 	siteId: number;
-	buttonLabel?: string;
+	buttonLabel?: string | TranslateResult;
 }
 
 const StatsCardUpsell: React.FC< Props > = ( { className, statType, siteId, buttonLabel } ) => {
@@ -16,9 +18,20 @@ const StatsCardUpsell: React.FC< Props > = ( { className, statType, siteId, butt
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
 	);
 
+	const plans = Plans.usePlans( { coupon: undefined } );
+	const planKey = statTypeToPlan( statType );
+	const plan = plans?.data?.[ planKey ];
+
 	let UpsellComponent = StatsCardUpsellWPCOM;
+	let upsellButtonLabel = ! plan?.productNameShort
+		? translate( 'Upgrade plan' )
+		: translate( 'Upgrade to %(planName)s', {
+				args: { planName: plan.productNameShort },
+		  } );
+
 	if ( isSiteJetpackNotAtomic ) {
 		UpsellComponent = StatsCardUpsellJetpack;
+		upsellButtonLabel = buttonLabel ?? translate( 'Upgrade plan' );
 	}
 
 	return (
@@ -26,7 +39,7 @@ const StatsCardUpsell: React.FC< Props > = ( { className, statType, siteId, butt
 			className={ className }
 			statType={ statType }
 			siteId={ siteId }
-			buttonLabel={ buttonLabel ?? translate( 'Upgrade plan' ) }
+			buttonLabel={ upsellButtonLabel }
 		/>
 	);
 };

--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-overlay.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-overlay.tsx
@@ -1,13 +1,13 @@
 import { Button, Gridicon } from '@automattic/components';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
 import React, { ReactNode } from 'react';
 
 interface Props {
 	className?: string;
 	copyText: string | ReactNode;
 	onClick: ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => void;
-	buttonLabel?: string;
+	buttonLabel?: string | TranslateResult;
 	buttonComponent?: React.ReactNode;
 }
 

--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-wpcom.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-wpcom.tsx
@@ -27,9 +27,11 @@ const getUpsellCopy = ( statType: string ) => {
 				'Learn what external links your visitors click on your site to reveal their areas of interest.'
 			);
 		case STAT_TYPE_COUNTRY_VIEWS:
-			return translate( 'See where your visitors come from.' );
+			return translate(
+				'Discover where your visitors are located and identify where your traffic is coming from.'
+			);
 		case STAT_TYPE_FILE_DOWNLOADS:
-			return translate( 'Monitor your file downloads engagement.' );
+			return translate( 'Discover the most downloaded files by your visitors.' );
 		case STAT_TYPE_REFERRERS:
 			return translate(
 				'Find out where your visitors come from to optimize your content strategy.'
@@ -39,7 +41,9 @@ const getUpsellCopy = ( statType: string ) => {
 		case STAT_TYPE_TOP_AUTHORS:
 			return translate( 'Identify your audience’s favorite writers and perspectives.' );
 		case STAT_TYPE_TOP_POSTS:
-			return translate( 'Track posts and pages views.' );
+			return translate(
+				'Discover your post and pages traffic in detail and learn what content resonates the most.'
+			);
 		case STAT_TYPE_VIDEO_PLAYS:
 			return translate( 'Discover your most popular videos and find out how they performed.' );
 		case STATS_FEATURE_DATE_CONTROL:
@@ -47,7 +51,7 @@ const getUpsellCopy = ( statType: string ) => {
 		case STATS_FEATURE_UTM_STATS:
 			return translate( 'Generate UTM parameters and track your campaign performance data.' );
 		case STATS_TYPE_DEVICE_STATS:
-			return translate( 'See which devices your visitors are using.' );
+			return translate( 'See which devices, browsers and OS your visitors are using.' );
 		default:
 			return translate( 'Upgrade your plan to unlock Jetpack Stats.' );
 	}

--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-wpcom.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-wpcom.tsx
@@ -54,9 +54,18 @@ const getUpsellCopy = ( statType: string ) => {
 					},
 				}
 			);
-		// https://wordpress.com/support/stats/understand-your-sites-traffic/#file-downloads
 		case STAT_TYPE_FILE_DOWNLOADS:
-			return translate( 'Discover the most downloaded files by your visitors.' );
+			return translate( 'Discover the most {{link}}downloaded files{{/link}} by your visitors.', {
+				components: {
+					link: (
+						<a
+							href={ localizeUrl( `${ SUPPORT_URL }#file-downloads` ) }
+							target="_blank"
+							rel="noreferrer"
+						/>
+					),
+				},
+			} );
 		case STAT_TYPE_REFERRERS:
 			return translate(
 				'Find out where your {{link}}visitors come from{{/link}} to optimize your content strategy.',

--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-wpcom.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-wpcom.tsx
@@ -1,7 +1,9 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import { preventWidows } from 'calypso/lib/formatting';
 import { toggleUpsellModal } from 'calypso/state/stats/paid-stats-upsell/actions';
+import { SUPPORT_URL } from '../const';
 import {
 	STATS_FEATURE_DATE_CONTROL,
 	STATS_FEATURE_UTM_STATS,
@@ -24,34 +26,140 @@ const getUpsellCopy = ( statType: string ) => {
 	switch ( statType ) {
 		case STAT_TYPE_CLICKS:
 			return translate(
-				'Learn what external links your visitors click on your site to reveal their areas of interest.'
+				'Learn what {{link}}external links{{/link}} your visitors click on your site to reveal their areas of interest.',
+				{
+					components: {
+						link: (
+							<a
+								href={ localizeUrl( `${ SUPPORT_URL }#clicks` ) }
+								target="_blank"
+								rel="noreferrer"
+							/>
+						),
+					},
+				}
 			);
 		case STAT_TYPE_COUNTRY_VIEWS:
 			return translate(
-				'Discover where your visitors are located and identify where your traffic is coming from.'
+				'Discover where your {{link}}visitors are located{{/link}} and identify where your traffic is coming from.',
+				{
+					components: {
+						link: (
+							<a
+								href={ localizeUrl( `${ SUPPORT_URL }#countries` ) }
+								target="_blank"
+								rel="noreferrer"
+							/>
+						),
+					},
+				}
 			);
+		// https://wordpress.com/support/stats/understand-your-sites-traffic/#file-downloads
 		case STAT_TYPE_FILE_DOWNLOADS:
 			return translate( 'Discover the most downloaded files by your visitors.' );
 		case STAT_TYPE_REFERRERS:
 			return translate(
-				'Find out where your visitors come from to optimize your content strategy.'
+				'Find out where your {{link}}visitors come from{{/link}} to optimize your content strategy.',
+				{
+					components: {
+						link: (
+							<a
+								href={ localizeUrl( `${ SUPPORT_URL }#referrers` ) }
+								target="_blank"
+								rel="noreferrer"
+							/>
+						),
+					},
+				}
 			);
 		case STAT_TYPE_SEARCH_TERMS:
-			return translate( 'Discover the terms and phrases your visitors use to find your site.' );
+			return translate(
+				'Discover the {{link}}terms and phrases{{/link}} your visitors use to find your site.',
+				{
+					components: {
+						link: (
+							<a
+								href={ localizeUrl( `${ SUPPORT_URL }#search-terms` ) }
+								target="_blank"
+								rel="noreferrer"
+							/>
+						),
+					},
+				}
+			);
 		case STAT_TYPE_TOP_AUTHORS:
-			return translate( 'Identify your audience’s favorite writers and perspectives.' );
+			return translate(
+				'Identify your audience’s {{link}}favorite writers{{/link}} and perspectives.',
+				{
+					components: {
+						link: (
+							<a
+								href={ localizeUrl( `${ SUPPORT_URL }#authors` ) }
+								target="_blank"
+								rel="noreferrer"
+							/>
+						),
+					},
+				}
+			);
 		case STAT_TYPE_TOP_POSTS:
 			return translate(
-				'Discover your post and pages traffic in detail and learn what content resonates the most.'
+				'Discover your {{link}}post and pages{{/link}} traffic in detail and learn what content resonates the most.',
+				{
+					components: {
+						link: (
+							<a
+								href={ localizeUrl( `${ SUPPORT_URL }#posts-amp-pages` ) }
+								target="_blank"
+								rel="noreferrer"
+							/>
+						),
+					},
+				}
 			);
 		case STAT_TYPE_VIDEO_PLAYS:
-			return translate( 'Discover your most popular videos and find out how they performed.' );
+			return translate(
+				'Discover your {{link}}most popular videos{{/link}} and find out how they performed.',
+				{
+					components: {
+						link: (
+							<a
+								href={ localizeUrl( `${ SUPPORT_URL }#videos` ) }
+								target="_blank"
+								rel="noreferrer"
+							/>
+						),
+					},
+				}
+			);
 		case STATS_FEATURE_DATE_CONTROL:
 			return translate( 'Compare different time periods to analyze your site’s growth.' );
 		case STATS_FEATURE_UTM_STATS:
-			return translate( 'Generate UTM parameters and track your campaign performance data.' );
+			return translate(
+				'Generate UTM parameters and track your {{link}}campaign performance data{{/link}}.',
+				{
+					components: {
+						link: (
+							<a href={ localizeUrl( `${ SUPPORT_URL }#utm` ) } target="_blank" rel="noreferrer" />
+						),
+					},
+				}
+			);
 		case STATS_TYPE_DEVICE_STATS:
-			return translate( 'See which devices, browsers and OS your visitors are using.' );
+			return translate(
+				'See which {{link}}devices, browsers and OS{{/link}} your visitors are using.',
+				{
+					components: {
+						link: (
+							<a
+								href={ localizeUrl( `${ SUPPORT_URL }#devices` ) }
+								target="_blank"
+								rel="noreferrer"
+							/>
+						),
+					},
+				}
+			);
 		default:
 			return translate( 'Upgrade your plan to unlock Jetpack Stats.' );
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1733945250966599/1733868801.711159-slack-C0438NHCLSY

## Proposed Changes

* Update stats module upsell copy
* Add inline links pointing to WPCOM support page for each module
* Update upsell card CTA to specify the plan to upgrade (Upgrade to Personal, Upgrade to Premium). 

| Before | After |
|---|---|
| ![CleanShot 2024-12-11 at 17 59 15@2x](https://github.com/user-attachments/assets/b253cee1-b2b6-446f-a389-84b39a1cf389) | ![CleanShot 2024-12-11 at 18 05 52@2x](https://github.com/user-attachments/assets/690889a1-8155-4917-8e09-704506731ae4) |
| ![CleanShot 2024-12-11 at 17 58 18@2x](https://github.com/user-attachments/assets/3c7b6dbf-7eeb-4684-9e2f-b7745883e2a8) | ![CleanShot 2024-12-11 at 17 58 32@2x](https://github.com/user-attachments/assets/feb4cf3d-dde6-4346-86a2-513f442a2669) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

p1733945250966599/1733868801.711159-slack-C0438NHCLSY

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Calypso Live Branch
* Using a new free site, you can manually visit some of the updated modules, and proofread the rest of the changes (since the changes are mostly texts and links).
* Upsell copy should match the spreadsheet shared in p1733945250966599/1733868801.711159-slack-C0438NHCLSY.
* Ensure it specifies the proper plan in the upgrade CTA.
 
Here is some partial paths for Personal and Premium:

* Personal
  * /stats/day/clicks/SITE_SLUG
  * /stats/day/countryviews/SITE_SLUG
* Premium
  * /stats/day/utm/SITE_SLUG
  * /stats/day/devices/SITE_SLUG

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?