### PR TITLE
Untangling: turn off untangling/hosting-menu flag everywhere

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -238,7 +238,7 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
-		"untangling/hosting-menu": true,
+		"untangling/hosting-menu": false,
 		"user-management-revamp": true,
 		"videomaker-trial": true,
 		"woop": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -201,7 +201,7 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
-		"untangling/hosting-menu": true,
+		"untangling/hosting-menu": false,
 		"use-translation-chunks": true,
 		"user-management-revamp": true,
 		"videomaker-trial": true,


### PR DESCRIPTION
Related to p1734355080201239/1734354151.267859-slack-CRWCHQGUB

## Proposed Changes

The `untangling/hosting-menu` feature flag is not ready yet, and its future is unclear. To avoid more confusion, let's turn it off for everyone.

## Testing Instructions

N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?