### PR TITLE
Import processing styles to the Big Sky launch step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
@@ -8,6 +8,7 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { useIsBigSkyEligible } from '../../../../hooks/use-is-site-big-sky-eligible';
 import { useSiteData } from '../../../../hooks/use-site-data';
+import '../processing-step/style.scss';
 import type { Step } from '../../types';
 import type { OnboardSelect } from '@automattic/data-stores';
 
@@ -120,17 +121,19 @@ const LaunchBigSky: Step = function () {
 
 	function LaunchingBigSky() {
 		return (
-			<div className="processing-step__container">
-				<div className="processing-step">
-					<h1 className="processing-step__progress-step">
-						{ __( 'Launching the AI Website Builder' ) }
-					</h1>
-					{ ! isError && <LoadingEllipsis /> }
-					{ isError && (
-						<p className="processing-step__error">
-							{ __( 'Something unexpected happened. Please go back and try again.' ) }
-						</p>
-					) }
+			<div className="is-big-sky-launching">
+				<div className="processing-step__container">
+					<div className="processing-step">
+						<h1 className="processing-step__progress-step">
+							{ __( 'Launching the AI Website Builder' ) }
+						</h1>
+						{ ! isError && <LoadingEllipsis /> }
+						{ isError && (
+							<p className="processing-step__error">
+								{ __( 'Something unexpected happened. Please go back and try again.' ) }
+							</p>
+						) }
+					</div>
 				</div>
 			</div>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
@@ -121,19 +121,17 @@ const LaunchBigSky: Step = function () {
 
 	function LaunchingBigSky() {
 		return (
-			<div className="is-big-sky-launching">
-				<div className="processing-step__container">
-					<div className="processing-step">
-						<h1 className="processing-step__progress-step">
-							{ __( 'Launching the AI Website Builder' ) }
-						</h1>
-						{ ! isError && <LoadingEllipsis /> }
-						{ isError && (
-							<p className="processing-step__error">
-								{ __( 'Something unexpected happened. Please go back and try again.' ) }
-							</p>
-						) }
-					</div>
+			<div className="processing-step__container">
+				<div className="processing-step">
+					<h1 className="processing-step__progress-step">
+						{ __( 'Launching the AI Website Builder' ) }
+					</h1>
+					{ ! isError && <LoadingEllipsis /> }
+					{ isError && (
+						<p className="processing-step__error">
+							{ __( 'Something unexpected happened. Please go back and try again.' ) }
+						</p>
+					) }
 				</div>
 			</div>
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

https://github.com/Automattic/wp-calypso/pull/97326 introduced some changes to lazy loading assets. For some reason this broke the Big Sky launching step, as the styles are no longer present. 

This approach works for now while we're working to revamp the styling of this page in general via #97150 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Right now it looks like this in trunk: 

![image](https://github.com/user-attachments/assets/42bb1d53-8ee6-497a-8cef-6d31652e3f65)

With this patch: 

<img width="1411" alt="image" src="https://github.com/user-attachments/assets/2184b050-0a5a-4aa5-ac56-01afb434fa5e" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Replace this URL with your Big Sky site, http://calypso.localhost:3000/setup/site-setup/launch-big-sky?siteSlug=dsmartbigsky38.wordpress.com
2. The styling should be present

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
