### PR TITLE
E2E Tests: Disable QUIC as it's sometimes unstable

### DIFF
--- a/packages/calypso-e2e/src/jest-playwright-config/playwright-config.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/playwright-config.ts
@@ -36,6 +36,7 @@ const targetDeviceOptions = getTargetDeviceOptions();
 const launchOptions: LaunchOptions = {
 	headless: envVariables.HEADLESS,
 	slowMo: envVariables.SLOW_MO,
+	args: [ '--disable-quic' ],
 };
 
 // Options for the BrowserContext level.


### PR DESCRIPTION
and browsers don't fallback :(
