### PR TITLE
Design Picker: Save the selected global styles to the onboard stores

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
@@ -28,17 +28,22 @@ const useRecipe = (
 ) => {
 	const [ searchParams, setSearchParams ] = useSearchParams();
 	const isPreviewingDesign = !! searchParams.get( 'theme' );
-	const { selectedDesign, selectedStyleVariation } = useSelect( ( select ) => {
-		const { getSelectedDesign, getSelectedStyleVariation } = select(
-			ONBOARD_STORE
-		) as OnboardSelect;
-		return {
-			selectedDesign: getSelectedDesign(),
-			selectedStyleVariation: getSelectedStyleVariation(),
-		};
-	}, [] );
+	const { selectedDesign, selectedStyleVariation, selectedGlobalStyles } = useSelect(
+		( select ) => {
+			const { getSelectedDesign, getSelectedStyleVariation, getSelectedGlobalStyles } = select(
+				ONBOARD_STORE
+			) as OnboardSelect;
+			return {
+				selectedDesign: getSelectedDesign(),
+				selectedStyleVariation: getSelectedStyleVariation(),
+				selectedGlobalStyles: getSelectedGlobalStyles(),
+			};
+		},
+		[]
+	);
 
-	const { setSelectedDesign, setSelectedStyleVariation } = useDispatch( ONBOARD_STORE );
+	const { setSelectedDesign, setSelectedStyleVariation, setSelectedGlobalStyles } =
+		useDispatch( ONBOARD_STORE );
 
 	const [ selectedColorVariation, setSelectedColorVariation ] =
 		useState< GlobalStylesObject | null >( null );
@@ -52,8 +57,6 @@ const useRecipe = (
 		!! selectedColorVariation,
 		!! selectedFontVariation,
 	].filter( Boolean ).length;
-
-	const [ globalStyles, setGlobalStyles ] = useState< GlobalStylesObject | null >( null );
 
 	/**
 	 * Get the preselect data only when mounting and ignore any changes later.
@@ -183,7 +186,7 @@ const useRecipe = (
 		handleSelectedStyleVariationChange();
 		handleSelectedColorVariationChange( null );
 		handleSelectedFontVariationChange( null );
-		setGlobalStyles( null );
+		setSelectedGlobalStyles( undefined );
 	};
 
 	// Unset the selected design, thus restarting the design picking experience.
@@ -258,14 +261,14 @@ const useRecipe = (
 		selectedColorVariation,
 		selectedFontVariation,
 		numOfSelectedGlobalStyles,
-		globalStyles,
+		globalStyles: selectedGlobalStyles,
 		previewDesign,
 		previewDesignVariation,
 		setSelectedDesign,
 		setSelectedStyleVariation,
 		setSelectedColorVariation: handleSelectedColorVariationChange,
 		setSelectedFontVariation: handleSelectedFontVariationChange,
-		setGlobalStyles,
+		setGlobalStyles: setSelectedGlobalStyles,
 		resetPreview,
 	};
 };

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -2,7 +2,7 @@ import { guessTimezone, getLanguage } from '@automattic/i18n-utils';
 import { dispatch, select } from '@wordpress/data-controls';
 import { __ } from '@wordpress/i18n';
 import { STORE_KEY as SITE_STORE } from '../site';
-import { Visibility } from '../site/types';
+import { Visibility, GlobalStyles } from '../site/types';
 import { SiteGoal, STORE_KEY } from './constants';
 import { ProfilerData, ReadymadeTemplate } from './types';
 import type { DomainTransferData, State } from '.';
@@ -169,6 +169,11 @@ export const setSelectedStyleVariation = (
 ) => ( {
 	type: 'SET_SELECTED_STYLE_VARIATION' as const,
 	selectedStyleVariation,
+} );
+
+export const setSelectedGlobalStyles = ( selectedGlobalStyles: GlobalStyles | undefined ) => ( {
+	type: 'SET_SELECTED_GLOBAL_STYLES' as const,
+	selectedGlobalStyles,
 } );
 
 export const setSelectedReadymadeTemplate = ( readymadeTemplate: ReadymadeTemplate ) => ( {
@@ -410,6 +415,7 @@ export type OnboardAction = ReturnType<
 	| typeof setRandomizedDesigns
 	| typeof setSelectedDesign
 	| typeof setSelectedStyleVariation
+	| typeof setSelectedGlobalStyles
 	| typeof setSelectedSite
 	| typeof setSelectedReadymadeTemplate
 	| typeof setShowSignupDialog

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -10,6 +10,7 @@ import type {
 } from './types';
 import type { DomainSuggestion } from '../domain-suggestions';
 import type { FeatureId } from '../shared-types';
+import type { GlobalStyles } from '../site';
 // somewhat hacky, but resolves the circular dependency issue
 import type { Design, StyleVariation } from '@automattic/design-picker/src/types';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
@@ -128,6 +129,22 @@ const selectedStyleVariation: Reducer< StyleVariation | undefined, OnboardAction
 		return undefined;
 	}
 	return state;
+};
+
+const selectedGlobalStyles: Reducer< GlobalStyles | undefined, OnboardAction > = (
+	state,
+	action
+) => {
+	switch ( action.type ) {
+		case 'SET_SELECTED_GLOBAL_STYLES':
+			return action.selectedGlobalStyles;
+
+		case 'RESET_ONBOARD_STORE':
+			return undefined;
+
+		default:
+			return state;
+	}
 };
 
 const readymadeTemplate: Reducer< ReadymadeTemplate | undefined, OnboardAction > = (
@@ -629,6 +646,7 @@ const reducer = combineReducers( {
 	storeType,
 	selectedDesign,
 	selectedStyleVariation,
+	selectedGlobalStyles,
 	selectedSite,
 	siteTitle,
 	showSignupDialog,

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -33,6 +33,7 @@ export const getLastLocation = ( state: State ) => state.lastLocation;
 export const getRandomizedDesigns = ( state: State ) => state.randomizedDesigns;
 export const getSelectedDesign = ( state: State ) => state.selectedDesign;
 export const getSelectedStyleVariation = ( state: State ) => state.selectedStyleVariation;
+export const getSelectedGlobalStyles = ( state: State ) => state.selectedGlobalStyles;
 export const getSelectedDomain = ( state: State ) => state.domain;
 export const getSelectedFeatures = ( state: State ) => state.selectedFeatures;
 export const getSelectedSite = ( state: State ) => state.selectedSite;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/97540

## Proposed Changes

* Save the selected global styles to the onboard stores so we can get the data in different flows

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Store the global styles between different onboarding flows

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* On the Goals screen, select any goals
* On the Design Picker screen,
  * Select a design with the style variation, and ensure it works as before
  * Select a design with the color/font variation, and ensure it works as before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
