### PR TITLE
A4A: Rename Pressable plans on the Hosting page. 

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -157,10 +157,10 @@ export default function PressablePlanSection( {
 					<p>
 						{ isStandardPlan
 							? translate(
-									'With Shared Resource Plans, your traffic & storage limits are shared amongst your total sites.'
+									'With Signature Plans, your traffic & storage limits are shared amongst your total sites.'
 							  )
 							: translate(
-									'With Signature Shared Resource Plans, your traffic & storage limits are shared amongst your total sites.'
+									'With Enterprise Plans, your traffic & storage limits are shared amongst your total sites.'
 							  ) }
 					</p>
 				) }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -209,18 +209,18 @@ export default function PlanSelectionFilter( {
 				tabs={ [
 					{
 						name: PLAN_CATEGORY_STANDARD,
-						title: translate( 'Shared Resource Plans' ),
+						title: translate( 'Signature Plans' ),
 						disabled: disableStandardTab,
 					},
 					{
 						name: PLAN_CATEGORY_ENTERPRISE,
-						title: translate( 'Signature Cloud Plans' ),
+						title: translate( 'Enterprise Plans' ),
 					},
 					...( showHighResourceTab
 						? [
 								{
 									name: PLAN_CATEGORY_HIGH_RESOURCE,
-									title: translate( 'High Resource Sites' ),
+									title: translate( 'High Resource Plans' ),
 								},
 						  ]
 						: [] ),


### PR DESCRIPTION
This PR updates several references to the Pressable plan names. We now use 'Signature' and 'Enterprise' for the plans. 

| Before | After |
|--------|--------|
| <img width="1129" alt="Screenshot 2024-12-18 at 8 40 10 PM" src="https://github.com/user-attachments/assets/90c8cec8-cba6-44fe-af59-d8f4b278bef4" /> | <img width="1154" alt="Screenshot 2024-12-18 at 8 33 20 PM" src="https://github.com/user-attachments/assets/c30a6298-1b15-41d6-afd3-6236d963b764" /> | 
| <img width="1561" alt="Screenshot 2024-12-18 at 8 47 10 PM" src="https://github.com/user-attachments/assets/ba959f56-ac6b-4280-852b-decafd6caea3" /> | <img width="1558" alt="Screenshot 2024-12-18 at 8 45 14 PM" src="https://github.com/user-attachments/assets/12c492fa-e06e-4e9a-b718-f97c28a6d4cb" /> |


## Proposed Changes

* Update a few copies.

## Why are these changes being made?

* We must ensure that we update A4A to comply with the new Pressable plan naming convention.

## Testing Instructions

* Apply this PR to your sandbox and follow the instructions in the PR description to set up your sandbox Apply WPCOM patch: 168951
* Use the Live link below and go to the `/marketplace/hosting/pressable?flags=-a4a-hosting-page-redesign-v3`, We will test the current hosting page (Not the redesigned).
* Confirm that you see the Plans are now changed.
* Use the Live link below and go to the `/marketplace/hosting/pressable` to test the new hosting page.
* Confirm that you see the Plans are now changed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
