### PR TITLE
Fix stuck plugin installation screen

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -103,7 +103,7 @@ const MarketplaceThankYou = ( {
 		allThemesFetched &&
 		isAtomicTransferCheckComplete &&
 		isLoadedPlugins &&
-		isLoadedThemes;
+		( ! hasThemes || isLoadedThemes );
 
 	const transferStatus = useSelector( ( state ) => getAutomatedTransferStatus( state, siteId ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -124,7 +124,11 @@ function getPluginsSelector( state, siteIds, pluginFilter ) {
 
 export const getPlugins = createSelector(
 	getPluginsSelector,
-	( state ) => state.plugins.installed.plugins,
+	( state, siteIds ) => [
+		state.plugins.installed.plugins,
+		isRequestingForAllSites( state ),
+		...siteIds.map( ( siteId ) => isRequesting( state, siteId ) ),
+	],
 	( state, siteIds, pluginFilter ) => {
 		return [ siteIds, pluginFilter ].flat().join( '-' );
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/10028

## Proposed Changes

* add a guard skip checking themes if no themes are being installed
* restore the memoization logic on the `getPlugins` selector

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The installation screen gets stuck when installing paid plugins

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins` and install any paid plugin
* Check that the plugin installation proceeds and the page redirects to the plugin defined page

https://github.com/user-attachments/assets/38612ed5-851e-404f-a9d7-b8ee2245a1f3
