### PR TITLE
Design Picker: Update the track event properties

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/analytics/record-step-navigation.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-step-navigation.ts
@@ -1,5 +1,5 @@
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
-import { reduce, snakeCase } from 'lodash';
+import { snakeCase } from 'lodash';
 import { STEPPER_TRACKS_EVENTS_STEP_NAV } from 'calypso/landing/stepper/constants';
 import { getStepOldSlug } from 'calypso/landing/stepper/declarative-flow/helpers/get-step-old-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -8,6 +8,7 @@ import { ProvidedDependencies } from '../types';
 export interface RecordStepNavigationParams {
 	event: ( typeof STEPPER_TRACKS_EVENTS_STEP_NAV )[ number ];
 	intent: string;
+	goals: string[];
 	flow: string;
 	step: string;
 	variant?: string;
@@ -29,6 +30,7 @@ const EXCLUDED_DEPENDENCIES = [
 export function recordStepNavigation( {
 	event,
 	intent,
+	goals,
 	flow,
 	step,
 	variant,
@@ -36,9 +38,8 @@ export function recordStepNavigation( {
 	additionalProps = {},
 }: RecordStepNavigationParams ) {
 	const device = resolveDeviceTypeByViewPort();
-	const inputs = reduce(
-		providedDependencies,
-		( props, propValue, propName: string ) => {
+	const inputs = Object.entries( providedDependencies ).reduce(
+		( props, [ propName, propValue ] ) => {
 			if ( EXCLUDED_DEPENDENCIES.includes( propName ) ) {
 				return props;
 			}
@@ -80,9 +81,8 @@ export function recordStepNavigation( {
 		{}
 	);
 
-	const additionalInputs = reduce(
-		additionalProps,
-		( props, propValue, propName: string ) => {
+	const additionalInputs = Object.entries( additionalProps ).reduce(
+		( props, [ propName, propValue ] ) => {
 			propName = snakeCase( propName );
 
 			return {
@@ -99,6 +99,7 @@ export function recordStepNavigation( {
 		variant,
 		step,
 		intent,
+		goals: goals.join( ',' ),
 		...inputs,
 		...additionalInputs,
 	} );
@@ -111,6 +112,7 @@ export function recordStepNavigation( {
 			variant,
 			step: stepOldSlug,
 			intent,
+			goals: goals.join( ',' ),
 			...inputs,
 			...additionalInputs,
 		} );

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-step-navigation.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-step-navigation.ts
@@ -8,7 +8,7 @@ import { ProvidedDependencies } from '../types';
 export interface RecordStepNavigationParams {
 	event: ( typeof STEPPER_TRACKS_EVENTS_STEP_NAV )[ number ];
 	intent: string;
-	goals: string[];
+	goals?: string[];
 	flow: string;
 	step: string;
 	variant?: string;
@@ -29,8 +29,8 @@ const EXCLUDED_DEPENDENCIES = [
 
 export function recordStepNavigation( {
 	event,
-	intent,
-	goals,
+	intent = '',
+	goals = [],
 	flow,
 	step,
 	variant,

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
@@ -1,6 +1,6 @@
 import { OnboardSelect } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback, useMemo, useRef } from '@wordpress/element';
 import {
 	STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW,
 	STEPPER_TRACKS_EVENT_STEP_NAV_GO_BACK,
@@ -27,27 +27,44 @@ export const useStepNavigationWithTracking = ( {
 	navigate,
 }: Params< ReturnType< Flow[ 'useSteps' ] > > ) => {
 	const stepNavigation = flow.useStepNavigation( currentStepRoute, navigate );
-	const intent =
-		useSelect( ( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(), [] ) ?? '';
+	const { intent, goals } = useSelect( ( select ) => {
+		const onboardStore = select( ONBOARD_STORE ) as OnboardSelect;
+		return {
+			intent: onboardStore.getIntent() ?? '',
+			goals: onboardStore.getGoals() ?? [],
+		};
+	}, [] );
+
 	const tracksEventPropsFromFlow = flow.useTracksEventProps?.();
+	const tracksEventPropsFromFlowRef = useRef( tracksEventPropsFromFlow );
+	tracksEventPropsFromFlowRef.current = tracksEventPropsFromFlow;
 
 	const handleRecordStepNavigation = useCallback(
 		( {
 			event,
 			providedDependencies,
-			additionalProps,
-		}: Omit< RecordStepNavigationParams, 'step' | 'intent' | 'flow' | 'variant' > ) => {
+		}: Omit< RecordStepNavigationParams, 'step' | 'intent' | 'goals' | 'flow' | 'variant' > ) => {
+			let eventProps;
+			if ( providedDependencies && providedDependencies.eventProps ) {
+				eventProps = providedDependencies.eventProps;
+				delete providedDependencies.eventProps;
+			}
+
 			recordStepNavigation( {
 				event,
 				intent,
+				goals,
 				flow: flow.name,
 				step: currentStepRoute,
 				variant: flow.variantSlug,
 				providedDependencies,
-				additionalProps,
+				additionalProps: {
+					...( eventProps ?? {} ),
+					...( tracksEventPropsFromFlowRef.current?.[ event ] ?? {} ),
+				},
 			} );
 		},
-		[ intent, currentStepRoute, flow ]
+		[ intent, goals, currentStepRoute, flow ]
 	);
 
 	return useMemo(
@@ -58,7 +75,6 @@ export const useStepNavigationWithTracking = ( {
 						handleRecordStepNavigation( {
 							event: STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
 							providedDependencies,
-							additionalProps: tracksEventPropsFromFlow?.[ STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT ],
 						} );
 					}
 					stepNavigation.submit?.( providedDependencies, ...params );
@@ -68,9 +84,10 @@ export const useStepNavigationWithTracking = ( {
 				exitFlow: ( to: string ) => {
 					handleRecordStepNavigation( {
 						event: STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW,
-						additionalProps: {
-							to,
-							...( tracksEventPropsFromFlow?.[ STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW ] ?? {} ),
+						providedDependencies: {
+							eventProps: {
+								to,
+							},
 						},
 					} );
 					stepNavigation.exitFlow?.( to );
@@ -80,7 +97,6 @@ export const useStepNavigationWithTracking = ( {
 				goBack: () => {
 					handleRecordStepNavigation( {
 						event: STEPPER_TRACKS_EVENT_STEP_NAV_GO_BACK,
-						additionalProps: tracksEventPropsFromFlow?.[ STEPPER_TRACKS_EVENT_STEP_NAV_GO_BACK ],
 					} );
 					stepNavigation.goBack?.();
 				},
@@ -89,7 +105,6 @@ export const useStepNavigationWithTracking = ( {
 				goNext: () => {
 					handleRecordStepNavigation( {
 						event: STEPPER_TRACKS_EVENT_STEP_NAV_GO_NEXT,
-						additionalProps: tracksEventPropsFromFlow?.[ STEPPER_TRACKS_EVENT_STEP_NAV_GO_NEXT ],
 					} );
 					stepNavigation.goNext?.();
 				},
@@ -98,15 +113,16 @@ export const useStepNavigationWithTracking = ( {
 				goToStep: ( step: string ) => {
 					handleRecordStepNavigation( {
 						event: STEPPER_TRACKS_EVENT_STEP_NAV_GO_TO,
-						additionalProps: {
-							to: step,
-							...( tracksEventPropsFromFlow?.[ STEPPER_TRACKS_EVENT_STEP_NAV_GO_TO ] ?? {} ),
+						providedDependencies: {
+							eventProps: {
+								to: step,
+							},
 						},
 					} );
 					stepNavigation.goToStep?.( step );
 				},
 			} ),
 		} ),
-		[ handleRecordStepNavigation, tracksEventPropsFromFlow, stepNavigation ]
+		[ handleRecordStepNavigation, stepNavigation ]
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
@@ -30,8 +30,8 @@ export const useStepNavigationWithTracking = ( {
 	const { intent, goals } = useSelect( ( select ) => {
 		const onboardStore = select( ONBOARD_STORE ) as OnboardSelect;
 		return {
-			intent: onboardStore.getIntent() ?? '',
-			goals: onboardStore.getGoals() ?? [],
+			intent: onboardStore.getIntent(),
+			goals: onboardStore.getGoals(),
 		};
 	}, [] );
 
@@ -44,20 +44,16 @@ export const useStepNavigationWithTracking = ( {
 			event,
 			providedDependencies,
 		}: Omit< RecordStepNavigationParams, 'step' | 'intent' | 'goals' | 'flow' | 'variant' > ) => {
-			let eventProps;
-			if ( providedDependencies && providedDependencies.eventProps ) {
-				eventProps = providedDependencies.eventProps;
-				delete providedDependencies.eventProps;
-			}
+			const { eventProps, ...dependencies } = providedDependencies || {};
 
 			recordStepNavigation( {
 				event,
-				intent,
-				goals,
+				intent: intent ?? '',
+				goals: goals ?? [],
 				flow: flow.name,
 				step: currentStepRoute,
 				variant: flow.variantSlug,
-				providedDependencies,
+				providedDependencies: dependencies,
 				additionalProps: {
 					...( eventProps ?? {} ),
 					...( tracksEventPropsFromFlowRef.current?.[ event ] ?? {} ),

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/test/index.tsx
@@ -12,8 +12,13 @@ import {
 import { recordStepNavigation } from '../../../analytics/record-step-navigation';
 import { useStepNavigationWithTracking } from '../index';
 
+const EMPTY_GOALS = [];
+
 jest.mock( '@wordpress/data', () => ( {
-	useSelect: jest.fn(),
+	useSelect: jest.fn( () => ( {
+		intent: '',
+		goals: EMPTY_GOALS,
+	} ) ),
 } ) );
 jest.mock( 'calypso/landing/stepper/stores', () => ( {
 	ONBOARD_STORE: {},
@@ -40,6 +45,16 @@ const mockParams = {
 	currentStepRoute: 'mock-step',
 	navigate: () => {},
 };
+
+const getDefaultProps = ( { flow, currentStepRoute } ) => ( {
+	intent: '',
+	goals: [],
+	flow: flow.name,
+	step: currentStepRoute,
+	variant: undefined,
+	providedDependencies: {},
+	additionalProps: {},
+} );
 
 describe( 'useStepNavigationWithTracking', () => {
 	beforeEach( () => {
@@ -79,13 +94,9 @@ describe( 'useStepNavigationWithTracking', () => {
 
 		expect( stepNavControls.submit ).toHaveBeenCalledWith( providedDependencies, 'bar', 'baz' );
 		expect( recordStepNavigation ).toHaveBeenCalledWith( {
+			...getDefaultProps( mockParams ),
 			event: STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
-			intent: '',
-			flow: 'mock-flow',
-			step: 'mock-step',
-			variant: undefined,
 			providedDependencies,
-			additionalProps: undefined,
 		} );
 	} );
 
@@ -98,13 +109,8 @@ describe( 'useStepNavigationWithTracking', () => {
 
 		expect( stepNavControls.goBack ).toHaveBeenCalled();
 		expect( recordStepNavigation ).toHaveBeenCalledWith( {
+			...getDefaultProps( mockParams ),
 			event: STEPPER_TRACKS_EVENT_STEP_NAV_GO_BACK,
-			intent: '',
-			flow: 'mock-flow',
-			step: 'mock-step',
-			variant: undefined,
-			providedDependencies: undefined,
-			additionalProps: undefined,
 		} );
 	} );
 
@@ -117,13 +123,8 @@ describe( 'useStepNavigationWithTracking', () => {
 
 		expect( stepNavControls.goNext ).toHaveBeenCalled();
 		expect( recordStepNavigation ).toHaveBeenCalledWith( {
+			...getDefaultProps( mockParams ),
 			event: STEPPER_TRACKS_EVENT_STEP_NAV_GO_NEXT,
-			intent: '',
-			flow: 'mock-flow',
-			step: 'mock-step',
-			variant: undefined,
-			providedDependencies: undefined,
-			additionalProps: undefined,
 		} );
 	} );
 
@@ -136,12 +137,8 @@ describe( 'useStepNavigationWithTracking', () => {
 
 		expect( stepNavControls.exitFlow ).toHaveBeenCalledWith( 'to' );
 		expect( recordStepNavigation ).toHaveBeenCalledWith( {
+			...getDefaultProps( mockParams ),
 			event: STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW,
-			intent: '',
-			flow: 'mock-flow',
-			step: 'mock-step',
-			variant: undefined,
-			providedDependencies: undefined,
 			additionalProps: { to: 'to' },
 		} );
 	} );
@@ -155,12 +152,8 @@ describe( 'useStepNavigationWithTracking', () => {
 
 		expect( stepNavControls.goToStep ).toHaveBeenCalledWith( 'to' );
 		expect( recordStepNavigation ).toHaveBeenCalledWith( {
+			...getDefaultProps( mockParams ),
 			event: STEPPER_TRACKS_EVENT_STEP_NAV_GO_TO,
-			intent: '',
-			flow: 'mock-flow',
-			step: 'mock-step',
-			variant: undefined,
-			providedDependencies: undefined,
 			additionalProps: { to: 'to' },
 		} );
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -317,7 +317,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				intent,
 				design,
 			} ),
-			category: categorization.selections?.join( ',' ),
+			categories: categorization.selections?.join( ',' ),
 			...( design.recipe?.pattern_ids && { pattern_ids: design.recipe.pattern_ids.join( ',' ) } ),
 			...( design.recipe?.header_pattern_ids && {
 				header_pattern_ids: design.recipe.header_pattern_ids.join( ',' ),
@@ -349,7 +349,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	function trackAllDesignsView() {
 		recordTracksEvent( 'calypso_signup_design_scrolled_to_end', {
 			intent,
-			category: categorization?.selections?.join( ',' ),
+			categories: categorization?.selections?.join( ',' ),
 		} );
 	}
 
@@ -693,7 +693,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			handleSubmit(
 				{
 					selectedDesign: _selectedDesign,
-					selectedSiteCategory: categorization.selections?.join( ',' ),
 				},
 				{ ...( positionIndex >= 0 && { position_index: positionIndex } ) }
 			);
@@ -709,6 +708,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		const _selectedDesign = providedDependencies?.selectedDesign as Design;
 		if ( ! isAssemblerDesign( _selectedDesign ) ) {
 			recordSelectedDesign( {
+				...commonFilterProperties,
 				flow,
 				intent,
 				design: _selectedDesign,
@@ -722,6 +722,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		submit?.( {
 			...providedDependencies,
 			...getDesignTypeProps( _selectedDesign ),
+			eventProps: commonFilterProperties,
 		} );
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10031

## Proposed Changes

* Update the track event properties for design picker

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* On the Goals screen, select any goals
* On the Design Picker screen
  * Select/Deselect any category
  * Toggle the `Free only` filter on/off
  * Select a design
  * Make sure the `calypso_signup_actions_submit_step` event is fired with the common filter properties

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
