### PR TITLE
Reader: fix auto scroll on recent feed dataview

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -204,13 +204,6 @@ export class FullPostView extends Component {
 		}
 	}
 
-	getScrollableContainer = () => {
-		return (
-			document.querySelector( '#primary > div > div.recent-feed > section' ) || // for Recent Feed in Dataview
-			document.querySelector( '#primary > div > div' )
-		); // for Recent Feed in Stream
-	};
-
 	setReadingStartTime = () => {
 		this.readingStartTime = new Date().getTime();
 	};

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -140,11 +140,12 @@ export class FullPostView extends Component {
 		document.addEventListener( 'visibilitychange', this.handleVisibilityChange );
 
 		const scrollableContainer =
-			document.querySelector( '#primary > div > div.recent-feed > section' ) ||
-			document.querySelector( '#primary > div > div' );
+			document.querySelector( '#primary > div > div.recent-feed > section' ) || // for Recent Feed in Dataview
+			document.querySelector( '#primary > div > div' ); // for Recent Feed in Stream
 		if ( scrollableContainer ) {
 			scrollableContainer.addEventListener( 'scroll', this.setScrollDepth );
 			this.scrollableContainer = scrollableContainer; // Save reference for cleanup
+			this.resetScroll();
 		}
 	}
 	componentDidUpdate( prevProps ) {
@@ -165,6 +166,7 @@ export class FullPostView extends Component {
 				this.trackScrollDepth( prevProps.post );
 				this.trackExitBeforeCompletion( prevProps.post );
 				this.setReadingStartTime();
+				this.resetScroll();
 			}
 		}
 
@@ -201,6 +203,13 @@ export class FullPostView extends Component {
 			this.scrollableContainer.removeEventListener( 'scroll', this.setScrollDepth );
 		}
 	}
+
+	getScrollableContainer = () => {
+		return (
+			document.querySelector( '#primary > div > div.recent-feed > section' ) || // for Recent Feed in Dataview
+			document.querySelector( '#primary > div > div' )
+		); // for Recent Feed in Stream
+	};
 
 	setReadingStartTime = () => {
 		this.readingStartTime = new Date().getTime();
@@ -249,6 +258,7 @@ export class FullPostView extends Component {
 			this.trackReadingTime();
 			this.trackScrollDepth();
 			this.trackExitBeforeCompletion();
+			this.resetScroll();
 		}
 	};
 
@@ -266,6 +276,19 @@ export class FullPostView extends Component {
 		}
 	}
 
+	resetScroll = () => {
+		setTimeout( () => {
+			if ( this.scrollableContainer ) {
+				this.scrollableContainer.scrollTo( {
+					top: 0,
+					left: 0,
+					behavior: 'smooth',
+				} );
+			}
+			this.setState( { maxScrollDepth: 0, hasCompleted: false } );
+		}, 0 ); // Defer until after the DOM update
+	};
+
 	setScrollDepth = () => {
 		if ( this.scrollableContainer ) {
 			const scrollTop = this.scrollableContainer.scrollTop;
@@ -273,7 +296,7 @@ export class FullPostView extends Component {
 			const clientHeight = this.scrollableContainer.clientHeight;
 			const scrollDepth = ( scrollTop / ( scrollHeight - clientHeight ) ) * 100;
 			this.setState( ( prevState ) => ( {
-				maxScrollDepth: Math.max( prevState.maxScrollDepth, scrollDepth ),
+				maxScrollDepth: Math.max( prevState.maxScrollDepth, scrollDepth ) || 0,
 				hasCompleted: prevState.hasCompleted || scrollDepth >= 90,
 			} ) );
 		}

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -275,7 +275,7 @@ export class FullPostView extends Component {
 				this.scrollableContainer.scrollTo( {
 					top: 0,
 					left: 0,
-					behavior: 'smooth',
+					behavior: 'instant',
 				} );
 			}
 			this.setState( { maxScrollDepth: 0, hasCompleted: false } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/loop/issues/274

### Before

https://github.com/user-attachments/assets/3e40aea9-ae5a-4796-a351-cebcbb480f87

### After

https://github.com/user-attachments/assets/f7770465-f59d-4a0f-91ff-3849b2cb6764

## Proposed Changes

* Resets scroll when viewing different posts in Recent feed dataview

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Better UX

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/read` and choose the dataview layout
* Select a feed (ideally with longer form content) and scroll each post
* When you go to a new post in that feed, it should return to the top of the post

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
