### PR TITLE
A4A > Agency Tier: Navigate user to the correct section of the KB article

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/lib/get-agency-tier-info.tsx
@@ -31,6 +31,7 @@ const getAgencyTierInfo = (
 		description: '',
 		logo: NoTierLogo,
 		includedTiers: [],
+		learnMoreLink: 'https://agencieshelp.automattic.com/knowledge-base/agency-tiering-benefits',
 	};
 	switch ( agencyTier ) {
 		case 'emerging-partner':
@@ -64,6 +65,8 @@ const getAgencyTierInfo = (
 					image: EmergingPartnerBackground,
 					cta: translate( 'Learn about Tiers' ),
 				},
+				learnMoreLink:
+					'https://agencieshelp.automattic.com/knowledge-base/agency-tiering-benefits/#account-activated',
 			};
 			break;
 		case 'agency-partner':
@@ -104,6 +107,8 @@ const getAgencyTierInfo = (
 					image: AgencyPartnerBackground,
 					cta: translate( 'Explore your benefits' ),
 				},
+				learnMoreLink:
+					'https://agencieshelp.automattic.com/knowledge-base/agency-tiering-benefits/#agency-partner',
 			};
 			break;
 		case 'pro-agency-partner':
@@ -143,6 +148,8 @@ const getAgencyTierInfo = (
 					image: ProAgencyPartnerBackground,
 					cta: translate( 'Explore your benefits' ),
 				},
+				learnMoreLink:
+					'https://agencieshelp.automattic.com/knowledge-base/agency-tiering-benefits/#pro-partner',
 			};
 	}
 	return { id: agencyTier, ...tierInfo };

--- a/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
@@ -33,9 +33,6 @@ export default function AgencyTierOverview() {
 	const currentAgencyTier = agency?.tier?.id;
 	const currentAgencyTierInfo = getAgencyTierInfo( currentAgencyTier, translate );
 
-	const learnMoreLink =
-		'https://agencieshelp.automattic.com/knowledge-base/agency-tiering-benefits/';
-
 	const ALL_TIERS: AgencyTier[] = [ 'emerging-partner', 'agency-partner', 'pro-agency-partner' ];
 
 	// todo: Restore this. We have to hide temporary the 'Download your badges' button until the WooCommerce ones are ready
@@ -87,7 +84,7 @@ export default function AgencyTierOverview() {
 											a: (
 												<a
 													target="_blank"
-													href={ learnMoreLink }
+													href={ currentAgencyTierInfo.learnMoreLink }
 													onClick={ () => {
 														dispatch(
 															recordTracksEvent( 'calypso_a4a_agency_tier_badge_learn_more_click', {

--- a/client/a8c-for-agencies/sections/agency-tier/types.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/types.ts
@@ -14,6 +14,7 @@ export interface AgencyTierInfo {
 	fullTitle: string;
 	subtitle: string;
 	description: string;
+	learnMoreLink: string;
 	logo: string;
 	includedTiers: string[];
 	celebrationModal?: AgencyTierCelebrationModal;


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1410

## Proposed Changes

This PR updates the learn more links for all the agency tiers.

## Why are these changes being made?

* To navigate the user to the correct section of the KB article for their agency tier

## Testing Instructions

* Use the Agency MC tool and set the current tier to undefined. 
* Open the A4A live link > Visit /agency-tier > Click the `Learn more` link on the top banner > Verify that you are redirected to the correct links as mentioned below:

**No tier:** https://agencieshelp.automattic.com/knowledge-base/agency-tiering-benefits/
**Emerging Partner**: https://agencieshelp.automattic.com/knowledge-base/agency-tiering-benefits/#account-activated
**Agency Partner** https://agencieshelp.automattic.com/knowledge-base/agency-tiering-benefits/#agency-partner
**Pro Agency Partner**: https://agencieshelp.automattic.com/knowledge-base/agency-tiering-benefits/#pro-partner

<img width="896" alt="Screenshot 2024-12-12 at 12 15 11 PM" src="https://github.com/user-attachments/assets/533005b6-f3bd-4c04-a280-3bd1478bab8c" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
