### PR TITLE
Unset font-weight on domains and plans screens

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -503,7 +503,6 @@ body.is-section-signup.is-white-signup {
 				height: auto;
 				line-height: 20px;
 				padding: 0.57em 1.17em;
-				font-weight: 500;
 				border-radius: 4px;
 				border: 1px solid #c3c4c7;
 				letter-spacing: 0.32px;

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -224,7 +224,6 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 	}
 
 	.button.domain-suggestion__action {
-		font-weight: 500;
 		padding: 0.57em 1.17em;
 		border-radius: 4px;
 		font-size: 0.875rem;

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -225,7 +225,6 @@
 
 button.register-domain-step__next-page-button {
 	font-size: 0.875rem;
-	font-weight: 500;
 }
 
 body.is-section-domains {

--- a/client/my-sites/plans-features-main/components/comparison-grid-toggle.tsx
+++ b/client/my-sites/plans-features-main/components/comparison-grid-toggle.tsx
@@ -25,7 +25,6 @@ const ComparisonGridToggle = forwardRef<
 			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.05 );
 			color: var( --studio-gray-100 );
 			font-size: var( --scss-font-body-small );
-			font-weight: 500;
 			height: 48px;
 			justify-content: center;
 			line-height: 20px;

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -20,7 +20,6 @@ $plan-features-header-banner-height: 20px;
 	button {
 		text-decoration: underline;
 		font-size: var(--scss-font-body-small);
-		font-weight: 500;
 	}
 }
 

--- a/packages/plans-grid-next/src/components/dropdown-option.tsx
+++ b/packages/plans-grid-next/src/components/dropdown-option.tsx
@@ -19,8 +19,6 @@ const Container = styled.div`
 		color: var( --studio-green-50 );
 	}
 
-	font-weight: 500;
-
 	.title {
 		margin-right: 4px;
 		line-height: 20px;

--- a/packages/plans-grid-next/src/components/plan-button/style.scss
+++ b/packages/plans-grid-next/src/components/plan-button/style.scss
@@ -1,7 +1,6 @@
 @import "@automattic/onboarding/styles/mixins";
 
 .plan-features-2023-grid__actions-button {
-	font-weight: 500;
 	line-height: 20px;
 	border-radius: 4px;
 	padding: 10px 12px;


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/97589

## Proposed Changes

* Removes 500 font weight from buttons on the domains and plans steps to match buttons elsewhere across dotcom

## Testing Instructions

| Plans Before | After |
| --- | --- |
| ![Screenshot 2024-12-19 at 12-40-26 Create a site — WordPress com](https://github.com/user-attachments/assets/74fcc208-c141-443d-97fc-25565c94577e) | ![Screenshot(189)](https://github.com/user-attachments/assets/d49450ef-afd4-4ab9-8239-d9f6b4c438df) |


| Domains Before | After |
| --- | --- |
|![Screenshot 2024-12-19 at 12-40-17 Create a site — WordPress com](https://github.com/user-attachments/assets/aeaaa2a9-ad61-4d66-a32f-08835e758da0) | ![Screenshot(187)](https://github.com/user-attachments/assets/c41ff324-d328-47c6-9d34-add00d599d27) |

Also check https://wordpress.com/domains/add/:site and https://wordpress.com/plans/:site screens for regressions.