### PR TITLE
Reader: add fast exit tracking

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -105,7 +105,6 @@ export class FullPostView extends Component {
 		isSuggestedFollowsModalOpen: false,
 		maxScrollDepth: 0, // Track the maximum scroll depth achieved
 		hasCompleted: false, // Track whether the user completed the post
-		fastExit: true, // Track whether the user fast exited the post
 	};
 
 	openSuggestedFollowsModal = ( followClicked ) => {

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -165,7 +165,6 @@ export class FullPostView extends Component {
 				this.trackReadingTime( prevProps.post );
 				this.trackScrollDepth( prevProps.post );
 				this.trackExitBeforeCompletion( prevProps.post );
-				this.checkFastExit( prevProps.post ); // Check if the user exited early
 				this.setReadingStartTime();
 				this.resetScroll();
 			}
@@ -197,7 +196,6 @@ export class FullPostView extends Component {
 		this.props.enableAppBanner(); // reset the app banner
 		document.querySelector( 'body' ).classList.remove( 'is-reader-full-post' );
 		this.trackReadingTime();
-		this.checkFastExit(); // Check if the user exited early
 		document.removeEventListener( 'keydown', this.handleKeydown, true );
 		document.removeEventListener( 'visibilitychange', this.handleVisibilityChange );
 
@@ -254,7 +252,6 @@ export class FullPostView extends Component {
 			this.trackReadingTime();
 			this.trackScrollDepth();
 			this.trackExitBeforeCompletion();
-			this.checkFastExit(); // Check if the user exited early
 			this.resetScroll();
 		}
 	};
@@ -270,6 +267,8 @@ export class FullPostView extends Component {
 				context: 'full-post',
 				engagement_time: engagementTime / 1000,
 			} );
+			// check if the user exited early
+			this.checkFastExit( post );
 		}
 	}
 

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -105,6 +105,7 @@ export class FullPostView extends Component {
 		isSuggestedFollowsModalOpen: false,
 		maxScrollDepth: 0, // Track the maximum scroll depth achieved
 		hasCompleted: false, // Track whether the user completed the post
+		fastExit: true, // Track whether the user fast exited the post
 	};
 
 	openSuggestedFollowsModal = ( followClicked ) => {
@@ -119,6 +120,7 @@ export class FullPostView extends Component {
 		this.hasSentPageView = false;
 		this.hasLoaded = false;
 		this.setReadingStartTime();
+		this.setEstimatedReadingTime();
 		this.attemptToSendPageView();
 		this.maybeDisableAppBanner();
 
@@ -165,7 +167,9 @@ export class FullPostView extends Component {
 				this.trackReadingTime( prevProps.post );
 				this.trackScrollDepth( prevProps.post );
 				this.trackExitBeforeCompletion( prevProps.post );
+				this.checkFastExit( prevProps.post ); // Check if the user exited early
 				this.setReadingStartTime();
+				this.setEstimatedReadingTime();
 				this.resetScroll();
 			}
 		}
@@ -196,6 +200,7 @@ export class FullPostView extends Component {
 		this.props.enableAppBanner(); // reset the app banner
 		document.querySelector( 'body' ).classList.remove( 'is-reader-full-post' );
 		this.trackReadingTime();
+		this.checkFastExit(); // Check if the user exited early
 		document.removeEventListener( 'keydown', this.handleKeydown, true );
 		document.removeEventListener( 'visibilitychange', this.handleVisibilityChange );
 
@@ -252,6 +257,7 @@ export class FullPostView extends Component {
 			this.trackReadingTime();
 			this.trackScrollDepth();
 			this.trackExitBeforeCompletion();
+			this.checkFastExit(); // Check if the user exited early
 			this.resetScroll();
 		}
 	};
@@ -268,6 +274,28 @@ export class FullPostView extends Component {
 				engagement_time: engagementTime / 1000,
 			} );
 		}
+	}
+
+	setEstimatedReadingTime = () => {
+		this.estimatedReadingTime = this.estimateReadingTime(); // In seconds;
+	};
+
+	estimateReadingTime() {
+		const { post } = this.props;
+		if ( ! post ) {
+			return 0;
+		}
+		const averageReadingSpeed = 200; // words per minute
+		const wordsPerSecond = averageReadingSpeed / 60;
+		const wordCount = post.word_count;
+
+		if ( ! wordCount ) {
+			return 0;
+		}
+
+		// Calculate reading time in seconds
+		const readingTime = Math.ceil( wordCount / wordsPerSecond );
+		return readingTime;
 	}
 
 	clearResetScrollTimeout = () => {
@@ -330,6 +358,32 @@ export class FullPostView extends Component {
 				context: 'full-post',
 				scroll_depth: maxScrollDepth,
 			} );
+		}
+	};
+
+	trackFastExit = ( post, elapsedTime, fastExitThreshold ) => {
+		recordTrackForPost( 'calypso_reader_article_fast_exit', post, {
+			context: 'full-post',
+			estimated_reading_time: this.estimatedReadingTime,
+			elapsed_time: elapsedTime,
+			fast_exit_threshold: fastExitThreshold,
+		} );
+	};
+
+	checkFastExit = ( post = null ) => {
+		if ( ! post ) {
+			post = this.props.post;
+		}
+
+		if ( ! this.readingStartTime || ! post?.ID || ! this.estimatedReadingTime ) {
+			return;
+		}
+
+		const elapsedTime = ( Date.now() - this.readingStartTime ) / 1000; // Convert to seconds
+		const fastExitThreshold = this.estimatedReadingTime * 0.25; // Define a "fast exit" as 25% of estimated time
+
+		if ( elapsedTime < fastExitThreshold ) {
+			this.trackFastExit( post, elapsedTime, fastExitThreshold );
 		}
 	};
 

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -335,11 +335,11 @@ export class FullPostView extends Component {
 		}
 	};
 
