### PR TITLE
i18n: Fix translate calls in hosting overview components

### DIFF
--- a/client/sites/overview/components/hosting-overview.tsx
+++ b/client/sites/overview/components/hosting-overview.tsx
@@ -1,4 +1,4 @@
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { isNotAtomicJetpack, isMigrationInProgress } from 'calypso/sites-dashboard/utils';
@@ -15,6 +15,7 @@ import './style.scss';
 
 const HostingOverview: FC = () => {
 	const site = useSelector( getSelectedSite );
+	const translate = useTranslate();
 
 	if ( site ) {
 		if ( isMigrationInProgress( site ) ) {

--- a/client/sites/overview/components/migration-overview/components/cards.tsx
+++ b/client/sites/overview/components/migration-overview/components/cards.tsx
@@ -1,47 +1,53 @@
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { HostingCard, HostingCardGrid } from 'calypso/components/hosting-card';
 
-export const cards = [
-	{
-		title: translate( 'Seriously secure' ),
-		text: translate(
-			"Firewalls, encryption, brute force, and DDoS protection. Your security's all taken care of so you can stay one step ahead of any threats."
-		),
-	},
-	{
-		title: translate( 'Unmetered bandwidth' ),
-		text: translate(
-			"With 99.999% uptime and entirely unmetered bandwidth and traffic on every plan, you'll never need to worry about being too successful."
-		),
-	},
-	{
-		title: translate( 'Power, meet performance' ),
-		text: translate(
-			'Our custom 28+ location CDN and 99.999% uptime ensure your site is always fast and always available from anywhere in the world.'
-		),
-	},
-	{
-		title: translate( 'Plugins, themes, and custom code' ),
-		text: translate(
-			'Build anything with full support and automatic updates for 50,000+ plugins and themes. Or start from scratch with your own custom code.'
-		),
-	},
-	{
-		title: translate( 'Expert support' ),
-		text: translate(
-			"Whenever you're stuck, whatever you're trying to make happen – our Happiness Engineers have the answers."
-		),
-	},
-];
+const Cards = () => {
+	const translate = useTranslate();
+	const cards = useMemo(
+		() => [
+			{
+				title: translate( 'Seriously secure' ),
+				text: translate(
+					"Firewalls, encryption, brute force, and DDoS protection. Your security's all taken care of so you can stay one step ahead of any threats."
+				),
+			},
+			{
+				title: translate( 'Unmetered bandwidth' ),
+				text: translate(
+					"With 99.999% uptime and entirely unmetered bandwidth and traffic on every plan, you'll never need to worry about being too successful."
+				),
+			},
+			{
+				title: translate( 'Power, meet performance' ),
+				text: translate(
+					'Our custom 28+ location CDN and 99.999% uptime ensure your site is always fast and always available from anywhere in the world.'
+				),
+			},
+			{
+				title: translate( 'Plugins, themes, and custom code' ),
+				text: translate(
+					'Build anything with full support and automatic updates for 50,000+ plugins and themes. Or start from scratch with your own custom code.'
+				),
+			},
+			{
+				title: translate( 'Expert support' ),
+				text: translate(
+					"Whenever you're stuck, whatever you're trying to make happen – our Happiness Engineers have the answers."
+				),
+			},
+		],
+		[ translate ]
+	);
 
-const Cards = () => (
-	<HostingCardGrid>
-		{ cards.map( ( { title, text } ) => (
-			<HostingCard inGrid key={ title } title={ title }>
-				<p>{ text }</p>
-			</HostingCard>
-		) ) }
-	</HostingCardGrid>
-);
+	return (
+		<HostingCardGrid>
+			{ cards.map( ( { title, text } ) => (
+				<HostingCard inGrid key={ title } title={ title }>
+					<p>{ text }</p>
+				</HostingCard>
+			) ) }
+		</HostingCardGrid>
+	);
+};
 
 export default Cards;

--- a/client/sites/overview/components/migration-overview/components/cards.tsx
+++ b/client/sites/overview/components/migration-overview/components/cards.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { HostingCard, HostingCardGrid } from 'calypso/components/hosting-card';
 

--- a/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
@@ -1,6 +1,6 @@
 import { LoadingPlaceholder } from '@automattic/components';
 import { Button } from '@wordpress/components';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import ConfirmModal from 'calypso/components/confirm-modal';
 import { HostingHeroButton } from 'calypso/components/hosting-hero';
 import Notice from 'calypso/components/notice';
@@ -31,6 +31,7 @@ const getContinueMigrationUrl = ( site: SiteDetails ): string | null => {
 };
 
 export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
+	const translate = useTranslate();
 	const continueMigrationUrl = getContinueMigrationUrl( site );
 
 	const title = translate( 'Your WordPress site is ready to be migrated' );

--- a/client/sites/overview/components/migration-overview/components/migration-started-diy.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-started-diy.tsx
@@ -1,9 +1,10 @@
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import Cards from './cards';
 import { Container, Header } from './layout';
 import type { SiteDetails } from '@automattic/data-stores';
 
 export const MigrationStartedDIY = ( { site }: { site: SiteDetails } ) => {
+	const translate = useTranslate();
 	const title = translate( 'Your migration is underway' );
 	const migrationSourceSiteDomain = site?.options?.migration_source_site_domain
 		? site?.options?.migration_source_site_domain?.replace( /^https?:\/\/|\/+$/g, '' )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/i18n-issues#895

## Proposed Changes

- In the hosting/migration overview components: Fixes a few instances of `translate` imported from `i18n-calypso`, which is not state reactive. Opts for `useTranslate` hook use instead.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Addresses Automattic/i18n-issues#895

### Media

<img width="800" alt="Screenshot 2024-12-17 at 6 52 45 PM" src="https://github.com/user-attachments/assets/a45e74c4-d7ff-427d-b26a-441865ad8788" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Same instructions as in https://github.com/Automattic/wp-calypso/pull/95963 that introduced the strings

Follow:

- Enable the feature flag (DevTools> Console > and run:
  - sessionStorage.setItem('flags,' 'automated-migration/pending-status')
- Use the /setup/hosted-site-migration flow'
- Follow all steps, choosing the DIY option
- Stop when you arrive at the instructions page
- Get the siteSlug value on the URL
- Open a new browser tab and access /sites
- Find and click on the created site (using the siteSlug that you got previously) to open the overview page. Please pay attention you need to remove the .wordpress.com domain to find your site
- Check if you can see the screen 1 (media above)

Then switch to ES locale. Confirm the descriptions properly translated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
