### PR TITLE
[Odie] We've missed to add the styling for error messages in the new help center experience

### DIFF
--- a/packages/odie-client/src/components/message/style_redesign.scss
+++ b/packages/odie-client/src/components/message/style_redesign.scss
@@ -102,6 +102,10 @@
 			}
 		}
 
+		&.odie-chatbox-message-error {
+			flex-direction: column;
+		}
+
 		.help-center-contact-page {
 			.help-center-contact-page__content {
 				margin-bottom: 0 !important;


### PR DESCRIPTION
## Proposed Changes

The error message when our backend fails to reply, is right now:
![image](https://github.com/user-attachments/assets/32529845-6dde-4ffb-9330-3ba18770a254)

This PR helps to fix the issue.

## Why are these changes being made?
The error message being displayed to users is awful, this is a fix for it.

## Testing Instructions

Public api your sandbox and add in the chain runner two kind of errors (right after the declaration of the run method):
First just a simple throw:

```php
		throw new \Exception( 'This method is not implemented yet' );
```

Try to talk with Wapuu
Assert that a correct error message is displayed

Second add a wp error:
```php
		$wp_error     = new \WP_Error( 'odie_chain_runner_error', "error" );
		return $wp_error;
```

Try to talk with Wapuu again and assert that a correct message is displayed

For reference, this is how it should look:
![image](https://github.com/user-attachments/assets/4ea07c4a-0a8c-4341-8793-0b196747cb5b)

Please, test also a free user, the user should be redirected to forums
![image](https://github.com/user-attachments/assets/ccce852d-2f6f-4854-a2fe-3b8e916f1ca1)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
