### PR TITLE
Keep accent color untouched in Stepper

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -3,7 +3,7 @@
 @import "@wordpress/base-styles/mixins";
 
 body.is-section-stepper .step-route {
-	--color-accent: #117ac9;
+	//--color-accent: #117ac9;
 	--color-accent-60: #0e64a5;
 }
 


### PR DESCRIPTION
## Proposed Changes

This removes some CSS that messes with the accent color in Stepper. 

This CSS was introduced in https://github.com/Automattic/wp-calypso/pull/91182.

## Why are these changes being made?
To fix accessibility in the goals step. 

## Testing Instructions

### Regression
1. Go to /setup/onboarding incognito and make sure it looks identical to production.

### Testing
1. Go to /setup/onboarding.
2. Run an Accessibility test in Lighthouse. 
3. The score should be a 100%. 

cc @ddc22 hi! Any chance you'd remember if removing this CSS can cause issues?
