### PR TITLE
Add i18n support to the ExpiredReportNotice component

### DIFF
--- a/client/hosting/performance/components/expired-report-notice/expired-report-notice.tsx
+++ b/client/hosting/performance/components/expired-report-notice/expired-report-notice.tsx
@@ -1,4 +1,5 @@
 import { Button, Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { scheduled } from '@wordpress/icons';
 import moment from 'moment';
 import './style.scss';
@@ -23,13 +24,13 @@ export const ExpiredReportNotice = ( { onRetest, reportTimestamp }: ExpiredRepor
 			<Icon className="icon" icon={ scheduled } size={ 24 } />
 			<div className="expired-report-notice-content">
 				<div className="expired-report-text">
-					<span className="text">These results are more than 24 hours old</span>
+					<span className="text">{ __( 'These results are more than 24 hours old' ) }</span>
 					<span className="subtext">
-						Test the page again if you have recently made updates to your site.
+						{ __( 'Test the page again if you have recently made updates to your site.' ) }
 					</span>
 				</div>
 				<Button variant="primary" onClick={ onRetest }>
-					Test again
+					{ __( 'Test again' ) }
 				</Button>
 			</div>
 		</div>

--- a/client/hosting/performance/components/expired-report-notice/expired-report-notice.tsx
+++ b/client/hosting/performance/components/expired-report-notice/expired-report-notice.tsx
@@ -1,6 +1,6 @@
 import { Button, Icon } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 import { scheduled } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import './style.scss';
 
@@ -12,6 +12,7 @@ type ExpiredReportNoticeProps = {
 };
 
 export const ExpiredReportNotice = ( { onRetest, reportTimestamp }: ExpiredReportNoticeProps ) => {
+	const translate = useTranslate();
 	const isOlderThan24Hours = reportTimestamp
 		? moment().diff( moment( reportTimestamp ), 'hours' ) > REFRESH_REPORT_INTERVAL
 		: false;
@@ -24,13 +25,13 @@ export const ExpiredReportNotice = ( { onRetest, reportTimestamp }: ExpiredRepor
 			<Icon className="icon" icon={ scheduled } size={ 24 } />
 			<div className="expired-report-notice-content">
 				<div className="expired-report-text">
-					<span className="text">{ __( 'These results are more than 24 hours old' ) }</span>
+					<span className="text">{ translate( 'These results are more than 24 hours old' ) }</span>
 					<span className="subtext">
-						{ __( 'Test the page again if you have recently made updates to your site.' ) }
+						{ translate( 'Test the page again if you have recently made updates to your site.' ) }
 					</span>
 				</div>
 				<Button variant="primary" onClick={ onRetest }>
-					{ __( 'Test again' ) }
+					{ translate( 'Test again' ) }
 				</Button>
 			</div>
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1733999450884729-slack-C02AED43D

## Proposed Changes

* Wrapped all user-facing text in the `__` function for proper translation handling.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* These changes allow the text displayed in the `ExpiredReportNotice` component to be translated into different languages.

### Screenshot
![image](https://github.com/user-attachments/assets/20616850-4a56-4e5f-9705-8f3ebee3fd43)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?