### PR TITLE
Post-purchase: Apply missing styles "migration pending" 

### DIFF
--- a/client/sites/components/sites-dataviews/sites-site-status.tsx
+++ b/client/sites/components/sites-dataviews/sites-site-status.tsx
@@ -31,6 +31,17 @@ const DeletedStatus = styled.div`
 	}
 `;
 
+const MigrationPendingStatus = styled.span`
+	display: inline-block;
+	padding: 0px 10px;
+	font-size: 12px;
+	border-radius: 4px;
+	background-color: var( --color-warning-20 );
+	line-height: 20px;
+	font-weight: 500;
+	color: var( --color-warning-80 );
+`;
+
 interface SiteStatusProps {
 	site: SiteExcerptData;
 }
@@ -51,7 +62,7 @@ export const SiteStatus = ( { site }: SiteStatusProps ) => {
 	}
 
 	const statusElement = isPending ? (
-		<span className="sites-dataviews__migration-pending-status">{ translatedStatus }</span>
+		<MigrationPendingStatus>{ translatedStatus }</MigrationPendingStatus>
 	) : (
 		translatedStatus
 	);

--- a/client/sites/components/sites-dataviews/style.scss
+++ b/client/sites/components/sites-dataviews/style.scss
@@ -97,15 +97,6 @@
 		gap: 6px;
 	}
 
-	.sites-dataviews__migration-pending-status {
-		display: inline-block;
-		padding: 0 10px;
-		font-size: rem(12px);
-		border-radius: 4px;
-		background-color: var(--color-warning-20);
-		line-height: 20px;
-		color: var(--color-warning-80);
-	}
 
 	.stats-sparkline {
 		padding-top: 0;


### PR DESCRIPTION
The previous place was only applying the style on the site list and not on the overview list

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes to #97410

## Proposed Changes
* Apply missing styles to the "Migration Pending" label on the site overview page.


Before:
<img width="852" alt="image" src="https://github.com/user-attachments/assets/3555f5c8-a4ae-4c28-9984-84be74712d0f" />

After:
<img width="679" alt="image" src="https://github.com/user-attachments/assets/e8242949-be4f-4a71-b8c4-b29b87501edf" />


## Testing Instructions
* Go to `/sites` 
* Select any site with pending migration
* Check if the "Migration Pending" label is stylized.

Extra note: If you don't have any site with pending migration, you can just run the flow `https://wordpress.com/setup/hosted-site-migration` by choosing the option ` I'll do it myself`  and skipping the instructions step.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
