### PR TITLE
Design Picker: Update filter styles

### DIFF
--- a/packages/design-picker/src/components/design-picker-category-filter/index.tsx
+++ b/packages/design-picker/src/components/design-picker-category-filter/index.tsx
@@ -39,6 +39,7 @@ export default function DesignPickerCategoryFilter( {
 			initialActiveIndexes={ initialActiveIndexes }
 			isMultiSelection={ isMultiSelection }
 			forceSwipe={ forceSwipe }
+			rootMargin="1px"
 			onClick={ onClick }
 		>
 			{ categories.map( ( category ) => (

--- a/packages/design-picker/src/components/design-picker-category-filter/index.tsx
+++ b/packages/design-picker/src/components/design-picker-category-filter/index.tsx
@@ -1,9 +1,10 @@
 import { ResponsiveToolbarGroup } from '@automattic/components';
+import clsx from 'clsx';
 import type { Category } from '../../types';
 import './style.scss';
 
 interface Props {
-	className: string;
+	className?: string;
 	categories: Category[];
 	selectedSlugs: string[];
 	isMultiSelection?: boolean;
@@ -33,7 +34,7 @@ export default function DesignPickerCategoryFilter( {
 		.filter( ( index ) => index >= 0 );
 	return (
 		<ResponsiveToolbarGroup
-			className={ className }
+			className={ clsx( 'design-picker__category-filter', className ) }
 			initialActiveIndex={ initialActiveIndex !== -1 ? initialActiveIndex : 0 }
 			initialActiveIndexes={ initialActiveIndexes }
 			isMultiSelection={ isMultiSelection }

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -2,113 +2,130 @@
 @import "@automattic/onboarding/styles/variables";
 @import "@automattic/typography/styles/fonts";
 
-$design-picker-category-filter-text-color: #3c434a;
-$design-picker-category-filter-text-color-active: var(--studio-gray-100);
+.design-picker__filters {
+	display: flex;
+	justify-content: space-between;
+	flex-direction: column;
+	gap: 10px;
+	margin-bottom: 24px;
 
-.design-picker-category-filter {
-	@include break-small {
-		flex: 0 245px;
-		padding-right: 1rem;
+	@include break-medium {
+		flex-direction: row;
+		align-items: flex-end;
+		gap: 24px;
 	}
 
-	button.components-button.design-picker-category-filter__menu-item {
-		padding: 0;
-		color: $design-picker-category-filter-text-color;
-		display: block;
-		width: auto;
-		font-size: 1rem;
+	.responsive-toolbar-group__dropdown .responsive-toolbar-group__grouped-list {
+		> div:first-of-type {
+			margin-inline-start: 0;
+		}
 
-		&:hover:not(:disabled),
-		&:active:not(:disabled) {
-			box-shadow: none;
-			background: transparent;
-			.design-picker-category-filter__item-name {
-				text-decoration: underline;
-				color: $design-picker-category-filter-text-color-active;
-			}
+		> div:last-of-type {
+			margin-inline-end: 0;
+		}
+	}
+
+	button.components-button.responsive-toolbar-group__button-item,
+	button.components-button.responsive-toolbar-group__swipe-item {
+		padding: 8px 16px;
+		margin-inline-start: -4px;
+		margin-inline-end: 4px;
+		font-size: rem(13px);
+
+		&::before {
+			left: 4px;
+			right: 4px;
+			height: 36px;
+			border-radius: 4px;
+			background-color: var(--studio-gray-0);
 		}
 
 		&.is-pressed {
-			.design-picker-category-filter__item-name {
-				text-decoration: underline;
-				font-weight: 500;
-				color: $design-picker-category-filter-text-color-active;
-
-				&:hover:not(:disabled) {
-					color: $design-picker-category-filter-text-color-active;
-				}
-			}
-			background: transparent;
-
-			&:focus:not(:disabled),
-			&:focus-visible:not(:disabled) {
-				box-shadow:
-					inset 0 0 0 1px #fff,
-					0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			&::before {
+				background-color: var(--studio-wordpress-blue);
 			}
 
-			&:focus:not(:disabled):not(:focus-visible) {
-				box-shadow: none;
+			&:hover {
+				opacity: 0.95;
 			}
-		}
 
-		.design-picker-category-filter__recommended-badge {
-			display: inline-block;
-			font-size: 0.75rem;
-			padding: 0 10px;
-			line-height: 20px;
-			margin-left: 12px;
-			background-color: #b8e6bf;
-			color: #00450c;
-			border-radius: 4px;
-		}
-
-		.components-menu-item__item {
-			min-width: auto;
+			&:active {
+				opacity: 0.9;
+			}
 		}
 	}
-}
 
-.design-picker-category-filter__sidebar {
-	display: none;
+	button.components-button.responsive-toolbar-group__menu-item {
+		height: 36px;
+		padding: 8px 12px;
+		border-radius: 4px;
+		line-height: 20px;
+		background-color: var(--studio-gray-0);
+		font-size: rem(13px);
 
-	@include break-small {
-		display: block;
+		&.is-selected {
+			background-color: var(--studio-wordpress-blue);
+
+			&:hover {
+				opacity: 0.95;
+			}
+
+			&:active {
+				opacity: 0.9;
+			}
+		}
 	}
-}
 
-.design-picker-category-filter__dropdown {
-	@include break-small {
+	.design-picker__category-group {
+		display: flex;
+		flex-direction: column;
+		&.grow {
+			flex-grow: 1;
+		}
+
+		.design-picker__category-group-content {
+			display: flex;
+			align-items: center;
+			flex-wrap: wrap;
+			gap: 8px 16px;
+		}
+	}
+
+	.design-picker__category-group-label {
+		text-transform: uppercase;
+		font-size: rem(13px);
+		font-weight: 500;
+	}
+
+	.design-picker__tier-filter {
+		height: 40px; // match button height
+		margin-bottom: 6px;
+	}
+
+	.design-picker__design-your-own-button {
+		flex-shrink: 0;
+		margin-bottom: 6px;
+	}
+
+	.design-picker__design-with-ai {
 		display: none;
+		
+		@include break-small {
+			display: block;
+		}
 	}
 
-	font-family: $sans;
-	font-size: $font-body-small;
-	line-height: 24px;
-	font-weight: 500;
-	border-radius: 4px;
-	border: 1px solid #c3c4c7;
-	padding: 0 35px 0 10px;
-	margin-bottom: 32px;
-	min-height: 44px;
-	height: 44px;
-	width: 100%;
-	-webkit-appearance: none;
-	appearance: none;
-	background:
-		transparent
-		url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHJlY3QgeD0iMCIgZmlsbD0ibm9uZSIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+PGc+PHBhdGggZmlsbD0iI2MzYzRjNyIgZD0iTTIwIDlsLTggOC04LTggMS40MTQtMS40MTRMMTIgMTQuMTcybDYuNTg2LTYuNTg2eiIvPjwvZz48L3N2Zz4=)
-		no-repeat right 12px top 50%;
-	background-size: 20px;
-
-	&:focus,
-	&:focus-visible {
-		outline: none;
-		box-shadow: 0 0 0 2px var(--color-primary-light);
+	.design-picker__design-your-own-button-without-categories {
+		margin-left: auto;
+		margin-top: -60px;
 	}
 
-	&:focus:not(:focus-visible) {
-		outline: none;
-		box-shadow: none;
+	.design-picker__category-filter.responsive-toolbar-group__dropdown {
+		width: 100%;
+		padding-bottom: 0;
+
+		.responsive-toolbar-group__grouped-list {
+			justify-content: flex-start;
+		}
 	}
 }

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -63,6 +63,10 @@
 		background-color: var(--studio-gray-0);
 		font-size: rem(13px);
 
+		&:not(:first-child) {
+			margin-top: 8px;
+		}
+
 		&.is-selected {
 			background-color: var(--studio-wordpress-blue);
 

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -15,16 +15,6 @@
 		gap: 24px;
 	}
 
-	.responsive-toolbar-group__dropdown .responsive-toolbar-group__grouped-list {
-		> div:first-of-type {
-			margin-inline-start: 0;
-		}
-
-		> div:last-of-type {
-			margin-inline-end: 0;
-		}
-	}
-
 	button.components-button.responsive-toolbar-group__button-item,
 	button.components-button.responsive-toolbar-group__swipe-item {
 		padding: 8px 16px;
@@ -130,6 +120,15 @@
 
 		.responsive-toolbar-group__grouped-list {
 			justify-content: flex-start;
+			border: none;
+
+			> div:first-of-type {
+				margin-inline-start: 0;
+			}
+	
+			> div:last-of-type {
+				margin-inline-end: 0;
+			}
 		}
 	}
 }

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -22,86 +22,12 @@
 		flex-grow: 1;
 	}
 
-	.design-picker__filters {
-		display: flex;
-		justify-content: space-between;
-		flex-direction: column;
-		gap: 10px;
-		margin-bottom: 24px;
-
-		@include break-small {
-			flex-direction: row;
-			align-items: flex-end;
-			gap: 30px;
-		}
-
-		button.responsive-toolbar-group__button-item,
-		button.responsive-toolbar-group__swipe-item {
-			&:not(.is-pressed)::before {
-				background-color: var(--studio-gray-0);
-			}
-		}
-
-		.design-picker__category-group {
-			display: flex;
-			flex-direction: column;
-			&.grow {
-				flex-grow: 1;
-			}
-
-			.design-picker__category-group-content {
-				display: flex;
-				align-items: center;
-				flex-wrap: wrap;
-				gap: 8px 16px;
-			}
-		}
-
-		.design-picker__category-group-label {
-			text-transform: uppercase;
-			font-size: rem(13px);
-			font-weight: 500;
-		}
-
-		.design-picker__tier-filter {
-			height: 40px; // match button height
-			margin-bottom: 6px;
-		}
-
-		.design-picker__design-your-own-button {
-			flex-shrink: 0;
-			margin-bottom: 6px;
-		}
-
-		.design-picker__design-with-ai {
-			display: none;
-			
-			@include break-small {
-				display: block;
-			}
-		}
-
-		.design-picker__design-your-own-button-without-categories {
-			margin-left: auto;
-			margin-top: -60px;
-		}
-
-		.design-picker__category-filter.responsive-toolbar-group__dropdown {
-			width: 100%;
-			padding-bottom: 0;
-
-			.responsive-toolbar-group__grouped-list {
-				justify-content: flex-start;
-			}
-		}
-	}
-
 	.design-picker__design-card-group {
 		.design-picker__design-card-title {
 			position: sticky;
 			top: 0;
 			padding: 16px 12px;
-			margin: 0 -12px 8px;
+			margin: -16px -12px 8px;
 			color: var(--studio-black);
 			background-color: var(--color-body-background);
 			font-size: $font-body;
@@ -495,10 +421,6 @@
 		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 	}
 
-	.components-button.is-pressed:active:hover {
-		color: var(--theme-base-color);
-	}
-
 	.unified-design-picker__designs {
 		min-height: 100vh;
 	}
@@ -509,26 +431,6 @@
 	.responsive-toolbar-group__swipe {
 		.responsive-toolbar-group__swipe-list {
 			padding: 0;
-
-			>div:first-of-type {
-				button {
-					padding-left: 8px;
-
-					&::before {
-						left: 0;
-					}
-				}
-			}
-
-			>div:last-of-type {
-				button {
-					padding-right: 8px;
-
-					&::before {
-						right: 0;
-					}
-				}
-			}
 		}
 	}
 

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -356,7 +356,6 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 				{ categorization && categoryTypes.length && isMultiFilterEnabled && (
 					<DesignPickerFilterGroup title={ translate( 'Type' ) }>
 						<DesignPickerCategoryFilter
-							className="design-picker__category-filter"
 							categories={ categoryTypes }
 							onSelect={ categorization.onSelect }
 							selectedSlugs={ categorization.selections }
@@ -368,7 +367,6 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 				{ categorization && categoryTopics.length && (
 					<DesignPickerFilterGroup title={ isMultiFilterEnabled ? translate( 'Topic' ) : '' } grow>
 						<DesignPickerCategoryFilter
-							className="design-picker__category-filter"
 							categories={ isMultiFilterEnabled ? categoryTopics : categorization.categories }
 							onSelect={ categorization.onSelect }
 							selectedSlugs={ categorization.selections }
@@ -376,8 +374,8 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						/>
 					</DesignPickerFilterGroup>
 				) }
-				<DesignPickerFilterGroup>
-					{ isBigSkyEligible && (
+				{ isBigSkyEligible && (
+					<DesignPickerFilterGroup>
 						<Button
 							className={ clsx(
 								'design-picker__design-your-own-button',
@@ -389,8 +387,8 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						>
 							{ translate( 'Design with AI' ) }
 						</Button>
-					) }
-				</DesignPickerFilterGroup>
+					</DesignPickerFilterGroup>
+				) }
 			</div>
 
 			{ showRecommendedDesigns && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10108

## Proposed Changes

* Update styles of the filters

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/740c060f-d62a-4e1b-a1ce-7aaed09ebd5a) | ![image](https://github.com/user-attachments/assets/10adcd45-2668-460f-9998-f5f24954b743) |
| ![image](https://github.com/user-attachments/assets/6767aae4-b69a-4b38-b096-05d4d144e39b) | ![image](https://github.com/user-attachments/assets/e591859f-80ae-4f50-bdef-b03534597527) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* On the Goals screen, select any goals
* On the Design Picker screen, select/deselect any categories
* Ensure new styles look good
* Disable the feature flag by adding `flags=-design-picker/goal-centric` to the end of the URL
* Ensure styles still look good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
