### PR TITLE
Enable onboarding/goals-first in wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -136,6 +136,7 @@
 		"onboarding/trail-map-feature-grid-structure": false,
 		"onboarding/trail-map-feature-grid": false,
 		"onboarding/user-on-stepper-hosting": true,
+		"onboarding/goals-first": true,
 		"p2/p2-plus": true,
 		"p2-enabled": false,
 		"performance-profiler/llm": true,


### PR DESCRIPTION
Related to #

## Proposed Changes

* Enable onboarding/goals-first feature flag in wpcalypso so that calypso.live links work

## Testing

Calypso live should load the goals step when visiting the onboarding flow: http://calypso.localhost:3000/setup/onboarding
