### PR TITLE
Place recomended list on top/bottom based on filter selection in design picker

### DIFF
--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -324,10 +324,13 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	}, [ designs, recommendedDesignSlugs ] );
 
 	// Show recommended themes only when the selected categories are never changed.
-	const showRecommendedDesigns =
+	const showRecommendedAtTop =
 		isMultiFilterEnabled &&
 		! categorization?.isSelectionsChanged &&
 		recommendedDesigns.length === 3;
+	const showRecommendedAtBottom =
+		isMultiFilterEnabled && categorization?.isSelectionsChanged && recommendedDesigns.length === 3;
+	const showRecommendedDesigns = showRecommendedAtTop || showRecommendedAtBottom;
 
 	const { all, best, ...designsByGroup } = useFilteredDesignsByGroup( designs, {
 		excludeDesigns: showRecommendedDesigns ? recommendedDesigns : [],
@@ -394,15 +397,6 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 				) }
 			</div>
 
-			{ showRecommendedDesigns && (
-				<DesignCardGroup
-					{ ...designCardProps }
-					title={ translate( 'Recommended themes' ) }
-					category="recommended"
-					designs={ recommendedDesigns }
-				/>
-			) }
-
 			{ isMultiFilterEnabled && selectedCategoriesWithoutDesignTier.length > 1 && (
 				<DesignCardGroup
 					{ ...designCardProps }
@@ -411,6 +405,15 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 					designs={ best }
 				/>
 			) }
+			{ showRecommendedAtTop && (
+				<DesignCardGroup
+					{ ...designCardProps }
+					title={ translate( 'Trending for your goals' ) }
+					category="recommended"
+					designs={ recommendedDesigns }
+				/>
+			) }
+
 			{ isMultiFilterEnabled && selectedCategoriesWithoutDesignTier.length === 0 && (
 				<DesignCardGroup { ...designCardProps } designs={ all } />
 			) }
@@ -434,6 +437,15 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						showNoResults={ index === array.length - 1 && showNoResults }
 					/>
 				) ) }
+
+			{ showRecommendedAtBottom && (
+				<DesignCardGroup
+					{ ...designCardProps }
+					title={ translate( 'Trending for your goals' ) }
+					category="recommended"
+					designs={ recommendedDesigns }
+				/>
+			) }
 		</div>
 	);
 };

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -41,8 +41,8 @@ export function useCategorization(
 	const { selectedCategories, setSelectedCategories } = useDesignPickerFilters();
 	const isSelectionsChanged = useMemo(
 		() =>
-			defaultSelections.length === selectedCategories.length &&
-			defaultSelections.every( ( selection ) => selectedCategories.includes( selection ) ),
+			defaultSelections.length !== selectedCategories.length ||
+			! defaultSelections.every( ( selection ) => selectedCategories.includes( selection ) ),
 		[ defaultSelections, selectedCategories ]
 	);
 

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useCallback, useRef, useState } from 'react';
+import { useEffect, useMemo, useCallback, useRef } from 'react';
 import { useDesignPickerFilters } from './use-design-picker-filters';
 import type { Category } from '../types';
 
@@ -28,7 +28,6 @@ export function useCategorization(
 	}: UseCategorizationOptions
 ): Categorization {
 	const isInitRef = useRef( false );
-	const [ isSelectionsChanged, setIsSelectionsChanged ] = useState( false );
 	const categories = useMemo( () => {
 		const categoryMapKeys = Object.keys( categoryMap ) || [];
 		const result = categoryMapKeys.map( ( slug ) => ( {
@@ -40,6 +39,12 @@ export function useCategorization(
 	}, [ categoryMap, sort ] );
 
 	const { selectedCategories, setSelectedCategories } = useDesignPickerFilters();
+	const isSelectionsChanged = useMemo(
+		() =>
+			defaultSelections.length === selectedCategories.length &&
+			defaultSelections.every( ( selection ) => selectedCategories.includes( selection ) ),
+		[ defaultSelections, selectedCategories ]
+	);
 
 	const onSelect = useCallback(
 		( value: string ) => {
@@ -47,10 +52,6 @@ export function useCategorization(
 				handleSelect?.( value );
 				setSelectedCategories( [ value ] );
 				return;
-			}
-
-			if ( ! isSelectionsChanged ) {
-				setIsSelectionsChanged( true );
 			}
 
 			const index = selectedCategories.findIndex( ( selection ) => selection === value );
@@ -72,7 +73,6 @@ export function useCategorization(
 			setSelectedCategories,
 			handleSelect,
 			handleDeselect,
-			setIsSelectionsChanged,
 		]
 	);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes: https://github.com/Automattic/dotcom-forge/issues/10135

## Proposed Changes

* Give Recommended group new name "Trending with your goals"
* show the "Trending for your goals" section below "Best matches" (if available).
* If users change filters, we move "Trending for your goals" to the bottom of the page.
* If users revert to the original filters, move "Trending for your goals" to below "Best matches" (if available).

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/206d1309-7a86-456f-9bf1-8847455f0fd1" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Choose goals from goals page
* On Next, design picker should show `Trending for your goals` category with recommended and best matching results together, but recommended on top.
* Update the filter and update back to original state.
* Now it should show only best matching themes under the same category.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
