### PR TITLE
Send Setup Intent ID when saving a new credit card

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -201,6 +201,7 @@ export async function assignNewCardProcessor(
 			stripeSetupIntentId
 		);
 		const token = tokenResponse.payment_method;
+		const setupKey = tokenResponse.id;
 		if ( ! token ) {
 			throw new Error( String( translate( 'Failed to add card.' ) ) );
 		}
@@ -234,6 +235,7 @@ export async function assignNewCardProcessor(
 			city,
 			organization,
 			address,
+			setupKey: String( setupKey ),
 		} );
 
 		return makeSuccessResponse( result );

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -235,7 +235,7 @@ export async function assignNewCardProcessor(
 			city,
 			organization,
 			address,
-			setupKey: String( setupKey ),
+			setupKey,
 		} );
 
 		return makeSuccessResponse( result );

--- a/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
@@ -16,6 +16,7 @@ export async function saveCreditCard( {
 	city,
 	organization,
 	address,
+	setupKey,
 }: {
 	token: string;
 	stripeConfiguration: StripeConfiguration;
@@ -27,6 +28,7 @@ export async function saveCreditCard( {
 	city?: string;
 	organization?: string;
 	address?: string;
+	setupKey?: string;
 } ): Promise< StoredCardEndpointResponse > {
 	const additionalData = getParamsForApi( {
 		cardToken: token,
@@ -39,6 +41,7 @@ export async function saveCreditCard( {
 		city,
 		organization,
 		address,
+		setupKey,
 	} );
 	const response = await wp.req.post(
 		{
@@ -147,6 +150,7 @@ function getParamsForApi( {
 	city,
 	organization,
 	address,
+	setupKey,
 }: {
 	cardToken: string;
 	stripeConfiguration: StripeConfiguration;
@@ -159,6 +163,7 @@ function getParamsForApi( {
 	city?: string;
 	organization?: string;
 	address?: string;
+	setupKey?: string;
 } ) {
 	return {
 		payment_partner: stripeConfiguration ? stripeConfiguration.processor_id : '',
@@ -173,5 +178,6 @@ function getParamsForApi( {
 		tax_city: city,
 		tax_organization: organization,
 		tax_address: address,
+		...( setupKey ? { setup_key: setupKey } : {} ),
 	};
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/payments-shilling/issues/3322

## Proposed Changes

* This PR adds a new optional parameter to the `saveCreditCard` method - the `setupKey`, which contains the  Stripe Setup Intent ID. 
## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need to store the `mandate` in the Stored Payment Method in the backend.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Testing that the mandate is stored in the Stored Details**
- Sandbox Store and `public-api.wordpress.com`
- Add a new payment method in  `https://wordpress.com/purchases/payment-methods/`
- Open up the Network tab in the Dev Console, we'll inspect a network call
- Use [the e-mandate test card](https://docs.stripe.com/india-recurring-payments?integration=paymentIntents-setupIntents#testing) (`4000003560000123`) as the new credit card
- Confirm the 3DS dialog
- Search for the network call to the `https://public-api.wordpress.com/rest/v1.1/me/stored-cards` endpoint
- Assert that the payload contains the `setup_key` key.
- Assert the value looks like `seti_xxxxx`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
