### PR TITLE
Defer survey rendering to prevent flickering

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/deferred-render/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/deferred-render/index.tsx
@@ -1,0 +1,16 @@
+import { useDeferredRender } from './use-deferred-render';
+
+interface DelayedRenderProps {
+	children: React.ReactNode;
+	timeMs?: number;
+}
+
+export const DeferredRender = ( { children, timeMs = 1000 }: DelayedRenderProps ) => {
+	const { isReadyToRender } = useDeferredRender( { timeMs } );
+
+	if ( ! isReadyToRender ) {
+		return null;
+	}
+
+	return <>{ children }</>;
+};

--- a/client/landing/stepper/declarative-flow/internals/components/deferred-render/use-deferred-render/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/deferred-render/use-deferred-render/index.tsx
@@ -13,7 +13,7 @@ export const useDeferredRender = ( { timeMs }: UseDeferredRenderProps ) => {
 			setIsReadyToRender( true );
 		}, timeMs );
 
-		timeoutId.current = id as unknown as number;
+		timeoutId.current = id;
 
 		return () => {
 			if ( timeoutId.current ) {

--- a/client/landing/stepper/declarative-flow/internals/components/deferred-render/use-deferred-render/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/deferred-render/use-deferred-render/index.tsx
@@ -9,7 +9,7 @@ export const useDeferredRender = ( { timeMs }: UseDeferredRenderProps ) => {
 	const timeoutId = useRef< number | null >( null );
 
 	useEffect( () => {
-		const id = setTimeout( () => {
+		const id = window.setTimeout( () => {
 			setIsReadyToRender( true );
 		}, timeMs );
 
@@ -17,7 +17,7 @@ export const useDeferredRender = ( { timeMs }: UseDeferredRenderProps ) => {
 
 		return () => {
 			if ( timeoutId.current ) {
-				clearTimeout( timeoutId.current );
+				window.clearTimeout( timeoutId.current );
 			}
 		};
 	}, [ timeMs ] );

--- a/client/landing/stepper/declarative-flow/internals/components/deferred-render/use-deferred-render/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/deferred-render/use-deferred-render/index.tsx
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseDeferredRenderProps {
+	timeMs: number;
+}
+
+export const useDeferredRender = ( { timeMs }: UseDeferredRenderProps ) => {
+	const [ isReadyToRender, setIsReadyToRender ] = useState( false );
+	const timeoutId = useRef< number | null >( null );
+
+	useEffect( () => {
+		const id = setTimeout( () => {
+			setIsReadyToRender( true );
+		}, timeMs );
+
+		timeoutId.current = id as unknown as number;
+
+		return () => {
+			if ( timeoutId.current ) {
+				clearTimeout( timeoutId.current );
+			}
+		};
+	}, [ timeMs ] );
+
+	const startDelayedRendering = useCallback( () => {
+		setIsReadyToRender( true );
+	}, [] );
+
+	return {
+		isReadyToRender,
+		startDelayedRendering,
+	};
+};

--- a/client/landing/stepper/declarative-flow/internals/components/deferred-render/use-deferred-render/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/deferred-render/use-deferred-render/test/index.tsx
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useDeferredRender } from '../index';
+
+describe( 'useDeferredRender', () => {
+	beforeAll( () => {
+		jest.resetAllMocks();
+		jest.useFakeTimers();
+	} );
+
+	afterAll( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'starts isReadyToRender as false', () => {
+		const { result } = renderHook( () => useDeferredRender( { timeMs: 1000 } ) );
+		expect( result.current.isReadyToRender ).toBe( false );
+	} );
+
+	it( 'enables to render after the delay', async () => {
+		const { result } = renderHook( () => useDeferredRender( { timeMs: 1000 } ) );
+
+		await act( () => {
+			jest.runAllTimers();
+		} );
+
+		await waitFor( () => {
+			expect( result.current.isReadyToRender ).toBe( true );
+		} );
+	} );
+
+	it( 'cancels the timeout when the component unmounts', async () => {
+		const clearTimeoutSpy = jest.spyOn( global, 'clearTimeout' );
+		const { result, unmount } = renderHook( () => useDeferredRender( { timeMs: 1000 } ) );
+		unmount();
+
+		await act( () => {
+			jest.runAllTimers();
+		} );
+
+		expect( result.current.isReadyToRender ).toBe( false );
+		expect( clearTimeoutSpy ).toHaveBeenCalled();
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -59,10 +59,14 @@ const StepRoute = ( { step, flow, showWooLogo, renderStep, navigate }: StepRoute
 				kebabCase( step.slug )
 			) }
 		>
-			{ stepContent && <SignupHeader pageTitle={ flow.title } showWooLogo={ showWooLogo } /> }
-			{ stepContent }
-			{ stepContent && <SurveyManager /> }
-			{ stepContent && <StepperPerformanceTrackerStop flow={ flow.name } step={ step.slug } /> }
+			{ stepContent && (
+				<>
+					<SignupHeader pageTitle={ flow.title } showWooLogo={ showWooLogo } />
+					{ stepContent }
+					<SurveyManager />
+					<StepperPerformanceTrackerStop flow={ flow.name } step={ step.slug } />
+				</>
+			) }
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -6,6 +6,7 @@ import { StepperPerformanceTrackerStop } from 'calypso/landing/stepper/utils/per
 import SignupHeader from 'calypso/signup/signup-header';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import SurveyManager from '../survery-manager';
 import { useStepRouteTracking } from './hooks/use-step-route-tracking';
 import type { Flow, Navigate, StepperStep } from '../../types';
 
@@ -60,6 +61,7 @@ const StepRoute = ( { step, flow, showWooLogo, renderStep, navigate }: StepRoute
 		>
 			{ stepContent && <SignupHeader pageTitle={ flow.title } showWooLogo={ showWooLogo } /> }
 			{ stepContent }
+			{ stepContent && <SurveyManager /> }
 			{ stepContent && <StepperPerformanceTrackerStop flow={ flow.name } step={ step.slug } /> }
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/components/survery-manager/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/survery-manager/index.tsx
@@ -27,7 +27,7 @@ const SurveyManager = () => {
 
 	if ( MIGRATION_SURVEY_FLOWS.includes( params.flow ) && isEnLocale ) {
 		return (
-			<DeferredRender timeMs={ 1000 }>
+			<DeferredRender timeMs={ 2000 }>
 				<Suspense>
 					<AsyncMigrationSurvey />
 				</Suspense>

--- a/client/landing/stepper/declarative-flow/internals/components/survery-manager/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/survery-manager/index.tsx
@@ -1,4 +1,3 @@
-import getTrackingPrefs from '@automattic/calypso-analytics/src/utils/get-tracking-prefs';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import {
 	MIGRATION_FLOW,
@@ -9,6 +8,7 @@ import {
 import { Suspense } from 'react';
 import { useFlowNavigation } from '../../hooks/use-flow-navigation';
 import AsyncMigrationSurvey from '../../steps-repository/components/migration-survey/async';
+import { DeferredRender } from '../deferred-render';
 
 const MIGRATION_SURVEY_FLOWS = [
 	MIGRATION_FLOW,
@@ -20,30 +20,22 @@ const MIGRATION_SURVEY_FLOWS = [
 const SurveyManager = () => {
 	const { params } = useFlowNavigation();
 	const isEnLocale = useIsEnglishLocale();
-	const { ok } = getTrackingPrefs();
-
-	// Skip survey for non-English locales
-	if ( ! isEnLocale ) {
-		return null;
-	}
 
 	if ( ! params.flow ) {
 		return null;
 	}
 
-	if ( ! MIGRATION_SURVEY_FLOWS.includes( params.flow ) ) {
-		return null;
+	if ( MIGRATION_SURVEY_FLOWS.includes( params.flow ) && isEnLocale ) {
+		return (
+			<DeferredRender timeMs={ 1000 }>
+				<Suspense>
+					<AsyncMigrationSurvey />
+				</Suspense>
+			</DeferredRender>
+		);
 	}
 
-	if ( ! ok ) {
-		return null;
-	}
-
-	return (
-		<Suspense>
-			<AsyncMigrationSurvey />
-		</Suspense>
-	);
+	return null;
 };
 
 export default SurveyManager;

--- a/client/landing/stepper/declarative-flow/internals/components/survery-manager/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/survery-manager/index.tsx
@@ -1,3 +1,4 @@
+import getTrackingPrefs from '@automattic/calypso-analytics/src/utils/get-tracking-prefs';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import {
 	MIGRATION_FLOW,
@@ -19,6 +20,7 @@ const MIGRATION_SURVEY_FLOWS = [
 const SurveyManager = () => {
 	const { params } = useFlowNavigation();
 	const isEnLocale = useIsEnglishLocale();
+	const { ok } = getTrackingPrefs();
 
 	// Skip survey for non-English locales
 	if ( ! isEnLocale ) {
@@ -30,6 +32,10 @@ const SurveyManager = () => {
 	}
 
 	if ( ! MIGRATION_SURVEY_FLOWS.includes( params.flow ) ) {
+		return null;
+	}
+
+	if ( ! ok ) {
 		return null;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -19,7 +19,6 @@ import { useStartStepperPerformanceTracking } from '../../utils/performance-trac
 import { StepperLoader, StepRoute } from './components';
 import { Boot } from './components/boot';
 import { RedirectToStep } from './components/redirect-to-step';
-import SurveyManager from './components/survery-manager';
 import { useFlowAnalytics } from './hooks/use-flow-analytics';
 import { useFlowNavigation } from './hooks/use-flow-navigation';
 import { useSignUpStartTracking } from './hooks/use-sign-up-start-tracking';
@@ -212,7 +211,6 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		<Boot fallback={ <StepperLoader /> }>
 			<DocumentHead title={ getDocumentHeadTitle() } />
 
-			<SurveyManager />
 			<Routes>
 				{ flowSteps.map( ( step ) => (
 					<Route

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/survey/index.tsx
@@ -98,7 +98,6 @@ export const Survey = ( {
 	const shouldShow = ! cookieValue[ name ];
 	const [ shouldShowSurvey, setShouldShowSurvey ] = useState( isOpen && shouldShow );
 	const element = bemElement( className );
-
 	const handleClose = useCallback(
 		( reason: 'skip' | 'accept' | 'skip_backdrop' ) => {
 			const PERIOD = reason === 'skip_backdrop' ? ONE_DAY_IN_SECONDS : ONE_YEAR_IN_SECONDS;


### PR DESCRIPTION
Closes #96966


## Proposed Changes
* Move survey rendering to step router after all login logic
* Defer the component rendering in 2 seconds

## Why are these changes being made?
* Before this PR, the survey modal was rendered too early, causing flickering when the login was required (see the video above). This change only renders the survey after the logic calculation and defers by 2 seconds to prevent the animation from running while the screen is still rendering. 



Before

https://github.com/user-attachments/assets/e45a06d3-d01b-4a16-a257-b8a90996d2e0

After

https://github.com/user-attachments/assets/7057bf7a-f2fc-48cd-a290-e9a42db4bfc0


## Testing Instructions

Scenario 1: Flickering
* Open a new tab without a wp.com session
* Delete the cookie `migration-survey` if it is available.
* Access `/setup/hosted-site-migration` 
* Pay attention to the bottom-right screen side to check if you can see any survey rendering quickly 

Scenario 2: Show 
* Delete the cookie `migration-survey` if it is available.
* Open a new tab with an already existent wp.com session
* Access `/setup/hosted-site-migration`
* Check if you can see the survey.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
