### PR TITLE
Plugins: Update position to avoid sidebar overlapping

### DIFF
--- a/client/components/section/index.tsx
+++ b/client/components/section/index.tsx
@@ -23,7 +23,6 @@ interface SectionHeaderProps {
 // https://github.com/Automattic/wp-calypso/pull/93425
 export const SectionContainer = styled.div< SectionContainerProps >`
 	padding: 56px 0;
-	position: relative;
 	z-index: 1;
 
 	::before {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/97614

Related to https://github.com/Automattic/wp-calypso/pull/93505

## Proposed Changes

* Removes `position: relative` that was causing the page sidebar to overlap

|Before | After|
|-------|------|
|![CleanShot 2024-12-19 at 13 36 38@2x](https://github.com/user-attachments/assets/303286c3-4204-43d2-8ed7-9d0d9482545d) |   ![CleanShot 2024-12-19 at 13 36 48@2x](https://github.com/user-attachments/assets/df029019-023d-4e31-a3da-821f789c4a26)   |

The background of the footer works as expected:

![CleanShot 2024-12-19 at 13 36 56@2x](https://github.com/user-attachments/assets/319a1c18-0be3-47c2-a97b-62a0edf80aca)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix a visual bug

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Please repeat testing instructions in https://github.com/Automattic/wp-calypso/pull/93505 and make sure they work as expected.
* Make sure the page sidebar does not overlap with the main content when the viewport size is around `1046px` when visiting the plugins page, e.g. `/plugins/robertofreesite.wordpress.com`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
