### PR TITLE
Help Center: Fix prod conversations in staging

### DIFF
--- a/packages/zendesk-client/src/use-authenticate-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-authenticate-zendesk-messaging.ts
@@ -22,8 +22,8 @@ export function useAuthenticateZendeskMessaging(
 	enabled = false,
 	type: ZendeskAuthType = 'zendesk'
 ) {
-	const currentEnvironment = config( 'env_id' );
-	const isTestMode = currentEnvironment !== 'production';
+	const currentEnvironment = config( 'env_id' ) as string;
+	const isTestMode = ! [ 'production', 'desktop' ].includes( currentEnvironment );
 
 	return useQuery( {
 		queryKey: [ 'getMessagingAuth', VERSION, type, isTestMode ],


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1734110936317609-slack-C07D72S1135

## Proposed Changes

We set test_mode to false if we are in the desktop app.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The Desktop app defines 'env_id' as 'desktop', and uses 'env' to define 'production'. In the Help Center we check `env_id` because that's where usually prod or staging are defined.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Desktop app
* Try to start a conversation 
* It should end in production