### PR TITLE
Fixes for goals screen styling

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -2,11 +2,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-body.is-section-stepper .step-route {
-	//--color-accent: #117ac9;
-	--color-accent-60: #0e64a5;
-}
-
 .step-route.user {
 	display: flex;
 	flex-direction: column;
@@ -21,7 +16,6 @@ body.is-section-stepper .step-route {
 			width: 100%;
 		}
 	}
-
 
 	a.step-wrapper__navigation-link {
 		color: #1d2327;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -115,7 +115,7 @@
 		width: 160px;
 	}
 
-	.select-goals__link.is-link { // extra specificity to override default link styles
+	.components-button.select-goals__link.is-link { // extra specificity to override default link styles
 		color: var(--studio-gray-100);
 		font-size: $font-body-small;
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/97209

## Proposed Changes

* Removes button accent color override from the user step that was leaking into all steps
* Increases specificity on the link button text so the expected gray-100 color is applied

## Testing Instructions

* http://calypso.localhost:3000/setup/onboarding/goals

## Before

![Screenshot 2024-12-16 at 13-12-18 What would you like to do — WordPress com](https://github.com/user-attachments/assets/b82d2ed5-0e78-49cd-ad67-5c35f5b6c5f5)

## After

![Screenshot 2024-12-16 at 13-11-57 What would you like to do — WordPress com](https://github.com/user-attachments/assets/c0eee47d-1a45-476e-b0ab-82b38ee3ff83)
