### PR TITLE
Help Center: Fix infinite loading when starting a chat session

### DIFF
--- a/packages/odie-client/src/data/use-get-unread-conversations.ts
+++ b/packages/odie-client/src/data/use-get-unread-conversations.ts
@@ -1,5 +1,6 @@
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
+import { useCallback } from 'react';
 import Smooch from 'smooch';
 import { ZendeskConversation } from '../types';
 
@@ -22,11 +23,14 @@ const calculateUnread = ( conversations: Conversation[] | ZendeskConversation[] 
 export const useGetUnreadConversations = () => {
 	const { setUnreadCount } = useDataStoreDispatch( HELP_CENTER_STORE );
 
-	return ( conversations?: Conversation[] | ZendeskConversation[] ) => {
-		const conversationsToCheck = conversations ? conversations : Smooch.getConversations();
-		const { unreadConversations, unreadMessages } = calculateUnread( conversationsToCheck );
-		setUnreadCount( unreadConversations );
+	return useCallback(
+		( conversations?: Conversation[] | ZendeskConversation[] ) => {
+			const conversationsToCheck = conversations ? conversations : Smooch.getConversations();
+			const { unreadConversations, unreadMessages } = calculateUnread( conversationsToCheck );
+			setUnreadCount( unreadConversations );
 
-		return { unreadConversations, unreadMessages };
-	};
+			return { unreadConversations, unreadMessages };
+		},
+		[ setUnreadCount ]
+	);
 };

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -87,6 +87,8 @@ export const useGetCombinedChat = (
 		odieId,
 		currentSupportInteraction,
 		shouldUseHelpCenterExperience,
+		canConnectToZendesk,
+		getZendeskConversation,
 	] );
 
 	return { mainChatState, setMainChatState };


### PR DESCRIPTION
p1734522853510969-slack-C07D72S1135

## Proposed Changes

There is another race condition between `canConnectToZendesk` and `useOdieChat` resolving. We had missing deps, and if the Odie chat was loaded before `canConnectToZendesk` flips, the chat was never considered loaded. 


## Testing Instructions

1. The issue is only reproducible in prod. Because it requires hitting the prod endpoint of ZD, which requires the env to be production.
2. Test that this PR does not break things.
3. Merge.
4. Test again in prod.