### PR TITLE
Stats: update "view all" link label for subscribers list 

### DIFF
--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -83,12 +83,11 @@ class StatModuleFollowers extends Component {
 		// Old, non-functional path: '/people/email-followers/' + summaryPageSlug.
 		// If the site is Atomic, Simple Classic or Jetpack self-hosted, it links to Jetpack Cloud.
 		// jetpack/manage-simple-sites is the feature flag for allowing Simple sites in Jetpack Cloud.
-		const jetpackCloudLink = `https://cloud.jetpack.com/subscribers/${ summaryPageSlug }`;
-		const wpcomLink = `https://wordpress.com/people/subscribers/${ summaryPageSlug }`;
-		const summaryPageLink =
-			isAtomic || isJetpack || ( isEnabled( 'jetpack/manage-simple-sites' ) && isAdminInterface )
-				? jetpackCloudLink
-				: wpcomLink;
+		const useJetpackCloudLinks =
+			isAtomic || isJetpack || ( isEnabled( 'jetpack/manage-simple-sites' ) && isAdminInterface );
+		const subscriberManagementUrl = useJetpackCloudLinks
+			? `https://cloud.jetpack.com/subscribers/${ summaryPageSlug }`
+			: `https://wordpress.com/subscribers/${ summaryPageSlug }`;
 
 		// Combine data sets, sort by recency, and limit to 10.
 		const data = [ ...( wpcomData?.subscribers ?? [] ), ...( emailData?.subscribers ?? [] ) ]
@@ -112,6 +111,9 @@ class StatModuleFollowers extends Component {
 					data={ data.map( ( dataPoint ) => ( {
 						...dataPoint,
 						value: this.calculateOffset( dataPoint.value?.value ), // case 'relative-date': value = this.props.moment( valueData.value ).fromNow( true );
+						url: dataPoint.login
+							? `${ subscriberManagementUrl }/${ dataPoint.ID }`
+							: `${ subscriberManagementUrl }/external/${ dataPoint.ID }`,
 					} ) ) }
 					usePlainCard
 					hasNoBackground
@@ -136,21 +138,10 @@ class StatModuleFollowers extends Component {
 					metricLabel={ translate( 'Since' ) }
 					splitHeader
 					useShortNumber
-					showMore={
-						summaryPageLink
-							? {
-									url: summaryPageLink,
-									label:
-										data.length >= 10 // TODO: reduce to 5 items when surrounding cards get a summary page
-											? this.props.translate( 'View all', {
-													context: 'Stats: Button link to show more detailed stats information',
-											  } )
-											: this.props.translate( 'View details', {
-													context: 'Stats: Button label to see the detailed content of a panel',
-											  } ),
-							  }
-							: undefined
-					}
+					showMore={ {
+						url: subscriberManagementUrl,
+						label: this.props.translate( 'Manage subscribers' ),
+					} }
 					error={
 						noData &&
 						! hasError &&

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -111,9 +111,6 @@ class StatModuleFollowers extends Component {
 					data={ data.map( ( dataPoint ) => ( {
 						...dataPoint,
 						value: this.calculateOffset( dataPoint.value?.value ), // case 'relative-date': value = this.props.moment( valueData.value ).fromNow( true );
-						url: dataPoint.login
-							? `${ subscriberManagementUrl }/${ dataPoint.ID }`
-							: `${ subscriberManagementUrl }/external/${ dataPoint.ID }`,
 					} ) ) }
 					usePlainCard
 					hasNoBackground


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/issues/40646

## Proposed Changes

* Change "View all" link to "Manage subscribers" 
* Clean up/simplify some code

Before

<img width="662" alt="Screenshot 2024-12-17 at 16 25 03" src="https://github.com/user-attachments/assets/d3b0affe-6fe8-441f-abb7-a164e575d3ed" />


After

<img width="548" alt="Screenshot 2024-12-17 at 16 25 21" src="https://github.com/user-attachments/assets/7a1e1aa2-ac8e-44cf-a2a5-6512679be855" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
