### PR TITLE
Checkout: Do not render PayPal unless paypal Buttons are available

### DIFF
--- a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
+++ b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
@@ -103,12 +103,18 @@ function PayPalSubmitButton( {
 	const { responseCart } = useShoppingCart( cartKey );
 
 	// Wait for PayPal.js to load before marking this payment method as active.
-	const [ { isResolved, isPending } ] = usePayPalScriptReducer();
+	const [ { isResolved: isPayPalJsLoaded, isPending: isPayPalJsStillLoading } ] =
+		usePayPalScriptReducer();
+	// Sometimes it appears that usePayPalScriptReducer lies about the script
+	// being loaded (or possibly the script does not correctly expose its
+	// Buttons property?) and we get a fatal error when trying to render
+	// PayPalButtons, so we double check before enabling the payment method.
+	const arePayPalButtonsAvailable = Boolean( window?.paypal?.Buttons );
 	useEffect( () => {
-		if ( isResolved ) {
+		if ( isPayPalJsLoaded && arePayPalButtonsAvailable ) {
 			togglePaymentMethod( 'paypal-js', true );
 		}
-	}, [ isResolved, togglePaymentMethod ] );
+	}, [ isPayPalJsLoaded, arePayPalButtonsAvailable, togglePaymentMethod ] );
 
 	useEffect( () => {
 		debug( 'cart changed; rerendering PayPalSubmitButton' );
@@ -126,7 +132,7 @@ function PayPalSubmitButton( {
 	const [ activePaymentMethodId ] = usePaymentMethodId();
 	const isActive = 'paypal-js' === activePaymentMethodId;
 
-	if ( isPending || ! isResolved || ! isActive ) {
+	if ( isPayPalJsStillLoading || ! isPayPalJsLoaded || ! arePayPalButtonsAvailable || ! isActive ) {
 		return <div>Loading</div>;
 	}
 

--- a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
+++ b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
@@ -115,6 +115,8 @@ function PayPalSubmitButton( {
 			togglePaymentMethod( 'paypal-js', true );
 		}
 		if ( isPayPalJsLoaded && ! arePayPalButtonsAvailable ) {
+			// eslint-disable-next-line no-console
+			console.error( 'PayPal says the script is loaded but Buttons are not available' );
 			logStashEvent(
 				'PayPal says the script is loaded but Buttons are not available',
 				{ tags: [ 'paypal-configuration', 'paypal-buttons-missing' ] },

--- a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
+++ b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
@@ -115,11 +115,22 @@ function PayPalSubmitButton( {
 			togglePaymentMethod( 'paypal-js', true );
 		}
 		if ( isPayPalJsLoaded && ! arePayPalButtonsAvailable ) {
+			let paypalObjectString = '';
+			try {
+				paypalObjectString = JSON.stringify( window?.paypal );
+			} catch ( error ) {
+				paypalObjectString = `${ window?.paypal }`;
+			}
 			// eslint-disable-next-line no-console
-			console.error( 'PayPal says the script is loaded but Buttons are not available' );
+			console.error(
+				`PayPal says the script is loaded but Buttons are not available. The paypal object is ${ paypalObjectString }`
+			);
 			logStashEvent(
 				'PayPal says the script is loaded but Buttons are not available',
-				{ tags: [ 'paypal-configuration', 'paypal-buttons-missing' ] },
+				{
+					paypal: paypalObjectString,
+					tags: [ 'paypal-configuration', 'paypal-buttons-missing' ],
+				},
 				'error'
 			);
 		}

--- a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
+++ b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
@@ -114,6 +114,13 @@ function PayPalSubmitButton( {
 		if ( isPayPalJsLoaded && arePayPalButtonsAvailable ) {
 			togglePaymentMethod( 'paypal-js', true );
 		}
+		if ( isPayPalJsLoaded && ! arePayPalButtonsAvailable ) {
+			logStashEvent(
+				'PayPal says the script is loaded but Buttons are not available',
+				{ tags: [ 'paypal-configuration', 'paypal-buttons-missing' ] },
+				'error'
+			);
+		}
 	}, [ isPayPalJsLoaded, arePayPalButtonsAvailable, togglePaymentMethod ] );
 
 	useEffect( () => {

--- a/packages/composite-checkout/src/lib/payment-methods/index.ts
+++ b/packages/composite-checkout/src/lib/payment-methods/index.ts
@@ -1,5 +1,5 @@
 import debugFactory from 'debug';
-import { useContext, useMemo } from 'react';
+import { useCallback, useContext, useMemo } from 'react';
 import CheckoutContext from '../checkout-context';
 import type { PaymentMethod, TogglePaymentMethod } from '../../types';
 
@@ -58,23 +58,26 @@ export function useTogglePaymentMethod(): TogglePaymentMethod {
 	if ( ! allPaymentMethods ) {
 		throw new Error( 'useTogglePaymentMethod cannot be used outside of CheckoutProvider' );
 	}
-	return ( paymentMethodId: string, available: boolean ) => {
-		const paymentMethod = allPaymentMethods.find( ( { id } ) => id === paymentMethodId );
-		if ( ! paymentMethod ) {
-			debug( `No payment method found matching id '${ paymentMethodId }' in`, allPaymentMethods );
-			return;
-		}
+	return useCallback(
+		( paymentMethodId: string, available: boolean ) => {
+			const paymentMethod = allPaymentMethods.find( ( { id } ) => id === paymentMethodId );
+			if ( ! paymentMethod ) {
+				debug( `No payment method found matching id '${ paymentMethodId }' in`, allPaymentMethods );
+				return;
+			}
 
-		if ( available && disabledPaymentMethodIds.includes( paymentMethodId ) ) {
-			debug( 'Adding available payment method', paymentMethodId );
-			setDisabledPaymentMethodIds(
-				disabledPaymentMethodIds.filter( ( id ) => id !== paymentMethodId )
-			);
-		}
+			if ( available && disabledPaymentMethodIds.includes( paymentMethodId ) ) {
+				debug( 'Adding available payment method', paymentMethodId );
+				setDisabledPaymentMethodIds(
+					disabledPaymentMethodIds.filter( ( id ) => id !== paymentMethodId )
+				);
+			}
 
-		if ( ! available && ! disabledPaymentMethodIds.includes( paymentMethodId ) ) {
-			debug( 'Removing available payment method', paymentMethodId );
-			setDisabledPaymentMethodIds( [ ...disabledPaymentMethodIds, paymentMethodId ] );
-		}
-	};
+			if ( ! available && ! disabledPaymentMethodIds.includes( paymentMethodId ) ) {
+				debug( 'Removing available payment method', paymentMethodId );
+				setDisabledPaymentMethodIds( [ ...disabledPaymentMethodIds, paymentMethodId ] );
+			}
+		},
+		[ allPaymentMethods, disabledPaymentMethodIds, setDisabledPaymentMethodIds ]
+	);
 }

--- a/packages/composite-checkout/src/lib/payment-methods/index.ts
+++ b/packages/composite-checkout/src/lib/payment-methods/index.ts
@@ -1,5 +1,5 @@
 import debugFactory from 'debug';
-import { useCallback, useContext, useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 import CheckoutContext from '../checkout-context';
 import type { PaymentMethod, TogglePaymentMethod } from '../../types';
 
@@ -58,26 +58,23 @@ export function useTogglePaymentMethod(): TogglePaymentMethod {
 	if ( ! allPaymentMethods ) {
 		throw new Error( 'useTogglePaymentMethod cannot be used outside of CheckoutProvider' );
 	}
-	return useCallback(
-		( paymentMethodId: string, available: boolean ) => {
-			const paymentMethod = allPaymentMethods.find( ( { id } ) => id === paymentMethodId );
-			if ( ! paymentMethod ) {
-				debug( `No payment method found matching id '${ paymentMethodId }' in`, allPaymentMethods );
-				return;
-			}
+	return ( paymentMethodId: string, available: boolean ) => {
+		const paymentMethod = allPaymentMethods.find( ( { id } ) => id === paymentMethodId );
+		if ( ! paymentMethod ) {
+			debug( `No payment method found matching id '${ paymentMethodId }' in`, allPaymentMethods );
+			return;
+		}
 
-			if ( available && disabledPaymentMethodIds.includes( paymentMethodId ) ) {
-				debug( 'Adding available payment method', paymentMethodId );
-				setDisabledPaymentMethodIds(
-					disabledPaymentMethodIds.filter( ( id ) => id !== paymentMethodId )
-				);
-			}
+		if ( available && disabledPaymentMethodIds.includes( paymentMethodId ) ) {
+			debug( 'Adding available payment method', paymentMethodId );
+			setDisabledPaymentMethodIds(
+				disabledPaymentMethodIds.filter( ( id ) => id !== paymentMethodId )
+			);
+		}
 
-			if ( ! available && ! disabledPaymentMethodIds.includes( paymentMethodId ) ) {
-				debug( 'Removing available payment method', paymentMethodId );
-				setDisabledPaymentMethodIds( [ ...disabledPaymentMethodIds, paymentMethodId ] );
-			}
-		},
-		[ allPaymentMethods, disabledPaymentMethodIds, setDisabledPaymentMethodIds ]
-	);
+		if ( ! available && ! disabledPaymentMethodIds.includes( paymentMethodId ) ) {
+			debug( 'Removing available payment method', paymentMethodId );
+			setDisabledPaymentMethodIds( [ ...disabledPaymentMethodIds, paymentMethodId ] );
+		}
+	};
 }


### PR DESCRIPTION
## Proposed Changes

This PR prevents making the PayPal PPCP (`paypal-js`) payment method available and visible in checkout if the PayPal JS script (loaded by `PayPalScriptProvider`) is not present or if its `Buttons` property is not present.

## Why are these changes being made?

We already wait for the PayPal JS script to be available [before enabling](https://github.com/Automattic/wp-calypso/blob/b6fda6e4542cb4cca17e399d8517a3f027be07dc/client/my-sites/checkout/src/payment-methods/paypal-js.tsx#L108-L110) the PayPal PPCP payment method and we explicitly [do not render the submit button until the payment method is enabled and selected](https://github.com/Automattic/wp-calypso/blob/b6fda6e4542cb4cca17e399d8517a3f027be07dc/client/my-sites/checkout/src/payment-methods/paypal-js.tsx#L129-L131), since rendering `PayPalButtons` requires it. We determine if the script is loaded by using the `usePayPalScriptReducer()` React hook as their documentation suggests. 

However, sometimes we still get the error `Unable to render <PayPalButtons \/> because window.paypal.Buttons is undefined`, which doesn't make a lot of sense. My guess is that either `usePayPalScriptReducer` is incorrect about the script being loaded, `PayPalScriptProvider` is incorrectly loading a script without the Buttons namespace (even though [we request it](https://github.com/Automattic/wp-calypso/blob/8c6b5700859be9b95e609758345e64a13ca96b96/packages/calypso-paypal/src/index.tsx#L112)), or something else is overwriting the `window.paypal` namespace (eg: if an HTML tag has the `id="paypal"` attribute).

## Testing Instructions

To verify that the happy path still works: add a product to your cart and visit checkout. Then verify that PayPal is an option in the list of payment methods and that there are no errors related to the payment method in the console.

To test the failure state, you'll need to break the paypal JS script. One way to do that is to apply the following patch to this branch. Then visit checkout and verify that the PayPal option is not available, but that there are no errors displayed on the page. In the browser console you will see `PayPal says the script is loaded but Buttons are not available`.

```diff
diff --git a/client/my-sites/checkout/src/components/checkout-main.tsx b/client/my-sites/checkout/src/components/checkout-main.tsx
index 7a668d5bf42..71b9721acc8 100644
--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -763,6 +763,7 @@ export default function CheckoutMain( {
                                        useAkismetGoogleAnalytics: sitelessCheckoutType === 'akismet',
                                } }
                        />
+                       <div id="paypal">test</div>
                        <CheckoutProvider
                                onPaymentComplete={ handlePaymentComplete }
                                onPaymentError={ handlePaymentError }
```