### PR TITLE
Site Migrations: Update strings for 2-year plan

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
@@ -276,7 +276,7 @@ export const UpgradePlanDetails = ( props: UpgradePlanDetailsProps ) => {
 						<Title className="plan-title" tagName="h2">
 							{ PLAN_BUSINESS_MONTHLY === planSlug
 								? translate( 'Monthly' )
-								: translate( 'Biennially' ) }
+								: translate( 'Every 2 years' ) }
 						</Title>
 					</div>
 
@@ -287,7 +287,7 @@ export const UpgradePlanDetails = ( props: UpgradePlanDetailsProps ) => {
 							<NextButton variant="secondary" onClick={ () => onCtaClick?.( planSlug ) }>
 								{ PLAN_BUSINESS_MONTHLY === planSlug
 									? translate( 'Get Monthly' )
-									: translate( 'Get Biennial' ) }
+									: translate( 'Every 2 years' ) }
 							</NextButton>
 						</div>
 					</div>

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
@@ -287,7 +287,7 @@ export const UpgradePlanDetails = ( props: UpgradePlanDetailsProps ) => {
 							<NextButton variant="secondary" onClick={ () => onCtaClick?.( planSlug ) }>
 								{ PLAN_BUSINESS_MONTHLY === planSlug
 									? translate( 'Get Monthly' )
-									: translate( 'Get every 2 years' ) }
+									: translate( 'Get Every 2 years' ) }
 							</NextButton>
 						</div>
 					</div>

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
@@ -287,7 +287,7 @@ export const UpgradePlanDetails = ( props: UpgradePlanDetailsProps ) => {
 							<NextButton variant="secondary" onClick={ () => onCtaClick?.( planSlug ) }>
 								{ PLAN_BUSINESS_MONTHLY === planSlug
 									? translate( 'Get Monthly' )
-									: translate( 'Every 2 years' ) }
+									: translate( 'Get every 2 years' ) }
 							</NextButton>
 						</div>
 					</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Update copy from "Biennially" to "Every 2 years" for consistency with our other pricing pages.

**Before**

<img width="1109" alt="Screenshot 2024-12-18 at 10 00 29 AM" src="https://github.com/user-attachments/assets/82bceea2-35b0-46f1-a2d4-934d5571dc2b" />

**After**

<img width="1113" alt="Screenshot 2024-12-18 at 10 00 05 AM" src="https://github.com/user-attachments/assets/3843dad6-e011-4054-bde5-4d75713143a6" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* p9Jlb4-fiH-p2#comment-14942 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Enable the feature flag in your console and reload:
* Go through the migration flow from `/start` by choosing "import or migrate" at the goals step (it's a link under the main CTA)
* Put in your test site to migrate and choose "Migrate"
* See the Upgrade screen changes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?