### PR TITLE
Goal First: Update the free plan modal for the paid themes

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -460,13 +460,15 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const isBundled = selectedDesign?.software_sets && selectedDesign.software_sets.length > 0;
 
 	const isLockedTheme =
-		( ! canSiteActivateTheme && ! isGoalsAtFrontExperiment ) ||
-		( selectedDesign?.design_tier === THEME_TIER_PREMIUM &&
-			! isPremiumThemeAvailable &&
-			! didPurchaseSelectedTheme ) ||
-		( selectedDesign?.is_externally_managed &&
-			( ! isMarketplaceThemeSubscribed || ! isExternallyManagedThemeAvailable ) ) ||
-		( ! isPluginBundleEligible && isBundled );
+		// The exp moves the Design Picker step in front of the plan selection so people can unlock theme later.
+		! isGoalsAtFrontExperiment &&
+		( ! canSiteActivateTheme ||
+			( selectedDesign?.design_tier === THEME_TIER_PREMIUM &&
+				! isPremiumThemeAvailable &&
+				! didPurchaseSelectedTheme ) ||
+			( selectedDesign?.is_externally_managed &&
+				( ! isMarketplaceThemeSubscribed || ! isExternallyManagedThemeAvailable ) ) ||
+			( ! isPluginBundleEligible && isBundled ) );
 
 	const [ showUpgradeModal, setShowUpgradeModal ] = useState( false );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -3,6 +3,7 @@ import { useStepPersistedState } from '@automattic/onboarding';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useSelect, useDispatch as useWPDispatch } from '@wordpress/data';
 import { useState } from 'react';
+import { useQueryTheme } from 'calypso/components/data/query-theme';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
@@ -10,7 +11,8 @@ import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { getHidePlanPropsBasedOnThemeType } from 'calypso/my-sites/plans-features-main/components/utils/utils';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
-import { getThemeType } from 'calypso/state/themes/selectors';
+import { getTheme, getThemeType } from 'calypso/state/themes/selectors';
+import StepperLoader from '../../components/stepper-loader';
 import UnifiedPlansStep from './unified-plans-step';
 import { getIntervalType } from './util';
 import type { ProvidedDependencies, StepProps } from '../../types';
@@ -37,9 +39,14 @@ export default function PlansStepAdaptor( props: StepProps ) {
 	);
 	const username = useSelector( getCurrentUserName );
 	const coupon = useQuery().get( 'coupon' ) ?? undefined;
