### PR TITLE
Cleanup: deprecate the availability checks of the storage add-on 

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -225,7 +225,6 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stepper-woocommerce-poc": true,
-		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -147,7 +147,6 @@
 		"stats/new-date-filtering": true,
 		"stats/paid-wpcom-v2": true,
 		"stepper-woocommerce-poc": true,
-		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/production.json
+++ b/config/production.json
@@ -196,7 +196,6 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stepper-woocommerce-poc": true,
-		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -192,7 +192,6 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stepper-woocommerce-poc": true,
-		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/test.json
+++ b/config/test.json
@@ -139,7 +139,6 @@
 		"stats/empty-module-v2": true,
 		"stats/new-date-filtering": true,
 		"stepper-woocommerce-poc": true,
-		"storage-addon": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -188,7 +188,6 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stepper-woocommerce-poc": true,
-		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/packages/data-stores/src/add-ons/hooks/use-add-ons.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-add-ons.ts
@@ -20,7 +20,6 @@ import {
 import customDesignIcon from '../icons/custom-design';
 import spaceUpgradeIcon from '../icons/space-upgrade';
 import unlimitedThemesIcon from '../icons/unlimited-themes';
-import isStorageAddonEnabled from '../lib/is-storage-addon-enabled';
 import useAddOnCheckoutLink from './use-add-on-checkout-link';
 import useAddOnDisplayCost from './use-add-on-display-cost';
 import useAddOnPrices from './use-add-on-prices';
@@ -118,13 +117,9 @@ const useActiveAddOnsDefs = ( selectedSiteId: Props[ 'selectedSiteId' ] ) => {
 
 interface Props {
 	selectedSiteId?: number | null | undefined;
-	enableStorageAddOns?: boolean;
 }
 
-const useAddOns = ( {
-	selectedSiteId,
-	enableStorageAddOns,
-}: Props = {} ): ( AddOnMeta | null )[] => {
+const useAddOns = ( { selectedSiteId }: Props = {} ): ( AddOnMeta | null )[] => {
 	const activeAddOns = useActiveAddOnsDefs( selectedSiteId );
 	const productSlugs = activeAddOns.map( ( item ) => item.productSlug );
 	const productsList = ProductsList.useProducts( productSlugs );
@@ -170,14 +165,6 @@ const useAddOns = ( {
 				 * If it's a storage add-on.
 				 */
 				if ( addOn.productSlug === PRODUCT_1GB_SPACE ) {
-					// if storage add-ons are not enabled in the config or disabled via hook prop, remove them
-					if (
-						( 'boolean' === typeof enableStorageAddOns && ! enableStorageAddOns ) ||
-						( ! isStorageAddonEnabled() && 'boolean' !== typeof enableStorageAddOns )
-					) {
-						return null;
-					}
-
 					/**
 					 * If storage add-on is already purchased.
 					 * TODO: Consider migrating this part to `use-add-on-purchase-status` and attach

--- a/packages/data-stores/src/add-ons/hooks/use-add-ons.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-add-ons.ts
@@ -211,7 +211,6 @@ const useAddOns = ( { selectedSiteId }: Props = {} ): ( AddOnMeta | null )[] => 
 			} ),
 		[
 			activeAddOns,
-			enableStorageAddOns,
 			mediaStorage.data?.maxStorageBytes,
 			productsList.data,
 			productsList.isLoading,

--- a/packages/data-stores/src/add-ons/lib/is-storage-addon-enabled.ts
+++ b/packages/data-stores/src/add-ons/lib/is-storage-addon-enabled.ts
@@ -1,9 +1,0 @@
-import config from '@automattic/calypso-config';
-
-/**
- * Is the storage addon (space upgrade) available, based on config flag vs. environment.
- * @returns {boolean} - Whether or not the storage addon is available
- */
-const isStorageAddonEnabled = (): boolean => !! config.isEnabled( 'storage-addon' );
-
-export default isStorageAddonEnabled;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Now that the storage add-ons have become part of our standard offers, this PR removes the availability checks of the storage add-on, particularly within the `use-add-on` hook:

* Remove all the storage add-on feature flag.
* Remove `enableStorageAddOn` parameter since it's not in used.
* Remove the function that checks if the storage add-on is enabled.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Since the storage add-ons are available by default now and there is no need for hiding them conditionally at the moment, cleaning the code up will ease the maintenance burden.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm that the storage add-ons related UX works as expected in `/add-ons`.
* Confirm that the storage add-on dropdown works as expected in `/plans`. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
