### PR TITLE
Checkout: Do not log errorMessage in checkout logstash if message is the same

### DIFF
--- a/client/my-sites/checkout/src/lib/analytics.ts
+++ b/client/my-sites/checkout/src/lib/analytics.ts
@@ -76,7 +76,13 @@ export function logStashLoadErrorEvent(
 		message: additionalData.message
 			? String( additionalData.message )
 			: convertErrorToString( error ),
-		errorMessage: convertErrorToString( error ),
+		...( additionalData.message
+			? // No need to log the `errorMessage` separately if it's the same as
+			  // the `message` property.
+			  {
+					errorMessage: convertErrorToString( error ),
+			  }
+			: {} ),
 		tags: [ 'checkout-error-boundary' ],
 	} );
 }

--- a/client/my-sites/checkout/src/lib/analytics.ts
+++ b/client/my-sites/checkout/src/lib/analytics.ts
@@ -94,15 +94,22 @@ export function logStashEvent(
 	dataForLog: DataForLog,
 	severity: 'error' | 'warning' | 'info' = 'error'
 ): Promise< void > {
+	const tags = dataForLog.tags ?? [];
+	const extra: Record< string, string | string[] > = {
+		env: config( 'env_id' ),
+	};
+	Object.keys( dataForLog ).forEach( ( key ) => {
+		if ( key === 'tags' ) {
+			return;
+		}
+		extra[ key ] = dataForLog[ key ];
+	} );
 	return logToLogstash( {
 		feature: 'calypso_client',
 		message,
 		severity: config( 'env_id' ) === 'production' ? severity : 'debug',
-		extra: {
-			env: config( 'env_id' ),
-			...dataForLog,
-		},
-		tags: dataForLog.tags ?? [],
+		extra,
+		tags,
 	} );
 }
 


### PR DESCRIPTION
## Proposed Changes

When `CheckoutErrorBoundary` logs an error to logstash it includes two key properties, `message` and `errorMessage`. `message` is the main one and is either the custom error message specified for that error boundary, or the serialized error itself. `errorMessage` is always the serialized error message. However, this means that if there is no custom error message, then the data we send to logstash always includes both these properties, leading to noisy errors that are hard to read (they contain the stack trace twice).

In this PR we do not include `errorMessage` if `message` is the same thing.

## Testing Instructions


To test this you'll need to be using a local dev environment. Edit the source code to apply this diff:

```diff
diff --git a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
index 6a6be693a25..4adf9cf7bd6 100644
--- a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
+++ b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
@@ -63,6 +63,9 @@ function PayPalSubmitButtonWrapper( {
        disabled?: boolean;
        onClick?: ProcessPayment;
 } ) {
+       useEffect( () => {
+               throw new Error( 'testing error' );
+       }, [] );
        const cartKey = useCartKey();
        const { responseCart } = useShoppingCart( cartKey );
        return (
```

- Using this modified calypso, add a product to your cart and visit checkout. Make sure to have your browser devtools open to the network requests page.
- View the network requests to the `https://public-api.wordpress.com/rest/v1.1/logstash` endpoint. Examine the payload of each request. Find one that mentions `composite checkout load error`.
- View the contents of the logged error. It should look something like the following. Make sure that there's no `errorMessage` property.

```
{
	"feature": "calypso_client",
	"message": "composite checkout load error",
	"severity": "debug",
	"extra": {
		"env": "development",
		"type": "submit_button_load",
		"message": "Message: Error while rendering submit button for payment method 'paypal-js': There was a problem with the submit button. (Error); (Cause: Message: There was a problem with the submit button.; (Cause: Message: testing error; (Stack: Error: ...))",
	},
	"tags": ["checkout-error-boundary"]
}
```