### PR TITLE
Checkout: Remove wpcom-proxy-request from calypso-paypal package

### DIFF
--- a/packages/calypso-paypal/package.json
+++ b/packages/calypso-paypal/package.json
@@ -38,8 +38,7 @@
 		"@paypal/react-paypal-js": "^8.7.0",
 		"@wordpress/i18n": "^5.8.0",
 		"react": "^18.3.1",
-		"react-dom": "^18.3.1",
-		"wpcom-proxy-request": "workspace:^"
+		"react-dom": "^18.3.1"
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",

--- a/packages/calypso-paypal/src/index.tsx
+++ b/packages/calypso-paypal/src/index.tsx
@@ -1,7 +1,6 @@
 import { PayPalScriptProvider, ReactPayPalScriptOptions } from '@paypal/react-paypal-js';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState, createContext, PropsWithChildren, useContext, useRef } from 'react';
-import wpcomRequest from 'wpcom-proxy-request';
 
 export interface PayPalConfigurationApiResponse {
 	client_id: string | undefined;
@@ -15,13 +14,6 @@ export interface UsePayPalConfiguration {
 	payPalConfiguration: PayPalConfiguration | undefined;
 }
 
-async function defaultFetchPayPalConfiguration(): Promise< PayPalConfigurationApiResponse > {
-	return await wpcomRequest( {
-		path: `/me/paypal-configuration`,
-		method: 'GET',
-	} );
-}
-
 const PayPalContext = createContext< PayPalConfiguration | undefined >( undefined );
 
 const defaultConfiguration: PayPalConfiguration = {
@@ -31,7 +23,7 @@ const defaultConfiguration: PayPalConfiguration = {
 function usePayPalConfigurationInternalOnly( {
 	fetchPayPalConfiguration,
 }: {
-	fetchPayPalConfiguration?: () => Promise< PayPalConfigurationApiResponse >;
+	fetchPayPalConfiguration: () => Promise< PayPalConfigurationApiResponse >;
 } ): {
 	payPalConfiguration: PayPalConfiguration | undefined;
 	error: undefined | Error;
@@ -43,7 +35,7 @@ function usePayPalConfigurationInternalOnly( {
 
 	useEffect( () => {
 		let isSubscribed = true;
-		( fetchPayPalConfiguration ?? defaultFetchPayPalConfiguration )()
+		fetchPayPalConfiguration()
 			.then( ( configuration ) => {
 				if ( ! isSubscribed ) {
 					return;
@@ -82,7 +74,7 @@ export function PayPalProvider( {
 }: PropsWithChildren< {
 	currency: string;
 	handleError?: ( error: Error ) => void;
-	fetchPayPalConfiguration?: () => Promise< PayPalConfigurationApiResponse >;
+	fetchPayPalConfiguration: () => Promise< PayPalConfigurationApiResponse >;
 } > ) {
 	const { payPalConfiguration, error } = usePayPalConfigurationInternalOnly( {
 		fetchPayPalConfiguration,

--- a/yarn.lock
+++ b/yarn.lock
@@ -442,7 +442,6 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     typescript: "npm:^5.3.3"
-    wpcom-proxy-request: "workspace:^"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Proposed Changes

This PR removes the `wpcom-proxy-request` from the dependencies of `@automattic/calypso-paypal`.

## Why are these changes being made?

Originally, I had added `wpcom-proxy-request` to the `calypso-paypal` package as a way to have the package make its own HTTP API requests to the WPCOM paypal configuration endpoint. However, it appears that in some cases this does not work well, so in #97487 I made checkout inject its own network request function as an argument. Since that seems to always work, this PR will make that technique required and remove the ability for the package to make its own calls.

## Testing Instructions

Add a product to your cart and visit checkout. Verify that you see PayPal as a payment method option listed.