### PR TITLE
Fix Email styles in Domains dashboard

### DIFF
--- a/client/my-sites/email/email-header/index.js
+++ b/client/my-sites/email/email-header/index.js
@@ -10,6 +10,7 @@ export default function EmailHeader() {
 	return (
 		<div className="email-header">
 			<NavigationHeader
+				className="domains-email__navigation-header"
 				navigationItems={ [] }
 				title={ translate( 'Emails' ) }
 				subtitle={ translate(

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -472,73 +472,120 @@
 	}
 
 	/* Mailboxes */
-	.email-plan-mailboxes-list__mailbox-list {
-		border: solid 1px var(--color-border-subtle);
-		border-radius: 4px;
-		margin-top: 0;
-		padding-bottom: 1.875rem;
+	.email-plan-mailboxes-list {
+		&__mailbox-list {
+			border: solid 1px var(--color-border-subtle);
+			border-radius: 4px;
+			margin-top: 0;
+			padding-bottom: 1.875rem;
 
-		.card {
-			box-shadow: none;
-			background: none;
+			.card {
+				box-shadow: none;
+				background: none;
+			}
+
+			.card.section-header {
+				margin: 0 1.5rem;
+				padding: 1.75rem 0 1.25em 0;
+			}
+
+			.section-header__label-text {
+				display: flex;
+				align-items: center;
+				font-size: 1rem;
+				color: var(--studio-gray-100);
+			}
+
+			.section-header__actions {
+				flex: none;
+
+				.components-button {
+					font-size: 0.875rem;
+				}
+
+				.components-button.is-link {
+					text-decoration: none;
+				}
+			}
+
+			&-item.card.is-compact {
+				border-top: solid 1px var(--color-border-subtle);
+				margin: 0 1.5rem;
+				padding: 1.375rem 0;
+
+				&:last-child {
+					padding-bottom: 0;
+				}
+			}
+
+			&-item > div {
+				flex-grow: initial;
+			}
+
+			.email-mailbox-action-menu__main {
+				right: 0;
+				top: 18px;
+			}
 		}
 
-		.card.section-header {
-			margin: 0 1.5rem;
-			padding: 1.75rem 0 1.25em 0;
-		}
-
-		.section-header__label-text {
+		&__mailbox-header-icon {
 			display: flex;
-			align-items: center;
-			font-size: 1rem;
-			color: var(--studio-gray-100);
-		}
+			margin-inline-end: 0.5rem;
+			width: 24px;
 
-		.section-header__actions {
-			flex: none;
-
-			.components-button {
-				font-size: 0.875rem;
+			img {
+				height: 24px;
 			}
 
-			.components-button.is-link {
-				text-decoration: none;
+			svg {
+				height: 24px;
+				fill: var(--color-accent);
 			}
 		}
 
-		.email-mailbox-action-menu__main {
-			right: 0;
-			top: 18px;
-		}
-	}
+		&__notice {
+			margin-top: 1rem;
+			margin-bottom: 2rem;
 
-	.email-plan-mailboxes-list__mailbox-header-icon {
-		display: flex;
-		margin-inline-end: 0.5rem;
-		width: 24px;
+			.email-plan-warnings__container {
+				margin: 0;
+			}
 
-		img {
-			height: 24px;
-		}
+			.email-plan-warnings__warning {
+				display: flex;
+				padding: 0;
 
-		svg {
-			height: 24px;
-			fill: var(--color-accent);
-		}
-	}
+				.email-plan-warnings__message,
+				.email-plan-warnings__cta {
+					display: inline;
+				}
 
-	.email-plan-mailboxes-list__mailbox-list-item > div {
-		flex-grow: initial;
-	}
+				.email-plan-warnings__message {
+					flex-grow: 1;
 
-	.email-plan-mailboxes-list__mailbox-list-item.card.is-compact {
-		border-top: solid 1px var(--color-border-subtle);
-		margin: 0 1.5rem;
-		padding: 1.375rem 0;
+					span {
+						display: inline-block;
+						max-width: 700px;
+					}
+				}
 
-		&:last-child {
-			padding-bottom: 0;
+				.email-plan-warnings__cta {
+					margin: 0;
+					flex-grow: 0;
+					align-self: center;
+					white-space: nowrap;
+
+					svg {
+						height: 14px;
+						vertical-align: middle;
+					}
+
+					a {
+						color: var(--studio-gray-20);
+						text-decoration: none;
+					}
+				}
+			}
 		}
 	}
 
@@ -546,50 +593,5 @@
 	.section-header__actions button[disabled] {
 		color: var(--theme-highlight-color-50);
 		opacity: 0.5;
-	}
-
-	.email-plan-mailboxes-list__notice {
-		margin-top: 1rem;
-		margin-bottom: 2rem;
-
-		.email-plan-warnings__container {
-			margin: 0;
-		}
-
-		.email-plan-warnings__warning {
-			display: flex;
-			padding: 0;
-
-			.email-plan-warnings__message,
-			.email-plan-warnings__cta {
-				display: inline;
-			}
-
-			.email-plan-warnings__message {
-				flex-grow: 1;
-
-				span {
-					display: inline-block;
-					max-width: 700px;
-				}
-			}
-
-			.email-plan-warnings__cta {
-				margin: 0;
-				flex-grow: 0;
-				align-self: center;
-				white-space: nowrap;
-
-				svg {
-					height: 14px;
-					vertical-align: middle;
-				}
-
-				a {
-					color: var(--studio-gray-20);
-					text-decoration: none;
-				}
-			}
-		}
 	}
 }

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -446,13 +446,23 @@
  */
 .context-all-domain-management {
 	&.main {
+		margin-left: 0;
 		width: 100%;
 
-		.email-header .navigation-header {
-			border-block-end: none;
+		.domains-email__navigation-header.navigation-header {
+			border: 0;
+			padding: 1.5rem;
+
+			@include break-medium {
+				padding: 0 0 1.5rem 0;
+			}
+
+			@include break-large {
+				padding-bottom: 2rem;
+			}
 
 			.navigation-header__main {
-				padding-inline: 0 !important;
+				padding-inline: 0;
 
 				.navigation-header__actions {
 					flex-grow: 0;
@@ -461,9 +471,12 @@
 		}
 	}
 
+	/* Mailboxes */
 	.email-plan-mailboxes-list__mailbox-list {
 		border: solid 1px var(--color-border-subtle);
 		border-radius: 4px;
+		margin-top: 0;
+		padding-bottom: 1.875rem;
 
 		.card {
 			box-shadow: none;
@@ -471,9 +484,8 @@
 		}
 
 		.card.section-header {
-			padding: 1.5rem 0 1rem 0;
 			margin: 0 1.5rem;
-			border-bottom: solid 1px var(--color-border-subtle);
+			padding: 1.75rem 0 1.25em 0;
 		}
 
 		.section-header__label-text {
@@ -494,6 +506,11 @@
 				text-decoration: none;
 			}
 		}
+
+		.email-mailbox-action-menu__main {
+			right: 0;
+			top: 18px;
+		}
 	}
 
 	.email-plan-mailboxes-list__mailbox-header-icon {
@@ -513,6 +530,16 @@
 
 	.email-plan-mailboxes-list__mailbox-list-item > div {
 		flex-grow: initial;
+	}
+
+	.email-plan-mailboxes-list__mailbox-list-item.card.is-compact {
+		border-top: solid 1px var(--color-border-subtle);
+		margin: 0 1.5rem;
+		padding: 1.375rem 0;
+
+		&:last-child {
+			padding-bottom: 0;
+		}
 	}
 
 	div.email-plan-mailboxes-list__mailbox-list-link span,

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -474,10 +474,13 @@
 	/* Mailboxes */
 	.email-plan-mailboxes-list {
 		&__mailbox-list {
-			border: solid 1px var(--color-border-subtle);
-			border-radius: 4px;
 			margin-top: 0;
 			padding-bottom: 1.875rem;
+
+			@include break-medium {
+				border: solid 1px var(--color-border-subtle);
+				border-radius: 4px;
+			}
 
 			.card {
 				box-shadow: none;


### PR DESCRIPTION
Fixes #97538.

## Proposed Changes

- Fix Email styles on mobile.
- Make Email styles consistent with the Overview tab.
- Fix alignment of the Email action menu.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get a .blog domain if you don't already have one.
* Enable the `calypso/all-domain-management` flag.
* In `/domains/manage`, select the .blog domain.
* On the _Email_ tab, add at least 2 mailboxes.
* Ensure the UI looks good on desktop and mobile as per the design - ePfz53j71KKDLWtuSm567A-fi-4949_53044
* Click back and forth between Overview and Email. Ensure the layout does not shift when switching.

## Screenshots

### Mobile

![Screenshot 2024-12-18 at 10 52 01 AM](https://github.com/user-attachments/assets/2256b37b-f122-4fec-881a-567c22389cf1)

### Desktop

![Screenshot 2024-12-18 at 11 29 08 AM](https://github.com/user-attachments/assets/8c7fecbd-685d-4de2-9451-4f8703c71d19)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?