### PR TITLE
Remove unused hook calls in the `useAddOns` hook

### DIFF
--- a/packages/data-stores/src/add-ons/hooks/use-add-ons.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-add-ons.ts
@@ -129,8 +129,6 @@ const useAddOns = ( {
 	const productSlugs = activeAddOns.map( ( item ) => item.productSlug );
 	const productsList = ProductsList.useProducts( productSlugs );
 	const mediaStorage = Site.useSiteMediaStorage( { siteIdOrSlug: selectedSiteId } );
-	const siteFeatures = Site.useSiteFeatures( { siteIdOrSlug: selectedSiteId } );
-	const sitePurchases = Purchases.useSitePurchases( { siteId: selectedSiteId } );
 	const spaceUpgradesPurchased = Purchases.useSitePurchasesByProductSlug( {
 		siteId: selectedSiteId,
 		productSlug: PRODUCT_1GB_SPACE,
@@ -148,7 +146,7 @@ const useAddOns = ( {
 				 * TODO: Potentially another candidate for migrating to `use-add-on-purchase-status`, and attach
 				 * that to the add-on's meta if need to.
 				 */
-				if ( siteFeatures.isLoading || sitePurchases.isLoading || productsList.isLoading ) {
+				if ( productsList.isLoading || mediaStorage.isLoading ) {
 					return {
 						...addOn,
 						name,
@@ -226,11 +224,9 @@ const useAddOns = ( {
 			activeAddOns,
 			enableStorageAddOns,
 			mediaStorage.data?.maxStorageBytes,
+			mediaStorage.isLoading,
 			productsList.data,
 			productsList.isLoading,
-			siteFeatures.data?.active,
-			siteFeatures.isLoading,
-			sitePurchases.isLoading,
 			spaceUpgradesPurchased,
 		]
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR removes the unused hook calls in `useAddOns` and adds `mediaStorage.isLoading` to the loading spinner condition and the dependency list.  `siteFeatures` and `sitePurchases` are not used anywhere in the function body except for the dependency list, so it should be safe to remove them.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Cleaning up the unnecessary code to ease the maintenance burden.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/add-ons` should work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
