### PR TITLE
Implement "Add new site" for WPCOM

### DIFF
--- a/client/a8c-for-agencies/sections/overview/header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/header-actions/index.tsx
@@ -3,11 +3,12 @@ import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import AddNewSiteButton from 'calypso/a8c-for-agencies/components/add-new-site-button';
+// import AddNewSiteButton from 'calypso/a8c-for-agencies/components/add-new-site-button';
 import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import SiteConfigurationsModal from 'calypso/a8c-for-agencies/components/site-configurations-modal';
 import { useRandomSiteName } from 'calypso/a8c-for-agencies/components/site-configurations-modal/use-random-site-name';
 import useSiteCreatedCallback from 'calypso/a8c-for-agencies/hooks/use-site-created-callback';
+import AddNewSite from 'calypso/components/add-new-site';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './style.scss';
@@ -35,10 +36,11 @@ export default function OverviewHeaderActions() {
 					onCreateSiteSuccess={ onCreateSiteSuccess }
 				/>
 			) }
-			<AddNewSiteButton
+			{ /* <AddNewSiteButton
 				showMainButtonLabel={ ! isNarrowView }
 				toggleDevSiteConfigurationsModal={ toggleDevSiteConfigurationsModal }
-			/>
+			/> */ }
+			<AddNewSite />
 			{ ! isNarrowView && (
 				<Button
 					primary

--- a/client/a8c-for-agencies/sections/overview/header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/header-actions/index.tsx
@@ -1,9 +1,10 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
-// import AddNewSiteButton from 'calypso/a8c-for-agencies/components/add-new-site-button';
+import AddNewSiteButton from 'calypso/a8c-for-agencies/components/add-new-site-button';
 import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import SiteConfigurationsModal from 'calypso/a8c-for-agencies/components/site-configurations-modal';
 import { useRandomSiteName } from 'calypso/a8c-for-agencies/components/site-configurations-modal/use-random-site-name';
@@ -28,19 +29,24 @@ export default function OverviewHeaderActions() {
 
 	return (
 		<div className="overview-header__actions">
-			{ showConfigurationModal && (
-				<SiteConfigurationsModal
-					closeModal={ toggleDevSiteConfigurationsModal }
-					randomSiteName={ randomSiteName }
-					isRandomSiteNameLoading={ isRandomSiteNameLoading }
-					onCreateSiteSuccess={ onCreateSiteSuccess }
-				/>
+			{ isEnabled( 'a4a-updated-add-new-site' ) ? (
+				<AddNewSite />
+			) : (
+				<>
+					{ showConfigurationModal && (
+						<SiteConfigurationsModal
+							closeModal={ toggleDevSiteConfigurationsModal }
+							randomSiteName={ randomSiteName }
+							isRandomSiteNameLoading={ isRandomSiteNameLoading }
+							onCreateSiteSuccess={ onCreateSiteSuccess }
+						/>
+					) }
+					<AddNewSiteButton
+						showMainButtonLabel={ ! isNarrowView }
+						toggleDevSiteConfigurationsModal={ toggleDevSiteConfigurationsModal }
+					/>
+				</>
 			) }
-			{ /* <AddNewSiteButton
-				showMainButtonLabel={ ! isNarrowView }
-				toggleDevSiteConfigurationsModal={ toggleDevSiteConfigurationsModal }
-			/> */ }
-			<AddNewSite />
 			{ ! isNarrowView && (
 				<Button
 					primary

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { getQueryArg } from '@wordpress/url';
@@ -10,6 +11,7 @@ import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/componen
 import SiteConfigurationsModal from 'calypso/a8c-for-agencies/components/site-configurations-modal';
 import { useRandomSiteName } from 'calypso/a8c-for-agencies/components/site-configurations-modal/use-random-site-name';
 import useSiteCreatedCallback from 'calypso/a8c-for-agencies/hooks/use-site-created-callback';
+import AddNewSite from 'calypso/components/add-new-site';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import './style.scss';
 
@@ -40,21 +42,29 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 
 	return (
 		<div className="sites-header__actions">
-			{ showConfigurationModal && (
-				<SiteConfigurationsModal
-					closeModal={ toggleDevSiteConfigurationsModal }
-					randomSiteName={ randomSiteName }
-					isRandomSiteNameLoading={ isRandomSiteNameLoading }
-					onCreateSiteSuccess={ onCreateSiteSuccess }
-				/>
+			{ isEnabled( 'a4a-updated-add-new-site' ) ? (
+				<div ref={ ( ref ) => setTourStepRef( ref ) }>
+					<AddNewSite />
+				</div>
+			) : (
+				<>
+					{ showConfigurationModal && (
+						<SiteConfigurationsModal
+							closeModal={ toggleDevSiteConfigurationsModal }
+							randomSiteName={ randomSiteName }
+							isRandomSiteNameLoading={ isRandomSiteNameLoading }
+							onCreateSiteSuccess={ onCreateSiteSuccess }
+						/>
+					) }
+					<div ref={ ( ref ) => setTourStepRef( ref ) }>
+						<AddNewSiteButton
+							showMainButtonLabel={ ! isMobile }
+							onWPCOMImport={ onWPCOMImport }
+							toggleDevSiteConfigurationsModal={ toggleDevSiteConfigurationsModal }
+						/>
+					</div>
+				</>
 			) }
-			<div ref={ ( ref ) => setTourStepRef( ref ) }>
-				<AddNewSiteButton
-					showMainButtonLabel={ ! isMobile }
-					onWPCOMImport={ onWPCOMImport }
-					toggleDevSiteConfigurationsModal={ toggleDevSiteConfigurationsModal }
-				/>
-			</div>
 			<GuidedTourStep id="add-new-site" tourId="addSiteStep1" context={ tourStepRef } />
 			<Button
 				primary

--- a/client/assets/images/wpcom/add-new-site-free-domain.svg
+++ b/client/assets/images/wpcom/add-new-site-free-domain.svg
@@ -1,0 +1,3 @@
+<svg width="224" height="78" viewBox="0 0 224 78" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect y="78" width="78" height="224" rx="4" transform="rotate(-90 0 78)" fill="#3858E9"/>
+</svg>

--- a/client/components/add-new-site/button.tsx
+++ b/client/components/add-new-site/button.tsx
@@ -1,0 +1,43 @@
+import { Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+
+type Props = {
+	showMainButtonLabel: boolean;
+	isMenuVisible: boolean;
+	toggleMenu: () => void;
+	popoverMenuContext: React.RefObject< HTMLButtonElement >;
+};
+
+const AddNewSiteButton: React.FC< Props > = ( {
+	showMainButtonLabel,
+	isMenuVisible,
+	toggleMenu,
+	popoverMenuContext,
+} ) => {
+	const translate = useTranslate();
+
+	return (
+		<Button
+			variant="secondary"
+			ref={ popoverMenuContext }
+			className="add-new-site__button"
+			onClick={ toggleMenu }
+		>
+			<>
+				{ showMainButtonLabel ? translate( 'Add sites' ) : null }
+				<Gridicon
+					className={ clsx(
+						{ reverse: showMainButtonLabel && isMenuVisible },
+						{ mobile: ! showMainButtonLabel }
+					) }
+					icon={ showMainButtonLabel ? 'chevron-down' : 'plus' }
+				/>
+			</>
+		</Button>
+	);
+};
+
+export default AddNewSiteButton;

--- a/client/components/add-new-site/context.ts
+++ b/client/components/add-new-site/context.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+import type { AddNewSiteContextInterface } from './types';
+
+export const AddNewSiteContext = createContext< AddNewSiteContextInterface >( {
+	visibleModalType: '',
+	setVisibleModalType: () => {
+		return undefined;
+	},
+} );

--- a/client/components/add-new-site/context.ts
+++ b/client/components/add-new-site/context.ts
@@ -1,9 +1,11 @@
 import { createContext } from 'react';
 import type { AddNewSiteContextInterface } from './types';
 
-export const AddNewSiteContext = createContext< AddNewSiteContextInterface >( {
+const AddNewSiteContext = createContext< AddNewSiteContextInterface >( {
 	visibleModalType: '',
 	setVisibleModalType: () => {
 		return undefined;
 	},
 } );
+
+export default AddNewSiteContext;

--- a/client/components/add-new-site/index.tsx
+++ b/client/components/add-new-site/index.tsx
@@ -1,7 +1,7 @@
 import { useBreakpoint } from '@automattic/viewport-react';
-import { useRef, useState, useCallback } from 'react';
+import { useRef, useState, useCallback, useMemo } from 'react';
 import AddNewSiteButton from './button';
-import { AddNewSiteContext } from './context';
+import AddNewSiteContext from './context';
 import AddNewSiteMenuItems from './menu-items';
 import AddNewSiteModals from './modals';
 import AddNewSitePopover from './popover';
@@ -20,8 +20,17 @@ const AddNewSite = () => {
 		setMenuVisible( ( isVisible ) => ! isVisible );
 	}, [] );
 
+	// Memoize the context value to avoid unnecessary re-renders
+	const contextValue = useMemo(
+		() => ( {
+			visibleModalType,
+			setVisibleModalType,
+		} ),
+		[ visibleModalType, setVisibleModalType ]
+	);
+
 	return (
-		<AddNewSiteContext.Provider value={ { visibleModalType, setVisibleModalType } }>
+		<AddNewSiteContext.Provider value={ contextValue }>
 			<AddNewSiteButton
 				showMainButtonLabel={ ! isNarrowView }
 				isMenuVisible={ isMenuVisible }

--- a/client/components/add-new-site/index.tsx
+++ b/client/components/add-new-site/index.tsx
@@ -21,6 +21,7 @@ const AddNewSite = () => {
 		setMenuVisible( ( isVisible ) => ! isVisible );
 	}, [] );
 
+	// Render the popover content based on the environment
 	const renderPopoverContent = useMemo( () => {
 		switch ( true ) {
 			case isA8CForAgencies():
@@ -30,6 +31,7 @@ const AddNewSite = () => {
 		}
 	}, [ setMenuVisible ] );
 
+	// Render the modals content based on the environment
 	const renderModalsContent = useMemo( () => {
 		switch ( true ) {
 			case isA8CForAgencies():

--- a/client/components/add-new-site/index.tsx
+++ b/client/components/add-new-site/index.tsx
@@ -1,0 +1,62 @@
+import { useBreakpoint } from '@automattic/viewport-react';
+import { useRef, useState, useCallback, useMemo } from 'react';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
+import AddNewSiteButton from './button';
+import { AddNewSiteContext } from './context';
+import AddNewSiteMenuItems from './menu-items';
+import AddNewSiteModals from './modals';
+import AddNewSitePopover from './popover';
+
+import './style.scss';
+
+const AddNewSite = () => {
+	const isNarrowView = useBreakpoint( '<660px' );
+
+	const [ isMenuVisible, setMenuVisible ] = useState( false );
+	const [ visibleModalType, setVisibleModalType ] = useState( '' );
+
+	const popoverMenuContext = useRef( null );
+
+	const toggleMenu = useCallback( () => {
+		setMenuVisible( ( isVisible ) => ! isVisible );
+	}, [] );
+
+	const renderPopoverContent = useMemo( () => {
+		switch ( true ) {
+			case isA8CForAgencies():
+				return <AddNewSiteMenuItems.A4A setMenuVisible={ setMenuVisible } />;
+			default:
+				return null;
+		}
+	}, [ setMenuVisible ] );
+
+	const renderModalsContent = useMemo( () => {
+		switch ( true ) {
+			case isA8CForAgencies():
+				return <AddNewSiteModals.A4A />;
+			default:
+				return null;
+		}
+	}, [] );
+
+	return (
+		<AddNewSiteContext.Provider value={ { visibleModalType, setVisibleModalType } }>
+			<AddNewSiteButton
+				showMainButtonLabel={ ! isNarrowView }
+				isMenuVisible={ isMenuVisible }
+				toggleMenu={ toggleMenu }
+				popoverMenuContext={ popoverMenuContext }
+			/>
+			<AddNewSitePopover
+				isMenuVisible={ isMenuVisible }
+				toggleMenu={ toggleMenu }
+				popoverMenuContext={ popoverMenuContext }
+			>
+				{ renderPopoverContent }
+			</AddNewSitePopover>
+			{ renderModalsContent }
+		</AddNewSiteContext.Provider>
+	);
+};
+
+export default AddNewSite;

--- a/client/components/add-new-site/index.tsx
+++ b/client/components/add-new-site/index.tsx
@@ -1,6 +1,5 @@
 import { useBreakpoint } from '@automattic/viewport-react';
-import { useRef, useState, useCallback, useMemo } from 'react';
-import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
+import { useRef, useState, useCallback } from 'react';
 import AddNewSiteButton from './button';
 import { AddNewSiteContext } from './context';
 import AddNewSiteMenuItems from './menu-items';
@@ -21,26 +20,6 @@ const AddNewSite = () => {
 		setMenuVisible( ( isVisible ) => ! isVisible );
 	}, [] );
 
-	// Render the popover content based on the environment
-	const renderPopoverContent = useMemo( () => {
-		switch ( true ) {
-			case isA8CForAgencies():
-				return <AddNewSiteMenuItems.A4A setMenuVisible={ setMenuVisible } />;
-			default:
-				return null;
-		}
-	}, [ setMenuVisible ] );
-
-	// Render the modals content based on the environment
-	const renderModalsContent = useMemo( () => {
-		switch ( true ) {
-			case isA8CForAgencies():
-				return <AddNewSiteModals.A4A />;
-			default:
-				return null;
-		}
-	}, [] );
-
 	return (
 		<AddNewSiteContext.Provider value={ { visibleModalType, setVisibleModalType } }>
 			<AddNewSiteButton
@@ -54,9 +33,9 @@ const AddNewSite = () => {
 				toggleMenu={ toggleMenu }
 				popoverMenuContext={ popoverMenuContext }
 			>
-				{ renderPopoverContent }
+				<AddNewSiteMenuItems setMenuVisible={ setMenuVisible } />
 			</AddNewSitePopover>
-			{ renderModalsContent }
+			<AddNewSiteModals />
 		</AddNewSiteContext.Provider>
 	);
 };

--- a/client/components/add-new-site/menu-item.tsx
+++ b/client/components/add-new-site/menu-item.tsx
@@ -11,7 +11,7 @@ type Props = {
 	children?: JSX.Element;
 	description: TranslateResult;
 	disabled?: boolean;
-	heading: string;
+	heading: TranslateResult;
 	icon: JSX.Element;
 	isBanner?: boolean;
 };

--- a/client/components/add-new-site/menu-item.tsx
+++ b/client/components/add-new-site/menu-item.tsx
@@ -1,0 +1,50 @@
+import { Button } from '@wordpress/components';
+import { Icon } from '@wordpress/icons';
+import clsx from 'clsx';
+import { TranslateResult } from 'i18n-calypso';
+import React from 'react';
+
+const ICON_SIZE = 32;
+
+type Props = {
+	icon: JSX.Element;
+	iconClassName?: string;
+	heading: string;
+	description: string | TranslateResult;
+	isBanner?: boolean;
+	disabled?: boolean;
+	buttonProps?: React.ComponentProps< typeof Button >;
+	extraContent?: JSX.Element;
+};
+
+const AddNewSiteMenuItem: React.FC< Props > = ( {
+	icon,
+	iconClassName,
+	heading,
+	description,
+	isBanner,
+	disabled,
+	buttonProps,
+	extraContent,
+} ) => {
+	return (
+		<Button
+			{ ...buttonProps }
+			className={ clsx( 'add-new-site__popover-button', {
+				banner: isBanner,
+				disabled,
+			} ) }
+		>
+			<div className={ clsx( 'add-new-site__popover-button-icon', iconClassName ) }>
+				<Icon className="sidebar__menu-icon" icon={ icon } size={ ICON_SIZE } />
+			</div>
+			<div className="add-new-site__popover-button-content">
+				<div className="add-new-site__popover-button-heading">{ heading }</div>
+				<div className="add-new-site__popover-button-description">{ description }</div>
+				{ extraContent }
+			</div>
+		</Button>
+	);
+};
+
+export default AddNewSiteMenuItem;

--- a/client/components/add-new-site/menu-item.tsx
+++ b/client/components/add-new-site/menu-item.tsx
@@ -7,25 +7,23 @@ import React from 'react';
 const ICON_SIZE = 32;
 
 type Props = {
-	icon: JSX.Element;
-	iconClassName?: string;
-	heading: string;
-	description: string | TranslateResult;
-	isBanner?: boolean;
-	disabled?: boolean;
 	buttonProps?: React.ComponentProps< typeof Button >;
-	extraContent?: JSX.Element;
+	children?: JSX.Element;
+	description: TranslateResult;
+	disabled?: boolean;
+	heading: string;
+	icon: JSX.Element;
+	isBanner?: boolean;
 };
 
 const AddNewSiteMenuItem: React.FC< Props > = ( {
-	icon,
-	iconClassName,
-	heading,
-	description,
-	isBanner,
-	disabled,
 	buttonProps,
-	extraContent,
+	children,
+	description,
+	disabled,
+	heading,
+	icon,
+	isBanner,
 } ) => {
 	return (
 		<Button
@@ -35,13 +33,13 @@ const AddNewSiteMenuItem: React.FC< Props > = ( {
 				'is-disabled': disabled,
 			} ) }
 		>
-			<div className={ clsx( 'add-new-site__popover-button-icon', iconClassName ) }>
+			<div className="add-new-site__popover-button-icon">
 				<Icon className="sidebar__menu-icon" icon={ icon } size={ ICON_SIZE } />
 			</div>
 			<div className="add-new-site__popover-button-content">
 				<div className="add-new-site__popover-button-heading">{ heading }</div>
 				<div className="add-new-site__popover-button-description">{ description }</div>
-				{ extraContent }
+				{ children }
 			</div>
 		</Button>
 	);

--- a/client/components/add-new-site/menu-item.tsx
+++ b/client/components/add-new-site/menu-item.tsx
@@ -31,8 +31,8 @@ const AddNewSiteMenuItem: React.FC< Props > = ( {
 		<Button
 			{ ...buttonProps }
 			className={ clsx( 'add-new-site__popover-button', {
-				banner: isBanner,
-				disabled,
+				'is-banner': isBanner,
+				'is-disabled': disabled,
 			} ) }
 		>
 			<div className={ clsx( 'add-new-site__popover-button-icon', iconClassName ) }>

--- a/client/components/add-new-site/menu-items/a4a.tsx
+++ b/client/components/add-new-site/menu-items/a4a.tsx
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import { WordPressLogo, JetpackLogo } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useContext } from 'react';
+import { useContext, useCallback } from 'react';
 import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
 import {
 	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
@@ -19,7 +19,7 @@ import usePaymentMethod from 'calypso/a8c-for-agencies/sections/purchases/paymen
 import devSiteBanner from 'calypso/assets/images/a8c-for-agencies/dev-site-banner.svg';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
 import { preventWidows } from 'calypso/lib/formatting';
-import { AddNewSiteContext } from '../context';
+import AddNewSiteContext from '../context';
 import AddNewSiteMenuItem from '../menu-item';
 import AddNewSitePopoverColumn from '../popover-column';
 import type { AddNewSiteMenuItemsProps } from '../types';
@@ -50,6 +50,14 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 
 	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
 
+	const handleOnClick = useCallback(
+		( modalType: string ) => {
+			setVisibleModalType( modalType );
+			setMenuVisible( false );
+		},
+		[ setVisibleModalType, setMenuVisible ]
+	);
+
 	return (
 		<>
 			<AddNewSitePopoverColumn heading={ translate( 'Import existing sites' ) }>
@@ -61,21 +69,19 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 					) }
 					buttonProps={ {
 						onClick: () => {
-							setVisibleModalType( 'import-from-wpcom' );
-							setMenuVisible( false );
+							handleOnClick( 'import-from-wpcom' );
 						},
 					} }
 				/>
 				<AddNewSiteMenuItem
 					icon={ <A4ALogo /> }
-					heading={ translate( 'Via the Automattic plugin ' ) }
+					heading={ translate( 'Via the Automattic plugin' ) }
 					description={ preventWidows(
 						translate( 'Connect with the Automattic for Agencies plugin' )
 					) }
 					buttonProps={ {
 						onClick: () => {
-							setVisibleModalType( 'a4a-connection' );
-							setMenuVisible( false );
+							handleOnClick( 'a4a-connection' );
 						},
 					} }
 				/>
@@ -87,8 +93,7 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 					) }
 					buttonProps={ {
 						onClick: () => {
-							setVisibleModalType( 'jetpack-connection' );
-							setMenuVisible( false );
+							handleOnClick( 'jetpack-connection' );
 						},
 					} }
 				/>
@@ -96,7 +101,7 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 			<AddNewSitePopoverColumn heading={ translate( 'Add a new production site' ) }>
 				<AddNewSiteMenuItem
 					icon={ <img src={ pressableIcon } alt="Pressable" /> }
-					heading={ translate( 'Pressable' ) }
+					heading="Pressable"
 					description={ translate( 'Bring your theme, plugins, and content to WordPress.com.' ) }
 					buttonProps={ {
 						href:
@@ -108,7 +113,7 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 				/>
 				<AddNewSiteMenuItem
 					icon={ <WordPressLogo /> }
-					heading={ translate( 'WordPress.com' ) }
+					heading="WordPress.com"
 					description={ preventWidows(
 						translate( 'Use a backup file to import your content into a new site.' )
 					) }
@@ -117,24 +122,19 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 							? A4A_SITES_LINK_NEEDS_SETUP
 							: A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
 					} }
-					extraContent={
-						hasPendingWPCOMSites ? (
-							<div className="add-new-site-popover__count">
-								{ translate(
-									'%(pendingSites)d site available',
-									'%(pendingSites)d sites available',
-									{
-										args: {
-											pendingSites: allAvailableSites.length,
-										},
-										count: allAvailableSites.length,
-										comment: '%(pendingSites)s is the number of sites available.',
-									}
-								) }
-							</div>
-						) : undefined
-					}
-				/>
+				>
+					{ hasPendingWPCOMSites ? (
+						<div className="add-new-site-popover__count">
+							{ translate( '%(pendingSites)d site available', '%(pendingSites)d sites available', {
+								args: {
+									pendingSites: allAvailableSites.length,
+								},
+								count: allAvailableSites.length,
+								comment: '%(pendingSites)s is the number of sites available.',
+							} ) }
+						</div>
+					) : undefined }
+				</AddNewSiteMenuItem>
 			</AddNewSitePopoverColumn>
 			{ devSitesEnabled && (
 				<AddNewSitePopoverColumn>
@@ -163,26 +163,25 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 								setMenuVisible( false );
 							},
 						} }
-						extraContent={
-							<div>
-								<div className="add-new-site-popover__count">
-									{ translate( '%(pendingSites)d of 5 free licenses available', {
-										args: {
-											pendingSites: availableDevSites,
-										},
-										comment: '%(pendingSites)s is the number of free licenses available.',
-									} ) }
-								</div>
-								<div
-									className={ clsx( 'add-new-site-popover__cta', {
-										disabled: ! hasAvailableDevSites,
-									} ) }
-								>
-									{ translate( 'Create a site now →' ) }
-								</div>
+					>
+						<div>
+							<div className="add-new-site-popover__count">
+								{ translate( '%(pendingSites)d of 5 free licenses available', {
+									args: {
+										pendingSites: availableDevSites,
+									},
+									comment: '%(pendingSites)s is the number of free licenses available.',
+								} ) }
 							</div>
-						}
-					/>
+							<div
+								className={ clsx( 'add-new-site-popover__cta', {
+									disabled: ! hasAvailableDevSites,
+								} ) }
+							>
+								{ translate( 'Create a site now →' ) }
+							</div>
+						</div>
+					</AddNewSiteMenuItem>
 				</AddNewSitePopoverColumn>
 			) }
 		</>

--- a/client/components/add-new-site/menu-items/a4a.tsx
+++ b/client/components/add-new-site/menu-items/a4a.tsx
@@ -52,10 +52,23 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 
 	return (
 		<>
-			<AddNewSitePopoverColumn heading={ translate( 'Add existing sites' ) }>
+			<AddNewSitePopoverColumn heading={ translate( 'Import existing sites' ) }>
+				<AddNewSiteMenuItem
+					icon={ <WordPressLogo /> }
+					heading={ translate( 'Via WordPress.com connection' ) }
+					description={ preventWidows(
+						translate( 'Import connected WordPress.com or Jetpack sites' )
+					) }
+					buttonProps={ {
+						onClick: () => {
+							setVisibleModalType( 'import-from-wpcom' );
+							setMenuVisible( false );
+						},
+					} }
+				/>
 				<AddNewSiteMenuItem
 					icon={ <A4ALogo /> }
-					heading={ translate( 'Via the Automattic plugin' ) }
+					heading={ translate( 'Via the Automattic plugin ' ) }
 					description={ preventWidows(
 						translate( 'Connect with the Automattic for Agencies plugin' )
 					) }
@@ -67,23 +80,10 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 					} }
 				/>
 				<AddNewSiteMenuItem
-					icon={ <WordPressLogo /> }
-					heading={ translate( 'Via WordPress.com' ) }
-					description={ preventWidows(
-						translate( 'Add sites already connected to WordPress.com' )
-					) }
-					buttonProps={ {
-						onClick: () => {
-							setVisibleModalType( 'import-from-wpcom' );
-							setMenuVisible( false );
-						},
-					} }
-				/>
-				<AddNewSiteMenuItem
 					icon={ <JetpackLogo /> }
-					heading={ translate( 'Via Jetpack' ) }
+					heading={ translate( 'Via the Jetpack plugin' ) }
 					description={ preventWidows(
-						translate( 'Add a site by remotely installing the Jetpack plugin' )
+						translate( 'Install the Jetpack plugin on an existing site' )
 					) }
 					buttonProps={ {
 						onClick: () => {
@@ -93,12 +93,24 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 					} }
 				/>
 			</AddNewSitePopoverColumn>
-			<AddNewSitePopoverColumn heading={ translate( 'Add new sites' ) }>
+			<AddNewSitePopoverColumn heading={ translate( 'Add a new production site' ) }>
+				<AddNewSiteMenuItem
+					icon={ <img src={ pressableIcon } alt="Pressable" /> }
+					heading={ translate( 'Pressable' ) }
+					description={ translate( 'Bring your theme, plugins, and content to WordPress.com.' ) }
+					buttonProps={ {
+						href:
+							pressableOwnership === 'regular'
+								? 'https://my.pressable.com/agency/auth'
+								: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
+						target: pressableOwnership === 'regular' ? '_blank' : '_self',
+					} }
+				/>
 				<AddNewSiteMenuItem
 					icon={ <WordPressLogo /> }
 					heading={ translate( 'WordPress.com' ) }
 					description={ preventWidows(
-						translate( 'Optimized and hassle-free hosting for business websites' )
+						translate( 'Use a backup file to import your content into a new site.' )
 					) }
 					buttonProps={ {
 						href: hasPendingWPCOMSites
@@ -123,32 +135,16 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 						) : undefined
 					}
 				/>
-				<AddNewSiteMenuItem
-					icon={ <img src={ pressableIcon } alt="Pressable" /> }
-					heading={ translate( 'Pressable' ) }
-					description={ translate( 'Best for large-scale businesses and major eCommerce sites' ) }
-					buttonProps={ {
-						href:
-							pressableOwnership === 'regular'
-								? 'https://my.pressable.com/agency/auth'
-								: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
-						target: pressableOwnership === 'regular' ? '_blank' : '_self',
-					} }
-				/>
 			</AddNewSitePopoverColumn>
 			{ devSitesEnabled && (
 				<AddNewSitePopoverColumn>
 					<AddNewSiteMenuItem
 						isBanner
-						icon={ <img src={ devSiteBanner } alt="Start Building for Free" /> }
-						heading={ translate( 'Start Building for Free' ) }
+						icon={ <img src={ devSiteBanner } alt="Start building for free" /> }
+						heading={ translate( 'Start building for free' ) }
 						description={ preventWidows(
 							translate(
-								'Develop up to 5 WordPress.com sites at{{nbsp/}}once with free development licenses.{{br/}}Only pay when you launch!',
-								{
-									components: { br: <br />, nbsp: <>&nbsp;</> },
-									comment: 'br is a line break, nbsp is a non-breaking space character',
-								}
+								'Develop WordPress.com sites for as long as you need, with free development sites. Only pay when you launch!'
 							)
 						) }
 						disabled={ ! hasAvailableDevSites }

--- a/client/components/add-new-site/menu-items/a4a.tsx
+++ b/client/components/add-new-site/menu-items/a4a.tsx
@@ -22,14 +22,11 @@ import { preventWidows } from 'calypso/lib/formatting';
 import { AddNewSiteContext } from '../context';
 import AddNewSiteMenuItem from '../menu-item';
 import AddNewSitePopoverColumn from '../popover-column';
+import type { AddNewSiteMenuItemsProps } from '../types';
 
 type PendingSite = { features: { wpcom_atomic: { state: string; license_key: string } } };
 
-export interface AddNewSiteA4AMenuItemsProps {
-	setMenuVisible: ( isVisible: boolean ) => void;
-}
-
-const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteA4AMenuItemsProps ) => {
+const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) => {
 	const translate = useTranslate();
 
 	const { setVisibleModalType } = useContext( AddNewSiteContext );

--- a/client/components/add-new-site/menu-items/a4a.tsx
+++ b/client/components/add-new-site/menu-items/a4a.tsx
@@ -165,7 +165,7 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteA4AMenuItemsProps
 										`${ A4A_PAYMENT_METHODS_ADD_LINK }?return=${ A4A_SITES_LINK }?add_new_dev_site=true`
 									);
 								} else {
-									// toggleDevSiteConfigurationsModal?.();
+									setVisibleModalType( 'dev-site-configurations' );
 								}
 								setMenuVisible( false );
 							},

--- a/client/components/add-new-site/menu-items/a4a.tsx
+++ b/client/components/add-new-site/menu-items/a4a.tsx
@@ -1,0 +1,199 @@
+import config from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
+import { WordPressLogo, JetpackLogo } from '@automattic/components';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { useContext } from 'react';
+import A4ALogo from 'calypso/a8c-for-agencies/components/a4a-logo';
+import {
+	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
+	A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
+	A4A_PAYMENT_METHODS_ADD_LINK,
+	A4A_SITES_LINK,
+	A4A_SITES_LINK_NEEDS_SETUP,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useFetchDevLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-dev-licenses';
+import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
+import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
+import usePaymentMethod from 'calypso/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-payment-method';
+import devSiteBanner from 'calypso/assets/images/a8c-for-agencies/dev-site-banner.svg';
+import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
+import { preventWidows } from 'calypso/lib/formatting';
+import { AddNewSiteContext } from '../context';
+import AddNewSiteMenuItem from '../menu-item';
+import AddNewSitePopoverColumn from '../popover-column';
+
+type PendingSite = { features: { wpcom_atomic: { state: string; license_key: string } } };
+
+export interface AddNewSiteA4AMenuItemsProps {
+	setMenuVisible: ( isVisible: boolean ) => void;
+}
+
+const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteA4AMenuItemsProps ) => {
+	const translate = useTranslate();
+
+	const { setVisibleModalType } = useContext( AddNewSiteContext );
+
+	const pressableOwnership = usePressableOwnershipType();
+
+	const { data: pendingSites } = useFetchPendingSites();
+	const { data: devLicenses } = useFetchDevLicenses();
+	const { paymentMethodRequired } = usePaymentMethod();
+
+	const allAvailableSites =
+		pendingSites?.filter(
+			( { features }: PendingSite ) =>
+				features.wpcom_atomic.state === 'pending' && !! features.wpcom_atomic.license_key
+		) ?? [];
+
+	const hasPendingWPCOMSites = allAvailableSites.length > 0;
+
+	const availableDevSites = devLicenses?.available;
+	const hasAvailableDevSites = devLicenses?.available > 0;
+
+	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
+
+	return (
+		<>
+			<AddNewSitePopoverColumn heading={ translate( 'Add existing sites' ) }>
+				<AddNewSiteMenuItem
+					icon={ <A4ALogo /> }
+					heading={ translate( 'Via the Automattic plugin' ) }
+					description={ preventWidows(
+						translate( 'Connect with the Automattic for Agencies plugin' )
+					) }
+					buttonProps={ {
+						onClick: () => {
+							setVisibleModalType( 'a4a-connection' );
+							setMenuVisible( false );
+						},
+					} }
+				/>
+				<AddNewSiteMenuItem
+					icon={ <WordPressLogo /> }
+					heading={ translate( 'Via WordPress.com' ) }
+					description={ preventWidows(
+						translate( 'Add sites already connected to WordPress.com' )
+					) }
+					buttonProps={ {
+						onClick: () => {
+							setVisibleModalType( 'import-from-wpcom' );
+							setMenuVisible( false );
+						},
+					} }
+				/>
+				<AddNewSiteMenuItem
+					icon={ <JetpackLogo /> }
+					heading={ translate( 'Via Jetpack' ) }
+					description={ preventWidows(
+						translate( 'Add a site by remotely installing the Jetpack plugin' )
+					) }
+					buttonProps={ {
+						onClick: () => {
+							setVisibleModalType( 'jetpack-connection' );
+							setMenuVisible( false );
+						},
+					} }
+				/>
+			</AddNewSitePopoverColumn>
+			<AddNewSitePopoverColumn heading={ translate( 'Add new sites' ) }>
+				<AddNewSiteMenuItem
+					icon={ <WordPressLogo /> }
+					heading={ translate( 'WordPress.com' ) }
+					description={ preventWidows(
+						translate( 'Optimized and hassle-free hosting for business websites' )
+					) }
+					buttonProps={ {
+						href: hasPendingWPCOMSites
+							? A4A_SITES_LINK_NEEDS_SETUP
+							: A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
+					} }
+					extraContent={
+						hasPendingWPCOMSites ? (
+							<div className="add-new-site-popover__count">
+								{ translate(
+									'%(pendingSites)d site available',
+									'%(pendingSites)d sites available',
+									{
+										args: {
+											pendingSites: allAvailableSites.length,
+										},
+										count: allAvailableSites.length,
+										comment: '%(pendingSites)s is the number of sites available.',
+									}
+								) }
+							</div>
+						) : undefined
+					}
+				/>
+				<AddNewSiteMenuItem
+					icon={ <img src={ pressableIcon } alt="Pressable" /> }
+					heading={ translate( 'Pressable' ) }
+					description={ translate( 'Best for large-scale businesses and major eCommerce sites' ) }
+					buttonProps={ {
+						href:
+							pressableOwnership === 'regular'
+								? 'https://my.pressable.com/agency/auth'
+								: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
+						target: pressableOwnership === 'regular' ? '_blank' : '_self',
+					} }
+				/>
+			</AddNewSitePopoverColumn>
+			{ devSitesEnabled && (
+				<AddNewSitePopoverColumn>
+					<AddNewSiteMenuItem
+						isBanner
+						icon={ <img src={ devSiteBanner } alt="Start Building for Free" /> }
+						heading={ translate( 'Start Building for Free' ) }
+						description={ preventWidows(
+							translate(
+								'Develop up to 5 WordPress.com sites at{{nbsp/}}once with free development licenses.{{br/}}Only pay when you launch!',
+								{
+									components: { br: <br />, nbsp: <>&nbsp;</> },
+									comment: 'br is a line break, nbsp is a non-breaking space character',
+								}
+							)
+						) }
+						disabled={ ! hasAvailableDevSites }
+						buttonProps={ {
+							onClick: () => {
+								if ( ! hasAvailableDevSites ) {
+									return;
+								}
+								if ( paymentMethodRequired ) {
+									page(
+										`${ A4A_PAYMENT_METHODS_ADD_LINK }?return=${ A4A_SITES_LINK }?add_new_dev_site=true`
+									);
+								} else {
+									// toggleDevSiteConfigurationsModal?.();
+								}
+								setMenuVisible( false );
+							},
+						} }
+						extraContent={
+							<div>
+								<div className="add-new-site-popover__count">
+									{ translate( '%(pendingSites)d of 5 free licenses available', {
+										args: {
+											pendingSites: availableDevSites,
+										},
+										comment: '%(pendingSites)s is the number of free licenses available.',
+									} ) }
+								</div>
+								<div
+									className={ clsx( 'add-new-site-popover__cta', {
+										disabled: ! hasAvailableDevSites,
+									} ) }
+								>
+									{ translate( 'Create a site now →' ) }
+								</div>
+							</div>
+						}
+					/>
+				</AddNewSitePopoverColumn>
+			) }
+		</>
+	);
+};
+
+export default AddNewSiteA4AMenuItems;

--- a/client/components/add-new-site/menu-items/index.tsx
+++ b/client/components/add-new-site/menu-items/index.tsx
@@ -1,16 +1,18 @@
-import React from 'react';
-import AddNewSiteA4AMenuItems, { AddNewSiteA4AMenuItemsProps } from './a4a';
+import { useMemo } from 'react';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
+import AddNewSiteA4AMenuItems from './a4a';
+import type { AddNewSiteMenuItemsProps } from '../types';
 
-type Props = {
-	children: React.ReactNode;
+const AddNewSiteMenuItems = ( props: AddNewSiteMenuItemsProps ) => {
+	const renderContent = useMemo( () => {
+		switch ( true ) {
+			case isA8CForAgencies():
+				return <AddNewSiteA4AMenuItems { ...props } />;
+			default:
+				return null;
+		}
+	}, [ props ] );
+	return renderContent;
 };
-
-const AddNewSiteMenuItems = ( { children }: Props ) => {
-	return children;
-};
-
-AddNewSiteMenuItems.A4A = ( props: AddNewSiteA4AMenuItemsProps ) => (
-	<AddNewSiteA4AMenuItems { ...props } />
-);
 
 export default AddNewSiteMenuItems;

--- a/client/components/add-new-site/menu-items/index.tsx
+++ b/client/components/add-new-site/menu-items/index.tsx
@@ -1,10 +1,15 @@
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
+import isWPCOMEnvironment from 'calypso/lib/wpcom/is-wpcom-environment';
 import AddNewSiteA4AMenuItems from './a4a';
+import AddNewSiteWPCOMMenuItems from './wpcom';
 import type { AddNewSiteMenuItemsProps } from '../types';
 
 const AddNewSiteMenuItems = ( props: AddNewSiteMenuItemsProps ) => {
 	if ( isA8CForAgencies() ) {
 		return <AddNewSiteA4AMenuItems { ...props } />;
+	}
+	if ( isWPCOMEnvironment() ) {
+		return <AddNewSiteWPCOMMenuItems { ...props } />;
 	}
 	return null;
 };

--- a/client/components/add-new-site/menu-items/index.tsx
+++ b/client/components/add-new-site/menu-items/index.tsx
@@ -1,18 +1,12 @@
-import { useMemo } from 'react';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import AddNewSiteA4AMenuItems from './a4a';
 import type { AddNewSiteMenuItemsProps } from '../types';
 
 const AddNewSiteMenuItems = ( props: AddNewSiteMenuItemsProps ) => {
-	const renderContent = useMemo( () => {
-		switch ( true ) {
-			case isA8CForAgencies():
-				return <AddNewSiteA4AMenuItems { ...props } />;
-			default:
-				return null;
-		}
-	}, [ props ] );
-	return renderContent;
+	if ( isA8CForAgencies() ) {
+		return <AddNewSiteA4AMenuItems { ...props } />;
+	}
+	return null;
 };
 
 export default AddNewSiteMenuItems;

--- a/client/components/add-new-site/menu-items/index.tsx
+++ b/client/components/add-new-site/menu-items/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import AddNewSiteA4AMenuItems, { AddNewSiteA4AMenuItemsProps } from './a4a';
+
+type Props = {
+	children: React.ReactNode;
+};
+
+const AddNewSiteMenuItems = ( { children }: Props ) => {
+	return children;
+};
+
+AddNewSiteMenuItems.A4A = ( props: AddNewSiteA4AMenuItemsProps ) => (
+	<AddNewSiteA4AMenuItems { ...props } />
+);
+
+export default AddNewSiteMenuItems;

--- a/client/components/add-new-site/menu-items/wpcom.tsx
+++ b/client/components/add-new-site/menu-items/wpcom.tsx
@@ -1,0 +1,96 @@
+import { WordPressLogo, JetpackLogo } from '@automattic/components';
+import { Icon, reusableBlock, download } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
+import freeDomain from 'calypso/assets/images/wpcom/add-new-site-free-domain.svg';
+import { preventWidows } from 'calypso/lib/formatting';
+import AddNewSiteMenuItem from '../menu-item';
+import AddNewSitePopoverColumn from '../popover-column';
+import type { AddNewSiteMenuItemsProps } from '../types';
+
+const AddNewSiteWPCOMMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) => {
+	const translate = useTranslate();
+
+	const handleOnClick = useCallback( () => {
+		// TODO: Implement the click handler
+		setMenuVisible( false );
+	}, [ setMenuVisible ] );
+
+	return (
+		<>
+			<AddNewSitePopoverColumn heading={ translate( 'Add a new site' ) }>
+				<AddNewSiteMenuItem
+					icon={ <WordPressLogo /> }
+					heading={ translate( 'WordPress.com' ) }
+					description={ preventWidows(
+						translate( 'Build and grow your site, all in one powerful platform.' )
+					) }
+					buttonProps={ {
+						onClick: () => handleOnClick,
+					} }
+				/>
+				<AddNewSiteMenuItem
+					icon={ <JetpackLogo /> }
+					heading={ translate( 'Via Jetpack plugin' ) }
+					description={ preventWidows(
+						translate( 'Add a site by remotely installing the Jetpack plugin.' )
+					) }
+					buttonProps={ {
+						onClick: () => handleOnClick,
+					} }
+				/>
+				<AddNewSiteMenuItem
+					icon={ <img src={ pressableIcon } alt="Pressable" /> }
+					heading={ translate( 'Pressable' ) }
+					description={ translate( 'Optimized and hassle-free hosting for business websites.' ) }
+					buttonProps={ {} }
+				/>
+			</AddNewSitePopoverColumn>
+			<AddNewSitePopoverColumn heading={ translate( 'Migrate & Import' ) }>
+				<AddNewSiteMenuItem
+					icon={ <Icon icon={ reusableBlock } /> }
+					heading={ translate( 'Migrate' ) }
+					description={ preventWidows(
+						translate( 'Bring your theme, plugins, and content to WordPress.com.' )
+					) }
+					buttonProps={ {
+						onClick: () => handleOnClick,
+					} }
+				/>
+				<AddNewSiteMenuItem
+					icon={ <Icon icon={ download } /> }
+					heading={ translate( 'Import' ) }
+					description={ preventWidows(
+						translate( 'Use a backup file to import your content into a new site.' )
+					) }
+					buttonProps={ {
+						onClick: () => handleOnClick,
+					} }
+				/>
+			</AddNewSitePopoverColumn>
+			<AddNewSitePopoverColumn>
+				<AddNewSiteMenuItem
+					isBanner
+					icon={ <img src={ freeDomain } alt="Free domain" /> }
+					heading={ translate( 'Get a Free Domain and Up to {{br/}}55% off', {
+						components: { br: <br /> },
+						comment: 'br is a line break',
+					} ) }
+					description={ preventWidows(
+						translate(
+							'Save up to 55% on annual plans and get a free custom domain for a year. Your next site is just a step away.'
+						)
+					) }
+					buttonProps={ {} }
+				>
+					<div>
+						<div className="add-new-site-popover__cta">{ translate( 'Unlock Offer →' ) }</div>
+					</div>
+				</AddNewSiteMenuItem>
+			</AddNewSitePopoverColumn>
+		</>
+	);
+};
+
+export default AddNewSiteWPCOMMenuItems;

--- a/client/components/add-new-site/modals/a4a.tsx
+++ b/client/components/add-new-site/modals/a4a.tsx
@@ -1,15 +1,32 @@
-import { useContext } from 'react';
+import { getQueryArg } from '@wordpress/url';
+import { useContext, useEffect } from 'react';
 import A4AConnectionModal from 'calypso/a8c-for-agencies/components/add-new-site-button/a4a-connection-modal';
 import ImportFromWPCOMModal from 'calypso/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal';
 import JetpackConnectionModal from 'calypso/a8c-for-agencies/components/add-new-site-button/jetpack-connection-modal';
+import SiteConfigurationsModal from 'calypso/a8c-for-agencies/components/site-configurations-modal';
+import { useRandomSiteName } from 'calypso/a8c-for-agencies/components/site-configurations-modal/use-random-site-name';
+import useSiteCreatedCallback from 'calypso/a8c-for-agencies/hooks/use-site-created-callback';
 import { AddNewSiteContext } from '../context';
 
 const AddNewSitesA4AModals = () => {
 	const { visibleModalType, setVisibleModalType } = useContext( AddNewSiteContext );
+	const { randomSiteName, isRandomSiteNameLoading, refetchRandomSiteName } = useRandomSiteName();
 
 	const handleOnClose = () => {
 		setVisibleModalType( '' );
 	};
+
+	const shouldAutoOpenDevSiteConfigModal = Boolean(
+		getQueryArg( window.location.href, 'add_new_dev_site' )
+	);
+
+	useEffect( () => {
+		if ( shouldAutoOpenDevSiteConfigModal ) {
+			setVisibleModalType( 'dev-site-configurations' );
+		}
+	}, [ shouldAutoOpenDevSiteConfigModal, setVisibleModalType ] );
+
+	const onCreateSiteSuccess = useSiteCreatedCallback( refetchRandomSiteName );
 
 	return (
 		<>
@@ -19,6 +36,14 @@ const AddNewSitesA4AModals = () => {
 			) }
 			{ visibleModalType === 'import-from-wpcom' && (
 				<ImportFromWPCOMModal onClose={ handleOnClose } />
+			) }
+			{ visibleModalType === 'dev-site-configurations' && (
+				<SiteConfigurationsModal
+					closeModal={ handleOnClose }
+					randomSiteName={ randomSiteName }
+					isRandomSiteNameLoading={ isRandomSiteNameLoading }
+					onCreateSiteSuccess={ onCreateSiteSuccess }
+				/>
 			) }
 		</>
 	);

--- a/client/components/add-new-site/modals/a4a.tsx
+++ b/client/components/add-new-site/modals/a4a.tsx
@@ -1,0 +1,27 @@
+import { useContext } from 'react';
+import A4AConnectionModal from 'calypso/a8c-for-agencies/components/add-new-site-button/a4a-connection-modal';
+import ImportFromWPCOMModal from 'calypso/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal';
+import JetpackConnectionModal from 'calypso/a8c-for-agencies/components/add-new-site-button/jetpack-connection-modal';
+import { AddNewSiteContext } from '../context';
+
+const AddNewSitesA4AModals = () => {
+	const { visibleModalType, setVisibleModalType } = useContext( AddNewSiteContext );
+
+	const handleOnClose = () => {
+		setVisibleModalType( '' );
+	};
+
+	return (
+		<>
+			{ visibleModalType === 'a4a-connection' && <A4AConnectionModal onClose={ handleOnClose } /> }
+			{ visibleModalType === 'jetpack-connection' && (
+				<JetpackConnectionModal onClose={ handleOnClose } />
+			) }
+			{ visibleModalType === 'import-from-wpcom' && (
+				<ImportFromWPCOMModal onClose={ handleOnClose } />
+			) }
+		</>
+	);
+};
+
+export default AddNewSitesA4AModals;

--- a/client/components/add-new-site/modals/a4a/index.tsx
+++ b/client/components/add-new-site/modals/a4a/index.tsx
@@ -6,7 +6,7 @@ import JetpackConnectionModal from 'calypso/a8c-for-agencies/components/add-new-
 import SiteConfigurationsModal from 'calypso/a8c-for-agencies/components/site-configurations-modal';
 import { useRandomSiteName } from 'calypso/a8c-for-agencies/components/site-configurations-modal/use-random-site-name';
 import useSiteCreatedCallback from 'calypso/a8c-for-agencies/hooks/use-site-created-callback';
-import { AddNewSiteContext } from '../../context';
+import AddNewSiteContext from '../../context';
 
 const AddNewSitesA4AModals = () => {
 	const { visibleModalType, setVisibleModalType } = useContext( AddNewSiteContext );
@@ -28,25 +28,26 @@ const AddNewSitesA4AModals = () => {
 
 	const onCreateSiteSuccess = useSiteCreatedCallback( refetchRandomSiteName );
 
-	return (
-		<>
-			{ visibleModalType === 'a4a-connection' && <A4AConnectionModal onClose={ handleOnClose } /> }
-			{ visibleModalType === 'jetpack-connection' && (
-				<JetpackConnectionModal onClose={ handleOnClose } />
-			) }
-			{ visibleModalType === 'import-from-wpcom' && (
-				<ImportFromWPCOMModal onClose={ handleOnClose } />
-			) }
-			{ visibleModalType === 'dev-site-configurations' && (
-				<SiteConfigurationsModal
-					closeModal={ handleOnClose }
-					randomSiteName={ randomSiteName }
-					isRandomSiteNameLoading={ isRandomSiteNameLoading }
-					onCreateSiteSuccess={ onCreateSiteSuccess }
-				/>
-			) }
-		</>
-	);
+	if ( visibleModalType === 'a4a-connection' ) {
+		return <A4AConnectionModal onClose={ handleOnClose } />;
+	}
+	if ( visibleModalType === 'jetpack-connection' ) {
+		return <JetpackConnectionModal onClose={ handleOnClose } />;
+	}
+	if ( visibleModalType === 'import-from-wpcom' ) {
+		return <ImportFromWPCOMModal onClose={ handleOnClose } />;
+	}
+	if ( visibleModalType === 'dev-site-configurations' ) {
+		return (
+			<SiteConfigurationsModal
+				closeModal={ handleOnClose }
+				randomSiteName={ randomSiteName }
+				isRandomSiteNameLoading={ isRandomSiteNameLoading }
+				onCreateSiteSuccess={ onCreateSiteSuccess }
+			/>
+		);
+	}
+	return null;
 };
 
 export default AddNewSitesA4AModals;

--- a/client/components/add-new-site/modals/a4a/index.tsx
+++ b/client/components/add-new-site/modals/a4a/index.tsx
@@ -6,7 +6,7 @@ import JetpackConnectionModal from 'calypso/a8c-for-agencies/components/add-new-
 import SiteConfigurationsModal from 'calypso/a8c-for-agencies/components/site-configurations-modal';
 import { useRandomSiteName } from 'calypso/a8c-for-agencies/components/site-configurations-modal/use-random-site-name';
 import useSiteCreatedCallback from 'calypso/a8c-for-agencies/hooks/use-site-created-callback';
-import { AddNewSiteContext } from '../context';
+import { AddNewSiteContext } from '../../context';
 
 const AddNewSitesA4AModals = () => {
 	const { visibleModalType, setVisibleModalType } = useContext( AddNewSiteContext );

--- a/client/components/add-new-site/modals/index.tsx
+++ b/client/components/add-new-site/modals/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import AddNewSitesA4AModals from './a4a';
+
+type Props = {
+	children: React.ReactNode;
+};
+
+const AddNewSiteModals = ( { children }: Props ) => {
+	return children;
+};
+
+AddNewSiteModals.A4A = () => <AddNewSitesA4AModals />;
+
+export default AddNewSiteModals;

--- a/client/components/add-new-site/modals/index.tsx
+++ b/client/components/add-new-site/modals/index.tsx
@@ -1,14 +1,19 @@
-import React from 'react';
-import AddNewSitesA4AModals from './a4a';
+import { useMemo } from 'react';
+import AsyncLoad from 'calypso/components/async-load';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 
-type Props = {
-	children: React.ReactNode;
+const AddNewSiteModals = () => {
+	const renderContent = useMemo( () => {
+		switch ( true ) {
+			case isA8CForAgencies():
+				return (
+					<AsyncLoad require="calypso/components/add-new-site/modals/a4a" placeholder={ null } />
+				);
+			default:
+				return null;
+		}
+	}, [] );
+	return renderContent;
 };
-
-const AddNewSiteModals = ( { children }: Props ) => {
-	return children;
-};
-
-AddNewSiteModals.A4A = () => <AddNewSitesA4AModals />;
 
 export default AddNewSiteModals;

--- a/client/components/add-new-site/modals/index.tsx
+++ b/client/components/add-new-site/modals/index.tsx
@@ -1,19 +1,11 @@
-import { useMemo } from 'react';
-import AsyncLoad from 'calypso/components/async-load';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
+import AddNewSitesA4AModals from './a4a';
 
 const AddNewSiteModals = () => {
-	const renderContent = useMemo( () => {
-		switch ( true ) {
-			case isA8CForAgencies():
-				return (
-					<AsyncLoad require="calypso/components/add-new-site/modals/a4a" placeholder={ null } />
-				);
-			default:
-				return null;
-		}
-	}, [] );
-	return renderContent;
+	if ( isA8CForAgencies() ) {
+		return <AddNewSitesA4AModals />;
+	}
+	return null;
 };
 
 export default AddNewSiteModals;

--- a/client/components/add-new-site/popover-column.tsx
+++ b/client/components/add-new-site/popover-column.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+type Props = {
+	heading?: string;
+	children: React.ReactNode;
+};
+
+const AddNewSitePopoverColumn: React.FC< Props > = ( { heading, children } ) => {
+	return (
+		<div className="add-new-site__popover-column">
+			{ heading && (
+				<div className="add-new-site__popover-column-heading">{ heading.toUpperCase() }</div>
+			) }
+			{ children }
+		</div>
+	);
+};
+
+export default AddNewSitePopoverColumn;

--- a/client/components/add-new-site/popover.tsx
+++ b/client/components/add-new-site/popover.tsx
@@ -1,11 +1,9 @@
 import { Popover } from '@automattic/components';
-import clsx from 'clsx';
 import React from 'react';
 
 type Props = {
 	isMenuVisible: boolean;
 	toggleMenu: () => void;
-	// devSitesEnabled: boolean;
 	popoverMenuContext: React.RefObject< HTMLButtonElement >;
 	children: React.ReactNode;
 };
@@ -13,15 +11,12 @@ type Props = {
 const AddNewSitePopover: React.FC< Props > = ( {
 	isMenuVisible,
 	toggleMenu,
-	// devSitesEnabled,
 	popoverMenuContext,
 	children,
 } ) => {
 	return (
 		<Popover
-			className={ clsx( 'add-new-site__popover', {
-				// 'dev-sites-enabled': devSitesEnabled,
-			} ) }
+			className="add-new-site__popover"
 			context={ popoverMenuContext?.current }
 			isVisible={ isMenuVisible }
 			closeOnEsc

--- a/client/components/add-new-site/popover.tsx
+++ b/client/components/add-new-site/popover.tsx
@@ -1,0 +1,37 @@
+import { Popover } from '@automattic/components';
+import clsx from 'clsx';
+import React from 'react';
+
+type Props = {
+	isMenuVisible: boolean;
+	toggleMenu: () => void;
+	// devSitesEnabled: boolean;
+	popoverMenuContext: React.RefObject< HTMLButtonElement >;
+	children: React.ReactNode;
+};
+
+const AddNewSitePopover: React.FC< Props > = ( {
+	isMenuVisible,
+	toggleMenu,
+	// devSitesEnabled,
+	popoverMenuContext,
+	children,
+} ) => {
+	return (
+		<Popover
+			className={ clsx( 'add-new-site__popover', {
+				// 'dev-sites-enabled': devSitesEnabled,
+			} ) }
+			context={ popoverMenuContext?.current }
+			isVisible={ isMenuVisible }
+			closeOnEsc
+			onClose={ toggleMenu }
+			autoPosition={ false }
+			position="bottom left"
+		>
+			<div className="add-new-site__popover-content">{ children }</div>
+		</Popover>
+	);
+};
+
+export default AddNewSitePopover;

--- a/client/components/add-new-site/style.scss
+++ b/client/components/add-new-site/style.scss
@@ -4,8 +4,9 @@
 .add-new-site__button {
 	.gridicon {
 		margin-left: 6px;
-		top: 2px;
 		transition: transform 100ms ease-in-out;
+		height: 18px;
+		width: 18px;
 
 		&.reverse {
 			transform: rotate(180deg);
@@ -13,7 +14,6 @@
 
 		&.mobile {
 			margin-left: 0;
-			top: 2px;
 		}
 	}
 }

--- a/client/components/add-new-site/style.scss
+++ b/client/components/add-new-site/style.scss
@@ -41,11 +41,7 @@
 	}
 
 	.add-new-site__popover-column {
-		width: 250px;
-
-		@include break-xlarge {
-			width: 300px;
-		}
+		width: 260px;
 	}
 }
 
@@ -98,7 +94,7 @@ button, a {
 				height: 78px;
 
 				.sidebar__menu-icon {
-					width: 249px;
+					width: 228px;
 					height: auto;
 				}
 			}

--- a/client/components/add-new-site/style.scss
+++ b/client/components/add-new-site/style.scss
@@ -20,7 +20,10 @@
 
 .popover.add-new-site__popover {
 	animation: fadeIn 0.2s ease-out;
-	margin-inline-start: 32px;
+
+	@include breakpoint-deprecated(">660px") {
+		margin-inline-start: 32px;
+	}
 
 	.popover__inner {
 		text-align: unset
@@ -38,9 +41,7 @@
 	}
 
 	.add-new-site__popover-column {
-		@include break-large {
-			width: 250px;
-		}
+		width: 250px;
 
 		@include break-xlarge {
 			width: 300px;
@@ -64,8 +65,10 @@ button, a {
 		width: 100%;
 		border-radius: 4px;
 		height: auto;
+		color: var(--color-text-black);
 
 		&:hover {
+			color: var(--color-text-black);
 			background-color: var(--color-neutral-0);
 		}
 
@@ -143,6 +146,16 @@ button, a {
 			line-height: 1.33;
 			color: var(--color-accent);
 			padding-top: 4px;
+		}
+	}
+}
+
+// Remove the focus outline from the button when clicked with the mouse,
+// but retain it for keyboard navigation (e.g., Tab key). */
+html:not(.accessible-focus) button, a {
+	&.components-button.add-new-site__popover-button {
+		&:focus-within {
+			box-shadow: none;
 		}
 	}
 }

--- a/client/components/add-new-site/style.scss
+++ b/client/components/add-new-site/style.scss
@@ -42,6 +42,9 @@
 
 	.add-new-site__popover-column {
 		width: 260px;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
 	}
 }
 
@@ -49,7 +52,6 @@
 	color: var(--color-accent-40);
 	font-size: rem(12px);
 	font-weight: 500;
-	margin-block-end: 8px;
 }
 
 button, a {
@@ -82,12 +84,12 @@ button, a {
 
 		&.is-banner {
 			flex-direction: column;
-			padding-top: 0;
 			gap: 4px;
 			background-color: var(--color-neutral-0);
 
 			@include break-large {
 				padding: 16px;
+				padding-top: 0;
 			}
 
 			.add-new-site__popover-button-icon {

--- a/client/components/add-new-site/style.scss
+++ b/client/components/add-new-site/style.scss
@@ -72,7 +72,7 @@ button, a {
 			background-color: var(--color-neutral-0);
 		}
 
-		&.disabled {
+		&.is-disabled {
 			cursor: not-allowed;
 			background-color: var(--color-neutral-0);
 		}
@@ -84,7 +84,7 @@ button, a {
 			justify-content: unset;
 		}
 
-		&.banner {
+		&.is-banner {
 			flex-direction: column;
 			padding-top: 0;
 			gap: 4px;

--- a/client/components/add-new-site/style.scss
+++ b/client/components/add-new-site/style.scss
@@ -89,7 +89,6 @@ button, a {
 
 			@include break-large {
 				padding: 16px;
-				padding-top: 0;
 			}
 
 			.add-new-site__popover-button-icon {
@@ -108,7 +107,8 @@ button, a {
 			}
 
 			.add-new-site__popover-button-heading {
-				@include a4a-font-body-md($font-weight: 500);
+				font-size: rem(14px);
+				font-weight: 500;
 			}
 		}
 
@@ -127,11 +127,12 @@ button, a {
 		}
 
 		.add-new-site__popover-button-heading {
-			@include a4a-font-body-md;
+			font-size: rem(14px);
 		}
 
 		.add-new-site__popover-button-description {
-			@include a4a-font-body-sm;
+			font-size: rem(12px);
+			font-weight: 400;
 			color: var(--color-accent);
 			padding-top: 4px;
 		}

--- a/client/components/add-new-site/style.scss
+++ b/client/components/add-new-site/style.scss
@@ -108,6 +108,10 @@ button, a {
 					padding: 8px 8px 0 8px;
 				}
 			}
+
+			.add-new-site__popover-button-heading {
+				@include a4a-font-body-md($font-weight: 500);
+			}
 		}
 
 		.add-new-site__popover-button-icon {
@@ -124,26 +128,12 @@ button, a {
 			}
 		}
 
-		// This is a workaround to make all the buttons the same dimensions
-		// .site-selector-and-importer__popover-button-wp-icon {
-		// 	.sidebar__menu-icon {
-		// 		width: 36px;
-		// 		height: 36px;
-		// 		position: relative;
-		// 		left: 6px;
-		// 		top: -6px;
-		// 		margin-left: -12px;
-		// 	}
-		// }
-
 		.add-new-site__popover-button-heading {
-			font-size: rem(14px);
-			font-weight: 600;
+			@include a4a-font-body-md;
 		}
 
 		.add-new-site__popover-button-description {
-			font-size: rem(12px);
-			line-height: 1.33;
+			@include a4a-font-body-sm;
 			color: var(--color-accent);
 			padding-top: 4px;
 		}

--- a/client/components/add-new-site/style.scss
+++ b/client/components/add-new-site/style.scss
@@ -1,0 +1,165 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.add-new-site__button {
+	.gridicon {
+		margin-left: 6px;
+		top: 2px;
+		transition: transform 100ms ease-in-out;
+
+		&.reverse {
+			transform: rotate(180deg);
+		}
+
+		&.mobile {
+			margin-left: 0;
+			top: 2px;
+		}
+	}
+}
+
+.popover.add-new-site__popover {
+	animation: fadeIn 0.2s ease-out;
+	margin-inline-start: 32px;
+
+	.popover__inner {
+		text-align: unset
+	}
+}
+
+.add-new-site__popover-content {
+	display: flex;
+	flex-direction: column;
+	padding: 28px 32px;
+	gap: 32px;
+
+	@include break-large {
+		flex-direction: row;
+	}
+
+	.add-new-site__popover-column {
+		@include break-large {
+			width: 250px;
+		}
+
+		@include break-xlarge {
+			width: 300px;
+		}
+	}
+}
+
+.add-new-site__popover-column-heading {
+	color: var(--color-accent-40);
+	font-size: rem(12px);
+	font-weight: 500;
+	margin-block-end: 8px;
+}
+
+button, a {
+	&.components-button.add-new-site__popover-button {
+		padding: 8px;
+		white-space: unset;
+		text-align: unset;
+		margin-block: 0;
+		width: 100%;
+		border-radius: 4px;
+		height: auto;
+
+		&:hover {
+			background-color: var(--color-neutral-0);
+		}
+
+		&.disabled {
+			cursor: not-allowed;
+			background-color: var(--color-neutral-0);
+		}
+
+		@include break-large {
+			display: flex;
+			gap: 8px;
+			align-items: unset;
+			justify-content: unset;
+		}
+
+		&.banner {
+			flex-direction: column;
+			padding-top: 0;
+			gap: 4px;
+			background-color: var(--color-neutral-0);
+
+			@include break-large {
+				padding: 16px;
+			}
+
+			.add-new-site__popover-button-icon {
+				height: 78px;
+
+				.sidebar__menu-icon {
+					width: 249px;
+					height: auto;
+				}
+			}
+
+			.add-new-site__popover-button-content {
+				@include break-large {
+					padding: 8px 8px 0 8px;
+				}
+			}
+		}
+
+		.add-new-site__popover-button-icon {
+			display: none;
+
+			@include break-large {
+				display: block;
+			}
+
+			.sidebar__menu-icon {
+				width: 24px;
+				height: 24px;
+				max-width: fit-content;
+			}
+		}
+
+		// This is a workaround to make all the buttons the same dimensions
+		// .site-selector-and-importer__popover-button-wp-icon {
+		// 	.sidebar__menu-icon {
+		// 		width: 36px;
+		// 		height: 36px;
+		// 		position: relative;
+		// 		left: 6px;
+		// 		top: -6px;
+		// 		margin-left: -12px;
+		// 	}
+		// }
+
+		.add-new-site__popover-button-heading {
+			font-size: rem(14px);
+			font-weight: 600;
+		}
+
+		.add-new-site__popover-button-description {
+			font-size: rem(12px);
+			line-height: 1.33;
+			color: var(--color-accent);
+			padding-top: 4px;
+		}
+	}
+}
+
+.add-new-site-popover__count {
+	font-size: rem(12px);
+	font-style: italic;
+	color: var(--color-accent-100);
+	padding-top: 4px;
+}
+
+.add-new-site-popover__cta {
+	padding-top: 12px;
+	font-size: rem(12px);
+	font-weight: 600;
+
+	&.disabled {
+		color: var(--color-accent-20);
+	}
+}

--- a/client/components/add-new-site/types.ts
+++ b/client/components/add-new-site/types.ts
@@ -2,3 +2,7 @@ export interface AddNewSiteContextInterface {
 	visibleModalType: string;
 	setVisibleModalType: ( value: string ) => void;
 }
+
+export interface AddNewSiteMenuItemsProps {
+	setMenuVisible: ( isVisible: boolean ) => void;
+}

--- a/client/components/add-new-site/types.ts
+++ b/client/components/add-new-site/types.ts
@@ -1,0 +1,4 @@
+export interface AddNewSiteContextInterface {
+	visibleModalType: string;
+	setVisibleModalType: ( value: string ) => void;
+}

--- a/client/lib/wpcom/is-wpcom-environment.ts
+++ b/client/lib/wpcom/is-wpcom-environment.ts
@@ -1,0 +1,7 @@
+import config from '@automattic/calypso-config';
+
+const wpcomEnvironments = [ 'development', 'stage', 'horizon', 'production' ];
+
+const isWPCOMEnvironment = (): boolean => wpcomEnvironments.includes( config( 'env_id' ) );
+
+export default isWPCOMEnvironment;

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -47,7 +47,8 @@
 		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
 		"a4a-tracking-site-migrations": true,
-		"a4a-product-feedback": true
+		"a4a-product-feedback": true,
+		"a4a-updated-add-new-site": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -40,7 +40,8 @@
 		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
 		"a4a-tracking-site-migrations": true,
-		"a4a-product-feedback": true
+		"a4a-product-feedback": true,
+		"a4a-updated-add-new-site": true
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
