### PR TITLE
Fix the Severity status overflow

### DIFF
--- a/client/sites/tools/logs/components/site-logs-table/site-logs-expanded-content.tsx
+++ b/client/sites/tools/logs/components/site-logs-table/site-logs-expanded-content.tsx
@@ -1,3 +1,4 @@
+import { Badge } from '@automattic/components';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { SiteLogsData } from 'calypso/data/hosting/use-site-logs-query';
@@ -30,6 +31,8 @@ function replaceKey( key: string ) {
 		return __( 'File' );
 	} else if ( key === 'line' ) {
 		return __( 'Line' );
+	} else if ( key === 'severity' ) {
+		return __( 'Severity' );
 	}
 }
 
@@ -56,6 +59,16 @@ export default function SiteLogsExpandedContent( { log, specifiedLogs }: Props )
 function renderCell( column: string, value: unknown ) {
 	if ( value === null || value === undefined || value === '' ) {
 		return '-';
+	}
+
+	if ( column === 'severity' ) {
+		const formattedSeverities = {
+			User: __( 'User' ),
+			Warning: __( 'Warning' ),
+			Deprecated: __( 'Deprecated' ),
+			'Fatal error': __( 'Fatal error' ),
+		};
+		return <Badge className={ `badge--${ value }` }>{ formattedSeverities[ value ] }</Badge>;
 	}
 
 	switch ( typeof value ) {

--- a/client/sites/tools/logs/components/site-logs-table/site-logs-table-row.tsx
+++ b/client/sites/tools/logs/components/site-logs-table/site-logs-table-row.tsx
@@ -36,7 +36,7 @@ export default function SiteLogsTableRow( { columns, log, siteGmtOffset, logType
 
 	const specifiedLogs =
 		logType === 'php'
-			? [ 'message', 'timestamp', 'kind', 'name', 'file', 'line' ]
+			? [ 'severity', 'message', 'timestamp', 'kind', 'name', 'file', 'line' ]
 			: [ 'timestamp', 'body_bytes_sent', 'cached', 'http_host', 'http_referer' ];
 
 	return (

--- a/client/sites/tools/logs/components/site-logs-table/style.scss
+++ b/client/sites/tools/logs/components/site-logs-table/style.scss
@@ -12,6 +12,13 @@ $border-color:#eeeeee; /* stylelint-disable-line color-hex-length */
 	&.is-loading {
 		opacity: 0.5;
 	}
+
+	.severity .badge {
+		max-width: 100%;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
 }
 
 .site-logs-table thead tr,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #97316

## Proposed Changes

* Fix the size of the Severity column to avoid overflow to the next table.
* We discussed that https://github.com/Automattic/wp-calypso/pull/97409 was probably not the best approach, and we decided to simplify it. More context: p1734010525105089-slack-C0Q664T29

### Before

![395179289-e1f80048-8d52-41f7-8aad-7db9b8755b90](https://github.com/user-attachments/assets/08b1d6ee-1e82-4d7c-ab32-9d2100dbee52)

### After

![Captura de Tela 2024-12-12 às 11 42 27](https://github.com/user-attachments/assets/89f80af7-dfa4-4c74-acc6-53a5bac52f2f)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Long translated words were breaking the design on the logs page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link below
* Change your language to German
* Find a site that contains an Error on the log
* Navigate to `/sites/tools/logs/{YOURSITE}/php`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?