### PR TITLE
Holiday Snow: allow usage on p2s as well

### DIFF
--- a/client/sites/settings/site/form.jsx
+++ b/client/sites/settings/site/form.jsx
@@ -16,7 +16,6 @@ export default function SiteSettingsForm( {
 	isUnlaunchedSite,
 	isAtomicAndEditingToolkitDeactivated,
 	isWpcomStagingSite,
-	isWPForTeamsSite,
 	fields,
 	updateFields,
 	onChangeField,
@@ -73,7 +72,7 @@ export default function SiteSettingsForm( {
 				urlRef="unlaunched-settings"
 			/>
 
-			{ siteIsWpcom && ! isWPForTeamsSite && (
+			{ siteIsWpcom && (
 				<HolidaySnow
 					fields={ fields }
 					handleToggle={ handleToggle }

--- a/client/sites/settings/site/index.tsx
+++ b/client/sites/settings/site/index.tsx
@@ -5,7 +5,6 @@ import wrapSettingsForm from 'calypso/my-sites/site-settings/wrap-settings-form'
 import { useSelector } from 'calypso/state';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
-import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import getIsUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { useSelectedSiteSelector } from 'calypso/state/sites/hooks';
 import { getSiteOption, isJetpackSite, isWpcomSite } from 'calypso/state/sites/selectors';
@@ -28,7 +27,6 @@ export function SiteSettings( props: any ) {
 	const isAtomicAndEditingToolkitDeactivated = isAtomic && editingToolkitIsActive === false;
 	const siteIsWpcom = useSelectedSiteSelector( isWpcomSite );
 	const isWpcomStagingSite = useSelectedSiteSelector( isSiteWpcomStaging );
-	const isWPForTeamsSite = useSelectedSiteSelector( isSiteWPForTeams );
 
 	const additionalProps = {
 		site,
@@ -37,7 +35,6 @@ export function SiteSettings( props: any ) {
 		isUnlaunchedSite,
 		isAtomicAndEditingToolkitDeactivated,
 		isWpcomStagingSite,
-		isWPForTeamsSite,
 	};
 
 	return (


### PR DESCRIPTION
## Proposed Changes

This effectively reverts #97238

## Why are these changes being made?

If https://github.com/Automattic/jetpack/pull/40629 gets merged, we will be able to use Holiday Snow on p2s on WordPress.com. We will consequently be able to display the settings to enable the feature again.

## Testing Instructions

* Load http://calypso.localhost:3000/settings/general/ap2site.com?flags=-untangling/hosting-menu
* You should see the Holiday Snow settings.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
