### PR TITLE
Allow users to restore deleted sites in the sites ellipsis menu

### DIFF
--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -199,9 +199,7 @@ export const isActionEligible = (
 			};
 		case 'restore':
 			return ( site: SiteExcerptData ) => {
-				const canManageOptions = capabilities[ site.ID ]?.manage_options;
 				if (
-					( ! canManageOptions && ! site?.is_deleted ) ||
 					isP2Site( site ) ||
 					isNotAtomicJetpack( site ) ||
 					isDisconnectedJetpackAndNotAtomic( site )

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -199,6 +199,9 @@ export const isActionEligible = (
 			};
 		case 'restore':
 			return ( site: SiteExcerptData ) => {
+				// For deleted sites, the `manage_options` capability is not returned so we  don't check for it here
+				// But this setting is guarded in the backend:
+				// https://github.a8c.com/Automattic/wpcom/blob/4508b82936f1502b580d49574b63aad3b6dc1c5a/wp-content/rest-api-plugins/endpoints/site-restore.php#L47
 				if (
 					isP2Site( site ) ||
 					isNotAtomicJetpack( site ) ||

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -201,7 +201,7 @@ export const isActionEligible = (
 			return ( site: SiteExcerptData ) => {
 				const canManageOptions = capabilities[ site.ID ]?.manage_options;
 				if (
-					! canManageOptions ||
+					( ! canManageOptions && ! site?.is_deleted ) ||
 					isP2Site( site ) ||
 					isNotAtomicJetpack( site ) ||
 					isDisconnectedJetpackAndNotAtomic( site )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/97347

## Proposed Changes

* Add an extra condition to display the `Restore` menu item in the ellipsis menu in the sites view

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The user was not able to restore a deleted site

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

They are detailed in the linked task https://github.com/Automattic/wp-calypso/issues/97347, but my steps were:

- Delete a test user that has sites, that will delete all the sites
- Restore the user. I did that using the user report card 
- Navigate to `/sites` and try to delete a user by clicking on the right-hand side elllipsis menu.
- In production, no menu items are displayed. By applying this patch, you should be able to restore the site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