-	const selectedThemeType = useSelector( ( state ) =>
-		selectedDesign ? getThemeType( state, selectedDesign.slug ) : ''
+
+	const theme = useSelector( ( state ) =>
+		selectedDesign ? getTheme( state, 'wpcom', selectedDesign.slug ) : null
 	);
+	const selectedThemeType = useSelector( ( state ) =>
+		theme ? getThemeType( state, theme.id ) : ''
+	);
+	const isLoadingSelectedTheme = selectedDesign && ! theme;
 
 	const { setDomainCartItem, setDomainCartItems, setSiteUrl } = useWPDispatch( ONBOARD_STORE );
 
@@ -68,6 +75,12 @@ export default function PlansStepAdaptor( props: StepProps ) {
 		const intervalType = getIntervalType( path );
 		setPlanInterval( intervalType );
 	};
+
+	useQueryTheme( 'wpcom', selectedDesign?.slug );
+
+	if ( isLoadingSelectedTheme ) {
+		return <StepperLoader />;
+	}
 
 	return (
 		<UnifiedPlansStep

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -7,11 +7,14 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { getHidePlanPropsBasedOnThemeType } from 'calypso/my-sites/plans-features-main/components/utils/utils';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
-import { ProvidedDependencies, StepProps } from '../../types';
+import { getThemeType } from 'calypso/state/themes/selectors';
+import { useGoalsFirstExperiment } from '../../../helpers/use-goals-first-experiment';
 import UnifiedPlansStep from './unified-plans-step';
 import { getIntervalType } from './util';
+import type { ProvidedDependencies, StepProps } from '../../types';
 
 import './style.scss';
 
@@ -19,19 +22,26 @@ export default function PlansStepAdaptor( props: StepProps ) {
 	const [ stepState, setStepState ] = useStepPersistedState< ProvidedDependencies >( 'plans-step' );
 	const siteSlug = useSiteSlug();
 	const isMobile = useMobileBreakpoint();
+	const [ isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 
-	const { siteTitle, domainItem, domainItems } = useSelect(
+	const { siteTitle, domainItem, domainItems, selectedDesign } = useSelect(
 		( select: ( key: string ) => OnboardSelect ) => {
+			const { getSelectedSiteTitle, getDomainCartItem, getDomainCartItems, getSelectedDesign } =
+				select( ONBOARD_STORE );
 			return {
-				siteTitle: select( ONBOARD_STORE ).getSelectedSiteTitle(),
-				domainItem: select( ONBOARD_STORE ).getDomainCartItem(),
-				domainItems: select( ONBOARD_STORE ).getDomainCartItems(),
+				siteTitle: getSelectedSiteTitle(),
+				domainItem: getDomainCartItem(),
+				domainItems: getDomainCartItems(),
+				selectedDesign: getSelectedDesign(),
 			};
 		},
 		[]
 	);
 	const username = useSelector( getCurrentUserName );
 	const coupon = useQuery().get( 'coupon' ) ?? undefined;
+	const selectedThemeType = useSelector( ( state ) =>
+		selectedDesign ? getThemeType( state, selectedDesign.slug ) : ''
+	);
 
 	const { setDomainCartItem, setDomainCartItems, setSiteUrl } = useWPDispatch( ONBOARD_STORE );
 
@@ -42,11 +52,13 @@ export default function PlansStepAdaptor( props: StepProps ) {
 		coupon,
 		domainItem,
 		domainCart: domainItems,
+		selectedThemeType,
 	};
 
 	const site = useSite();
 	const customerType = useQuery().get( 'customerType' ) ?? undefined;
 	const [ planInterval, setPlanInterval ] = useState< string | undefined >( undefined );
+	const hidePlanProps = getHidePlanPropsBasedOnThemeType( selectedThemeType || '' );
 
 	/**
 	 * The plans step has a quirk where it calls `submitSignupStep` then synchronously calls `goToNextStep` after it.
@@ -61,6 +73,7 @@ export default function PlansStepAdaptor( props: StepProps ) {
 
 	return (
 		<UnifiedPlansStep
+			{ ...hidePlanProps }
 			selectedSite={ site ?? undefined }
 			saveSignupStep={ ( step ) => {
 				setStepState( ( mostRecentState = { ...stepState, ...step } ) );
@@ -96,6 +109,7 @@ export default function PlansStepAdaptor( props: StepProps ) {
 				isExtraWideLayout: false,
 			} }
 			useStepperWrapper
+			isGoalsAtFrontExperiment={ isGoalsAtFrontExperiment }
 		/>
 	);
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -11,7 +11,6 @@ import { getHidePlanPropsBasedOnThemeType } from 'calypso/my-sites/plans-feature
 import { useSelector } from 'calypso/state';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import { getThemeType } from 'calypso/state/themes/selectors';
-import { useGoalsFirstExperiment } from '../../../helpers/use-goals-first-experiment';
 import UnifiedPlansStep from './unified-plans-step';
 import { getIntervalType } from './util';
 import type { ProvidedDependencies, StepProps } from '../../types';
@@ -22,7 +21,6 @@ export default function PlansStepAdaptor( props: StepProps ) {
 	const [ stepState, setStepState ] = useStepPersistedState< ProvidedDependencies >( 'plans-step' );
 	const siteSlug = useSiteSlug();
 	const isMobile = useMobileBreakpoint();
-	const [ isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 
 	const { siteTitle, domainItem, domainItems, selectedDesign } = useSelect(
 		( select: ( key: string ) => OnboardSelect ) => {
@@ -109,7 +107,6 @@ export default function PlansStepAdaptor( props: StepProps ) {
 				isExtraWideLayout: false,
 			} }
 			useStepperWrapper
-			isGoalsAtFrontExperiment={ isGoalsAtFrontExperiment }
 		/>
 	);
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -14,6 +14,7 @@ import {
 import { PlansIntent } from '@automattic/plans-grid-next';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { isDesktop as isDesktopViewport, subscribeIsDesktop } from '@automattic/viewport';
+import { useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -32,7 +33,7 @@ import useLongerPlanTermDefaultExperiment from 'calypso/my-sites/plans-features-
 import { SurveyData } from 'calypso/signup/steps/initial-intent/types';
 import { getStepUrl } from 'calypso/signup/utils';
 import { getDomainFromUrl } from 'calypso/site-profiler/utils/get-valid-url';
-import { useDispatch, useSelector } from 'calypso/state';
+import { useDispatch as reduxUseDispatch, useSelector } from 'calypso/state';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import isDomainOnlySiteSelector from 'calypso/state/selectors/is-domain-only-site';
 import {
@@ -222,7 +223,7 @@ function UnifiedPlansStep( {
 	shouldHideNavButtons,
 }: UnifiedPlansStepProps ) {
 	const [ isDesktop, setIsDesktop ] = useState< boolean | undefined >( isDesktopViewport() );
-	const dispatch = useDispatch();
+	const dispatch = reduxUseDispatch();
 	const longerPlanTermDefaultExperiment = useLongerPlanTermDefaultExperiment();
 	const translate = useTranslate();
 	const initializedSitesBackUrl = useSelector( ( state ) =>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -169,11 +169,6 @@ export interface UnifiedPlansStepProps {
 	 * Used only in "onboarding-pm" flow (old Signup/Start)
 	 */
 	isCustomDomainAllowedOnFreePlan?: boolean;
-
-	/**
-	 * Whether the user should have the "goals first" onboarding experience
-	 */
-	isGoalsAtFrontExperiment?: boolean;
 }
 
 /**
@@ -222,7 +217,6 @@ function UnifiedPlansStep( {
 	progress,
 	queryParams: queryParamsFromProps,
 	shouldHideNavButtons,
-	isGoalsAtFrontExperiment,
 }: UnifiedPlansStepProps ) {
 	const [ isDesktop, setIsDesktop ] = useState< boolean | undefined >( isDesktopViewport() );
 	const dispatch = useDispatch();
@@ -551,7 +545,6 @@ function UnifiedPlansStep( {
 									) }
 									onPlanIntervalUpdate={ onPlanIntervalUpdate }
 									selectedThemeType={ selectedThemeType }
-									isGoalsAtFrontExperiment={ isGoalsAtFrontExperiment }
 								/>
 							</div>
 						}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -2,11 +2,13 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { UrlFriendlyTermType } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
+import { FREE_THEME } from '@automattic/design-picker';
 import { localizeUrl } from '@automattic/i18n-utils';
 import {
 	isSiteAssemblerFlow,
 	isTailoredSignupFlow,
 	isOnboardingGuidedFlow,
+	ONBOARDING_FLOW,
 	ONBOARDING_GUIDED_FLOW,
 } from '@automattic/onboarding';
 import { PlansIntent } from '@automattic/plans-grid-next';
@@ -444,7 +446,7 @@ function UnifiedPlansStep( {
 			};
 
 			if (
-				( 'onboarding' === flowName || 'onboarding-pm' === flowName ) &&
+				( ONBOARDING_FLOW === flowName || 'onboarding-pm' === flowName ) &&
 				undefined === previousStep?.providedDependencies?.domainItem
 			) {
 				backUrl = getStepUrl( flowName, 'domains' );
@@ -456,7 +458,7 @@ function UnifiedPlansStep( {
 		intervalType ||
 		getIntervalType(
 			path,
-			flowName === 'onboarding' && longerPlanTermDefaultExperiment?.term
+			flowName === ONBOARDING_FLOW && longerPlanTermDefaultExperiment?.term
 				? longerPlanTermDefaultExperiment.term
 				: undefined
 		);
@@ -491,8 +493,10 @@ function UnifiedPlansStep( {
 		freeWPComSubdomain = siteUrl;
 	}
 
+	const isPaidTheme = selectedThemeType && selectedThemeType !== FREE_THEME;
 	const deemphasizeFreePlan =
-		( [ 'onboarding', ONBOARDING_GUIDED_FLOW ].includes( flowName ) && paidDomainName != null ) ||
+		( [ ONBOARDING_FLOW, ONBOARDING_GUIDED_FLOW ].includes( flowName ) &&
+			( paidDomainName != null || isPaidTheme ) ) ||
 		deemphasizeFreePlanFromProps;
 
 	return (
@@ -532,7 +536,7 @@ function UnifiedPlansStep( {
 									plansWithScroll={ isDesktop }
 									intent={ intent || surveyedIntent }
 									flowName={ flowName }
-									hideFreePlan={ hideFreePlan }
+									hideFreePlan={ hideFreePlan && ! deemphasizeFreePlan }
 									hidePersonalPlan={ hidePersonalPlan }
 									hidePremiumPlan={ hidePremiumPlan }
 									hideEcommercePlan={ shouldHideEcommercePlan() }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -2,7 +2,6 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { UrlFriendlyTermType } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
-import { SiteDetails } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import {
 	isSiteAssemblerFlow,
@@ -42,6 +41,7 @@ import { StepState } from 'calypso/state/signup/progress/schema';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import { getIntervalType, shouldBasePlansOnSegment } from './util';
 import './unified-plans-step-styles.scss';
+import type { SiteDetails } from '@automattic/data-stores';
 
 export interface UnifiedPlansStepProps {
 	hideFreePlan?: boolean;
@@ -92,6 +92,7 @@ export interface UnifiedPlansStepProps {
 		username?: string | null;
 		coupon?: string | null;
 		segmentationSurveyAnswers?: SurveyData;
+		selectedThemeType?: string;
 	};
 	onPlanIntervalUpdate: ( path: string ) => void;
 
@@ -168,6 +169,11 @@ export interface UnifiedPlansStepProps {
 	 * Used only in "onboarding-pm" flow (old Signup/Start)
 	 */
 	isCustomDomainAllowedOnFreePlan?: boolean;
+
+	/**
+	 * Whether the user should have the "goals first" onboarding experience
+	 */
+	isGoalsAtFrontExperiment?: boolean;
 }
 
 /**
@@ -216,6 +222,7 @@ function UnifiedPlansStep( {
 	progress,
 	queryParams: queryParamsFromProps,
 	shouldHideNavButtons,
+	isGoalsAtFrontExperiment,
 }: UnifiedPlansStepProps ) {
 	const [ isDesktop, setIsDesktop ] = useState< boolean | undefined >( isDesktopViewport() );
 	const dispatch = useDispatch();
@@ -460,8 +467,15 @@ function UnifiedPlansStep( {
 				: undefined
 		);
 
-	const { siteUrl, domainItem, siteTitle, username, coupon, segmentationSurveyAnswers } =
-		signupDependencies;
+	const {
+		siteUrl,
+		domainItem,
+		siteTitle,
+		username,
+		coupon,
+		segmentationSurveyAnswers,
+		selectedThemeType,
+	} = signupDependencies;
 
 	const { segmentSlug } = getSegmentedIntent( segmentationSurveyAnswers );
 
@@ -536,6 +550,8 @@ function UnifiedPlansStep( {
 										'onboarding/interval-dropdown'
 									) }
 									onPlanIntervalUpdate={ onPlanIntervalUpdate }
+									selectedThemeType={ selectedThemeType }
+									isGoalsAtFrontExperiment={ isGoalsAtFrontExperiment }
 								/>
 							</div>
 						}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -41,6 +41,7 @@ import {
 } from 'calypso/state/signup/progress/actions';
 import { StepState } from 'calypso/state/signup/progress/schema';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
+import { ONBOARD_STORE } from '../../../../stores';
 import { getIntervalType, shouldBasePlansOnSegment } from './util';
 import './unified-plans-step-styles.scss';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -245,6 +246,20 @@ function UnifiedPlansStep( {
 		signupDependencies.siteId ? isDomainOnlySiteSelector( state, signupDependencies.siteId ) : false
 	);
 
+	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
+
+	const {
+		siteUrl,
+		domainItem,
+		siteTitle,
+		username,
+		coupon,
+		segmentationSurveyAnswers,
+		selectedThemeType,
+	} = signupDependencies;
+
+	const isPaidTheme = selectedThemeType && selectedThemeType !== FREE_THEME;
+
 	const effectiveSubmitSignupStep = useMemo(
 		() =>
 			submitSignupStepFromProps ??
@@ -276,6 +291,10 @@ function UnifiedPlansStep( {
 
 	const handleUpgradeClick = useCallback(
 		( cartItems?: MinimalRequestCartProduct[] | null ) => {
+			if ( isPaidTheme && cartItems === null ) {
+				setSelectedDesign( null );
+			}
+
 			buildUpgradeFunction(
 				{
 					additionalStepData,
@@ -463,16 +482,6 @@ function UnifiedPlansStep( {
 				: undefined
 		);
 
-	const {
-		siteUrl,
-		domainItem,
-		siteTitle,
-		username,
-		coupon,
-		segmentationSurveyAnswers,
-		selectedThemeType,
-	} = signupDependencies;
-
 	const { segmentSlug } = getSegmentedIntent( segmentationSurveyAnswers );
 
 	const surveyedIntent = shouldBasePlansOnSegment(
@@ -493,7 +502,6 @@ function UnifiedPlansStep( {
 		freeWPComSubdomain = siteUrl;
 	}
 
-	const isPaidTheme = selectedThemeType && selectedThemeType !== FREE_THEME;
 	const deemphasizeFreePlan =
 		( [ ONBOARDING_FLOW, ONBOARDING_GUIDED_FLOW ].includes( flowName ) &&
 			( paidDomainName != null || isPaidTheme ) ) ||

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/paid-domain-suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/paid-domain-suggested-plan-section.tsx
@@ -1,0 +1,54 @@
+import { type PlanSlug, PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import PlanUpsellButton from './plan-upsell-button';
+import { DomainName } from '.';
+
+const FreeDomainText = styled.div`
+	font-size: 14px;
+	line-height: 20px;
+	letter-spacing: -0.15px;
+	color: var( --studio-green-50 );
+	margin-top: 4px;
+`;
+
+/**
+ * List the suggested plans only for the paid domain.
+ */
+export default function PaidDomainSuggestedPlanSection( props: {
+	paidDomainName?: string;
+	onPlanSelected: ( planSlug: PlanSlug ) => void;
+	isBusy: boolean;
+} ) {
+	const translate = useTranslate();
+	const { paidDomainName, onPlanSelected, isBusy } = props;
+
+	return (
+		<>
+			{ paidDomainName && (
+				<DomainName>
+					<div>{ paidDomainName }</div>
+					<FreeDomainText>{ translate( 'Free for one year' ) }</FreeDomainText>
+				</DomainName>
+			) }
+			<PlanUpsellButton
+				planSlug={ PLAN_PERSONAL }
+				onPlanSelected={ onPlanSelected }
+				isBusy={ isBusy }
+			/>
+			{ paidDomainName && (
+				<DomainName>
+					<div>{ paidDomainName }</div>
+					<FreeDomainText>
+						{ translate( 'Free for one year. Includes Premium themes.' ) }
+					</FreeDomainText>
+				</DomainName>
+			) }
+			<PlanUpsellButton
+				planSlug={ PLAN_PREMIUM }
+				onPlanSelected={ onPlanSelected }
+				isBusy={ isBusy }
+			/>
+		</>
+	);
+}

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/plan-item.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/plan-item.tsx
@@ -1,0 +1,74 @@
+import { useTranslate } from 'i18n-calypso';
+import { usePlanUpsellInfo } from '../hooks/use-plan-upsell-info';
+import PlanUpsellButton from './plan-upsell-button';
+import type { PlanSlug } from '@automattic/calypso-products';
+import type { ReactNode } from 'react';
+
+interface Props {
+	planSlug: PlanSlug;
+	description: ReactNode;
+	isBusy: boolean;
+	onPlanSelected: ( planSlug: PlanSlug ) => void;
+}
+
+const PlanInfoContainer = styled.div`
+	font-size: 16px;
+	line-height: 20px;
+	color: var( --studio-gray-80 );
+	overflow-wrap: break-word;
+	max-width: 100%;
+	@media ( min-width: 780px ) {
+		max-width: 54%;
+	}
+`;
+
+const PlanPrice = styled.span`
+	font-size: 14px;
+	line-height: 20px;
+	letter-spacing: -0.15px;
+	color: var( --studio-gray-50 );
+`;
+
+export const PlanName = styled.span`
+	font-size: 16px;
+	font-style: normal;
+	font-weight: 500;
+	line-height: 24px;
+	letter-spacing: -0.32px;
+	color: var( --studio-gray-90 );
+`;
+
+export const PlanDescription = styled.div`
+	font-size: 14px;
+	line-height: 20px;
+	letter-spacing: -0.15px;
+	color: var( --studio-gray-50 );
+	margin-top: 4px;
+`;
+
+const PlanInfo = ( { planSlug, description, isBusy, onPlanSelected }: Props ) => {
+	const translate = useTranslate();
+	const planUpsellInfo = usePlanUpsellInfo( { planSlug } );
+
+	return (
+		<>
+			<PlanInfoContainer>
+				<div>
+					<PlanName>{ paidDomainName }</PlanName>
+					<PlanPrice>
+						{ translate( '%(planPrice)s/month', {
+							comment: 'Eg: $4/month',
+							args: {
+								planPrice: planUpsellInfo.formattedPriceMonthly,
+							},
+						} ) }
+					</PlanPrice>
+				</div>
+				<PlanDescription>{ description }</PlanDescription>
+			</PlanInfoContainer>
+			<PlanUpsellButton planSlug={ planSlug } isBusy={ isBusy } onPlanSelected={ onPlanSelected } />
+		</>
+	);
+};
+
+export default PlanInfo;

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/plan-item.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/plan-item.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { usePlanUpsellInfo } from '../hooks/use-plan-upsell-info';
 import PlanUpsellButton from './plan-upsell-button';
@@ -23,6 +24,7 @@ const PlanInfoContainer = styled.div`
 `;
 
 const PlanPrice = styled.span`
+	margin-inline-start: 8px;
 	font-size: 14px;
 	line-height: 20px;
 	letter-spacing: -0.15px;
@@ -39,11 +41,11 @@ export const PlanName = styled.span`
 `;
 
 export const PlanDescription = styled.div`
+	margin-top: 4px;
 	font-size: 14px;
 	line-height: 20px;
 	letter-spacing: -0.15px;
 	color: var( --studio-gray-50 );
-	margin-top: 4px;
 `;
 
 const PlanInfo = ( { planSlug, description, isBusy, onPlanSelected }: Props ) => {
@@ -54,7 +56,7 @@ const PlanInfo = ( { planSlug, description, isBusy, onPlanSelected }: Props ) =>
 		<>
 			<PlanInfoContainer>
 				<div>
-					<PlanName>{ paidDomainName }</PlanName>
+					<PlanName>{ planUpsellInfo.title }</PlanName>
 					<PlanPrice>
 						{ translate( '%(planPrice)s/month', {
 							comment: 'Eg: $4/month',
@@ -66,7 +68,12 @@ const PlanInfo = ( { planSlug, description, isBusy, onPlanSelected }: Props ) =>
 				</div>
 				<PlanDescription>{ description }</PlanDescription>
 			</PlanInfoContainer>
-			<PlanUpsellButton planSlug={ planSlug } isBusy={ isBusy } onPlanSelected={ onPlanSelected } />
+			<PlanUpsellButton
+				planSlug={ planSlug }
+				isBusy={ isBusy }
+				hidePrice
+				onPlanSelected={ onPlanSelected }
+			/>
 		</>
 	);
 };

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/plan-upsell-button.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/plan-upsell-button.tsx
@@ -8,11 +8,13 @@ function PlanUpsellButton( {
 	onPlanSelected,
 	disabled = false,
 	isBusy = false,
+	hidePrice = false,
 }: {
 	planSlug: PlanSlug;
 	onPlanSelected: ( planSlug: PlanSlug ) => void;
 	disabled?: boolean;
 	isBusy?: boolean;
+	hidePrice?: boolean;
 } ) {
 	const translate = useTranslate();
 	const planUpsellInfo = usePlanUpsellInfo( { planSlug } );
@@ -26,13 +28,20 @@ function PlanUpsellButton( {
 				onPlanSelected( planSlug );
 			} }
 		>
-			{ translate( 'Get %(planTitle)s - %(planPrice)s/month', {
-				comment: 'Eg: Get Personal $4/month',
-				args: {
-					planTitle: planUpsellInfo.title,
-					planPrice: planUpsellInfo.formattedPriceMonthly,
-				},
-			} ) }
+			{ ! hidePrice
+				? translate( 'Get %(planTitle)s - %(planPrice)s/month', {
+						comment: 'Eg: Get Personal $4/month',
+						args: {
+							planTitle: planUpsellInfo.title,
+							planPrice: planUpsellInfo.formattedPriceMonthly,
+						},
+				  } )
+				: translate( 'Get %(planTitle)s', {
+						comment: 'Eg: Get Personal',
+						args: {
+							planTitle: planUpsellInfo.title,
+						},
+				  } ) }
 		</PlanButton>
 	);
 }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
@@ -1,51 +1,65 @@
-import { type PlanSlug, PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
-import styled from '@emotion/styled';
+import {
+	type PlanSlug,
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
+} from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
-import PlanUpsellButton from './plan-upsell-button';
-import { DomainName } from '.';
+import PlanItem from './plan-item';
 
-const FreeDomainText = styled.div`
-	font-size: 14px;
-	line-height: 20px;
-	letter-spacing: -0.15px;
-	color: var( --studio-green-50 );
-	margin-top: 4px;
-`;
-
-export default function SuggestedPlanSection( props: {
-	paidDomainName?: string;
-	onPlanSelected: ( planSlug: PlanSlug ) => void;
+interface Props {
+	hidePersonalPlan?: boolean;
+	hidePremiumPlan?: boolean;
 	isBusy: boolean;
-} ) {
+	onPlanSelected: ( planSlug: PlanSlug ) => void;
+}
+
+/**
+ * List the suggested plan for paid features.
+ */
+export default function SuggestedPlanSection( {
+	hidePersonalPlan,
+	hidePremiumPlan,
+	isBusy,
+	onPlanSelected,
+}: Props ) {
 	const translate = useTranslate();
-	const { paidDomainName, onPlanSelected, isBusy } = props;
+	const suggestedPlans = [
+		{
+			planSlug: PLAN_PERSONAL,
+			description: translate( 'Domain credit, some premium themes' ),
+			disabled: hidePersonalPlan,
+		},
+		{
+			planSlug: PLAN_PREMIUM,
+			description: translate( 'Domain credit, all premium themes' ),
+			disabled: hidePremiumPlan,
+		},
+		{
+			planSlug: PLAN_BUSINESS,
+			description: translate( 'Domain credit, plugins, all premium themes' ),
+		},
+		{
+			planSlug: PLAN_ECOMMERCE,
+			description: translate( 'Domain credit, plugins, all premium and store themes, WooCommerce' ),
+		},
+	];
 
 	return (
 		<>
-			{ paidDomainName && (
-				<DomainName>
-					<div>{ paidDomainName }</div>
-					<FreeDomainText>{ translate( 'Free for one year' ) }</FreeDomainText>
-				</DomainName>
-			) }
-			<PlanUpsellButton
-				planSlug={ PLAN_PERSONAL }
-				onPlanSelected={ onPlanSelected }
-				isBusy={ isBusy }
-			/>
-			{ paidDomainName && (
-				<DomainName>
-					<div>{ paidDomainName }</div>
-					<FreeDomainText>
-						{ translate( 'Free for one year. Includes Premium themes.' ) }
-					</FreeDomainText>
-				</DomainName>
-			) }
-			<PlanUpsellButton
-				planSlug={ PLAN_PREMIUM }
-				onPlanSelected={ onPlanSelected }
-				isBusy={ isBusy }
-			/>
+			{ suggestedPlans
+				.filter( ( plan ) => ! plan.disabled )
+				.slice( 0, 2 )
+				.map( ( { planSlug, description } ) => (
+					<PlanItem
+						key={ planSlug }
+						planSlug={ plan }
+						description={ description }
+						isBusy={ isBusy }
+						onPlanSelected={ onPlanSelected }
+					/>
+				) ) }
 		</>
 	);
 }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
@@ -7,6 +7,7 @@ import {
 } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import PlanItem from './plan-item';
+import { RowWithBorder } from '.';
 
 interface Props {
 	hidePersonalPlan?: boolean;
@@ -52,13 +53,15 @@ export default function SuggestedPlanSection( {
 				.filter( ( plan ) => ! plan.disabled )
 				.slice( 0, 2 )
 				.map( ( { planSlug, description } ) => (
-					<PlanItem
-						key={ planSlug }
-						planSlug={ plan }
-						description={ description }
-						isBusy={ isBusy }
-						onPlanSelected={ onPlanSelected }
-					/>
+					<RowWithBorder>
+						<PlanItem
+							key={ planSlug }
+							planSlug={ planSlug as PlanSlug }
+							description={ description }
+							isBusy={ isBusy }
+							onPlanSelected={ onPlanSelected }
+						/>
+					</RowWithBorder>
 				) ) }
 		</>
 	);

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-paid-domain-dialog.tsx
@@ -13,7 +13,7 @@ import {
 	SubHeading,
 	DomainName,
 } from './components';
-import SuggestedPlanSection from './components/suggested-plan-section';
+import PaidDomainSuggestedPlanSection from './components/paid-domain-suggested-plan-section';
 import { DomainPlanDialogProps, MODAL_VIEW_EVENT_NAME } from '.';
 
 export function FreePlanPaidDomainDialog( {
@@ -61,7 +61,7 @@ export function FreePlanPaidDomainDialog( {
 			</SubHeading>
 			<ButtonContainer>
 				<RowWithBorder>
-					<SuggestedPlanSection
+					<PaidDomainSuggestedPlanSection
 						paidDomainName={ paidDomainName }
 						isBusy={ isBusy }
 						onPlanSelected={ onPlanSelected }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
@@ -1,5 +1,6 @@
 import { isFreePlan } from '@automattic/calypso-products';
-import { ONBOARDING_GUIDED_FLOW } from '@automattic/onboarding';
+import { FREE_THEME } from '@automattic/design-picker';
+import { ONBOARDING_GUIDED_FLOW, ONBOARDING_FLOW } from '@automattic/onboarding';
 import { useCallback } from '@wordpress/element';
 import {
 	FREE_PLAN_FREE_DOMAIN_DIALOG,
@@ -7,11 +8,13 @@ import {
 	ModalType,
 	PAID_PLAN_IS_REQUIRED_DIALOG,
 } from '..';
+
 type Props = {
 	isCustomDomainAllowedOnFreePlan?: boolean | null;
 	flowName?: string | null;
 	paidDomainName?: string | null;
 	intent?: string | null;
+	selectedThemeType?: string;
 };
 
 /**
@@ -22,30 +25,38 @@ export function useModalResolutionCallback( {
 	flowName,
 	paidDomainName,
 	intent,
+	selectedThemeType,
 }: Props ) {
 	return useCallback(
 		( currentSelectedPlan?: string | null ): ModalType | null => {
-			if ( currentSelectedPlan && isFreePlan( currentSelectedPlan ) ) {
-				if ( isCustomDomainAllowedOnFreePlan ) {
-					if ( paidDomainName ) {
-						return FREE_PLAN_PAID_DOMAIN_DIALOG;
-					}
-					return FREE_PLAN_FREE_DOMAIN_DIALOG;
-				}
-
-				// TODO: look into decoupling the flowName from here as well.
-				if (
-					paidDomainName &&
-					( ( flowName && [ ONBOARDING_GUIDED_FLOW, 'onboarding' ].includes( flowName ) ) ||
-						[ 'plans-jetpack-app-site-creation', 'plans-site-selected-legacy' ].includes(
-							intent || ''
-						) )
-				) {
-					return PAID_PLAN_IS_REQUIRED_DIALOG;
-				}
+			if ( ! currentSelectedPlan || ! isFreePlan( currentSelectedPlan ) ) {
+				return null;
 			}
+
+			if ( selectedThemeType && selectedThemeType !== FREE_THEME ) {
+				return PAID_PLAN_IS_REQUIRED_DIALOG;
+			}
+
+			if ( isCustomDomainAllowedOnFreePlan ) {
+				if ( paidDomainName ) {
+					return FREE_PLAN_PAID_DOMAIN_DIALOG;
+				}
+				return FREE_PLAN_FREE_DOMAIN_DIALOG;
+			}
+
+			// TODO: look into decoupling the flowName from here as well.
+			if (
+				paidDomainName &&
+				( ( flowName && [ ONBOARDING_GUIDED_FLOW, ONBOARDING_FLOW ].includes( flowName ) ) ||
+					[ 'plans-jetpack-app-site-creation', 'plans-site-selected-legacy' ].includes(
+						intent || ''
+					) )
+			) {
+				return PAID_PLAN_IS_REQUIRED_DIALOG;
+			}
+
 			return null;
 		},
-		[ isCustomDomainAllowedOnFreePlan, flowName, paidDomainName, intent ]
+		[ isCustomDomainAllowedOnFreePlan, flowName, paidDomainName, intent, selectedThemeType ]
 	);
 }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
@@ -5,8 +5,9 @@ import { useCallback } from '@wordpress/element';
 import {
 	FREE_PLAN_FREE_DOMAIN_DIALOG,
 	FREE_PLAN_PAID_DOMAIN_DIALOG,
-	ModalType,
+	PAID_PLAN_PAID_DOMAIN_DIALOG,
 	PAID_PLAN_IS_REQUIRED_DIALOG,
+	ModalType,
 } from '..';
 
 type Props = {
@@ -52,7 +53,7 @@ export function useModalResolutionCallback( {
 						intent || ''
 					) )
 			) {
-				return PAID_PLAN_IS_REQUIRED_DIALOG;
+				return PAID_PLAN_PAID_DOMAIN_DIALOG;
 			}
 
 			return null;

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/index.tsx
@@ -20,6 +20,8 @@ export type ModalType =
 export type DomainPlanDialogProps = {
 	paidDomainName?: string;
 	generatedWPComSubdomain: DataResponse< { domain_name: string } >;
+	selectedThemeType?: string;
+	isGoalsAtFrontExperiment?: boolean;
 	upsellPremiumPlan?: boolean;
 	onFreePlanSelected: ( isDomainRetained?: boolean ) => void;
 	onPlanSelected: ( planSlug: PlanSlug ) => void;
@@ -47,7 +49,7 @@ function getDisplayedModal( modalType: ModalType, dialogProps: DomainPlanDialogP
 	}
 }
 
-export default function ModalContainer( props: ModalContainerProps ) {
+export default function PlanUpsellModal( props: ModalContainerProps ) {
 	const { isModalOpen, modalType } = props;
 
 	if ( ! modalType ) {

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/index.tsx
@@ -3,17 +3,20 @@ import { Dialog } from '@automattic/components';
 import { Global, css } from '@emotion/react';
 import { FreePlanFreeDomainDialog } from './free-plan-free-domain-dialog';
 import { FreePlanPaidDomainDialog } from './free-plan-paid-domain-dialog';
-import PaidPlanIsRequiredDialog from './paid-plan-is-required-dialog';
+import { PaidPlanIsRequiredDialog } from './paid-plan-is-required-dialog';
+import { PaidPlanPaidDomainDialog } from './paid-plan-paid-domain-dialog';
 import type { DataResponse } from '@automattic/plans-grid-next';
 
 export const PAID_PLAN_IS_REQUIRED_DIALOG = 'PAID_PLAN_IS_REQUIRED_DIALOG';
 export const FREE_PLAN_PAID_DOMAIN_DIALOG = 'FREE_PLAN_PAID_DOMAIN_DIALOG';
 export const FREE_PLAN_FREE_DOMAIN_DIALOG = 'FREE_PLAN_FREE_DOMAIN_DIALOG';
+export const PAID_PLAN_PAID_DOMAIN_DIALOG = 'PAID_PLAN_FREE_DOMAIN_DIALOG';
 export const MODAL_LOADER = 'MODAL_LOADER';
 
 export type ModalType =
 	| typeof FREE_PLAN_FREE_DOMAIN_DIALOG
 	| typeof FREE_PLAN_PAID_DOMAIN_DIALOG
+	| typeof PAID_PLAN_PAID_DOMAIN_DIALOG
 	| typeof PAID_PLAN_IS_REQUIRED_DIALOG
 	| typeof MODAL_LOADER;
 
@@ -21,7 +24,6 @@ export type DomainPlanDialogProps = {
 	paidDomainName?: string;
 	generatedWPComSubdomain: DataResponse< { domain_name: string } >;
 	selectedThemeType?: string;
-	isGoalsAtFrontExperiment?: boolean;
 	upsellPremiumPlan?: boolean;
 	onFreePlanSelected: ( isDomainRetained?: boolean ) => void;
 	onPlanSelected: ( planSlug: PlanSlug ) => void;
@@ -42,6 +44,8 @@ function getDisplayedModal( modalType: ModalType, dialogProps: DomainPlanDialogP
 			return <FreePlanPaidDomainDialog { ...dialogProps } />;
 		case FREE_PLAN_FREE_DOMAIN_DIALOG:
 			return <FreePlanFreeDomainDialog { ...dialogProps } />;
+		case PAID_PLAN_PAID_DOMAIN_DIALOG:
+			return <PaidPlanPaidDomainDialog { ...dialogProps } />;
 		case PAID_PLAN_IS_REQUIRED_DIALOG:
 			return <PaidPlanIsRequiredDialog { ...dialogProps } />;
 		default:
@@ -61,6 +65,7 @@ export default function PlanUpsellModal( props: ModalContainerProps ) {
 			case FREE_PLAN_PAID_DOMAIN_DIALOG:
 			case FREE_PLAN_FREE_DOMAIN_DIALOG:
 				return '605px';
+			case PAID_PLAN_PAID_DOMAIN_DIALOG:
 			case PAID_PLAN_IS_REQUIRED_DIALOG:
 			default:
 				return '639px';

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getHidePlanPropsBasedOnThemeType } from '../utils/utils';
-import { ButtonContainer, DialogContainer, Heading, Row, RowWithBorder } from './components';
+import { ButtonContainer, DialogContainer, Heading, Row } from './components';
 import { PlanName, PlanDescription } from './components/plan-item';
 import SuggestedPlanSection from './components/suggested-plan-section';
 import { DomainPlanDialogProps, MODAL_VIEW_EVENT_NAME } from '.';
@@ -51,14 +51,12 @@ export const PaidPlanIsRequiredDialog = ( {
 				{ getUpsellTitle() }
 			</Heading>
 			<ButtonContainer>
-				<RowWithBorder>
-					<SuggestedPlanSection
-						{ ...hidePlanProps }
-						paidDomainName={ paidDomainName }
-						isBusy={ isBusy }
-						onPlanSelected={ onPlanSelected }
-					/>
-				</RowWithBorder>
+				<SuggestedPlanSection
+					{ ...hidePlanProps }
+					paidDomainName={ paidDomainName }
+					isBusy={ isBusy }
+					onPlanSelected={ onPlanSelected }
+				/>
 				<Row>
 					<div>
 						<PlanName>{ translate( 'Free' ) }</PlanName>
@@ -75,7 +73,7 @@ export const PaidPlanIsRequiredDialog = ( {
 						busy={ isBusy }
 						onClick={ handleFreeDomainClick }
 					>
-						{ translate( 'Continue with Free plan' ) }
+						{ translate( 'Continue with Free' ) }
 					</PlanButton>
 				</Row>
 			</ButtonContainer>

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
@@ -4,14 +4,9 @@ import { PlanButton } from '@automattic/plans-grid-next';
 import { useEffect, useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import {
-	ButtonContainer,
-	DialogContainer,
-	Heading,
-	Row,
-	RowWithBorder,
-	DomainName,
-} from './components';
+import { getHidePlanPropsBasedOnThemeType } from '../utils/utils';
+import { ButtonContainer, DialogContainer, Heading, Row, RowWithBorder } from './components';
+import { PlanName, PlanDescription } from './components/plan-item';
 import SuggestedPlanSection from './components/suggested-plan-section';
 import { DomainPlanDialogProps, MODAL_VIEW_EVENT_NAME } from '.';
 
@@ -25,14 +20,15 @@ export const PaidPlanIsRequiredDialog = ( {
 	const translate = useTranslate();
 	const [ isBusy, setIsBusy ] = useState( false );
 	const isPaidTheme = selectedThemeType && selectedThemeType !== FREE_THEME;
+	const hidePlanProps = getHidePlanPropsBasedOnThemeType( selectedThemeType );
 
 	const getUpsellTitle = () => {
 		if ( isPaidTheme && paidDomainName ) {
-			return translate( 'Custom domains and paid themes are only available with a paid plan' );
+			return translate( 'Custom domains and premium themes are only available with a paid plan' );
 		}
 
 		if ( isPaidTheme ) {
-			return translate( 'Paid themes are only available with a paid plan' );
+			return translate( 'Premium themes are only available with a paid plan' );
 		}
 
 		return translate( 'Custom domains are only available with a paid plan' );
@@ -57,18 +53,23 @@ export const PaidPlanIsRequiredDialog = ( {
 			<ButtonContainer>
 				<RowWithBorder>
 					<SuggestedPlanSection
+						{ ...hidePlanProps }
 						paidDomainName={ paidDomainName }
 						isBusy={ isBusy }
 						onPlanSelected={ onPlanSelected }
 					/>
 				</RowWithBorder>
 				<Row>
-					<DomainName>
-						{ generatedWPComSubdomain.isLoading && <LoadingPlaceholder /> }
-						{ generatedWPComSubdomain.result && (
-							<div>{ generatedWPComSubdomain.result.domain_name }</div>
-						) }
-					</DomainName>
+					<div>
+						<PlanName>{ translate( 'Free' ) }</PlanName>
+						<PlanDescription>
+							{ generatedWPComSubdomain.isLoading && <LoadingPlaceholder /> }
+							{ generatedWPComSubdomain.result && (
+								<div>{ generatedWPComSubdomain.result.domain_name }</div>
+							) }
+							{ translate( 'Switch to our free default theme' ) }
+						</PlanDescription>
+					</div>
 					<PlanButton
 						disabled={ generatedWPComSubdomain.isLoading || ! generatedWPComSubdomain.result }
 						busy={ isBusy }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
@@ -61,8 +61,8 @@ export const PaidPlanIsRequiredDialog = ( {
 					<div>
 						<PlanName>{ translate( 'Free' ) }</PlanName>
 						<PlanDescription>
-							{ generatedWPComSubdomain.isLoading && <LoadingPlaceholder /> }
-							{ generatedWPComSubdomain.result && (
+							{ paidDomainName && generatedWPComSubdomain.isLoading && <LoadingPlaceholder /> }
+							{ paidDomainName && generatedWPComSubdomain.result && (
 								<div>{ generatedWPComSubdomain.result.domain_name }</div>
 							) }
 							{ translate( 'Switch to our free default theme' ) }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
@@ -20,7 +20,7 @@ export const PaidPlanIsRequiredDialog = ( {
 	const translate = useTranslate();
 	const [ isBusy, setIsBusy ] = useState( false );
 	const isPaidTheme = selectedThemeType && selectedThemeType !== FREE_THEME;
-	const hidePlanProps = getHidePlanPropsBasedOnThemeType( selectedThemeType );
+	const hidePlanProps = getHidePlanPropsBasedOnThemeType( selectedThemeType || '' );
 
 	const getUpsellTitle = () => {
 		if ( isPaidTheme && paidDomainName ) {
@@ -53,7 +53,6 @@ export const PaidPlanIsRequiredDialog = ( {
 			<ButtonContainer>
 				<SuggestedPlanSection
 					{ ...hidePlanProps }
-					paidDomainName={ paidDomainName }
 					isBusy={ isBusy }
 					onPlanSelected={ onPlanSelected }
 				/>

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-paid-domain-dialog.tsx
@@ -12,7 +12,7 @@ import {
 	RowWithBorder,
 	DomainName,
 } from './components';
-import SuggestedPlanSection from './components/suggested-plan-section';
+import PaidDomainSuggestedPlanSection from './components/paid-domain-suggested-plan-section';
 import { DomainPlanDialogProps, MODAL_VIEW_EVENT_NAME } from '.';
 
 export function PaidPlanPaidDomainDialog( {
@@ -47,7 +47,7 @@ export function PaidPlanPaidDomainDialog( {
 			<SubHeading id="plan-upsell-modal-description">{ upsellDescription }</SubHeading>
 			<ButtonContainer>
 				<RowWithBorder>
-					<SuggestedPlanSection
+					<PaidDomainSuggestedPlanSection
 						paidDomainName={ paidDomainName }
 						isBusy={ isBusy }
 						onPlanSelected={ onPlanSelected }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-paid-domain-dialog.tsx
@@ -1,5 +1,4 @@
 import { LoadingPlaceholder } from '@automattic/components';
-import { FREE_THEME } from '@automattic/design-picker';
 import { PlanButton } from '@automattic/plans-grid-next';
 import { useEffect, useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
@@ -8,6 +7,7 @@ import {
 	ButtonContainer,
 	DialogContainer,
 	Heading,
+	SubHeading,
 	Row,
 	RowWithBorder,
 	DomainName,
@@ -15,33 +15,14 @@ import {
 import SuggestedPlanSection from './components/suggested-plan-section';
 import { DomainPlanDialogProps, MODAL_VIEW_EVENT_NAME } from '.';
 
-export const PaidPlanIsRequiredDialog = ( {
+export function PaidPlanPaidDomainDialog( {
 	paidDomainName,
 	generatedWPComSubdomain,
-	selectedThemeType,
 	onFreePlanSelected,
 	onPlanSelected,
-}: DomainPlanDialogProps ) => {
+}: DomainPlanDialogProps ) {
 	const translate = useTranslate();
 	const [ isBusy, setIsBusy ] = useState( false );
-	const isPaidTheme = selectedThemeType && selectedThemeType !== FREE_THEME;
-
-	const getUpsellTitle = () => {
-		if ( isPaidTheme && paidDomainName ) {
-			return translate( 'Custom domains and paid themes are only available with a paid plan' );
-		}
-
-		if ( isPaidTheme ) {
-			return translate( 'Paid themes are only available with a paid plan' );
-		}
-
-		return translate( 'Custom domains are only available with a paid plan' );
-	};
-
-	const handleFreeDomainClick = () => {
-		setIsBusy( true );
-		onFreePlanSelected();
-	};
 
 	useEffect( () => {
 		recordTracksEvent( MODAL_VIEW_EVENT_NAME, {
@@ -49,11 +30,21 @@ export const PaidPlanIsRequiredDialog = ( {
 		} );
 	}, [] );
 
+	function handleFreeDomainClick() {
+		setIsBusy( true );
+		onFreePlanSelected();
+	}
+
+	const upsellDescription = translate(
+		"Custom domains are only available with a paid plan. Choose annual billing and receive the domain's first year free."
+	);
+
 	return (
 		<DialogContainer>
 			<Heading id="plan-upsell-modal-title" shrinkMobileFont>
-				{ getUpsellTitle() }
+				{ translate( 'A paid plan is required for your domain.' ) }
 			</Heading>
+			<SubHeading id="plan-upsell-modal-description">{ upsellDescription }</SubHeading>
 			<ButtonContainer>
 				<RowWithBorder>
 					<SuggestedPlanSection
@@ -80,4 +71,4 @@ export const PaidPlanIsRequiredDialog = ( {
 			</ButtonContainer>
 		</DialogContainer>
 	);
-};
+}

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/test/plan-upsell-modal.test.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/test/plan-upsell-modal.test.tsx
@@ -6,7 +6,7 @@ import { screen, renderHook } from '@testing-library/react';
 import {
 	FREE_PLAN_FREE_DOMAIN_DIALOG,
 	FREE_PLAN_PAID_DOMAIN_DIALOG,
-	PAID_PLAN_IS_REQUIRED_DIALOG,
+	PAID_PLAN_PAID_DOMAIN_DIALOG,
 } from '..';
 import { renderWithProvider } from '../../../../../test-helpers/testing-library';
 import { useModalResolutionCallback } from '../hooks/use-modal-resolution-callback';
@@ -65,7 +65,7 @@ describe( 'PlanUpsellModal tests', () => {
 			expect( screen.queryByText( /DIALOG/i ) ).toBeNull();
 		} );
 
-		test( 'A paid domain should show the PAID_PLAN_IS_REQUIRED_DIALOG without custom domains enabled for the Free plan', () => {
+		test( 'A paid domain should show the PAID_PLAN_PAID_DOMAIN_DIALOG without custom domains enabled for the Free plan', () => {
 			renderWithProvider(
 				<MockPlansFeaturesMain
 					flowName="onboarding"
@@ -74,7 +74,7 @@ describe( 'PlanUpsellModal tests', () => {
 				/>
 			);
 			expect( screen.getByTestId( 'modal-render' ) ).toHaveTextContent(
-				PAID_PLAN_IS_REQUIRED_DIALOG
+				PAID_PLAN_PAID_DOMAIN_DIALOG
 			);
 		} );
 
@@ -124,7 +124,7 @@ describe( 'PlanUpsellModal tests', () => {
 			expect( queryByText4( /DIALOG/i ) ).toBeNull();
 		} );
 
-		test( 'A paid domain with Jetpack App intent should show the PAID_PLAN_IS_REQUIRED_DIALOG', () => {
+		test( 'A paid domain with Jetpack App intent should show the PAID_PLAN_PAID_DOMAIN_DIALOG', () => {
 			renderWithProvider(
 				<MockPlansFeaturesMain
 					selectedPlan={ PLAN_FREE }
@@ -133,7 +133,7 @@ describe( 'PlanUpsellModal tests', () => {
 				/>
 			);
 			expect( screen.getByTestId( 'modal-render' ) ).toHaveTextContent(
-				PAID_PLAN_IS_REQUIRED_DIALOG
+				PAID_PLAN_PAID_DOMAIN_DIALOG
 			);
 		} );
 

--- a/client/my-sites/plans-features-main/components/utils/utils.ts
+++ b/client/my-sites/plans-features-main/components/utils/utils.ts
@@ -1,3 +1,10 @@
+import {
+	PERSONAL_THEME,
+	PREMIUM_THEME,
+	DOT_ORG_THEME,
+	BUNDLED_THEME,
+	MARKETPLACE_THEME,
+} from '@automattic/design-picker';
 import { PlansIntent } from '@automattic/plans-grid-next';
 
 /* For Guided Signup intents we want to force the default plans for the comparison table. See: pdDR7T-1xi-p2 */
@@ -12,4 +19,36 @@ export const shouldForceDefaultPlansBasedOnIntent = ( intent: PlansIntent | unde
 			'plans-guided-segment-developer-or-agency',
 		].includes( intent )
 	);
+};
+
+/**
+ * Determine which plans should be displayed based on the type of the selected theme.
+ */
+export const getHidePlanPropsBasedOnThemeType = ( themeType: string ) => {
+	/**
+	 * Marketplace themes: Display only Business and eCommerce plans.
+	 */
+	if (
+		themeType === DOT_ORG_THEME ||
+		themeType === MARKETPLACE_THEME ||
+		themeType === BUNDLED_THEME
+	) {
+		return { hidePremiumPlan: true, hidePersonalPlan: true, hideFreePlan: true };
+	}
+
+	/**
+	 * Premium themes: Display Premium, Business and eCommerce
+	 */
+	if ( themeType === PREMIUM_THEME ) {
+		return { hidePersonalPlan: true, hideFreePlan: true };
+	}
+
+	/**
+	 * Personal themes: Display Personal, Premium, Business and eCommerce
+	 */
+	if ( themeType === PERSONAL_THEME ) {
+		return { hideFreePlan: true };
+	}
+
+	return {};
 };

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -177,6 +177,13 @@ export interface PlansFeaturesMainProps {
 	 * It's outside of the intent system since it is about the way the Free plan is presented, not the plan mix available to choose.
 	 */
 	deemphasizeFreePlan?: boolean;
+
+	selectedThemeType?: string;
+
+	/**
+	 * Whether the user should have the "goals first" onboarding experience
+	 */
+	isGoalsAtFrontExperiment?: boolean;
 }
 
 const PlansFeaturesMain = ( {
@@ -220,6 +227,8 @@ const PlansFeaturesMain = ( {
 	showPlanTypeSelectorDropdown = false,
 	coupon,
 	onPlanIntervalUpdate,
+	selectedThemeType,
+	isGoalsAtFrontExperiment,
 }: PlansFeaturesMainProps ) => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	// TODO: Remove temporary eslint disable
@@ -250,6 +259,7 @@ const PlansFeaturesMain = ( {
 		flowName,
 		paidDomainName,
 		intent: intentFromProps,
+		selectedThemeType,
 	} );
 
 	const toggleShowPlansComparisonGrid = () => {
@@ -783,6 +793,8 @@ const PlansFeaturesMain = ( {
 					paidDomainName={ paidDomainName }
 					modalType={ resolveModal( lastClickedPlan ) }
 					generatedWPComSubdomain={ resolvedSubdomainName }
+					selectedThemeType={ selectedThemeType }
+					isGoalsAtFrontExperiment={ isGoalsAtFrontExperiment }
 					onClose={ () => setIsModalOpen( false ) }
 					onFreePlanSelected={ ( isDomainRetained ) => {
 						if ( ! isDomainRetained ) {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -179,11 +179,6 @@ export interface PlansFeaturesMainProps {
 	deemphasizeFreePlan?: boolean;
 
 	selectedThemeType?: string;
-
-	/**
-	 * Whether the user should have the "goals first" onboarding experience
-	 */
-	isGoalsAtFrontExperiment?: boolean;
 }
 
 const PlansFeaturesMain = ( {
@@ -228,7 +223,6 @@ const PlansFeaturesMain = ( {
 	coupon,
 	onPlanIntervalUpdate,
 	selectedThemeType,
-	isGoalsAtFrontExperiment,
 }: PlansFeaturesMainProps ) => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	// TODO: Remove temporary eslint disable
@@ -794,7 +788,6 @@ const PlansFeaturesMain = ( {
 					modalType={ resolveModal( lastClickedPlan ) }
 					generatedWPComSubdomain={ resolvedSubdomainName }
 					selectedThemeType={ selectedThemeType }
-					isGoalsAtFrontExperiment={ isGoalsAtFrontExperiment }
 					onClose={ () => setIsModalOpen( false ) }
 					onFreePlanSelected={ ( isDomainRetained ) => {
 						if ( ! isDomainRetained ) {

--- a/client/signup/steps/plans-theme-preselected/index.tsx
+++ b/client/signup/steps/plans-theme-preselected/index.tsx
@@ -1,15 +1,9 @@
 import { Button } from '@automattic/components';
-import {
-	FREE_THEME,
-	PERSONAL_THEME,
-	PREMIUM_THEME,
-	DOT_ORG_THEME,
-	BUNDLED_THEME,
-	MARKETPLACE_THEME,
-} from '@automattic/design-picker';
+import { FREE_THEME } from '@automattic/design-picker';
 import { isDesktop } from '@automattic/viewport';
 import { localize, translate } from 'i18n-calypso';
 import { buildUpgradeFunction } from 'calypso/lib/signup/step-actions';
+import { getHidePlanPropsBasedOnThemeType } from 'calypso/my-sites/plans-features-main/components/utils/utils';
 import PlansStep from 'calypso/signup/steps/plans';
 
 type SignupDependencies = {
@@ -17,45 +11,10 @@ type SignupDependencies = {
 	styleVariation: string | null;
 };
 
-/**
- * Determine which plans should be displayed based on the signupDependencies.
- *
- * Instead of making an API call (which is expensive), we are retrieving the information based on the query Params that were passed when the flow started.
- * @param signupDependencies
- */
-function getHidePlanPropsBasedOnSignupDependencies(
-	signupDependencies: SignupDependencies
-): object {
-	/**
-	 * Marketplace themes: Display only Business and eCommerce plans.
-	 */
-	if (
-		signupDependencies.themeType === DOT_ORG_THEME ||
-		signupDependencies.themeType === MARKETPLACE_THEME ||
-		signupDependencies.themeType === BUNDLED_THEME
-	) {
-		return { hidePremiumPlan: true, hidePersonalPlan: true, hideFreePlan: true };
-	}
-
-	/**
-	 * Premium themes: Display Premium, Business and eCommerce
-	 */
-	if ( signupDependencies.themeType === PREMIUM_THEME ) {
-		return { hidePersonalPlan: true, hideFreePlan: true };
-	}
-
-	/**
-	 * Personal themes: Display Personal, Premium, Business and eCommerce
-	 */
-	if ( signupDependencies.themeType === PERSONAL_THEME ) {
-		return { hideFreePlan: true };
-	}
-
-	return {};
-}
-
 function PlansThemePreselectedStep( props: object & { signupDependencies: SignupDependencies } ) {
-	const hidePlanProps = getHidePlanPropsBasedOnSignupDependencies( props.signupDependencies );
+	const hidePlanProps = getHidePlanPropsBasedOnThemeType(
+		props.signupDependencies.themeType || ''
+	);
 
 	const freePlanButton = (
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/client/state/themes/selectors/get-theme-type.js
+++ b/client/state/themes/selectors/get-theme-type.js
@@ -1,5 +1,6 @@
 import {
 	FREE_THEME,
+	PERSONAL_THEME,
 	PREMIUM_THEME,
 	DOT_ORG_THEME,
 	BUNDLED_THEME,
@@ -7,6 +8,7 @@ import {
 } from '@automattic/design-picker';
 import { doesThemeBundleSoftwareSet } from 'calypso/state/themes/selectors/does-theme-bundle-software-set';
 import { isExternallyManagedTheme } from 'calypso/state/themes/selectors/is-externally-managed-theme';
+import { isThemePersonal } from 'calypso/state/themes/selectors/is-theme-personal';
 import { isThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
 import { isWpcomTheme } from 'calypso/state/themes/selectors/is-wpcom-theme';
 import { isWporgTheme } from 'calypso/state/themes/selectors/is-wporg-theme';
@@ -32,7 +34,11 @@ export function getThemeType( state, themeId ) {
 		return PREMIUM_THEME;
 	}
 
-	if ( isWpcomTheme( state, themeId ) && ! isThemePremium( state, themeId ) ) {
+	if ( isThemePersonal( state, themeId ) ) {
+		return PERSONAL_THEME;
+	}
+
+	if ( isWpcomTheme( state, themeId ) ) {
 		return FREE_THEME;
 	}
 

--- a/client/state/themes/selectors/is-theme-personal.js
+++ b/client/state/themes/selectors/is-theme-personal.js
@@ -1,0 +1,17 @@
+import { getThemeTierForTheme } from 'calypso/state/themes/selectors/get-theme-tier-for-theme';
+
+import 'calypso/state/themes/init';
+
+/**
+ * Whether a WPCOM theme given by its ID is personal.
+ * @param  {Object} state   Global state tree
+ * @param  {string} themeId Theme ID
+ * @returns {boolean}        True if the theme is personal
+ */
+export function isThemePersonal( state, themeId ) {
+	const themeTier = getThemeTierForTheme( state, themeId );
+	if ( themeTier?.slug ) {
+		return 'personal' === themeTier?.slug;
+	}
+	return false;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/97300

## Proposed Changes

* Display the free plan modal correctly for paid themes & paid domains
* Fix the premium theme cannot be selected
* Make `getThemeType` return the `personal` theme type for the personal theme

| Case | Screenshot |
| - | - |
| Paid Domain (Keep the same) | <img width="660" alt="image" src="https://github.com/user-attachments/assets/78c602af-2e71-4344-9759-2de863bf65b4" /> |
| Free Domain + Personal Theme | <img width="655" alt="image" src="https://github.com/user-attachments/assets/0ef38fd9-81b5-4345-aeee-81525def4ba9" /> |
| Paid Domain + Personal Theme | <img width="658" alt="image" src="https://github.com/user-attachments/assets/05e8492a-1119-4a69-aad4-05df7de83321" /> |
| Free Domain + Premium Theme | <img width="654" alt="image" src="https://github.com/user-attachments/assets/ae3b1e9c-f86e-4329-8d82-733a8dea9e57" /> |
| Free Domain + Business/Woo Theme | <img width="657" alt="image" src="https://github.com/user-attachments/assets/67df67f6-a4c6-4565-b0b5-476441c4bd05" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/onboarding
* On the Goals screen, select any goals
* On the Design Picker screen, select following themes
  * Free themes
  * Personal themes, e.g.: Psychedeli
  * Premium themes, e.g.: Bark
  * Business/Woo themes, e.g.: Tsubaki
* On the Domain screen, select free/paid domain
* On the Plan screen, click `start with a free plan` below the header
* Ensure the modal works as expected
* Pick "Continue with Free"
* Ensure the selected theme won't be applied

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
