### PR TITLE
Paid Stats: Redirect users back to the Stats page after checkout from upsell prompts

### DIFF
--- a/client/my-sites/stats/stats-upsell-modal/index.tsx
+++ b/client/my-sites/stats/stats-upsell-modal/index.tsx
@@ -47,6 +47,8 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 		dispatch( toggleUpsellModal( siteId, statType ) );
 	};
 
+	const redirectTo = encodeURIComponent( window.location.href );
+
 	const onClick = ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => {
 		event.preventDefault();
 		closeModal();
@@ -57,10 +59,10 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 			const checkoutProductUrl = new URL(
 				`https://wordpress.com/checkout/${ siteSlug }/${ planSlug }`
 			);
-			checkoutProductUrl.searchParams.set( 'redirect_to', window.location.href );
+			checkoutProductUrl.searchParams.set( 'redirect_to', redirectTo );
 			window.open( checkoutProductUrl, '_self' );
 		} else {
-			page( `/checkout/${ siteSlug }/${ planSlug }` );
+			page( `/checkout/${ siteSlug }/${ planSlug }?redirect_to=${ redirectTo }` );
 		}
 	};
 

--- a/client/my-sites/stats/stats-upsell/index.tsx
+++ b/client/my-sites/stats/stats-upsell/index.tsx
@@ -58,6 +58,7 @@ export default function StatsUpsell( {
 	const { setShowHelpCenter, setShowSupportDoc } = useDataStoreDispatch( HELP_CENTER_STORE );
 	const localizeUrl = useLocalizeUrl();
 	const [ isExpanded, setIsExpanded ] = useState( false );
+	const redirectTo = encodeURIComponent( window.location.href );
 
 	const onClick = ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => {
 		event.preventDefault();
@@ -66,11 +67,11 @@ export default function StatsUpsell( {
 		} );
 		if ( isOdysseyStats ) {
 			const checkoutProductUrl = new URL(
-				`https://wordpress.com/checkout/${ siteSlug }/${ planSlug }`
+				`https://wordpress.com/checkout/${ siteSlug }/${ planSlug }?redirect_to=${ redirectTo }`
 			);
 			window.open( checkoutProductUrl, '_self' );
 		} else {
-			page( `/checkout/${ siteSlug }/${ planSlug }` );
+			page( `/checkout/${ siteSlug }/${ planSlug }?redirect_to=${ redirectTo }` );
 		}
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/red-team/issues/321

## Proposed Changes

* Add the `redirect_to` parameter to the checkout URL in the `StatsUpsell` and `StatsUpsellModal` components to ensure users are redirected back to the Stats page after completing their purchase.

## Why are these changes being made?

These changes ensure that users return to the Stats page where they initiated the purchase, providing a smoother and more intuitive user experience.


## Testing Instructions

- Spin up a Calypso Live Branch.  
- Using a new free site, navigate to the Stats page.  
- Click on **Upgrade to Personal** in the upsell prompt on the Traffic or Insights page.  
- Ensure it navigates to the checkout page, and verify that the `redirect_to` parameter in the URL matches the page URL you were on.  
- Attempt to purchase the WordPress.com Personal plan and confirm that you are redirected back to the Traffic or Insights page (whichever page you clicked the button on) after completing the purchase.  
- Now, with your site upgraded to the Personal plan, click on **Upgrade to Premium** in the UTM or Devices module.  
  - It should prompt you with an upgrade modal.  
  - Click on **Upgrade to Premium** in that modal.  
  - Ensure it navigates to the checkout page, and verify that the `redirect_to` parameter in the URL matches the page URL you were on.  
  - Attempt to purchase the WordPress.com Premium plan and confirm that you are redirected back to the Traffic page after completing the purchase.  
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
