### PR TITLE
Reader: fix style in tags page sidebar

### DIFF
--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -272,7 +272,7 @@ body.is-section-reader {
 			position: relative;
 			left: calc(-1 * (100vw - 100%)/2 - 132px);
 			margin: 24px 0;
-			width: 100vw;
+			width: 110vw;
 			height: 1px;
 			background: var(--color-border-secondary);
 		}

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -117,16 +117,6 @@
 
 // Tag page only shows site titles in the sidebar, so spacing needs to be tighter
 .tag-stream__main {
-	.stream__two-column .reader__content::before {
-		content: "";
-		background-color: #e9e9ea;
-		position: absolute;
-		right: -56px;
-		top: 0;
-		height: calc(100% + 180px);
-		margin-top: -200px;
-		width: 1px;
-	}
 
 	.stream__two-column .stream__right-column {
 		margin-top: 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/loop/issues/272

| Before | After |
|--------|-------|
| <img width="1422" alt="Screenshot 2024-12-12 at 14 43 58" src="https://github.com/user-attachments/assets/9e9d5eb5-5a94-4b18-8edd-4517b60b3e18" /> |  <img width="1419" alt="Screenshot 2024-12-12 at 14 44 07" src="https://github.com/user-attachments/assets/a9c66e27-8473-4b38-b1c0-322816986827" /> |

## Proposed Changes

* Removes style that causes vertical line to appear in tags page sidebar
* Extends the horizontal header line to go full width of content area

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Tidy UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm line is no longer visible on tags page, i.e. `/tag/gadgets`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
