### PR TITLE
Checkout: Add tags to sentry error log in checkout error boundary

### DIFF
--- a/client/my-sites/checkout/src/lib/analytics.ts
+++ b/client/my-sites/checkout/src/lib/analytics.ts
@@ -59,7 +59,9 @@ export function logStashLoadErrorEvent(
 	error: Error,
 	additionalData: Record< string, string | number | undefined > = {}
 ): Promise< void > {
-	captureException( error.cause ? error.cause : error );
+	captureException( error, {
+		tags: { calypso_checkout: 'true', error_type: errorType, ...additionalData },
+	} );
 	return logStashEvent( 'composite checkout load error', {
 		...additionalData,
 		type: errorType,

--- a/client/my-sites/checkout/src/lib/analytics.ts
+++ b/client/my-sites/checkout/src/lib/analytics.ts
@@ -14,7 +14,10 @@ function serializeCaughtError(
 	// type. It can be used to keep another Error but it could also be anything
 	// else so let's not make any assumptions. Also things other than Error
 	// objects can be thrown so let's not even assume this is an Error.
-	error: unknown
+	error: unknown,
+	options: {
+		excludeStack?: boolean;
+	} = {}
 ): string {
 	const messages = [];
 	messages.push( getErrorMessageFromError( error ) );
@@ -22,13 +25,13 @@ function serializeCaughtError(
 	const errorObject = error as Error;
 	if ( 'cause' in errorObject && errorObject.cause ) {
 		hasCause = true;
-		const cause = serializeCaughtError( errorObject.cause );
+		const cause = serializeCaughtError( errorObject.cause, options );
 		messages.push( `(Cause: ${ cause })` );
 	}
 	// We only include the stack trace if there is no cause, meaning this is
 	// the deepest error in the chain. The others are all likely re-thrown
 	// errors so we should know their stack trace already.
-	if ( ! hasCause && 'stack' in errorObject && errorObject.stack ) {
+	if ( ! options?.excludeStack && ! hasCause && 'stack' in errorObject && errorObject.stack ) {
 		messages.push( `(Stack: ${ errorObject.stack })` );
 	}
 	return messages.join( '; ' );
@@ -60,7 +63,12 @@ export function logStashLoadErrorEvent(
 	additionalData: Record< string, string | number | undefined > = {}
 ): Promise< void > {
 	captureException( error, {
-		tags: { calypso_checkout: 'true', error_type: errorType, ...additionalData },
+		tags: {
+			serialized_message: serializeCaughtError( error, { excludeStack: true } ),
+			calypso_checkout: 'true',
+			error_type: errorType,
+			...additionalData,
+		},
 	} );
 	return logStashEvent( 'composite checkout load error', {
 		...additionalData,


### PR DESCRIPTION
## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/87506 (and some earlier diffs; see that issue for details) we began sending errors caught by the `CheckoutErrorBoundary` React error boundary component to Sentry for logging. However, it's often difficult to determine what is going on when we look at the data for these events. In this PR we add some tags to help differentiate the events.

In addition, this diff reverts the changes to the Sentry logging in https://github.com/Automattic/wp-calypso/pull/79766 which sent the `cause` property of an error instead of the top-level Error. Since Errors can have nested levels of `cause` (see https://github.com/Automattic/wp-calypso/pull/97432), that behavior is too simple and may in fact miss important info contained in the top-level error. Instead I think we must rely on Sentry's ability to parse nested Errors. However, for some additional context I've included the custom serialized error message (see https://github.com/Automattic/wp-calypso/pull/97468) in the tags which includes all levels of the error.

## Testing Instructions

I don't think there's a way to really test this. A visual check should be enough.

You can use the test instructions in https://github.com/Automattic/wp-calypso/pull/97468 to make sure that this doesn't cause any new errors at least!