### PR TITLE
Performace Profiler: uses the account creation url for weekly report signups.

### DIFF
--- a/client/landing/stepper/utils/path.ts
+++ b/client/landing/stepper/utils/path.ts
@@ -98,6 +98,7 @@ export const useLoginUrl = ( {
 	extra?: Record< string, string | number >;
 } ): string => {
 	const currentLocale = useFlowLocale();
+
 	return getLoginUrl( {
 		variationName,
 		redirectTo,

--- a/client/landing/stepper/utils/path.ts
+++ b/client/landing/stepper/utils/path.ts
@@ -98,7 +98,6 @@ export const useLoginUrl = ( {
 	extra?: Record< string, string | number >;
 } ): string => {
 	const currentLocale = useFlowLocale();
-
 	return getLoginUrl( {
 		variationName,
 		redirectTo,

--- a/client/performance-profiler/controller.tsx
+++ b/client/performance-profiler/controller.tsx
@@ -3,8 +3,10 @@ import { UniversalNavbarFooter, UniversalNavbarHeader } from '@automattic/wpcom-
 import { translate } from 'i18n-calypso';
 import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
+import { getLoginUrl } from 'calypso/landing/stepper/utils/path';
 import { WeeklyReportUnsubscribe } from 'calypso/performance-profiler/pages/weekly-report/unsubscribe';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import { TabType } from './components/header';
 import { PerformanceProfilerDashboard } from './pages/dashboard';
 import { WeeklyReport } from './pages/weekly-report';
@@ -61,7 +63,13 @@ export function WeeklyReportContext( context: Context, next: () => void ): void 
 	const isLoggedIn = isUserLoggedIn( context.store.getState() );
 
 	if ( ! isLoggedIn ) {
-		window.location.href = '/log-in?redirect_to=' + encodeURIComponent( context.path );
+		const logInUrl = getLoginUrl( {
+			variationName: 'performance-profiler-weekly-report-subscribe',
+			redirectTo: encodeURIComponent( context.path ),
+			locale: getCurrentLocaleSlug( context.store.getState() ),
+		} );
+
+		window.location.href = logInUrl;
 		return;
 	}
 

--- a/client/performance-profiler/controller.tsx
+++ b/client/performance-profiler/controller.tsx
@@ -65,7 +65,7 @@ export function WeeklyReportContext( context: Context, next: () => void ): void 
 	if ( ! isLoggedIn ) {
 		const logInUrl = getLoginUrl( {
 			variationName: 'performance-profiler-weekly-report-subscribe',
-			redirectTo: encodeURIComponent( context.path ),
+			redirectTo: `${ window.location.protocol }//${ window.location.host }${ context.path }`,
 			locale: getCurrentLocaleSlug( context.store.getState() ),
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/97464
Fixes https://github.com/Automattic/wp-calypso/issues/97463

## Proposed Changes

* Uses `getLoginUrl` function which by default returns the account creation step
* Passes the locale to the `getLoginUrl` so that the page gets translated

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In incognito, go to `es/speed-test-tool?url=https://wordpress.com/&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MzI1ODB9.PaK-TU9gAkCdxRW4YFIIA7Y_7X3Vrq46FKZ95-ZBBP4`
* Subscribe to the weekly email reports
* You should land to the Spanish Account creation page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
