### PR TITLE
Route migrate link click into existing /setup/hosted-site-migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -114,9 +114,13 @@ const onboarding: Flow = {
 					}
 
 					switch ( intent ) {
-						case SiteIntent.Import:
-							// TODO Implement exit to site migration
-							return;
+						case SiteIntent.Import: {
+							const migrationFlowLink =
+								locale && locale !== 'en'
+									? `/setup/hosted-site-migration/${ locale }`
+									: '/setup/hosted-site-migration';
+							return window.location.assign( migrationFlowLink );
+						}
 
 						case SiteIntent.DIFM: {
 							const difmFlowLink =


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/97452

## Proposed Changes

* Route migrate link click into existing /setup/hosted-site-migration flow
* Replicates https://github.com/Automattic/wp-calypso/pull/97436 for the import flow

## Testing

- http://calypso.localhost:3000/setup/onboarding/goals - Confirm import link takes you to /setup/hosted-site-migration flow, if logged out it will attempt to log you in or create an account first
- http://calypso.localhost:3000/setup/onboarding/goals/es - Confirm import link takes you to /setup/hosted-site-migration/es

![Screenshot(172)](https://github.com/user-attachments/assets/5a979593-70ed-499d-87f3-262e85b34aca)
