### PR TITLE
Goals First experiment should only be assigned in onboarding flow

### DIFF
--- a/client/landing/stepper/declarative-flow/helpers/use-goals-first-experiment.ts
+++ b/client/landing/stepper/declarative-flow/helpers/use-goals-first-experiment.ts
@@ -1,5 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { useEffect, useState } from 'react';
+import { ONBOARDING_FLOW } from '@automattic/onboarding';
+import { useEffect, useMemo, useState } from 'react';
+import { getFlowFromURL } from '../../utils/get-flow-from-url';
 
 /**
  * Check whether the user should have the "goals first" onboarding experience.
@@ -12,9 +14,12 @@ import { useEffect, useState } from 'react';
  * i.e. when the feature flag is disabled.
  */
 export function useGoalsFirstExperiment(): [ boolean, boolean ] {
+	const flow = useMemo( () => getFlowFromURL(), [] );
+	const isEligible = isEnabled( 'onboarding/goals-first' ) && flow === ONBOARDING_FLOW;
+
 	const [ isLoading, setIsLoading ] = useState( true );
 	useEffect( () => {
-		if ( ! isEnabled( 'onboarding/goals-first' ) ) {
+		if ( ! isEligible ) {
 			return;
 		}
 
@@ -22,9 +27,9 @@ export function useGoalsFirstExperiment(): [ boolean, boolean ] {
 		return () => {
 			clearTimeout( id );
 		};
-	}, [] );
+	}, [ isEligible ] );
 
-	if ( ! isEnabled( 'onboarding/goals-first' ) ) {
+	if ( ! isEligible ) {
 		return [ false, false ];
 	}
 

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -16,7 +16,7 @@ import { useDispatch } from '@wordpress/data';
 import defaultCalypsoI18n from 'i18n-calypso';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
-import { BrowserRouter, matchPath } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 import { requestAllBlogsAccess } from 'wpcom-proxy-request';
 import { setupErrorLogger } from 'calypso/boot/common';
 import { setupLocale } from 'calypso/boot/locale';
@@ -43,6 +43,7 @@ import { USER_STORE } from './stores';
 import { setupWpDataDebug } from './utils/devtools';
 import { enhanceFlowWithAuth } from './utils/enhanceFlowWithAuth';
 import redirectPathIfNecessary from './utils/flow-redirect-handler';
+import { getFlowFromURL } from './utils/get-flow-from-url';
 import { startStepperPerformanceTracking } from './utils/performance-tracking';
 import { WindowLocaleEffectManager } from './utils/window-locale-effect-manager';
 import type { Flow } from './declarative-flow/internals/types';
@@ -78,13 +79,6 @@ interface AppWindow extends Window {
 }
 
 const DEFAULT_FLOW = 'site-setup';
-
-const getFlowFromURL = () => {
-	const fromPath = matchPath( { path: '/setup/:flow/*' }, window.location.pathname )?.params?.flow;
-	// backward support the old Stepper URL structure (?flow=something)
-	const fromQuery = new URLSearchParams( window.location.search ).get( 'flow' );
-	return fromPath || fromQuery;
-};
 
 const getSiteIdFromURL = () => {
 	const siteId = new URLSearchParams( window.location.search ).get( 'siteId' );

--- a/client/landing/stepper/utils/get-flow-from-url.ts
+++ b/client/landing/stepper/utils/get-flow-from-url.ts
@@ -1,0 +1,8 @@
+import { matchPath } from 'react-router-dom';
+
+export const getFlowFromURL = () => {
+	const fromPath = matchPath( { path: '/setup/:flow/*' }, window.location.pathname )?.params?.flow;
+	// backward support the old Stepper URL structure (?flow=something)
+	const fromQuery = new URLSearchParams( window.location.search ).get( 'flow' );
+	return fromPath || fromQuery;
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Adds eligibility check to the `useGoalsFirstExperiment` hook.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When this hook is implemented by a real A/B test under the hood then it will start to assign people to experiment variants. When the design picker starts calling this hook we don't want it to assign users to experiment variations unless it really needs to. For example when we're in the `site-setup` flow showing the design picker, we don't want it to assign the user to an experiment variation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm that this change doesn't alter any existing flows. There should be no observable change.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
