### PR TITLE
Stepper: Fix domains step persistence

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
@@ -100,7 +100,7 @@ export default function DomainsStep( props: StepProps ) {
 				saveSignupStep={ ( step: ProvidedDependencies ) => {
 					setStepState( ( mostRecentState = { ...stepState, ...step } ) );
 				} }
-				submitSignupStep={ ( _, step: ProvidedDependencies ) => {
+				submitSignupStep={ ( _: never, step: ProvidedDependencies ) => {
 					setStepState( ( mostRecentState = { ...stepState, ...step } ) );
 				} }
 				goToNextStep={ ( state: ProvidedDependencies ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
@@ -33,7 +33,7 @@ import { ProvidedDependencies, StepProps } from '../../types';
 import { useIsManagedSiteFlowProps } from './use-is-managed-site-flow';
 
 const RenderDomainsStepConnect = connect(
-	( state, { flow, step }: StepProps ) => {
+	( state, { flow, step }: { flow: string; step: ProvidedDependencies } ) => {
 		const productsList = getAvailableProductsList( state );
 		const productsLoaded = ! isEmpty( productsList );
 		const multiDomainDefaultPlan = planItem( PLAN_PERSONAL );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
@@ -3,7 +3,6 @@ import { useStepPersistedState } from '@automattic/onboarding';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { localize } from 'i18n-calypso';
 import { isEmpty } from 'lodash';
-import { useRef, useCallback } from 'react';
 import { connect } from 'react-redux';
 import { recordUseYourDomainButtonClick } from 'calypso/components/domains/register-domain-step/analytics';
 import { planItem } from 'calypso/lib/cart-values/cart-items';
@@ -34,7 +33,7 @@ import { ProvidedDependencies, StepProps } from '../../types';
 import { useIsManagedSiteFlowProps } from './use-is-managed-site-flow';
 
 const RenderDomainsStepConnect = connect(
-	( state, { flow }: StepProps ) => {
+	( state, { flow, step }: StepProps ) => {
 		const productsList = getAvailableProductsList( state );
 		const productsLoaded = ! isEmpty( productsList );
 		const multiDomainDefaultPlan = planItem( PLAN_PERSONAL );
@@ -64,6 +63,7 @@ const RenderDomainsStepConnect = connect(
 			positionInFlow: 1,
 			isReskinned: true,
 			stepSectionName,
+			signupDependencies: step,
 		};
 	},
 	{
@@ -80,21 +80,16 @@ const RenderDomainsStepConnect = connect(
 	}
 )( withCartKey( withShoppingCart( localize( RenderDomainsStep ) ) ) );
 
+/**
+ * The domains step has a quirk where it calls `submitSignupStep` then synchronously calls `goToNextStep` after it.
+ * This doesn't give `setStepState` a chance to update and the data is not passed to `submit`.
+ */
+let mostRecentState: ProvidedDependencies = {};
+
 export default function DomainsStep( props: StepProps ) {
 	const [ stepState, setStepState ] =
 		useStepPersistedState< ProvidedDependencies >( 'domains-step' );
 	const managedSiteFlowProps = useIsManagedSiteFlowProps();
-
-	const mostRecentStateRef = useRef< ProvidedDependencies | undefined >( undefined );
-
-	const updateSignupStepState = useCallback(
-		( state: ProvidedDependencies, providedDependencies: ProvidedDependencies ) => {
-			setStepState(
-				( mostRecentStateRef.current = { ...stepState, ...providedDependencies, ...state } )
-			);
-		},
-		[ stepState, setStepState ]
-	);
 
 	return (
 		<CalypsoShoppingCartProvider>
@@ -102,11 +97,15 @@ export default function DomainsStep( props: StepProps ) {
 				{ ...props }
 				{ ...managedSiteFlowProps }
 				page={ ( url: string ) => window.location.assign( url ) }
-				saveSignupStep={ updateSignupStepState }
-				submitSignupStep={ updateSignupStepState }
+				saveSignupStep={ ( step: ProvidedDependencies ) => {
+					setStepState( ( mostRecentState = { ...stepState, ...step } ) );
+				} }
+				submitSignupStep={ ( _, step: ProvidedDependencies ) => {
+					setStepState( ( mostRecentState = { ...stepState, ...step } ) );
+				} }
 				goToNextStep={ ( state: ProvidedDependencies ) => {
 					props.navigation.submit?.( {
-						...( mostRecentStateRef.current ?? {} ),
+						...mostRecentState,
 						...state,
 						shouldSkipSubmitTracking: state?.navigateToUseMyDomain ? true : false,
 					} );


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/97176

## Proposed Changes

- This simplifies the persistence logic of the Unified Domains step and copies over the one in the Unified Plans step.
- It records the `providedDependencies` when submitted by the domain step, rather than the `signupDependencies`. 

## Why are these changes being made?
- So that coming back to the domain step, when picking a free domain, keeps that domain picked during the whole session.
- The persistence of the paid domain, on the other hand, is handled by the cart. 

## Testing Instructions
- Go to /setup/onboarding.
- Pick a free domain.
- Go to plans.
- Go back.
- The free domain should remain picked. 


