### PR TITLE
Performance Profiler: Pass translate function to metrics when rendering

### DIFF
--- a/client/performance-profiler/components/core-web-vitals-accordion/index.tsx
+++ b/client/performance-profiler/components/core-web-vitals-accordion/index.tsx
@@ -5,7 +5,7 @@ import { Metrics } from 'calypso/data/site-profiler/types';
 import { CircularPerformanceScore } from 'calypso/hosting/performance/components/circular-performance-score/circular-performance-score';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
-	metricsNames,
+	getMetricsNames,
 	mapThresholdsToStatus,
 	displayValue,
 } from 'calypso/performance-profiler/utils/metrics';
@@ -67,6 +67,7 @@ export const CoreWebVitalsAccordion = ( props: Props ) => {
 		}
 	};
 
+	const metricsNames = getMetricsNames( translate );
 	const entries = Object.entries( metricsNames );
 	const overallEntry = entries.find( ( [ key ] ) => key === 'overall' );
 	const otherEntries = entries.filter( ( [ key ] ) => key !== 'overall' );

--- a/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/core-web-vitals-details.tsx
@@ -7,10 +7,10 @@ import {
 } from 'calypso/data/site-profiler/types';
 import { CircularPerformanceScore } from 'calypso/hosting/performance/components/circular-performance-score/circular-performance-score';
 import {
-	metricsNames,
+	getMetricsNames,
 	metricsThresholds,
 	mapThresholdsToStatus,
-	metricValuations,
+	getMetricValuations,
 	displayValue,
 	filterRecommendations,
 } from 'calypso/performance-profiler/utils/metrics';
@@ -41,6 +41,7 @@ export const CoreWebVitalsDetails: React.FC< CoreWebVitalsDetailsProps > = ( {
 		return null;
 	}
 
+	const metricsNames = getMetricsNames( translate );
 	const { name: displayName } = metricsNames[ activeTab ];
 	const value = metrics[ activeTab ];
 
@@ -138,7 +139,7 @@ export const CoreWebVitalsDetails: React.FC< CoreWebVitalsDetailsProps > = ( {
 					/>
 				</div>
 				<p>
-					{ metricValuations[ activeTab ].explanation }
+					{ getMetricValuations( translate )[ activeTab ].explanation }
 					&nbsp;
 					{ isPerformanceScoreSelected ? (
 						<a

--- a/client/performance-profiler/components/insights-section/index.tsx
+++ b/client/performance-profiler/components/insights-section/index.tsx
@@ -9,7 +9,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { MetricsInsight } from 'calypso/performance-profiler/components/metrics-insight';
 import {
 	filterRecommendations,
-	metricsNames,
+	getMetricsNames,
 	highImpactAudits,
 } from 'calypso/performance-profiler/utils/metrics';
 import { profilerVersion } from 'calypso/performance-profiler/utils/profiler-version';
@@ -58,6 +58,8 @@ export const InsightsSection = forwardRef(
 				setSelectedFilter( filter );
 			}
 		}, [ selectedFilter, filter ] );
+
+		const metricsNames = getMetricsNames( translate );
 
 		return (
 			<div className="performance-profiler-insights-section" ref={ ref }>
@@ -122,6 +124,8 @@ function getSubtitleText(
 	numRecommendations: number,
 	translate: ReturnType< typeof useTranslate >
 ) {
+	const metricsNames = getMetricsNames( translate );
+
 	if ( numRecommendations ) {
 		if ( selectedFilter === 'all' ) {
 			return translate(

--- a/client/performance-profiler/components/metric-tab-bar/index.tsx
+++ b/client/performance-profiler/components/metric-tab-bar/index.tsx
@@ -4,7 +4,7 @@ import { Metrics } from 'calypso/data/site-profiler/types';
 import { CircularPerformanceScore } from 'calypso/hosting/performance/components/circular-performance-score/circular-performance-score';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
-	metricsNames,
+	getMetricsNames,
 	mapThresholdsToStatus,
 	displayValue,
 } from 'calypso/performance-profiler/utils/metrics';
@@ -29,6 +29,8 @@ const MetricTabBar = ( props: Props ) => {
 			version: profilerVersion(),
 		} );
 	};
+
+	const metricsNames = getMetricsNames( translate );
 
 	return (
 		<div className="metric-tab-bar">

--- a/client/performance-profiler/utils/metrics.ts
+++ b/client/performance-profiler/utils/metrics.ts
@@ -1,30 +1,17 @@
-import { translate } from 'i18n-calypso';
 import { Metrics, PerformanceMetricsItemQueryResponse } from 'calypso/data/site-profiler/types';
 import { Valuation } from '../types/performance-metrics';
 
-export const metricsNames = {
+export const getMetricsNames = ( translate: ( text: string ) => string ) => ( {
 	fcp: { name: translate( 'First Contentful Paint' ) },
-	lcp: {
-		name: translate( 'Largest Contentful Paint' ),
-	},
-	cls: {
-		name: translate( 'Cumulative Layout Shift' ),
-	},
-	inp: {
-		name: translate( 'Interaction to Next Paint' ),
-	},
-	ttfb: {
-		name: translate( 'Time to First Byte' ),
-	},
-	tbt: {
-		name: translate( 'Total Blocking Time' ),
-	},
-	overall: {
-		name: translate( 'Performance Score' ),
-	},
-};
+	lcp: { name: translate( 'Largest Contentful Paint' ) },
+	cls: { name: translate( 'Cumulative Layout Shift' ) },
+	inp: { name: translate( 'Interaction to Next Paint' ) },
+	ttfb: { name: translate( 'Time to First Byte' ) },
+	tbt: { name: translate( 'Total Blocking Time' ) },
+	overall: { name: translate( 'Performance Score' ) },
+} );
 
-export const metricValuations = {
+export const getMetricValuations = ( translate: ( text: string ) => string ) => ( {
 	fcp: {
 		good: translate( 'Your site‘s First Contentful Paint is excellent' ),
 		needsImprovement: translate( 'Your site‘s First Contentful Paint needs improvement' ),
@@ -95,7 +82,7 @@ export const metricValuations = {
 			'The performance score is a combined representation of your site‘s individual speed metrics.'
 		),
 	},
-};
+} );
 
 // bad values are only needed as a maximum value on the scales
 export const metricsThresholds = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/10050

## Proposed Changes

* Pass the `translate` function to the metrics names and definitions from render as they don't have the correct locale for the static objects

|Before | After|
|-------|------|
|![CleanShot 2024-12-12 at 17 14 14@2x](https://github.com/user-attachments/assets/1d81a79a-dd5f-46a6-9d9b-92cb6d5dc768)| ![CleanShot 2024-12-12 at 17 14 01@2x](https://github.com/user-attachments/assets/f7121e9c-ec65-4c65-af70-f03e0f30bd8b)|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The `translate` being used by the objects was not correctly getting the locale, please see video in the linked task

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this changes
* With a logged-out user, run a Speed Test tool using a different locale than English, for example: `/speed-test-tool?locale=it&url=www.atliq.com`
* Check the Core Web Vitals are correctly translated to the locale

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
