### PR TITLE
Remove design picker from site-setup flow

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,6 +1,7 @@
-import { Onboard } from '@automattic/data-stores';
+import { Onboard, updateLaunchpadSettings } from '@automattic/data-stores';
 import { MIGRATION_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
 import { isTargetSitePlanCompatible } from 'calypso/blocks/importer/util';
 import { useIsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-big-sky-eligible';
@@ -10,6 +11,7 @@ import { addQueryArgs } from 'calypso/lib/route';
 import { useDispatch as reduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getInitialQueryArguments } from 'calypso/state/selectors/get-initial-query-arguments';
+import { setActiveTheme } from 'calypso/state/themes/actions';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { WRITE_INTENT_DEFAULT_DESIGN } from '../constants';
 import { useIsGoalsHoldout } from '../hooks/use-is-goals-holdout';
@@ -29,6 +31,7 @@ import {
 	ProvidedDependencies,
 } from './internals/types';
 import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-stores';
+import type { ActiveTheme } from 'calypso/data/themes/use-active-theme-query';
 
 const SiteIntent = Onboard.SiteIntent;
 
@@ -676,6 +679,55 @@ const siteSetupFlow: Flow = {
 		}
 
 		return result;
+	},
+
+	useSideEffect() {
+		const isGoalsAtFrontExperiment = useGoalsAtFrontExperimentQueryParam();
+		const { siteSlugOrId, siteId } = useSiteData();
+		const { setPendingAction } = useDispatch( ONBOARD_STORE );
+		const { setDesignOnSite } = useDispatch( SITE_STORE );
+		const { selectedDesign, selectedStyleVariation } = useSelect( ( select ) => {
+			const { getSelectedDesign, getSelectedStyleVariation } = select(
+				ONBOARD_STORE
+			) as OnboardSelect;
+			return {
+				selectedDesign: getSelectedDesign(),
+				selectedStyleVariation: getSelectedStyleVariation(),
+			};
+		}, [] );
+		const dispatch = reduxDispatch();
+
+		useEffect( () => {
+			if ( ! isGoalsAtFrontExperiment || ! siteSlugOrId || ! siteId ) {
+				return;
+			}
+
+			setPendingAction( async () => {
+				await updateLaunchpadSettings( siteSlugOrId, {
+					checklist_statuses: { design_completed: true },
+				} );
+
+				if ( ! selectedDesign ) {
+					return;
+				}
+
+				return setDesignOnSite( siteSlugOrId, selectedDesign, {
+					styleVariation: selectedStyleVariation,
+					globalStyles: {},
+				} ).then( ( theme: ActiveTheme ) => {
+					return dispatch( setActiveTheme( siteId, theme ) );
+				} );
+			} );
+		}, [
+			isGoalsAtFrontExperiment,
+			siteSlugOrId,
+			siteId,
+			setDesignOnSite,
+			selectedDesign,
+			setPendingAction,
+			dispatch,
+			selectedStyleVariation,
+		] );
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -686,15 +686,20 @@ const siteSetupFlow: Flow = {
 		const { siteSlugOrId, siteId } = useSiteData();
 		const { setPendingAction } = useDispatch( ONBOARD_STORE );
 		const { setDesignOnSite } = useDispatch( SITE_STORE );
-		const { selectedDesign, selectedStyleVariation } = useSelect( ( select ) => {
-			const { getSelectedDesign, getSelectedStyleVariation } = select(
-				ONBOARD_STORE
-			) as OnboardSelect;
-			return {
-				selectedDesign: getSelectedDesign(),
-				selectedStyleVariation: getSelectedStyleVariation(),
-			};
-		}, [] );
+		const { selectedDesign, selectedStyleVariation, selectedGlobalStyles } = useSelect(
+			( select ) => {
+				const { getSelectedDesign, getSelectedStyleVariation, getSelectedGlobalStyles } = select(
+					ONBOARD_STORE
+				) as OnboardSelect;
+				return {
+					selectedDesign: getSelectedDesign(),
+					selectedStyleVariation: getSelectedStyleVariation(),
+					selectedGlobalStyles: getSelectedGlobalStyles(),
+				};
+			},
+			[]
+		);
+
 		const dispatch = reduxDispatch();
 
 		useEffect( () => {
@@ -713,7 +718,7 @@ const siteSetupFlow: Flow = {
 
 				return setDesignOnSite( siteSlugOrId, selectedDesign, {
 					styleVariation: selectedStyleVariation,
-					globalStyles: {},
+					globalStyles: selectedGlobalStyles,
 				} ).then( ( theme: ActiveTheme ) => {
 					return dispatch( setActiveTheme( siteId, theme ) );
 				} );
@@ -727,6 +732,7 @@ const siteSetupFlow: Flow = {
 			setPendingAction,
 			dispatch,
 			selectedStyleVariation,
+			selectedGlobalStyles,
 		] );
 	},
 };

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -40,14 +40,16 @@ function isLaunchpadIntent( intent: string ) {
 	return intent === SiteIntent.Write || intent === SiteIntent.Build;
 }
 
+function useGoalsAtFrontExperimentQueryParam() {
+	return Boolean( useSelector( getInitialQueryArguments )?.[ 'goals-at-front-experiment' ] );
+}
+
 const siteSetupFlow: Flow = {
 	name: 'site-setup',
 	isSignupFlow: false,
 
 	useSteps() {
-		const isGoalsAtFrontExperiment = Boolean(
-			useSelector( getInitialQueryArguments )?.[ 'goals-at-front-experiment' ]
-		);
+		const isGoalsAtFrontExperiment = useGoalsAtFrontExperimentQueryParam();
 
 		const steps = [
 			STEPS.GOALS,
@@ -78,9 +80,7 @@ const siteSetupFlow: Flow = {
 		];
 
 		if ( isGoalsAtFrontExperiment ) {
-			// The user has already seen the goals step in the `onboarding` flow
-			// TODO Ensure that DESIGN_CHOICES is at the front if the user is Big Sky eligible
-			steps.splice( 0, 4 );
+			return [ STEPS.PROCESSING, STEPS.ERROR ];
 		}
 
 		return steps;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/97383

## Proposed Changes

Builds on the changes in #97383 which moves the design picker to the `onboarding` flow.

In the "goals first" experiment:
* Removes all steps from the `site-setup` flow other than those needed for processing
* Upon loading the `site-setup` flow, queues a processing job to apply the selected design to the selected site
  * The `useSideEffects` hook is mostly a copy-paste from the unified design picker's click handler: https://github.com/Automattic/wp-calypso/blob/955b41404db5450e1dc6a78c0764d2ca9f8c0b5f/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx#L644


https://github.com/user-attachments/assets/683d52d9-b946-4c16-999f-304d4f20c885


You still can't test premium themes/variations because this modal still blocks the user from moving forward. That can be removed in another PR.

![CleanShot 2024-12-17 at 19 39 48@2x](https://github.com/user-attachments/assets/696b6353-cebd-47e3-a779-8048c3ccc99b)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

For free sites with free themes it just needs to happen after site creation. It strikes me now that if a user chooses free everything we can do it in the onboarding flow before redirecting to /home
For paid themes, we need to be sure the user successfully completed checkout before we apply the design. That's why it has to be in a separate flow after the checkout.
This PR implements the separate flow, since that works for free and paid. But skipping the extra flow for free sites seems like a nice bit of polish.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Test by running through the `/setup/onboarding` flow
   - Need to test using sites with a free plan and sites with paid plans. Both should have the theme applied to the site once the flow is complete
- Also make sure the `/start` flow hasn't changed! The `/start` flow eventually lands in the `site-setup` flow and it needs to still have the goals and design picker step working as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
