### PR TITLE
Checkout: Fetch PayPal configuration directly in calypso

### DIFF
--- a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
+++ b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
@@ -1,4 +1,4 @@
-import { PayPalProvider } from '@automattic/calypso-paypal';
+import { PayPalConfigurationApiResponse, PayPalProvider } from '@automattic/calypso-paypal';
 import {
 	useTogglePaymentMethod,
 	type PaymentMethod,
@@ -14,10 +14,18 @@ import {
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
+import wp from 'calypso/lib/wp';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { PaymentMethodLogos } from '../components/payment-method-logos';
 
 const debug = debugFactory( 'calypso:paypal-js' );
+
+async function fetchPayPalConfiguration(): Promise< PayPalConfigurationApiResponse > {
+	return await wp.req.get( {
+		path: `/me/paypal-configuration`,
+		method: 'GET',
+	} );
+}
 
 export function createPayPal(): PaymentMethod {
 	return {
@@ -66,7 +74,10 @@ function PayPalSubmitButtonWrapper( {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	return (
-		<PayPalProvider currency={ responseCart.currency }>
+		<PayPalProvider
+			currency={ responseCart.currency }
+			fetchPayPalConfiguration={ fetchPayPalConfiguration }
+		>
 			<PayPalSubmitButton disabled={ disabled } onClick={ onClick } />
 		</PayPalProvider>
 	);

--- a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
+++ b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
@@ -17,6 +17,7 @@ import { useEffect, useState } from 'react';
 import wp from 'calypso/lib/wp';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { PaymentMethodLogos } from '../components/payment-method-logos';
+import { convertErrorToString, logStashEvent } from '../lib/analytics';
 
 const debug = debugFactory( 'calypso:paypal-js' );
 
@@ -77,10 +78,15 @@ function PayPalSubmitButtonWrapper( {
 		<PayPalProvider
 			currency={ responseCart.currency }
 			fetchPayPalConfiguration={ fetchPayPalConfiguration }
+			handleError={ handlePayPalConfigurationError }
 		>
 			<PayPalSubmitButton disabled={ disabled } onClick={ onClick } />
 		</PayPalProvider>
 	);
+}
+
+function handlePayPalConfigurationError( error: Error ) {
+	logStashEvent( convertErrorToString( error ), { tags: [ 'paypal-configuration' ] }, 'error' );
 }
 
 function PayPalSubmitButton( {

--- a/packages/calypso-paypal/src/index.tsx
+++ b/packages/calypso-paypal/src/index.tsx
@@ -1,9 +1,9 @@
 import { PayPalScriptProvider, ReactPayPalScriptOptions } from '@paypal/react-paypal-js';
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect, useState, createContext, PropsWithChildren, useContext } from 'react';
+import { useEffect, useState, createContext, PropsWithChildren, useContext, useRef } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
 
-interface PayPalConfigurationApiResponse {
+export interface PayPalConfigurationApiResponse {
 	client_id: string | undefined;
 }
 
@@ -15,7 +15,7 @@ export interface UsePayPalConfiguration {
 	payPalConfiguration: PayPalConfiguration | undefined;
 }
 
-async function fetchPayPalConfiguration(): Promise< PayPalConfigurationApiResponse > {
+async function defaultFetchPayPalConfiguration(): Promise< PayPalConfigurationApiResponse > {
 	return await wpcomRequest( {
 		path: `/me/paypal-configuration`,
 		method: 'GET',
@@ -28,7 +28,11 @@ const defaultConfiguration: PayPalConfiguration = {
 	clientId: undefined,
 };
 
-function usePayPalConfigurationInternalOnly(): {
+function usePayPalConfigurationInternalOnly( {
+	fetchPayPalConfiguration,
+}: {
+	fetchPayPalConfiguration?: () => Promise< PayPalConfigurationApiResponse >;
+} ): {
 	payPalConfiguration: PayPalConfiguration | undefined;
 	error: undefined | Error;
 } {
@@ -39,7 +43,7 @@ function usePayPalConfigurationInternalOnly(): {
 
 	useEffect( () => {
 		let isSubscribed = true;
-		fetchPayPalConfiguration()
+		( fetchPayPalConfiguration ?? defaultFetchPayPalConfiguration )()
 			.then( ( configuration ) => {
 				if ( ! isSubscribed ) {
 					return;
@@ -57,7 +61,7 @@ function usePayPalConfigurationInternalOnly(): {
 		return () => {
 			isSubscribed = false;
 		};
-	}, [] );
+	}, [ fetchPayPalConfiguration ] );
 
 	return { payPalConfiguration, error: configurationError };
 }
@@ -73,12 +77,35 @@ export function usePayPalConfiguration(): UsePayPalConfiguration {
 export function PayPalProvider( {
 	children,
 	currency,
-}: PropsWithChildren< { currency: string } > ) {
-	const { payPalConfiguration, error } = usePayPalConfigurationInternalOnly();
+	handleError,
+	fetchPayPalConfiguration,
+}: PropsWithChildren< {
+	currency: string;
+	handleError?: ( error: Error ) => void;
+	fetchPayPalConfiguration?: () => Promise< PayPalConfigurationApiResponse >;
+} > ) {
+	const { payPalConfiguration, error } = usePayPalConfigurationInternalOnly( {
+		fetchPayPalConfiguration,
+	} );
+	const lastError = useRef< Error | undefined >();
 
-	if ( error ) {
-		throw error;
-	}
+	useEffect( () => {
+		if ( ! error || lastError.current === error ) {
+			return;
+		}
+		lastError.current = error;
+		const errorWithCause = new Error(
+			`Error fetching PayPal configuration: ${ error?.message ?? error }`,
+			{
+				cause: error,
+			}
+		);
+		// eslint-disable-next-line no-console
+		console.error( errorWithCause );
+		if ( handleError ) {
+			handleError( errorWithCause );
+		}
+	}, [ error, handleError ] );
 
 	const payPalScriptOptions: ReactPayPalScriptOptions = {
 		clientId: payPalConfiguration?.clientId ?? 'loading-client-id',


### PR DESCRIPTION
## Proposed Changes

When the `@automattic/calypso-paypal` package was made, I decided to use the `wpcom-proxy-request` package directly to call the `/me/paypal-configuration` endpoint. This seemed to be a simpler way to make a network call without needing to inject the fetching function from the call-site. However, it's possible that there are some cases where it fails. We've seen some intermittent fatals in the `paypal-js` submit button that appear to originate at this API call.

In this PR, I return to the way of making an API call inside an external package that I'm used to: injecting the call as an argument, or in this case a prop, to `PayPalProvider`. The call can then be made with `wp.req.get()` directly inside the calypso app.

This PR also modifies the provider so that if there is an error calling the endpoint, it will call a custom error handler function which is also injected, rather than throwing at runtime. This should allow us to log such failures without causing fatal errors.

## Testing Instructions

To verify that the happy path still works: add a product to your cart and visit checkout. Then verify that PayPal is an option in the list of payment methods and that there are no errors related to the payment method in the console.

To test the failure state, you'll need to modify something. Either you need to modify the paypal configuration endpoint to fail, or modify the new injected function (`fetchPayPalConfiguration`) to throw. Verify that when you load checkout you see an error logged in the console but that checkout itself should be unaffected. The only difference is that PayPal should not show up as a payment method option.

Here's an example of how to break the configuration:

```diff
diff --git a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
index 7ec6f51077f..8330b0c595f 100644
--- a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
+++ b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
@@ -22,6 +22,7 @@ import { convertErrorToString, logStashEvent } from '../lib/analytics';
 const debug = debugFactory( 'calypso:paypal-js' );

 async function fetchPayPalConfiguration(): Promise< PayPalConfigurationApiResponse > {
+       throw new Error( 'testing failure' );
        return await wp.req.get( {
                path: `/me/paypal-configuration`,
                method: 'GET',
```