### PR TITLE
A4A: update referral dashboard cards view and data

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -116,7 +116,7 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 						<div className="consolidated-view__popover-content">
 							{ translate(
 								'The exact amount your agency has been paid out for referrals.' +
-									'{{br/}}{{a}}Learn more{{/a}} ↗',
+									'{{br/}}{{br/}}{{a}}Learn more{{/a}} ↗',
 								{
 									components: {
 										a: <a href={ link } target="_blank" rel="noreferrer noopener" />,
@@ -143,7 +143,7 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 								'We estimate the commission based on the active use for the current month. ' +
 								'{{br/}}{{br}}{{/br}}The next payout range is for:' +
 								'{{br/}}{{span}}%(nextPayoutActivityWindow)s{{/span}}' +
-								'{{br/}}{{a}}Learn more{{/a}} ↗',
+								'{{br/}}{{br/}}{{a}}Learn more{{/a}} ↗',
 							{
 								components: {
 									a: <a href={ link } target="_blank" rel="noreferrer noopener" />,
@@ -170,7 +170,7 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 						{ translate(
 							'*Commissions are paid quarterly, after a 60-day waiting period, excluding refunds and chargebacks. ' +
 								'Payout dates mark the start of processing, which may take a few extra days. Payments scheduled on weekends are processed the next business day. ' +
-								'{{br/}}{{a}}Learn more{{/a}} ↗',
+								'{{br/}}{{br/}}{{a}}Learn more{{/a}} ↗',
 							{
 								components: {
 									a: <a href={ link } target="_blank" rel="noreferrer noopener" />,
@@ -193,7 +193,7 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 					<div className="consolidated-view__popover-content">
 						{ translate(
 							'These are the number of pending referrals (unpaid carts). ' +
-								'{{br/}}{{a}}Learn more{{/a}} ↗',
+								'{{br/}}{{br/}}{{a}}Learn more{{/a}} ↗',
 							{
 								components: {
 									a: <a href={ link } target="_blank" rel="noreferrer noopener" />,

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -135,7 +135,7 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 				<CardInfo
 					title={ translate( 'Estimated amount' ) }
 					wrapperRef={ pendingCommissionRef }
-					footerText={ translate( 'Commissions expected' ) }
+					footerText={ translate( 'Next estimated payout amount' ) }
 				>
 					<div className="consolidated-view__popover-content">
 						{ translate(

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -4,14 +4,13 @@ import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState, useRef } from 'react';
+import { useState, useRef } from 'react';
 import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
-import { getConsolidatedData } from '../lib/commissions';
-import { getNextPayoutDate } from '../lib/get-next-payout-date';
+import useGetConsolidatedPayoutData from '../hooks/use-get-consolidated-payout-data';
 import InfoModal from './info-modal';
-import type { Referral, ReferralInvoice } from '../types';
+import type { Referral } from '../types';
 
 import './style.scss';
 
@@ -80,81 +79,58 @@ const CardInfo = ( { children, wrapperRef, footerText, title }: FooterInfoProps 
 	);
 };
 
-export default function ConsolidatedViews( {
-	referrals,
-	referralInvoices,
-	isFetchingInvoices,
-}: {
+type ConsolidatedViewsProps = {
 	referrals: Referral[];
-	referralInvoices: ReferralInvoice[];
-	isFetchingInvoices?: boolean;
-} ) {
+	totalPayouts?: number;
+};
+
+export default function ConsolidatedViews( { referrals, totalPayouts }: ConsolidatedViewsProps ) {
 	const translate = useTranslate();
 
-	const { data, isFetching } = useProductsQuery( false, false, true );
-
-	const [ consolidatedData, setConsolidatedData ] = useState( {
-		allTimeCommissions: 0,
-		pendingOrders: 0,
-		pendingCommission: 0,
-	} );
+	const { data: productsData, isFetching } = useProductsQuery( false, false, true );
 
 	const commissionInfoRef = useRef< HTMLDivElement | null >( null );
 	const pendingOrdersRef = useRef< HTMLDivElement | null >( null );
 	const nextPayoutDateRef = useRef< HTMLDivElement | null >( null );
 	const pendingCommissionRef = useRef< HTMLDivElement | null >( null );
 
-	useEffect( () => {
-		if ( data?.length ) {
-			const consolidatedData = getConsolidatedData( referrals, data || [], referralInvoices );
-			setConsolidatedData( consolidatedData );
-		}
-	}, [ referrals, data, referralInvoices ] );
+	// Logic is moved to the hook for better readability
+	const { expectedCommission, pendingOrders, nextPayoutActivityWindow, nextPayoutDate } =
+		useGetConsolidatedPayoutData( referrals, productsData );
 
 	const link =
 		'https://agencieshelp.automattic.com/knowledge-base/automattic-for-agencies-earnings/';
 
-	const showLoader = isFetching || isFetchingInvoices;
-
-	const nextPayoutDate = getNextPayoutDate( new Date() ).toLocaleString( 'default', {
-		month: 'short',
-		day: 'numeric',
-	} );
+	const showLoader = isFetching;
 
 	return (
 		<div className="consolidated-view">
-			<Card compact ref={ commissionInfoRef }>
-				<div className="consolidated-view__value">
-					{ showLoader ? (
-						<TextPlaceholder />
-					) : (
-						formatCurrency( consolidatedData.allTimeCommissions, 'USD' )
-					) }
-				</div>
-				<CardInfo
-					title={ translate( 'Total payouts' ) }
-					wrapperRef={ commissionInfoRef }
-					footerText={ translate( 'All time referral payouts' ) }
-				>
-					<div className="consolidated-view__popover-content">
-						{ translate(
-							'Every 60 days, we pay out commissions. {{a}}Learn more about payouts and commissions{{/a}}.',
-							{
-								components: {
-									a: <a href={ link } target="_blank" rel="noreferrer noopener" />,
-								},
-							}
-						) }
-					</div>
-				</CardInfo>
-			</Card>
+			{ totalPayouts !== undefined && (
+				<Card compact ref={ commissionInfoRef }>
+					<div className="consolidated-view__value">{ formatCurrency( totalPayouts, 'USD' ) }</div>
+					<CardInfo
+						title={ translate( 'Total payouts' ) }
+						wrapperRef={ commissionInfoRef }
+						footerText={ translate( 'All time referral payouts' ) }
+					>
+						<div className="consolidated-view__popover-content">
+							{ translate(
+								'The exact amount your agency has been paid out for referrals.' +
+									'{{br/}}{{a}}Learn more{{/a}} ↗',
+								{
+									components: {
+										a: <a href={ link } target="_blank" rel="noreferrer noopener" />,
+										br: <br />,
+									},
+								}
+							) }
+						</div>
+					</CardInfo>
+				</Card>
+			) }
 			<Card compact ref={ pendingCommissionRef }>
 				<div className="consolidated-view__value">
-					{ showLoader ? (
-						<TextPlaceholder />
-					) : (
-						formatCurrency( consolidatedData.pendingCommission, 'USD' )
-					) }
+					{ showLoader ? <TextPlaceholder /> : formatCurrency( expectedCommission, 'USD' ) }
 				</div>
 				<CardInfo
 					title={ translate( 'Estimated amount' ) }
@@ -163,11 +139,19 @@ export default function ConsolidatedViews( {
 				>
 					<div className="consolidated-view__popover-content">
 						{ translate(
-							'When your client buys products or hosting from Automattic for Agencies, they are billed on the first of every month rather than immediately.' +
-								' We estimate the commission based on the active use for the current month. {{a}}Learn more about payouts and commissions{{/a}}.',
+							'When your client buys products or hosting from Automattic for Agencies, they are billed on the first of every month rather than immediately. ' +
+								'We estimate the commission based on the active use for the current month. ' +
+								'{{br/}}{{br}}{{/br}}The next payout range is for:' +
+								'{{br/}}{{span}}%(nextPayoutActivityWindow)s{{/span}}' +
+								'{{br/}}{{a}}Learn more{{/a}} ↗',
 							{
 								components: {
 									a: <a href={ link } target="_blank" rel="noreferrer noopener" />,
+									br: <br />,
+									span: <span className="consolidated-view__popover-content-activity-dates" />,
+								},
+								args: {
+									nextPayoutActivityWindow,
 								},
 								comment: 'This is a tooltip explaining how the commission is calculated',
 							}
@@ -186,7 +170,7 @@ export default function ConsolidatedViews( {
 						{ translate(
 							'*Commissions are paid quarterly, after a 60-day waiting period, excluding refunds and chargebacks. ' +
 								'Payout dates mark the start of processing, which may take a few extra days. Payments scheduled on weekends are processed the next business day. ' +
-								'{{br}}{{/br}}{{a}}Learn more{{/a}} ↗',
+								'{{br/}}{{a}}Learn more{{/a}} ↗',
 							{
 								components: {
 									a: <a href={ link } target="_blank" rel="noreferrer noopener" />,
@@ -200,7 +184,7 @@ export default function ConsolidatedViews( {
 				</CardInfo>
 			</Card>
 			<Card compact ref={ pendingOrdersRef }>
-				<div className="consolidated-view__value">{ consolidatedData.pendingOrders }</div>
+				<div className="consolidated-view__value">{ pendingOrders }</div>
 				<CardInfo
 					title={ translate( 'Pending orders' ) }
 					wrapperRef={ pendingOrdersRef }
@@ -208,15 +192,12 @@ export default function ConsolidatedViews( {
 				>
 					<div className="consolidated-view__popover-content">
 						{ translate(
-							'These are the number of pending referrals (unpaid carts).' +
-								'{{br}}{{/br}}{{a}}Learn more{{/a}} ↗',
+							'These are the number of pending referrals (unpaid carts). ' +
+								'{{br/}}{{a}}Learn more{{/a}} ↗',
 							{
 								components: {
 									a: <a href={ link } target="_blank" rel="noreferrer noopener" />,
 									br: <br />,
-								},
-								args: {
-									estimatedCommission: 154,
 								},
 								comment:
 									'This is a tooltip explaining how the commission payout date is calculated',

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/style.scss
@@ -93,6 +93,10 @@
 	a:focus {
 		outline: none;
 	}
+
+	.consolidated-view__popover-content-activity-dates {
+		font-weight: 700;
+	}
 }
 
 .consolidated-view__info-icon {

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/style.scss
@@ -16,7 +16,8 @@
 	}
 
 	.card {
-		flex: 0 1 calc(50% - 12px);
+		flex: 0 1 calc(50% - 16px);
+		max-width: 45%;
 		border-radius: 6px; /* stylelint-disable-line scales/radii */
 		width: 100%;
 		padding: 1rem;

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-get-consolidated-payout-data.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-get-consolidated-payout-data.ts
@@ -1,0 +1,56 @@
+import { useMemo } from 'react';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import { getEstimatedCommission } from '../lib/get-estimated-commission';
+import { getNextPayoutDate, getNextPayoutDateActivityWindow } from '../lib/get-next-payout-date';
+import { Referral } from '../types';
+
+export default function useGetConsolidatedPayoutData(
+	referrals: Referral[],
+	products?: APIProductFamilyProduct[]
+) {
+	const expectedCommission = useMemo(
+		() => getEstimatedCommission( referrals, products || [] ),
+		[ referrals, products ]
+	);
+
+	const pendingOrders = useMemo(
+		() =>
+			referrals.reduce(
+				( acc, referral ) =>
+					acc + referral.referralStatuses.filter( ( status ) => status === 'pending' ).length,
+				0
+			),
+		[ referrals ]
+	);
+
+	const nextPayoutActivityWindow = useMemo( () => {
+		const { start, finish } = getNextPayoutDateActivityWindow( new Date() );
+		const startDate = start.toLocaleString( 'default', {
+			month: 'short',
+			day: 'numeric',
+			year: 'numeric',
+		} );
+		const finishDate = finish.toLocaleString( 'default', {
+			month: 'short',
+			day: 'numeric',
+			year: 'numeric',
+		} );
+		return `${ startDate } - ${ finishDate }`;
+	}, [] );
+
+	const nextPayoutDate = useMemo(
+		() =>
+			getNextPayoutDate( new Date() ).toLocaleString( 'default', {
+				month: 'short',
+				day: 'numeric',
+			} ),
+		[]
+	);
+
+	return {
+		expectedCommission,
+		pendingOrders,
+		nextPayoutActivityWindow,
+		nextPayoutDate,
+	};
+}

--- a/client/a8c-for-agencies/sections/referrals/lib/commissions.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/commissions.ts
@@ -28,6 +28,7 @@ export const calculateCommissions = ( referral: Referral, products: APIProductFa
 		.reduce( ( acc, current ) => acc + current, 0 );
 };
 
+// TODO: Remove this file once we establish new commission logic works properly
 export const getConsolidatedData = (
 	referrals: Referral[],
 	products: APIProductFamilyProduct[],

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -55,7 +55,6 @@ export default function LayoutBodyContent( {
 	dataViewsState,
 	setDataViewsState,
 	referralInvoices,
-	isFetchingInvoices,
 	isArchiveView,
 	onReferralRefetch,
 }: Props ) {
@@ -128,8 +127,7 @@ export default function LayoutBodyContent( {
 				{ ! dataViewsState.selectedItem && ! isArchiveView && (
 					<ConsolidatedViews
 						referrals={ referrals }
-						referralInvoices={ referralInvoices }
-						isFetchingInvoices={ isFetchingInvoices }
+						totalPayouts={ tipaltiData?.PaymentsStatus?.submittedTotal }
 					/>
 				) }
 				<ReferralList

--- a/client/a8c-for-agencies/sections/referrals/referral-details/commissions.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/commissions.tsx
@@ -1,12 +1,6 @@
 import ConsolidatedViews from '../consolidated-view';
-import type { Referral, ReferralInvoice } from '../types';
+import type { Referral } from '../types';
 
-export default function ReferralCommissions( {
-	referral,
-	referralInvoices,
-}: {
-	referral: Referral;
-	referralInvoices: ReferralInvoice[];
-} ) {
-	return <ConsolidatedViews referrals={ [ referral ] } referralInvoices={ referralInvoices } />;
+export default function ReferralCommissions( { referral }: { referral: Referral } ) {
+	return <ConsolidatedViews referrals={ [ referral ] } />;
 }

--- a/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
@@ -27,7 +27,6 @@ const REFERRAL_COMMISSIONS_ID = 'referral-commissions';
 export default function ReferralDetails( {
 	referral,
 	closeSitePreviewPane,
-	referralInvoices,
 	isArchiveView,
 }: Props ) {
 	const translate = useTranslate();
@@ -55,10 +54,6 @@ export default function ReferralDetails( {
 
 	const isDesktop = useDesktopBreakpoint();
 
-	const clientReferralInvoices = referralInvoices.filter(
-		( invoice ) => invoice.clientId === referral.client.id
-	);
-
 	const features = useMemo(
 		() => [
 			createFeaturePreview(
@@ -79,10 +74,10 @@ export default function ReferralDetails( {
 				true,
 				selectedReferralTab,
 				setSelectedReferralTab,
-				<ReferralCommissions referral={ referral } referralInvoices={ clientReferralInvoices } />
+				<ReferralCommissions referral={ referral } />
 			),
 		],
-		[ translate, selectedReferralTab, isDesktop, referral, clientReferralInvoices ]
+		[ translate, selectedReferralTab, isDesktop, referral ]
 	);
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1578

## Proposed Changes

This PR wraps up UI part of [Referral Dashboard revised commission expected area](https://github.com/Automattic/automattic-for-agencies-dev/issues/900). Descriptions and tooltips were updated.
Payout calculations are based on pfunGA-3Wy-p2#comment-7052
Designs: fuufP6VNfZXYmvLsTRWRlG-fi-8332_118153

https://github.com/user-attachments/assets/33dd282d-64f4-46a0-84bd-74c34c8093f3



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link below, navigate to /referrals/dashboard and check looks according to the designs.
- Check that the data looks good and links in tooltip works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?