### PR TITLE
Goals First: Display the back button on domains and plans step on mobile

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -123,7 +123,7 @@ button {
 			&.courses,
 			&.site-picker,
 			&.new-or-existing-site,
-			&.domains:not(.copy-site) {
+			&.domains:not(.copy-site):not(.onboarding) {
 				margin-top: -60px;
 			}
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -6,7 +6,6 @@ import {
 	useStarterDesignBySlug,
 } from '@automattic/data-stores';
 import { isOnboardingFlow, useStepPersistedState } from '@automattic/onboarding';
-import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useDispatch, useSelect, useDispatch as useWPDispatch } from '@wordpress/data';
 import { useState } from 'react';
 import { useQueryTheme } from 'calypso/components/data/query-theme';
@@ -31,7 +30,6 @@ import './style.scss';
 export default function PlansStepAdaptor( props: StepProps ) {
 	const [ stepState, setStepState ] = useStepPersistedState< ProvidedDependencies >( 'plans-step' );
 	const siteSlug = useSiteSlug();
-	const isMobile = useMobileBreakpoint();
 
 	const { siteTitle, domainItem, domainItems, selectedDesign } = useSelect(
 		( select: ( key: string ) => OnboardSelect ) => {
@@ -164,7 +162,7 @@ export default function PlansStepAdaptor( props: StepProps ) {
 			onPlanIntervalUpdate={ onPlanIntervalUpdate }
 			intervalType={ planInterval }
 			wrapperProps={ {
-				hideBack: isMobile,
+				hideBack: false,
 				goBack: props.navigation.goBack,
 				isFullLayout: true,
 				isExtraWideLayout: false,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
@@ -1,7 +1,7 @@
 @import "@automattic/onboarding/styles/mixins";
 
 .step-route.plans {
-	padding: 48px 0 0;
+	padding: 60px 0 0;
 	@include break-xlarge {
 		padding: 0;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -113,7 +113,7 @@ export interface UnifiedPlansStepProps {
 	 * Passed from Stepper for @automattic/onboarding step-container
 	 */
 	wrapperProps?: {
-		hideBack: boolean;
+		hideBack?: boolean;
 		goBack: NavigationControls[ 'goBack' ];
 		isFullLayout: boolean;
 		isExtraWideLayout: boolean;

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -250,10 +250,8 @@ body.is-section-stepper .domains__step-content,
 .onboarding {
 	&.domains {
 		&.step-route {
-			padding: 48px 0 0;
-			@include break-mobile {
-				padding: 48px 12px 0 12px;
-			}
+			padding: 60px 12px 0 12px;
+
 			.step-container {
 				.step-container__header {
 					margin: 36px 0 24px 0;
@@ -262,12 +260,6 @@ body.is-section-stepper .domains__step-content,
 					}
 					@include break-large {
 						margin: 48px 0 40px;
-					}
-				}
-
-				.action-buttons.step-container__navigation {
-					@media (max-width: $break-mobile) {
-						display: none;
 					}
 				}
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Display the back button on domains and plans step on mobile

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/onboarding
* Switch to the mobile viewport
* Go through every steps, especially for domains and plans
* Ensure the back button is always visible and works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
