### PR TITLE
A4A > Client: Implement client invoices

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-client-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-client-menu-items.ts
@@ -1,7 +1,11 @@
-import { category, payment } from '@wordpress/icons';
+import { category, payment, receipt } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import { A4A_CLIENT_SUBSCRIPTIONS_LINK, A4A_CLIENT_PAYMENT_METHODS_LINK } from '../lib/constants';
+import {
+	A4A_CLIENT_SUBSCRIPTIONS_LINK,
+	A4A_CLIENT_PAYMENT_METHODS_LINK,
+	A4A_CLIENT_INVOICES_LINK,
+} from '../lib/constants';
 import { createItem } from '../lib/utils';
 
 const useClientMenuItems = ( path: string ) => {
@@ -25,6 +29,15 @@ const useClientMenuItems = ( path: string ) => {
 				title: translate( 'Payment methods' ),
 				trackEventProps: {
 					menu_item: 'Automattic for Agencies / Client > Payment methods',
+				},
+			},
+			{
+				icon: receipt,
+				path: '/',
+				link: A4A_CLIENT_INVOICES_LINK,
+				title: translate( 'Invoices' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Client > Invoices',
 				},
 			},
 		].map( ( item ) => createItem( item, path ) );

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -55,6 +55,7 @@ export const A4A_AGENCY_TIER_LINK = '/agency-tier';
 export const A4A_CLIENT_LANDING_LINK = '/client/landing';
 export const A4A_CLIENT_SUBSCRIPTIONS_LINK = '/client/subscriptions';
 export const A4A_CLIENT_PAYMENT_METHODS_LINK = '/client/payment-methods';
+export const A4A_CLIENT_INVOICES_LINK = '/client/invoices';
 export const A4A_CLIENT_PAYMENT_METHODS_ADD_LINK = `${ A4A_CLIENT_PAYMENT_METHODS_LINK }/add`;
 export const A4A_CLIENT_CHECKOUT = '/client/checkout';
 export const EXTERNAL_A4A_CLIENT_KNOWLEDGE_BASE =

--- a/client/a8c-for-agencies/data/purchases/use-fetch-invoices.ts
+++ b/client/a8c-for-agencies/data/purchases/use-fetch-invoices.ts
@@ -1,5 +1,5 @@
 import { useQuery, UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
-import { addQueryArgs } from 'calypso/lib/url';
+import { isClientView } from 'calypso/a8c-for-agencies/sections/purchases/payment-methods/lib/is-client-view';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -42,7 +42,9 @@ export const getFetchInvoicesQueryKey = ( {
 	agencyId?: number;
 	status?: InvoiceStatus;
 } ) => {
-	return [ 'a4a', 'invoices', starting_after, ending_before, agencyId, status ];
+	return isClientView()
+		? [ 'a4a-client-invoices', starting_after, ending_before, status ]
+		: [ 'a4a', 'invoices', starting_after, ending_before, agencyId, status ];
 };
 
 export default function useFetchInvoices(
@@ -51,20 +53,31 @@ export default function useFetchInvoices(
 	status?: InvoiceStatus
 ): UseQueryResult< Invoices, QueryError > {
 	const { starting_after, ending_before } = pagination;
+
 	const agencyId = useSelector( getActiveAgencyId );
+	const isClientUI = isClientView();
 
 	return useQuery< APIInvoices, QueryError, Invoices >( {
+		// isClientUI is used to send or not send the agency_id parameter to the API.
+		// eslint-disable-next-line @tanstack/query/exhaustive-deps
 		queryKey: getFetchInvoicesQueryKey( { starting_after, ending_before, agencyId, status } ),
 		queryFn: () =>
-			wpcom.req.get( {
-				apiNamespace: 'wpcom/v2',
-				path: addQueryArgs(
-					{ starting_after, ending_before, agency_id: agencyId, status },
-					'/jetpack-licensing/partner/invoices'
-				),
-			} ),
+			wpcom.req.get(
+				{
+					apiNamespace: 'wpcom/v2',
+					path: isClientUI
+						? '/agency-client/stripe/invoices'
+						: '/jetpack-licensing/partner/invoices',
+				},
+				{
+					...( ! isClientUI && agencyId && { agency_id: agencyId } ),
+					starting_after,
+					ending_before,
+					status,
+				}
+			),
 		refetchOnWindowFocus: false,
-		enabled: !! agencyId,
+		enabled: isClientUI || !! agencyId,
 		select: selectInvoices,
 		...options,
 	} );

--- a/client/a8c-for-agencies/sections/client/controller.tsx
+++ b/client/a8c-for-agencies/sections/client/controller.tsx
@@ -3,6 +3,7 @@ import { getQueryArg } from '@wordpress/url';
 import SidebarPlaceholder from 'calypso/a8c-for-agencies/components/sidebar-placeholder';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import ClientSidebar from '../../components/sidebar-menu/client';
+import InvoicesOverview from '../purchases/invoices/invoices-overview';
 import PaymentMethodAdd from '../purchases/payment-methods/payment-method-add';
 import PaymentMethodOverview from '../purchases/payment-methods/payment-method-overview';
 import ClientLanding from './client-landing';
@@ -50,6 +51,17 @@ export const clientPaymentMethodsAddContext: Callback = ( context, next ) => {
 	if ( ! agencyId ) {
 		context.secondary = <ClientSidebar path={ context.path } />;
 	}
+	next();
+};
+
+export const clientInvoicesContext: Callback = ( context, next ) => {
+	context.primary = (
+		<>
+			<PageViewTracker title="Client > Invoices" path={ context.path } />
+			<InvoicesOverview />
+		</>
+	);
+	context.secondary = <ClientSidebar path={ context.path } />;
 	next();
 };
 

--- a/client/a8c-for-agencies/sections/client/index.tsx
+++ b/client/a8c-for-agencies/sections/client/index.tsx
@@ -4,6 +4,7 @@ import {
 	A4A_CLIENT_SUBSCRIPTIONS_LINK,
 	A4A_CLIENT_PAYMENT_METHODS_LINK,
 	A4A_CLIENT_PAYMENT_METHODS_ADD_LINK,
+	A4A_CLIENT_INVOICES_LINK,
 	A4A_CLIENT_CHECKOUT,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { requireClientAccessContext } from 'calypso/a8c-for-agencies/controller';
@@ -30,6 +31,13 @@ export default function () {
 		A4A_CLIENT_PAYMENT_METHODS_ADD_LINK,
 		requireClientAccessContext,
 		controller.clientPaymentMethodsAddContext,
+		makeLayout,
+		clientRender
+	);
+	page(
+		A4A_CLIENT_INVOICES_LINK,
+		requireClientAccessContext,
+		controller.clientInvoicesContext,
 		makeLayout,
 		clientRender
 	);

--- a/client/sections.js
+++ b/client/sections.js
@@ -902,6 +902,7 @@ const sections = [
 			'/client/subscriptions',
 			'/client/payment-methods',
 			'/client/payment-methods/add',
+			'/client/invoices',
 			'/client/checkout',
 		],
 		module: 'calypso/a8c-for-agencies/sections/client',


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1204

## Proposed Changes

This PR implements client invoices for A4A.

## Why are these changes being made?

* As we got multiple requests from agencies asking for this feature, we are now implementing a way for them to view and download the invoices for the clients. 

## Testing Instructions

* Switch to the branch locally and start the server
* Login using a client account > Verify you can see the Invoices tab and invoices load.

<img width="1723" alt="Screenshot 2024-12-13 at 11 32 57 AM" src="https://github.com/user-attachments/assets/24c4b97e-247e-41a0-af65-16c02237e382" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
