### PR TITLE
Fix long domains in header on Domains dashboard

### DIFF
--- a/client/my-sites/domains/style.scss
+++ b/client/my-sites/domains/style.scss
@@ -54,16 +54,16 @@ body.is-section-domains.is-domain-plan-package-flow {
 }
 
 .domains-overview .multi-sites-dashboard-layout-with-columns__container {
-    background: var(--color-sidebar-background);
+	background: var(--color-sidebar-background);
 }
 
 .domains-overview .item-preview__pane {
-    flex-grow: 1;
-    width: auto;
-    transition: flex-grow 0.2s;
-    background: var(--color-light-backdrop);
-    max-height: calc(100vh - 32px - var(--masterbar-height));
-    border-radius: 8px; /* stylelint-disable-line scales/radii */
+	flex-grow: 1;
+	width: auto;
+	transition: flex-grow 0.2s;
+	background: var(--color-light-backdrop);
+	max-height: calc(100vh - 32px - var(--masterbar-height));
+	border-radius: 8px; /* stylelint-disable-line scales/radii */
 }
 
 .domains-overview {
@@ -75,7 +75,7 @@ body.is-section-domains.is-domain-plan-package-flow {
 		max-width: 1200px;
 		margin-left: 0;
 	}
-	
+
 	.item-preview__content div {
 		flex-grow: 1;
 	}

--- a/client/my-sites/domains/style.scss
+++ b/client/my-sites/domains/style.scss
@@ -53,30 +53,30 @@ body.is-section-domains.is-domain-plan-package-flow {
 	}
 }
 
-.domains-overview .multi-sites-dashboard-layout-with-columns__container {
-	background: var(--color-sidebar-background);
-}
-
-.domains-overview .item-preview__pane {
-	flex-grow: 1;
-	width: auto;
-	transition: flex-grow 0.2s;
-	background: var(--color-light-backdrop);
-	max-height: calc(100vh - 32px - var(--masterbar-height));
-	border-radius: 8px; /* stylelint-disable-line scales/radii */
-}
-
 .domains-overview {
+	.multi-sites-dashboard-layout-with-columns__container {
+		background: var(--color-sidebar-background);
+	}
+
+	.item-preview__pane {
+		background: var(--color-light-backdrop);
+		border-radius: 8px; /* stylelint-disable-line scales/radii */
+		flex-grow: 1;
+		max-height: calc(100vh - 32px - var(--masterbar-height));
+		transition: flex-grow 0.2s;
+		width: auto;
+	}
+
 	.item-preview__header-info {
 		flex-wrap: wrap;
 	}
 
-	.domain-settings-page {
-		max-width: 1200px;
-		margin-left: 0;
-	}
-
 	.item-preview__content div {
 		flex-grow: 1;
+	}
+
+	.domain-settings-page {
+		margin-left: 0;
+		max-width: 1200px;
 	}
 }

--- a/client/my-sites/domains/style.scss
+++ b/client/my-sites/domains/style.scss
@@ -67,6 +67,10 @@ body.is-section-domains.is-domain-plan-package-flow {
 }
 
 .domains-overview {
+	.item-preview__header-info {
+		flex-wrap: wrap;
+	}
+
 	.domain-settings-page {
 		max-width: 1200px;
 		margin-left: 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #97617.

## Proposed Changes

- Allow flex items to break onto multiple lines.
- Update spaces to tabs to conform to Calypso coding guidelines.
- Nest related CSS under `.domains-overview` for improved readability.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the `calypso/all-domain-management` flag.
* On `/domains/manage`, select a longer domain.
* View the page at a mobile resolution.
* Ensure the header isn't broken.

### Before
![Image](https://github.com/user-attachments/assets/7125da65-5974-42d1-8419-17a6a4b6970b)

### After
![Screenshot 2024-12-18 at 2 12 52 PM](https://github.com/user-attachments/assets/3c7bbd82-aba5-4304-995c-fe1fc098b36d)

## Pre-merge Checklist
<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
