### PR TITLE
Login: Fix Safari autozoom

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -133,7 +133,7 @@ export class LoginForm extends Component {
 
 		// eslint-disable-next-line react/no-did-mount-set-state
 		this.setState( { isFormDisabledWhileLoading: false }, () => {
-			! disableAutoFocus && this.usernameOrEmail && this.usernameOrEmail.focus();
+			! disableAutoFocus && defer( () => this.usernameOrEmail && this.usernameOrEmail.focus() );
 		} );
 		// Remove url param to keep the last used login consistent upon refresh
 		const url = new URL( window.location );

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -370,7 +370,7 @@ $image-height: 47px;
 			height: 44px;
 			border-radius: 4px;
 			border: 1px solid var(--studio-gray-10);
-			font-size: $font-body-small;
+			font-size: $font-body;
 
 			&[disabled],
 			&:disabled,


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/97174

## Proposed Changes

- Defer focusing (consistent with all the other focus calls in the component) to make sure Safari does not over zoom. This probably happens because we used to focus on the field during its transition from disabled to enabled. Which likely messes with Safari's math that automatically zooms on small input fields (probably the field's font size is zero at some point, which implies Safari should zoom as much as possible to make readable).

- Change input font size to match the body font size. This prevents Safari from auto-zooming at all. Safari automatically zooms when input fields have font sizes smaller than 16px. This may need design review. cc @lucasmendes-design.

## Testing Instructions

This issue is only reproducible in iOS simulator. You'll have to install xCode emulator to test it. Or jump in a call with me.

1. Go to /setup/onboarding.
2. Skip Goals.
3. At the user step, click Continue with email.
4. Type an existing email.
5. You'll be redirected to login. Screen shouldn't be zoomed in.
6. The field should be focused.


## Video

### Before

https://github.com/user-attachments/assets/7f5b12c6-f0e4-4ac3-ae71-2aa46587ec60

### After

https://github.com/user-attachments/assets/bbfa441f-03ff-4f04-bcf5-8e8770c17376


