### PR TITLE
Goals and DP first: Gracefully continue the flow after leaving checkout

### DIFF
--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -85,14 +85,11 @@ const onboarding: Flow = {
 		} = useDispatch( ONBOARD_STORE );
 		const locale = useFlowLocale();
 
-		const { planCartItem, signupDomainOrigin, selectedDesign, selectedStyleVariation } = useSelect(
+		const { planCartItem, signupDomainOrigin } = useSelect(
 			( select: ( key: string ) => OnboardSelect ) => ( {
 				domainCartItem: select( ONBOARD_STORE ).getDomainCartItem(),
 				planCartItem: select( ONBOARD_STORE ).getPlanCartItem(),
-				signupDomainOrigin: select( ONBOARD_STORE ).getSignupDomainOrigin(),
-				selectedDesign: select( ONBOARD_STORE ).getSelectedDesign(),
-				selectedStyleVariation: select( ONBOARD_STORE ).getSelectedStyleVariation(),
-				selectedGlobalStyles: select( ONBOARD_STORE ).getSelectedGlobalStyles(),
+				signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
 			} ),
 			[]
 		);
@@ -235,15 +232,7 @@ const onboarding: Flow = {
 							addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
 								redirect_to: destination,
 								signup: 1,
-								checkoutBackUrl: isGoalsAtFrontExperiment
-									? pathToUrl(
-											addQueryArgs( '/setup/onboarding/designSetup', {
-												siteSlug,
-												theme: selectedDesign?.slug,
-												style_variation: selectedStyleVariation?.slug,
-											} )
-									  )
-									: pathToUrl( addQueryArgs( destination, { skippedCheckout: 1 } ) ),
+								checkoutBackUrl: pathToUrl( addQueryArgs( destination, { skippedCheckout: 1 } ) ),
 								coupon,
 							} )
 						);

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -85,11 +85,14 @@ const onboarding: Flow = {
 		} = useDispatch( ONBOARD_STORE );
 		const locale = useFlowLocale();
 
-		const { planCartItem, signupDomainOrigin } = useSelect(
+		const { planCartItem, signupDomainOrigin, selectedDesign, selectedStyleVariation } = useSelect(
 			( select: ( key: string ) => OnboardSelect ) => ( {
 				domainCartItem: select( ONBOARD_STORE ).getDomainCartItem(),
 				planCartItem: select( ONBOARD_STORE ).getPlanCartItem(),
-				signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
+				signupDomainOrigin: select( ONBOARD_STORE ).getSignupDomainOrigin(),
+				selectedDesign: select( ONBOARD_STORE ).getSelectedDesign(),
+				selectedStyleVariation: select( ONBOARD_STORE ).getSelectedStyleVariation(),
+				selectedGlobalStyles: select( ONBOARD_STORE ).getSelectedGlobalStyles(),
 			} ),
 			[]
 		);
@@ -232,7 +235,15 @@ const onboarding: Flow = {
 							addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
 								redirect_to: destination,
 								signup: 1,
-								checkoutBackUrl: pathToUrl( addQueryArgs( destination, { skippedCheckout: 1 } ) ),
+								checkoutBackUrl: isGoalsAtFrontExperiment
+									? pathToUrl(
+											addQueryArgs( '/setup/onboarding/designSetup', {
+												siteSlug,
+												theme: selectedDesign?.slug,
+												style_variation: selectedStyleVariation?.slug,
+											} )
+									  )
+									: pathToUrl( addQueryArgs( destination, { skippedCheckout: 1 } ) ),
 								coupon,
 							} )
 						);
@@ -272,6 +283,11 @@ const onboarding: Flow = {
 						return navigate( 'use-my-domain' );
 					}
 					return navigate( 'domains' );
+				case 'designSetup':
+					if ( isGoalsAtFrontExperiment ) {
+						return navigate( 'goals' );
+					}
+					return;
 				default:
 					return;
 			}

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -726,6 +726,11 @@ const siteSetupFlow: Flow = {
 						return dispatch( setActiveTheme( siteId, theme ) );
 					} )
 					.catch( ( error: Error ) => {
+						// We attempt to set the design on the site anyway even when the checkout is skipped.
+						// That's because the user might have selected a free design, and there's no reason
+						// we shouldn't set that design on the site when the checkout is skipped.
+						// If the ThemeNotPurchasedError is thrown we know that they actually selected a
+						// paid theme and we're unable to apply it.
 						if ( error.name === 'ThemeNotPurchasedError' && skippedCheckout === '1' ) {
 							return;
 						}

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -702,16 +702,14 @@ const siteSetupFlow: Flow = {
 
 		const dispatch = reduxDispatch();
 
+		const skippedCheckout = useQuery().get( 'skippedCheckout' );
+
 		useEffect( () => {
 			if ( ! isGoalsAtFrontExperiment || ! siteSlugOrId || ! siteId ) {
 				return;
 			}
 
 			setPendingAction( async () => {
-				await updateLaunchpadSettings( siteSlugOrId, {
-					checklist_statuses: { design_completed: true },
-				} );
-
 				if ( ! selectedDesign ) {
 					return;
 				}
@@ -719,9 +717,19 @@ const siteSetupFlow: Flow = {
 				return setDesignOnSite( siteSlugOrId, selectedDesign, {
 					styleVariation: selectedStyleVariation,
 					globalStyles: selectedGlobalStyles,
-				} ).then( ( theme: ActiveTheme ) => {
-					return dispatch( setActiveTheme( siteId, theme ) );
-				} );
+				} )
+					.then( async ( theme: ActiveTheme ) => {
+						await updateLaunchpadSettings( siteSlugOrId, {
+							checklist_statuses: { design_completed: true },
+						} );
+
+						return dispatch( setActiveTheme( siteId, theme ) );
+					} )
+					.catch( ( error: Error ) => {
+						if ( error.name === 'ThemeNotPurchasedError' && skippedCheckout === '1' ) {
+							return;
+						}
+					} );
 			} );
 		}, [
 			isGoalsAtFrontExperiment,
@@ -733,6 +741,7 @@ const siteSetupFlow: Flow = {
 			dispatch,
 			selectedStyleVariation,
 			selectedGlobalStyles,
+			skippedCheckout,
 		] );
 	},
 };

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -734,6 +734,7 @@ const siteSetupFlow: Flow = {
 						if ( error.name === 'ThemeNotPurchasedError' && skippedCheckout === '1' ) {
 							return;
 						}
+						throw error;
 					} );
 			} );
 		}, [


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/97571.

## Proposed Changes

Title. Continue the flow even if the user left the checkout without paying, meaning their selected paid theme wasn't activated.

## Why are these changes being made?

Because right now the user sees an error page after leaving checkout:

![image](https://github.com/user-attachments/assets/ac19b688-cc1e-447f-bc40-b122b7a807ba)

## Testing Instructions

On `trunk` visit `/setup/onboarding`, go through the flow with a paid theme and verify you see the error page after leaving checkout.

With this PR, that scenario should not happen and the user should see the Launchpad.