### PR TITLE
Design Picker: Dedupe themes shown on the Recommended themes section

### DIFF
--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -299,7 +299,6 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 } ) => {
 	const translate = useTranslate();
 	const { selectedCategoriesWithoutDesignTier } = useDesignPickerFilters();
-	const { all, best, ...designsByGroup } = useFilteredDesignsByGroup( designs );
 
 	const categories = categorization?.categories || [];
 
@@ -329,6 +328,10 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 		isMultiFilterEnabled &&
 		! categorization?.isSelectionsChanged &&
 		recommendedDesigns.length === 3;
+
+	const { all, best, ...designsByGroup } = useFilteredDesignsByGroup( designs, {
+		excludeDesigns: showRecommendedDesigns ? recommendedDesigns : [],
+	} );
 
 	// Show no results only when the recommended themes is hidden and no design matches the selected categories and tiers.
 	const showNoResults =

--- a/packages/design-picker/src/hooks/use-filtered-designs.ts
+++ b/packages/design-picker/src/hooks/use-filtered-designs.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { isBlankCanvasDesign } from '../utils';
+import { isBlankCanvasDesign, getDesignSlug } from '../utils';
 import { useDesignPickerFilters } from './use-design-picker-filters';
 import type { Design } from '../types';
 
@@ -62,22 +62,38 @@ export const getFilteredDesignsByCategory = (
 	return filteredDesignsByCategory;
 };
 
-export const useFilteredDesignsByGroup = ( designs: Design[] ): { [ key: string ]: Design[] } => {
+interface UseFilteredDesignsByGroupOptions {
+	excludeDesigns?: Design[];
+}
+
+export const useFilteredDesignsByGroup = (
+	designs: Design[],
+	{ excludeDesigns }: UseFilteredDesignsByGroupOptions = {}
+): { [ key: string ]: Design[] } => {
 	const { selectedCategoriesWithoutDesignTier, selectedDesignTiers } = useDesignPickerFilters();
 
 	const filteredDesigns = useMemo( () => {
+		const excludeDesignSlugs = excludeDesigns
+			? excludeDesigns.map( ( design ) => getDesignSlug( design ) )
+			: [];
+		const excludeDesignSlugsSet = new Set( excludeDesignSlugs );
+		const all =
+			excludeDesignSlugs.length > 0
+				? designs.filter( ( design ) => ! excludeDesignSlugsSet.has( getDesignSlug( design ) ) )
+				: designs;
+
 		if ( selectedCategoriesWithoutDesignTier.length > 0 || selectedDesignTiers.length > 0 ) {
 			return getFilteredDesignsByCategory(
-				designs,
+				all,
 				selectedCategoriesWithoutDesignTier,
 				selectedDesignTiers
 			);
 		}
 
 		return {
-			all: designs,
+			all,
 		};
-	}, [ designs, selectedCategoriesWithoutDesignTier ] );
+	}, [ designs, excludeDesigns, selectedCategoriesWithoutDesignTier, selectedDesignTiers ] );
 
 	return filteredDesigns;
 };

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -44,3 +44,5 @@ export function isBlankCanvasDesign( design?: Design ): boolean {
 	}
 	return /blank-canvas/i.test( design.slug ) && ! design.is_virtual;
 }
+
+export const getDesignSlug = ( design: Design ) => design.recipe?.slug || design.slug;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1734075867537459/1734068865.321919-slack-CRWCHQGUB

## Proposed Changes

* Dedupe themes shown on the Recommended themes section

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* On the Goals screen, select `Promote my business` & `Sell services or digital goods`
* On the Design Picker screen, ensure themes shown on the Recommended themes section are not shown on other sections

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?