### PR TITLE
Avoid using select and ensure isLoggedIn is correct

### DIFF
--- a/packages/zendesk-client/src/use-authenticate-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-authenticate-zendesk-messaging.ts
@@ -14,9 +14,7 @@ import type { APIFetchOptions, MessagingAuth, ZendeskAuthType } from './types';
 /**
  * Bump me when the API response structure goes through a breaking change.
  */
-const VERSION = 'v1';
-
-let isLoggedIn = false;
+const VERSION = 'v2';
 
 export function useAuthenticateZendeskMessaging(
 	enabled = false,
@@ -27,11 +25,11 @@ export function useAuthenticateZendeskMessaging(
 
 	return useQuery( {
 		queryKey: [ 'getMessagingAuth', VERSION, type, isTestMode ],
-		queryFn: () => {
+		queryFn: async () => {
 			const params = { type, test_mode: String( isTestMode ) };
 			const wpcomParams = new URLSearchParams( params );
 
-			return canAccessWpcomApis()
+			const auth = await ( canAccessWpcomApis()
 				? wpcomRequest< MessagingAuth >( {
 						path: '/help/authenticate/chat',
 						query: wpcomParams.toString(),
@@ -43,23 +41,21 @@ export function useAuthenticateZendeskMessaging(
 						path: addQueryArgs( '/help-center/authenticate/chat', params ),
 						method: 'POST',
 						global: true,
-				  } as APIFetchOptions );
+				  } as APIFetchOptions ) );
+
+			const jwt = auth?.user?.jwt;
+			await new Promise< void >( ( resolve, reject ) => {
+				if ( ! jwt ) {
+					reject();
+				}
+				window?.zE?.( 'messenger', 'loginUser', function ( callback ) {
+					callback( jwt );
+					resolve();
+				} );
+			} );
+			return { isLoggedIn: true, jwt, externalId: auth?.user.external_id };
 		},
 		staleTime: 7 * 24 * 60 * 60 * 1000, // 1 week (JWT is actually 2 weeks, but lets be on the safe side)
 		enabled,
-		select: ( messagingAuth ) => {
-			const jwt = messagingAuth?.user.jwt;
-			if ( ! isLoggedIn ) {
-				if ( typeof window.zE !== 'function' || ! jwt ) {
-					return;
-				}
-
-				window.zE( 'messenger', 'loginUser', function ( callback ) {
-					callback( jwt );
-				} );
-				isLoggedIn = true;
-			}
-			return { isLoggedIn, jwt, externalId: messagingAuth?.user.external_id };
-		},
 	} );
 }

--- a/packages/zendesk-client/src/use-authenticate-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-authenticate-zendesk-messaging.ts
@@ -44,16 +44,18 @@ export function useAuthenticateZendeskMessaging(
 				  } as APIFetchOptions ) );
 
 			const jwt = auth?.user?.jwt;
-			await new Promise< void >( ( resolve, reject ) => {
-				if ( ! jwt ) {
-					reject();
+
+			return new Promise< { isLoggedIn: boolean; jwt: string; externalId: string | undefined } >(
+				( resolve, reject ) => {
+					if ( ! jwt ) {
+						reject();
+					}
+					window?.zE?.( 'messenger', 'loginUser', function ( callback ) {
+						callback( jwt );
+						resolve( { isLoggedIn: true, jwt, externalId: auth?.user.external_id } );
+					} );
 				}
-				window?.zE?.( 'messenger', 'loginUser', function ( callback ) {
-					callback( jwt );
-					resolve();
-				} );
-			} );
-			return { isLoggedIn: true, jwt, externalId: auth?.user.external_id };
+			);
 		},
 		staleTime: 7 * 24 * 60 * 60 * 1000, // 1 week (JWT is actually 2 weeks, but lets be on the safe side)
 		enabled,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fix isLoggedIn value

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The `select` implementation was buggy

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Close all conversations for your testing user
* After reloading the page and opening the hc the `isLoggedIn` value should be correct.
* Test for regressions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
