### PR TITLE
Reader: add tracking for scroll depth on full post article

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -103,8 +103,8 @@ export class FullPostView extends Component {
 
 	state = {
 		isSuggestedFollowsModalOpen: false,
-        maxScrollDepth: 0, // Track the maximum scroll depth achieved
-        hasCompleted: false, // Track whether the user completed the post
+		maxScrollDepth: 0, // Track the maximum scroll depth achieved
+		hasCompleted: false, // Track whether the user completed the post
 	};
 
 	openSuggestedFollowsModal = ( followClicked ) => {
@@ -139,9 +139,11 @@ export class FullPostView extends Component {
 
 		document.addEventListener( 'visibilitychange', this.handleVisibilityChange );
 
-		if (this.postContentWrapper.current) {
-            this.postContentWrapper.current.addEventListener('scroll', this.setScrollDepth);
-        }
+		const scrollableContainer = document.querySelector( '#primary > div > div' );
+		if ( scrollableContainer ) {
+			scrollableContainer.addEventListener( 'scroll', this.setScrollDepth );
+			this.scrollableContainer = scrollableContainer; // Save reference for cleanup
+		}
 	}
 	componentDidUpdate( prevProps ) {
 		// Send page view if applicable
@@ -161,7 +163,6 @@ export class FullPostView extends Component {
 				this.trackScrollDepth( prevProps.post );
 				this.trackExitBeforeCompletion( prevProps.post );
 				this.setReadingStartTime();
-
 			}
 		}
 
@@ -194,9 +195,9 @@ export class FullPostView extends Component {
 		document.removeEventListener( 'keydown', this.handleKeydown, true );
 		document.removeEventListener( 'visibilitychange', this.handleVisibilityChange );
 
-		if (this.postContentWrapper.current) {
-            this.postContentWrapper.current.removeEventListener('scroll', this.setScrollDepth);
-        }
+		if ( this.scrollableContainer ) {
+			this.scrollableContainer.removeEventListener( 'scroll', this.setScrollDepth );
+		}
 	}
 
 	setReadingStartTime = () => {
@@ -253,7 +254,7 @@ export class FullPostView extends Component {
 		if ( ! post ) {
 			post = this.props.post;
 		}
-		if ( this.readingStartTime ) {
+		if ( this.readingStartTime && post.ID ) {
 			const endTime = Math.floor( Date.now() );
 			const engagementTime = endTime - this.readingStartTime;
 			recordTrackForPost( 'calypso_reader_article_engaged_time', post, {
@@ -264,54 +265,46 @@ export class FullPostView extends Component {
 	}
 
 	setScrollDepth = () => {
-        const contentElement = this.postContentWrapper.current;
-
-        if (contentElement) {
-            const scrollTop = contentElement.scrollTop;
-            const scrollHeight = contentElement.scrollHeight;
-            const clientHeight = contentElement.clientHeight;
-
-            // Calculate the percentage scrolled
-            const scrollDepth = (scrollTop / (scrollHeight - clientHeight)) * 100;
-
-            // Update the maximum scroll depth and check for completion
-            this.setState((prevState) => {
-                const hasCompleted = scrollDepth >= 90; // Define "completion" as 90% scroll
-                return {
-                    maxScrollDepth: Math.max(prevState.maxScrollDepth, scrollDepth),
-                    hasCompleted: prevState.hasCompleted || hasCompleted,
-                };
-            });
-        }
-    };
+		if ( this.scrollableContainer ) {
+			const scrollTop = this.scrollableContainer.scrollTop;
+			const scrollHeight = this.scrollableContainer.scrollHeight;
+			const clientHeight = this.scrollableContainer.clientHeight;
+			const scrollDepth = ( scrollTop / ( scrollHeight - clientHeight ) ) * 100;
+			this.setState( ( prevState ) => ( {
+				maxScrollDepth: Math.max( prevState.maxScrollDepth, scrollDepth ),
+				hasCompleted: prevState.hasCompleted || scrollDepth >= 90,
+			} ) );
+		}
+	};
 
 	trackScrollDepth = ( post = null ) => {
-        const { maxScrollDepth } = this.state;
-        if ( ! post ) {
+		const { maxScrollDepth } = this.state;
+		if ( ! post ) {
 			post = this.props.post;
 		}
 
-        const roundedDepth = Math.round(maxScrollDepth * 100) / 100;
-
-        recordTrackForPost('calypso_reader_article_scroll_depth', post, {
-			context: 'full-post',
-            scroll_depth: roundedDepth,
-        });
-    };
-
-    trackExitBeforeCompletion = ( post = null ) => {
-        const { hasCompleted, maxScrollDepth } = this.state;
-        if ( ! post ) {
-			post = this.props.post;
-		}
-
-        if (!hasCompleted) {
-            recordTrackForPost('calypso_reader_article_exit_before_completion', post, {
+		if ( this.scrollableContainer && post.ID ) {
+			const roundedDepth = Math.round( maxScrollDepth * 100 ) / 100;
+			recordTrackForPost( 'calypso_reader_article_scroll_depth', post, {
 				context: 'full-post',
-                max_scroll_depth: Math.round(maxScrollDepth * 100) / 100,
-            });
-        }
-    };
+				scroll_depth: roundedDepth,
+			} );
+		}
+	};
+
+	trackExitBeforeCompletion = ( post = null ) => {
+		const { hasCompleted, maxScrollDepth } = this.state;
+		if ( ! post ) {
+			post = this.props.post;
+		}
+
+		if ( this.scrollableContainer && post.ID && ! hasCompleted ) {
+			recordTrackForPost( 'calypso_reader_article_exit_before_completion', post, {
+				context: 'full-post',
+				scroll_depth: maxScrollDepth,
+			} );
+		}
+	};
 
 	handleBack = ( event ) => {
 		event.preventDefault();

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -139,7 +139,9 @@ export class FullPostView extends Component {
 
 		document.addEventListener( 'visibilitychange', this.handleVisibilityChange );
 
-		const scrollableContainer = document.querySelector( '#primary > div > div' );
+		const scrollableContainer =
+			document.querySelector( '#primary > div > div.recent-feed > section' ) ||
+			document.querySelector( '#primary > div > div' );
 		if ( scrollableContainer ) {
 			scrollableContainer.addEventListener( 'scroll', this.setScrollDepth );
 			this.scrollableContainer = scrollableContainer; // Save reference for cleanup

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -103,6 +103,8 @@ export class FullPostView extends Component {
 
 	state = {
 		isSuggestedFollowsModalOpen: false,
+        maxScrollDepth: 0, // Track the maximum scroll depth achieved
+        hasCompleted: false, // Track whether the user completed the post
 	};
 
 	openSuggestedFollowsModal = ( followClicked ) => {
@@ -136,6 +138,10 @@ export class FullPostView extends Component {
 		document.addEventListener( 'keydown', this.handleKeydown, true );
 
 		document.addEventListener( 'visibilitychange', this.handleVisibilityChange );
+
+		if (this.postContentWrapper.current) {
+            this.postContentWrapper.current.addEventListener('scroll', this.setScrollDepth);
+        }
 	}
 	componentDidUpdate( prevProps ) {
 		// Send page view if applicable
@@ -152,7 +158,10 @@ export class FullPostView extends Component {
 			// If the post being viewed changes, track the reading time.
 			if ( get( prevProps, 'post.ID' ) !== get( this.props, 'post.ID' ) ) {
 				this.trackReadingTime( prevProps.post );
+				this.trackScrollDepth( prevProps.post );
+				this.trackExitBeforeCompletion( prevProps.post );
 				this.setReadingStartTime();
+
 			}
 		}
 
@@ -184,6 +193,10 @@ export class FullPostView extends Component {
 		this.trackReadingTime();
 		document.removeEventListener( 'keydown', this.handleKeydown, true );
 		document.removeEventListener( 'visibilitychange', this.handleVisibilityChange );
+
+		if (this.postContentWrapper.current) {
+            this.postContentWrapper.current.removeEventListener('scroll', this.setScrollDepth);
+        }
 	}
 
 	setReadingStartTime = () => {
@@ -231,6 +244,8 @@ export class FullPostView extends Component {
 	handleVisibilityChange = () => {
 		if ( document.hidden ) {
 			this.trackReadingTime();
+			this.trackScrollDepth();
+			this.trackExitBeforeCompletion();
 		}
 	};
 
@@ -247,6 +262,56 @@ export class FullPostView extends Component {
 			} );
 		}
 	}
+
+	setScrollDepth = () => {
+        const contentElement = this.postContentWrapper.current;
+
+        if (contentElement) {
+            const scrollTop = contentElement.scrollTop;
+            const scrollHeight = contentElement.scrollHeight;
+            const clientHeight = contentElement.clientHeight;
+
+            // Calculate the percentage scrolled
+            const scrollDepth = (scrollTop / (scrollHeight - clientHeight)) * 100;
+
+            // Update the maximum scroll depth and check for completion
+            this.setState((prevState) => {
+                const hasCompleted = scrollDepth >= 90; // Define "completion" as 90% scroll
+                return {
+                    maxScrollDepth: Math.max(prevState.maxScrollDepth, scrollDepth),
+                    hasCompleted: prevState.hasCompleted || hasCompleted,
+                };
+            });
+        }
+    };
+
+	trackScrollDepth = ( post = null ) => {
+        const { maxScrollDepth } = this.state;
+        if ( ! post ) {
+			post = this.props.post;
+		}
+
+        const roundedDepth = Math.round(maxScrollDepth * 100) / 100;
+
+        recordTrackForPost('calypso_reader_article_scroll_depth', post, {
+			context: 'full-post',
+            scroll_depth: roundedDepth,
+        });
+    };
+
+    trackExitBeforeCompletion = ( post = null ) => {
+        const { hasCompleted, maxScrollDepth } = this.state;
+        if ( ! post ) {
+			post = this.props.post;
+		}
+
+        if (!hasCompleted) {
+            recordTrackForPost('calypso_reader_article_exit_before_completion', post, {
+				context: 'full-post',
+                max_scroll_depth: Math.round(maxScrollDepth * 100) / 100,
+            });
+        }
+    };
 
 	handleBack = ( event ) => {
 		event.preventDefault();

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -191,6 +191,7 @@ export function recordTracksRailcarInteract( eventName, railcar, overrides ) {
 }
 
 export function recordTrackForPost( eventName, post = {}, additionalProps = {}, options ) {
+	console.log( 'recordTrackForPost', eventName, { ...getTracksPropertiesForPost( post ), ...additionalProps }, options );
 	recordTrack( eventName, { ...getTracksPropertiesForPost( post ), ...additionalProps }, options );
 	if ( post.railcar && allowedTracksRailcarEventNames.has( eventName ) ) {
 		// check for overrides for the railcar

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -191,7 +191,6 @@ export function recordTracksRailcarInteract( eventName, railcar, overrides ) {
 }
 
 export function recordTrackForPost( eventName, post = {}, additionalProps = {}, options ) {
-	console.log( 'recordTrackForPost', eventName, { ...getTracksPropertiesForPost( post ), ...additionalProps }, options );
 	recordTrack( eventName, { ...getTracksPropertiesForPost( post ), ...additionalProps }, options );
 	if ( post.railcar && allowedTracksRailcarEventNames.has( eventName ) ) {
 		// check for overrides for the railcar


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/loop/issues/262
Fixes https://github.com/Automattic/loop/issues/263

## Proposed Changes

1. Added new state variables `maxScrollDepth` and `hasCompleted` to track scroll depth and completion status.
2. Added an event listener for the 'scroll' event to track scroll depth.
3. Added methods `setScrollDepth`, `trackScrollDepth`, and `trackExitBeforeCompletion` to handle tracking scroll depth and user exit before completion events.
4. Updated `componentDidUpdate` to include calls to `trackScrollDepth` and `trackExitBeforeCompletion` when the post being viewed changes.
5. Updated `componentWillUnmount` to remove the scroll event listener.
6. Updated `handleVisibilityChange` to include calls to `trackScrollDepth` and `trackExitBeforeCompletion` when the document becomes hidden.
7. Updated `trackReadingTime` to check for post.ID.
8. Added logic to calculate and record the maximum scroll depth achieved and whether the user has completed the post.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Extra metrics to measure user engagement

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  Go to `/read` and navigate between full post views
*  When you navigate away from the post, you should see the track event `calypso_reader_article_scroll_depth` logged
*  If the scroll depth doesn't go past 90% then a track event `calypso_reader_article_exit_before_completion` should also be logged.
*  You should be able to see these events on tracks after 5 mins
*  To see them live, I suggest adding console.log to the `recordTrackForPost` method.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
