### PR TITLE
Unblock flow for premium styles and themes for onboarding/goals-first

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -532,26 +532,30 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			forceRedirection: true,
 		} );
 	}
-	function handleCheckout() {
+
+	function goToNextStep() {
+		if ( ! wpcomSiteSlug && ! siteSlug ) {
+			return pickDesign();
+		}
+
+		navigateToCheckout();
+	}
+
+	function handleCheckoutModalConfirmation() {
 		recordTracksEvent( 'calypso_signup_design_upgrade_modal_checkout_button_click', {
 			theme: selectedDesign?.slug,
 			theme_tier: selectedDesign?.design_tier,
 			is_externally_managed: selectedDesign?.is_externally_managed,
 		} );
 
-		if ( siteSlugOrId ) {
-			// We want to display the Eligibility Modal only for externally managed themes
-			// and when no domain was purchased yet.
-			if (
-				selectedDesign?.is_externally_managed &&
-				hasEligibilityMessages &&
-				! didPurchaseDomain
-			) {
-				setShowEligibility( true );
-			} else {
-				navigateToCheckout();
-			}
+		// We want to display the Eligibility Modal only for externally managed themes
+		// and when no domain was purchased yet.
+		if ( selectedDesign?.is_externally_managed && hasEligibilityMessages && ! didPurchaseDomain ) {
+			setShowEligibility( true );
+		} else {
+			goToNextStep();
 		}
+
 		setShowUpgradeModal( false );
 	}
 
@@ -698,6 +702,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				{
 					selectedDesign: _selectedDesign,
 					selectedSiteCategory: categorization.selections?.join( ',' ),
+					plan: requiredPlanSlug,
 				},
 				{ ...( positionIndex >= 0 && { position_index: positionIndex } ) }
 			);
@@ -833,7 +838,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 						marketplaceProduct={ selectedMarketplaceProduct }
 						requiredPlan={ requiredPlanSlug }
 						closeModal={ closeUpgradeModal }
-						checkout={ handleCheckout }
+						checkout={ handleCheckoutModalConfirmation }
 					/>
 				) }
 				<QueryEligibility siteId={ site?.ID } />
@@ -849,7 +854,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 						setShowEligibility( false );
 					} }
 					handleContinue={ () => {
-						navigateToCheckout();
+						goToNextStep();
 						setShowEligibility( false );
 					} }
 				/>

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -133,6 +133,12 @@ const onboarding: Flow = {
 				}
 
 				case 'designSetup': {
+					const { plan } = providedDependencies;
+
+					if ( plan ) {
+						setPlanCartItem( plan );
+					}
+
 					return navigate( 'domains' );
 				}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/97383#issuecomment-2542562566

## Proposed Changes

This is a snippet that's part of https://github.com/Automattic/wp-calypso/pull/97383#issuecomment-2542562566 as currently, when we select a non-free theme, it will block us from testing the next steps as we can't get past this modal
![modal@2x](https://github.com/user-attachments/assets/3143f5cd-7873-419c-b2d2-62bb10c7030c)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
