### PR TITLE
Goals first flow allows "Back" from signup to design picker step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -175,12 +175,22 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 				lang: lang === 'en' || isLoggedIn ? null : lang,
 			} );
 
+			const lastPreAuthWalledStepIndex =
+				flowSteps.findIndex( ( step ) => step.slug === 'user' ) - 1;
+			const lastPreAuthWalledStep =
+				lastPreAuthWalledStepIndex < 0 ? null : flowSteps[ lastPreAuthWalledStepIndex ];
+
 			return (
 				<StepComponent
 					navigation={ {
 						submit() {
 							navigate( firstAuthWalledStep.slug, undefined, true );
 						},
+						...( lastPreAuthWalledStep && {
+							goBack() {
+								navigate( lastPreAuthWalledStep.slug, undefined, true );
+							},
+						} ),
 					} }
 					flow={ flow.name }
 					variantSlug={ flow.variantSlug }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -77,7 +77,8 @@ const UserStepComponent: Step = function UserStep( {
 				isWideLayout={ false }
 				isFullLayout
 				isLargeSkipLayout={ false }
-				hideBack
+				hideBack={ ! navigation.goBack }
+				goBack={ navigation.goBack }
 				stepContent={
 					<>
 						<FormattedHeader


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/pull/97627






## Proposed Changes

* Show back link on log in step when there are steps that came before it in the flow.

https://github.com/user-attachments/assets/3eab5221-60dc-4420-a0d4-29def14a47c6

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Up until now, the user step has always been the first step in the stepper framework. With the goals first experiment it means the user step can be half way through the flow. The back link should work as expected.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Test `/setup/onboarding` while logged out
  - Once you land on the sign up step you should be able to go back to the design picker
- Test `/setup/onboarding?flags=-onboarding/goals-first`
  - You should land on the signup step immediately
  - There should be no back link

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
