### PR TITLE
Fix multiple selected sidebar icons

### DIFF
--- a/client/my-sites/sidebar/body.jsx
+++ b/client/my-sites/sidebar/body.jsx
@@ -46,9 +46,15 @@ export const MySitesSidebarUnifiedBody = ( {
 					const isSelected =
 						( item?.url && itemLinkMatches( item.url, path ) ) ||
 						// Keep the Sites icon selected when there is a selected site.
-						( item.slug === 'sites' && site && ! isP2Site && ! path.startsWith( '/p2s' ) ) ||
+						( item.slug === 'sites' &&
+							site &&
+							! isP2Site &&
+							! [ '/p2s', '/domains' ].some( ( slug ) => path.startsWith( slug ) ) ) ||
 						// Keep the P2s icon selected when there is a selected site and that site is a P2.
-						( item.slug === 'sites-p2' && site && isP2Site && ! path.startsWith( '/sites' ) );
+						( item.slug === 'sites-p2' &&
+							site &&
+							isP2Site &&
+							! [ '/sites', '/domains' ].some( ( slug ) => path.startsWith( slug ) ) );
 
 					if ( 'current-site' === item?.type ) {
 						return (

--- a/client/my-sites/sidebar/body.jsx
+++ b/client/my-sites/sidebar/body.jsx
@@ -13,7 +13,7 @@ import {
 import MySitesSidebarUnifiedItem from './item';
 import MySitesSidebarUnifiedMenu from './menu';
 import useSiteMenuItems from './use-site-menu-items';
-import { itemLinkMatches } from './utils';
+import { isItemSelected } from './utils';
 import 'calypso/state/admin-menu/init';
 
 import './style.scss';
@@ -43,18 +43,7 @@ export const MySitesSidebarUnifiedBody = ( {
 		<>
 			{ menuItems &&
 				menuItems.map( ( item, i ) => {
-					const isSelected =
-						( item?.url && itemLinkMatches( item.url, path ) ) ||
-						// Keep the Sites icon selected when there is a selected site.
-						( item.slug === 'sites' &&
-							site &&
-							! isP2Site &&
-							! [ '/p2s', '/domains' ].some( ( slug ) => path.startsWith( slug ) ) ) ||
-						// Keep the P2s icon selected when there is a selected site and that site is a P2.
-						( item.slug === 'sites-p2' &&
-							site &&
-							isP2Site &&
-							! [ '/sites', '/domains' ].some( ( slug ) => path.startsWith( slug ) ) );
+					const isSelected = isItemSelected( item, path, site, isP2Site );
 
 					if ( 'current-site' === item?.type ) {
 						return (

--- a/client/my-sites/sidebar/test/index.js
+++ b/client/my-sites/sidebar/test/index.js
@@ -1,4 +1,4 @@
-import { itemLinkMatches } from '../utils';
+import { isItemSelected, itemLinkMatches } from '../utils';
 
 describe( 'MySitesSidebar', () => {
 	describe( '#itemLinkMatches()', () => {
@@ -67,6 +67,73 @@ describe( 'MySitesSidebar', () => {
 			);
 
 			expect( isSelected ).toBe( true );
+		} );
+	} );
+
+	describe( '#isItemSelected()', () => {
+		const site = { ID: 1234 };
+
+		describe( 'Sites', () => {
+			const menuItem = { url: '/sites', slug: 'sites' };
+			const path = '/overview/test.wordpress.com';
+
+			test( 'should return false when `site` is not set', () => {
+				const isSelected = isItemSelected( menuItem, path, null );
+
+				expect( isSelected ).toBe( false );
+			} );
+
+			test( 'should not highlight Sites menu when viewing a domain', () => {
+				const isSelected = isItemSelected( menuItem, '/domains/manage', site );
+
+				expect( isSelected ).toBe( false );
+			} );
+
+			test( 'should not highlight Sites menu when the site is a P2', () => {
+				const isSelected = isItemSelected( menuItem, path, site, true );
+
+				expect( isSelected ).toBe( false );
+			} );
+
+			test( 'should highlight Sites menu when the site is not a P2', () => {
+				const isSelected = isItemSelected( menuItem, path, site, false );
+
+				expect( isSelected ).toBe( true );
+			} );
+		} );
+
+		describe( 'P2s', () => {
+			const menuItem = { url: '/p2s', slug: 'sites-p2' };
+			const path = '/hosting-features/test.wordpress.com/test.wordpress.com';
+
+			test( 'should not highlight P2s menu when viewing a domain', () => {
+				const isSelected = isItemSelected( menuItem, '/domains/manage', site );
+
+				expect( isSelected ).toBe( false );
+			} );
+
+			test( 'should not highlight P2s menu when the site is not a P2', () => {
+				const isSelected = isItemSelected( menuItem, path, site, false );
+
+				expect( isSelected ).toBe( false );
+			} );
+
+			test( 'should highlight P2s menu when the site is a P2', () => {
+				const isSelected = isItemSelected( menuItem, path, site, true );
+
+				expect( isSelected ).toBe( true );
+			} );
+		} );
+
+		describe( 'Domains', () => {
+			const menuItem = { url: '/domains/manage', slug: 'domains' };
+			const path = '/domains/manage/all/overview/test.wordpress.com/test.wordpress.com';
+
+			test( 'should highlight Domains menu when viewing a domain', () => {
+				const isSelected = isItemSelected( menuItem, path, site );
+
+				expect( isSelected ).toBe( true );
+			} );
 		} );
 	} );
 } );

--- a/client/my-sites/sidebar/utils.js
+++ b/client/my-sites/sidebar/utils.js
@@ -111,3 +111,33 @@ export const itemLinkMatches = ( path, currentPath ) => {
 
 	return fragmentIsEqual( path, currentPath, 1 );
 };
+
+/**
+ * Checks if the current menu item should be selected for a given path.
+ * @param {Object} menuItem The current menu item.
+ * @param {string} path The path to check against.
+ * @param {string} site The current site.
+ * @param {boolean} isP2Site True if this site is a P2, false otherwise.
+ * @returns {boolean} True if the current menu item should be selected, false otherwise.
+ */
+export const isItemSelected = ( menuItem, path, site, isP2Site = false ) => {
+	let isSelected = menuItem?.url && itemLinkMatches( menuItem.url, path );
+
+	if (
+		isSelected ||
+		! [ 'sites', 'sites-p2' ].includes( menuItem.slug ) ||
+		! site ||
+		path.startsWith( '/domains' )
+	) {
+		return isSelected;
+	}
+
+	// Ensure the Sites and P2s icons are selected as appropriate.
+	if ( menuItem.slug === 'sites' && ! isP2Site ) {
+		isSelected = true;
+	} else if ( menuItem.slug === 'sites-p2' && isP2Site ) {
+		isSelected = true;
+	}
+
+	return isSelected;
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #97444.

## Proposed Changes

* Refactors the logic that checks whether a particular menu item in the sidebar should be selected.
* Ensures that only one menu item is selected at a time.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On the `/sites` page, select a site.
* Ensure that only the Sites sidebar menu item is selected.
* On the `/p2s` page, find the _Access Checklists_ site.
* Click on the three dots and select _Hosting_.
* Ensure that only the P2s sidebar menu item is selected.
* Enable the `calypso/all-domain-management` feature flag.
* On the `/domains/manage` page, select a domain.
* Ensure that only the Domains sidebar menu item is selected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?