### PR TITLE
Remove duplicate views: update the preferred editor view

### DIFF
--- a/client/state/selectors/get-preferred-editor-view.js
+++ b/client/state/selectors/get-preferred-editor-view.js
@@ -14,5 +14,5 @@ export const getPreferredEditorView = ( state, siteId, postType = 'post' ) => {
 		return 'default';
 	}
 
-	return postsMenuItem.url.includes( 'wp-admin/edit.php' ) ? 'classic' : 'default';
+	return postsMenuItem.use_core_editor ? 'classic' : 'default';
 };


### PR DESCRIPTION
This PR uses the newly added `use_core_editor` property available in the admin menu editor - allowing us to control from the back-end which editor to use.

Fix: https://github.com/Automattic/wp-calypso/issues/97396

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Use the `use_core_editor` property from the API to determine which editor to use. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need this to be able to stop the iframe editor redirecting to the core one when the users are part of the treatment group of the remove duplicate views experiment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the live link
* Sandbox your Simple site with this Jetpack [PR](https://github.com/Automattic/jetpack/pull/40585)
* go to wp-admin/edit.php and grab an edit link from the posts list.
* Replace `WordPress.com` domain with the Calypso.live link domain
* Open the link and notice that you're not redirected to the Core Editor anymore

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
