### PR TITLE
Domain management: Email: Provide missing 'context-all-domain-management' class

### DIFF
--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -30,10 +30,12 @@ import type { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';
 
-type ContentWithHeaderProps = React.PropsWithChildren< {
+type PropsWithClass = {
 	className?: string;
-} >;
-const ContentWithHeader = ( { children, className }: ContentWithHeaderProps ) => {
+};
+type PropsWithClassAndChildren = React.PropsWithChildren< PropsWithClass >;
+
+const ContentWithHeader = ( { children, className }: PropsWithClassAndChildren ) => {
 	const translate = useTranslate();
 
 	return (
@@ -47,10 +49,10 @@ const ContentWithHeader = ( { children, className }: ContentWithHeaderProps ) =>
 	);
 };
 
-const NoAccess = () => {
+const NoAccess = ( { className }: PropsWithClass ) => {
 	const translate = useTranslate();
 	return (
-		<ContentWithHeader>
+		<ContentWithHeader className={ className }>
 			<EmptyContent
 				title={ translate( 'You are not authorized to view this page' ) }
 				illustration="/calypso/images/illustrations/illustration-404.svg"
@@ -59,9 +61,9 @@ const NoAccess = () => {
 	);
 };
 
-const LoadingPlaceholder = () => {
+const LoadingPlaceholder = ( { className }: PropsWithClass ) => {
 	return (
-		<ContentWithHeader>
+		<ContentWithHeader className={ className }>
 			<SectionHeader className="email-home__section-placeholder is-placeholder" />
 			<Card className="email-home__content-placeholder is-placeholder" />
 		</ContentWithHeader>
@@ -125,11 +127,19 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 		domainsWithEmail.length === 1 && domainsWithNoEmail.length === 0;
 
 	if ( isSiteDomainLoading || ! hasSitesLoaded || ! selectedSite || ! domains ) {
-		return <LoadingPlaceholder />;
+		return (
+			<LoadingPlaceholder
+				className={ clsx( { 'context-all-domain-management': isAllDomainManagementContext } ) }
+			/>
+		);
 	}
 
 	if ( ! canManageSite ) {
-		return <NoAccess />;
+		return (
+			<NoAccess
+				className={ clsx( { 'context-all-domain-management': isAllDomainManagementContext } ) }
+			/>
+		);
 	}
 
 	if ( selectedDomainName ) {

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -441,6 +441,9 @@
 	}
 }
 
+/**
+ * Context: All Domain Management
+ */
 .context-all-domain-management {
 	&.main {
 		width: 100%;


### PR DESCRIPTION
Related to #

## Proposed Changes

* Provide missing `content-all-domain-management` class

## Why are these changes being made?

* Support All domain management context

## Testing Instructions

* Go to `/domains/manage?flags=calypso/all-domain-management`
* Select a domain
* Check the loading state placeholder
* Select a domain with no access permission
* Check if the no-access state

| Before | After |
|--------|--------|
| <img width="1022" alt="Screenshot 2024-12-16 at 16 22 07" src="https://github.com/user-attachments/assets/c9c6e76f-626c-4e52-aca7-68eaf05f9a7e" /> | <img width="1023" alt="Screenshot 2024-12-16 at 16 29 26" src="https://github.com/user-attachments/assets/fd3e1e44-9daa-4678-bc2b-26b2cafa52c6" /> |
| <img width="1023" alt="Screenshot 2024-12-16 at 16 54 58" src="https://github.com/user-attachments/assets/36532188-c91e-40ba-95a2-acc1a81b937b" /> | <img width="1027" alt="Screenshot 2024-12-16 at 16 56 23" src="https://github.com/user-attachments/assets/ed2831cc-2477-4deb-a311-6681b1516f81" /> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
