### PR TITLE
Moves design picker after the goals step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -74,6 +74,7 @@ button {
 .import-hosted-site,
 .site-setup,
 .onboarding.goals,
+.onboarding.design-setup,
 .site-migration,
 .migration,
 .migration-signup,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
@@ -19,7 +19,6 @@ const makeSearchParams = (
 ) => callback( new URLSearchParams( window.location.search ) );
 
 const useRecipe = (
-	//siteId = 0,
 	allDesigns: StarterDesigns | undefined,
 	pickDesign: ( design?: Design, options?: { shouldGoToAssembler: boolean } ) => void,
 	pickUnlistedDesign: ( theme: string ) => void,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
@@ -7,7 +7,6 @@ import { useColorPaletteVariations, useFontPairingVariations } from '@automattic
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { ONBOARD_STORE } from '../../../../../stores';
 import type { GlobalStyles, OnboardSelect, StarterDesigns } from '@automattic/data-stores';
 import type { Design, StyleVariation } from '@automattic/design-picker';
@@ -20,7 +19,7 @@ const makeSearchParams = (
 ) => callback( new URLSearchParams( window.location.search ) );
 
 const useRecipe = (
-	siteId = 0,
+	//siteId = 0,
 	allDesigns: StarterDesigns | undefined,
 	pickDesign: ( design?: Design, options?: { shouldGoToAssembler: boolean } ) => void,
 	pickUnlistedDesign: ( theme: string ) => void,
@@ -80,11 +79,11 @@ const useRecipe = (
 
 	const { stylesheet = '' } = selectedDesign?.recipe || {};
 
-	const colorVariations = useColorPaletteVariations( siteId, stylesheet, {
+	const colorVariations = useColorPaletteVariations( stylesheet, {
 		enabled: !! preselectedColorVariationTitle,
 	} );
 
-	const fontVariations = useFontPairingVariations( siteId, stylesheet, {
+	const fontVariations = useFontPairingVariations( stylesheet, {
 		enabled: !! preselectedFontVariationTitle,
 	} );
 
@@ -169,17 +168,6 @@ const useRecipe = (
 			pickDesign( design );
 			return;
 		}
-
-		const searchParams = new URLSearchParams( window.location.search );
-		searchParams.set(
-			'siteSlug',
-			design.demo_uri ? urlToSlug( design.demo_uri.replace( /\/$/, '' ) ) : ''
-		);
-		window.history.replaceState(
-			{},
-			'',
-			`${ window.location.pathname }?${ searchParams.toString() }`
-		);
 
 		handleSelectedDesignChange( design );
 		handleSelectedStyleVariationChange( styleVariation );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
@@ -7,6 +7,7 @@ import { useColorPaletteVariations, useFontPairingVariations } from '@automattic
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { ONBOARD_STORE } from '../../../../../stores';
 import type { GlobalStyles, OnboardSelect, StarterDesigns } from '@automattic/data-stores';
 import type { Design, StyleVariation } from '@automattic/design-picker';
@@ -168,6 +169,17 @@ const useRecipe = (
 			pickDesign( design );
 			return;
 		}
+
+		const searchParams = new URLSearchParams( window.location.search );
+		searchParams.set(
+			'siteSlug',
+			design.demo_uri ? urlToSlug( design.demo_uri.replace( /\/$/, '' ) ) : ''
+		);
+		window.history.replaceState(
+			{},
+			'',
+			`${ window.location.pathname }?${ searchParams.toString() }`
+		);
 
 		handleSelectedDesignChange( design );
 		handleSelectedStyleVariationChange( styleVariation );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -693,6 +693,17 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				},
 				{ ...( positionIndex >= 0 && { position_index: positionIndex } ) }
 			);
+		} else if ( ! isSiteRequired && ! siteSlugOrId && _selectedDesign ) {
+			const positionIndex = designs.findIndex(
+				( design ) => design.slug === _selectedDesign?.slug
+			);
+			handleSubmit(
+				{
+					selectedDesign: _selectedDesign,
+					selectedSiteCategory: categorization.selections?.join( ',' ),
+				},
+				{ ...( positionIndex >= 0 && { position_index: positionIndex } ) }
+			);
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -121,9 +121,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	const isGoalCentricFeature = isEnabled( 'design-picker/goal-centric' ) && ! isGoalsHoldout;
 
-	const [ isGoalsAtFrontExperimentLoading, isGoalsAtFrontExperiment ] = useGoalsFirstExperiment( {
-		isEligible: flow === ONBOARDING_FLOW,
-	} );
+	const [ isGoalsAtFrontExperimentLoading, isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 	const isSiteRequired = flow !== ONBOARDING_FLOW || ! isGoalsAtFrontExperiment;
 
 	const { isEligible } = useIsBigSkyEligible();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -271,7 +271,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		setGlobalStyles,
 		resetPreview,
 	} = useRecipe(
-		site?.ID,
 		allDesigns,
 		pickDesign,
 		pickUnlistedDesign,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -24,7 +24,7 @@ import {
 	PERSONAL_THEME,
 } from '@automattic/design-picker';
 import { useLocale, useHasEnTranslation } from '@automattic/i18n-utils';
-import { StepContainer, DESIGN_FIRST_FLOW } from '@automattic/onboarding';
+import { StepContainer, DESIGN_FIRST_FLOW, ONBOARDING_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
@@ -76,6 +76,7 @@ import { useQuery } from '../../../../hooks/use-query';
 import { useSiteData } from '../../../../hooks/use-site-data';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import { goToCheckout } from '../../../../utils/checkout';
+import { useGoalsFirstExperiment } from '../../../helpers/use-goals-first-experiment';
 import {
 	getDesignEventProps,
 	getDesignTypeProps,
@@ -119,6 +120,11 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const isGoalsHoldout = useIsGoalsHoldout( stepName );
 
 	const isGoalCentricFeature = isEnabled( 'design-picker/goal-centric' ) && ! isGoalsHoldout;
+
+	const [ isGoalsAtFrontExperimentLoading, isGoalsAtFrontExperiment ] = useGoalsFirstExperiment( {
+		isEligible: flow === ONBOARDING_FLOW,
+	} );
+	const isSiteRequired = flow !== ONBOARDING_FLOW || ! isGoalsAtFrontExperiment;
 
 	const { isEligible } = useIsBigSkyEligible();
 	const isBigSkyEligible = isEligible && isGoalCentricFeature;
@@ -784,7 +790,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	// ********** Main render logic
 
 	// Don't render until we've done fetching all the data needed for initial render.
-	if ( ! site || isLoadingDesigns ) {
+	if ( ( ! site && isSiteRequired ) || isLoadingDesigns || isGoalsAtFrontExperimentLoading ) {
 		return <StepperLoader />;
 	}
 
@@ -824,7 +830,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				) }
 				<QueryEligibility siteId={ site?.ID } />
 				<EligibilityWarningsModal
-					site={ site }
+					site={ site ?? undefined }
 					isMarketplace={ selectedDesign?.is_externally_managed }
 					isOpen={ showEligibility }
 					handleClose={ () => {
@@ -871,7 +877,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					actionButtons={ actionButtons }
 					recordDeviceClick={ recordDeviceClick }
 					limitGlobalStyles={ shouldLimitGlobalStyles }
-					siteId={ site.ID }
+					siteId={ site?.ID }
 					stylesheet={ selectedDesign.recipe?.stylesheet }
 					screenshot={ fullLengthScreenshot }
 					isExternallyManaged={ selectedDesign.is_externally_managed }

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -135,11 +135,6 @@ const onboarding: Flow = {
 				}
 
 				case 'designSetup': {
-					const { selectedDesign: _selectedDesign } = providedDependencies;
-					if ( isAssemblerDesign( _selectedDesign as Design ) && isAssemblerSupported() ) {
-						return navigate( 'pattern-assembler' );
-					}
-
 					return navigate( 'domains' );
 				}
 

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -1,5 +1,4 @@
 import { OnboardSelect, Onboard } from '@automattic/data-stores';
-import { type Design, isAssemblerDesign, isAssemblerSupported } from '@automattic/design-picker';
 import { ONBOARDING_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -1,4 +1,5 @@
 import { OnboardSelect, Onboard } from '@automattic/data-stores';
+import { type Design, isAssemblerDesign, isAssemblerSupported } from '@automattic/design-picker';
 import { ONBOARDING_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
@@ -66,8 +67,8 @@ const onboarding: Flow = {
 		] );
 
 		if ( isGoalsAtFrontExperiment ) {
-			// This step is not wrapped in `stepsWithRequiredLogin`
-			steps.unshift( STEPS.GOALS );
+			// Note: these steps are not wrapped in `stepsWithRequiredLogin`
+			steps.unshift( STEPS.GOALS, STEPS.DESIGN_SETUP );
 		}
 
 		return steps;
@@ -128,9 +129,18 @@ const onboarding: Flow = {
 						}
 
 						default: {
-							return navigate( 'domains' );
+							return navigate( 'designSetup' );
 						}
 					}
+				}
+
+				case 'designSetup': {
+					const { selectedDesign: _selectedDesign } = providedDependencies;
+					if ( isAssemblerDesign( _selectedDesign as Design ) && isAssemblerSupported() ) {
+						return navigate( 'pattern-assembler' );
+					}
+
+					return navigate( 'domains' );
 				}
 
 				case 'domains':

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -50,6 +50,7 @@ interface StarterDesign {
 	theme_type?: string;
 	screenshot?: string;
 	theme_tier: ThemeTier;
+	demo_uri?: string;
 }
 
 export function useStarterDesignsQuery(
@@ -100,6 +101,7 @@ function apiStarterDesignsToDesign( design: StarterDesign ): Design {
 		design_type,
 		screenshot,
 		theme_tier,
+		demo_uri,
 	} = design;
 
 	const is_externally_managed = design.theme_type === 'managed-external';
@@ -124,5 +126,6 @@ function apiStarterDesignsToDesign( design: StarterDesign ): Design {
 		theme: '',
 		screenshot,
 		design_tier: theme_tier?.slug,
+		demo_uri,
 	};
 }

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -100,6 +100,7 @@ export interface Design {
 	is_virtual?: boolean;
 	preview_data?: PreviewData;
 	screenshot?: string;
+	demo_uri?: string;
 
 	/** @deprecated TODO: replace both with just stylesheet */
 	stylesheet?: string;

--- a/packages/global-styles/src/components/color-palette-variations/index.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/index.tsx
@@ -82,14 +82,14 @@ const ColorPaletteVariation = ( {
 };
 
 const ColorPaletteVariations = ( {
-	siteId,
+	//siteId,
 	stylesheet,
 	selectedColorPaletteVariation,
 	onSelect,
 	limitGlobalStyles,
 }: ColorPaletteVariationsProps ) => {
 	const { base } = useContext( GlobalStylesContext );
-	const colorPaletteVariations = useColorPaletteVariations( siteId, stylesheet ) ?? [];
+	const colorPaletteVariations = useColorPaletteVariations( stylesheet ) ?? [];
 	const composite = useCompositeState();
 
 	return (

--- a/packages/global-styles/src/components/font-pairing-variations/index.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/index.tsx
@@ -83,14 +83,14 @@ const FontPairingVariation = ( {
 };
 
 const FontPairingVariations = ( {
-	siteId,
+	//siteId,
 	stylesheet,
 	selectedFontPairingVariation,
 	onSelect,
 	limitGlobalStyles,
 }: FontPairingVariationsProps ) => {
 	// The theme font pairings don't include the default font pairing
-	const fontPairingVariations = useFontPairingVariations( siteId, stylesheet ) ?? [];
+	const fontPairingVariations = useFontPairingVariations( stylesheet ) ?? [];
 	const composite = useCompositeState();
 	return (
 		<Composite

--- a/packages/global-styles/src/components/global-styles-provider/index.tsx
+++ b/packages/global-styles/src/components/global-styles-provider/index.tsx
@@ -38,19 +38,16 @@ const useGlobalStylesUserConfig = (): [ boolean, GlobalStylesObject, SetConfig ]
 };
 
 const useGlobalStylesBaseConfig = (
-	siteId: number | string,
 	stylesheet: string
 ): [ boolean, GlobalStylesObject | undefined ] => {
-	const { data } = useGetGlobalStylesBaseConfig( siteId, stylesheet );
+	const { data } = useGetGlobalStylesBaseConfig( stylesheet );
 	return [ !! data, data ];
 };
 
-const useGlobalStylesContext = ( siteId: number | string, stylesheet: string ) => {
+const useGlobalStylesContext = ( stylesheet: string ) => {
 	const [ isUserConfigReady, userConfig, setUserConfig ] = useGlobalStylesUserConfig();
-	const [ isBaseConfigReady, baseConfig = DEFAULT_GLOBAL_STYLES ] = useGlobalStylesBaseConfig(
-		siteId,
-		stylesheet
-	);
+	const [ isBaseConfigReady, baseConfig = DEFAULT_GLOBAL_STYLES ] =
+		useGlobalStylesBaseConfig( stylesheet );
 	const mergedConfig = useMemo( () => {
 		if ( ! baseConfig || ! userConfig ) {
 			return DEFAULT_GLOBAL_STYLES;
@@ -83,8 +80,8 @@ interface Props {
 	placeholder: JSX.Element | null;
 }
 
-const GlobalStylesProvider = ( { siteId, stylesheet, children, placeholder = null }: Props ) => {
-	const context = useGlobalStylesContext( siteId, stylesheet );
+const GlobalStylesProvider = ( { stylesheet, children, placeholder = null }: Props ) => {
+	const context = useGlobalStylesContext( stylesheet );
 	const isBlocksRegistered = useRegisterCoreBlocks();
 
 	if ( ! context.isReady || ! isBlocksRegistered ) {

--- a/packages/global-styles/src/hooks/use-color-palette-variations.ts
+++ b/packages/global-styles/src/hooks/use-color-palette-variations.ts
@@ -14,7 +14,7 @@ const useColorPaletteVariations = ( stylesheet: string, { enabled = true }: Opti
 			wpcomRequest< GlobalStylesObject[] >( {
 				path: `/global-styles-variation/color-palettes`,
 				method: 'GET',
-				apiNamespace: 'wpcom/v2',
+				apiNamespace: 'wpcom/v3',
 				query: new URLSearchParams( {
 					stylesheet,
 					...( isEnabled( 'design-picker/use-assembler-styles' )

--- a/packages/global-styles/src/hooks/use-color-palette-variations.ts
+++ b/packages/global-styles/src/hooks/use-color-palette-variations.ts
@@ -7,16 +7,12 @@ type Options = {
 	enabled?: boolean;
 };
 
-const useColorPaletteVariations = (
-	siteId: number | string,
-	stylesheet: string,
-	{ enabled = true }: Options = {}
-) => {
+const useColorPaletteVariations = ( stylesheet: string, { enabled = true }: Options = {} ) => {
 	const { data } = useQuery< any, unknown, GlobalStylesObject[] >( {
-		queryKey: [ 'global-styles-color-palette', siteId, stylesheet ],
+		queryKey: [ 'global-styles-color-palette', stylesheet ],
 		queryFn: async () =>
 			wpcomRequest< GlobalStylesObject[] >( {
-				path: `/sites/${ encodeURIComponent( siteId ) }/global-styles-variation/color-palettes`,
+				path: `/global-styles-variation/color-palettes`,
 				method: 'GET',
 				apiNamespace: 'wpcom/v2',
 				query: new URLSearchParams( {
@@ -28,7 +24,7 @@ const useColorPaletteVariations = (
 			} ),
 		refetchOnMount: 'always',
 		staleTime: Infinity,
-		enabled: !! siteId && !! stylesheet && enabled,
+		enabled: !! stylesheet && enabled,
 	} );
 
 	return data;

--- a/packages/global-styles/src/hooks/use-font-pairing-variations.ts
+++ b/packages/global-styles/src/hooks/use-font-pairing-variations.ts
@@ -15,7 +15,7 @@ const useFontPairingVariations = ( stylesheet: string, { enabled = true }: Optio
 			wpcomRequest< GlobalStylesObject[] >( {
 				path: `/global-styles-variation/font-pairings`,
 				method: 'GET',
-				apiNamespace: 'wpcom/v2',
+				apiNamespace: 'wpcom/v3',
 				query: new URLSearchParams( {
 					stylesheet,
 					...( isEnabled( 'design-picker/use-assembler-styles' )

--- a/packages/global-styles/src/hooks/use-font-pairing-variations.ts
+++ b/packages/global-styles/src/hooks/use-font-pairing-variations.ts
@@ -8,16 +8,12 @@ type Options = {
 	base_variation_stylesheet?: string;
 };
 
-const useFontPairingVariations = (
-	siteId: number | string,
-	stylesheet: string,
-	{ enabled = true }: Options = {}
-) => {
+const useFontPairingVariations = ( stylesheet: string, { enabled = true }: Options = {} ) => {
 	const { data } = useQuery< any, unknown, GlobalStylesObject[] >( {
-		queryKey: [ 'global-styles-font-pairings', siteId, stylesheet ],
+		queryKey: [ 'global-styles-font-pairings', stylesheet ],
 		queryFn: async () =>
 			wpcomRequest< GlobalStylesObject[] >( {
-				path: `/sites/${ encodeURIComponent( siteId ) }/global-styles-variation/font-pairings`,
+				path: `/global-styles-variation/font-pairings`,
 				method: 'GET',
 				apiNamespace: 'wpcom/v2',
 				query: new URLSearchParams( {
@@ -29,7 +25,7 @@ const useFontPairingVariations = (
 			} ),
 		refetchOnMount: 'always',
 		staleTime: Infinity,
-		enabled: !! siteId && !! stylesheet && enabled,
+		enabled: !! stylesheet && enabled,
 	} );
 
 	return data;

--- a/packages/global-styles/src/hooks/use-get-global-styles-base-config.ts
+++ b/packages/global-styles/src/hooks/use-get-global-styles-base-config.ts
@@ -2,21 +2,21 @@ import { useQuery } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { GlobalStylesObject } from '../types';
 
-const useGetGlobalStylesBaseConfig = ( siteId: number | string, stylesheet: string ) => {
+const useGetGlobalStylesBaseConfig = ( stylesheet: string ) => {
 	return useQuery< any, unknown, GlobalStylesObject >( {
-		queryKey: [ 'global-styles-base-config', siteId, stylesheet ],
+		queryKey: [ 'global-styles-base-config', stylesheet ],
 		queryFn: async () =>
 			wpcomRequest< GlobalStylesObject >( {
 				// We have to fetch the base config from wpcom as the core endpoint only supports
 				// active theme
-				path: `/sites/${ encodeURIComponent( siteId ) }/global-styles-variation/theme`,
+				path: `/global-styles-variation/theme`,
 				method: 'GET',
 				apiNamespace: 'wpcom/v2',
 				query: new URLSearchParams( { stylesheet } ).toString(),
 			} ),
 		refetchOnMount: 'always',
 		staleTime: Infinity,
-		enabled: !! ( siteId && stylesheet ),
+		enabled: !! stylesheet,
 	} );
 };
 

--- a/packages/global-styles/src/hooks/use-get-global-styles-base-config.ts
+++ b/packages/global-styles/src/hooks/use-get-global-styles-base-config.ts
@@ -11,7 +11,7 @@ const useGetGlobalStylesBaseConfig = ( stylesheet: string ) => {
 				// active theme
 				path: `/global-styles-variation/theme`,
 				method: 'GET',
-				apiNamespace: 'wpcom/v2',
+				apiNamespace: 'wpcom/v3',
 				query: new URLSearchParams( { stylesheet } ).toString(),
 			} ),
 		refetchOnMount: 'always',


### PR DESCRIPTION
> [!WARNING]  
> ~DO NOT MERGE UNTIL D168479-code HAS BEEN MERGED~
> Merged via: Automattic/wpcom/pull/168479 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #97208

## Proposed Changes

* Adds design picker to `onboarding`
* TODO Removes design picker from `site-setup` in https://github.com/Automattic/wp-calypso/pull/97540

https://github.com/user-attachments/assets/d84e5aa7-d1db-49b9-b34c-df291ba45a10


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* ~Apply the patch D168479-code~
* Make sure you're logged out
* Go to /setup/onboarding, should show goals screen first, if not, please add `flags=onboarding/goals-first`
* Second step is design picker
* Select a design and see if it shows the preview

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?