### PR TITLE
Checkout: Recursively serialize error causes when logging errors

### DIFF
--- a/client/my-sites/checkout/src/lib/analytics.ts
+++ b/client/my-sites/checkout/src/lib/analytics.ts
@@ -9,11 +9,44 @@ import {
 import type { CheckoutPaymentMethodSlug } from '@automattic/wpcom-checkout';
 import type { CalypsoDispatch } from 'calypso/state/types';
 
-export function convertErrorToString( error: Error ): string {
-	if ( error.cause ) {
-		return `${ error }; Cause: ${ error.cause }; Stack: ${ error.stack }`;
+function serializeCaughtError(
+	// This may come from Error.cause which I'm pretty sure has no defined
+	// type. It can be used to keep another Error but it could also be anything
+	// else so let's not make any assumptions. Also things other than Error
+	// objects can be thrown so let's not even assume this is an Error.
+	error: unknown
+): string {
+	const messages = [];
+	messages.push( getErrorMessageFromError( error ) );
+	const errorObject = error as Error;
+	if ( 'cause' in errorObject && errorObject.cause ) {
+		const cause = serializeCaughtError( errorObject.cause );
+		messages.push( `(Cause: ${ cause })` );
 	}
-	return `${ error }; Stack: ${ error.stack }`;
+	if ( 'stack' in errorObject && errorObject.stack ) {
+		messages.push( `(Stack: ${ errorObject.stack })` );
+	}
+	return messages.join( '; ' );
+}
+
+function getErrorMessageFromError( error: unknown ): string {
+	const errorObject = error as Error;
+	if ( 'message' in errorObject && errorObject.message ) {
+		return `Message: ${ errorObject.message }`;
+	}
+	return `Non-Error: ${ error }`;
+}
+
+/**
+ * Convert a thrown error to a string for logging.
+ *
+ * I've typed this function as requiring an Error because that's the intended
+ * behavior and I'd like TypeScript to enforce that as best as it can. However,
+ * other things can be thrown besides Error objects and so this will actually
+ * handle other things like strings just fine.
+ */
+export function convertErrorToString( error: Error ): string {
+	return serializeCaughtError( error );
 }
 
 export function logStashLoadErrorEvent(

--- a/client/my-sites/checkout/src/lib/analytics.ts
+++ b/client/my-sites/checkout/src/lib/analytics.ts
@@ -14,16 +14,17 @@ function serializeCaughtError(
 	// type. It can be used to keep another Error but it could also be anything
 	// else so let's not make any assumptions. Also things other than Error
 	// objects can be thrown so let's not even assume this is an Error.
-	error: unknown
+	error: unknown,
+	includeStack: boolean
 ): string {
 	const messages = [];
 	messages.push( getErrorMessageFromError( error ) );
 	const errorObject = error as Error;
 	if ( 'cause' in errorObject && errorObject.cause ) {
-		const cause = serializeCaughtError( errorObject.cause );
+		const cause = serializeCaughtError( errorObject.cause, includeStack );
 		messages.push( `(Cause: ${ cause })` );
 	}
-	if ( 'stack' in errorObject && errorObject.stack ) {
+	if ( includeStack && 'stack' in errorObject && errorObject.stack ) {
 		messages.push( `(Stack: ${ errorObject.stack })` );
 	}
 	return messages.join( '; ' );
@@ -46,7 +47,10 @@ function getErrorMessageFromError( error: unknown ): string {
  * handle other things like strings just fine.
  */
 export function convertErrorToString( error: Error ): string {
-	return serializeCaughtError( error );
+	// We do not include the Stack trace because it will be minified and won't
+	// be of much use. It makes the actual error message more difficult to
+	// read.
+	return serializeCaughtError( error, false );
 }
 
 export function logStashLoadErrorEvent(

--- a/client/my-sites/checkout/src/lib/analytics.ts
+++ b/client/my-sites/checkout/src/lib/analytics.ts
@@ -14,17 +14,21 @@ function serializeCaughtError(
 	// type. It can be used to keep another Error but it could also be anything
 	// else so let's not make any assumptions. Also things other than Error
 	// objects can be thrown so let's not even assume this is an Error.
-	error: unknown,
-	includeStack: boolean
+	error: unknown
 ): string {
 	const messages = [];
 	messages.push( getErrorMessageFromError( error ) );
+	let hasCause = false;
 	const errorObject = error as Error;
 	if ( 'cause' in errorObject && errorObject.cause ) {
-		const cause = serializeCaughtError( errorObject.cause, includeStack );
+		hasCause = true;
+		const cause = serializeCaughtError( errorObject.cause );
 		messages.push( `(Cause: ${ cause })` );
 	}
-	if ( includeStack && 'stack' in errorObject && errorObject.stack ) {
+	// We only include the stack trace if there is no cause, meaning this is
+	// the deepest error in the chain. The others are all likely re-thrown
+	// errors so we should know their stack trace already.
+	if ( ! hasCause && 'stack' in errorObject && errorObject.stack ) {
 		messages.push( `(Stack: ${ errorObject.stack })` );
 	}
 	return messages.join( '; ' );
@@ -47,10 +51,7 @@ function getErrorMessageFromError( error: unknown ): string {
  * handle other things like strings just fine.
  */
 export function convertErrorToString( error: Error ): string {
-	// We do not include the Stack trace because it will be minified and won't
-	// be of much use. It makes the actual error message more difficult to
-	// read.
-	return serializeCaughtError( error, false );
+	return serializeCaughtError( error );
 }
 
 export function logStashLoadErrorEvent(

--- a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
+++ b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
@@ -63,9 +63,6 @@ function PayPalSubmitButtonWrapper( {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
 } ) {
-	useEffect( () => {
-		throw new Error( 'testing error' );
-	}, [] );
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	return (

--- a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
+++ b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
@@ -63,6 +63,9 @@ function PayPalSubmitButtonWrapper( {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
 } ) {
+	useEffect( () => {
+		throw new Error( 'testing error' );
+	}, [] );
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	return (


### PR DESCRIPTION
## Proposed Changes

When a checkout error boundary catches a render-time error, it serializes it to a string and logs it by sending the error to logstash. To serialize it, we use a function called `convertErrorToString()` which tries to capture the error message, its stack trace, and (if it exists), the `cause` property, which is often used to keep track of an underlying Error when re-throwing an Error.

However, if the underlying Error _also_ has a `cause`, then that may be lost by this serialization. Notably, the changes in https://github.com/Automattic/wp-calypso/pull/97432 stack a `cause` on an Error that already has one.

In this PR we modify `convertErrorToString()` so it recursively serializes the `cause` of every Error.

In addition, this PR stops logging the stack trace of the errors that have a `cause` because only the trace of the deepest error is likely to be useful.

## Testing Instructions

To test this you'll need to be using a local dev environment. Edit the source code to apply this diff:

```diff
diff --git a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
index 6a6be693a25..4adf9cf7bd6 100644
--- a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
+++ b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
@@ -63,6 +63,9 @@ function PayPalSubmitButtonWrapper( {
        disabled?: boolean;
        onClick?: ProcessPayment;
 } ) {
+       useEffect( () => {
+               throw new Error( 'testing error' );
+       }, [] );
        const cartKey = useCartKey();
        const { responseCart } = useShoppingCart( cartKey );
        return (
```

- Using this modified calypso, add a product to your cart and visit checkout. Make sure to have your browser devtools open to the network requests page.
- View the network requests to the `https://public-api.wordpress.com/rest/v1.1/logstash` endpoint. Examine the payload of each request. Find one that mentions `composite checkout load error`.
- View the contents of the logged error. It should look something like this, including two layers of causes:

```
Message: Error while rendering submit button for payment method 'paypal-js': 
There was a problem with the submit button.; 
(Cause: Message: There was a problem with the submit button.; (Cause: Message: testing error; (Stack: ... )))
```