### PR TITLE
A4A: add estimated payout date card on referrals dashboard

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -6,6 +6,7 @@ import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import { getConsolidatedData } from '../lib/commissions';
+import { getNextPayoutDate } from '../lib/get-next-payout-date';
 import type { Referral, ReferralInvoice } from '../types';
 
 import './style.scss';
@@ -71,9 +72,14 @@ export default function ConsolidatedViews( {
 	}, [ referrals, data, referralInvoices ] );
 
 	const link =
-		'https://agencieshelp.automattic.com/knowledge-base/about-automattic-for-agencies/#payout-calculation-and-schedule';
+		'https://agencieshelp.automattic.com/knowledge-base/automattic-for-agencies-earnings/';
 
 	const showLoader = isFetching || isFetchingInvoices;
+
+	const nextPayoutDate = getNextPayoutDate( new Date() ).toLocaleString( 'default', {
+		month: 'short',
+		day: 'numeric',
+	} );
 
 	return (
 		<div className="consolidated-view">
@@ -124,6 +130,29 @@ export default function ConsolidatedViews( {
 										a: <a href={ link } target="_blank" rel="noreferrer noopener" />,
 									},
 									comment: 'This is a tooltip explaining how the commission is calculated',
+								}
+							) }
+						</div>
+					</InfoIconWithPopover>
+				</div>
+			</Card>
+			<Card compact>
+				<div className="consolidated-view__value">{ nextPayoutDate + '*' }</div>
+				<div className="consolidated-view__label">
+					{ translate( 'Next estimated payout date' ) }
+					<InfoIconWithPopover>
+						<div className="consolidated-view__popover-content">
+							{ translate(
+								'*Commissions are paid quarterly, after a 60-day waiting period, excluding refunds and chargebacks. ' +
+									'Payout dates mark the start of processing, which may take a few extra days. Payments scheduled on weekends are processed the next business day. ' +
+									'{{br}}{{/br}}{{a}}Learn more{{/a}} ↗.',
+								{
+									components: {
+										a: <a href={ link } target="_blank" rel="noreferrer noopener" />,
+										br: <br />,
+									},
+									comment:
+										'This is a tooltip explaining how the commission payout date is calculated',
 								}
 							) }
 						</div>

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -145,7 +145,7 @@ export default function ConsolidatedViews( {
 							{ translate(
 								'*Commissions are paid quarterly, after a 60-day waiting period, excluding refunds and chargebacks. ' +
 									'Payout dates mark the start of processing, which may take a few extra days. Payments scheduled on weekends are processed the next business day. ' +
-									'{{br}}{{/br}}{{a}}Learn more{{/a}} ↗.',
+									'{{br}}{{/br}}{{a}}Learn more{{/a}} ↗',
 								{
 									components: {
 										a: <a href={ link } target="_blank" rel="noreferrer noopener" />,

--- a/client/a8c-for-agencies/sections/referrals/lib/get-next-payout-date.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-next-payout-date.ts
@@ -1,0 +1,29 @@
+const PAYOUT_SCHEDULE = {
+	Q1: { start: '01-01', end: '03-31', payoutDate: '06-01' },
+	Q2: { start: '04-01', end: '06-30', payoutDate: '09-01' },
+	Q3: { start: '07-01', end: '09-30', payoutDate: '12-01' },
+	Q4: { start: '10-01', end: '12-31', payoutDate: '03-01' }, // Next year
+};
+
+export const getNextPayoutDate = ( currentDate: Date ): Date => {
+	const currentMonth = currentDate.getMonth() + 1; // Convert to 1-based month
+	const currentYear = currentDate.getFullYear();
+
+	// Find which quarter we're in
+	const quarterKey = Object.keys( PAYOUT_SCHEDULE ).find( ( quarter ) => {
+		const schedule = PAYOUT_SCHEDULE[ quarter as keyof typeof PAYOUT_SCHEDULE ];
+		const [ startMonth ] = schedule.start.split( '-' ).map( Number );
+		const [ endMonth ] = schedule.end.split( '-' ).map( Number );
+		return currentMonth >= startMonth && currentMonth <= endMonth;
+	} ) as keyof typeof PAYOUT_SCHEDULE;
+
+	// Get payout month and day
+	const [ payoutMonth, payoutDay ] = PAYOUT_SCHEDULE[ quarterKey ].payoutDate
+		.split( '-' )
+		.map( Number );
+
+	// Calculate payout year (next year if we're in Q4)
+	const payoutYear = quarterKey === 'Q4' ? currentYear + 1 : currentYear;
+
+	return new Date( payoutYear, payoutMonth - 1, payoutDay );
+};

--- a/client/a8c-for-agencies/sections/referrals/lib/get-next-payout-date.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-next-payout-date.ts
@@ -1,5 +1,5 @@
 const PAYOUT_DATES = [
-	{ month: 3, day: 1 }, // March 1
+	{ month: 3, day: 2 }, // March 2
 	{ month: 6, day: 1 }, // June 1
 	{ month: 9, day: 1 }, // September 1
 	{ month: 12, day: 1 }, // December 1
@@ -10,14 +10,9 @@ export const getNextPayoutDate = ( currentDate: Date ): Date => {
 	const currentMonth = currentDate.getMonth() + 1; // Convert to 1-based month
 	const currentDay = currentDate.getDate();
 
-	// For December dates, return March 1st of next year
-	if ( currentMonth === 12 ) {
-		return new Date( currentYear + 1, 2, 1 ); // Month is 0-based, so 2 = March
-	}
-
 	// Find the next payout date that's closest to current date
-	const nextPayout = PAYOUT_DATES.find( ( { month } ) => {
-		return month > currentMonth || ( month === currentMonth && currentDay > 1 );
+	const nextPayout = PAYOUT_DATES.find( ( { month, day } ) => {
+		return month > currentMonth || ( month === currentMonth && day > currentDay );
 	} );
 
 	if ( nextPayout ) {

--- a/client/a8c-for-agencies/sections/referrals/lib/get-next-payout-date.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-next-payout-date.ts
@@ -1,29 +1,29 @@
-const PAYOUT_SCHEDULE = {
-	Q1: { start: '01-01', end: '03-31', payoutDate: '06-01' },
-	Q2: { start: '04-01', end: '06-30', payoutDate: '09-01' },
-	Q3: { start: '07-01', end: '09-30', payoutDate: '12-01' },
-	Q4: { start: '10-01', end: '12-31', payoutDate: '03-01' }, // Next year
-};
+const PAYOUT_DATES = [
+	{ month: 3, day: 1 }, // March 1
+	{ month: 6, day: 1 }, // June 1
+	{ month: 9, day: 1 }, // September 1
+	{ month: 12, day: 1 }, // December 1
+];
 
 export const getNextPayoutDate = ( currentDate: Date ): Date => {
-	const currentMonth = currentDate.getMonth() + 1; // Convert to 1-based month
 	const currentYear = currentDate.getFullYear();
+	const currentMonth = currentDate.getMonth() + 1; // Convert to 1-based month
+	const currentDay = currentDate.getDate();
 
-	// Find which quarter we're in
-	const quarterKey = Object.keys( PAYOUT_SCHEDULE ).find( ( quarter ) => {
-		const schedule = PAYOUT_SCHEDULE[ quarter as keyof typeof PAYOUT_SCHEDULE ];
-		const [ startMonth ] = schedule.start.split( '-' ).map( Number );
-		const [ endMonth ] = schedule.end.split( '-' ).map( Number );
-		return currentMonth >= startMonth && currentMonth <= endMonth;
-	} ) as keyof typeof PAYOUT_SCHEDULE;
+	// For December dates, return March 1st of next year
+	if ( currentMonth === 12 ) {
+		return new Date( currentYear + 1, 2, 1 ); // Month is 0-based, so 2 = March
+	}
 
-	// Get payout month and day
-	const [ payoutMonth, payoutDay ] = PAYOUT_SCHEDULE[ quarterKey ].payoutDate
-		.split( '-' )
-		.map( Number );
+	// Find the next payout date that's closest to current date
+	const nextPayout = PAYOUT_DATES.find( ( { month } ) => {
+		return month > currentMonth || ( month === currentMonth && currentDay > 1 );
+	} );
 
-	// Calculate payout year (next year if we're in Q4)
-	const payoutYear = quarterKey === 'Q4' ? currentYear + 1 : currentYear;
+	if ( nextPayout ) {
+		return new Date( currentYear, nextPayout.month - 1, nextPayout.day );
+	}
 
-	return new Date( payoutYear, payoutMonth - 1, payoutDay );
+	// If no payout dates left this year, return first payout of next year
+	return new Date( currentYear + 1, PAYOUT_DATES[ 0 ].month - 1, PAYOUT_DATES[ 0 ].day );
 };

--- a/client/a8c-for-agencies/sections/referrals/lib/test/get-next-payout-date.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/test/get-next-payout-date.ts
@@ -1,0 +1,32 @@
+import { getNextPayoutDate } from '../get-next-payout-date';
+
+describe( 'getNextPayoutDate', () => {
+	it( 'should return June 1st for Q1 dates', () => {
+		const result = getNextPayoutDate( new Date( '2024-02-15' ) );
+		expect( result ).toEqual( new Date( '2024-06-01' ) );
+	} );
+
+	it( 'should return September 1st for Q2 dates', () => {
+		const result = getNextPayoutDate( new Date( '2024-05-15' ) );
+		expect( result ).toEqual( new Date( '2024-09-01' ) );
+	} );
+	it( 'should return December 1st for Q3 dates', () => {
+		const result = getNextPayoutDate( new Date( '2024-08-15' ) );
+		expect( result ).toEqual( new Date( '2024-12-01' ) );
+	} );
+
+	it( 'should return March 1st of next year for Q4 dates', () => {
+		const result = getNextPayoutDate( new Date( '2024-11-15' ) );
+		expect( result ).toEqual( new Date( '2025-03-01' ) );
+	} );
+
+	it( 'should handle quarter boundaries correctly', () => {
+		// Test first day of Q1
+		let result = getNextPayoutDate( new Date( '2024-01-01' ) );
+		expect( result ).toEqual( new Date( '2024-06-01' ) );
+
+		// Test last day of Q4
+		result = getNextPayoutDate( new Date( '2024-12-31' ) );
+		expect( result ).toEqual( new Date( '2025-03-01' ) );
+	} );
+} );

--- a/client/a8c-for-agencies/sections/referrals/lib/test/get-next-payout-date.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/test/get-next-payout-date.ts
@@ -1,9 +1,9 @@
 import { getNextPayoutDate } from '../get-next-payout-date';
 
 describe( 'getNextPayoutDate', () => {
-	it( 'should return March 1st for dates before March 1st', () => {
+	it( 'should return March 2nd for dates before March 2nd', () => {
 		const result = getNextPayoutDate( new Date( '2024-02-15' ) );
-		expect( result ).toEqual( new Date( '2024-03-01' ) );
+		expect( result ).toEqual( new Date( '2024-03-02' ) );
 	} );
 
 	it( 'should return June 1st for dates between March 1st and June 1st', () => {
@@ -21,18 +21,26 @@ describe( 'getNextPayoutDate', () => {
 		expect( result ).toEqual( new Date( '2024-12-01' ) );
 	} );
 
-	it( 'should return March 1st of next year for dates after December 1st', () => {
+	it( 'should return March 2nd of next year for dates after December 1st', () => {
 		const result = getNextPayoutDate( new Date( '2024-12-15' ) );
-		expect( result ).toEqual( new Date( '2025-03-01' ) );
+		expect( result ).toEqual( new Date( '2025-03-02' ) );
+	} );
+	it( 'should return March 2nd of next year for dates on December 1st', () => {
+		const result = getNextPayoutDate( new Date( '2024-12-01' ) );
+		expect( result ).toEqual( new Date( '2025-03-02' ) );
 	} );
 
 	it( 'should handle exact payout dates correctly', () => {
-		// On March 1st, next payout is June 1st
+		// On March 1st, next payout is March 2nd
 		let result = getNextPayoutDate( new Date( '2024-03-01' ) );
+		expect( result ).toEqual( new Date( '2024-03-02' ) );
+
+		// On March 2nd, next payout is June 1st
+		result = getNextPayoutDate( new Date( '2024-03-02' ) );
 		expect( result ).toEqual( new Date( '2024-06-01' ) );
 
-		// On December 1st, next payout is March 1st of next year
+		// On December 1st, next payout is March 2nd of next year
 		result = getNextPayoutDate( new Date( '2024-12-01' ) );
-		expect( result ).toEqual( new Date( '2025-03-01' ) );
+		expect( result ).toEqual( new Date( '2025-03-02' ) );
 	} );
 } );

--- a/client/a8c-for-agencies/sections/referrals/lib/test/get-next-payout-date.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/test/get-next-payout-date.ts
@@ -1,32 +1,38 @@
 import { getNextPayoutDate } from '../get-next-payout-date';
 
 describe( 'getNextPayoutDate', () => {
-	it( 'should return June 1st for Q1 dates', () => {
+	it( 'should return March 1st for dates before March 1st', () => {
 		const result = getNextPayoutDate( new Date( '2024-02-15' ) );
+		expect( result ).toEqual( new Date( '2024-03-01' ) );
+	} );
+
+	it( 'should return June 1st for dates between March 1st and June 1st', () => {
+		const result = getNextPayoutDate( new Date( '2024-04-15' ) );
 		expect( result ).toEqual( new Date( '2024-06-01' ) );
 	} );
 
-	it( 'should return September 1st for Q2 dates', () => {
-		const result = getNextPayoutDate( new Date( '2024-05-15' ) );
+	it( 'should return September 1st for dates between June 1st and September 1st', () => {
+		const result = getNextPayoutDate( new Date( '2024-07-15' ) );
 		expect( result ).toEqual( new Date( '2024-09-01' ) );
 	} );
-	it( 'should return December 1st for Q3 dates', () => {
-		const result = getNextPayoutDate( new Date( '2024-08-15' ) );
+
+	it( 'should return December 1st for dates between September 1st and December 1st', () => {
+		const result = getNextPayoutDate( new Date( '2024-10-15' ) );
 		expect( result ).toEqual( new Date( '2024-12-01' ) );
 	} );
 
-	it( 'should return March 1st of next year for Q4 dates', () => {
-		const result = getNextPayoutDate( new Date( '2024-11-15' ) );
+	it( 'should return March 1st of next year for dates after December 1st', () => {
+		const result = getNextPayoutDate( new Date( '2024-12-15' ) );
 		expect( result ).toEqual( new Date( '2025-03-01' ) );
 	} );
 
-	it( 'should handle quarter boundaries correctly', () => {
-		// Test first day of Q1
-		let result = getNextPayoutDate( new Date( '2024-01-01' ) );
+	it( 'should handle exact payout dates correctly', () => {
+		// On March 1st, next payout is June 1st
+		let result = getNextPayoutDate( new Date( '2024-03-01' ) );
 		expect( result ).toEqual( new Date( '2024-06-01' ) );
 
-		// Test last day of Q4
-		result = getNextPayoutDate( new Date( '2024-12-31' ) );
+		// On December 1st, next payout is March 1st of next year
+		result = getNextPayoutDate( new Date( '2024-12-01' ) );
 		expect( result ).toEqual( new Date( '2025-03-01' ) );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1577

## Proposed Changes

This PR adds 'Estimated Payout Date' card to referrals dashboard. 
<img width="1353" alt="Screenshot 2024-12-13 at 2 17 26 PM" src="https://github.com/user-attachments/assets/121afd93-9e6a-4257-b0e1-77f0db508cb1" />

The logic is added separately to calculate the closest payout date.
We pay these out quarterly, on March, June, September and December first day. 

Additionally added tests to check logic through the year.

cc @simonktnga8c I know we postponed this payout to Dec 31, should we for now display Dec 31?

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link below navigate to `/referrals/dashboard` and check if they date displayed correctly.
- Checkout this branch locally
- Run tests: `yarn test-client client/a8c-for-agencies/sections/referrals/lib`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
