### PR TITLE
Help Center: Enhance article styles for callouts and submenu items

### DIFF
--- a/packages/help-center/src/components/help-center-article.scss
+++ b/packages/help-center/src/components/help-center-article.scss
@@ -103,6 +103,10 @@
 				color: var(--color-neutral-80);
 				list-style-position: outside;
 				margin: 0 0 1.5em 1.5em;
+
+				ul, li {
+					margin-bottom: 0;
+				}
 			}
 
 			ul {
@@ -165,10 +169,46 @@
 			}
 
 			.callout .wp-block-column {
-				background-color: var(--color-neutral-0);
+				padding: .5em;
+				border-radius: 4px;
+				border: 1px solid var(--color-neutral-5, #dcdcde);
+				background: #fff;
 
 				.wp-block-quote {
 					margin: 0;
+					background: #fff;
+				}
+
+				.has-text-align-center {
+					text-align: center;
+				}
+
+				.has-large-font-size {
+					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+					font-size: 40px;
+					line-height: 48px;
+				}
+
+				.is-vertically-aligned-center {
+					align-self: center;
+				}
+
+				.wp-block-jetpack-layout-grid {
+					display: grid;
+					grid-template-columns: repeat(4, 1fr);
+
+					&.wp-block-jetpack-layout-gutter__none {
+						grid-gap: 0;
+					}
+
+					&.column1-tablet-grid__row-1>.wp-block-jetpack-layout-grid-column:nth-child(1) {
+						grid-row-start: 1;
+					}
+
+					&.column2-desktop-grid__start-2>.wp-block-jetpack-layout-grid-column:nth-child(2) {
+						grid-column-start: 2;
+						grid-column-end: span 4;
+					}
 				}
 			}
 

--- a/packages/help-center/src/components/help-center-article.scss
+++ b/packages/help-center/src/components/help-center-article.scss
@@ -169,14 +169,19 @@
 			}
 
 			.callout .wp-block-column {
+
+				$callout-border: #dcdcde;
+				$callout-background: #fff;
+				$callout-large-font-size: 40px;
+
 				padding: .5em;
 				border-radius: 4px;
-				border: 1px solid var(--color-neutral-5, #dcdcde);
-				background: #fff;
+				border: 1px solid $callout-border;
+				background: $callout-background;
 
 				.wp-block-quote {
 					margin: 0;
-					background: #fff;
+					background: $callout-background;
 				}
 
 				.has-text-align-center {
@@ -184,8 +189,7 @@
 				}
 
 				.has-large-font-size {
-					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-					font-size: 40px;
+					font-size: $callout-large-font-size;
 					line-height: 48px;
 				}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/10122
Fixes: https://github.com/Automattic/dotcom-forge/issues/10124

## Proposed Changes

* Remove extra space (margin bottom) for submenu items
* Update callout styling to match support doc and improve visibility

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve UX and improve visibility for support doc callouts

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Open the Help Center, search `Protect Your Website From Malware` doc, open it and scroll to the bottom. (Test other articles as well)
* Verify the callout styling is correct. You should see an icon on the left and the callout text on the right.
* Search for the `Image block` doc and scroll down to the `insert an image` section. Make sure the submenu list doesn't have the extra margin at the bottom. For example, the last item in the `Select image` list shouldn't have significant spacing below it.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
