### PR TITLE
i18n: Fix translate calls in JP stats

### DIFF
--- a/client/components/date-range/use-shortcuts.ts
+++ b/client/components/date-range/use-shortcuts.ts
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { createSelector } from '@automattic/state-utils';
-import { translate, useTranslate } from 'i18n-calypso';
+import { translate as i18nCalypsoTranslate, useTranslate } from 'i18n-calypso';
 import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -41,10 +41,10 @@ export const getShortcuts = createSelector(
 			chartStart: string;
 			chartEnd: string;
 		},
-		translateFunction,
+		translateFromProps,
 		isNewDateFilteringEnabled = config.isEnabled( 'stats/new-date-filtering' )
 	) => {
-		translateFunction = translateFunction ?? translate;
+		const translate = translateFromProps ?? i18nCalypsoTranslate;
 		const siteId = getSelectedSiteId( state );
 		const siteToday = getMomentSiteZone( state, siteId );
 		const siteTodayStr = siteToday.format( DATE_FORMAT );
@@ -54,35 +54,35 @@ export const getShortcuts = createSelector(
 		const supportedShortcutList = [
 			{
 				id: 'last_7_days',
-				label: translateFunction( 'Last 7 Days' ),
+				label: translate( 'Last 7 Days' ),
 				startDate: siteToday.clone().subtract( 6, 'days' ).format( DATE_FORMAT ),
 				endDate: siteTodayStr,
 				period: DATERANGE_PERIOD.DAY,
 			},
 			{
 				id: 'last_30_days',
-				label: translateFunction( 'Last 30 Days' ),
+				label: translate( 'Last 30 Days' ),
 				startDate: siteToday.clone().subtract( 29, 'days' ).format( DATE_FORMAT ),
 				endDate: siteTodayStr,
 				period: DATERANGE_PERIOD.DAY,
 			},
 			{
 				id: 'last_3_months',
-				label: translateFunction( 'Last 90 Days' ),
+				label: translate( 'Last 90 Days' ),
 				startDate: siteToday.clone().subtract( 89, 'days' ).format( DATE_FORMAT ),
 				endDate: siteTodayStr,
 				period: DATERANGE_PERIOD.WEEK,
 			},
 			{
 				id: 'last_year',
-				label: translateFunction( 'Last Year' ),
+				label: translate( 'Last Year' ),
 				startDate: siteToday.clone().subtract( 364, 'days' ).format( DATE_FORMAT ),
 				endDate: siteTodayStr,
 				period: DATERANGE_PERIOD.MONTH,
 			},
 			{
 				id: 'custom_date_range',
-				label: translateFunction( 'Custom Range' ),
+				label: translate( 'Custom Range' ),
 				startDate: '',
 				endDate: '',
 				period: DATERANGE_PERIOD.DAY,
@@ -93,14 +93,14 @@ export const getShortcuts = createSelector(
 			supportedShortcutList.unshift(
 				{
 					id: 'today',
-					label: translateFunction( 'Today' ),
+					label: translate( 'Today' ),
 					startDate: siteTodayStr,
 					endDate: siteTodayStr,
 					period: DATERANGE_PERIOD.DAY,
 				},
 				{
 					id: 'yesterday',
-					label: translateFunction( 'Yesterday' ),
+					label: translate( 'Yesterday' ),
 					startDate: yesterdayStr,
 					endDate: yesterdayStr,
 					period: DATERANGE_PERIOD.DAY,
@@ -119,7 +119,7 @@ export const getShortcuts = createSelector(
 			chartStart: string;
 			chartEnd: string;
 		},
-		translateFunction,
+		translateFromProps,
 		isNewDateFilteringEnabled
 	) => {
 		const siteId = getSelectedSiteId( state );

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import page from '@automattic/calypso-router';
 import clsx from 'clsx';
-import { localize, translate, withRtl } from 'i18n-calypso';
+import { localize, withRtl } from 'i18n-calypso';
 import { flowRight } from 'lodash';
 import PropTypes from 'prop-types';
 import qs from 'qs';
@@ -363,7 +363,7 @@ const addIsGatedFor = ( state, siteId ) => ( shortcut ) => ( {
 } );
 
 const connectComponent = connect(
-	( state, { period, isNewDateFilteringEnabled } ) => {
+	( state, { period, isNewDateFilteringEnabled, translate } ) => {
 		const siteId = getSelectedSiteId( state );
 		const gateDateControl = shouldGateStats( state, siteId, STATS_FEATURE_DATE_CONTROL );
 		const gatePeriodInterval = shouldGateStats(
@@ -378,7 +378,7 @@ const connectComponent = connect(
 		const { supportedShortcutList } = getShortcuts(
 			state,
 			{},
-			undefined,
+			translate,
 			isNewDateFilteringEnabled
 		);
 		const shortcutList = supportedShortcutList.map( addIsGatedFor( state, siteId ) );

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -423,8 +423,8 @@ const connectComponent = connect(
 );
 
 export default flowRight(
-	connectComponent,
 	localize,
+	connectComponent,
 	withRtl,
 	withLocalizedMoment,
 	withStatsPurchases


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/i18n-issues#905

## Proposed Changes

- Fixes a few instances of `translate` calls where the function name/call was `translateFunction`. These are apparently not picked up by the string extraction (I believe that's  [babel-plugin-i18n-calypso](https://github.com/Automattic/wp-calypso/tree/96c6818718a35f07dbee51e8e02c0d987c0bc574/packages/babel-plugin-i18n-calypso)), which searches for calls to a `translate` function instead.
- Fixes a few instances of using `translate` directly from `i18n-calypso` in `stats-period-navigation`, which does not react to state changes. Component's already `localized`.

### Media

**Before**

<img width="800" alt="Screenshot 2024-12-17 at 6 01 49 PM" src="https://github.com/user-attachments/assets/912af313-2115-49d8-882a-9a6a83877688" />

**After**

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Address Automattic/i18n-issues#905

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Not quite sure how to test this. Check GlotPress to see whether these strings are present there now? 
Then wait for translations before shipping, or would this be good to go otherwise?

- Switch locale to ES
- Go to `/stats/day/:site` and confirm the translations effectively applied

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
