### PR TITLE
Reader: Remove the sidebar from recent and discover pages and increase width on all single column feeds

### DIFF
--- a/client/reader/conversations/stream.scss
+++ b/client/reader/conversations/stream.scss
@@ -1,6 +1,6 @@
 .is-section-reader .conversations__header.navigation-header {
 	margin: 0 auto;
-	max-width: 600px;
+
 	@media only screen and (max-width: 660px) {
 		padding: 0 24px;
 	}

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -6,13 +6,9 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import isBloganuary from 'calypso/data/blogging-prompt/is-bloganuary';
 import withDimensions from 'calypso/lib/with-dimensions';
 import wpcom from 'calypso/lib/wp';
-import { READER_DISCOVER_POPULAR_SITES } from 'calypso/reader/follow-sources';
 import Stream, { WIDE_DISPLAY_CUTOFF } from 'calypso/reader/stream';
-import ReaderPopularSitesSidebar from 'calypso/reader/stream/reader-popular-sites-sidebar';
-import ReaderTagSidebar from 'calypso/reader/stream/reader-tag-sidebar';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { getReaderRecommendedSites } from 'calypso/state/reader/recommended-sites/selectors';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
 import DiscoverNavigation from './discover-navigation';
 import {
@@ -58,11 +54,6 @@ const DiscoverStream = ( props ) => {
 	const followedTags = useSelector( getReaderFollowedTags );
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const selectedTab = props.selectedTab;
-	const recommendedSitesSeed =
-		selectedTab === FIRST_POSTS_TAB ? 'discover-new-sites' : 'discover-recommendations';
-	const recommendedSites = useSelector(
-		( state ) => getReaderRecommendedSites( state, recommendedSitesSeed ) || []
-	);
 	const { data: interestTags = [] } = useQuery( {
 		queryKey: [ 'read/interests', locale ],
 		queryFn: () =>
@@ -97,35 +88,10 @@ const DiscoverStream = ( props ) => {
 	);
 	const streamKey = buildDiscoverStreamKey( selectedTab, recommendedStreamTags );
 
-	const streamSidebar = () => {
-		if ( selectedTab === FIRST_POSTS_TAB && recommendedSites?.length ) {
-			return (
-				<ReaderPopularSitesSidebar
-					items={ recommendedSites }
-					followSource={ READER_DISCOVER_POPULAR_SITES }
-					title={ translate( 'New sites' ) }
-				/>
-			);
-		}
-
-		if ( ( isDefaultTab || selectedTab === 'latest' ) && recommendedSites?.length ) {
-			return (
-				<ReaderPopularSitesSidebar
-					items={ recommendedSites }
-					followSource={ READER_DISCOVER_POPULAR_SITES }
-					title={ translate( 'Popular sites' ) }
-				/>
-			);
-		} else if ( ! ( isDefaultTab || selectedTab === 'latest' ) ) {
-			return <ReaderTagSidebar tag={ selectedTab } showFollow />;
-		}
-	};
-
 	const streamProps = {
 		...props,
 		streamKey,
 		useCompactCards: true,
-		streamSidebar,
 		sidebarTabTitle: isDefaultTab ? translate( 'Sites' ) : translate( 'Related' ),
 		selectedStreamName: selectedTab,
 	};

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -9,7 +9,6 @@ import ReaderOnboarding from 'calypso/reader/onboarding';
 import SuggestionProvider from 'calypso/reader/search-stream/suggestion-provider';
 import ReaderStream, { WIDE_DISPLAY_CUTOFF } from 'calypso/reader/stream';
 import Recent from '../recent';
-import ReaderStreamSidebar from './reader-stream-sidebar';
 import { useSiteSubscriptions } from './use-site-subscriptions';
 import { useFollowingView } from './view-preference';
 import ViewToggle from './view-toggle';
@@ -44,11 +43,7 @@ function FollowingStream( { ...props } ) {
 			{ currentView === 'recent' && config.isEnabled( 'reader/recent-feed-overhaul' ) ? (
 				<Recent viewToggle={ viewToggle } />
 			) : (
-				<ReaderStream
-					{ ...props }
-					className="following"
-					streamSidebar={ () => <ReaderStreamSidebar /> }
-				>
+				<ReaderStream { ...props } className="following">
 					<BloganuaryHeader />
 					<NavigationHeader
 						title={ translate( 'Recent' ) }

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -43,7 +43,7 @@ function FollowingStream( { ...props } ) {
 			{ currentView === 'recent' && config.isEnabled( 'reader/recent-feed-overhaul' ) ? (
 				<Recent viewToggle={ viewToggle } />
 			) : (
-				<ReaderStream { ...props } className="following">
+				<ReaderStream { ...props } className="following recent-scrolling-feed">
 					<BloganuaryHeader />
 					<NavigationHeader
 						title={ translate( 'Recent' ) }

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -43,7 +43,7 @@ function FollowingStream( { ...props } ) {
 			{ currentView === 'recent' && config.isEnabled( 'reader/recent-feed-overhaul' ) ? (
 				<Recent viewToggle={ viewToggle } />
 			) : (
-				<ReaderStream { ...props } className="following recent-scrolling-feed">
+				<ReaderStream { ...props } className="following">
 					<BloganuaryHeader />
 					<NavigationHeader
 						title={ translate( 'Recent' ) }

--- a/client/reader/liked-stream/style.scss
+++ b/client/reader/liked-stream/style.scss
@@ -1,6 +1,6 @@
 .is-section-reader .navigation-header.liked-stream-header {
 	margin: 0 auto;
-	max-width: 600px;
+
 	@media only screen and (max-width: 660px) {
 		padding: 0 16px;
 

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -5,12 +5,7 @@
 // Overrides default 720px width
 .is-reader-page .following.main,
 .is-reader-page .tag-stream__main.main {
-	max-width: 600px;
-
-	&.recent-scrolling-feed,
-	&.is-discover-stream {
-		max-width: 768px;
-	}
+	max-width: 768px;
 
 	&.reader-two-column {
 		max-width: 968px;

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -7,6 +7,11 @@
 .is-reader-page .tag-stream__main.main {
 	max-width: 600px;
 
+	&.recent-scrolling-feed,
+	&.is-discover-stream {
+		max-width: 768px;
+	}
+
 	&.reader-two-column {
 		max-width: 968px;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/244

## Proposed Changes

* Removes the "Popular sites" sidebar from /read
* Removes "Popular sites", "New sites", and "Related Tags" sidebars from /discover (Note that the Discover feed has a different sidebar depending on what button on the top you select. This PR removes the sidebar from all of them.)
* Increases the max-width for /read (scrolling view) /discover and all other single column feeds to 768px.

Before | After
--|--
<img width="1724" alt="Screenshot 2024-12-11 at 5 25 11 PM" src="https://github.com/user-attachments/assets/8296c24e-10bb-4073-bf99-1cb25e587f74" />  | <img width="1724" alt="Screenshot 2024-12-12 at 3 27 49 PM" src="https://github.com/user-attachments/assets/0b7a385a-a334-4c1d-a4a2-c80d16c97adc" />

Before | After
--|--
<img width="1722" alt="Screenshot 2024-12-11 at 5 24 58 PM" src="https://github.com/user-attachments/assets/7978d566-eba3-4194-a6a9-35ca0b311cd4" /> | <img width="1723" alt="Screenshot 2024-12-12 at 3 27 37 PM" src="https://github.com/user-attachments/assets/15aa6b18-c477-4156-bccd-537f5a3895be" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Simplify the /read and /discover sections and give them a wider width so they're easier to read.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /read and select the "Scrolling feed" and view the "Popular sites" sidebar is gone.
* Go to /discover and select different topics at the top like "Recommended", "Fire posts", "etc. View that the sidebar is gone from all of the topics.
* Check all the other single column sections for proper increased width:
  * /activities/likes
  * /read/conversations
  * /read/a8c
  * /read/p2
  * /read/conversations/a8c
* Smoke test other pages for styling issues.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
