### PR TITLE
Plans -> Pricing redirect: preserve coupon query param

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -719,6 +719,7 @@ function wpcomPages( app ) {
 		if ( ! req.context.isLoggedIn ) {
 			const queryFor = req.query?.for;
 			const ref = req.query?.ref;
+			const coupon = req.query?.coupon;
 
 			if ( queryFor && 'jetpack' === queryFor ) {
 				res.redirect(
@@ -726,8 +727,11 @@ function wpcomPages( app ) {
 				);
 			} else {
 				const pricingPage = 'https://wordpress.com/pricing/';
-				const refQuery = ref ? `?ref=${ ref }` : '';
-				const pricingPageUrl = localizeUrl( `${ pricingPage }${ refQuery }`, locale );
+				const queryString = stringify( { ref, coupon } );
+				const pricingPageUrl = localizeUrl(
+					`${ pricingPage }${ queryString ? '?' + queryString : '' }`,
+					locale
+				);
 				res.redirect( pricingPageUrl );
 			}
 		} else {

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -1016,12 +1016,14 @@ describe( 'main app', () => {
 				'https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fwordpress.com%2Fplans'
 			);
 		} );
-		it( 'redirects to public pricing page', async () => {
+		it( 'redirects to public pricing page with coupon and ref params', async () => {
 			app.withConfigEnabled( {
 				'jetpack-cloud/connect': false,
 			} );
-			const { response } = await app.run( { request: { url: '/plans' } } );
-			expect( response.redirect ).toHaveBeenCalledWith( 'https://wordpress.com/pricing/' );
+			const { response } = await app.run( { request: { url: '/plans?ref=test&coupon=test' } } );
+			expect( response.redirect ).toHaveBeenCalledWith(
+				'https://wordpress.com/pricing/?ref=test&coupon=test'
+			);
 		} );
 	} );
 

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -1020,7 +1020,9 @@ describe( 'main app', () => {
 			app.withConfigEnabled( {
 				'jetpack-cloud/connect': false,
 			} );
-			const { response } = await app.run( { request: { url: '/plans?ref=test&coupon=test' } } );
+			const { response } = await app.run( {
+				request: { url: '/plans', query: { ref: 'test', coupon: 'test' } },
+			} );
 			expect( response.redirect ).toHaveBeenCalledWith(
 				'https://wordpress.com/pricing/?ref=test&coupon=test'
 			);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1734469567803829/1734116832.839169-slack-C06H55Q6UEM

## Proposed Changes

* If the user is logged-out, we redirect `/plans` to https://wordpress.com/pricing/. This PR preserves the `coupon` query param for the redirect.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* If a logged-out user visits `/plans?coupon=xyz`, they are redirected to https://wordpress.com/pricing/ and the coupon code is lost in that redirect.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans?coupon=ABC` in a logged-out window.
* Confirm that you are redirected to `https://wordpress.com/pricing/?coupon=ABC`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?