### PR TITLE
Remove podcast type filter from design picker and its mapping from goals

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -11,19 +11,14 @@ const GOALS_TO_CATEGORIES: { [ key in Onboard.SiteGoal ]: string[] } = {
 	[ Onboard.SiteGoal.Promote ]: [ CATEGORIES.BUSINESS, CATEGORIES.LINK_IN_BIO ],
 	[ Onboard.SiteGoal.CollectDonations ]: [ CATEGORIES.COMMUNITY_NON_PROFIT ],
 	[ Onboard.SiteGoal.Newsletter ]: [ CATEGORIES.NEWSLETTER, CATEGORIES.BLOG ],
-	[ Onboard.SiteGoal.Engagement ]: [
-		CATEGORIES.PODCAST,
-		CATEGORIES.BLOG,
-		CATEGORIES.NEWSLETTER,
-		CATEGORIES.LINK_IN_BIO,
-	],
+	[ Onboard.SiteGoal.Engagement ]: [ CATEGORIES.BLOG, CATEGORIES.LINK_IN_BIO ],
 	[ Onboard.SiteGoal.SellPhysical ]: [ CATEGORIES.STORE ],
 	[ Onboard.SiteGoal.Videos ]: [ CATEGORIES.PORTFOLIO ],
 	[ Onboard.SiteGoal.ContactForm ]: [ CATEGORIES.BUSINESS ],
 	[ Onboard.SiteGoal.BuildNonprofit ]: [ CATEGORIES.COMMUNITY_NON_PROFIT, CATEGORIES.EDUCATION ],
 	[ Onboard.SiteGoal.SellDigital ]: [ CATEGORIES.STORE, CATEGORIES.BUSINESS ],
 
-	// The following goals are deprecated. They are no longer availabe in the goals
+	// The following goals are deprecated. They are no longer available in the goals
 	// signup step, but existing sites still use them.
 	[ Onboard.SiteGoal.Sell ]: [ CATEGORIES.STORE ],
 	[ Onboard.SiteGoal.DIFM ]: [ CATEGORIES.BUSINESS ],

--- a/packages/design-picker/src/constants.ts
+++ b/packages/design-picker/src/constants.ts
@@ -41,7 +41,6 @@ export const FEATURE_CATEGORIES = {
 	BLOG: 'blog',
 	NEWSLETTER: 'newsletter',
 	PORTFOLIO: 'portfolio',
-	PODCAST: 'podcast',
 	STORE: 'store',
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes: https://github.com/Automattic/dotcom-forge/issues/10128
Closes: https://github.com/Automattic/dotcom-forge/issues/10129

## Proposed Changes

* Removes `Podcast` filter from design picker type filters

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because it doesn't connect with any of the selected goals (in the prev page)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit: `setup/site-setup/designSetup?siteSlug=:slug&siteId=:id`
* It should not have `Podcast` type filter.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
