### PR TITLE
Stats: Subscribers: Show rates

### DIFF
--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -65,7 +65,7 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 						),
 						body: ( item ) => (
 							<>
-								<span>{ item.opens }</span>
+								<span>{ `${ item.opens_rate }%` }</span>
 							</>
 						),
 					} }
@@ -77,6 +77,8 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 					mainItemLabel={ translate( 'Latest Emails' ) }
 					hideSummaryLink
 					metricLabel={ translate( 'Clicks' ) }
+					valueField="clicks_rate"
+					formatValue={ ( value ) => `${ value }%` }
 					listItemClassName="stats__summary--narrow-mobile"
 				/>
 				<JetpackColophon />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/issues/40538

## Proposed Changes

* Before:

<img width="1090" alt="Screenshot 2024-12-17 at 10 53 08 PM" src="https://github.com/user-attachments/assets/4a064f5f-9d90-4302-a4bf-5ef132363cbf" />

* After:

<img width="1101" alt="Screenshot 2024-12-17 at 10 52 19 PM" src="https://github.com/user-attachments/assets/aab914c6-cd7a-4c2d-9f63-30755e9d21d7" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check email stats at http://calypso.localhost:3000/stats/day/emails/<your_site_url>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
