### PR TITLE
Bulk plugin management: only trigger updates for sites where available

### DIFF
--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -248,12 +248,6 @@ export class PluginsList extends Component {
 	}
 
 	bulkActionDialog = ( actionName, selectedPlugins ) => {
-		if ( this.props.newBulkPluginManagement ) {
-			this.setState( {
-				selectedPlugins,
-			} );
-		}
-
 		const { plugins, allSites, showPluginActionDialog } = this.props;
 
 		if ( ! this.props.newBulkPluginManagement ) {
@@ -282,6 +276,12 @@ export class PluginsList extends Component {
 					Object.entries( plugin.sites ).filter( ( [ , site ] ) => site.update?.new_version )
 				);
 				return { ...plugin, sites: filteredSites };
+			} );
+		}
+
+		if ( this.props.newBulkPluginManagement ) {
+			this.setState( {
+				selectedPlugins,
 			} );
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/10084

## Proposed Changes

On https://github.com/Automattic/dotcom-forge/issues/10084 we discussed that we need to filter the list of sites where an update is needed. I found that we already implement filtering for these here, but the filtered results are then not passed to the `doActionOverSelected` function. Most likely the confirmation dialog isn't forwarding all the parameters.

However, when the `newBulkPluginManagement` flag is set, the `doActionOverSelected` function takes the list of `selectedPlugins` from state. This PR moves the state update to happen after the filtering is done.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When updating a plugin on all sites, we need the update to happen only on sites which need an update

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If needed, set up one or more test sites with an older version of a plugin, so that these will need updates
* Open devtools and go to the Network tab
* Go to `/plugins/manage`
* On the top right, filter for plugins pending updates
* Click on the plugin name to check how many sites need updates
* Close the list dialog, then click on the `Update to #.#.# version` button on the plugin row
* Accept the confirmation dialog
* Confirm that the `update` request is only sent for the sites which needed updates

https://github.com/user-attachments/assets/66d75df5-9ae6-45da-8ce4-8bc773e129d0