### PR TITLE
Stepper: Fix 404 error

### DIFF
--- a/client/landing/stepper/hooks/use-site.ts
+++ b/client/landing/stepper/hooks/use-site.ts
@@ -25,13 +25,15 @@ export function useSite() {
 
 	// Request the site for the redux store
 	useEffect( () => {
-		dispatch( ( d, getState ) => {
-			const state = getState();
-			if ( getSite( state, siteIdOrSlug ) || isRequestingSite( state, siteIdOrSlug ) ) {
-				return;
-			}
-			d( requestSite( siteIdOrSlug ) );
-		} );
+		if ( siteIdOrSlug ) {
+			dispatch( ( d, getState ) => {
+				const state = getState();
+				if ( getSite( state, siteIdOrSlug ) || isRequestingSite( state, siteIdOrSlug ) ) {
+					return;
+				}
+				d( requestSite( siteIdOrSlug ) );
+			} );
+		}
 	}, [ dispatch, siteIdOrSlug ] );
 
 	if ( siteIdOrSlug && site ) {


### PR DESCRIPTION
This fixes the annoying 404 error you see in every Stepper flow. It also has sliiiight performance implications.

## Proposed Changes

Only try to fetch the site if you have its id or slug.

## Why are these changes being made?
To save on requests and clean up logs.

## Testing Instructions

1. Open DevTools > Console.
2. Go to /setup/onboarding
3. You shouldn't see an error.
4. Go to `/setup/newsletter-post-setup/newsletterPostSetup?siteSlug=YOUR_SITE`.
5. The page should render your actual site title, which implies the hook still works. 
