### PR TITLE
Fix: Reinstate mobile nav bar on most stepper framework steps (except signup)

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -79,6 +79,7 @@ const UserStepComponent: Step = function UserStep( {
 				isLargeSkipLayout={ false }
 				hideBack={ ! navigation.goBack }
 				goBack={ navigation.goBack }
+				disableMobileStickyFooter
 				stepContent={
 					<>
 						<FormattedHeader

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -123,6 +123,7 @@ const FAQHeader = styled.h1`
 const FAQSection = styled.div`
 	display: flex;
 	flex-direction: column;
+	margin-bottom: 48px;
 `;
 
 const FoldableFAQ = styled( FoldableFAQComponent )`

--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -12,6 +12,7 @@ interface Props {
 	stepContent: ReactElement;
 	shouldHideNavButtons?: boolean;
 	hasStickyNavButtonsPadding?: boolean;
+	disableMobileStickyFooter?: boolean;
 	hideBack?: boolean;
 	hideSkip?: boolean;
 	hideNext?: boolean;
@@ -52,6 +53,7 @@ const StepContainer: React.FC< Props > = ( {
 	stepName,
 	shouldHideNavButtons,
 	hasStickyNavButtonsPadding,
+	disableMobileStickyFooter,
 	hideBack,
 	backLabelText,
 	hideSkip,
@@ -180,6 +182,7 @@ const StepContainer: React.FC< Props > = ( {
 			<ActionButtons
 				className={ clsx( 'step-container__navigation', {
 					'should-hide-nav-buttons': shouldHideNavButtons,
+					'disable-mobile-sticky-footer': disableMobileStickyFooter,
 					'has-sticky-nav-buttons-padding': hasStickyNavButtonsPadding,
 				} ) }
 			>

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -220,7 +220,7 @@
 		@mixin disable-sticky-footer {
 			position: absolute;
 			top: 8px;
-			inset-inline-start: 72px;
+			inset-inline-start: 56px;
 			inset-inline-end: 24px;
 			// Align with wordpress logo in signup-header
 			padding: 1px 0 0;

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -151,29 +151,21 @@
 		}
 	}
 	.step-container__navigation.action-buttons {
+		background-color: $white;
 		height: 60px;
 		align-items: center;
 		justify-content: space-between;
 		display: flex;
 		font-size: 0.875rem;
+		position: fixed;
 		z-index: 30;
+		inset-inline-start: 0;
+		inset-inline-end: 0;
 		bottom: 0;
+		padding: 0 20px;
 		margin: 0;
 		border-top: none;
-
-		position: absolute;
-		top: 8px;
-		inset-inline-start: 72px;
-		inset-inline-end: 24px;
-		// Align with wordpress logo in signup-header
-		padding: 1px 0 0;
-		background-color: transparent;
-		border: none;
-		box-shadow: none;
-
-		&.has-sticky-nav-buttons-padding {
-			padding-bottom: 48px;
-		}
+		box-shadow: inset 0 1px 0 #e2e4e7;
 
 		&:empty {
 			display: none;
@@ -222,6 +214,22 @@
 
 			@include break-small {
 				display: block;
+			}
+		}
+
+		@include break-small {
+			position: absolute;
+			top: 8px;
+			inset-inline-start: 72px;
+			inset-inline-end: 24px;
+			// Align with wordpress logo in signup-header
+			padding: 1px 0 0;
+			background-color: transparent;
+			border: none;
+			box-shadow: none;
+
+			&.has-sticky-nav-buttons-padding {
+				padding-bottom: 48px;
 			}
 		}
 	}

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -217,7 +217,7 @@
 			}
 		}
 
-		@include break-small {
+		@mixin disable-sticky-footer {
 			position: absolute;
 			top: 8px;
 			inset-inline-start: 72px;
@@ -231,6 +231,14 @@
 			&.has-sticky-nav-buttons-padding {
 				padding-bottom: 48px;
 			}
+		}
+
+		@include break-small {
+			@include disable-sticky-footer;
+		}
+
+		&.disable-mobile-sticky-footer {
+			@include disable-sticky-footer;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #97256 and #97067

## Proposed Changes

* Reinstates the floating nav button CSS which was removed in #97067
* Adds `disableMobileStickyFooter` prop to `<StepContainer>`
* The `__user` step uses the `disableMobileStickyFooter`, which addresses the design problem initially raised in #97067

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://github.com/Automattic/wp-calypso/pull/97256 appears to have overzealously removed CSS which it thought was no longer needed. This PR reinstates that CSS because many stepper frameworks steps use a floating nav footer on mobile.

| goals | design |
| --- | --- |
| ![CleanShot 2024-12-16 at 20 11 58@2x](https://github.com/user-attachments/assets/2a4abbc6-ad79-4194-bbec-5f722e0ed90e) | ![CleanShot 2024-12-16 at 20 11 42@2x](https://github.com/user-attachments/assets/07622e5a-bcdc-49f5-9579-650ca0e5c00b)

However we don't want the `Log in` link on the `__user` step to be in a footer. Hence the new prop.

<img src="https://private-user-images.githubusercontent.com/1500769/396003021-a87e28f9-9163-4733-b696-b38ca13556e8.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MzQzMzUxOTMsIm5iZiI6MTczNDMzNDg5MywicGF0aCI6Ii8xNTAwNzY5LzM5NjAwMzAyMS1hODdlMjhmOS05MTYzLTQ3MzMtYjY5Ni1iMzhjYTEzNTU2ZTgucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MTIxNiUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDEyMTZUMDc0MTMzWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9ODI3Njg2OGU0MGRiZWIwOGNmYjgzMzdkNjhiM2ZmYjIxNmJkNDAzZjNmMWY4ZmI4YmM4MzZhZWFiZWFjMjA4MSZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.Kd0nL82jSCH7_EOfUjDFZO6t_bf2rGRvNONHQg-q4AU" alt="CleanShot 2024-12-16 at 20 32 36@2x" style="max-width: 100%;" width="50%" height="50%">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test the onboarding flow (with goal step moved) with `calypso.localhost:3000/setup/onboarding`
Test the onboarding flow with `calypso.localhost:3000/setup/onboarding?flags=-onboarding/goals-first`
Test the onboarding flow from `calypso.localhost:3000/start` and when you get to the `site-setup` flow the footer should be floating as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
