### PR TITLE
Add new category: Remove margin to fix alignment

### DIFF
--- a/client/blocks/term-form-dialog/style.scss
+++ b/client/blocks/term-form-dialog/style.scss
@@ -25,7 +25,6 @@
 	color: var(--color-text-subtle);
 	display: block;
 	font-weight: normal;
-	margin-left: 50px;
 }
 
 .term-form-dialog__parent-tree-selector {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1734354357252349/1734352629.009269-slack-C052XEUUBL4

## Proposed Changes

* Remove the left margin to align the description under the toggle.

Before | After
---- | ----
<img width="838" alt="Screen Shot 2024-12-16 at 4 25 21 PM" src="https://github.com/user-attachments/assets/5c4d3473-1686-4a8a-90b9-e53ec415ff63" /> | <img width="843" alt="Screen Shot 2024-12-16 at 4 25 12 PM" src="https://github.com/user-attachments/assets/b2f0bd66-065c-4e18-82d5-3977e5155da3" />

Mobile and RTL locale:
<img width="297" alt="Screen Shot 2024-12-16 at 4 35 45 PM" src="https://github.com/user-attachments/assets/40a238f1-1030-4e8f-9a66-b997609c0076" />
<img width="833" alt="Screen Shot 2024-12-16 at 4 35 20 PM" src="https://github.com/user-attachments/assets/8921b560-acda-4a9e-aa8f-3643598c8c96" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix alignment bug.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /settings/newsletter
* Under Newsletter categories, enable categories.
* Click "Add New Category"
* "Top level Category" should be left-aligned with "Disable to select a Parent Category"
* Repeat on /settings/taxonomies/category/

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?