### PR TITLE
A4A > Add sites: Fix the "Add site" modals responsiveness

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/a4a-connection-modal/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/a4a-connection-modal/style.scss
@@ -18,12 +18,14 @@
 .a4a-connection-modal__input-container {
 	display: flex;
 	gap: 16px;
-	align-items: flex-end;
 	flex-direction: column;
 
 	.form-fieldset {
 		margin: 0;
-		width: 70%;
+
+		@include break-small {
+			width: 70%;
+		}
 	}
 
 	.button {
@@ -31,7 +33,7 @@
 	}
 
 	@include break-small {
-
+		align-items: flex-end;
 		flex-direction: row;
 	}
 }

--- a/client/a8c-for-agencies/components/add-new-site-button/jetpack-connection-modal/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/jetpack-connection-modal/style.scss
@@ -18,12 +18,14 @@
 .jetpack-connection-modal__input-container {
 	display: flex;
 	gap: 16px;
-	align-items: flex-end;
 	flex-direction: column;
 
 	.form-fieldset {
 		margin: 0;
-		width: 70%;
+
+		@include break-small {
+			width: 70%;
+		}
 	}
 
 	.button {
@@ -31,7 +33,7 @@
 	}
 
 	@include break-small {
-
+		align-items: flex-end;
 		flex-direction: row;
 	}
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1574

## Proposed Changes

This PR fixes the "Add site" modals responsiveness on mobile devices.

## Why are these changes being made?

* To fix the responsiveness of the "Add site" modals.

## Testing Instructions

* Open the A4A live link > Click the "Add sites" button on the top right of the Overview page
* Click the `Via the Automattic plugin` option > Verify the modal looks good on all the screen sizes, especially the mobile devices (~375px)


| Before | After |
|--------|--------|
| <img width="413" alt="Screenshot 2024-12-19 at 11 12 10 AM" src="https://github.com/user-attachments/assets/97f58548-c798-4e21-80b6-b42633f60626" />| <img width="413" alt="Screenshot 2024-12-19 at 11 11 31 AM" src="https://github.com/user-attachments/assets/6b42d595-c46b-425c-87d8-480ee8006bc3" /> |


* * Click the `Via Jetpack` option > Verify the modal looks good on all the screen sizes, especially the mobile devices (~375px)

| Before | After |
|--------|--------|
| <img width="413" alt="Screenshot 2024-12-19 at 11 12 14 AM" src="https://github.com/user-attachments/assets/d142a3cd-47bc-48f5-b20c-fe6dd1a4fa0a" /> | <img width="413" alt="Screenshot 2024-12-19 at 11 11 36 AM" src="https://github.com/user-attachments/assets/320ba448-b79a-4a3b-a2ac-b0bb0e2cbedf" /> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
