### PR TITLE
A4A: Implement the WPCOM Plan selector in the new hosting page.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-number-input-v2/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-number-input-v2/index.tsx
@@ -1,0 +1,64 @@
+import { Button, TextControl } from '@wordpress/components';
+import { Icon, lineSolid, plus } from '@wordpress/icons';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import './style.scss';
+
+type Props = {
+	value: number;
+	onChange: ( value: number ) => void;
+	minimum?: number;
+	maximum?: number;
+	increment?: number;
+};
+
+export default function A4ANumberInputV2( {
+	value,
+	onChange,
+	minimum = 1,
+	maximum,
+	increment = 1,
+}: Props ) {
+	const inputRef = useRef< HTMLInputElement >( null );
+	const [ dirtyValue, setDirtyValue ] = useState( '' );
+
+	const onDecrement = useCallback( () => {
+		onChange( Math.max( value - increment, minimum ) );
+	}, [ increment, minimum, onChange, value ] );
+
+	const onIncrement = useCallback( () => {
+		onChange( maximum ? Math.min( value + increment, maximum ) : value + increment );
+	}, [ increment, maximum, onChange, value ] );
+
+	const onBlur = useCallback( () => {
+		const next = Number( dirtyValue );
+		if ( ! isNaN( next ) && next >= minimum && ( ! maximum || next <= maximum ) ) {
+			onChange( next );
+		} else {
+			setDirtyValue( `${ value }` );
+		}
+	}, [ dirtyValue, maximum, minimum, onChange, value ] );
+
+	useEffect( () => {
+		setDirtyValue( `${ value }` );
+	}, [ value ] );
+
+	return (
+		<div className="a4a-number-input-v2">
+			<TextControl
+				ref={ inputRef }
+				value={ dirtyValue }
+				onChange={ ( newValue ) => setDirtyValue( newValue ) }
+				onBlur={ onBlur }
+				onFocus={ () => inputRef.current?.select() }
+				type="number"
+			/>
+			<Button onMouseDown={ onIncrement }>
+				<Icon icon={ plus } size={ 18 } />
+			</Button>
+			<Button onMouseDown={ onDecrement }>
+				<Icon icon={ lineSolid } size={ 18 } />
+			</Button>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/components/a4a-number-input-v2/style.scss
+++ b/client/a8c-for-agencies/components/a4a-number-input-v2/style.scss
@@ -1,0 +1,58 @@
+.theme-a8c-for-agencies .a4a-number-input-v2 {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: center;
+	gap: 4px;
+
+	padding: 4px;
+	height: 40px;
+	box-sizing: border-box;
+	border: 1px solid var(--color-neutral-5);
+	border-radius: 4px;
+
+	&:has(.components-text-control__input[type="number"]:focus),
+	&:has(.components-text-control__input[type="number"]:focus-visible) {
+		border-color: var(--color-primary);
+		box-shadow: 0 0 0 0.5px var(--color-primary);
+		outline: 2px solid transparent;
+	}
+
+	.components-button {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border: none;
+		padding: 0 6px;
+		max-height: 32px;
+
+		&:focus,
+		&:focus-visible {
+			border: none;
+			box-shadow: none;
+			outline: none;
+		}
+	}
+
+	.components-text-control__input[type="number"] {
+		width: 50px;
+		text-align: center;
+		border: none;
+		padding: 0;
+
+		-moz-appearance: textfield;
+
+		&:focus,
+		&:focus-visible {
+			border: none;
+			box-shadow: none;
+			outline: none;
+		}
+
+		&::-webkit-outer-spin-button,
+		&::-webkit-inner-spin-button {
+			-webkit-appearance: none;
+			margin: 0;
+		}
+	}
+}

--- a/client/a8c-for-agencies/components/page-section/index.tsx
+++ b/client/a8c-for-agencies/components/page-section/index.tsx
@@ -9,7 +9,7 @@ import './style.scss';
 export type PageSectionProps = {
 	className?: string;
 	children: ReactNode;
-	heading: TranslateResult;
+	heading?: TranslateResult;
 	subheading?: TranslateResult;
 	icon?: ReactNode;
 	description?: TranslateResult;
@@ -42,11 +42,14 @@ export default function PageSection( {
 					{ subheading && <span className="page-section__sub-header-title">{ subheading }</span> }
 				</div>
 
-				<div className="page-section__header">
-					<h2 className="page-section__header-title">{ heading }</h2>
+				{ heading && (
+					<div className="page-section__header">
+						<h2 className="page-section__header-title">{ heading }</h2>
 
-					{ description && <p className="page-section__header-description">{ description }</p> }
-				</div>
+						{ description && <p className="page-section__header-description">{ description }</p> }
+					</div>
+				) }
+
 				{ children }
 			</div>
 		</section>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hero-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hero-section/style.scss
@@ -12,7 +12,7 @@ $tab-background-selected: var(--color-surface);
 	flex-direction: column;
 	justify-content: space-between;
 	gap: 39px;
-	transition: height .35s ease-out;
+	transition: height .2s ease-out;
 
 	&:not(.is-compact) {
 		height: 389px;
@@ -99,11 +99,17 @@ $tab-background-selected: var(--color-surface);
 	}
 
 	&:first-child {
-		border-start-start-radius: 4px;
+		&,
+		.section-nav-tab__link {
+			border-start-start-radius: 4px;
+		}
 	}
 
 	&:last-child {
+		&,
+		.section-nav-tab__link {
 		border-start-end-radius: 4px;
+		}
 	}
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hooks/use-compact-on-scroll.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hooks/use-compact-on-scroll.ts
@@ -13,6 +13,7 @@ export default function useCompactOnScroll() {
 
 	const onTransitionEnd = useCallback( () => {
 		setIsTransitioning( false );
+		setLastScrollPosition( 0 );
 		ref.current?.removeEventListener( 'transitionend', onTransitionEnd );
 	}, [] );
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/common/hosting-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/common/hosting-plan-section/index.tsx
@@ -1,0 +1,106 @@
+import { Button } from '@wordpress/components';
+import { Icon } from '@wordpress/icons';
+import clsx from 'clsx';
+import { TranslateResult } from 'i18n-calypso';
+import { Children } from 'react';
+import PageSection from 'calypso/a8c-for-agencies/components/page-section';
+
+import './style.scss';
+
+type BaseProps = {
+	className?: string;
+	children: React.ReactNode;
+};
+
+type AsideProps = BaseProps & {
+	heading: string;
+	cta?: {
+		variant: 'primary' | 'secondary';
+		icon?: JSX.Element;
+		label: string;
+		onClick?: () => void;
+		disabled?: boolean;
+	};
+};
+
+function Banner( { children }: BaseProps ) {
+	return <div className="hosting-plan-section__banner">{ children }</div>;
+}
+
+function Aside( { heading, cta, children }: AsideProps ) {
+	return (
+		<aside className="hosting-plan-section__aside">
+			<div className="hosting-plan-section__aside-top">
+				<h3 className="hosting-plan-section__aside-heading">{ heading }</h3>
+				<div className="hosting-plan-section__aside-content">{ children }</div>
+			</div>
+
+			<footer className="hosting-plan-section__aside-footer">
+				{ cta && (
+					<Button variant={ cta.variant } onClick={ cta.onClick } disabled={ cta.disabled }>
+						{ cta.label }
+						{ cta.icon && <Icon icon={ cta.icon } /> }
+					</Button>
+				) }
+			</footer>
+		</aside>
+	);
+}
+
+function Card( { children }: BaseProps ) {
+	return <div className="hosting-plan-section__card">{ children }</div>;
+}
+
+type DetailsProps = BaseProps & {
+	heading: TranslateResult;
+};
+
+function Details( { children, heading }: DetailsProps ) {
+	return (
+		<div className="hosting-plan-section__details">
+			{ heading && <h3 className="hosting-plan-section__details-heading">{ heading }</h3> }
+			<div className="hosting-plan-section__details-content">{ children }</div>
+		</div>
+	);
+}
+
+export default function HostingPlanSection( { children, className }: BaseProps ) {
+	const banner = Children.toArray( children ).find(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( child: any ) => child.type === Banner
+	);
+
+	const card = Children.toArray( children ).find(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( child: any ) => child.type === Card
+	);
+
+	const aside = Children.toArray( children ).find(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( child: any ) => child.type === Aside
+	);
+
+	const detail = Children.toArray( children ).find(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( child: any ) => child.type === Details
+	);
+
+	return (
+		<PageSection className={ clsx( 'hosting-plan-section', className ) }>
+			{ banner }
+
+			<div className="hosting-plan-section__content">
+				<main className="hosting-plan-section__main">
+					{ card }
+					{ detail }
+				</main>
+				{ aside }
+			</div>
+		</PageSection>
+	);
+}
+
+HostingPlanSection.Banner = Banner;
+HostingPlanSection.Card = Card;
+HostingPlanSection.Aside = Aside;
+HostingPlanSection.Details = Details;

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/common/hosting-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/common/hosting-plan-section/style.scss
@@ -1,0 +1,82 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.hosting-plan-section {
+	padding-block-start: 0;
+}
+
+.hosting-plan-section__banner {
+	max-width: 1000px;
+	margin-inline: auto;
+	margin-block-end: 32px;
+}
+
+.hosting-plan-section__content {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 32px;
+
+	@include break-wide {
+		grid-template-columns: 2fr 1fr;
+	}
+}
+
+.hosting-plan-section__main {
+	border-radius: 8px; // stylelint-disable-line scales/radii
+	background-color: var(--color-primary-0);
+	padding: 32px;
+
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 16px;
+
+	@include break-wide {
+		grid-template-columns: repeat( 2, 1fr );
+	}
+}
+
+.hosting-plan-section__card {
+	border-radius: 8px; // stylelint-disable-line scales/radii
+	box-shadow: 0 3px 1px 0 #0000000A;
+	padding: 32px;
+	background-color: var(--color-surface);
+}
+
+.hosting-plan-section__details {
+	margin-inline-start: 32px;
+}
+
+.hosting-plan-section__aside {
+	border-radius: 8px; // stylelint-disable-line scales/radii
+	border: 1px solid var(--color-neutral-5);
+	padding: 32px;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	gap: 32px;
+}
+
+.hosting-plan-section__details-heading,
+.hosting-plan-section__aside-heading {
+	@include a4a-font-heading-lg;
+}
+
+.hosting-plan-section__details-content,
+.hosting-plan-section__aside-content {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	margin-block: 16px;
+
+	> * {
+		@include a4a-font-body-md;
+		margin: 0;
+		padding: 0;
+	}
+}
+
+.hosting-plan-section__aside-footer {
+	> * {
+		width: 100%;
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/common/hosting-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/common/hosting-plan-section/style.scss
@@ -43,7 +43,9 @@
 }
 
 .hosting-plan-section__details {
+	@include break-wide {
 	margin-inline-start: 32px;
+	}
 }
 
 .hosting-plan-section__aside {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/index.tsx
@@ -23,7 +23,7 @@ export const HostingContent = ( { section, onAddToCart }: Props ) => {
 	const { content, title } = useMemo( () => {
 		if ( section === 'wpcom' ) {
 			return {
-				content: <StandardAgencyHosting />,
+				content: <StandardAgencyHosting onAddToCart={ onAddToCart } />,
 				title: isReferMode
 					? translate( 'Refer a WordPress.com site to your client' )
 					: translate( 'Purchase sites individually or in bulk, as you need them' ),

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/index.tsx
@@ -22,8 +22,6 @@ export default function PremierAgencyHosting() {
 
 	return (
 		<div className="premier-agency-hosting">
-			<section className="premier-agency-hosting__plan-selector-container">TODO</section>
-
 			<HostingFeatures heading={ translate( 'Included with every Pressable site' ) } />
 
 			<HostingAdditionalFeaturesSection

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/index.tsx
@@ -2,16 +2,22 @@ import { useTranslate } from 'i18n-calypso';
 import { BackgroundType10 } from 'calypso/a8c-for-agencies/components/page-section/backgrounds';
 import ProfileAvatar1 from 'calypso/assets/images/a8c-for-agencies/hosting/standard-testimonial-1.png';
 import ProfileAvatar2 from 'calypso/assets/images/a8c-for-agencies/hosting/standard-testimonial-2.png';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import HostingTestimonialsSection from '../../../common/hosting-testimonials-section';
 import ClientRelationships from '../common/client-relationships';
 import HostingFeatures from '../common/hosting-features';
+import WPCOMPlanSection from './wpcom-plan-section';
 
-export default function StandardAgencyHosting() {
+type Props = {
+	onAddToCart: ( plan: APIProductFamilyProduct, quantity: number ) => void;
+};
+
+export default function StandardAgencyHosting( { onAddToCart }: Props ) {
 	const translate = useTranslate();
 
 	return (
 		<div className="standard-agency-hosting">
-			<section className="standard-agency-hosting__plan-selector-container">TODO</section>
+			<WPCOMPlanSection onSelect={ onAddToCart } />
 
 			<HostingFeatures heading={ translate( 'Included with every WordPress.com site' ) } />
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/index.tsx
@@ -1,0 +1,174 @@
+import { arrowRight } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useContext, useMemo, useState } from 'react';
+import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
+import SiteConfigurationsModal from 'calypso/a8c-for-agencies/components/site-configurations-modal';
+import { useRandomSiteName } from 'calypso/a8c-for-agencies/components/site-configurations-modal/use-random-site-name';
+import useFetchDevLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-dev-licenses';
+import useSiteCreatedCallback from 'calypso/a8c-for-agencies/hooks/use-site-created-callback';
+import useWPCOMOwnedSites from 'calypso/a8c-for-agencies/hooks/use-wpcom-owned-sites';
+import { MarketplaceTypeContext } from 'calypso/a8c-for-agencies/sections/marketplace/context';
+import useProductAndPlans from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans';
+import WPCOMPlanSlider from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/slider';
+import { getWPCOMCreatorPlan } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import HostingPlanSection from '../../common/hosting-plan-section';
+import WPCOMPlanSelector from './wpcom-plan-selector';
+
+import './style.scss';
+
+const MAX_PLANS_FOR_SLIDER = 10;
+
+type Props = {
+	onSelect: ( plan: APIProductFamilyProduct, quantity: number ) => void;
+};
+
+export default function WPCOMPlanSection( { onSelect }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const { data: devLicenses } = useFetchDevLicenses();
+
+	const availableDevSites = devLicenses?.available;
+
+	const [ showWPCOMDevSiteConfigurationsModal, setShowWPCOMDevSiteConfigurationsModal ] =
+		useState( false );
+
+	const { randomSiteName, isRandomSiteNameLoading, refetchRandomSiteName } = useRandomSiteName();
+
+	const onCreateSiteSuccess = useSiteCreatedCallback( refetchRandomSiteName );
+
+	const onHideWPCOMDevSiteConfigurationsModal = useCallback( () => {
+		setShowWPCOMDevSiteConfigurationsModal( false );
+	}, [ setShowWPCOMDevSiteConfigurationsModal ] );
+
+	const onClickCreateWPCOMDevSite = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_hosting_page_create_wpcom_dev_site_click' ) );
+		setShowWPCOMDevSiteConfigurationsModal( true );
+	}, [ dispatch, setShowWPCOMDevSiteConfigurationsModal ] );
+
+	const { count, isReady: isLicenseCountsReady } = useWPCOMOwnedSites();
+
+	const { wpcomPlans } = useProductAndPlans( {} );
+
+	const plan = getWPCOMCreatorPlan( wpcomPlans ) ?? wpcomPlans[ 0 ];
+
+	const { marketplaceType } = useContext( MarketplaceTypeContext );
+	const referralMode = marketplaceType === 'referral';
+
+	const ownedPlans = useMemo( () => {
+		if ( referralMode ) {
+			return 0;
+		}
+
+		return count;
+	}, [ count, referralMode ] );
+
+	const [ quantity, setQuantity ] = useState( 1 );
+
+	if ( ! plan ) {
+		return;
+	}
+
+	// Show the WPCOM slider if the user has less than 10 plans and is not in referral mode.
+	const showWPCOMSlider = ! referralMode && ownedPlans < MAX_PLANS_FOR_SLIDER;
+
+	const displayQuantity = referralMode ? 1 : quantity;
+
+	return (
+		<>
+			<HostingPlanSection className="wpcom-plan-section">
+				{ showWPCOMSlider && (
+					<HostingPlanSection.Banner>
+						<WPCOMPlanSlider
+							quantity={ displayQuantity }
+							onChange={ setQuantity }
+							ownedPlans={ ownedPlans }
+						/>
+					</HostingPlanSection.Banner>
+				) }
+
+				<HostingPlanSection.Card>
+					{ isLicenseCountsReady ? (
+						<WPCOMPlanSelector
+							plan={ plan }
+							onSelect={ onSelect }
+							ownedPlans={ ownedPlans }
+							referralMode={ referralMode }
+							quantity={ displayQuantity }
+							setQuantity={ setQuantity }
+						/>
+					) : (
+						<WPCOMPlanSelector.Placeholder />
+					) }
+				</HostingPlanSection.Card>
+
+				<HostingPlanSection.Details
+					heading={ translate(
+						'%(quantity)s WordPress.com site',
+						'%(quantity)s WordPress.com sites',
+						{
+							args: {
+								quantity: displayQuantity,
+							},
+							count: displayQuantity,
+							comment: '%(quantity)s is the number of WordPress.com sites.',
+						}
+					) }
+				>
+					<p>
+						{ translate(
+							'Enjoy cumulative volume discounts on WordPress.com site purchases, regardless of when you buy. Every site includes:'
+						) }
+					</p>
+
+					<SimpleList
+						items={ [
+							translate( '{{b}}50GB{{/b}} of storage', { components: { b: <b /> } } ),
+							translate( '{{b}}Free{{/b}} staging site', { components: { b: <b /> } } ),
+							translate( '{{b}}Unrestricted bandwidth{{/b}}', { components: { b: <b /> } } ),
+							translate( '{{b}}Everything listed below{{/b}}', { components: { b: <b /> } } ),
+						] }
+					/>
+				</HostingPlanSection.Details>
+
+				<HostingPlanSection.Aside
+					heading={ translate( 'Start building for free' ) }
+					cta={ {
+						label: translate( 'Create a development site' ),
+						variant: 'secondary',
+						icon: arrowRight,
+						disabled: ! availableDevSites,
+						onClick: onClickCreateWPCOMDevSite,
+					} }
+				>
+					<p>
+						{ translate(
+							'Included in your membership to Automattic for Agencies. Develop up to 5 WordPress.com sites with free development licenses. Only pay when you launch.'
+						) }
+					</p>
+
+					<i>
+						{ translate( '%(pendingSites)d of 5 free licenses available', {
+							args: {
+								pendingSites: availableDevSites,
+							},
+							comment: '%(pendingSites)s is the number of free licenses available.',
+						} ) }
+					</i>
+				</HostingPlanSection.Aside>
+			</HostingPlanSection>
+
+			{ showWPCOMDevSiteConfigurationsModal && (
+				<SiteConfigurationsModal
+					closeModal={ onHideWPCOMDevSiteConfigurationsModal }
+					randomSiteName={ randomSiteName }
+					isRandomSiteNameLoading={ isRandomSiteNameLoading }
+					onCreateSiteSuccess={ onCreateSiteSuccess }
+				/>
+			) }
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/style.scss
@@ -3,8 +3,15 @@
 
 
 .wpcom-plan-section .a4a-slider {
-		position: relative;
-		z-index: 1;
+	position: relative;
+	z-index: 1;
+}
+.wpcom-plan-section .a4a-number-input-v2 {
+	width: 100%;
+
+	@include break-medium {
+		width: auto;
+	}
 }
 
 .wpcom-plan-selector__price-actual-value,
@@ -51,18 +58,19 @@
 
 .wpcom-plan-selector__cta-component {
 	display: flex;
-	flex-direction: column-reverse;
-	align-items: flex-start;
+	flex-direction: column;
+	justify-content: stretch;
 	gap: 16px;
 
-	@include break-huge {
+	@include break-mobile {
 		flex-direction: row;
 	}
 }
 
 .wpcom-plan-selector__cta-button {
-	min-width: 260px;
+	min-width: 0;
 	width: 100%;
+	min-height: 40px;
 }
 
 .wpcom-plan-selector__details.is-placeholder {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/style.scss
@@ -1,0 +1,120 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+
+.wpcom-plan-section .a4a-slider {
+		position: relative;
+		z-index: 1;
+}
+
+.wpcom-plan-selector__price-actual-value,
+.wpcom-plan-selector__price-original-value {
+	@include a4a-font-heading-lg;
+	color: var(--color-text);
+}
+
+.wpcom-plan-selector__price-original-value {
+	display: inline-block;
+	text-decoration: line-through;
+	margin-inline: 8px;
+}
+
+.wpcom-plan-selector__price-discount {
+	@include a4a-font-body-md;
+	color: var(--color-success);
+	text-wrap: nowrap;
+}
+
+.wpcom-plan-selector__price-interval {
+	@include a4a-font-body-sm;
+}
+
+.wpcom-plan-selector__cta {
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	gap: 16px;
+	margin-block-start: 24px;
+}
+
+.wpcom-plan-selector__cta-label {
+	@include a4a-font-body-md;
+}
+
+.wpcom-plan-selector__owned-plan {
+	@include a4a-font-heading-md;
+
+	display: inline-block;
+	border: 1px solid var(--color-neutral-5);
+	background-color: var(--color-neutral-0);
+	padding: 4px 16px;
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 16px;
+	margin-block-end: 8px;
+}
+
+.wpcom-plan-selector__cta-component {
+	display: flex;
+	flex-direction: column-reverse;
+	align-items: flex-start;
+	gap: 16px;
+
+	@include break-huge {
+		flex-direction: row;
+	}
+}
+
+.wpcom-plan-selector__cta-button {
+	min-width: 260px;
+	width: 100%;
+}
+
+.wpcom-plan-selector__details.is-placeholder {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+
+	.wpcom-plan-selector__owned-plan,
+	.wpcom-plan-selector__plan-name,
+	.wpcom-plan-selector__price,
+	.wpcom-plan-selector__price-interval,
+	.wpcom-plan-selector__cta-label,
+	.wpcom-plan-selector__cta-component {
+		@include placeholder( --color-neutral-10 );
+		border-radius: 4px;
+		box-sizing: border-box;
+	}
+
+	.wpcom-plan-selector__owned-plan {
+		width: 150px;
+	}
+
+	.wpcom-plan-selector__plan-name {
+		height: 30px;
+		margin-block-end: 4px;
+		width: 200px;
+	}
+
+	.wpcom-plan-selector__price {
+		width: 260px;
+		margin-block-end: 2px;
+	}
+
+	.wpcom-plan-selector__price-interval {
+		width: 50px;
+		height: 14px;
+	}
+
+	.wpcom-plan-selector__cta {
+		gap: 16px;
+	}
+
+	.wpcom-plan-selector__cta-label {
+		width: 250px;
+	}
+
+	.wpcom-plan-selector__cta-component {
+		width: 436px;
+		height: 36px;
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/style.scss
@@ -37,10 +37,6 @@
 	margin-block-start: 24px;
 }
 
-.wpcom-plan-selector__cta-label {
-	@include a4a-font-body-md;
-}
-
 .wpcom-plan-selector__owned-plan {
 	@include a4a-font-heading-md;
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
@@ -1,0 +1,137 @@
+import formatCurrency from '@automattic/format-currency';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import A4ANumberInput from 'calypso/a8c-for-agencies/components/a4a-number-input';
+import useWPCOMDiscountTiers from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-wpcom-discount-tiers';
+import { calculateTier } from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-values-utils';
+import useWPCOMPlanDescription from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/hooks/use-wpcom-plan-description';
+import WPCOMLogo from 'calypso/assets/images/a8c-for-agencies/wpcom-logo.svg';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+
+type Props = {
+	plan: APIProductFamilyProduct;
+	onSelect: ( plan: APIProductFamilyProduct, quantity: number ) => void;
+	ownedPlans: number;
+	referralMode?: boolean;
+	quantity: number;
+	setQuantity: ( quantity: number ) => void;
+};
+
+function Placeholder() {
+	return (
+		<div className="wpcom-plan-selector__details is-placeholder">
+			<div className="wpcom-plan-selector__owned-plan"></div>
+			<div className="wpcom-plan-selector__plan-name"></div>
+			<div className="wpcom-plan-selector__price"></div>
+			<div className="wpcom-plan-selector__price-interval"></div>
+			<div className="wpcom-plan-selector__cta">
+				<div className="wpcom-plan-selector__cta-label"></div>
+				<div className="wpcom-plan-selector__cta-component"></div>
+			</div>
+		</div>
+	);
+}
+
+export default function WPCOMPlanSelector( {
+	plan,
+	onSelect,
+	ownedPlans,
+	referralMode,
+	quantity,
+	setQuantity,
+}: Props ) {
+	const translate = useTranslate();
+
+	const discountTiers = useWPCOMDiscountTiers();
+
+	const discount = useMemo( () => {
+		if ( referralMode ) {
+			return discountTiers[ 0 ].discount;
+		}
+
+		return calculateTier( discountTiers, quantity + ownedPlans ).discount;
+	}, [ discountTiers, ownedPlans, quantity, referralMode ] );
+
+	const originalPrice = Number( plan?.amount ?? 0 ) * quantity;
+	const actualPrice = originalPrice - originalPrice * discount;
+
+	const { name: planName } = useWPCOMPlanDescription( plan?.slug ?? '' );
+
+	const ctaLabel = useMemo( () => {
+		if ( referralMode ) {
+			return translate( 'Add to referral' );
+		}
+
+		return translate( 'Add %(quantity)s site to cart', 'Add %(quantity)s sites to cart', {
+			args: {
+				quantity,
+				planName,
+			},
+			count: quantity,
+			comment: '%(quantity)s is the quantity of plans and %(planName)s is the name of the plan.',
+		} );
+	}, [ planName, quantity, referralMode, translate ] );
+
+	return (
+		<div className="wpcom-plan-selector__details">
+			{ ownedPlans > 0 && (
+				<div className="wpcom-plan-selector__owned-plan">
+					{ translate( 'You own %(count)s site', 'You own %(count)s sites', {
+						args: {
+							count: ownedPlans,
+						},
+						count: ownedPlans,
+						comment: '%(count)s is the number of WordPress.com sites owned by the user',
+					} ) }
+				</div>
+			) }
+
+			<div className="wpcom-plan-selector__plan-name">
+				<img src={ WPCOMLogo } alt="WPCOM" />
+			</div>
+
+			<div className="wpcom-plan-selector__price">
+				<b className="wpcom-plan-selector__price-actual-value">
+					{ formatCurrency( actualPrice, plan.currency ) }
+				</b>
+				{ !! discount && (
+					<>
+						<b className="wpcom-plan-selector__price-original-value">
+							{ formatCurrency( originalPrice, plan.currency ) }
+						</b>
+
+						<span className="wpcom-plan-selector__price-discount">
+							{ translate( 'You save %(discount)s%', {
+								args: {
+									discount: Math.floor( discount * 100 ),
+								},
+								comment: '%(discount)s is the discount percentage.',
+							} ) }
+						</span>
+					</>
+				) }
+				<div className="wpcom-plan-selector__price-interval">
+					{ plan.price_interval === 'day' && translate( 'per day, billed monthly' ) }
+					{ plan.price_interval === 'month' && translate( 'per month, billed monthly' ) }
+				</div>
+			</div>
+
+			<div className="wpcom-plan-selector__cta">
+				<div className="wpcom-plan-selector__cta-component">
+					<Button
+						className="wpcom-plan-selector__cta-button"
+						variant="primary"
+						onClick={ () => onSelect( plan, quantity ) }
+					>
+						{ ctaLabel }
+					</Button>
+
+					{ ! referralMode && <A4ANumberInput value={ quantity } onChange={ setQuantity } /> }
+				</div>
+			</div>
+		</div>
+	);
+}
+
+WPCOMPlanSelector.Placeholder = Placeholder;

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
@@ -26,7 +26,6 @@ function Placeholder() {
 			<div className="wpcom-plan-selector__price"></div>
 			<div className="wpcom-plan-selector__price-interval"></div>
 			<div className="wpcom-plan-selector__cta">
-				<div className="wpcom-plan-selector__cta-label"></div>
 				<div className="wpcom-plan-selector__cta-component"></div>
 			</div>
 		</div>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
@@ -2,7 +2,7 @@ import formatCurrency from '@automattic/format-currency';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import A4ANumberInput from 'calypso/a8c-for-agencies/components/a4a-number-input';
+import A4ANumberInputV2 from 'calypso/a8c-for-agencies/components/a4a-number-input-v2';
 import useWPCOMDiscountTiers from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-wpcom-discount-tiers';
 import { calculateTier } from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-values-utils';
 import useWPCOMPlanDescription from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/hooks/use-wpcom-plan-description';
@@ -126,7 +126,7 @@ export default function WPCOMPlanSelector( {
 						{ ctaLabel }
 					</Button>
 
-					{ ! referralMode && <A4ANumberInput value={ quantity } onChange={ setQuantity } /> }
+					{ ! referralMode && <A4ANumberInputV2 value={ quantity } onChange={ setQuantity } /> }
 				</div>
 			</div>
 		</div>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/style.scss
@@ -25,6 +25,7 @@ $background-color: #05374A;
 		padding-block-end: 0;
 		position: sticky;
 		top: 0;
+		z-index: 100;
     }
 
 	.a4a-layout__header-breadcrumb {


### PR DESCRIPTION
This PR implements the WPCOM plan selector on the new hosting page.

<img width="1497" alt="Screenshot 2024-12-12 at 10 54 24 PM" src="https://github.com/user-attachments/assets/ac173ace-7fbd-4518-a2ef-4919706cab12" />


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1546

## Proposed Changes

* Implement a reusable Hosting plan section (later, we will reuse this as well for the Pressable plans).
* Create a new `A4AnumberInputV2` component derived from `A4AnumberInput`, incorporating a minor UI update that aligns with the latest design. We developed this separate component to prevent adding complexity to the `A4AnumberInput` code. Eventually, we will eliminate this as part of the project's post-cleanup process.
* Implement the new WPCOM plan section based on the new design.

## Why are these changes being made?

* This is part of the In-product hosting page v3 project.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace/hosting/wpcom` page.
* Confirm you see the plan selector.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
