### PR TITLE
Adjust spacing on design picker

### DIFF
--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -22,12 +22,16 @@
 		flex-grow: 1;
 	}
 
+	.components-toolbar {
+		background-color: transparent;
+	}
+
 	.design-picker__design-card-group {
 		.design-picker__design-card-title {
 			position: sticky;
 			top: 0;
-			padding: 16px 12px;
-			margin: -16px -12px 8px;
+			padding: 16px 12px 8px;
+			margin: -16px -12px 0;
 			color: var(--studio-black);
 			background-color: var(--color-body-background);
 			font-size: $font-body;
@@ -35,10 +39,24 @@
 			font-weight: 500;
 			line-height: 24px;
 			z-index: 10;
+
+			@include break-small {
+				padding: 16px 24px 12px;
+				margin: -16px -24px 0;
+			}
 		}
 
 		.design-picker__grid {
-			margin-bottom: 24px;
+			margin-bottom: 32px;
+		}
+
+		.theme-card__info {
+			margin-top: 8px;
+			height: auto;
+
+			@include break-small {
+				margin-top: 12px;
+			}
 		}
 	}
 

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -41,7 +41,7 @@
 			z-index: 10;
 
 			@include break-small {
-				padding: 24px 24px 12px;
+				padding: 24px 24px 16px;
 				margin: -24px -24px 0;
 			}
 		}

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -30,19 +30,19 @@
 		.design-picker__design-card-title {
 			position: sticky;
 			top: 0;
-			padding: 16px 12px 8px;
+			padding: 16px 12px 12px;
 			margin: -16px -12px 0;
 			color: var(--studio-black);
 			background-color: var(--color-body-background);
-			font-size: $font-body;
+			font-size: $font-title-small;
 			font-style: normal;
 			font-weight: 500;
 			line-height: 24px;
 			z-index: 10;
 
 			@include break-small {
-				padding: 16px 24px 12px;
-				margin: -16px -24px 0;
+				padding: 24px 24px 12px;
+				margin: -24px -24px 0;
 			}
 		}
 


### PR DESCRIPTION
## Proposed Changes

This PR tweaks the spacing for the design picker to better group various elements and balance the layout better. It also increases the group title size to better differentiate it from the theme names.

**Before**
<img width="1808" alt="image" src="https://github.com/user-attachments/assets/5e02fff0-3d87-4bdb-b9ed-6b8365576912" />

**After**
<img width="1627" alt="image" src="https://github.com/user-attachments/assets/6dabc456-e7c0-4eb2-893a-c4c33fb9d84a" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The current spacing feels like some elements are drifting away from each other. This makes it hard to discern one group from the other. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
