### PR TITLE
Fixes the Blaze Dashboad app in older versions of Jetpack

### DIFF
--- a/apps/blaze-dashboard/src/styles/wp-admin.scss
+++ b/apps/blaze-dashboard/src/styles/wp-admin.scss
@@ -32,6 +32,10 @@
 	box-sizing: border-box;
 }
 
+.components-popover .components-popover__content .components-button:focus:not(:disabled) {
+	box-shadow: none;
+}
+
 // Since the component `Notice` styles affect the WP Admin notice styles,
 // we need to restore by overriding them except for `.wpcomsh-notice` on Atomic sites.
 .notice:not(.wpcomsh-notice, .promote-post-notice) {

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -429,6 +429,11 @@ export const useJetpackBlazeVersionCheck = (
 	const blazeAdsVersion =
 		useSelector( ( state ) => getSiteOption( state, siteId, 'blaze_ads_version' ) ) ?? 0;
 
+	// If we don't have a version (Jetpack or Blaze Ads), we must be in a simple site, and we use latest Jetpack version in there.
+	if ( ! siteJetpackVersion && ! blazeAdsVersion ) {
+		return true;
+	}
+
 	return Boolean(
 		( siteJetpackVersion && versionCompare( siteJetpackVersion, minJetpackVersion, '>=' ) ) ||
 			( blazeAdsVersion && versionCompare( siteJetpackVersion, minBlazeAdsVersion, '>=' ) )

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -411,3 +411,26 @@ export const usePromoteWidget = (): PromoteWidgetStatus => {
 			return PromoteWidgetStatus.FETCHING;
 	}
 };
+
+/**
+ * Hook to verify if Jetpack/Blaze Ads version is greater than or equals the provided versions.
+ * It will return true if any of the checks passes.
+ * @param siteId Site Id.
+ * @param minJetpackVersion Minimum Jetpack version to check.
+ * @param minBlazeAdsVersion Minimum Blaze Ads version to check.
+ */
+export const useJetpackBlazeVersionCheck = (
+	siteId: number,
+	minJetpackVersion: string,
+	minBlazeAdsVersion: string
+): boolean => {
+	const siteJetpackVersion =
+		useSelector( ( state ) => getSiteOption( state, siteId, 'jetpack_version' ) ) ?? 0;
+	const blazeAdsVersion =
+		useSelector( ( state ) => getSiteOption( state, siteId, 'blaze_ads_version' ) ) ?? 0;
+
+	return Boolean(
+		( siteJetpackVersion && versionCompare( siteJetpackVersion, minJetpackVersion, '>=' ) ) ||
+			( blazeAdsVersion && versionCompare( siteJetpackVersion, minBlazeAdsVersion, '>=' ) )
+	);
+};

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
 import { chevronDown, chevronLeft, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment/moment';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import InfoPopover from 'calypso/components/info-popover';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -25,6 +25,7 @@ import {
 	Order,
 } from 'calypso/data/promote-post/use-promote-post-campaigns-query';
 import useCancelCampaignMutation from 'calypso/data/promote-post/use-promote-post-cancel-campaign-mutation';
+import { useJetpackBlazeVersionCheck } from 'calypso/lib/promote-post';
 import AdPreview from 'calypso/my-sites/promote-post-i2/components/ad-preview';
 import AdPreviewModal from 'calypso/my-sites/promote-post-i2/components/campaign-item-details/AdPreviewModal';
 import CampaignDownloadStats from 'calypso/my-sites/promote-post-i2/components/campaign-item-details/CampaignDownloadStats';
@@ -334,11 +335,13 @@ export default function CampaignItemDetails( props: Props ) {
 		setSelectedDateRange( newDateRange );
 	};
 
+	const areStatsEnabled = useJetpackBlazeVersionCheck( siteId, '14.1', '0.5.3' );
+
 	const campaignStatsQuery = useCampaignChartStatsQuery(
 		siteId,
 		campaignId,
 		chartParams,
-		!! impressions_total
+		!! impressions_total && areStatsEnabled
 	);
 	const { isLoading: campaignsStatsIsLoading } = campaignStatsQuery;
 	const { data: campaignStats } = campaignStatsQuery;
@@ -837,69 +840,71 @@ export default function CampaignItemDetails( props: Props ) {
 										) }
 									</div>
 
-									<>
-										<div className="campaign-item-details__main-stats-row campaign-item-details__graph-stats-row">
-											<div>
-												<div className="campaign-item-page__graph">
-													<DropdownMenu
-														class="campaign-item-page__graph-selector"
-														controls={ chartControls }
-														icon={ chevronDown }
-														text={ ChartSourceDateRangeLabels[ selectedDateRange ] }
-														label={ ChartSourceDateRangeLabels[ selectedDateRange ] }
-													/>
-													<DropdownMenu
-														class="campaign-item-page__graph-selector"
-														controls={ [
-															{
-																onClick: () => setChartSource( ChartSourceOptions.Clicks ),
-																title: __( 'Clicks' ),
-																isDisabled: chartSource === ChartSourceOptions.Clicks,
-															},
-															{
-																onClick: () => setChartSource( ChartSourceOptions.Impressions ),
-																title: __( 'Impressions' ),
-																isDisabled: chartSource === ChartSourceOptions.Impressions,
-															},
-														] }
-														icon={ chevronDown }
-														text={
-															chartSource === ChartSourceOptions.Clicks
-																? __( 'Clicks' )
-																: __( 'Impressions' )
-														}
-														label={ chartSource }
-													/>
-													{ getCampaignStatsChart(
-														campaignStats?.series[ chartSource ] ?? null,
-														chartSource,
-														campaignsStatsIsLoading
-													) }
-												</div>
-											</div>
-										</div>
-
-										{ campaignStats && (
+									{ areStatsEnabled && (
+										<>
 											<div className="campaign-item-details__main-stats-row campaign-item-details__graph-stats-row">
 												<div>
-													<div className="campaign-item-page__locaton-charts">
-														<span className="campaign-item-details__label">
-															{ chartSource === ChartSourceOptions.Clicks
-																? __( 'Clicks by location' )
-																: __( 'Impressions by location' ) }
-														</span>
-														<div>
-															<LocationChart
-																stats={ campaignStats?.total_stats.countryStats[ chartSource ] }
-																total={ campaignStats.total_stats.total[ chartSource ] }
-																source={ chartSource }
-															/>
-														</div>
+													<div className="campaign-item-page__graph">
+														<DropdownMenu
+															class="campaign-item-page__graph-selector"
+															controls={ chartControls }
+															icon={ chevronDown }
+															text={ ChartSourceDateRangeLabels[ selectedDateRange ] }
+															label={ ChartSourceDateRangeLabels[ selectedDateRange ] }
+														/>
+														<DropdownMenu
+															class="campaign-item-page__graph-selector"
+															controls={ [
+																{
+																	onClick: () => setChartSource( ChartSourceOptions.Clicks ),
+																	title: __( 'Clicks' ),
+																	isDisabled: chartSource === ChartSourceOptions.Clicks,
+																},
+																{
+																	onClick: () => setChartSource( ChartSourceOptions.Impressions ),
+																	title: __( 'Impressions' ),
+																	isDisabled: chartSource === ChartSourceOptions.Impressions,
+																},
+															] }
+															icon={ chevronDown }
+															text={
+																chartSource === ChartSourceOptions.Clicks
+																	? __( 'Clicks' )
+																	: __( 'Impressions' )
+															}
+															label={ chartSource }
+														/>
+														{ getCampaignStatsChart(
+															campaignStats?.series[ chartSource ] ?? null,
+															chartSource,
+															campaignsStatsIsLoading
+														) }
 													</div>
 												</div>
 											</div>
-										) }
-									</>
+
+											{ campaignStats && (
+												<div className="campaign-item-details__main-stats-row campaign-item-details__graph-stats-row">
+													<div>
+														<div className="campaign-item-page__locaton-charts">
+															<span className="campaign-item-details__label">
+																{ chartSource === ChartSourceOptions.Clicks
+																	? __( 'Clicks by location' )
+																	: __( 'Impressions by location' ) }
+															</span>
+															<div>
+																<LocationChart
+																	stats={ campaignStats?.total_stats.countryStats[ chartSource ] }
+																	total={ campaignStats.total_stats.total[ chartSource ] }
+																	source={ chartSource }
+																/>
+															</div>
+														</div>
+													</div>
+												</div>
+											) }
+										</>
+									) }
 								</div>
 							</div>
 						) }
