### PR TITLE
Newsletter settings: Show copy and error asking user to choose categories.

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -187,7 +187,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 		scrollToAnchor( { offset: 15 } );
 	}, [ savedSubscriptionOptions, updateFields ] );
 
-	const onNewsletterCategoriesSubmit = ( event?: React.FormEvent | React.MouseEvent ) => {
+	const onSubmit = ( event?: React.FormEvent | React.MouseEvent ) => {
 		event?.preventDefault();
 
 		if (
@@ -204,14 +204,14 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 	};
 
 	return (
-		<form onSubmit={ handleSubmitForm }>
+		<form onSubmit={ onSubmit }>
 			{ siteId && <QueryJetpackModules siteId={ siteId } /> }
 
 			<SettingsSectionHeader
 				disabled={ disabled }
 				id="subscriptions"
 				isSaving={ isSavingSettings }
-				onButtonClick={ handleSubmitForm }
+				onButtonClick={ onSubmit }
 				showButton
 				title={ translate( 'Subscriptions' ) }
 			/>
@@ -270,7 +270,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 				disabled={ disabled }
 				id="email-settings"
 				isSaving={ isSavingSettings }
-				onButtonClick={ handleSubmitForm }
+				onButtonClick={ onSubmit }
 				showButton
 				title={ translate( 'Email' ) }
 			/>
@@ -317,7 +317,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 				id="newsletter-categories-settings"
 				title={ translate( 'Newsletter categories' ) }
 				showButton
-				onButtonClick={ onNewsletterCategoriesSubmit }
+				onButtonClick={ onSubmit }
 				disabled={ disabled }
 				isSaving={ isSavingSettings }
 			/>
@@ -332,7 +332,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 				disabled={ disabled }
 				id="messages"
 				isSaving={ isSavingSettings }
-				onButtonClick={ handleSubmitForm }
+				onButtonClick={ onSubmit }
 				showButton
 				title={ translate( 'Messages' ) }
 			/>

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -110,8 +110,6 @@ const getFormSettings = ( settings?: Fields ) => {
 	};
 };
 
-type ErrorNotice = ( text: string ) => void;
-
 type NewsletterSettingsFormProps = {
 	fields: Fields;
 	handleToggle: ( field: string ) => ( value: boolean ) => void;
@@ -120,7 +118,7 @@ type NewsletterSettingsFormProps = {
 	isSavingSettings: boolean;
 	settings: { subscription_options?: SubscriptionOptions };
 	updateFields: ( fields: Fields ) => void;
-	errorNotice: ErrorNotice;
+	errorNotice: ( text: string ) => void;
 };
 
 const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
@@ -189,7 +187,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 		scrollToAnchor( { offset: 15 } );
 	}, [ savedSubscriptionOptions, updateFields ] );
 
-	const onSubmit = ( event?: React.FormEvent | React.MouseEvent ) => {
+	const onNewsletterCategoriesSubmit = ( event?: React.FormEvent | React.MouseEvent ) => {
 		event?.preventDefault();
 
 		if (
@@ -319,7 +317,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 				id="newsletter-categories-settings"
 				title={ translate( 'Newsletter categories' ) }
 				showButton
-				onButtonClick={ onSubmit }
+				onButtonClick={ onNewsletterCategoriesSubmit }
 				disabled={ disabled }
 				isSaving={ isSavingSettings }
 			/>

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -110,6 +110,8 @@ const getFormSettings = ( settings?: Fields ) => {
 	};
 };
 
+type ErrorNotice = ( text: string ) => void;
+
 type NewsletterSettingsFormProps = {
 	fields: Fields;
 	handleToggle: ( field: string ) => ( value: boolean ) => void;
@@ -118,6 +120,7 @@ type NewsletterSettingsFormProps = {
 	isSavingSettings: boolean;
 	settings: { subscription_options?: SubscriptionOptions };
 	updateFields: ( fields: Fields ) => void;
+	errorNotice: ErrorNotice;
 };
 
 const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
@@ -128,6 +131,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 	isSavingSettings,
 	settings,
 	updateFields,
+	errorNotice,
 }: NewsletterSettingsFormProps ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
@@ -184,6 +188,22 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 		// If the URL has a hash, scroll to it.
 		scrollToAnchor( { offset: 15 } );
 	}, [ savedSubscriptionOptions, updateFields ] );
+
+	const onSubmit = ( event?: React.FormEvent | React.MouseEvent ) => {
+		event?.preventDefault();
+
+		if (
+			fields.wpcom_newsletter_categories_enabled &&
+			! fields.wpcom_newsletter_categories?.length
+		) {
+			errorNotice(
+				translate( 'Please select at least one category when newsletter categories are enabled.' )
+			);
+			return;
+		}
+
+		handleSubmitForm();
+	};
 
 	return (
 		<form onSubmit={ handleSubmitForm }>
@@ -299,7 +319,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 				id="newsletter-categories-settings"
 				title={ translate( 'Newsletter categories' ) }
 				showButton
-				onButtonClick={ handleSubmitForm }
+				onButtonClick={ onSubmit }
 				disabled={ disabled }
 				isSaving={ isSavingSettings }
 			/>

--- a/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-section.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-section.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import TermTreeSelector from 'calypso/blocks/term-tree-selector';
+import FormLegend from 'calypso/components/forms/form-legend';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import NewsletterCategoriesToggle from './newsletter-categories-toggle';
 import './style.scss';
@@ -44,6 +45,11 @@ const NewsletterCategoriesSection = ( {
 				) }
 				aria-hidden={ ! newsletterCategoriesEnabled }
 			>
+				<FormLegend>
+					{ translate(
+						'Which categories will you use for newsletter subscribers? Select all that apply:'
+					) }
+				</FormLegend>
 				<TermTreeSelector
 					taxonomy="category"
 					addTerm


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

See: p1734114241935889/1733936868.332319-slack-C083ZPVVDTK

* Show "Which categories will you use for newsletter subscribers? Select all that apply:" above the newsletter category selection.

<img width="732" alt="Screen Shot 2024-12-13 at 3 09 02 PM" src="https://github.com/user-attachments/assets/6e7baa38-b07c-4552-89d9-0c1f61ed51da" />

* Show an error message when newsletter categories are enabled, but none are selected: "Please select at least one category when newsletter categories are enabled."

<img width="1185" alt="Screen Shot 2024-12-13 at 3 09 17 PM" src="https://github.com/user-attachments/assets/97da5d3b-d2ca-4c05-911f-eb9e7791ac2c" />

Noting that:
- I'd like to add a test for the error, but I had an issue with how the component is exported. I might need to do some refactoring.
- This will need translations once the copy is finalized.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve the UX. It wasn't clear that you needed to select categories.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /settings/newsletter/ > Newsletter categories.
* Enable categories.
* Without selecting any, click "Save settings."
* You should see an error, and settings won't save.
* Select one or more categories.
* Settings should save successfully.
* Disable categories.
* Settings should save successfully.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?