### PR TITLE
Theme Collections: fix hosting view theme collection header

### DIFF
--- a/client/my-sites/themes/collections/theme-collection-view-header.scss
+++ b/client/my-sites/themes/collections/theme-collection-view-header.scss
@@ -1,6 +1,10 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+.layout__primary .theme-showcase.is-collection-view .theme-collection-view-header.is-logged-in {
+	padding: 0 48px;
+}
+
 .theme-showcase.is-collection-view {
 	.theme-collection-view-header {
 		&.is-logged-in {

--- a/client/my-sites/themes/collections/theme-collection-view-header.scss
+++ b/client/my-sites/themes/collections/theme-collection-view-header.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.layout__primary .theme-showcase.is-collection-view .theme-collection-view-header.is-logged-in {
+.is-global .theme-showcase.is-collection-view .theme-collection-view-header.is-logged-in {
 	padding: 0 48px;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/10145

## Proposed Changes

* Added padding to the Collection View's screen header when in the hosting view.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

| Before | After |
| ------  | ----- |
| ![Screenshot 2024-12-19 at 15 12 06](https://github.com/user-attachments/assets/06c04ac3-2d04-4f89-8382-752c9679dafc)|![Screenshot 2024-12-19 at 15 11 43](https://github.com/user-attachments/assets/546ca8c8-13fb-4b76-8f57-b8cd91ff5f92)|
 

* This is a bug in production.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Go to `/themes/partner/collection`
* Check that the header has padding.
* Check for regressions on LoTS & Lits

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
