### PR TITLE
Site Migration: Add A/B test check before showing certain UI/UX updates

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-migration-experiment/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-migration-experiment/index.ts
@@ -1,0 +1,9 @@
+import { useExperiment } from 'calypso/lib/explat';
+
+export function useMigrationExperiment() {
+	const [ , experimentAssignment ] = useExperiment(
+		'calypso_signup_onboarding_site_migration_flow_202501_v1'
+	);
+
+	return 'treatment' === experimentAssignment?.variationName;
+}

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-migration-experiment/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-migration-experiment/index.ts
@@ -1,9 +1,9 @@
 import { useExperiment } from 'calypso/lib/explat';
 
-export function useMigrationExperiment() {
+export function useMigrationExperiment( flowName: string ) {
 	const [ , experimentAssignment ] = useExperiment(
 		'calypso_signup_onboarding_site_migration_flow_202501_v1'
 	);
 
-	return 'treatment' === experimentAssignment?.variationName;
+	return 'treatment' === experimentAssignment?.variationName && 'site-migration' === flowName;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -26,8 +26,8 @@ interface Props extends StepProps {
 }
 
 const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
-	const { navigation, headerText, stepName, subHeaderText } = props;
-	const isMigrationExperimentEnabled = useMigrationExperiment();
+	const { navigation, headerText, stepName, subHeaderText, flow } = props;
+	const isMigrationExperimentEnabled = useMigrationExperiment( flow );
 	const translate = useTranslate();
 	const importSiteQueryParam = useQuery().get( 'from' ) || '';
 	const site = useSite();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -12,9 +12,9 @@ import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useExperiment } from 'calypso/lib/explat';
 import { usePresalesChat } from 'calypso/lib/presales-chat';
 import useHostingProviderName from 'calypso/site-profiler/hooks/use-hosting-provider-name';
+import { useMigrationExperiment } from '../../hooks/use-migration-experiment';
 import FlowCard from '../components/flow-card';
 import { DIYOption } from './diy-option';
 import type { StepProps } from '../../types';
@@ -27,10 +27,7 @@ interface Props extends StepProps {
 
 const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 	const { navigation, headerText, stepName, subHeaderText } = props;
-	const [ , experimentAssignment ] = useExperiment(
-		'calypso_signup_onboarding_site_migration_flow_202501_v1'
-	);
-	const isMigrationExperimentEnabled = 'treatment' === experimentAssignment?.variationName;
+	const isMigrationExperimentEnabled = useMigrationExperiment();
 	const translate = useTranslate();
 	const importSiteQueryParam = useQuery().get( 'from' ) || '';
 	const site = useSite();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { PLAN_BUSINESS, getPlan, isWpComBusinessPlan } from '@automattic/calypso-products';
 import { NextButton, StepContainer } from '@automattic/onboarding';
 import { Icon, copy, globe, lockOutline, scheduled } from '@wordpress/icons';
@@ -13,6 +12,7 @@ import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useExperiment } from 'calypso/lib/explat';
 import { usePresalesChat } from 'calypso/lib/presales-chat';
 import useHostingProviderName from 'calypso/site-profiler/hooks/use-hosting-provider-name';
 import FlowCard from '../components/flow-card';
@@ -27,7 +27,10 @@ interface Props extends StepProps {
 
 const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 	const { navigation, headerText, stepName, subHeaderText } = props;
-	const isMigrationExperimentEnabled = config.isEnabled( 'migration-flow/experiment' );
+	const [ , experimentAssignment ] = useExperiment(
+		'calypso_signup_onboarding_site_migration_flow_202501_v1'
+	);
+	const isMigrationExperimentEnabled = 'treatment' === experimentAssignment?.variationName;
 	const translate = useTranslate();
 	const importSiteQueryParam = useQuery().get( 'from' ) || '';
 	const site = useSite();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/test/index.tsx
@@ -1,15 +1,14 @@
 /**
  * @jest-environment jsdom
  */
-import config, { isEnabled } from '@automattic/calypso-config';
 import { screen } from '@testing-library/react';
 import { ComponentProps } from 'react';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import SiteMigrationHowToMigrate from '../';
+import { useMigrationExperiment } from '../../../hooks/use-migration-experiment';
 import { defaultSiteDetails } from '../../launchpad/test/lib/fixtures';
 import { mockStepProps, renderStep, RenderStepOptions } from '../../test/helpers';
 
-const isMigrationExperimentEnabled = isEnabled( 'migration-flow/experiment' );
 const navigation = { submit: jest.fn() };
 
 type Props = ComponentProps< typeof SiteMigrationHowToMigrate >;
@@ -28,17 +27,16 @@ jest.mock( 'calypso/lib/presales-chat', () => ( {
 	usePresalesChat: () => {},
 } ) );
 
-describe( 'SiteMigrationHowToMigrate', () => {
-	beforeAll( () => {
-		config.enable( 'migration-flow/experiment' );
-	} );
+jest.mock(
+	'calypso/landing/stepper/declarative-flow/internals/hooks/use-migration-experiment/index.ts',
+	() => ( {
+		useMigrationExperiment: jest.fn(),
+	} )
+);
 
-	afterAll( () => {
-		if ( isMigrationExperimentEnabled ) {
-			config.enable( 'migration-flow/experiment' );
-		} else {
-			config.disable( 'migration-flow/experiment' );
-		}
+describe( 'SiteMigrationHowToMigrate', () => {
+	beforeEach( () => {
+		( useMigrationExperiment as jest.Mock ).mockReturnValue( true );
 	} );
 
 	afterEach( () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/test/index.tsx
@@ -30,7 +30,7 @@ jest.mock( 'calypso/lib/presales-chat', () => ( {
 jest.mock(
 	'calypso/landing/stepper/declarative-flow/internals/hooks/use-migration-experiment/index.ts',
 	() => ( {
-		useMigrationExperiment: jest.fn(),
+		useMigrationExperiment: jest.fn( ( flowName: string ) => flowName === 'site-migration' ),
 	} )
 );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { StepContainer, Title, SubTitle, HOSTED_SITE_MIGRATION_FLOW } from '@automattic/onboarding';
 import { Icon, next, published, shield } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -10,6 +9,7 @@ import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-q
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useExperiment } from 'calypso/lib/explat';
 import wpcom from 'calypso/lib/wp';
 import { GUIDED_ONBOARDING_FLOW_REFERRER } from 'calypso/signup/steps/initial-intent/constants';
 import { useSitePreviewMShotImageHandler } from '../site-migration-instructions/site-preview/hooks/use-site-preview-mshot-image-handler';
@@ -28,8 +28,6 @@ interface HostingDetailsWithIconsProps {
 		description: string;
 	}[];
 }
-
-const isMigrationExperimentEnabled = config.isEnabled( 'migration-flow/experiment' );
 
 const HostingDetailsWithIcons: FC< HostingDetailsWithIconsProps > = ( { items } ) => {
 	const translate = useTranslate();
@@ -95,6 +93,12 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 		isFetching,
 		isFetched,
 	} = useAnalyzeUrlQuery( siteURL, siteURL !== '' );
+
+	const [ , experimentAssignment ] = useExperiment(
+		'calypso_signup_onboarding_site_migration_flow_202501_v1'
+	);
+
+	const isMigrationExperimentEnabled = 'treatment' === experimentAssignment?.variationName;
 
 	useEffect( () => {
 		if ( siteInfo ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -82,9 +82,15 @@ interface Props {
 	onComplete: ( siteInfo: UrlData ) => void;
 	onSkip: () => void;
 	hideImporterListLink: boolean;
+	flowName: string;
 }
 
-export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLink = false } ) => {
+export const Analyzer: FC< Props > = ( {
+	onComplete,
+	onSkip,
+	hideImporterListLink = false,
+	flowName,
+} ) => {
 	const translate = useTranslate();
 	const [ siteURL, setSiteURL ] = useState< string >( '' );
 	const {
@@ -94,7 +100,7 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 		isFetched,
 	} = useAnalyzeUrlQuery( siteURL, siteURL !== '' );
 
-	const isMigrationExperimentEnabled = useMigrationExperiment();
+	const isMigrationExperimentEnabled = useMigrationExperiment( flowName );
 
 	useEffect( () => {
 		if ( siteInfo ) {
@@ -199,7 +205,7 @@ const saveSiteSettings = async ( siteSlug: string, settings: Record< string, unk
 	);
 };
 
-const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
+const SiteMigrationIdentify: Step = function ( { navigation, variantSlug, flow } ) {
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
 	const { createScreenshots } = useSitePreviewMShotImageHandler();
@@ -262,6 +268,7 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 						onSkip={ () => {
 							handleSubmit( 'skip_platform_identification' );
 						} }
+						flowName={ flow }
 					/>
 				}
 				recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -9,9 +9,9 @@ import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-q
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useExperiment } from 'calypso/lib/explat';
 import wpcom from 'calypso/lib/wp';
 import { GUIDED_ONBOARDING_FLOW_REFERRER } from 'calypso/signup/steps/initial-intent/constants';
+import { useMigrationExperiment } from '../../hooks/use-migration-experiment';
 import { useSitePreviewMShotImageHandler } from '../site-migration-instructions/site-preview/hooks/use-site-preview-mshot-image-handler';
 import type { Step } from '../../types';
 import type { UrlData } from 'calypso/blocks/import/types';
@@ -94,11 +94,7 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 		isFetched,
 	} = useAnalyzeUrlQuery( siteURL, siteURL !== '' );
 
-	const [ , experimentAssignment ] = useExperiment(
-		'calypso_signup_onboarding_site_migration_flow_202501_v1'
-	);
-
-	const isMigrationExperimentEnabled = 'treatment' === experimentAssignment?.variationName;
+	const isMigrationExperimentEnabled = useMigrationExperiment();
 
 	useEffect( () => {
 		if ( siteInfo ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -16,7 +16,7 @@ import FlowCard from '../components/flow-card';
 import type { Step } from '../../types';
 import './style.scss';
 
-const SiteMigrationImportOrMigrate: Step = function ( { navigation } ) {
+const SiteMigrationImportOrMigrate: Step = function ( { navigation, flow } ) {
 	const translate = useTranslate();
 	const site = useSite();
 	const importSiteQueryParam = getQueryArg( window.location.href, 'from' )?.toString() || '';
@@ -29,7 +29,7 @@ const SiteMigrationImportOrMigrate: Step = function ( { navigation } ) {
 
 	let options;
 
-	const isMigrationExperimentEnabled = useMigrationExperiment();
+	const isMigrationExperimentEnabled = useMigrationExperiment( flow );
 
 	if ( isMigrationExperimentEnabled ) {
 		const badgeText = isBusinessPlan

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -11,7 +11,7 @@ import { useMigrationStickerMutation } from 'calypso/data/site-migration/use-mig
 import { useHostingProviderUrlDetails } from 'calypso/data/site-profiler/use-hosting-provider-url-details';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useExperiment } from 'calypso/lib/explat';
+import { useMigrationExperiment } from '../../hooks/use-migration-experiment';
 import FlowCard from '../components/flow-card';
 import type { Step } from '../../types';
 import './style.scss';
@@ -29,11 +29,7 @@ const SiteMigrationImportOrMigrate: Step = function ( { navigation } ) {
 
 	let options;
 
-	const [ , experimentAssignment ] = useExperiment(
-		'calypso_signup_onboarding_site_migration_flow_202501_v1'
-	);
-
-	const isMigrationExperimentEnabled = 'treatment' === experimentAssignment?.variationName;
+	const isMigrationExperimentEnabled = useMigrationExperiment();
 
 	if ( isMigrationExperimentEnabled ) {
 		const badgeText = isBusinessPlan

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { getPlan, isWpComBusinessPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { BadgeType } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
@@ -12,11 +11,10 @@ import { useMigrationStickerMutation } from 'calypso/data/site-migration/use-mig
 import { useHostingProviderUrlDetails } from 'calypso/data/site-profiler/use-hosting-provider-url-details';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useExperiment } from 'calypso/lib/explat';
 import FlowCard from '../components/flow-card';
 import type { Step } from '../../types';
 import './style.scss';
-
-const isMigrationExperimentEnabled = config.isEnabled( 'migration-flow/experiment' );
 
 const SiteMigrationImportOrMigrate: Step = function ( { navigation } ) {
 	const translate = useTranslate();
@@ -30,6 +28,12 @@ const SiteMigrationImportOrMigrate: Step = function ( { navigation } ) {
 		: false;
 
 	let options;
+
+	const [ , experimentAssignment ] = useExperiment(
+		'calypso_signup_onboarding_site_migration_flow_202501_v1'
+	);
+
+	const isMigrationExperimentEnabled = 'treatment' === experimentAssignment?.variationName;
 
 	if ( isMigrationExperimentEnabled ) {
 		const badgeText = isBusinessPlan

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	PLAN_BUSINESS,
 	PLAN_MIGRATION_TRIAL_MONTHLY,
@@ -19,6 +18,7 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useExperiment } from 'calypso/lib/explat';
 import { MigrationAssistanceModal } from '../../components/migration-assistance-modal';
 import type { StepProps } from '../../types';
 import './style.scss';
@@ -39,7 +39,10 @@ const SiteMigrationUpgradePlan: FC< Props > = ( {
 	customizedActionButtons,
 	...props
 } ) => {
-	const showVariants = config.isEnabled( 'migration-flow/experiment' );
+	const [ , experimentAssignment ] = useExperiment(
+		'calypso_signup_onboarding_site_migration_flow_202501_v1'
+	);
+	const showVariants = 'treatment' === experimentAssignment?.variationName;
 	const { onSkip, skipLabelText, skipPosition } = props;
 	const siteItem = useSite();
 	const siteSlug = useSiteSlug();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -37,9 +37,10 @@ const SiteMigrationUpgradePlan: FC< Props > = ( {
 	navigation,
 	data,
 	customizedActionButtons,
+	flow,
 	...props
 } ) => {
-	const showVariants = useMigrationExperiment();
+	const showVariants = useMigrationExperiment( flow );
 	const { onSkip, skipLabelText, skipPosition } = props;
 	const siteItem = useSite();
 	const siteSlug = useSiteSlug();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -18,8 +18,8 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useExperiment } from 'calypso/lib/explat';
 import { MigrationAssistanceModal } from '../../components/migration-assistance-modal';
+import { useMigrationExperiment } from '../../hooks/use-migration-experiment';
 import type { StepProps } from '../../types';
 import './style.scss';
 
@@ -39,10 +39,7 @@ const SiteMigrationUpgradePlan: FC< Props > = ( {
 	customizedActionButtons,
 	...props
 } ) => {
-	const [ , experimentAssignment ] = useExperiment(
-		'calypso_signup_onboarding_site_migration_flow_202501_v1'
-	);
-	const showVariants = 'treatment' === experimentAssignment?.variationName;
+	const showVariants = useMigrationExperiment();
 	const { onSkip, skipLabelText, skipPosition } = props;
 	const siteItem = useSite();
 	const siteSlug = useSiteSlug();

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -8,7 +8,6 @@ import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-tri
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
-import { useExperiment } from 'calypso/lib/explat';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import { ImporterPlatform } from 'calypso/lib/importer/types';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -108,18 +107,6 @@ const siteMigration: Flow = {
 			true
 		);
 		const isFromSiteWordPress = ! isLoadingFromData && urlData?.platform === 'wordpress';
-
-		const [ , experimentAssignment ] = useExperiment(
-			'calypso_signup_onboarding_site_migration_flow_202501_v1'
-		);
-
-		// Enable the feature flag if the user is in the treatment group.
-		if (
-			'treatment' === experimentAssignment?.variationName &&
-			! config.isEnabled( 'migration-flow/experiment' )
-		) {
-			config.enable( 'migration-flow/experiment' );
-		}
 
 		const exitFlow = ( to: string ) => {
 			window.location.assign( to );

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -8,6 +8,7 @@ import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-tri
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
+import { useExperiment } from 'calypso/lib/explat';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import { ImporterPlatform } from 'calypso/lib/importer/types';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -107,6 +108,18 @@ const siteMigration: Flow = {
 			true
 		);
 		const isFromSiteWordPress = ! isLoadingFromData && urlData?.platform === 'wordpress';
+
+		const [ , experimentAssignment ] = useExperiment(
+			'calypso_signup_onboarding_site_migration_flow_202501_v1'
+		);
+
+		// Enable the feature flag if the user is in the treatment group.
+		if (
+			'treatment' === experimentAssignment?.variationName &&
+			! config.isEnabled( 'migration-flow/experiment' )
+		) {
+			config.enable( 'migration-flow/experiment' );
+		}
 
 		const exitFlow = ( to: string ) => {
 			window.location.assign( to );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* We have a variation of the new migration flow working behind a feature flag `migration-flow/experiment`.
* This swaps out the changes behind the feature flag for an upcoming A/B test assignment -- users assigned to the `treatment` group will see the UI/UX changes.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* p9Jlb4-fiH-p2 A/B testing these changes

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TBD until the test has been set up in ExPlat

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?