### PR TITLE
Hide skip to dashboard on goals screen when goals screen is first in flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -5,6 +5,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
+import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
 import { isGoalsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-big-sky-eligible';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -55,6 +56,8 @@ const GoalsStep: Step = ( { navigation } ) => {
 	);
 	const { setGoals, setIntent, resetIntent } = useDispatch( ONBOARD_STORE );
 	const refParameter = getQueryArgs()?.ref as string;
+
+	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 
 	useEffect( () => {
 		resetIntent();
@@ -187,14 +190,16 @@ const GoalsStep: Step = ( { navigation } ) => {
 							<Button variant="link" onClick={ handleDIFMClick } className="select-goals__link">
 								{ translate( 'Let us build a custom site for you' ) }
 							</Button>
-							<Button
-								variant="link"
-								onClick={ handleDashboardClick }
-								className="select-goals__link select-goals__dashboard-button"
-							>
-								<DashboardIcon />
-								{ translate( 'Skip to dashboard' ) }
-							</Button>
+							{ ! isGoalsAtFrontExperiment && (
+								<Button
+									variant="link"
+									onClick={ handleDashboardClick }
+									className="select-goals__link select-goals__dashboard-button"
+								>
+									<DashboardIcon />
+									{ translate( 'Skip to dashboard' ) }
+								</Button>
+							) }
 						</div>
 					</>
 				}

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -106,12 +106,7 @@ const onboarding: Flow = {
 		const submit = async ( providedDependencies: ProvidedDependencies = {} ) => {
 			switch ( currentStepSlug ) {
 				case 'goals': {
-					const { intent, skip } = providedDependencies;
-
-					if ( skip ) {
-						// TODO Implement skipping to dashboard
-						return;
-					}
+					const { intent } = providedDependencies;
 
 					switch ( intent ) {
 						case SiteIntent.Import:


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/97469
Related to https://github.com/Automattic/wp-calypso/issues/96905 and https://github.com/Automattic/wp-calypso/issues/97469

## Proposed Changes

* Hides the "Skip to dashboard" button when in the goals first flow per figma W9xI27S6Swvw5Ku21EbZvn-fi-8689_8480

The skip button continues to take you to the domains step.

## Testing Instructions

http://calypso.localhost:3000/setup/onboarding/goals

Before

![Screenshot 2024-12-16 at 16-22-13 What would you like to do — WordPress com](https://github.com/user-attachments/assets/1e0cfb4a-2a65-4275-86c3-ae18a188dfaa)


After

![Screenshot 2024-12-16 at 16-22-03 What would you like to do — WordPress com](https://github.com/user-attachments/assets/73284e6a-654f-4074-83aa-2d82ca1a04c5)