### PR TITLE
Reader: Fix CSS padding on mobile subscription manager

### DIFF
--- a/client/reader/site-subscriptions-manager/style.scss
+++ b/client/reader/site-subscriptions-manager/style.scss
@@ -29,12 +29,11 @@
 	}
 }
 
-.site-subscriptions-manager {
+body.is-section-reader .layout.is-section-reader .site-subscriptions-manager {
 	&.main {
 		max-width: 1168px;
 		min-height: 100vh;
 		margin: 0 auto;
-		padding: 0 32px;
 
 		@media (max-width: $break-small) {
 			padding: 0 16px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fix padding on the mobile view of /read/subscriptions by increasing CSS selector specificity and removing an unnecessary style.

Before | After
--|--
<img width="388" alt="Screenshot 2024-12-13 at 11 01 55 AM" src="https://github.com/user-attachments/assets/5dee8e5c-bb67-4661-a43b-097f4164c605" />  | <img width="387" alt="Screenshot 2024-12-13 at 11 02 03 AM" src="https://github.com/user-attachments/assets/f08e4275-2933-4faa-b601-359914a0f900" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /read/subscriptions on desktop.
* Test various widths and confirm nothing has changed on widths > 600px. Widths < 600px should look improved.
* Test the mobile view of /read/subscriptions. The padding should look improved.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
