### PR TITLE
A4A > Referrals: Implement commissions payment delayed banner

### DIFF
--- a/client/a8c-for-agencies/components/a4a-payment-delayed-notice/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-payment-delayed-notice/index.tsx
@@ -1,0 +1,40 @@
+import { useTranslate } from 'i18n-calypso';
+import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
+
+import './style.scss';
+
+const PAYMENT_DELAYED_DISMISS_PREFERENCE = 'a4a-payment-delayed-notice-dismissed';
+
+const A4APaymentDelayedNotice = () => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const dismissNotice = () => {
+		dispatch( savePreference( PAYMENT_DELAYED_DISMISS_PREFERENCE, true ) );
+		dispatch( recordTracksEvent( 'calypso_a4a_payment_delayed_notice_dismissed' ) );
+	};
+
+	const isDismissed = useSelector( ( state ) =>
+		getPreference( state, PAYMENT_DELAYED_DISMISS_PREFERENCE )
+	);
+
+	if ( isDismissed ) {
+		return null;
+	}
+
+	return (
+		<LayoutBanner level="warning" onClose={ dismissNotice } className="a4a-payment-delayed-notice">
+			<div>
+				{ translate(
+					'December 1 payouts have been postponed to December 31 due to higher-than-usual volume. We apologize for any inconvenience.'
+				) }
+			</div>
+		</LayoutBanner>
+	);
+};
+
+export default A4APaymentDelayedNotice;

--- a/client/a8c-for-agencies/components/a4a-payment-delayed-notice/style.scss
+++ b/client/a8c-for-agencies/components/a4a-payment-delayed-notice/style.scss
@@ -1,0 +1,3 @@
+.a4a-payment-delayed-notice {
+	margin-block-end: 24px;
+}

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
@@ -2,6 +2,7 @@ import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useState } from 'react';
+import A4APaymentDelayedNotice from 'calypso/a8c-for-agencies/components/a4a-payment-delayed-notice';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -12,6 +13,7 @@ import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_MIGRATIONS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
+import useGetTipaltiPayee from 'calypso/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-payee';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import MigrationsCommissionsList from '../../commissions-list';
@@ -25,6 +27,10 @@ import './style.scss';
 export default function MigrationsCommissions() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const { data: tipaltiData } = useGetTipaltiPayee();
+
+	const isPayable = !! tipaltiData?.IsPayable;
 
 	const [ showAddSitesModal, setShowAddSitesModal ] = useState( false );
 
@@ -75,6 +81,7 @@ export default function MigrationsCommissions() {
 			wide
 		>
 			<LayoutTop>
+				{ isPayable && ! showEmptyState && <A4APaymentDelayedNotice /> }
 				<LayoutHeader>
 					<Breadcrumb
 						hideOnMobile

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -6,6 +6,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
 import { A4AFeedback } from 'calypso/a8c-for-agencies/components/a4a-feedback';
 import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
+import A4APaymentDelayedNotice from 'calypso/a8c-for-agencies/components/a4a-payment-delayed-notice';
 import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
 import {
 	DATAVIEWS_TABLE,
@@ -130,6 +131,8 @@ export default function ReferralsOverview( {
 							<MissingPaymentSettingsNotice onClose={ () => setRequiredNoticeClosed( true ) } />
 						</div>
 					) }
+
+					{ hasReferrals && isPayable && ! actionRequiredNotice && <A4APaymentDelayedNotice /> }
 
 					{ ! isAutomatedReferral && <AutomatedReferralComingSoonBanner /> }
 


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1595

## Proposed Changes

This PR implements a banner to inform users that the commission payment is delayed.

## Testing Instructions

* Open the A4A live link
* Go to the Referrals page > Verify the banner is displayed as shown below. This will be shown only if the Tipalti status is payable & there are referrals. Please don't dismiss the banner yet.

<img width="1728" alt="Screenshot 2024-12-13 at 3 21 44 PM" src="https://github.com/user-attachments/assets/d954aa1d-bf51-4c97-830d-f642fd2fb2cd" />

* Go to Migrations > Commissions page > Verify the banner is displayed as shown below.  This will be shown only if the Tipalti status is payable & there are tagged sites for commissions.

<img width="1728" alt="Screenshot 2024-12-13 at 3 22 25 PM" src="https://github.com/user-attachments/assets/dbbb6b95-a5a4-47a0-a364-c10e10e8ed6a" />

* Dismiss the banner and verify it is not shown again on the commission's page or referrals page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
