### PR TITLE
Domain management: Match forward email list screen design

### DIFF
--- a/client/my-sites/email/email-management/home/email-mailbox-warnings.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-warnings.jsx
@@ -29,7 +29,7 @@ const EmailMailboxWarningAction = ( { buttonText, isExternal, ...otherProps } ) 
 	);
 };
 
-const EmailMailboxReverifyWarning = ( { mailbox } ) => {
+const EmailMailboxReverifyWarning = ( { mailbox, ctaProps } ) => {
 	const translate = useTranslate();
 
 	const { mutate: resendVerificationEmail } = useResendVerifyEmailForwardMutation( mailbox.domain );
@@ -56,12 +56,13 @@ const EmailMailboxReverifyWarning = ( { mailbox } ) => {
 
 					resendVerificationEmail( mailbox, destination );
 				} }
+				{ ...ctaProps }
 			/>
 		</>
 	);
 };
 
-const EmailMailboxWarnings = ( { account, mailbox } ) => {
+const EmailMailboxWarnings = ( { account, mailbox, ctaProps } ) => {
 	if ( ! mailbox?.warnings?.length ) {
 		return null;
 	}
@@ -73,7 +74,13 @@ const EmailMailboxWarnings = ( { account, mailbox } ) => {
 
 				if ( isEmailForwardAccount( account ) ) {
 					if ( warning.warning_slug === EMAIL_WARNING_SLUG_UNVERIFIED_FORWARDS ) {
-						return <EmailMailboxReverifyWarning key={ warningKey } mailbox={ mailbox } />;
+						return (
+							<EmailMailboxReverifyWarning
+								key={ warningKey }
+								mailbox={ mailbox }
+								ctaProps={ ctaProps }
+							/>
+						);
 					}
 				}
 
@@ -86,6 +93,7 @@ const EmailMailboxWarnings = ( { account, mailbox } ) => {
 EmailMailboxWarnings.propTypes = {
 	account: PropTypes.object.isRequired,
 	mailbox: PropTypes.object.isRequired,
+	ctaProps: PropTypes.object,
 };
 
 export default EmailMailboxWarnings;

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -62,7 +62,7 @@ function EmailPlanMailboxesList( {
 		return (
 			<MailboxListItem>
 				<div className="email-plan-mailboxes-list__mailbox-list-item-main">
-					<div className="email-plan-mailboxes-list__mailbox-list-link">
+					<div className="email-plan-mailboxes-list__mailbox-list-link disabled">
 						<span>{ domain.domain }</span>
 					</div>
 				</div>

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -155,7 +155,10 @@ function EmailPlanMailboxesList( {
 					) }
 
 					{ accountType === EMAIL_ACCOUNT_TYPE_FORWARD && (
-						<EmailForwardHeader className="email-plan-mailboxes-list__mailbox-list">
+						<EmailForwardHeader
+							className="email-plan-mailboxes-list__mailbox-list"
+							actionPath={ addMailboxPath }
+						>
 							<MailboxItems />
 						</EmailForwardHeader>
 					) }

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -46,7 +46,7 @@ function EmailPlanMailboxesList( {
 		isRecentlyRegistered( domain.registrationDate, 45 ) &&
 		getGSuiteSubscriptionStatus( domain ) === 'unknown';
 
-	function MailboxItemsEmpty() {
+	function MailboxListEmpty() {
 		return (
 			<MailboxListItem>
 				<div className="email-plan-mailboxes-list__mailbox-list-item-main">
@@ -58,7 +58,7 @@ function EmailPlanMailboxesList( {
 		);
 	}
 
-	function MailboxContent( { type }: { type: 'configuring' | 'no-mailboxes' } ) {
+	function MailboxContentInfo( { type }: { type: 'configuring' | 'no-mailboxes' } ) {
 		let message;
 
 		switch ( type ) {
@@ -181,7 +181,7 @@ function EmailPlanMailboxesList( {
 							domain={ domain }
 							disableActions={ isGoogleConfiguring }
 						>
-							{ isNoMailboxes ? <MailboxItemsEmpty /> : <MailboxItems /> }
+							{ isNoMailboxes ? <MailboxListEmpty /> : <MailboxItems /> }
 						</MailboxListHeader>
 					) }
 				</>
@@ -190,11 +190,11 @@ function EmailPlanMailboxesList( {
 		case 'email':
 		default: {
 			if ( isGoogleConfiguring ) {
-				return <MailboxContent type="configuring" />;
+				return <MailboxContentInfo type="configuring" />;
 			}
 
 			if ( isNoMailboxes ) {
-				return <MailboxContent type="no-mailboxes" />;
+				return <MailboxContentInfo type="no-mailboxes" />;
 			}
 
 			return (
@@ -205,7 +205,7 @@ function EmailPlanMailboxesList( {
 					domain={ domain }
 					disableActions={ isGoogleConfiguring }
 				>
-					{ isNoMailboxes ? <MailboxItemsEmpty /> : <MailboxItems /> }
+					{ isNoMailboxes ? <MailboxListEmpty /> : <MailboxItems /> }
 				</MailboxListHeader>
 			);
 		}

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -21,7 +21,10 @@ type Props = {
 	domain: ResponseDomain;
 	account: EmailAccount;
 	mailboxes: Mailbox[];
-	addMailboxPath: string;
+	actionPathProps?: {
+		disabled: boolean;
+		path: string;
+	};
 	isLoadingEmails: boolean;
 };
 function EmailPlanMailboxesList( {
@@ -29,7 +32,7 @@ function EmailPlanMailboxesList( {
 	domain,
 	account,
 	mailboxes,
-	addMailboxPath,
+	actionPathProps,
 	isLoadingEmails,
 }: Props ) {
 	const translate = useTranslate();
@@ -157,7 +160,7 @@ function EmailPlanMailboxesList( {
 					{ accountType === EMAIL_ACCOUNT_TYPE_FORWARD && (
 						<EmailForwardHeader
 							className="email-plan-mailboxes-list__mailbox-list"
-							actionPath={ addMailboxPath }
+							actionPath={ ( ! actionPathProps?.disabled && actionPathProps?.path ) || undefined }
 						>
 							<MailboxItems />
 						</EmailForwardHeader>
@@ -166,8 +169,10 @@ function EmailPlanMailboxesList( {
 					{ accountType !== EMAIL_ACCOUNT_TYPE_FORWARD && (
 						<MailboxListHeader
 							accountType={ accountType }
-							addMailboxPath={ addMailboxPath }
-							showIcon={ !! addMailboxPath }
+							addMailboxPath={
+								( ! actionPathProps?.disabled && actionPathProps?.path ) || undefined
+							}
+							showIcon={ !! actionPathProps }
 							domain={ domain }
 							disableActions={ isGoogleConfiguring }
 						>
@@ -190,8 +195,8 @@ function EmailPlanMailboxesList( {
 			return (
 				<MailboxListHeader
 					accountType={ accountType }
-					addMailboxPath={ addMailboxPath }
-					showIcon={ !! addMailboxPath }
+					addMailboxPath={ ( ! actionPathProps?.disabled && actionPathProps?.path ) || undefined }
+					showIcon={ !! actionPathProps }
 					domain={ domain }
 					disableActions={ isGoogleConfiguring }
 				>

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -3,10 +3,12 @@ import { useTranslate } from 'i18n-calypso';
 import Notice from 'calypso/components/notice';
 import { isRecentlyRegistered } from 'calypso/lib/domains/utils';
 import { isEmailUserAdmin } from 'calypso/lib/emails';
+import { EMAIL_ACCOUNT_TYPE_FORWARD } from 'calypso/lib/emails/email-provider-constants';
 import { getGSuiteSubscriptionStatus } from 'calypso/lib/gsuite';
 import EmailMailboxActionMenu from 'calypso/my-sites/email/email-management/home/email-mailbox-action-menu';
 import EmailMailboxWarnings from 'calypso/my-sites/email/email-management/home/email-mailbox-warnings';
 import EmailPlanWarnings from 'calypso/my-sites/email/email-management/home/email-plan-warnings';
+import EmailForwardHeader from './email-plan-mailboxes/email-forward-header';
 import EmailForwardSecondaryDetails from './email-plan-mailboxes/email-forward-secondary-details';
 import MailboxListHeader from './email-plan-mailboxes/list-header';
 import MailboxListItem from './email-plan-mailboxes/list-item';
@@ -15,20 +17,20 @@ import type { EmailAccount, Mailbox } from 'calypso/data/emails/types';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
 type Props = {
+	context: 'domains' | 'email';
 	domain: ResponseDomain;
 	account: EmailAccount;
 	mailboxes: Mailbox[];
 	addMailboxPath: string;
 	isLoadingEmails: boolean;
-	configuringStateMode?: 'message' | 'notice';
 };
 function EmailPlanMailboxesList( {
+	context,
 	domain,
 	account,
 	mailboxes,
 	addMailboxPath,
 	isLoadingEmails,
-	configuringStateMode = 'message',
 }: Props ) {
 	const translate = useTranslate();
 	const accountType = account?.account_type;
@@ -38,25 +40,6 @@ function EmailPlanMailboxesList( {
 	const isGoogleConfiguring =
 		isRecentlyRegistered( domain.registrationDate, 45 ) &&
 		getGSuiteSubscriptionStatus( domain ) === 'unknown';
-
-	if ( isLoadingEmails ) {
-		return (
-			<MailboxListHeader isPlaceholder>
-				<MailboxListItem isPlaceholder>
-					<MaterialIcon icon="email" />
-					<span />
-				</MailboxListItem>
-			</MailboxListHeader>
-		);
-	}
-
-	if ( isGoogleConfiguring && configuringStateMode === 'message' ) {
-		return <MailboxContent type="configuring" />;
-	}
-
-	if ( isNoMailboxes && configuringStateMode === 'message' ) {
-		return <MailboxContent type="no-mailboxes" />;
-	}
 
 	function MailboxItemsEmpty() {
 		return (
@@ -106,8 +89,13 @@ function EmailPlanMailboxesList( {
 								mailbox={ mailbox }
 								readonly={ isGoogleConfiguring }
 							/>
-							<EmailForwardSecondaryDetails mailbox={ mailbox } />
+							{ context !== 'domains' && <EmailForwardSecondaryDetails mailbox={ mailbox } /> }
 						</div>
+						{ context === 'domains' && (
+							<div className="email-plan-mailboxes-list__mailbox-list-item-main">
+								<EmailForwardSecondaryDetails mailbox={ mailbox } hideIcon />
+							</div>
+						) }
 						{ isEmailUserAdmin( mailbox ) && (
 							<Badge type="info">
 								{ translate( 'Admin', {
@@ -126,39 +114,89 @@ function EmailPlanMailboxesList( {
 		} );
 	}
 
-	return (
-		<>
-			{ ( isGoogleConfiguring || isAccountWarningPresent ) && configuringStateMode === 'notice' && (
-				<Notice
-					className="email-plan-mailboxes-list__notice"
-					status="is-warning"
-					showDismiss={ false }
-				>
-					{ isAccountWarningPresent ? (
-						<EmailPlanWarnings
-							domain={ domain }
-							emailAccount={ account }
-							ctaBtnProps={ { primary: false, plain: true } }
-						/>
-					) : (
-						translate(
-							'We are configuring your mailboxes. You will receive an email shortly when they are ready to use.'
-						)
-					) }
-				</Notice>
-			) }
-
-			<MailboxListHeader
-				accountType={ accountType }
-				addMailboxPath={ addMailboxPath }
-				showIcon={ !! addMailboxPath }
-				domain={ domain }
-				disableActions={ isGoogleConfiguring }
-			>
-				{ isNoMailboxes ? <MailboxItemsEmpty /> : <MailboxItems /> }
+	/**
+	 * ↓ Template rendering
+	 */
+	// Common loading placeholder
+	if ( isLoadingEmails ) {
+		return (
+			<MailboxListHeader isPlaceholder>
+				<MailboxListItem isPlaceholder>
+					<MaterialIcon icon="email" />
+					<span />
+				</MailboxListItem>
 			</MailboxListHeader>
-		</>
-	);
+		);
+	}
+
+	// Rendering based on the context
+	switch ( context ) {
+		case 'domains':
+			return (
+				<>
+					{ ( isGoogleConfiguring || isAccountWarningPresent ) && (
+						<Notice
+							className="email-plan-mailboxes-list__notice"
+							status="is-warning"
+							showDismiss={ false }
+						>
+							{ isAccountWarningPresent ? (
+								<EmailPlanWarnings
+									domain={ domain }
+									emailAccount={ account }
+									ctaBtnProps={ { primary: false, plain: true } }
+								/>
+							) : (
+								translate(
+									'We are configuring your mailboxes. You will receive an email shortly when they are ready to use.'
+								)
+							) }
+						</Notice>
+					) }
+
+					{ accountType === EMAIL_ACCOUNT_TYPE_FORWARD && (
+						<EmailForwardHeader className="email-plan-mailboxes-list__mailbox-list">
+							<MailboxItems />
+						</EmailForwardHeader>
+					) }
+
+					{ accountType !== EMAIL_ACCOUNT_TYPE_FORWARD && (
+						<MailboxListHeader
+							accountType={ accountType }
+							addMailboxPath={ addMailboxPath }
+							showIcon={ !! addMailboxPath }
+							domain={ domain }
+							disableActions={ isGoogleConfiguring }
+						>
+							{ isNoMailboxes ? <MailboxItemsEmpty /> : <MailboxItems /> }
+						</MailboxListHeader>
+					) }
+				</>
+			);
+
+		case 'email':
+		default: {
+			if ( isGoogleConfiguring ) {
+				return <MailboxContent type="configuring" />;
+			}
+
+			if ( isNoMailboxes ) {
+				return <MailboxContent type="no-mailboxes" />;
+			}
+
+			return (
+				<MailboxListHeader
+					accountType={ accountType }
+					addMailboxPath={ addMailboxPath }
+					showIcon={ !! addMailboxPath }
+					domain={ domain }
+					disableActions={ isGoogleConfiguring }
+				>
+					{ isNoMailboxes ? <MailboxItemsEmpty /> : <MailboxItems /> }
+				</MailboxListHeader>
+			);
+		}
+	}
 }
 
 export default EmailPlanMailboxesList;

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -88,17 +88,18 @@ function EmailPlanMailboxesList( {
 	function MailboxItems() {
 		return mailboxes.map( ( mailbox ) => {
 			const mailboxHasWarnings = Boolean( mailbox?.warnings?.length );
+			const showErrorStyling = context === 'email' && mailboxHasWarnings;
 
 			return (
 				<>
-					<MailboxListItem key={ mailbox.mailbox } isError={ mailboxHasWarnings }>
+					<MailboxListItem key={ mailbox.mailbox } isError={ showErrorStyling }>
 						<div className="email-plan-mailboxes-list__mailbox-list-item-main">
 							<MailboxLink
 								account={ account }
 								mailbox={ mailbox }
 								readonly={ isGoogleConfiguring }
 							/>
-							{ context !== 'domains' && <EmailForwardSecondaryDetails mailbox={ mailbox } /> }
+							{ context === 'email' && <EmailForwardSecondaryDetails mailbox={ mailbox } /> }
 						</div>
 						{ context === 'domains' && (
 							<div className="email-plan-mailboxes-list__mailbox-list-item-main">
@@ -106,6 +107,15 @@ function EmailPlanMailboxesList( {
 									mailbox={ mailbox }
 									hideIcon={ isDesktopResolution }
 								/>
+								{ mailboxHasWarnings && (
+									<div className="email-mailbox-warnings">
+										<EmailMailboxWarnings
+											account={ account }
+											mailbox={ mailbox }
+											ctaProps={ { primary: true, borderless: true, compact: false } }
+										/>
+									</div>
+								) }
 							</div>
 						) }
 						{ isEmailUserAdmin( mailbox ) && (
@@ -116,7 +126,9 @@ function EmailPlanMailboxesList( {
 							</Badge>
 						) }
 
-						<EmailMailboxWarnings account={ account } mailbox={ mailbox } />
+						{ context === 'email' && (
+							<EmailMailboxWarnings account={ account } mailbox={ mailbox } />
+						) }
 						{ ! mailbox.temporary && ! isGoogleConfiguring && (
 							<EmailMailboxActionMenu account={ account } domain={ domain } mailbox={ mailbox } />
 						) }

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -5,12 +5,14 @@ import Notice from 'calypso/components/notice';
 import { isRecentlyRegistered } from 'calypso/lib/domains/utils';
 import { isEmailUserAdmin } from 'calypso/lib/emails';
 import { EMAIL_ACCOUNT_TYPE_FORWARD } from 'calypso/lib/emails/email-provider-constants';
-import { getGSuiteSubscriptionStatus } from 'calypso/lib/gsuite';
+import { getGSuiteSubscriptionStatus, hasGSuiteWithUs } from 'calypso/lib/gsuite';
+import { hasTitanMailWithUs } from 'calypso/lib/titan';
 import EmailMailboxActionMenu from 'calypso/my-sites/email/email-management/home/email-mailbox-action-menu';
 import EmailMailboxWarnings from 'calypso/my-sites/email/email-management/home/email-mailbox-warnings';
 import EmailPlanWarnings from 'calypso/my-sites/email/email-management/home/email-plan-warnings';
 import EmailForwardHeader from './email-plan-mailboxes/email-forward-header';
 import EmailForwardSecondaryDetails from './email-plan-mailboxes/email-forward-secondary-details';
+import EmailUpgradeNotice from './email-plan-mailboxes/email-upgrade-notice';
 import MailboxListHeader from './email-plan-mailboxes/list-header';
 import MailboxListItem from './email-plan-mailboxes/list-item';
 import MailboxLink from './email-plan-mailboxes/list-item-link';
@@ -26,6 +28,7 @@ type Props = {
 		disabled: boolean;
 		path: string;
 	};
+	purchaseNewEmailAccountPath?: string;
 	isLoadingEmails: boolean;
 };
 function EmailPlanMailboxesList( {
@@ -34,6 +37,7 @@ function EmailPlanMailboxesList( {
 	account,
 	mailboxes,
 	actionPathProps,
+	purchaseNewEmailAccountPath,
 	isLoadingEmails,
 }: Props ) {
 	const translate = useTranslate();
@@ -163,12 +167,17 @@ function EmailPlanMailboxesList( {
 					) }
 
 					{ accountType === EMAIL_ACCOUNT_TYPE_FORWARD && (
-						<EmailForwardHeader
-							className="email-plan-mailboxes-list__mailbox-list"
-							actionPath={ ( ! actionPathProps?.disabled && actionPathProps?.path ) || undefined }
-						>
-							<MailboxItems />
-						</EmailForwardHeader>
+						<>
+							<EmailForwardHeader
+								className="email-plan-mailboxes-list__mailbox-list"
+								actionPath={ ( ! actionPathProps?.disabled && actionPathProps?.path ) || undefined }
+							>
+								<MailboxItems />
+							</EmailForwardHeader>
+							{ ! hasGSuiteWithUs( domain ) && ! hasTitanMailWithUs( domain ) && (
+								<EmailUpgradeNotice path={ purchaseNewEmailAccountPath } />
+							) }
+						</>
 					) }
 
 					{ accountType !== EMAIL_ACCOUNT_TYPE_FORWARD && (

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -1,4 +1,5 @@
 import { Badge, MaterialIcon } from '@automattic/components';
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import Notice from 'calypso/components/notice';
 import { isRecentlyRegistered } from 'calypso/lib/domains/utils';
@@ -38,6 +39,7 @@ function EmailPlanMailboxesList( {
 	const translate = useTranslate();
 	const accountType = account?.account_type;
 
+	const isDesktopResolution = useDesktopBreakpoint();
 	const isNoMailboxes = ! mailboxes || mailboxes.length < 1;
 	const isAccountWarningPresent = !! account?.warnings.length;
 	const isGoogleConfiguring =
@@ -96,7 +98,10 @@ function EmailPlanMailboxesList( {
 						</div>
 						{ context === 'domains' && (
 							<div className="email-plan-mailboxes-list__mailbox-list-item-main">
-								<EmailForwardSecondaryDetails mailbox={ mailbox } hideIcon />
+								<EmailForwardSecondaryDetails
+									mailbox={ mailbox }
+									hideIcon={ isDesktopResolution }
+								/>
 							</div>
 						) }
 						{ isEmailUserAdmin( mailbox ) && (

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/email-forward-header.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/email-forward-header.tsx
@@ -6,8 +6,9 @@ import React from 'react';
 
 type Props = React.PropsWithChildren< {
 	className?: string;
+	actionPath?: string;
 } >;
-export default function EmailForwardHeader( { className, children }: Props ) {
+export default function EmailForwardHeader( { className, children, actionPath }: Props ) {
 	const translate = useTranslate();
 
 	return (
@@ -20,7 +21,9 @@ export default function EmailForwardHeader( { className, children }: Props ) {
 					<span className="section-header__label-text">{ translate( 'Destination' ) }</span>
 				</div>
 				<div className="section-header__actions">
-					<Button isLink>{ translate( 'Add forward' ) }</Button>
+					<Button href={ actionPath } isLink>
+						{ translate( 'Add forward' ) }
+					</Button>
 				</div>
 			</CompactCard>
 			{ children }

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/email-forward-header.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/email-forward-header.tsx
@@ -1,0 +1,29 @@
+import { CompactCard } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+
+type Props = React.PropsWithChildren< {
+	className?: string;
+} >;
+export default function EmailForwardHeader( { className, children }: Props ) {
+	const translate = useTranslate();
+
+	return (
+		<div className={ clsx( className, 'email-plan-mailboxes-list__email-forward-header' ) }>
+			<CompactCard className="section-header">
+				<div className="section-header__label">
+					<span className="section-header__label-text">{ translate( 'Email forwards' ) }</span>
+				</div>
+				<div className="section-header__label">
+					<span className="section-header__label-text">{ translate( 'Destination' ) }</span>
+				</div>
+				<div className="section-header__actions">
+					<Button isLink>{ translate( 'Add forward' ) }</Button>
+				</div>
+			</CompactCard>
+			{ children }
+		</div>
+	);
+}

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/email-forward-header.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/email-forward-header.tsx
@@ -17,13 +17,15 @@ export default function EmailForwardHeader( { className, children, actionPath }:
 				<div className="section-header__label">
 					<span className="section-header__label-text">{ translate( 'Email forwards' ) }</span>
 				</div>
-				<div className="section-header__label">
+				<div className="section-header__label destination">
 					<span className="section-header__label-text">{ translate( 'Destination' ) }</span>
 				</div>
 				<div className="section-header__actions">
-					<Button href={ actionPath } isLink>
-						{ translate( 'Add forward' ) }
-					</Button>
+					{ actionPath && (
+						<Button href={ actionPath } isLink>
+							{ translate( 'Add forward' ) }
+						</Button>
+					) }
 				</div>
 			</CompactCard>
 			{ children }

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/email-forward-header.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/email-forward-header.tsx
@@ -11,7 +11,7 @@ export default function EmailForwardHeader( { className, children }: Props ) {
 	const translate = useTranslate();
 
 	return (
-		<div className={ clsx( className, 'email-plan-mailboxes-list__email-forward-header' ) }>
+		<div className={ clsx( className, 'email-plan-mailboxes-list__email-forward' ) }>
 			<CompactCard className="section-header">
 				<div className="section-header__label">
 					<span className="section-header__label-text">{ translate( 'Email forwards' ) }</span>

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/email-forward-secondary-details.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/email-forward-secondary-details.tsx
@@ -4,12 +4,13 @@ import type { Mailbox } from 'calypso/data/emails/types';
 
 type Props = {
 	mailbox: Mailbox;
+	hideIcon?: boolean;
 };
-function EmailForwardSecondaryDetails( { mailbox }: Props ) {
+function EmailForwardSecondaryDetails( { mailbox, hideIcon }: Props ) {
 	if ( isEmailForward( mailbox ) ) {
 		return (
 			<div className="email-plan-mailboxes-list__mailbox-secondary-details">
-				<Gridicon icon="chevron-right" />
+				{ ! hideIcon && <Gridicon icon="chevron-right" /> }
 				<span>{ getEmailForwardAddress( mailbox ) }</span>
 			</div>
 		);

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/email-upgrade-notice.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/email-upgrade-notice.tsx
@@ -2,7 +2,10 @@ import { Button, Notice } from '@wordpress/components';
 import { Icon, starFilled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 
-export default function EmailUpgradeNotice() {
+type Props = {
+	path?: string;
+};
+export default function EmailUpgradeNotice( { path }: Props ) {
 	const translate = useTranslate();
 
 	return (
@@ -22,9 +25,11 @@ export default function EmailUpgradeNotice() {
 					) }
 				</p>
 			</div>
-			<Button variant="primary" size="compact">
-				{ translate( 'Compare options' ) }
-			</Button>
+			{ path && (
+				<Button variant="primary" size="compact" href={ path }>
+					{ translate( 'Compare options' ) }
+				</Button>
+			) }
 		</Notice>
 	);
 }

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/email-upgrade-notice.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/email-upgrade-notice.tsx
@@ -1,0 +1,30 @@
+import { Button, Notice } from '@wordpress/components';
+import { Icon, starFilled } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+
+export default function EmailUpgradeNotice() {
+	const translate = useTranslate();
+
+	return (
+		<Notice
+			className="email-plan-mailboxes-list__email-upgrade-notice"
+			status="info"
+			isDismissible={ false }
+		>
+			<div className="icon">
+				<Icon icon={ starFilled } />
+			</div>
+			<div className="content">
+				<strong>{ translate( 'Unlock the full power of your inbox' ) }</strong>
+				<p>
+					{ translate(
+						'Upgrade to our professional email suite and enjoy advanced features, seamless organization, and enhanced productivity. Try it risk-free with a 14-day money back guarantee.'
+					) }
+				</p>
+			</div>
+			<Button variant="primary" size="compact">
+				{ translate( 'Compare options' ) }
+			</Button>
+		</Notice>
+	);
+}

--- a/client/my-sites/email/email-management/home/email-plan/index.jsx
+++ b/client/my-sites/email/email-management/home/email-plan/index.jsx
@@ -361,12 +361,12 @@ function EmailPlan( {
 				/>
 			) }
 			<EmailPlanMailboxesList
+				context={ context }
 				account={ getAccount( emailAccounts ) }
 				domain={ domain }
 				mailboxes={ getMailboxes( emailAccounts ) }
 				isLoadingEmails={ isLoading }
 				addMailboxPath={ hidePlanActions && getAddMailboxProps()?.path }
-				configuringStateMode={ context === 'domains' && 'notice' }
 			/>
 			{ ! hidePlanActions && (
 				<div className="email-plan__actions">

--- a/client/my-sites/email/email-management/home/email-plan/index.jsx
+++ b/client/my-sites/email/email-management/home/email-plan/index.jsx
@@ -367,6 +367,11 @@ function EmailPlan( {
 				mailboxes={ getMailboxes( emailAccounts ) }
 				isLoadingEmails={ isLoading }
 				actionPathProps={ hidePlanActions && getAddMailboxProps() }
+				purchaseNewEmailAccountPath={ getPurchaseNewEmailAccountPath(
+					selectedSite.slug,
+					domain.name,
+					currentRoute
+				) }
 			/>
 			{ ! hidePlanActions && (
 				<div className="email-plan__actions">

--- a/client/my-sites/email/email-management/home/email-plan/index.jsx
+++ b/client/my-sites/email/email-management/home/email-plan/index.jsx
@@ -366,7 +366,7 @@ function EmailPlan( {
 				domain={ domain }
 				mailboxes={ getMailboxes( emailAccounts ) }
 				isLoadingEmails={ isLoading }
-				addMailboxPath={ hidePlanActions && getAddMailboxProps()?.path }
+				actionPathProps={ hidePlanActions && getAddMailboxProps() }
 			/>
 			{ ! hidePlanActions && (
 				<div className="email-plan__actions">

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -655,6 +655,31 @@
 		.email-plan-mailboxes-list__mailbox-secondary-details svg {
 			width: 1rem;
 		}
+
+		.email-mailbox-warnings {
+			.email-mailbox-warnings__warning,
+			.email-mailbox-warnings__action {
+				display: inline-block;
+				border: none;
+				padding: 0;
+				margin: 0;
+			}
+
+			.email-mailbox-warnings__action {
+				button {
+					padding: 0;
+				}
+			}
+
+			.email-mailbox-warnings__warning {
+				margin-left: 0;
+				margin-right: 0.75rem;
+
+				svg {
+					fill: var(--color-error);
+				}
+			}
+		}
 	}
 }
 

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -651,5 +651,9 @@
 		.email-plan-mailboxes-list__mailbox-list-item-main {
 			font-size: 0.875rem;
 		}
+
+		.email-plan-mailboxes-list__mailbox-secondary-details svg {
+			width: 1rem;
+		}
 	}
 }

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -657,3 +657,35 @@
 		}
 	}
 }
+
+.email-plan-mailboxes-list__email-upgrade-notice {
+	margin-top: 1rem;
+	box-shadow: 0 0 0 1px var(--color-border-subtle);
+
+	.components-notice__content {
+		display: flex;
+		margin-left: 0.25rem;
+		margin-right: 0.75rem;
+		align-items: center;
+	}
+
+	p {
+		margin: 0;
+		font-size: 0.75rem;
+		color: var(--studio-gray-70);
+	}
+
+	.icon {
+		svg {
+			fill: #fff;
+			padding: 4px;
+			border-radius: 100%;
+			background: var(--color-accent-60);
+		}
+	}
+
+	.content {
+		flex: 1 1 auto;
+		margin: 0 0.75rem;
+	}
+}

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -592,7 +592,7 @@
 		}
 	}
 
-	div.email-plan-mailboxes-list__mailbox-list-link span,
+	div.email-plan-mailboxes-list__mailbox-list-link span.disabled,
 	.section-header__actions button[disabled] {
 		color: var(--theme-highlight-color-50);
 		opacity: 0.5;

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -613,11 +613,6 @@
 		.email-mailbox-action-menu__main {
 			text-align: end;
 
-			svg {
-				width: 1rem;
-				height: 1rem;
-			}
-
 			@include break-xlarge {
 				position: static;
 			}
@@ -635,21 +630,12 @@
 			}
 		}
 
-		.email-plan-mailboxes-list__mailbox-list-item {
-			gap: 5px;
-			border-bottom: solid 1px var(--color-border-subtle);
-			padding-left: 0;
-			padding-right: 0;
-			margin-left: 1.5rem;
-			margin-right: 1.5rem;
-
-			&:last-child {
-				border-bottom: none;
-			}
-		}
-
 		.email-plan-mailboxes-list__mailbox-list-item-main {
 			font-size: 0.875rem;
+
+			span {
+				align-self: center;
+			}
 		}
 
 		.email-plan-mailboxes-list__mailbox-secondary-details svg {

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -597,4 +597,28 @@
 		color: var(--theme-highlight-color-50);
 		opacity: 0.5;
 	}
+
+	.email-plan-mailboxes-list__email-forward {
+		.section-header__label,
+		.email-plan-mailboxes-list__mailbox-list-item-main {
+			flex: 1 1 0;
+		}
+
+		.section-header__actions,
+		.email-mailbox-action-menu__main {
+			flex: 0 0 auto;
+		}
+
+		.email-plan-mailboxes-list__mailbox-list-item {
+			padding-right: 110px;
+		}
+
+		.section-header__label {
+			font-weight: 500;
+		}
+
+		.email-plan-mailboxes-list__mailbox-list-item-main {
+			font-size: 0.875rem;
+		}
+	}
 }

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -606,15 +606,46 @@
 
 		.section-header__actions,
 		.email-mailbox-action-menu__main {
+			min-width: 80px;
 			flex: 0 0 auto;
 		}
 
-		.email-plan-mailboxes-list__mailbox-list-item {
-			padding-right: 110px;
+		.email-mailbox-action-menu__main {
+			text-align: end;
+
+			svg {
+				width: 1rem;
+				height: 1rem;
+			}
+
+			@include break-xlarge {
+				position: static;
+			}
 		}
 
 		.section-header__label {
 			font-weight: 500;
+
+			&.destination {
+				display: none;
+
+				@include break-xlarge {
+					display: block;
+				}
+			}
+		}
+
+		.email-plan-mailboxes-list__mailbox-list-item {
+			gap: 5px;
+			border-bottom: solid 1px var(--color-border-subtle);
+			padding-left: 0;
+			padding-right: 0;
+			margin-left: 1.5rem;
+			margin-right: 1.5rem;
+
+			&:last-child {
+				border-bottom: none;
+			}
 		}
 
 		.email-plan-mailboxes-list__mailbox-list-item-main {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/97234

## Proposed Changes

* Creates `EmailForwardHeader` component
* Refactor the `EmailPlanMailboxesList` to support two different contexts in a more structured way

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Domain management revamp project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/domains/manage?flags=calypso/all-domain-management`
* Create or select domain
* Add one or more forwarded emails
* Check the Email forwarding list screen and compare it with Figma; link will be `domains/manage/all/email/{DOMAIN}/{DOMAIN}`
* Check the current flow and check if there is any regression

**The new UI**
<img width="1225" alt="Screenshot 2024-12-20 at 12 18 57" src="https://github.com/user-attachments/assets/ba271781-11bf-4988-84f9-20a65b3c04dc" />

<img width="753" alt="Screenshot 2024-12-20 at 12 19 15" src="https://github.com/user-attachments/assets/f767dc1c-6cfa-4ac0-957d-460c1008b2d7" />

**The existing UI**
<img width="1089" alt="Screenshot 2024-12-20 at 12 18 17" src="https://github.com/user-attachments/assets/0dc243a0-1295-4a4e-b0d8-fb6e4db1cfe2" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
