### PR TITLE
Help Center: Avoid authenticating to Zendesk for free users

### DIFF
--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -41,7 +41,11 @@ const initSmooch = ( {
 };
 
 const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } ) => {
-	const { data: authData } = useAuthenticateZendeskMessaging( enableAuth, 'messenger' );
+	const { isEligibleForChat } = useChatStatus();
+	const { data: authData } = useAuthenticateZendeskMessaging(
+		enableAuth && isEligibleForChat,
+		'messenger'
+	);
 	const smoochRef = useRef< HTMLDivElement >( null );
 	const { isHelpCenterShown, isChatLoaded } = useSelect( ( select ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
@@ -51,7 +55,6 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 		};
 	}, [] );
 
-	const { isEligibleForChat } = useChatStatus();
 	const { isMessagingScriptLoaded } = useLoadZendeskMessaging(
 		'zendesk_support_chat_key',
 		isHelpCenterShown && isEligibleForChat,

--- a/packages/odie-client/src/components/send-message-input/attachment-button.tsx
+++ b/packages/odie-client/src/components/send-message-input/attachment-button.tsx
@@ -34,8 +34,11 @@ const getPlaceholderAttachmentMessage = ( file: File ) => {
 };
 
 export const AttachmentButton: React.FC = () => {
-	const { chat, addMessage, trackEvent } = useOdieAssistantContext();
-	const { data: authData } = useAuthenticateZendeskMessaging( true, 'messenger' );
+	const { chat, addMessage, trackEvent, isUserEligibleForPaidSupport } = useOdieAssistantContext();
+	const { data: authData } = useAuthenticateZendeskMessaging(
+		isUserEligibleForPaidSupport,
+		'messenger'
+	);
 	const { isPending: isAttachingFile, mutateAsync: attachFileToConversation } =
 		useAttachFileToConversation();
 	const { zendeskClientId } = useSelect( ( select ) => {

--- a/packages/zendesk-client/src/use-authenticate-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-authenticate-zendesk-messaging.ts
@@ -19,7 +19,7 @@ const VERSION = 'v1';
 let isLoggedIn = false;
 
 export function useAuthenticateZendeskMessaging(
-	enabled = true,
+	enabled = false,
 	type: ZendeskAuthType = 'zendesk'
 ) {
 	const currentEnvironment = config( 'env_id' );

--- a/packages/zendesk-client/src/use-load-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-load-zendesk-messaging.ts
@@ -13,8 +13,8 @@ import type { ZendeskConfigName } from './types';
 
 export function useLoadZendeskMessaging(
 	keyConfigName: ZendeskConfigName,
-	enabled = true,
-	tryAuthenticating = true,
+	enabled = false,
+	tryAuthenticating = false,
 	shouldUseHelpCenterExperience = false
 ) {
 	const [ isMessagingScriptLoaded, setMessagingScriptLoaded ] = useState( false );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Avoid zd auth for free users

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Avoid unnecessary zendesk api calls 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test for regressions
* Test with a free user
* Open the help center
* Check if the chat auth request is not sent `wpcom/v2/help/authenticate`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
