### PR TITLE
Domains Management Revamp: Create Add Forwarding Email subpage

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -28,7 +28,7 @@ import {
 import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { getSubPageParams } from './subpage-wrapper/subpage-params';
+import { getSubPageParams } from './subpage-wrapper/subpages';
 import DomainManagement from '.';
 
 export default {

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { isFreeUrlDomainName } from '@automattic/domains-table/src/utils/is-free-url-domain-name';
 import DomainManagementData from 'calypso/components/data/domain-management';
 import { decodeURIComponentIfValid } from 'calypso/lib/url';
-import SubPageWrapper from 'calypso/my-sites/domains/domain-management/subpage-wrapper';
+import SubpageWrapper from 'calypso/my-sites/domains/domain-management/subpage-wrapper';
 import {
 	domainManagementAllEditSelectedContactInfo,
 	domainManagementEditSelectedContactInfo,
@@ -28,7 +28,7 @@ import {
 import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { getSubPageParams } from './subpage-wrapper/subpages';
+import { getSubpageParams } from './subpage-wrapper/subpages';
 import DomainManagement from '.';
 
 export default {
@@ -374,18 +374,18 @@ export default {
 		};
 	},
 
-	domainManagementSubPageParams( subPageKey ) {
+	domainManagementSubpageParams( subPageKey ) {
 		return ( pageContext, next ) => {
-			pageContext.params = getSubPageParams( subPageKey );
+			pageContext.params = getSubpageParams( subPageKey );
 			next();
 		};
 	},
 
-	domainManagementSubPageView( pageContext, next ) {
+	domainManagementSubpageView( pageContext, next ) {
 		pageContext.primary = (
-			<SubPageWrapper subPageKey={ pageContext.params.subPageKey }>
+			<SubpageWrapper subpageKey={ pageContext.params.subPageKey }>
 				{ pageContext.primary }
-			</SubPageWrapper>
+			</SubpageWrapper>
 		);
 		next();
 	},

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -2,6 +2,7 @@ import page from '@automattic/calypso-router';
 import { isFreeUrlDomainName } from '@automattic/domains-table/src/utils/is-free-url-domain-name';
 import DomainManagementData from 'calypso/components/data/domain-management';
 import { decodeURIComponentIfValid } from 'calypso/lib/url';
+import SubPageWrapper from 'calypso/my-sites/domains/domain-management/subpage-wrapper';
 import {
 	domainManagementAllEditSelectedContactInfo,
 	domainManagementEditSelectedContactInfo,
@@ -27,6 +28,7 @@ import {
 import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSubPageParams } from './subpage-wrapper/subpage-params';
 import DomainManagement from '.';
 
 export default {
@@ -370,5 +372,21 @@ export default {
 
 			next();
 		};
+	},
+
+	domainManagementSubPageParams( subPageKey ) {
+		return ( pageContext, next ) => {
+			pageContext.params = getSubPageParams( subPageKey );
+			next();
+		};
+	},
+
+	domainManagementSubPageView( pageContext, next ) {
+		pageContext.primary = (
+			<SubPageWrapper subPageKey={ pageContext.params.subPageKey }>
+				{ pageContext.primary }
+			</SubPageWrapper>
+		);
+		next();
 	},
 };

--- a/client/my-sites/domains/domain-management/subpage-wrapper/index.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/index.tsx
@@ -1,0 +1,27 @@
+import NavigationHeader from 'calypso/components/navigation-header';
+import { getSubPageParams } from './subpage-params';
+import './style.scss';
+
+type SubPageWrapperProps = {
+	children: React.ReactNode;
+	subPageKey: string;
+};
+
+const SubPageWrapper = ( { children, subPageKey }: SubPageWrapperProps ) => {
+	const subPageParams = getSubPageParams( subPageKey );
+
+	return subPageParams ? (
+		<>
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ subPageParams.title }
+				subtitle={ subPageParams.subtitle }
+			/>
+			<div className="subpage-wrapper">{ children }</div>
+		</>
+	) : (
+		<>{ children }</>
+	);
+};
+
+export default SubPageWrapper;

--- a/client/my-sites/domains/domain-management/subpage-wrapper/index.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/index.tsx
@@ -1,21 +1,21 @@
 import NavigationHeader from 'calypso/components/navigation-header';
-import { getSubPageParams } from './subpages';
+import { getSubpageParams } from './subpages';
 import './style.scss';
 
-type SubPageWrapperProps = {
+type SubpageWrapperProps = {
 	children: React.ReactNode;
-	subPageKey: string;
+	subpageKey: string;
 };
 
-const SubPageWrapper = ( { children, subPageKey }: SubPageWrapperProps ) => {
-	const subPageParams = getSubPageParams( subPageKey );
+const SubpageWrapper = ( { children, subpageKey }: SubpageWrapperProps ) => {
+	const subpageParams = getSubpageParams( subpageKey );
 
-	return subPageParams ? (
+	return subpageParams ? (
 		<>
 			<NavigationHeader
 				navigationItems={ [] }
-				title={ subPageParams.title }
-				subtitle={ subPageParams.subtitle }
+				title={ subpageParams.title }
+				subtitle={ subpageParams.subtitle }
 			/>
 			<div className="subpage-wrapper">{ children }</div>
 		</>
@@ -24,4 +24,4 @@ const SubPageWrapper = ( { children, subPageKey }: SubPageWrapperProps ) => {
 	);
 };
 
-export default SubPageWrapper;
+export default SubpageWrapper;

--- a/client/my-sites/domains/domain-management/subpage-wrapper/index.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/index.tsx
@@ -1,5 +1,5 @@
 import NavigationHeader from 'calypso/components/navigation-header';
-import { getSubPageParams } from './subpage-params';
+import { getSubPageParams } from './subpages';
 import './style.scss';
 
 type SubPageWrapperProps = {

--- a/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
@@ -1,9 +1,9 @@
 .subpage-wrapper {
     display: flex;
+    justify-content: center;
 
     .main.is-wide-layout {
         width: 100%;
-        max-width: inherit;
         margin: 32px 48px 0;
     }
 

--- a/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
@@ -1,0 +1,26 @@
+.subpage-wrapper {
+    display: flex;
+
+    .main.is-wide-layout {
+        width: 100%;
+        max-width: inherit;
+        margin: 32px 48px 0;
+    }
+
+    .email-forwards-add {
+        .card {
+            border-radius: 4px;
+        }
+
+        .card-heading {
+            font-size: 1rem;
+            font-weight: 500;
+            line-height: 24px;
+            margin-top: 0;
+        }
+
+        .form-text-input {
+            border-radius: 2px 0 0 2px;
+        }
+    }
+}

--- a/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
@@ -22,5 +22,9 @@
         .form-text-input-with-affixes .form-text-input {
             border-radius: 2px 0 0 2px;
         }
+
+        .button {
+            padding: 10px 24px;
+        }
     }
 }

--- a/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
@@ -17,6 +17,7 @@
             font-weight: 500;
             line-height: 24px;
             margin-top: 0;
+            margin-bottom: 16px;
         }
 
         .form-text-input-with-affixes .form-text-input {
@@ -25,6 +26,7 @@
 
         .button {
             padding: 10px 24px;
+            border-radius: 4px;
         }
     }
 }

--- a/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
@@ -19,7 +19,7 @@
             margin-top: 0;
         }
 
-        .form-text-input {
+        .form-text-input-with-affixes .form-text-input {
             border-radius: 2px 0 0 2px;
         }
     }

--- a/client/my-sites/domains/domain-management/subpage-wrapper/subpage-params.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/subpage-params.tsx
@@ -1,0 +1,25 @@
+import { __ } from '@wordpress/i18n';
+import CardHeading from 'calypso/components/card-heading';
+
+export const ADD_FOWARDING_EMAIL = 'add-forwarding-email';
+
+type SubPageWrapperParamsType = {
+	subPageKey: string;
+	title: string;
+	subtitle?: string;
+	[ key: string ]: unknown;
+};
+
+const SUBPAGE_TO_PARAMS_MAP: Record< string, SubPageWrapperParamsType > = {
+	[ ADD_FOWARDING_EMAIL ]: {
+		subPageKey: ADD_FOWARDING_EMAIL,
+		title: __( 'Add new email forwarding' ),
+		subtitle: __( 'Seamlessly redirect your messages to where you need them.' ),
+		showPageHeader: false,
+		formHeader: <CardHeading>{ __( 'New email forwarding address' ) }</CardHeading>,
+	},
+};
+
+export const getSubPageParams = ( subPageKey: string ): SubPageWrapperParamsType => {
+	return SUBPAGE_TO_PARAMS_MAP[ subPageKey ];
+};

--- a/client/my-sites/domains/domain-management/subpage-wrapper/subpages.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/subpages.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import CardHeading from 'calypso/components/card-heading';
 
-type SubPageWrapperParamsType = {
+type SubpageWrapperParamsType = {
 	subPageKey: string;
 	title: string;
 	subtitle?: string;
@@ -12,7 +12,7 @@ type SubPageWrapperParamsType = {
 export const ADD_FOWARDING_EMAIL = 'add-forwarding-email';
 
 // Subpage params map
-const SUBPAGE_TO_PARAMS_MAP: Record< string, SubPageWrapperParamsType > = {
+const SUBPAGE_TO_PARAMS_MAP: Record< string, SubpageWrapperParamsType > = {
 	[ ADD_FOWARDING_EMAIL ]: {
 		subPageKey: ADD_FOWARDING_EMAIL,
 		title: __( 'Add new email forwarding' ),
@@ -22,6 +22,6 @@ const SUBPAGE_TO_PARAMS_MAP: Record< string, SubPageWrapperParamsType > = {
 	},
 };
 
-export const getSubPageParams = ( subPageKey: string ): SubPageWrapperParamsType => {
+export const getSubpageParams = ( subPageKey: string ): SubpageWrapperParamsType => {
 	return SUBPAGE_TO_PARAMS_MAP[ subPageKey ];
 };

--- a/client/my-sites/domains/domain-management/subpage-wrapper/subpages.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/subpages.tsx
@@ -1,8 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import CardHeading from 'calypso/components/card-heading';
 
-export const ADD_FOWARDING_EMAIL = 'add-forwarding-email';
-
 type SubPageWrapperParamsType = {
 	subPageKey: string;
 	title: string;
@@ -10,6 +8,10 @@ type SubPageWrapperParamsType = {
 	[ key: string ]: unknown;
 };
 
+// Subpage keys
+export const ADD_FOWARDING_EMAIL = 'add-forwarding-email';
+
+// Subpage params map
 const SUBPAGE_TO_PARAMS_MAP: Record< string, SubPageWrapperParamsType > = {
 	[ ADD_FOWARDING_EMAIL ]: {
 		subPageKey: ADD_FOWARDING_EMAIL,

--- a/client/my-sites/domains/domain-management/subpage-wrapper/test/index.test.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/test/index.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import SubPageWrapper from '../index';
+import { ADD_FOWARDING_EMAIL } from '../subpages';
+
+describe( 'SubPageWrapper', () => {
+	it( 'should render the children', () => {
+		render(
+			<SubPageWrapper subPageKey={ ADD_FOWARDING_EMAIL }>
+				<span>Hello</span>
+			</SubPageWrapper>
+		);
+
+		expect( screen.getByText( 'Hello' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render the children with the subpage header', () => {
+		render(
+			<SubPageWrapper subPageKey={ ADD_FOWARDING_EMAIL }>
+				<span>Hello</span>
+			</SubPageWrapper>
+		);
+
+		expect( screen.getByText( 'Add new email forwarding' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Seamlessly redirect your messages to where you need them.' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render the children without the subpage header', () => {
+		render(
+			<SubPageWrapper subPageKey="non-existent">
+				<span>Hello</span>
+			</SubPageWrapper>
+		);
+
+		expect( screen.getByText( 'Hello' ) ).toBeInTheDocument();
+	} );
+} );

--- a/client/my-sites/domains/domain-management/subpage-wrapper/test/index.test.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/test/index.test.tsx
@@ -3,15 +3,15 @@
  */
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import SubPageWrapper from '../index';
+import SubpageWrapper from '../index';
 import { ADD_FOWARDING_EMAIL } from '../subpages';
 
-describe( 'SubPageWrapper', () => {
+describe( 'SubpageWrapper', () => {
 	it( 'should render the children', () => {
 		render(
-			<SubPageWrapper subPageKey={ ADD_FOWARDING_EMAIL }>
+			<SubpageWrapper subpageKey={ ADD_FOWARDING_EMAIL }>
 				<span>Hello</span>
-			</SubPageWrapper>
+			</SubpageWrapper>
 		);
 
 		expect( screen.getByText( 'Hello' ) ).toBeInTheDocument();
@@ -19,9 +19,9 @@ describe( 'SubPageWrapper', () => {
 
 	it( 'should render the children with the subpage header', () => {
 		render(
-			<SubPageWrapper subPageKey={ ADD_FOWARDING_EMAIL }>
+			<SubpageWrapper subpageKey={ ADD_FOWARDING_EMAIL }>
 				<span>Hello</span>
-			</SubPageWrapper>
+			</SubpageWrapper>
 		);
 
 		expect( screen.getByText( 'Add new email forwarding' ) ).toBeInTheDocument();
@@ -32,9 +32,9 @@ describe( 'SubPageWrapper', () => {
 
 	it( 'should render the children without the subpage header', () => {
 		render(
-			<SubPageWrapper subPageKey="non-existent">
+			<SubpageWrapper subpageKey="non-existent">
 				<span>Hello</span>
-			</SubPageWrapper>
+			</SubpageWrapper>
 		);
 
 		expect( screen.getByText( 'Hello' ) ).toBeInTheDocument();

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -16,6 +16,7 @@ import {
 	DOMAIN_OVERVIEW,
 	EMAIL_MANAGEMENT,
 } from './domain-management/domain-overview-pane/constants';
+import { ADD_FOWARDING_EMAIL } from './domain-management/subpage-wrapper/subpage-params';
 import * as paths from './paths';
 
 /**
@@ -401,6 +402,18 @@ export default function () {
 		navigation,
 		emailController.emailManagement,
 		domainManagementController.domainManagementPaneView( EMAIL_MANAGEMENT ),
+		domainManagementController.domainDashboardLayout,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		paths.allDomainEmailManagementRoot() + '/:domain/forwarding/add/:site',
+		siteSelection,
+		navigation,
+		domainManagementController.domainManagementSubPageParams( ADD_FOWARDING_EMAIL ),
+		emailController.emailManagementAddEmailForwards,
+		domainManagementController.domainManagementSubPageView,
 		domainManagementController.domainDashboardLayout,
 		makeLayout,
 		clientRender

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -397,7 +397,7 @@ export default function () {
 	);
 
 	page(
-		paths.domainManagementEmailRoot() + '/:domain/:site',
+		paths.domainManagementAllEmailRoot() + '/:domain/:site',
 		siteSelection,
 		navigation,
 		emailController.emailManagement,
@@ -408,7 +408,7 @@ export default function () {
 	);
 
 	page(
-		paths.domainManagementEmailRoot() + '/:domain/forwarding/add/:site',
+		paths.domainManagementAllEmailRoot() + '/:domain/forwarding/add/:site',
 		siteSelection,
 		navigation,
 		domainManagementController.domainManagementSubpageParams( ADD_FOWARDING_EMAIL ),

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -411,9 +411,9 @@ export default function () {
 		paths.allDomainEmailManagementRoot() + '/:domain/forwarding/add/:site',
 		siteSelection,
 		navigation,
-		domainManagementController.domainManagementSubPageParams( ADD_FOWARDING_EMAIL ),
+		domainManagementController.domainManagementSubpageParams( ADD_FOWARDING_EMAIL ),
 		emailController.emailManagementAddEmailForwards,
-		domainManagementController.domainManagementSubPageView,
+		domainManagementController.domainManagementSubpageView,
 		domainManagementController.domainDashboardLayout,
 		makeLayout,
 		clientRender

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -408,7 +408,7 @@ export default function () {
 	);
 
 	page(
-		paths.allDomainEmailManagementRoot() + '/:domain/forwarding/add/:site',
+		paths.domainManagementEmailRoot() + '/:domain/forwarding/add/:site',
 		siteSelection,
 		navigation,
 		domainManagementController.domainManagementSubpageParams( ADD_FOWARDING_EMAIL ),

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -16,7 +16,7 @@ import {
 	DOMAIN_OVERVIEW,
 	EMAIL_MANAGEMENT,
 } from './domain-management/domain-overview-pane/constants';
-import { ADD_FOWARDING_EMAIL } from './domain-management/subpage-wrapper/subpage-params';
+import { ADD_FOWARDING_EMAIL } from './domain-management/subpage-wrapper/subpages';
 import * as paths from './paths';
 
 /**

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -90,7 +90,7 @@ export function domainManagementOverviewRoot() {
 	return domainManagementAllRoot() + '/overview';
 }
 
-export function domainManagementEmailRoot() {
+export function domainManagementAllEmailRoot() {
 	return domainManagementAllRoot() + '/email';
 }
 

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -27,6 +27,8 @@ export default {
 				<EmailForwardsAdd
 					selectedDomainName={ pageContext.params.domain }
 					source={ pageContext.query.source }
+					showPageHeader={ pageContext.params.showPageHeader }
+					formHeader={ pageContext.params.formHeader }
 				/>
 			</CalypsoShoppingCartProvider>
 		);

--- a/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list.tsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list.tsx
@@ -13,12 +13,14 @@ type Props = {
 	onBeforeAddEmailForwards?: () => void;
 	onAddedEmailForwards: () => void;
 	selectedDomainName: string;
+	formHeader?: React.ReactNode;
 };
 
 const EmailForwardingAddNewCompactList = ( {
 	onAddedEmailForwards,
 	onBeforeAddEmailForwards,
 	selectedDomainName,
+	formHeader,
 }: Props ) => {
 	const translate = useTranslate();
 
@@ -100,6 +102,7 @@ const EmailForwardingAddNewCompactList = ( {
 							onRemoveEmailForward={ onRemoveEmailForward }
 							onUpdateEmailForward={ onUpdateEmailForward }
 							selectedDomainName={ selectedDomainName }
+							formHeader={ formHeader }
 						/>
 					</div>
 				</Fragment>

--- a/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact.jsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact.jsx
@@ -18,6 +18,7 @@ class EmailForwardingAddNewCompact extends Component {
 		selectedDomainName: PropTypes.string.isRequired,
 		onUpdateEmailForward: PropTypes.func.isRequired,
 		emailForwards: PropTypes.array,
+		formHeader: PropTypes.element,
 	};
 
 	isMounted = false;
@@ -89,7 +90,7 @@ class EmailForwardingAddNewCompact extends Component {
 	}
 
 	renderFormFields() {
-		const { translate, selectedDomainName, index, fields } = this.props;
+		const { translate, selectedDomainName, index, fields, formHeader } = this.props;
 		const isValidMailbox = this.isValid( 'mailbox' );
 		const isValidDestination = this.isValid( 'destination' );
 		const { mailbox, destination } = fields;
@@ -98,6 +99,7 @@ class EmailForwardingAddNewCompact extends Component {
 
 		return (
 			<div className="email-forwarding__form-content">
+				{ formHeader ? <>{ formHeader }</> : null }
 				<FormFieldset>
 					<FormLabel>{ translate( 'Emails sent to' ) }</FormLabel>
 					<FormTextInputWithAffixes

--- a/client/my-sites/email/email-forwards-add/index.tsx
+++ b/client/my-sites/email/email-forwards-add/index.tsx
@@ -31,12 +31,19 @@ import './style.scss';
 type EmailForwardsAddProps = {
 	selectedDomainName: string;
 	source?: string;
+	showPageHeader?: boolean;
+	formHeader?: React.ReactNode;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = (): void => {};
 
-const EmailForwardsAdd = ( { selectedDomainName, source }: EmailForwardsAddProps ) => {
+const EmailForwardsAdd = ( {
+	selectedDomainName,
+	source,
+	showPageHeader = true,
+	formHeader,
+}: EmailForwardsAddProps ) => {
 	const currentRoute = useSelector( getCurrentRoute );
 	const selectedSite = useSelector( getSelectedSite );
 
@@ -97,31 +104,36 @@ const EmailForwardsAdd = ( { selectedDomainName, source }: EmailForwardsAddProps
 					onAddedEmailForwards={ onAddedEmailForwards }
 					onBeforeAddEmailForwards={ noop }
 					selectedDomainName={ selectedDomainName }
+					formHeader={ formHeader }
 				/>
 			) }
 		</Card>
 	);
 
 	return (
-		<div className="email-forwards-add">
+		<>
 			<QueryProductsList />
 
 			{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 
-			<Main wideLayout>
+			<Main wideLayout className="email-forwards-add">
 				<DocumentHead title={ translate( 'Add New Email Forwards' ) } />
 
-				<EmailHeader />
+				{ showPageHeader && (
+					<>
+						<EmailHeader />
 
-				<HeaderCake onClick={ goToEmail }>
-					{ translate( 'Email Forwarding' ) + ': ' + selectedDomainName }
-				</HeaderCake>
+						<HeaderCake onClick={ goToEmail }>
+							{ translate( 'Email Forwarding' ) + ': ' + selectedDomainName }
+						</HeaderCake>
 
-				<SectionHeader label={ translate( 'Add New Email Forwards' ) } />
+						<SectionHeader label={ translate( 'Add New Email Forwards' ) } />
+					</>
+				) }
 
 				{ content }
 			</Main>
-		</div>
+		</>
 	);
 };
 

--- a/client/my-sites/email/paths.ts
+++ b/client/my-sites/email/paths.ts
@@ -12,6 +12,7 @@ type EmailPathUtilityFunction = (
 
 export const emailManagementPrefix = '/email';
 export const emailManagementAllSitesPrefix = '/email/all';
+export const domainsManagementPrefix = '/domains/manage/all/email';
 
 export function isUnderEmailManagementAll( path?: string | null ) {
 	return path?.startsWith( emailManagementAllSitesPrefix + '/' );
@@ -26,8 +27,12 @@ function resolveRootPath( relativeTo?: string | null ) {
 		return emailManagementAllSitesPrefix;
 	}
 
-	if ( isUnderEmailManagementAll( relativeTo ) || isUnderDomainManagementAll( relativeTo ) ) {
+	if ( isUnderEmailManagementAll( relativeTo ) ) {
 		return emailManagementAllSitesPrefix;
+	}
+
+	if ( isUnderDomainManagementAll( relativeTo ) ) {
+		return domainsManagementPrefix;
 	}
 
 	return emailManagementPrefix;

--- a/client/my-sites/email/paths.ts
+++ b/client/my-sites/email/paths.ts
@@ -27,12 +27,8 @@ function resolveRootPath( relativeTo?: string | null ) {
 		return emailManagementAllSitesPrefix;
 	}
 
-	if ( isUnderEmailManagementAll( relativeTo ) ) {
+	if ( isUnderEmailManagementAll( relativeTo ) || isUnderDomainManagementAll( relativeTo ) ) {
 		return emailManagementAllSitesPrefix;
-	}
-
-	if ( isUnderDomainManagementAll( relativeTo ) ) {
-		return domainsManagementPrefix;
 	}
 
 	return emailManagementPrefix;
@@ -79,7 +75,15 @@ export const getAddEmailForwardsPath: EmailPathUtilityFunction = (
 	domainName,
 	relativeTo,
 	urlParameters
-) => getPath( siteName, domainName, 'forwarding/add', relativeTo, urlParameters );
+) => {
+	if ( isUnderDomainManagementAll( relativeTo ) ) {
+		return `${ domainsManagementPrefix }/${ domainName }/forwarding/add/${ siteName }${ buildQueryString(
+			urlParameters
+		) }`;
+	}
+
+	return getPath( siteName, domainName, 'forwarding/add', relativeTo, urlParameters );
+};
 
 // Retrieves the URL of the Add New Mailboxes page either for G Suite or Google Workspace
 export function getAddGSuiteUsersPath(

--- a/client/my-sites/email/paths.ts
+++ b/client/my-sites/email/paths.ts
@@ -41,7 +41,7 @@ function resolveRootPath( relativeTo?: string | null ) {
 function getPath(
 	siteName: string | null | undefined,
 	domainName: string | null | undefined,
-	slug: string,
+	slug?: string | null,
 	relativeTo?: string | null,
 	urlParameters?: QueryStringParameters
 ) {
@@ -53,12 +53,13 @@ function getPath(
 			domainName = encodeURIComponent( encodeURIComponent( domainName ) );
 		}
 
+		const slugFragment = slug ? '/' + slug : '';
+
 		return (
 			resolveRootPath( relativeTo ) +
 			'/' +
 			domainName +
-			'/' +
-			slug +
+			slugFragment +
 			'/' +
 			siteName +
 			buildQueryString( urlParameters )
@@ -143,7 +144,13 @@ export const getEmailManagementPath: EmailPathUtilityFunction = (
 	domainName,
 	relativeTo,
 	urlParameters
-) => getPath( siteName, domainName, 'manage', relativeTo, urlParameters );
+) => {
+	if ( isUnderDomainManagementAll( relativeTo ) ) {
+		return getPath( siteName, domainName, null, relativeTo, urlParameters );
+	}
+
+	return getPath( siteName, domainName, 'manage', relativeTo, urlParameters );
+};
 
 export const getForwardingPath: EmailPathUtilityFunction = ( siteName, domainName, relativeTo ) =>
 	getPath( siteName, domainName, 'forwarding', relativeTo );

--- a/client/my-sites/email/test/paths.ts
+++ b/client/my-sites/email/test/paths.ts
@@ -4,6 +4,7 @@
 
 import { GOOGLE_WORKSPACE_PRODUCT_TYPE, GSUITE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
 import {
+	domainsManagementPrefix,
 	emailManagementAllSitesPrefix,
 	getAddEmailForwardsPath,
 	getAddGSuiteUsersPath,
@@ -37,6 +38,9 @@ describe( 'path helper functions', () => {
 		);
 		expect( getAddEmailForwardsPath( siteName, null ) ).toEqual( `/email/${ siteName }` );
 		expect( getAddEmailForwardsPath( null, null ) ).toEqual( '/email' );
+		expect( getAddEmailForwardsPath( ':site', ':domain', domainsManagementPrefix ) ).toEqual(
+			'/domains/manage/all/email/:domain/forwarding/add/:site'
+		);
 	} );
 
 	it( 'getAddGSuiteUsersPath', () => {
@@ -129,6 +133,10 @@ describe( 'path helper functions', () => {
 		expect( getEmailManagementPath( ':site' ) ).toEqual( '/email/:site' );
 		expect( getEmailManagementPath( siteName, null ) ).toEqual( `/email/${ siteName }` );
 		expect( getEmailManagementPath( null, null ) ).toEqual( '/email' );
+
+		expect( getEmailManagementPath( siteName, domainName, domainsManagementPrefix ) ).toEqual(
+			`/domains/manage/all/email/${ domainName }/${ siteName }`
+		);
 	} );
 
 	it( 'getForwardingPath', () => {

--- a/client/my-sites/email/test/paths.ts
+++ b/client/my-sites/email/test/paths.ts
@@ -133,10 +133,6 @@ describe( 'path helper functions', () => {
 		expect( getEmailManagementPath( ':site' ) ).toEqual( '/email/:site' );
 		expect( getEmailManagementPath( siteName, null ) ).toEqual( `/email/${ siteName }` );
 		expect( getEmailManagementPath( null, null ) ).toEqual( '/email' );
-
-		expect( getEmailManagementPath( siteName, domainName, domainsManagementPrefix ) ).toEqual(
-			`/domains/manage/all/email/${ domainName }/${ siteName }`
-		);
 	} );
 
 	it( 'getForwardingPath', () => {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/97235

## Proposed Changes

* Created Add Forwarding Email route and customized the component layout.
* Created a SubPageWrapper component and controller functions so it can be reused on the next subpages.
* The page header is slightly different from the design, as the default is to have a border-bottom on the other pages. So, I kept it with the same size and format as the others for consistency, but we can change it if needed.
* Note that the subpage breaks on mobile size since it's missing to hide the domains list (not part of this task).

<img width="839" alt="Screenshot 2024-12-12 at 14 39 30" src="https://github.com/user-attachments/assets/8c91d347-3751-459b-80a0-a36763c1e0a2" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of the Domain Management Revamp project: pfuQfP-13x-p2

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/domains/manage?flags=calypso/all-domain-management
* Click on a domain that doesn't have emails configured
* Click on the Email tab
* Scroll to the bottom of the page and click the Email Forwarding link
* You should be redirected to the Add Forwarding Email page
* Check if the page is rendered as expected
* Add an email forwarding. Use any email on the first input and a valid email on the second
* After clicking "Add" you should be redirected back to the Emails tab, which will be updated with the new email forwarding
* Go to the old email management page, on Site Dashboard > Hosting > Email
* Scroll to the bottom of the page and click the Email Forwarding link
* Perform regression tests, the old page should continue working as before without any visual changes 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?