### PR TITLE
Update Studio connect site event

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -64,6 +64,7 @@ const Home = ( {
 	site,
 	siteId,
 	trackViewSiteAction,
+	trackStudioSyncConnectSite,
 	isSiteWooExpressEcommerceTrial,
 	ssoModuleActive,
 	fetchingJetpackModules,
@@ -130,12 +131,9 @@ const Home = ( {
 			return;
 		}
 		const studioSiteUrl = `wpcom-local-dev://sync-connect-site?studioSiteId=${ studioSiteId }&remoteSiteId=${ siteId }`;
-		recordTracksEvent( 'calypso_studio_sync_connect_site', {
-			remoteSiteId: siteId,
-			click: false,
-		} );
+		trackStudioSyncConnectSite( false );
 		window.location.href = studioSiteUrl;
-	}, [ siteId ] );
+	}, [ siteId, trackStudioSyncConnectSite ] );
 
 	const isFirstSecondaryCardInPrimaryLocation =
 		Array.isArray( layout?.primary ) &&
@@ -282,10 +280,7 @@ const Home = ( {
 			>
 				<NoticeAction
 					onClick={ () => {
-						recordTracksEvent( 'calypso_studio_sync_connect_site', {
-							remoteSiteId: siteId,
-							click: true,
-						} );
+						trackStudioSyncConnectSite( true );
 						window.location.href = studioSiteUrl;
 					} }
 				>
@@ -379,8 +374,14 @@ const trackViewSiteAction = ( isStaticHomePage ) =>
 		bumpStat( 'calypso_customer_home', 'my_site_view_site' )
 	);
 
+const trackStudioSyncConnectSite = ( click = false ) =>
+	recordTracksEvent( 'calypso_studio_sync_connect_site', {
+		click,
+	} );
+
 const mapDispatchToProps = {
 	trackViewSiteAction,
+	trackStudioSyncConnectSite,
 	verifyIcannEmail,
 };
 
@@ -390,6 +391,7 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 		...ownProps,
 		...stateProps,
 		trackViewSiteAction: () => dispatchProps.trackViewSiteAction( isStaticHomePage ),
+		trackStudioSyncConnectSite: dispatchProps.trackStudioSyncConnectSite,
 		handleVerifyIcannEmail: dispatchProps.verifyIcannEmail,
 	};
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
- Related to https://github.com/Automattic/dotcom-forge/issues/10151
- Follow up from https://github.com/Automattic/dotcom-forge/issues/9359 (https://github.com/Automattic/wp-calypso/pull/96691)

## Proposed Changes

* Trigger the event using dispatch and remove unnecessary eventprop "remoteSiteId"

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The event was not correctly triggered

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use tracks vigilante
* Navigate to /home/${yourSiteSlug}?studioSiteId=026a8080-362a-4ab9-921d-2c63510ffe5a
* Observe in vigilante the event is tracked correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
