### PR TITLE
A4A > Agency Tier: Make tier banner take full width on all screen sizes.

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/style.scss
+++ b/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/style.scss
@@ -30,7 +30,7 @@ $light-green: #53dc81;
 	.agency-tier-overview__current-tier-container {
 		display: flex;
 
-		@include break-large {
+		@include break-medium {
 			height: 180px;
 		}
 
@@ -54,13 +54,8 @@ $light-green: #53dc81;
 		overflow: hidden;
 		box-sizing: border-box;
 		width: 100%;
-		max-width: 400px;
 		background-color: $color-pink;
 		min-height: 150px;
-
-		@include break-large {
-			max-width: unset;
-		}
 
 		@include break-xlarge {
 			flex: 0 0 70%;


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1406

## Proposed Changes

This PR makes the tier banner take full width on all the screen sizes.

## Why are these changes being made?

* To keep the experience same for the agency tier banner throughout different screens sizes.

## Testing Instructions

* Open the A4A live link > Go to /agency-tier > Verify the tier banner looks good and take full width on all the screen sizes.

<img width="514" alt="Screenshot 2024-12-12 at 1 45 30 PM" src="https://github.com/user-attachments/assets/08c21e72-d553-4065-be9e-61c6369676dc" />

<img width="822" alt="Screenshot 2024-12-12 at 1 46 03 PM" src="https://github.com/user-attachments/assets/dfc09994-49c9-408e-b603-067b6b002f0e" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
