### PR TITLE
Paid stats: update UTM and Devices on empty state to point to the right support URL

### DIFF
--- a/client/my-sites/stats/features/modules/stats-devices/stats-module-devices.tsx
+++ b/client/my-sites/stats/features/modules/stats-devices/stats-module-devices.tsx
@@ -10,6 +10,7 @@ import PieChart from 'calypso/components/pie-chart';
 import PieChartLegend from 'calypso/components/pie-chart/legend';
 import StatsInfoArea from 'calypso/my-sites/stats/features/modules/shared/stats-info-area';
 import { useSelector } from 'calypso/state';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
 import { JETPACK_SUPPORT_URL_TRAFFIC, SUPPORT_URL } from '../../../const';
@@ -151,7 +152,11 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 		/>
 	);
 
-	const supportUrl = isOdysseyStats
+	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
+		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
+	);
+
+	const supportUrl = isSiteJetpackNotAtomic
 		? localizeUrl( `${ JETPACK_SUPPORT_URL_TRAFFIC }#devices-stats` )
 		: localizeUrl( `${ SUPPORT_URL }#devices` );
 

--- a/client/my-sites/stats/features/modules/stats-devices/stats-module-devices.tsx
+++ b/client/my-sites/stats/features/modules/stats-devices/stats-module-devices.tsx
@@ -12,7 +12,7 @@ import StatsInfoArea from 'calypso/my-sites/stats/features/modules/shared/stats-
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
-import { JETPACK_SUPPORT_URL_TRAFFIC } from '../../../const';
+import { JETPACK_SUPPORT_URL_TRAFFIC, SUPPORT_URL } from '../../../const';
 import useModuleDevicesQuery, { StatsDevicesData } from '../../../hooks/use-modeule-devices-query';
 import { QueryStatsParams } from '../../../hooks/utils';
 import StatsListCard from '../../../stats-list/stats-list-card';
@@ -151,6 +151,10 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 		/>
 	);
 
+	const supportUrl = isOdysseyStats
+		? localizeUrl( `${ JETPACK_SUPPORT_URL_TRAFFIC }#devices-stats` )
+		: localizeUrl( `${ SUPPORT_URL }#devices` );
+
 	const titleNodes = (
 		<StatsInfoArea isNew>
 			{ translate(
@@ -158,13 +162,7 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 				{
 					comment: '{{link}} links to support documentation.',
 					components: {
-						link: (
-							<a
-								target="_blank"
-								rel="noreferrer"
-								href={ localizeUrl( `${ JETPACK_SUPPORT_URL_TRAFFIC }#devices-stats` ) }
-							/>
-						),
+						link: <a target="_blank" rel="noreferrer" href={ supportUrl } />,
 					},
 					context: 'Stats: Info popover content when the Devices module has data.',
 				}
@@ -201,15 +199,7 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 											{
 												comment: '{{link}} links to support documentation.',
 												components: {
-													link: (
-														<a
-															target="_blank"
-															rel="noreferrer"
-															href={ localizeUrl(
-																`${ JETPACK_SUPPORT_URL_TRAFFIC }#devices-stats`
-															) }
-														/>
-													),
+													link: <a target="_blank" rel="noreferrer" href={ supportUrl } />,
 												},
 												context: 'Stats: Info box label when the Devices module is empty',
 											}

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
@@ -7,7 +7,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import StatsInfoArea from 'calypso/my-sites/stats/features/modules/shared/stats-info-area';
 import { useSelector } from 'calypso/state';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
 import { JETPACK_SUPPORT_URL_TRAFFIC, SUPPORT_URL } from '../../../const';
@@ -129,8 +129,11 @@ const StatsModuleUTM = ( {
 		? generateFileNameForDownload( siteSlug, period )
 		: '';
 
-	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-	const supportUrl = isOdysseyStats
+	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
+		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
+	);
+
+	const supportUrl = isSiteJetpackNotAtomic
 		? localizeUrl( `${ JETPACK_SUPPORT_URL_TRAFFIC }#harnessing-utm-stats-for-precision-tracking` )
 		: localizeUrl( `${ SUPPORT_URL }#utm` );
 

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
@@ -10,7 +10,7 @@ import { useSelector } from 'calypso/state';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
-import { JETPACK_SUPPORT_URL_TRAFFIC } from '../../../const';
+import { JETPACK_SUPPORT_URL_TRAFFIC, SUPPORT_URL } from '../../../const';
 import useUTMMetricsQuery from '../../../hooks/use-utm-metrics-query';
 import ErrorPanel from '../../../stats-error';
 import StatsListCard from '../../../stats-list/stats-list-card';
@@ -129,6 +129,11 @@ const StatsModuleUTM = ( {
 		? generateFileNameForDownload( siteSlug, period )
 		: '';
 
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	const supportUrl = isOdysseyStats
+		? localizeUrl( `${ JETPACK_SUPPORT_URL_TRAFFIC }#harnessing-utm-stats-for-precision-tracking` )
+		: localizeUrl( `${ SUPPORT_URL }#utm` );
+
 	const titleNodes = (
 		<StatsInfoArea isNew>
 			{ translate(
@@ -136,15 +141,7 @@ const StatsModuleUTM = ( {
 				{
 					comment: '{{link}} links to support documentation.',
 					components: {
-						link: (
-							<a
-								target="_blank"
-								rel="noreferrer"
-								href={ localizeUrl(
-									`${ JETPACK_SUPPORT_URL_TRAFFIC }#harnessing-utm-stats-for-precision-tracking`
-								) }
-							/>
-						),
+						link: <a target="_blank" rel="noreferrer" href={ supportUrl } />,
 					},
 					context: 'Stats: Popover information when the UTM module has data',
 				}
@@ -179,15 +176,7 @@ const StatsModuleUTM = ( {
 											{
 												comment: '{{link}} links to support documentation.',
 												components: {
-													link: (
-														<a
-															target="_blank"
-															rel="noreferrer"
-															href={ localizeUrl(
-																`${ JETPACK_SUPPORT_URL_TRAFFIC }#harnessing-utm-stats-for-precision-tracking`
-															) }
-														/>
-													),
+													link: <a target="_blank" rel="noreferrer" href={ supportUrl } />,
 												},
 												context: 'Stats: Info box label when the UTM module is empty',
 											}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Update UTM and Devices empty state inline support link since they know exists on WPCOM.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Simple and Atomic sites support links should point to WordPress.com.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Calypso Live branch
* Using a site with a Premium plan, navigate to the Stats traffic page
* Ensure the inline links on UTM and Devices (on empty state) points to WordPress.com support page
  * https://wordpress.com/support/stats/understand-your-sites-traffic/#utm
  * https://wordpress.com/support/stats/understand-your-sites-traffic/#devices

| UTM | Devices |
|---|---|
| ![CleanShot 2024-12-11 at 20 05 16@2x](https://github.com/user-attachments/assets/2e3a698a-db19-420c-bb49-1ef2d7774051) | ![CleanShot 2024-12-11 at 20 05 24@2x](https://github.com/user-attachments/assets/369a7efd-1276-4ff7-9559-e03c54ed2739) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
