### PR TITLE
Goals step: Link to the logged-out DIFM flow

### DIFF
--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -117,8 +117,7 @@ const onboarding: Flow = {
 							return;
 
 						case SiteIntent.DIFM:
-							// TODO Implement exit to DIFM
-							return;
+							return window.location.assign( '/start/do-it-for-me' );
 
 						default: {
 							return navigate( 'domains' );

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -11,6 +11,7 @@ import {
 	setSignupCompleteSlug,
 } from 'calypso/signup/storageUtils';
 import { STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT } from '../constants';
+import { useFlowLocale } from '../hooks/use-flow-locale';
 import { useQuery } from '../hooks/use-query';
 import { ONBOARD_STORE } from '../stores';
 import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
@@ -82,6 +83,7 @@ const onboarding: Flow = {
 			setSiteUrl,
 			setSignupDomainOrigin,
 		} = useDispatch( ONBOARD_STORE );
+		const locale = useFlowLocale();
 
 		const { planCartItem, signupDomainOrigin } = useSelect(
 			( select: ( key: string ) => OnboardSelect ) => ( {
@@ -116,8 +118,14 @@ const onboarding: Flow = {
 							// TODO Implement exit to site migration
 							return;
 
-						case SiteIntent.DIFM:
-							return window.location.assign( '/start/do-it-for-me' );
+						case SiteIntent.DIFM: {
+							const difmFlowLink =
+								locale && locale !== 'en'
+									? `/start/do-it-for-me/${ locale }`
+									: '/start/do-it-for-me';
+
+							return window.location.assign( difmFlowLink );
+						}
 
 						default: {
 							return navigate( 'domains' );


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/97461.

## Proposed Changes

Point the "Let us build a custom site for you" link to "/start/do-it-for-me." The initial idea was to display the "DIFM Intro Screen" before sending the user to the flow, but there are some technical limitations, so we'll redirect them directly for now.

This PR does not attempt to rework the back button or move the Account step after the DIFM Intro Screen. These tasks will be handled at https://github.com/Automattic/wp-calypso/issues/97466.

## Why are these changes being made?

So the `/setup/onboarding` flow becomes more functional.

## Testing Instructions

As a logged-out user, go to `/setup/onboarding`, click the DIFM CTA, verify that you can create an account, click the "Get Started" button in the DIFM Intro Screen, fill out the details, pick a design, and proceed to checkout.

As a logged-in user, go to `/setup/onboarding`, click the DIFM CTA, verify you see the DIFM Intro Screen with the option to pick an existing site or create a new site. Then, you should be able to fill out the details and proceed to checkout.