### PR TITLE
Checkout: scroll to the top on load

### DIFF
--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -82,6 +82,10 @@ export default function CheckoutMainWrapper( {
 	const selectedSiteId = useSelector( getSelectedSiteId ) ?? undefined;
 
 	useEffect( () => {
+		window.scrollTo( 0, 0 );
+	}, [] );
+
+	useEffect( () => {
 		if ( productAliasFromUrl ) {
 			logToLogstash( {
 				feature: 'calypso_client',


### PR DESCRIPTION
When navigating to Checkout (or reloading Checkout), this will scroll to the top of the window to make sure that you see everything and start from the beginning.

Fixes: #97423

**To test:**
- add something to your cart, but don't visit checkout
- find a calypso page with a decent amount of content (e.g. My Home) and scroll to the bottom
- from the admin bar shopping cart, click "Checkout"
- verify that Checkout loads scrolled to the top of the page.