### PR TITLE
Introduce collapsed view in design picker

### DIFF
--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -58,6 +58,11 @@
 				margin-top: 12px;
 			}
 		}
+
+		.design-picker__design-card-group-footer {
+			margin-top: -12px;
+			margin-bottom: 36px;
+		}
 	}
 
 	.design-picker__grid {

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -246,7 +246,7 @@ const DesignCardGroup = ( {
 			{ content }
 			{ isCollapsed && designs.length > collapsedDesignCount && (
 				<div className="design-picker__design-card-group-footer">
-					<Button compact onClick={ () => setIsCollapsed( false ) }>
+					<Button onClick={ () => setIsCollapsed( false ) }>
 						{ translate( 'Show all %s themes', {
 							args: categoryName,
 							comment: '%s will be a name of the theme category. e.g. Blog.',

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -176,6 +176,7 @@ interface DesignCardGroup {
 	designs: Design[];
 	locale: string;
 	category?: string | null;
+	categoryName?: string;
 	isPremiumThemeAvailable?: boolean;
 	shouldLimitGlobalStyles?: boolean;
 	oldHighResImageLoading?: boolean; // Temporary for A/B test.
@@ -191,6 +192,7 @@ const DesignCardGroup = ( {
 	title,
 	designs,
 	category,
+	categoryName,
 	locale,
 	isPremiumThemeAvailable,
 	shouldLimitGlobalStyles,
@@ -202,9 +204,14 @@ const DesignCardGroup = ( {
 	onPreview,
 	getBadge,
 }: DesignCardGroup ) => {
+	const translate = useTranslate();
+	const [ isCollapsed, setIsCollapsed ] = useState( !! categoryName || false );
+	const collapsedDesignCount = 9;
+	const visibleDesigns = isCollapsed ? designs.slice( 0, collapsedDesignCount ) : designs;
+
 	const content = (
 		<div className="design-picker__grid">
-			{ designs.map( ( design, index ) => {
+			{ visibleDesigns.map( ( design, index ) => {
 				return (
 					<DesignCard
 						key={ design.recipe?.slug ?? design.slug ?? index }
@@ -229,16 +236,24 @@ const DesignCardGroup = ( {
 		return null;
 	}
 
-	if ( ! title || designs.length === 0 ) {
-		return content;
-	}
-
 	return (
 		<div className="design-picker__design-card-group">
-			<div className="design-picker__design-card-title">
-				{ title } ({ designs.length })
-			</div>
+			{ title && designs.length > 0 && (
+				<div className="design-picker__design-card-title">
+					{ title } ({ designs.length })
+				</div>
+			) }
 			{ content }
+			{ isCollapsed && designs.length > collapsedDesignCount && (
+				<div className="design-picker__design-card-group-footer">
+					<Button compact onClick={ () => setIsCollapsed( false ) }>
+						{ translate( 'Show all %s themes', {
+							args: categoryName,
+							comment: '%s will be a name of the theme category. e.g. Blog.',
+						} ) }
+					</Button>
+				</div>
+			) }
 		</div>
 	);
 };
@@ -430,6 +445,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 								: ''
 						}
 						category={ categorySlug }
+						categoryName={ isMultiFilterEnabled ? getCategoryName( categorySlug ) : '' }
 						designs={ categoryDesigns }
 						showNoResults={ index === array.length - 1 && showNoResults }
 					/>

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -206,7 +206,7 @@ const DesignCardGroup = ( {
 }: DesignCardGroup ) => {
 	const translate = useTranslate();
 	const [ isCollapsed, setIsCollapsed ] = useState( !! categoryName || false );
-	const collapsedDesignCount = 9;
+	const collapsedDesignCount = 6;
 	const visibleDesigns = isCollapsed ? designs.slice( 0, collapsedDesignCount ) : designs;
 
 	const content = (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes: https://github.com/Automattic/dotcom-forge/issues/10134

## Proposed Changes

* Add collapsed view (show only 9 items) for each category group
* Show load more button when there are more items in the group
* On click of the load more, show all designs in that category group.

<img width="931" alt="image" src="https://github.com/user-attachments/assets/53ea9502-8b9d-4de1-9fd5-ffb53e0b9ed8" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* For a better scroll experience of being able to reach categories in the bottom quickly.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load design picker
* Initially each category group should show only 9 items and a show all button.
* on click of the show all, it should expand to complete list of themes.
* Changing filters doesn't effect the groups that are already expanded.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
