### PR TITLE
i18n: Sites overview dashboard - fix capitalisation in column headers

### DIFF
--- a/client/sites/components/dotcom-style.scss
+++ b/client/sites/components/dotcom-style.scss
@@ -357,7 +357,7 @@
 		font-size: rem(13px);
 		line-height: 20px;
 		color: var(--studio-gray-50);
-		text-transform: capitalize;
+		text-transform: initial;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/i18n-issues#840

## Proposed Changes

Removes the CSS rule that capitalizes the column headers at the bottom of the overview page

### Media

#### Before

<img width="800" alt="Screenshot 2024-12-18 at 6 36 36 PM" src="https://github.com/user-attachments/assets/16b4cae6-f02b-48bd-a6d1-e256bbe0eea3" />


#### After

<img width="800" alt="Screenshot 2024-12-18 at 5 51 52 PM" src="https://github.com/user-attachments/assets/aa9db288-a08c-48f9-b26b-eb1679bd83af" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

If my understanding of the issue is correct: Capitalizing via CSS may work for EN but can mess up translations that don't make sense to be capitalized this way. So it's best to render translations as they are (or lowercase/uppercase all instead).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/overview/:site`
* Confirm at the bottom the domains table does not have capitalized headers. Otherwise confirm the text is rendered as it exists in GlotPress.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