-	trackFastExit = ( post, elapsedTime, fastExitThreshold ) => {
+	trackFastExit = ( post, elapsedSeconds, fastExitThreshold ) => {
 		recordTrackForPost( 'calypso_reader_article_fast_exit', post, {
 			context: 'full-post',
 			estimated_reading_time: post.minutes_to_read,
-			elapsed_time: elapsedTime,
+			elapsed_seconds: elapsedSeconds,
 			fast_exit_threshold: fastExitThreshold,
 		} );
 	};

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -268,7 +268,7 @@ export class FullPostView extends Component {
 				engagement_time: engagementTime / 1000,
 			} );
 			// check if the user exited early
-			this.checkFastExit( post );
+			this.checkFastExit( post, engagementTime );
 		}
 	}
 
@@ -344,7 +344,7 @@ export class FullPostView extends Component {
 		} );
 	};
 
-	checkFastExit = ( post = null ) => {
+	checkFastExit = ( post = null, engagementTime ) => {
 		if ( ! post ) {
 			post = this.props.post;
 		}
@@ -358,12 +358,12 @@ export class FullPostView extends Component {
 			return;
 		}
 
-		const elapsedTime = ( Date.now() - this.readingStartTime ) / 1000; // Convert to seconds
-		const secondsToRead = post.minutes_to_read * 60;
-		const fastExitThreshold = secondsToRead * 0.25; // Define a "fast exit" as 25% of estimated time
+		const elapsedSeconds = engagementTime / 1000;
+		const estimatedSecondsToRead = post.minutes_to_read * 60;
+		const fastExitThreshold = estimatedSecondsToRead * 0.25; // Define a "fast exit" as 25% of estimated time
 
-		if ( elapsedTime < fastExitThreshold ) {
-			this.trackFastExit( post, elapsedTime, fastExitThreshold );
+		if ( elapsedSeconds < fastExitThreshold ) {
+			this.trackFastExit( post, elapsedSeconds, fastExitThreshold );
 		}
 	};
 

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -120,7 +120,6 @@ export class FullPostView extends Component {
 		this.hasSentPageView = false;
 		this.hasLoaded = false;
 		this.setReadingStartTime();
-		this.setEstimatedReadingTime();
 		this.attemptToSendPageView();
 		this.maybeDisableAppBanner();
 
@@ -169,7 +168,6 @@ export class FullPostView extends Component {
 				this.trackExitBeforeCompletion( prevProps.post );
 				this.checkFastExit( prevProps.post ); // Check if the user exited early
 				this.setReadingStartTime();
-				this.setEstimatedReadingTime();
 				this.resetScroll();
 			}
 		}
@@ -276,28 +274,6 @@ export class FullPostView extends Component {
 		}
 	}
 
-	setEstimatedReadingTime = () => {
-		this.estimatedReadingTime = this.estimateReadingTime(); // In seconds;
-	};
-
-	estimateReadingTime() {
-		const { post } = this.props;
-		if ( ! post ) {
-			return 0;
-		}
-		const averageReadingSpeed = 200; // words per minute
-		const wordsPerSecond = averageReadingSpeed / 60;
-		const wordCount = post.word_count;
-
-		if ( ! wordCount ) {
-			return 0;
-		}
-
-		// Calculate reading time in seconds
-		const readingTime = Math.ceil( wordCount / wordsPerSecond );
-		return readingTime;
-	}
-
 	clearResetScrollTimeout = () => {
 		if ( this.resetScrollTimeout ) {
 			clearTimeout( this.resetScrollTimeout );
@@ -364,7 +340,7 @@ export class FullPostView extends Component {
 	trackFastExit = ( post, elapsedTime, fastExitThreshold ) => {
 		recordTrackForPost( 'calypso_reader_article_fast_exit', post, {
 			context: 'full-post',
-			estimated_reading_time: this.estimatedReadingTime,
+			estimated_reading_time: post.minutes_to_read,
 			elapsed_time: elapsedTime,
 			fast_exit_threshold: fastExitThreshold,
 		} );
@@ -375,12 +351,18 @@ export class FullPostView extends Component {
 			post = this.props.post;
 		}
 
-		if ( ! this.readingStartTime || ! post?.ID || ! this.estimatedReadingTime ) {
+		if (
+			! this.readingStartTime ||
+			! post?.ID ||
+			! post?.minutes_to_read ||
+			post?.minutes_to_read === 0
+		) {
 			return;
 		}
 
 		const elapsedTime = ( Date.now() - this.readingStartTime ) / 1000; // Convert to seconds
-		const fastExitThreshold = this.estimatedReadingTime * 0.25; // Define a "fast exit" as 25% of estimated time
+		const secondsToRead = post.minutes_to_read * 60;
+		const fastExitThreshold = secondsToRead * 0.25; // Define a "fast exit" as 25% of estimated time
 
 		if ( elapsedTime < fastExitThreshold ) {
 			this.trackFastExit( post, elapsedTime, fastExitThreshold );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/loop/issues/264

This PR considers a fast exit as when a user exits a post in less than 25% of estimated reading time.

## Proposed Changes

- Estimated reading time is taken from the `post.minutes_to_read` added in https://github.com/Automattic/wp-calypso/pull/97529
- Adding `checkFastExit` and `trackFastExit` methods to log and track if a user exits the post before completing it, defined as exiting in less than **25%** of the estimated reading time.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/read`  - add some debug to the `recordTrackForPost` function to output track event to console when hit.
* Test loading a long form post and exiting quickly - you should see console for the fastExit track event.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
