### PR TITLE
Onboarding: Fix the back button on the Domain screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -10,6 +10,7 @@ import {
 	HUNDRED_YEAR_PLAN_FLOW,
 	isDomainUpsellFlow,
 	isSiteAssemblerFlow,
+	isOnboardingFlow,
 	HUNDRED_YEAR_DOMAIN_FLOW,
 } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
@@ -282,14 +283,14 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			return setShowUseYourDomain( false );
 		}
 
-		if ( isDomainUpsellFlow( flow ) || isSiteAssemblerFlow( flow ) ) {
+		if ( isDomainUpsellFlow( flow ) || isSiteAssemblerFlow( flow ) || isOnboardingFlow( flow ) ) {
 			return goBack?.();
 		}
 		return exitFlow?.( '/sites' );
 	};
 
 	const getBackLabelText = () => {
-		if ( isDomainUpsellFlow( flow ) || isSiteAssemblerFlow( flow ) ) {
+		if ( isDomainUpsellFlow( flow ) || isSiteAssemblerFlow( flow ) || isOnboardingFlow( flow ) ) {
 			return __( 'Back' );
 		}
 		return __( 'Back to sites' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -10,7 +10,6 @@ import {
 	HUNDRED_YEAR_PLAN_FLOW,
 	isDomainUpsellFlow,
 	isSiteAssemblerFlow,
-	isOnboardingFlow,
 	HUNDRED_YEAR_DOMAIN_FLOW,
 } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
@@ -283,14 +282,14 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			return setShowUseYourDomain( false );
 		}
 
-		if ( isDomainUpsellFlow( flow ) || isSiteAssemblerFlow( flow ) || isOnboardingFlow( flow ) ) {
+		if ( isDomainUpsellFlow( flow ) || isSiteAssemblerFlow( flow ) ) {
 			return goBack?.();
 		}
 		return exitFlow?.( '/sites' );
 	};
 
 	const getBackLabelText = () => {
-		if ( isDomainUpsellFlow( flow ) || isSiteAssemblerFlow( flow ) || isOnboardingFlow( flow ) ) {
+		if ( isDomainUpsellFlow( flow ) || isSiteAssemblerFlow( flow ) ) {
 			return __( 'Back' );
 		}
 		return __( 'Back to sites' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
@@ -29,6 +29,7 @@ import { fetchUsernameSuggestion } from 'calypso/state/signup/optional-dependenc
 import { removeStep } from 'calypso/state/signup/progress/actions';
 import { setDesignType } from 'calypso/state/signup/steps/design-type/actions';
 import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors';
+import { useGoalsFirstExperiment } from '../../../helpers/use-goals-first-experiment';
 import { ProvidedDependencies, StepProps } from '../../types';
 import { useIsManagedSiteFlowProps } from './use-is-managed-site-flow';
 
@@ -90,6 +91,7 @@ export default function DomainsStep( props: StepProps ) {
 	const [ stepState, setStepState ] =
 		useStepPersistedState< ProvidedDependencies >( 'domains-step' );
 	const managedSiteFlowProps = useIsManagedSiteFlowProps();
+	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 
 	return (
 		<CalypsoShoppingCartProvider>
@@ -112,6 +114,7 @@ export default function DomainsStep( props: StepProps ) {
 				} }
 				step={ stepState }
 				flowName={ props.flow }
+				goBack={ isGoalsAtFrontExperiment ? props.navigation.goBack : undefined }
 				useStepperWrapper
 			/>
 		</CalypsoShoppingCartProvider>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
@@ -29,7 +29,6 @@ import { fetchUsernameSuggestion } from 'calypso/state/signup/optional-dependenc
 import { removeStep } from 'calypso/state/signup/progress/actions';
 import { setDesignType } from 'calypso/state/signup/steps/design-type/actions';
 import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors';
-import { useGoalsFirstExperiment } from '../../../helpers/use-goals-first-experiment';
 import { ProvidedDependencies, StepProps } from '../../types';
 import { useIsManagedSiteFlowProps } from './use-is-managed-site-flow';
 
@@ -91,7 +90,6 @@ export default function DomainsStep( props: StepProps ) {
 	const [ stepState, setStepState ] =
 		useStepPersistedState< ProvidedDependencies >( 'domains-step' );
 	const managedSiteFlowProps = useIsManagedSiteFlowProps();
-	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 
 	return (
 		<CalypsoShoppingCartProvider>
@@ -114,7 +112,6 @@ export default function DomainsStep( props: StepProps ) {
 				} }
 				step={ stepState }
 				flowName={ props.flow }
-				goBack={ isGoalsAtFrontExperiment ? props.navigation.goBack : undefined }
 				useStepperWrapper
 			/>
 		</CalypsoShoppingCartProvider>

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -272,11 +272,14 @@ const onboarding: Flow = {
 						return navigate( 'use-my-domain' );
 					}
 					return navigate( 'domains' );
+				case 'domains':
+					if ( isGoalsAtFrontExperiment ) {
+						return navigate( 'designSetup' );
+					}
 				case 'designSetup':
 					if ( isGoalsAtFrontExperiment ) {
 						return navigate( 'goals' );
 					}
-					return;
 				default:
 					return;
 			}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -92,6 +92,7 @@ export class RenderDomainsStep extends Component {
 		domainsWithPlansOnly: PropTypes.bool,
 		flowName: PropTypes.string.isRequired,
 		goToNextStep: PropTypes.func.isRequired,
+		goBack: PropTypes.func,
 		isDomainOnly: PropTypes.bool.isRequired,
 		locale: PropTypes.string,
 		path: PropTypes.string.isRequired,
@@ -103,7 +104,6 @@ export class RenderDomainsStep extends Component {
 		selectedSite: PropTypes.object,
 		isReskinned: PropTypes.bool,
 		recordTracksEvent: PropTypes.func,
-		navigation: PropTypes.object,
 	};
 
 	constructor( props ) {
@@ -1303,7 +1303,7 @@ export class RenderDomainsStep extends Component {
 			userSiteCount,
 			previousStepName,
 			useStepperWrapper,
-			navigation: { goBack },
+			goBack,
 		} = this.props;
 		const siteUrl = this.props.selectedSite?.URL;
 		const siteSlug = this.props.queryObject?.siteSlug;

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -5,6 +5,7 @@ import {
 	isWithThemeFlow,
 	isHostingSignupFlow,
 	isOnboardingGuidedFlow,
+	isOnboardingFlow,
 } from '@automattic/onboarding';
 import { isTailoredSignupFlow } from '@automattic/onboarding/src';
 import { withShoppingCart } from '@automattic/shopping-cart';
@@ -1349,6 +1350,11 @@ export class RenderDomainsStep extends Component {
 		} else if ( isOnboardingGuidedFlow( flowName ) ) {
 			// Let the framework decide the back url.
 			backUrl = undefined;
+		} else if ( isOnboardingFlow( flowName ) ) {
+			const searchParams = new URLSearchParams( window.location.search );
+			const existingParams = Object.fromEntries( searchParams.entries() );
+			backUrl = getStepUrl( flowName, 'designSetup', null, this.getLocale(), existingParams );
+			backLabelText = translate( 'Back' );
 		} else {
 			backUrl = getStepUrl( flowName, stepName, null, this.getLocale() );
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -92,6 +92,7 @@ export class RenderDomainsStep extends Component {
 		domainsWithPlansOnly: PropTypes.bool,
 		flowName: PropTypes.string.isRequired,
 		goToNextStep: PropTypes.func.isRequired,
+		goBack: PropTypes.func,
 		isDomainOnly: PropTypes.bool.isRequired,
 		locale: PropTypes.string,
 		path: PropTypes.string.isRequired,
@@ -102,6 +103,7 @@ export class RenderDomainsStep extends Component {
 		stepSectionName: PropTypes.string,
 		selectedSite: PropTypes.object,
 		isReskinned: PropTypes.bool,
+		recordTracksEvent: PropTypes.func,
 	};
 
 	constructor( props ) {
@@ -1301,6 +1303,7 @@ export class RenderDomainsStep extends Component {
 			userSiteCount,
 			previousStepName,
 			useStepperWrapper,
+			goBack,
 		} = this.props;
 		const siteUrl = this.props.selectedSite?.URL;
 		const siteSlug = this.props.queryObject?.siteSlug;
@@ -1350,10 +1353,8 @@ export class RenderDomainsStep extends Component {
 		} else if ( isOnboardingGuidedFlow( flowName ) ) {
 			// Let the framework decide the back url.
 			backUrl = undefined;
-		} else if ( isOnboardingFlow( flowName ) ) {
-			const searchParams = new URLSearchParams( window.location.search );
-			const existingParams = Object.fromEntries( searchParams.entries() );
-			backUrl = getStepUrl( flowName, 'designSetup', null, this.getLocale(), existingParams );
+		} else if ( isOnboardingFlow( flowName ) && !! goBack ) {
+			backUrl = null;
 			backLabelText = translate( 'Back' );
 		} else {
 			backUrl = getStepUrl( flowName, stepName, null, this.getLocale() );
@@ -1414,6 +1415,8 @@ export class RenderDomainsStep extends Component {
 					hideSkip
 					align="center"
 					isWideLayout
+					goBack={ goBack }
+					recordTracksEvent={ this.props.recordTracksEvent }
 				/>
 			);
 		}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -92,7 +92,6 @@ export class RenderDomainsStep extends Component {
 		domainsWithPlansOnly: PropTypes.bool,
 		flowName: PropTypes.string.isRequired,
 		goToNextStep: PropTypes.func.isRequired,
-		goBack: PropTypes.func,
 		isDomainOnly: PropTypes.bool.isRequired,
 		locale: PropTypes.string,
 		path: PropTypes.string.isRequired,
@@ -104,6 +103,7 @@ export class RenderDomainsStep extends Component {
 		selectedSite: PropTypes.object,
 		isReskinned: PropTypes.bool,
 		recordTracksEvent: PropTypes.func,
+		navigation: PropTypes.object,
 	};
 
 	constructor( props ) {
@@ -1303,7 +1303,7 @@ export class RenderDomainsStep extends Component {
 			userSiteCount,
 			previousStepName,
 			useStepperWrapper,
-			goBack,
+			navigation: { goBack },
 		} = this.props;
 		const siteUrl = this.props.selectedSite?.URL;
 		const siteSlug = this.props.queryObject?.siteSlug;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* The label of the back button on the Domain screen in the onboarding flow should be `Back` and goes back to the previous step

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/onboarding
* On the Goals screen, select any goal
* On the Design Picker screen, select any design
* On the Domain screen,
  * Ensure the label of the back button is `Back`
  * Click the back button
  * Ensure you go back to the previous step
* Go to /setup/onboarding?flags=-onboarding/goals-first
* Ensure the label of the back button is `Back to sites`
* Click the back button
* Ensure you go back to /sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
