### PR TITLE
Writing settings: Add "Default post category" selector

### DIFF
--- a/client/my-sites/site-settings/composing/default-post-category.jsx
+++ b/client/my-sites/site-settings/composing/default-post-category.jsx
@@ -1,0 +1,60 @@
+import { FormLabel } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import QueryTerms from 'calypso/components/data/query-terms';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormSelect from 'calypso/components/forms/form-select';
+import { getTermsForQuery } from 'calypso/state/terms/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+const DefaultPostCategory = ( {
+	fields,
+	onChangeField,
+	eventTracker,
+	isRequestingSettings,
+	isSavingSettings,
+} ) => {
+	const siteId = useSelector( getSelectedSiteId );
+	const translate = useTranslate();
+	const query = { page: 0 };
+	const terms = useSelector( ( state ) => getTermsForQuery( state, siteId, 'category', query ) );
+
+	return (
+		<FormFieldset>
+			<QueryTerms siteId={ siteId } taxonomy="category" query={ query } />
+			<FormLabel htmlFor="default_category">{ translate( 'Default post category' ) }</FormLabel>
+			<FormSelect
+				name="default_category"
+				id="default_category"
+				value={ fields.default_category }
+				onChange={ onChangeField( 'default_category' ) }
+				disabled={ isRequestingSettings || isSavingSettings }
+				onClick={ eventTracker( 'Selected Default Post Category' ) }
+			>
+				{ terms &&
+					terms.map( ( { ID, name } ) => (
+						<option key={ ID } value={ ID }>
+							{ name }
+						</option>
+					) ) }
+			</FormSelect>
+		</FormFieldset>
+	);
+};
+
+DefaultPostCategory.defaultProps = {
+	isSavingSettings: false,
+	isRequestingSettings: true,
+	fields: {},
+};
+
+DefaultPostCategory.propTypes = {
+	onChangeField: PropTypes.func.isRequired,
+	eventTracker: PropTypes.func.isRequired,
+	isSavingSettings: PropTypes.bool,
+	isRequestingSettings: PropTypes.bool,
+	fields: PropTypes.object,
+};
+
+export default DefaultPostCategory;

--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -2,6 +2,7 @@ import { CompactCard } from '@automattic/components';
 import PropTypes from 'prop-types';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import DateTimeFormat from '../date-time-format';
+import DefaultPostCategory from './default-post-category';
 import DefaultPostFormat from './default-post-format';
 import Latex from './latex';
 import Markdown from './markdown';
@@ -30,6 +31,13 @@ const Composing = ( {
 			title={ translate( 'Composing' ) }
 		/>
 		<CompactCard className="composing__card site-settings">
+			<DefaultPostCategory
+				eventTracker={ eventTracker }
+				fields={ fields }
+				isRequestingSettings={ isRequestingSettings }
+				isSavingSettings={ isSavingSettings }
+				onChangeField={ onChangeField }
+			/>
 			<DefaultPostFormat
 				eventTracker={ eventTracker }
 				fields={ fields }

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -145,6 +145,7 @@ const getFormSettings = ( settings ) => {
 		'posts_per_page',
 		'posts_per_rss',
 		'rss_use_excerpt',
+		'default_category',
 		'default_post_format',
 		'custom-content-types',
 		'jetpack_testimonial',

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -40,6 +40,7 @@ export const SITE_REQUEST_OPTIONS = [
 	'allowed_file_types',
 	'anchor_podcast',
 	'created_at',
+	'default_category',
 	'default_comment_status',
 	'default_ping_status',
 	'default_post_format',


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/95621
See pekYwv-4RI-p2

## Proposed Changes

Adds a new dropdown to the Writing Settings page to change the default post category so users can follow Core tutorials instructing them to go to "Settings > Writing" to do so.

<img width="748" alt="Screenshot 2024-12-18 at 13 28 07" src="https://github.com/user-attachments/assets/3114d94e-11bc-4c27-9140-11ab26e552c7" />

## Why are these changes being made?

Because we don't want users participating in the "Remove duplicate views" projects to be forced to use `/wp-admin/options-writing.php` to change the default category, since we're not untangling the Writing Settings page in the short/mid term.

## Testing Instructions

- Use the Calypso live link below
- Go to `/settings/writing/:site` 
- Make sure you can change the default post category
- Make sure the changes are reflected in `/wp-admin/edit-tags.php?taxonomy=category` and in `/wp-admin/options-writing.php`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?