### PR TITLE
Cancellation Form: Minor UI updates

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -117,7 +117,7 @@
 
 	.cancel-purchase-form__atomic-revert-checkbox-enabled {
 		.components-base-control__field {
-			border: 1px solid var(--studio-blue-50);
+			border: 1px solid var(--color-accent);
 			background: #f9fbfd;
 		}
 	}
@@ -151,7 +151,7 @@
 	border: 1px solid var(--studio-gray-5);
 	padding: 12px 10px 12px 20px;
 	font-size: 0.75rem;
-	border-left: 3px solid var(--studio-blue-50);
+	border-left: 3px solid var(--color-accent);
 
 	h4 {
 		color: var(--studio-gray-70);
@@ -279,6 +279,10 @@
 	.blank-canvas__back {
 		z-index: 1;
 		font-size: 0.875rem;
+	}
+
+	.components-base-control__label {
+		text-transform: none;
 	}
 
 	.components-base-control__field {

--- a/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
@@ -13,11 +13,11 @@ export async function cancelPurchaseFlow(
 	}
 ) {
 	await page
-		.getByRole( 'combobox', { name: 'WHY WOULD YOU LIKE TO CANCEL?' } )
+		.getByRole( 'combobox', { name: 'Why would you like to cancel?' } )
 		.selectOption( feedback.reason );
 
 	await page
-		.getByRole( 'textbox', { name: 'CAN YOU PLEASE SPECIFY?' } )
+		.getByRole( 'textbox', { name: 'Can you please specify?' } )
 		.fill( feedback.customReasonText );
 
 	await page.getByRole( 'button', { name: 'Submit' } ).click();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/wp-calypso/issues/96953

## Proposed Changes

* The form questions are now not in uppercase.
* Updated the color of the Atomic downgrade screen.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need to update the design so that it adheres to our current standards.


| Before | After |
| ----- | ----- |
| ![Screenshot 2024-12-19 at 13 38 37](https://github.com/user-attachments/assets/99d06410-a824-49ac-92f9-be1e456761a9) | ![Screenshot 2024-12-19 at 13 35 23](https://github.com/user-attachments/assets/0e2c61fb-f583-473e-87fb-34aa74e47eec)|
|![Screenshot 2024-12-19 at 13 37 59](https://github.com/user-attachments/assets/32356ede-62b3-48d5-bde4-b366fa338cb1)|![Screenshot 2024-12-19 at 13 35 37](https://github.com/user-attachments/assets/69ecf5d4-9a31-4ef6-b2c6-975ed30bfdc3)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Make sure you have an Atomic site selected with Atomic transfer complete.
* Go to `/purchases/subscriptions/{site}/{subscription}/cancel`
* Check that there are no uppercase labels.
* Check that the Atomic downgrade uses the new color.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
