### PR TITLE
A4A: Check if agency website is active during signup

### DIFF
--- a/client/a8c-for-agencies/components/form/utils/index.ts
+++ b/client/a8c-for-agencies/components/form/utils/index.ts
@@ -1,3 +1,8 @@
+import debugFactory from 'debug';
+import wpcom from 'calypso/lib/wp';
+
+const debug = debugFactory( 'calypso:a4a:form-utils' );
+
 export function isValidUrl( url: string ) {
 	return (
 		url.length > 3 &&
@@ -8,4 +13,28 @@ export function isValidUrl( url: string ) {
 export function areURLsUnique( urls: unknown[] ) {
 	const urlSet = new Set( urls );
 	return urlSet.size === urls.length;
+}
+
+export async function isSiteActive( url: string ) {
+	// Ensure the URL has a valid protocol (default to HTTPS if missing)
+	if ( ! /^https?:\/\//i.test( url ) ) {
+		url = `https://${ url }`;
+	}
+
+	try {
+		// Make a request to the wpcom API to validate the URL
+		const response = await wpcom.req.get( {
+			path: `/agency/validate/url?value=${ encodeURIComponent( url ) }`,
+			apiNamespace: 'wpcom/v2',
+		} );
+
+		if ( response?.is_valid ) {
+			return true;
+		}
+
+		return false;
+	} catch ( error ) {
+		debug( `Error checking site: ${ error }` );
+		return false;
+	}
 }

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-signup-form-validation.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-signup-form-validation.ts
@@ -5,6 +5,8 @@ import { AgencyDetailsPayload } from '../types';
 
 export const CAPTURE_URL_RGX =
 	/^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([-.][a-z0-9]+)*\.[a-z]{2,63}(:[0-9]{1,5})?(\/.*)?$/i;
+const CAPTURE_SOCIAL_URL_RGX =
+	/^(https?:\/\/)?(www\.)?(facebook\.com|linkedin\.com|instagram\.com)(\/.*)?$/i;
 
 type ValidationState = {
 	firstName?: string;
@@ -42,7 +44,10 @@ const useSignupFormValidation = () => {
 				newValidationError.agencyUrl = translate( `Agency URL can't be empty` );
 			} else if ( ! CAPTURE_URL_RGX.test( payload.agencyUrl ) ) {
 				newValidationError.agencyUrl = translate( `Please enter a valid URL` );
-			} else if ( ! ( await isSiteActive( payload.agencyUrl ) ) ) {
+			} else if (
+				CAPTURE_SOCIAL_URL_RGX.test( payload.agencyUrl ) ||
+				! ( await isSiteActive( payload.agencyUrl ) )
+			) {
 				newValidationError.agencyUrl = translate(
 					`Please enter a live site URL for your business`
 				);

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-signup-form-validation.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-signup-form-validation.ts
@@ -44,7 +44,7 @@ const useSignupFormValidation = () => {
 				newValidationError.agencyUrl = translate( `Please enter a valid URL` );
 			} else if ( ! ( await isSiteActive( payload.agencyUrl ) ) ) {
 				newValidationError.agencyUrl = translate(
-					`Please enter a live site URL for your business.`
+					`Please enter a live site URL for your business`
 				);
 			}
 

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-signup-form-validation.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-signup-form-validation.ts
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
+import { isSiteActive } from 'calypso/a8c-for-agencies/components/form/utils';
 import { AgencyDetailsPayload } from '../types';
 
 export const CAPTURE_URL_RGX =
@@ -24,7 +25,7 @@ const useSignupFormValidation = () => {
 	};
 
 	const validate = useCallback(
-		( payload: AgencyDetailsPayload ) => {
+		async ( payload: AgencyDetailsPayload ) => {
 			const newValidationError: ValidationState = {};
 			if ( payload.firstName === '' ) {
 				newValidationError.firstName = translate( `First name can't be empty` );
@@ -41,6 +42,10 @@ const useSignupFormValidation = () => {
 				newValidationError.agencyUrl = translate( `Agency URL can't be empty` );
 			} else if ( ! CAPTURE_URL_RGX.test( payload.agencyUrl ) ) {
 				newValidationError.agencyUrl = translate( `Please enter a valid URL` );
+			} else if ( ! ( await isSiteActive( payload.agencyUrl ) ) ) {
+				newValidationError.agencyUrl = translate(
+					`Please enter a live site URL for your business.`
+				);
 			}
 
 			if ( payload.line1 === '' ) {

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-signup-form-validation.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-signup-form-validation.ts
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import { isSiteActive } from 'calypso/a8c-for-agencies/components/form/utils';
+import { preventWidows } from 'calypso/lib/formatting';
 import { AgencyDetailsPayload } from '../types';
 
 export const CAPTURE_URL_RGX =
@@ -48,8 +49,10 @@ const useSignupFormValidation = () => {
 				CAPTURE_SOCIAL_URL_RGX.test( payload.agencyUrl ) ||
 				! ( await isSiteActive( payload.agencyUrl ) )
 			) {
-				newValidationError.agencyUrl = translate(
-					`Please enter a live site URL for your business`
+				newValidationError.agencyUrl = preventWidows(
+					translate(
+						"Please enter a valid site URL for your business. If you're experiencing issues contact us at partnerships@automattic.com"
+					)
 				);
 			}
 

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
@@ -131,14 +131,14 @@ export default function AgencyDetailsForm( {
 	);
 
 	const handleSubmit = useCallback(
-		( e: React.SyntheticEvent ) => {
+		async ( e: React.SyntheticEvent ) => {
 			e.preventDefault();
 
 			if ( ! showCountryFields || isLoading ) {
 				return;
 			}
 
-			const error = validate( payload );
+			const error = await validate( payload );
 			if ( error ) {
 				// Scrolling only for fields positioned on top
 				if ( error.firstName || error.lastName || error.agencyName || error.agencyUrl ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: https://github.com/Automattic/automattic-for-agencies-dev/issues/1589
PT: pfunGA-3ie-p2

## Proposed Changes

* When submitting the signup form make an API request to check if the agency website is actually an active site.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of the changes we're introducing to mitigate fraud by introducing some intentional friction in the process. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test this with the backend changes in D168665-code and while sandboxing `public-api.wordpress.com`
* As a logged-out user, visit /signup
* Fill in all required fields
* For the "Business URL" field test 4 different things (keep an eye on network requests in the browser console):
  1. An invalid URL (eg. `travisblog`) 
  This should act as it did before, showing the error "Please enter a valid URL" and not making any new network requests.
  <img width="655" alt="Screenshot 2024-12-13 at 1 22 11 PM" src="https://github.com/user-attachments/assets/b628b4eb-052f-4965-ad2f-3020e5db7bd0" />

  2. A valid URL to facebook.com, linkedin.com, or instagram.com (eg. `facebook.com/user`)
  This should show the error "Please enter a valid site URL for your business. If you're experiencing issues contact us at partnerships@automattic.com" and not making any new network requests.
  <img width="670" alt="Screenshot 2024-12-17 at 10 54 46 AM" src="https://github.com/user-attachments/assets/1defb5fe-afb7-487c-bce4-7ccbeba2d6af" />


  3. A valid URL that **isn't** a real active site (eg. `travisinvalid.blog`)
  This should make a request to the new endpoint and show the error "Please enter a valid site URL for your business. If you're experiencing issues contact us at partnerships@automattic.com"
  <img width="2337" alt="Screenshot 2024-12-17 at 10 54 29 AM" src="https://github.com/user-attachments/assets/e02af6fd-0fa1-450b-ab25-d9bda9ece3df" />


  4. A valid URL that **is** a real active site (eg. `travis.blog`)
  This should make a request to the new endpoint, not show any validation error, and continue to the next signup step.
    * Also test this as a logged-in user without an existing A4A account. You should similarly proceed to the next signup step.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?