### PR TITLE
Help Center: articles missing header translation

### DIFF
--- a/packages/help-center/src/components/help-center-support-article-header.tsx
+++ b/packages/help-center/src/components/help-center-support-article-header.tsx
@@ -1,5 +1,6 @@
 import { ExternalLink } from '@automattic/components';
 import { decodeEntities } from '@wordpress/html-entities';
+import { __ } from '@wordpress/i18n';
 import type { PostObject } from '../types';
 
 export const SupportArticleHeader = ( {
@@ -21,7 +22,7 @@ export const SupportArticleHeader = ( {
 				target="_blank"
 				icon
 			>
-				Open support page
+				{ __( 'Open support page', __i18n_text_domain__ ) }
 			</ExternalLink>
 			<h1 className="help-center-article-content__header-title">
 				{ decodeEntities( post.title ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/97000/files#r1883899412

## Proposed Changes

* Add missing translation

<img width="444" alt="image" src="https://github.com/user-attachments/assets/d8a71bca-06a1-491b-a328-962d342d2f8c" />

