### PR TITLE
A4A: Fix the mobile responsiveness issue with the new Hosting page v3.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-migration-offer-v3/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v3/index.tsx
@@ -57,7 +57,7 @@ const MigrationOfferV3 = ( { isExpanded, onToggleView }: Props ) => {
 						) }
 					</span>
 
-					<Button className="a4a-migration-offer-v3__view-toggle-mobile" onClick={ onToggleView }>
+					<Button className="a4a-migration-offer-v3__view-toggle-mobile">
 						<Icon icon={ chevronDown } size={ 24 } />
 					</Button>
 				</h3>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hero-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hero-section/index.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { forwardRef, useCallback, useEffect, useMemo, useState } from 'react';
 import MigrationOfferV3 from 'calypso/a8c-for-agencies/components/a4a-migration-offer-v3';
 import NavItem from 'calypso/components/section-nav/item';
+import { preventWidows } from 'calypso/lib/formatting';
 import { SectionProps } from '..';
 
 import './style.scss';
@@ -88,13 +89,15 @@ export function HeroSection(
 		<div className={ clsx( 'hosting-v3-hero-section', { 'is-compact': isCompact } ) } ref={ ref }>
 			<div className="hosting-v3-hero-section__content">
 				<div className="hosting-v3-hero-section__heading">
-					{ translate(
-						'High Performance, Highly-Secure{{br/}}Managed WordPress Hosting for Agencies',
-						{
-							components: {
-								br: <br />,
-							},
-						}
+					{ preventWidows(
+						translate(
+							'High Performance, Highly-Secure{{br/}}Managed WordPress Hosting for Agencies',
+							{
+								components: {
+									br: <br />,
+								},
+							}
+						)
 					) }
 				</div>
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hero-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hero-section/style.scss
@@ -7,7 +7,7 @@ $tab-background-selected: var(--color-surface);
 .hosting-v3-hero-section {
 	max-width: 1500px;
 	margin-inline: auto;
-	padding: 32px 64px 0;
+	padding: 24px 32px 0;
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
@@ -30,6 +30,7 @@ $tab-background-selected: var(--color-surface);
 		}
 
 		@include break-medium {
+			padding: 32px 64px 0;
 			height: 254px;
 		}
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hero-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hero-section/style.scss
@@ -12,7 +12,7 @@ $tab-background-selected: var(--color-surface);
 	flex-direction: column;
 	justify-content: space-between;
 	gap: 39px;
-	transition: height .2s ease-out;
+	transition: height .25s ease-out;
 
 	&:not(.is-compact) {
 		height: 389px;

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hero-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hero-section/style.scss
@@ -14,23 +14,35 @@ $tab-background-selected: var(--color-surface);
 	gap: 39px;
 	transition: height .25s ease-out;
 
-	&:not(.is-compact) {
-		height: 389px;
+	.a4a-migration-offer-v3 {
+		display: none;
 
-		&:has(.a4a-migration-offer-v3.is-expanded) {
-			height: 797px;
+		@include break-large {
+			display: flex;
+		}
+	}
+
+	&:not(.is-compact) {
+		height: 163px;
+
+		@include break-small {
+			height: 188px;
+		}
+
+		@include break-medium {
+			height: 254px;
 		}
 
 		@include break-large {
-			height: 321px;
+			height: 380px;
 
 			&:has(.a4a-migration-offer-v3.is-expanded) {
-				height: 517px;
+				height: 636px;
 			}
 		}
 
 		@include break-wide {
-			height: 315px;
+			height: 340px;
 
 			&:has(.a4a-migration-offer-v3.is-expanded) {
 				height: 485px;
@@ -50,23 +62,27 @@ $tab-background-selected: var(--color-surface);
 	}
 
 	height: 55px;
-
-	@include break-wide {
-		height: 74px;
-	}
 }
 
 
 .hosting-v3-hero-section__heading {
-	@include a4a-font-heading-xxl;
+	@include a4a-font-heading-lg;
 	color: var( --color-text-inverted );
 	margin-block-start: 0;
+
+	@include break-medium {
+		@include a4a-font-heading-xxl;
+	}
 }
 
 .hosting-v3-hero-section__content {
 	display: flex;
 	flex-direction: column;
-	gap: 39px;
+	gap: 24px;
+
+	@include break-medium {
+		gap: 39px;
+	}
 }
 
 .hosting-v3-hero-section__tabs {
@@ -77,7 +93,10 @@ $tab-background-selected: var(--color-surface);
 	list-style: none;
 	margin: 0;
 	padding: 0;
-	height: 74px;
+
+	@include break-wide {
+		height: 74px;
+	}
 }
 
 .hosting-v3-hero-section__tab.section-nav-tab {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/common/hosting-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/common/hosting-plan-section/style.scss
@@ -31,11 +31,17 @@
 .hosting-plan-section__main {
 	border-radius: 8px; // stylelint-disable-line scales/radii
 	background-color: var(--color-primary-0);
-	padding: 32px;
+	padding: 24px;
+	max-width: 100%;
+	overflow: hidden;
 
 	display: grid;
 	grid-template-columns: 1fr;
 	gap: 16px;
+
+	@include break-mobile {
+		padding: 32px;
+	}
 
 	@include break-huge {
 		grid-template-columns: 400px 2fr;
@@ -53,6 +59,8 @@
 	box-shadow: 0 3px 1px 0 #0000000A;
 	padding: 32px;
 	background-color: var(--color-surface);
+	max-width: 100%;
+	overflow: hidden;
 }
 
 .hosting-plan-section__details {
@@ -64,11 +72,16 @@
 .hosting-plan-section__aside {
 	border-radius: 8px; // stylelint-disable-line scales/radii
 	border: 1px solid var(--color-neutral-5);
-	padding: 32px;
+	padding: 24px;
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
-	gap: 32px;
+	gap: 16px;
+
+	@include break-mobile {
+		padding: 32px;
+		gap: 32px;
+	}
 }
 
 .hosting-plan-section__details-heading,

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/common/hosting-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/common/hosting-plan-section/style.scss
@@ -24,6 +24,16 @@
 	&:has( .hosting-plan-section__aside ) {
 		@include break-wide {
 			grid-template-columns: 2fr 1fr;
+
+			.hosting-plan-section__main {
+				grid-template-columns: 1fr 1fr;
+			}
+		}
+
+		@include break-huge {
+			.hosting-plan-section__main {
+				grid-template-columns: 400px 1fr;
+			}
 		}
 	}
 }
@@ -43,14 +53,12 @@
 		padding: 32px;
 	}
 
-	@include break-huge {
-		grid-template-columns: 400px 2fr;
+	@include break-large {
+		grid-template-columns: 1fr 1fr;
 	}
 
-	&:has( .hosting-plan-section__aside ) {
-		@include break-huge {
-			grid-template-columns: 300px 1fr;
-		}
+	@include break-huge {
+		grid-template-columns: 400px 2fr;
 	}
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/enterprise-agency-hosting/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/enterprise-agency-hosting/style.scss
@@ -43,6 +43,12 @@
 
 	background-color: var(--color-text);
 	color: var(--color-text-inverted);
+
+	&:hover:not( :disabled ),
+	&:focus:not( :disabled ) {
+		background-color: #d8a45f;
+		color: var(--color-text);
+	}
 }
 
 .enterprise-agency-hosting-v3__logos {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -88,7 +88,6 @@ export default function PressablePlanSection( {
 					onSelectPlan={ setSelectedPlan }
 					pressablePlan={ isReferralMode ? null : existingPlanInfo }
 					isLoading={ ! isFetching }
-					showHighResourceTab
 				/>
 			</HostingPlanSection.Banner>
 		);
@@ -125,94 +124,29 @@ export default function PressablePlanSection( {
 
 	const PRESSABLE_CONTACT_LINK = 'https://pressable.com/request-demo';
 
-	if ( ! selectedPlan ) {
-		return (
-			<HostingPlanSection className="pressable-plan-section" heading={ heading }>
-				{ banner }
-
-				<HostingPlanSection.Card>
-					<CustomPlanCardContent isReferralMode={ isReferralMode } />
-				</HostingPlanSection.Card>
-
-				<HostingPlanSection.Details
-					heading={
-						isReferralMode
-							? translate( 'Refer High Resource Sites' )
-							: translate( 'High Resource Sites' )
-					}
-				>
-					<p>
-						{ translate(
-							'Single site plan add-ons designed to offer completely custom traffic and storage limits for your high profile clients that need more resources than the rest of your portfolio.'
-						) }
-					</p>
-
-					<div className="pressable-plan-section__details-two-lists">
-						<SimpleList
-							items={ [
-								translate( '{{b}}1 WordPress install{{/b}}', {
-									components: {
-										b: <b />,
-									},
-								} ),
-								translate( '{{b}}1 staging site{{/b}}', {
-									components: {
-										b: <b />,
-									},
-								} ),
-								translate( '{{b}}Custom visits{{/b}} per month', {
-									components: {
-										b: <b />,
-									},
-								} ),
-							] }
-						/>
-
-						<SimpleList
-							items={ [
-								translate( '{{b}}Custom storage{{/b}} per month', {
-									components: {
-										b: <b />,
-									},
-								} ),
-								translate( '{{b}}Unmetered bandwidth{{/b}}', {
-									components: {
-										b: <b />,
-									},
-								} ),
-
-								translate( '{{b}}Custom{{/b}} PHP & CPU usage', {
-									components: {
-										b: <b />,
-									},
-								} ),
-							] }
-						/>
-					</div>
-
-					<span className="pressable-plan-section__details-footnote">
-						{ translate(
-							`*If you exceed your plan's storage or traffic limits, you will be charged $0.50 per GB and $8 per 10K visits per month.`
-						) }
-					</span>
-				</HostingPlanSection.Details>
-			</HostingPlanSection>
-		);
-	}
+	const isCustomPlan = ! selectedPlan;
 
 	return (
 		<HostingPlanSection className="pressable-plan-section" heading={ heading }>
 			{ banner }
 			<HostingPlanSection.Card>
-				<RegularPlanCardContent
-					plan={ selectedPlan }
-					onSelect={ onPlanAddToCart }
-					isReferralMode={ isReferralMode }
-					pressableOwnership={ pressableOwnership }
-				/>
+				{ isCustomPlan ? (
+					<CustomPlanCardContent isReferralMode={ isReferralMode } />
+				) : (
+					<RegularPlanCardContent
+						plan={ selectedPlan }
+						onSelect={ onPlanAddToCart }
+						isReferralMode={ isReferralMode }
+						pressableOwnership={ pressableOwnership }
+					/>
+				) }
 			</HostingPlanSection.Card>
 
-			<HostingPlanSection.Details heading={ selectedPlan.name.replace( /Pressable/g, '' ) }>
+			<HostingPlanSection.Details
+				heading={
+					isCustomPlan ? translate( 'Custom' ) : selectedPlan.name.replace( /Pressable/g, '' )
+				}
+			>
 				{ isReferralMode ? (
 					<p>
 						{ translate(
@@ -231,61 +165,86 @@ export default function PressablePlanSection( {
 					</p>
 				) }
 
-				<SimpleList
-					items={ [
-						translate(
-							'Up to {{b}}%(count)d WordPress install{{/b}}',
-							'Up to {{b}}%(count)d WordPress installs{{/b}}',
-							{
+				{ isCustomPlan ? (
+					<SimpleList
+						items={ [
+							translate( 'Custom WordPress installs' ),
+							translate( '{{b}}%(count)s{{/b}} visits per month*', {
 								args: {
-									count: selectedPlanInfo?.install ?? 0,
+									count: translate( 'Custom' ),
 								},
-								count: selectedPlanInfo?.install ?? 0,
+								components: { b: <b /> },
+								comment: '%(count)s is the number of visits per month.',
+							} ),
+							translate( '{{b}}%(size)s{{/b}} storage per month*', {
+								args: {
+									size: translate( 'Custom' ),
+								},
+								components: { b: <b /> },
+								comment: '%(size)s is the amount of storage in gigabytes.',
+							} ),
+							translate( '{{b}}Unmetered{{/b}} bandwidth', {
+								components: { b: <b /> },
+							} ),
+						] }
+					/>
+				) : (
+					<SimpleList
+						items={ [
+							translate(
+								'Up to {{b}}%(count)d WordPress install{{/b}}',
+								'Up to {{b}}%(count)d WordPress installs{{/b}}',
+								{
+									args: {
+										count: selectedPlanInfo?.install ?? 0,
+									},
+									count: selectedPlanInfo?.install ?? 0,
+									components: {
+										b: <b />,
+									},
+									comment: '%(count)d is the number of WordPress installs.',
+								}
+							),
+							translate(
+								'Up to {{b}}%(count)d staging site{{/b}}',
+								'Up to {{b}}%(count)d staging sites{{/b}}',
+								{
+									args: {
+										count: selectedPlanInfo?.install ?? 0,
+									},
+									count: selectedPlanInfo?.install ?? 0,
+									components: {
+										b: <b />,
+									},
+									comment: '%(count)d is the number of staging sites.',
+								}
+							),
+							translate( '{{b}}%(count)s visits{{/b}} per month*', {
+								args: {
+									count: formatNumber( selectedPlanInfo?.visits ?? 0 ),
+								},
 								components: {
 									b: <b />,
 								},
-								comment: '%(count)d is the number of WordPress installs.',
-							}
-						),
-						translate(
-							'Up to {{b}}%(count)d staging site{{/b}}',
-							'Up to {{b}}%(count)d staging sites{{/b}}',
-							{
+								comment: '%(count)d is the number of visits.',
+							} ),
+							translate( '{{b}}%(storageSize)dGB of storage*{{/b}}', {
 								args: {
-									count: selectedPlanInfo?.install ?? 0,
+									storageSize: selectedPlanInfo?.storage ?? 0,
 								},
-								count: selectedPlanInfo?.install ?? 0,
 								components: {
 									b: <b />,
 								},
-								comment: '%(count)d is the number of staging sites.',
-							}
-						),
-						translate( '{{b}}%(count)s visits{{/b}} per month*', {
-							args: {
-								count: formatNumber( selectedPlanInfo?.visits ?? 0 ),
-							},
-							components: {
-								b: <b />,
-							},
-							comment: '%(count)d is the number of visits.',
-						} ),
-						translate( '{{b}}%(storageSize)dGB of storage*{{/b}}', {
-							args: {
-								storageSize: selectedPlanInfo?.storage ?? 0,
-							},
-							components: {
-								b: <b />,
-							},
-							comment: '%(storageSize)d is the size of storage in GB.',
-						} ),
-						translate( '{{b}}Unmetered bandwidth{{/b}}', {
-							components: {
-								b: <b />,
-							},
-						} ),
-					] }
-				/>
+								comment: '%(storageSize)d is the size of storage in GB.',
+							} ),
+							translate( '{{b}}Unmetered bandwidth{{/b}}', {
+								components: {
+									b: <b />,
+								},
+							} ),
+						] }
+					/>
+				) }
 
 				<span className="pressable-plan-section__details-footnote">
 					{ translate(

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/pressable-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/pressable-plan-section/style.scss
@@ -24,10 +24,13 @@
 	@include a4a-font-body-sm;
 }
 
-.pressable-plan-card-content__cta-button {
+// We need to do this specifically to override the white-space.
+.pressable-plan-card-content__cta-button.pressable-plan-card-content__cta-button.pressable-plan-card-content__cta-button {
 	min-width: 0;
 	width: 100%;
 	min-height: 40px;
+	max-width: 100%;
+	white-space: normal;
 }
 
 .pressable-plan-section__details-two-lists {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/style.scss
@@ -5,7 +5,9 @@
 .wpcom-plan-section .a4a-slider {
 	position: relative;
 	z-index: 1;
+	align-items: flex-end;
 }
+
 .wpcom-plan-section .a4a-number-input-v2 {
 	width: 100%;
 
@@ -72,6 +74,15 @@
 	width: 100%;
 	min-height: 40px;
 }
+
+.wpcom-plan-selector__details {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	justify-content: space-between;
+	height: 100%;
+}
+
 
 .wpcom-plan-selector__details.is-placeholder {
 	display: flex;

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/style.scss
@@ -5,7 +5,18 @@
 .wpcom-plan-section .a4a-slider {
 	position: relative;
 	z-index: 1;
-	align-items: flex-end;
+
+	.a4a-slider__label-container {
+		display: none;
+	}
+
+	@include break-medium {
+		align-items: flex-end;
+
+		.a4a-slider__label-container {
+			display: block;
+		}
+	}
 }
 
 .wpcom-plan-section .a4a-number-input-v2 {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/style.scss
@@ -94,6 +94,11 @@
 	height: 100%;
 }
 
+.wpcom-plan-selector__details.is-compact .wpcom-plan-selector__cta-component {
+	flex-direction: column;
+	align-items: stretch;
+}
+
 
 .wpcom-plan-selector__details.is-placeholder {
 	display: flex;

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
@@ -74,45 +74,47 @@ export default function WPCOMPlanSelector( {
 
 	return (
 		<div className="wpcom-plan-selector__details">
-			{ ownedPlans > 0 && (
-				<div className="wpcom-plan-selector__owned-plan">
-					{ translate( 'You own %(count)s site', 'You own %(count)s sites', {
-						args: {
+			<div className="wpcom-plan-selector__top">
+				{ ownedPlans > 0 && (
+					<div className="wpcom-plan-selector__owned-plan">
+						{ translate( 'You own %(count)s site', 'You own %(count)s sites', {
+							args: {
+								count: ownedPlans,
+							},
 							count: ownedPlans,
-						},
-						count: ownedPlans,
-						comment: '%(count)s is the number of WordPress.com sites owned by the user',
-					} ) }
-				</div>
-			) }
-
-			<div className="wpcom-plan-selector__plan-name">
-				<img src={ WPCOMLogo } alt="WPCOM" />
-			</div>
-
-			<div className="wpcom-plan-selector__price">
-				<b className="wpcom-plan-selector__price-actual-value">
-					{ formatCurrency( actualPrice, plan.currency ) }
-				</b>
-				{ !! discount && (
-					<>
-						<b className="wpcom-plan-selector__price-original-value">
-							{ formatCurrency( originalPrice, plan.currency ) }
-						</b>
-
-						<span className="wpcom-plan-selector__price-discount">
-							{ translate( 'You save %(discount)s%', {
-								args: {
-									discount: Math.floor( discount * 100 ),
-								},
-								comment: '%(discount)s is the discount percentage.',
-							} ) }
-						</span>
-					</>
+							comment: '%(count)s is the number of WordPress.com sites owned by the user',
+						} ) }
+					</div>
 				) }
-				<div className="wpcom-plan-selector__price-interval">
-					{ plan.price_interval === 'day' && translate( 'per day, billed monthly' ) }
-					{ plan.price_interval === 'month' && translate( 'per month, billed monthly' ) }
+
+				<div className="wpcom-plan-selector__plan-name">
+					<img src={ WPCOMLogo } alt="WPCOM" />
+				</div>
+
+				<div className="wpcom-plan-selector__price">
+					<b className="wpcom-plan-selector__price-actual-value">
+						{ formatCurrency( actualPrice, plan.currency ) }
+					</b>
+					{ !! discount && (
+						<>
+							<b className="wpcom-plan-selector__price-original-value">
+								{ formatCurrency( originalPrice, plan.currency ) }
+							</b>
+
+							<span className="wpcom-plan-selector__price-discount">
+								{ translate( 'You save %(discount)s%', {
+									args: {
+										discount: Math.floor( discount * 100 ),
+									},
+									comment: '%(discount)s is the discount percentage.',
+								} ) }
+							</span>
+						</>
+					) }
+					<div className="wpcom-plan-selector__price-interval">
+						{ plan.price_interval === 'day' && translate( 'per day, billed monthly' ) }
+						{ plan.price_interval === 'month' && translate( 'per month, billed monthly' ) }
+					</div>
 				</div>
 			</div>
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
@@ -1,7 +1,8 @@
 import formatCurrency from '@automattic/format-currency';
 import { Button } from '@wordpress/components';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import A4ANumberInputV2 from 'calypso/a8c-for-agencies/components/a4a-number-input-v2';
 import useWPCOMDiscountTiers from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-wpcom-discount-tiers';
 import { calculateTier } from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-values-utils';
@@ -44,6 +45,8 @@ export default function WPCOMPlanSelector( {
 
 	const discountTiers = useWPCOMDiscountTiers();
 
+	const [ isCompact, setIsCompact ] = useState( false );
+
 	const discount = useMemo( () => {
 		if ( isReferralMode ) {
 			return discountTiers[ 0 ].discount;
@@ -72,8 +75,29 @@ export default function WPCOMPlanSelector( {
 		} );
 	}, [ planName, quantity, isReferralMode, translate ] );
 
+	const containerRef = useRef< HTMLDivElement >( null );
+
+	useEffect( () => {
+		if ( ! containerRef.current ) {
+			return;
+		}
+
+		const resizeObserver = new ResizeObserver( ( entry ) => {
+			setIsCompact( entry[ 0 ].contentRect.width < 300 );
+		} );
+
+		resizeObserver.observe( containerRef.current );
+
+		return () => {
+			resizeObserver.disconnect();
+		};
+	}, [ containerRef ] );
+
 	return (
-		<div className="wpcom-plan-selector__details">
+		<div
+			className={ clsx( 'wpcom-plan-selector__details', { 'is-compact': isCompact } ) }
+			ref={ containerRef }
+		>
 			<div className="wpcom-plan-selector__top">
 				{ ownedPlans > 0 && (
 					<div className="wpcom-plan-selector__owned-plan">

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/index.tsx
@@ -83,7 +83,7 @@ function HostingOverviewV3( { section }: SectionProps ) {
 	return (
 		<Layout
 			className="hosting-overview-v3"
-			title={ isNarrowView ? translate( 'Hosting' ) : translate( 'Hosting Marketplace' ) }
+			title={ isNarrowView ? '' : translate( 'Hosting Marketplace' ) }
 			onScroll={ onScroll }
 			wide
 		>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/style.scss
@@ -46,5 +46,9 @@ $background-color: #05374A;
 			margin: 0;
 		}
 	}
+
+	.components-button {
+		min-height: 40px;
+	}
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-slider-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-slider-options.ts
@@ -6,7 +6,8 @@ import { PressablePlan } from './get-pressable-plan';
 export default function getSliderOptions(
 	type: FilterType,
 	plans: PressablePlan[],
-	category?: string
+	category?: string,
+	compact?: boolean
 ) {
 	return plans
 		.filter( ( plan ) => plan !== undefined )
@@ -20,7 +21,7 @@ export default function getSliderOptions(
 			} else if ( type === FILTER_TYPE_VISITS ) {
 				label = `${ formatNumber( plan.visits ) }`;
 			} else if ( type === FILTER_TYPE_STORAGE ) {
-				label = `${ plan.storage }GB`;
+				label = `${ plan.storage }${ compact ? '' : 'GB' }`;
 			}
 
 			return {

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -1,3 +1,4 @@
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { RadioControl, TabPanel } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -47,14 +48,17 @@ export default function PlanSelectionFilter( {
 	const [ selectedTab, setSelectedTab ] = useState( PLAN_CATEGORY_STANDARD );
 	const [ disableStandardTab, setDisableStandardTab ] = useState( false );
 
+	const isMobile = useMobileBreakpoint();
+
 	const standardOptions = useMemo(
 		() =>
 			getSliderOptions(
 				filterType,
 				plans.map( ( plan ) => getPressablePlan( plan.slug ) ),
-				PLAN_CATEGORY_STANDARD
+				PLAN_CATEGORY_STANDARD,
+				isMobile
 			),
-		[ filterType, plans ]
+		[ filterType, isMobile, plans ]
 	);
 
 	const enterpriseOptions = useMemo(
@@ -62,7 +66,8 @@ export default function PlanSelectionFilter( {
 			...getSliderOptions(
 				filterType,
 				plans.map( ( plan ) => getPressablePlan( plan.slug ) ),
-				PLAN_CATEGORY_ENTERPRISE
+				PLAN_CATEGORY_ENTERPRISE,
+				isMobile
 			),
 			...( showHighResourceTab
 				? []
@@ -74,7 +79,7 @@ export default function PlanSelectionFilter( {
 						},
 				  ] ),
 		],
-		[ filterType, plans, showHighResourceTab, translate ]
+		[ filterType, isMobile, plans, showHighResourceTab, translate ]
 	);
 
 	const onSelectOption = useCallback(
@@ -183,7 +188,10 @@ export default function PlanSelectionFilter( {
 				options={ [
 					{ label: translate( 'WordPress installs' ), value: FILTER_TYPE_INSTALL },
 					{ label: translate( 'Traffic' ), value: FILTER_TYPE_VISITS },
-					{ label: translate( 'Storage' ), value: FILTER_TYPE_STORAGE },
+					{
+						label: isMobile ? translate( 'Storage (GB)' ) : translate( 'Storage' ),
+						value: FILTER_TYPE_STORAGE,
+					},
 				] }
 				onChange={ ( value ) => onSelectFilterType( value as FilterType ) }
 			/>

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -138,11 +138,16 @@
 	.pressable-overview-plan-selection__filter-label {
 		@include a4a-font-heading-md($font-size: rem(14px));
 		margin: 0;
+
 	}
 
 	.pressable-overview-plan-selection__filter-radio-control {
 		.components-base-control__label {
 			display: none;
+		}
+
+		.components-radio-control__label {
+			text-align: start;
 		}
 
 		.components-radio-control__group-wrapper {
@@ -209,6 +214,10 @@
 }
 
 .pressable-overview-plan-selection__filter {
+	.a4a-slider {
+		margin-block-start: 16px;
+	}
+
 	.a4a-slider__marker-label {
 		height: 0.95rem;
 	}


### PR DESCRIPTION
This PR addresses several UI issues regarding mobile responsiveness for the new hosting page v3.

## Proposed Changes

* Change the header collapse animation duration to 0.25 seconds for better user perception.
* Improve the responsiveness of the header for different screen sizes. To address this, we need to hide the Migration Offer banner on smaller screens, as it causes issues with the sticky position. When the banner is expanded, it tends to take up 100% of the viewport, which does not work well with the sticky header.  Additionally, some of the font sizes are reduced to better fit on a narrower screen, and the 'Hosting' text is hidden as well to provide more space for header action buttons.

| Before | After |
|--------|--------|
| <img width="358" alt="Screenshot 2024-12-17 at 9 20 01 PM" src="https://github.com/user-attachments/assets/3b396740-6c49-4ae9-a855-7920b9845cea" /> | <img width="361" alt="Screenshot 2024-12-17 at 9 20 09 PM" src="https://github.com/user-attachments/assets/593f3aa9-5e8b-4c36-a181-88009bd8cd10" /> | 

* Fixed some spacing issues in the Hosting Plan section on smaller screens.

| Before | After |
|--------|--------|
| <img width="410" alt="Screenshot 2024-12-17 at 9 26 05 PM" src="https://github.com/user-attachments/assets/6e2f5290-9eb1-46c7-a3f0-9664a529179b" /> | <img width="411" alt="Screenshot 2024-12-17 at 9 26 30 PM" src="https://github.com/user-attachments/assets/085bf9b1-8ed9-4654-ab0d-32a9f101dfd8" /> | 

* Fixed the Pressable plan slider to work with smaller screens.

| Before | After |
|--------|--------|
| <img width="371" alt="Screenshot 2024-12-17 at 9 28 35 PM" src="https://github.com/user-attachments/assets/350f41db-c59e-46c0-8596-8a2ea147173c" /> | <img width="362" alt="Screenshot 2024-12-17 at 9 28 20 PM" src="https://github.com/user-attachments/assets/7e89a5d6-4282-4513-89f5-1d356f56b1a2" /> | 

## Why are these changes being made?

* This is part of the In-product hosting page v3 project.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace/hosting` page.
* Verify that the fixed and improvements above are working as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
