### PR TITLE
Sites Dashboard: Remove A4A overrides

### DIFF
--- a/client/sites/components/dotcom-style.scss
+++ b/client/sites/components/dotcom-style.scss
@@ -9,49 +9,49 @@
 	padding-bottom: 0;
 }
 
-.wpcom-site .a4a-layout-with-columns__container {
-	background: var(--color-sidebar-background);
-}
+// .wpcom-site .a4a-layout-with-columns__container {
+// 	background: var(--color-sidebar-background);
+// }
 
 .wpcom-site .main.a4a-layout.sites-dashboard {
-	.a4a-layout__top-wrapper,
-	.a4a-layout__body {
-		> * {
-			padding-inline: 48px;
-			// Override the max-width set in a8c-for-agencies/components/layout/style.scss
-			// as the title aligns with DataViews (full width).
-			// TODO: Remove when we drop A4A Layout or when A4A Layout drops the max-width.
-			max-width: revert;
-		}
-	}
+	// .a4a-layout__top-wrapper,
+	// .a4a-layout__body {
+	// 	> * {
+	// 		padding-inline: 48px;
+	// 		// Override the max-width set in a8c-for-agencies/components/layout/style.scss
+	// 		// as the title aligns with DataViews (full width).
+	// 		// TODO: Remove when we drop A4A Layout or when A4A Layout drops the max-width.
+	// 		max-width: revert;
+	// 	}
+	// }
 
-	.a4a-layout__header {
-		align-items: center;
-	}
+	// .a4a-layout__header {
+	// 	align-items: center;
+	// }
 
-	.a4a-layout__header-main {
-		display: block;
-	}
+	// .a4a-layout__header-main {
+	// 	display: block;
+	// }
 
-	.a4a-layout__header-title {
-		display: block;
-	}
+	// .a4a-layout__header-title {
+	// 	display: block;
+	// }
 
-	.a4a-layout__header-subtitle {
-		font-size: 0.875rem;
-		margin: 4px 0 0 0;
-		line-height: 20px;
-		letter-spacing: -0.15px;
-	}
+	// .a4a-layout__header-subtitle {
+	// 	font-size: 0.875rem;
+	// 	margin: 4px 0 0 0;
+	// 	line-height: 20px;
+	// 	letter-spacing: -0.15px;
+	// }
 
-	.a4a-layout__header-actions {
-		width: auto;
-		a {
-			font-weight: normal;
-		}
-	}
+	// .a4a-layout__header-actions {
+	// 	width: auto;
+	// 	a {
+	// 		font-weight: normal;
+	// 	}
+	// }
 
-	height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
+	// height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
 
 	.sites-site-favicon {
 		margin-right: 0;
@@ -59,16 +59,16 @@
 }
 
 .wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout .sites-overview {
-	background: var(--studio-white);
+	// background: var(--studio-white);
 
-	.a4a-layout__top-wrapper {
-		border-block-end: none;
+	// .a4a-layout__top-wrapper {
+	// 	border-block-end: none;
 
-		@include break-medium {
-			border-block-end: 1px solid var(--color-border-secondary);
-			margin-bottom: 24px;
-		}
-	}
+	// 	@include break-medium {
+	// 		border-block-end: 1px solid var(--color-border-secondary);
+	// 		margin-bottom: 24px;
+	// 	}
+	// }
 
 	.sites-banner-container {
 		box-sizing: border-box;
@@ -91,9 +91,9 @@
 
 	}
 
-	.a4a-layout__header {
-		flex-wrap: nowrap;
-	}
+	// .a4a-layout__header {
+	// 	flex-wrap: nowrap;
+	// }
 }
 
 .wpcom-site {
@@ -210,23 +210,23 @@
 	}
 
 	.sites-dashboard:not(.preview-hidden) {
-		.a4a-layout__header {
-			align-items: center !important;
-		}
+		// .a4a-layout__header {
+		// 	align-items: center !important;
+		// }
 
-		.sites-manage-all-domains-button,
-		.a4a-layout__header-subtitle {
-			display: none;
-		}
+		// .sites-manage-all-domains-button,
+		// .a4a-layout__header-subtitle {
+		// 	display: none;
+		// }
 
-		.a4a-layout__viewport {
-			width: 360px;
-			justify-content: space-between;
-		}
+		// .a4a-layout__viewport {
+		// 	width: 360px;
+		// 	justify-content: space-between;
+		// }
 
-		.a4a-layout__viewport > div:first-child {
-			width: 100%;
-		}
+		// .a4a-layout__viewport > div:first-child {
+		// 	width: 100%;
+		// }
 
 		.list-tile__leading {
 			margin-right: 12px;
@@ -243,90 +243,90 @@
 		margin-left: 4px;
 	}
 
-	.section-nav-tabs__list {
-		box-sizing: border-box;
-		overflow-x: auto;
+	// .section-nav-tabs__list {
+	// 	box-sizing: border-box;
+	// 	overflow-x: auto;
 
-		@media (max-width: $break-large) {
-			padding: 0 8px;
-		}
-	}
+	// 	@media (max-width: $break-large) {
+	// 		padding: 0 8px;
+	// 	}
+	// }
 
-	.item-preview__header {
-		.item-preview__header-title {
-			font-family: Recoleta, sans-serif;
-			font-weight: 400;
-			line-height: 1;
-			letter-spacing: normal;
-		}
+	// .item-preview__header {
+	// 	.item-preview__header-title {
+	// 		font-family: Recoleta, sans-serif;
+	// 		font-weight: 400;
+	// 		line-height: 1;
+	// 		letter-spacing: normal;
+	// 	}
 
-		.item-preview__header-content {
-			.item-preview__header-info {
-				flex-wrap: wrap;
-			}
+	// 	.item-preview__header-content {
+	// 		.item-preview__header-info {
+	// 			flex-wrap: wrap;
+	// 		}
 
-			@media (max-width: $break-large) {
-				padding: 0;
-			}
-		}
+	// 		@media (max-width: $break-large) {
+	// 			padding: 0;
+	// 		}
+	// 	}
 
-		.item-preview__header-content .item-preview__header-title-summary .item-preview__header-summary {
-			display: flex;
-			flex-wrap: wrap;
-			gap: 0.5rem;
-			.item-preview__header-summary-link {
-				color: var(--studio-gray-70, #3c434a);
-				text-decoration: none;
-				&:hover {
-					color: var(--color-accent, #3858e9);
-				}
-			}
-		}
+	// 	.item-preview__header-content .item-preview__header-title-summary .item-preview__header-summary {
+	// 		display: flex;
+	// 		flex-wrap: wrap;
+	// 		gap: 0.5rem;
+	// 		.item-preview__header-summary-link {
+	// 			color: var(--studio-gray-70, #3c434a);
+	// 			text-decoration: none;
+	// 			&:hover {
+	// 				color: var(--color-accent, #3858e9);
+	// 			}
+	// 		}
+	// 	}
 
-		.item-preview__header-actions .button {
-			border-radius: 4px;
-		}
+	// 	.item-preview__header-actions .button {
+	// 		border-radius: 4px;
+	// 	}
 
-		.item-preview__header-content .item-preview__close-preview {
-			height: 16px;
-			padding-left: 0;
-			padding-right: 0;
-			color: var(--color-link);
+	// 	.item-preview__header-content .item-preview__close-preview {
+	// 		height: 16px;
+	// 		padding-left: 0;
+	// 		padding-right: 0;
+	// 		color: var(--color-link);
 
-			@include break-medium {
-				height: 32px;
-			}
-		}
-	}
-	.item-preview__content {
-		padding: 32px 48px 48px;
-		font-size: rem(14px);
-		color: var(--studio-gray-100);
+	// 		@include break-medium {
+	// 			height: 32px;
+	// 		}
+	// 	}
+	// }
+	// .item-preview__content {
+	// 	padding: 32px 48px 48px;
+	// 	font-size: rem(14px);
+	// 	color: var(--studio-gray-100);
 
-		.navigation-header {
-			padding: 0;
-		}
+	// 	.navigation-header {
+	// 		padding: 0;
+	// 	}
 
-		> * {
-			margin-top: 0;
-			margin-left: 0;
-			margin-right: 0;
-			margin-bottom: auto;
-			padding-top: 0;
-			padding-left: 0;
-			padding-right: 0;
-			overflow-y: initial;
-			max-height: initial;
-			max-width: 1400px;
-			width: 100%;
-		}
+	// 	> * {
+	// 		margin-top: 0;
+	// 		margin-left: 0;
+	// 		margin-right: 0;
+	// 		margin-bottom: auto;
+	// 		padding-top: 0;
+	// 		padding-left: 0;
+	// 		padding-right: 0;
+	// 		overflow-y: initial;
+	// 		max-height: initial;
+	// 		max-width: 1400px;
+	// 		width: 100%;
+	// 	}
 
-		@media (max-width: $break-large) {
-			padding-top: 24px;
-			padding-left: 24px;
-			padding-right: 24px;
-		}
-	}
+	// 	@media (max-width: $break-large) {
+	// 		padding-top: 24px;
+	// 		padding-left: 24px;
+	// 		padding-right: 24px;
+	// 	}
+	// }
 
 	.is-staging-site {
 		position: relative;
@@ -361,44 +361,44 @@
 	}
 }
 
-.wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout,
-.wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout .a4a-layout-with-columns__container .a4a-layout-column {
-	.a4a-layout-column__container {
-		display: flex;
-		flex-direction: column;
-		height: 100%;
-	}
-}
+// .wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout,
+// .wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout .a4a-layout-with-columns__container .a4a-layout-column {
+// 	.a4a-layout-column__container {
+// 		display: flex;
+// 		flex-direction: column;
+// 		height: 100%;
+// 	}
+// }
 
 // Use flexbox to structure of fly-out panel.
 .wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout:not(.preview-hidden) {
-	&.a4a-layout,
-	.a4a-layout-column,
-	.a4a-layout-with-columns__container {
-		overflow: visible;
-		height: calc(100vh - 32px - var(--masterbar-height));
-	}
+	// &.a4a-layout,
+	// .a4a-layout-column,
+	// .a4a-layout-with-columns__container {
+	// 	overflow: visible;
+	// 	height: calc(100vh - 32px - var(--masterbar-height));
+	// }
 
 	.a4a-layout-column__container {
-		display: flex;
-		flex-direction: column;
-		height: calc(100vh - 32px);
+		// display: flex;
+		// flex-direction: column;
+		// height: calc(100vh - 32px);
 
-		.a4a-layout__top-wrapper {
-			display: flex;
-			margin-bottom: 0;
-			padding: 0;
+		// .a4a-layout__top-wrapper {
+		// 	display: flex;
+		// 	margin-bottom: 0;
+		// 	padding: 0;
 
-			.a4a-layout__viewport {
-				display: flex;
-				margin: 0;
-				padding: 16px 24px;
-			}
+		// 	.a4a-layout__viewport {
+		// 		display: flex;
+		// 		margin: 0;
+		// 		padding: 16px 24px;
+		// 	}
 
-			.a4a-layout__header {
-				margin: 0;
-			}
-		}
+		// 	.a4a-layout__header {
+		// 		margin: 0;
+		// 	}
+		// }
 
 		.sites-banner-container {
 			display: none;
@@ -421,9 +421,9 @@
 			padding-left: calc(var(--sidebar-width-max));
 			padding-right: 16px;
 
-			.main.a4a-layout.sites-dashboard.sites-dashboard__layout {
-				height: calc(100vh - var(--masterbar-height) - var(--content-padding-bottom) - var(--content-padding-top));
-			}
+			// .main.a4a-layout.sites-dashboard.sites-dashboard__layout {
+			// 	height: calc(100vh - var(--masterbar-height) - var(--content-padding-bottom) - var(--content-padding-top));
+			// }
 		}
 
 		// Prevent the content pushed out via translateX(100%) creating a scrollbar
@@ -433,10 +433,10 @@
 	}
 }
 
-.is-mobile-app-view {
-	.wpcom-site .a4a-layout.sites-dashboard .site-preview-pane {
-		.item-preview__header {
-			padding: 0;
-		}
-	}
-}
+// .is-mobile-app-view {
+// 	.wpcom-site .a4a-layout.sites-dashboard .site-preview-pane {
+// 		.item-preview__header {
+// 			padding: 0;
+// 		}
+// 	}
+// }

--- a/client/sites/components/sites-dataviews/dataview-style.scss
+++ b/client/sites/components/sites-dataviews/dataview-style.scss
@@ -16,19 +16,19 @@
 	}
 }
 
-.wpcom-site .main.a4a-layout.sites-dashboard {
-	.a4a-layout__top-wrapper,
-	.a4a-layout__body {
-		> * {
-			// dataviews-override: To align with Core's hard-coded device width.
-			// https://github.com/WordPress/gutenberg/blob/ed66cc50e3c0b6785a48c15230c090790c0b0e6c/packages/dataviews/src/components/dataviews/style.scss#L84
-			// TODO: Remove when Core changes to use one of the predefined breakpoints.
-			@media (max-width: 430px) {
-				padding-inline: 24px;
-			}
-		}
-	}
-}
+// .wpcom-site .main.a4a-layout.sites-dashboard {
+// 	.a4a-layout__top-wrapper,
+// 	.a4a-layout__body {
+// 		> * {
+// 			// dataviews-override: To align with Core's hard-coded device width.
+// 			// https://github.com/WordPress/gutenberg/blob/ed66cc50e3c0b6785a48c15230c090790c0b0e6c/packages/dataviews/src/components/dataviews/style.scss#L84
+// 			// TODO: Remove when Core changes to use one of the predefined breakpoints.
+// 			@media (max-width: 430px) {
+// 				padding-inline: 24px;
+// 			}
+// 		}
+// 	}
+// }
 
 .wpcom-site .main.a4a-layout.sites-dashboard.sites-dashboard__layout .sites-overview {
 	.sites-banner-container {

--- a/client/sites/components/style.scss
+++ b/client/sites/components/style.scss
@@ -6,21 +6,21 @@
 }
 
 .main.a4a-layout.sites-dashboard {
-	padding-block-start: 0;
+	// padding-block-start: 0;
 
-	.a4a-layout__header-actions {
-		white-space: nowrap;
-	}
+	// .a4a-layout__header-actions {
+	// 	white-space: nowrap;
+	// }
 
-	.item-preview-pane .a4a-layout-column__container {
-		display: flex;
-	}
+	// .item-preview-pane .a4a-layout-column__container {
+	// 	display: flex;
+	// }
 
-	.a4a-layout-column {
-		@include breakpoint-deprecated( "<660px" ) {
-			border-radius: 0;
-		}
-	}
+	// .a4a-layout-column {
+	// 	@include breakpoint-deprecated( "<660px" ) {
+	// 		border-radius: 0;
+	// 	}
+	// }
 
 	.site-actions__actions-large-screen {
 		display: block;
@@ -34,9 +34,9 @@
 		margin-right: 10px;
 	}
 
-	.a4a-layout__top-wrapper:not(.preview-hidden) {
-		padding-block-start: 24px;
-	}
+	// .a4a-layout__top-wrapper:not(.preview-hidden) {
+	// 	padding-block-start: 24px;
+	// }
 
 	.sites-dataviews__site {
 		.button {
@@ -59,11 +59,11 @@
 		}
 	}
 
-	@media (max-width: 660px) {
-		.a4a-layout__header-main {
-			display: none;
-		}
-	}
+	// @media (max-width: 660px) {
+	// 	.a4a-layout__header-main {
+	// 		display: none;
+	// 	}
+	// }
 
 	@media (max-width: $break-large) {
 		.section-nav__mobile-header {
@@ -72,11 +72,11 @@
 
 		&.sites-dashboard__layout {
 			.sites-overview {
-				overflow: hidden;
+				// overflow: hidden;
 
-				.sites-overview__page-title-container {
-					display: flex;
-				}
+				// .sites-overview__page-title-container {
+				// 	display: flex;
+				// }
 
 				#sites-overview-add-sites-button {
 					a.button.split-button__main {
@@ -102,20 +102,20 @@
 					flex-grow: 0;
 				}
 
-				.sites-overview__tabs {
-					border-bottom: 1px solid var(--color-accent-5);
-				}
+				// .sites-overview__tabs {
+				// 	border-bottom: 1px solid var(--color-accent-5);
+				// }
 
-				.sites-overview__content {
-					padding: 0;
-					margin: 0;
-					margin-top: 16px;
-				}
+				// .sites-overview__content {
+				// 	padding: 0;
+				// 	margin: 0;
+				// 	margin-top: 16px;
+				// }
 			}
 		}
 
 		.item-preview__content {
-			padding: 10px 10px 88px; /* 88px matches the padding from PR #39201. */
+			// padding: 10px 10px 88px; /* 88px matches the padding from PR #39201. */
 
 			.backup__page .main {
 				/* Prevents the backup page from overriding our padding and overflow settings. */
@@ -148,20 +148,20 @@
 
 	@media (min-width: $break-large) {
 		&.sites-dashboard__layout:not(.preview-hidden) {
-			.sites-overview {
-				padding: 0;
+			// .sites-overview {
+				// padding: 0;
 
-				.a4a-layout__header-title {
-					font-size: rem(20px);
-					font-weight: 500;
-					letter-spacing: normal;
-				}
-			}
+				// .a4a-layout__header-title {
+				// 	font-size: rem(20px);
+				// 	font-weight: 500;
+				// 	letter-spacing: normal;
+				// }
+			// }
 
-			.sites-overview__content {
-				padding: 0;
-				padding-inline: 0 !important;
-			}
+			// .sites-overview__content {
+			// 	padding: 0;
+			// 	padding-inline: 0 !important;
+			// }
 
 			.sites-overview__issue-license-button-short-caption {
 				height: 28px;
@@ -170,19 +170,19 @@
 				font-size: rem(12px);
 			}
 
-			.sites-overview__page-subtitle {
-				display: none;
-			}
+			// .sites-overview__page-subtitle {
+			// 	display: none;
+			// }
 
-			.sites-overview__tabs {
-				border-bottom: 1px solid var(--color-accent-5);
-				padding: 0 24px;
-			}
+			// .sites-overview__tabs {
+			// 	border-bottom: 1px solid var(--color-accent-5);
+			// 	padding: 0 24px;
+			// }
 
-			.sites-overview__page-title {
-				font-size: rem(20px);
-				font-weight: 500;
-			}
+			// .sites-overview__page-title {
+			// 	font-size: rem(20px);
+			// 	font-weight: 500;
+			// }
 
 			.sites-overview__issue-license-button {
 				display: flex;
@@ -194,33 +194,33 @@
 		}
 	}
 
-	.sites-overview__content-wrapper {
-		max-width: none;
-	}
+	// .sites-overview__content-wrapper {
+	// 	max-width: none;
+	// }
 
 	&.sites-dashboard__layout:not(.preview-hidden) {
 
 
-		.a4a-layout__top-wrapper {
-			padding-block-start: 16px;
+		// .a4a-layout__top-wrapper {
+		// 	padding-block-start: 16px;
 
-			.a4a-layout__header {
-				padding: 0;
-			}
-		}
+		// 	.a4a-layout__header {
+		// 		padding: 0;
+		// 	}
+		// }
 
-		.components-base-control {
-			margin-right: 6px;
-		}
+		// .components-base-control {
+		// 	margin-right: 6px;
+		// }
 
-		.site-preview__open {
-			display: none;
-		}
+		// .site-preview__open {
+		// 	display: none;
+		// }
 	}
 
-	&.sites-dashboard__layout:not(.preview-hidden) .a4a-layout__navigation-wrapper {
-		display: none;
-	}
+	// &.sites-dashboard__layout:not(.preview-hidden) .a4a-layout__navigation-wrapper {
+	// 	display: none;
+	// }
 
 	&.sites-dashboard__layout {
 
@@ -259,81 +259,81 @@
 			white-space: nowrap;
 		}
 
-		.sites-overview {
-			height: 100%;
-			width: 400px;
-			flex: unset;
-			transition: all 0.2s;
-			background: var(--color-light-backdrop);
+		// .sites-overview {
+		// 	height: 100%;
+		// 	width: 400px;
+		// 	flex: unset;
+		// 	transition: all 0.2s;
+		// 	background: var(--color-light-backdrop);
 
-			.sites-overview__content {
-				display: flex;
-				flex: 1;
-				height: 100%;
-				overflow: auto;
-				margin-top: 24px;
-			}
-		}
+		// 	.sites-overview__content {
+		// 		display: flex;
+		// 		flex: 1;
+		// 		height: 100%;
+		// 		overflow: auto;
+		// 		margin-top: 24px;
+		// 	}
+		// }
 
-		@media only screen and (min-width: $break-large) {
-			.sites-overview {
-				padding: 24px 18px;
-			}
-		}
+		// @media only screen and (min-width: $break-large) {
+		// 	.sites-overview {
+		// 		padding: 24px 18px;
+		// 	}
+		// }
 
 
-		.sites-overview__container {
-			min-height: calc(100vh - 90px);
-		}
+		// .sites-overview__container {
+		// 	min-height: calc(100vh - 90px);
+		// }
 
-		.sites-overview__page-title {
-			font-size: rem(24px);
-		}
+		// .sites-overview__page-title {
+		// 	font-size: rem(24px);
+		// }
 
-		.item-preview__pane {
-			flex-grow: 1;
-			width: auto;
-			transition: flex-grow 0.2s;
-			background: var(--color-light-backdrop);
-			max-height: calc(100vh - 32px - var(--masterbar-height));
-			border-radius: 8px; /* stylelint-disable-line scales/radii */
-			@media (max-width: $break-small) {
-				max-height: calc(100vh - var(--masterbar-height));
-			}
-			.preview-pane__navigation {
-				box-shadow: none;
-				border-bottom: 1px solid var(--color-border-subtle);
-				padding-top: 1px;
-			}
-		}
+		// .item-preview__pane {
+		// 	flex-grow: 1;
+		// 	width: auto;
+		// 	transition: flex-grow 0.2s;
+		// 	background: var(--color-light-backdrop);
+		// 	max-height: calc(100vh - 32px - var(--masterbar-height));
+		// 	border-radius: 8px; /* stylelint-disable-line scales/radii */
+		// 	@media (max-width: $break-small) {
+		// 		max-height: calc(100vh - var(--masterbar-height));
+		// 	}
+		// 	.preview-pane__navigation {
+		// 		box-shadow: none;
+		// 		border-bottom: 1px solid var(--color-border-subtle);
+		// 		padding-top: 1px;
+		// 	}
+		// }
 
-		.site-preview__open {
-			display: block;
-		}
+		// .site-preview__open {
+		// 	display: block;
+		// }
 
-		&.preview-hidden {
-			.sites-overview {
-				flex-grow: 1;
-				transition: flex-grow 0.2s;
-			}
+		// &.preview-hidden {
+			// .sites-overview {
+			// 	flex-grow: 1;
+			// 	transition: flex-grow 0.2s;
+			// }
 
-			.item-preview__pane {
-				max-width: 0;
-				padding: 0;
-			}
+			// .item-preview__pane {
+			// 	max-width: 0;
+			// 	padding: 0;
+			// }
 
-			@media only screen and (min-width: $break-large) {
-				.sites-overview {
-					padding: 0;
-				}
-			}
-		}
+			// @media only screen and (min-width: $break-large) {
+			// 	.sites-overview {
+			// 		padding: 0;
+			// 	}
+			// }
+		// }
 
-		@media (max-width: 660px) {
-			.sites-overview__page-heading {
-				display: none;
-			}
-		}
+		// @media (max-width: 660px) {
+		// 	.sites-overview__page-heading {
+		// 		display: none;
+		// 	}
+		// }
 	}
 
 	.sites-overview__add-site-issue-license-buttons {
@@ -380,60 +380,60 @@
 		white-space: nowrap;
 	}
 
-	.sites-overview__column-action-button {
-		max-width: 100%;
-		display: inline-flex;
-		flex-direction: row;
-		justify-content: center;
-		align-items: center;
-		width: fit-content;
-		height: 22px;
-		background: var(--color-light-backdrop);
-		box-sizing: border-box;
-		border-radius: 12px; /* stylelint-disable-line scales/radii */
-		font-weight: 500;
-		font-size: 0.75rem;
-		vertical-align: middle;
-		color: var(--color-accent-80);
-		border: 1px solid var(--color-accent-5);
-		padding: 2px 11px;
-		cursor: pointer;
-		white-space: nowrap;
+	// .sites-overview__column-action-button {
+	// 	max-width: 100%;
+	// 	display: inline-flex;
+	// 	flex-direction: row;
+	// 	justify-content: center;
+	// 	align-items: center;
+	// 	width: fit-content;
+	// 	height: 22px;
+	// 	background: var(--color-light-backdrop);
+	// 	box-sizing: border-box;
+	// 	border-radius: 12px; /* stylelint-disable-line scales/radii */
+	// 	font-weight: 500;
+	// 	font-size: 0.75rem;
+	// 	vertical-align: middle;
+	// 	color: var(--color-accent-80);
+	// 	border: 1px solid var(--color-accent-5);
+	// 	padding: 2px 11px;
+	// 	cursor: pointer;
+	// 	white-space: nowrap;
 
-		span {
-			margin: 0 0.2em;
-		}
-		svg {
-			margin-inline-start: -0.4em;
-		}
-		&:hover:not(.is-link) {
-			background: var(--color-accent-80);
-			color: var(--color-light-backdrop);
-		}
+	// 	span {
+	// 		margin: 0 0.2em;
+	// 	}
+	// 	svg {
+	// 		margin-inline-start: -0.4em;
+	// 	}
+	// 	&:hover:not(.is-link) {
+	// 		background: var(--color-accent-80);
+	// 		color: var(--color-light-backdrop);
+	// 	}
 
-		&:visited:not(:hover) {
-			color: var(--color-accent-80);
-		}
+	// 	&:visited:not(:hover) {
+	// 		color: var(--color-accent-80);
+	// 	}
 
-		&.is-selected {
-			background: var(--color-jetpack-50);
-			color: var(--color-light-backdrop);
-			border: none;
-		}
+	// 	&.is-selected {
+	// 		background: var(--color-jetpack-50);
+	// 		color: var(--color-light-backdrop);
+	// 		border: none;
+	// 	}
 
-		&.is-link {
-			border: none;
-			background: none;
-			text-decoration: underline;
-			outline: none;
-			margin: 0;
-			padding: 0;
+	// 	&.is-link {
+	// 		border: none;
+	// 		background: none;
+	// 		text-decoration: underline;
+	// 		outline: none;
+	// 		margin: 0;
+	// 		padding: 0;
 
-			&:hover {
-				color: var(--color-accent-80);
-			}
-		}
-	}
+	// 		&:hover {
+	// 			color: var(--color-accent-80);
+	// 		}
+	// 	}
+	// }
 
 	.sites-overview__grey-icon {
 		vertical-align: middle;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

A spike to remove all A4A overrides from Sites Dashboard.

What feels broken;
- The site list is not scrollable
- The site pane is too wide
- Maybe minor
	- many margin/padding adjustments to make it look consistent on Dotcom
	- something that is not aligned with A4A (e.g., “Sites” title is not displayed on mobile)

![e1a1d2a71e6f91c75839d7347396754e](https://github.com/user-attachments/assets/9f95542f-de4f-48ab-9496-69e82569b949)

<img width="1434" alt="Screenshot 2024-12-13 at 16 50 07" src="https://github.com/user-attachments/assets/c0080e8d-3fbd-4087-b22f-777433796eed" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