@@ -990,7 +995,7 @@ export default function CampaignItemDetails( props: Props ) {
 									</>
 								</div>
 
-								{ campaign?.campaign_stats?.impressions_total > 0 && (
+								{ areStatsEnabled && campaign?.campaign_stats?.impressions_total > 0 && (
 									<div className="campaign-item-details__main-stats-row campaign-item-details__graph-stats-row">
 										<div>
 											<div className="campaign-item-page__graph">


### PR DESCRIPTION
This PR fixes the Blaze Dashboard - Campaign details page for sites using older Jetpack/Blaze Ads plugins versions.

## Proposed Changes

* Add a check for the jetpack version and hide the new stats section of the campaign details page if the version is not supported.

## Why are these changes being made?

The latest changes to the  blaze dashboard added a new endpoint inside the Jetpack blaze module, but olders version of Jetpack doesn't have that endpoint and will fail to fetch the data. 

The main objective of this PR is to hide the stats section if we detect an unsupported version of Jetpack/Blaze Ads plugin.

## Testing Instructions

* Test in the Live preview and verify that you correctly see the new Stats section in the Campaign details page
<img width="735" alt="Screenshot 2024-12-13 at 3 40 26 PM" src="https://github.com/user-attachments/assets/d5b75d15-ccce-4c41-85fc-55187883a9e6" />

Now, you will need to have a sandbox to test the following part.
* On a console, connect to your sandbox to activate the connection
* On a different console, navigate to `wp-calypso/apps/blaze-dashboard` and execute `yarn dev --sync`
* Move all the traffic from `widgets.wp.com` to your sandbox
* Now, test any Jetpack site with an older Jetpack version (14.0 and bellow). You shouldn't see the new section with the graphs on the campaign details page
* Run the same test, but now only with the Blaze Ads plugin (0.5.2 and bellow). As before, the new stats endpoint should be hidden.
* If you test with newer versions of the plugins (Jetpack and/or Blaze Ads), the section should be displayed.

**Note:** If you don't have a Jetpack site with a completed campaign, you could do one of the following:
a) Tunnel your local DSP server and manually create/activate a campaign for that site with stats
b) Add the following changes to the file `client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx` test the change with console.log:
```
const areStatsEnabled = useJetpackBlazeVersionCheck( siteId, '14.1', '0.5.3' );
console.log(` Stats Enabled: ${ areStatsEnabled } `);
```

With this, you should be able to see in the console if the version check was successful. If you want to verify if the stats endpoint will work on that setup, you could for the last parameter to true in this call:
```
const campaignStatsQuery = useCampaignChartStatsQuery(
	siteId,
	campaignId,
	chartParams,
	!! impressions_total
	true // !! impressions_total && areStatsEnabled
);
```

With this, you should see a call in the network tab, and verify if you correctly get a response code different than 404 (we get 404 when Jetpack doesn't support the endpoint).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
