### PR TITLE
composite-checkout: Add paymentMethod ID to errors logged by submit_button_load

### DIFF
--- a/packages/composite-checkout/src/components/checkout-submit-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-submit-button.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-import { cloneElement } from 'react';
+import { cloneElement, useCallback } from 'react';
 import joinClasses from '../lib/join-classes';
 import { useAllPaymentMethods, usePaymentMethodId } from '../lib/payment-methods';
 import { makeErrorResponse } from '../lib/payment-processors';
@@ -99,6 +99,21 @@ function CheckoutSubmitButtonForPaymentMethod( {
 		return onClick( processorData );
 	};
 
+	// Add payment method to any errors that get logged.
+	const onLoadErrorWithPaymentMethodId = useCallback(
+		( error: Error ) => {
+			if ( ! onLoadError ) {
+				return;
+			}
+			const errorWithCause = new Error(
+				`Error while rendering submit button for payment method '${ paymentMethod.id }': ${ error.message } (${ error.name })`,
+				{ cause: error }
+			);
+			onLoadError( errorWithCause );
+		},
+		[ onLoadError, paymentMethod.id ]
+	);
+
 	const { submitButton } = paymentMethod;
 	if ( ! submitButton ) {
 		return null;
@@ -112,7 +127,7 @@ function CheckoutSubmitButtonForPaymentMethod( {
 	return (
 		<CheckoutErrorBoundary
 			errorMessage={ __( 'There was a problem with the submit button.' ) }
-			onError={ onLoadError }
+			onError={ onLoadErrorWithPaymentMethodId }
 		>
 			<CheckoutSubmitButtonWrapper
 				className={ joinClasses( [


### PR DESCRIPTION
## Proposed Changes

The `composite-checkout` package includes built-in React error boundaries that have an optional logging function. In calypso we use that function to send those errors to our logging system and alert us to bugs. One of those error boundaries sits inside of the `CheckoutSubmitButtonForPaymentMethod` component which is rendered for each payment method by the `CheckoutSubmitButton` and its parent, the `CheckoutFormSubmit` component which is part of the public API. This makes it so that if a payment method's submit button throws an error, only the submit button gets broken in the UI.

The log message, however, doesn't tell us which payment method was having the issue. If the error message itself doesn't contain anything useful, then it may be very hard to tell. For example, these errors: p1734045467240689-slack-C096PD42U

In this PR we alter the logging code so that the caught Error is wrapped in the `cause` property of another Error which describes the payment method that failed.

## Testing Instructions

To test this, you'll need to alter the code to trigger a fatal error during render of the submit button of a payment method. Then check the network tab of your browser for a logstash call and make sure that it mentions the payment method.