### PR TITLE
Add delete site option to sites kebab menu

### DIFF
--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -238,7 +238,8 @@ export const isActionEligible = (
 			};
 		case 'delete-site':
 			return ( site: SiteExcerptData ) => {
-				return ! site.is_deleted && ! isNotAtomicJetpack( site );
+				const canManageOptions = capabilities[ site.ID ]?.manage_options;
+				return ! site.is_deleted && canManageOptions && site.jetpack;
 			};
 		default:
 			return () => true;

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -240,7 +240,10 @@ export const isActionEligible = (
 			return ( site: SiteExcerptData ) => {
 				const canManageOptions = capabilities[ site.ID ]?.manage_options;
 				return (
-					! site.is_deleted && canManageOptions && ( ! site.jetpack || !! site.is_wpcom_atomic )
+					! site.is_deleted &&
+					canManageOptions &&
+					( ! site.jetpack || !! site.is_wpcom_atomic ) &&
+					! site.is_vip
 				);
 			};
 		default:

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -236,6 +236,10 @@ export const isActionEligible = (
 
 				return isNotAtomicJetpack( site ) || !! isDisconnectedJetpackAndNotAtomic( site );
 			};
+		case 'delete-site':
+			return ( site: SiteExcerptData ) => {
+				return ! site.is_deleted && ! isNotAtomicJetpack( site );
+			};
 		default:
 			return () => true;
 	}
@@ -557,6 +561,17 @@ export function useActions( {
 					recordTracksEvent( 'calypso_sites_dashboard_site_action_migrate_to_wpcom_click' );
 				},
 				isEligible: isActionEligible( 'migrate-to-wpcom', capabilities ),
+			},
+
+			{
+				id: 'delete-site',
+				label: __( 'Delete site' ),
+				callback: ( sites ) => {
+					const site = sites[ 0 ];
+					page( `/sites/settings/administration/${ site.slug }/delete-site` );
+					dispatch( recordTracksEvent( 'calypso_sites_dashboard_site_action_delete_click' ) );
+				},
+				isEligible: isActionEligible( 'delete-site', capabilities ),
 			},
 		],
 		[ __, capabilities, dispatch, openSitePreviewPane, restoreSite, viewType, localizeUrl ]

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -239,7 +239,9 @@ export const isActionEligible = (
 		case 'delete-site':
 			return ( site: SiteExcerptData ) => {
 				const canManageOptions = capabilities[ site.ID ]?.manage_options;
-				return ! site.is_deleted && canManageOptions && site.jetpack;
+				return (
+					! site.is_deleted && canManageOptions && ( ! site.jetpack || !! site.is_wpcom_atomic )
+				);
 			};
 		default:
 			return () => true;
@@ -569,7 +571,7 @@ export function useActions( {
 				label: __( 'Delete site' ),
 				callback: ( sites ) => {
 					const site = sites[ 0 ];
-					page( `/sites/settings/administration/${ site.slug }/delete-site` );
+					page( `/settings/delete-site/${ site.slug }` );
 					dispatch( recordTracksEvent( 'calypso_sites_dashboard_site_action_delete_click' ) );
 				},
 				isEligible: isActionEligible( 'delete-site', capabilities ),

--- a/packages/sites/src/site-excerpt-constants.ts
+++ b/packages/sites/src/site-excerpt-constants.ts
@@ -6,6 +6,7 @@ export const SITE_EXCERPT_REQUEST_FIELDS = [
 	'is_coming_soon',
 	'is_private',
 	'is_deleted',
+	'is_vip',
 	'visible',
 	'launch_status',
 	'icon',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: #95300 

## Proposed Changes

* Adds new option `Delete site` to the sites kebab menu
* Click takes to `/sites/settings/administration/${ site.slug }/delete-site`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/sites` and open the kebab menu of any of the site.
* It should have new option `Delete site`
* Click should take to site deletion page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
