### PR TITLE
Newsletter: add warning to email preference setting

### DIFF
--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -230,6 +230,11 @@ class NotificationSubscriptions extends Component {
 									) }
 								</span>
 							</FormLabel>
+							<FormSettingExplanation>
+								{ this.props.translate(
+									'Newsletters are sent via WordPress.com. If you pause emails, you will not receive newsletters from the sites you are subscribed to.'
+								) }
+							</FormSettingExplanation>
 						</FormFieldset>
 
 						{ isAutomattician && (

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -230,11 +230,16 @@ class NotificationSubscriptions extends Component {
 									) }
 								</span>
 							</FormLabel>
-							<FormSettingExplanation>
-								{ this.props.translate(
+							{ ( locale === 'en' ||
+								i18n.hasTranslation(
 									'Newsletters are sent via WordPress.com. If you pause emails, you will not receive newsletters from the sites you are subscribed to.'
-								) }
-							</FormSettingExplanation>
+								) ) && (
+								<FormSettingExplanation>
+									{ this.props.translate(
+										'Newsletters are sent via WordPress.com. If you pause emails, you will not receive newsletters from the sites you are subscribed to.'
+									) }
+								</FormSettingExplanation>
+							) }
 						</FormFieldset>
 
 						{ isAutomattician && (


### PR DESCRIPTION
Fixes https://github.com/Automattic/loop/issues/280

## Proposed Changes

* Add more context to the email preference setting in WordPress.com
* Conditionally show if translation exists.

<img width="1606" alt="Screen Shot 2024-12-18 at 10 05 26" src="https://github.com/user-attachments/assets/28d204fc-d86a-45a9-9f4e-9b81c1d59219" />
<img width="1566" alt="Screen Shot 2024-12-18 at 18 35 32" src="https://github.com/user-attachments/assets/33d8d60a-f466-48dc-9510-26554becf294" />

## Why are these changes being made?

It is not common knowledge that the Newsletter emails going out are from WordPress.com and that this setting will prevent them from getting emails from the sites they subscribe to.

## Testing Instructions

1. Go to the live link
2. Navigate to `/me/notifications/subscriptions`
