### PR TITLE
Implementation of 'Add site' flow for WPCOM

### DIFF
--- a/client/components/add-new-site/content/index.tsx
+++ b/client/components/add-new-site/content/index.tsx
@@ -1,5 +1,6 @@
 import AsyncLoad from 'calypso/components/async-load';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
+import isWPCOMEnvironment from 'calypso/lib/wpcom/is-wpcom-environment';
 import type { AddNewSiteContentProps } from 'calypso/components/add-new-site/types';
 
 // Always ensure that we load env-specific content asychronously
@@ -9,6 +10,15 @@ const AddNewSiteContent = ( props: AddNewSiteContentProps ) => {
 			<AsyncLoad
 				{ ...props }
 				require="calypso/components/add-new-site/content/a4a"
+				placeholder={ null }
+			/>
+		);
+	}
+	if ( isWPCOMEnvironment() ) {
+		return (
+			<AsyncLoad
+				{ ...props }
+				require="calypso/components/add-new-site/content/wpcom"
 				placeholder={ null }
 			/>
 		);

--- a/client/components/add-new-site/content/wpcom/index.tsx
+++ b/client/components/add-new-site/content/wpcom/index.tsx
@@ -1,0 +1,24 @@
+import AddNewSiteA4AMenuItems from 'calypso/components/add-new-site/menu-items/a4a';
+import AddNewSitePopover from 'calypso/components/add-new-site/popover';
+import type { AddNewSiteContentProps } from 'calypso/components/add-new-site/types';
+
+const AddNewSiteA4A = ( {
+	isMenuVisible,
+	popoverMenuContext,
+	setMenuVisible,
+	toggleMenu,
+}: AddNewSiteContentProps ) => {
+	return (
+		<>
+			<AddNewSitePopover
+				isMenuVisible={ isMenuVisible }
+				toggleMenu={ toggleMenu }
+				popoverMenuContext={ popoverMenuContext }
+			>
+				<AddNewSiteA4AMenuItems setMenuVisible={ setMenuVisible } />
+			</AddNewSitePopover>
+		</>
+	);
+};
+
+export default AddNewSiteA4A;

--- a/client/components/add-new-site/menu-item.tsx
+++ b/client/components/add-new-site/menu-item.tsx
@@ -11,7 +11,7 @@ type Props = {
 	children?: JSX.Element;
 	description: TranslateResult;
 	disabled?: boolean;
-	heading: string;
+	heading: TranslateResult;
 	icon: JSX.Element;
 	isBanner?: boolean;
 };

--- a/client/components/add-new-site/menu-items/wpcom.tsx
+++ b/client/components/add-new-site/menu-items/wpcom.tsx
@@ -1,0 +1,96 @@
+import { WordPressLogo, JetpackLogo } from '@automattic/components';
+import { Icon, reusableBlock, download } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
+import freeDomain from 'calypso/assets/images/wpcom/add-new-site-free-domain.svg';
+import AddNewSiteMenuItem from 'calypso/components/add-new-site/menu-item';
+import AddNewSitePopoverColumn from 'calypso/components/add-new-site/popover-column';
+import { preventWidows } from 'calypso/lib/formatting';
+import type { AddNewSiteMenuItemsProps } from 'calypso/components/add-new-site/types';
+
+const AddNewSiteWPCOMMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) => {
+	const translate = useTranslate();
+
+	const handleOnClick = useCallback( () => {
+		// TODO: Implement the click handler
+		setMenuVisible( false );
+	}, [ setMenuVisible ] );
+
+	return (
+		<>
+			<AddNewSitePopoverColumn heading={ translate( 'Add a new site' ) }>
+				<AddNewSiteMenuItem
+					icon={ <WordPressLogo /> }
+					heading="WordPress.com"
+					description={ preventWidows(
+						translate( 'Build and grow your site, all in one powerful platform.' )
+					) }
+					buttonProps={ {
+						onClick: () => handleOnClick,
+					} }
+				/>
+				<AddNewSiteMenuItem
+					icon={ <JetpackLogo /> }
+					heading={ translate( 'Via Jetpack plugin' ) }
+					description={ preventWidows(
+						translate( 'Add a site by remotely installing the Jetpack plugin.' )
+					) }
+					buttonProps={ {
+						onClick: () => handleOnClick,
+					} }
+				/>
+				<AddNewSiteMenuItem
+					icon={ <img src={ pressableIcon } alt="Pressable" /> }
+					heading="Pressable"
+					description={ translate( 'Optimized and hassle-free hosting for business websites.' ) }
+					buttonProps={ {} }
+				/>
+			</AddNewSitePopoverColumn>
+			<AddNewSitePopoverColumn heading={ translate( 'Migrate & Import' ) }>
+				<AddNewSiteMenuItem
+					icon={ <Icon icon={ reusableBlock } /> }
+					heading={ translate( 'Migrate' ) }
+					description={ preventWidows(
+						translate( 'Bring your theme, plugins, and content to WordPress.com.' )
+					) }
+					buttonProps={ {
+						onClick: () => handleOnClick,
+					} }
+				/>
+				<AddNewSiteMenuItem
+					icon={ <Icon icon={ download } /> }
+					heading={ translate( 'Import' ) }
+					description={ preventWidows(
+						translate( 'Use a backup file to import your content into a new site.' )
+					) }
+					buttonProps={ {
+						onClick: () => handleOnClick,
+					} }
+				/>
+			</AddNewSitePopoverColumn>
+			<AddNewSitePopoverColumn>
+				<AddNewSiteMenuItem
+					isBanner
+					icon={ <img src={ freeDomain } alt="Free domain" /> }
+					heading={ translate( 'Get a Free Domain and Up to {{br/}}55% off', {
+						components: { br: <br /> },
+						comment: 'br is a line break',
+					} ) }
+					description={ preventWidows(
+						translate(
+							'Save up to 55% on annual plans and get a free custom domain for a year. Your next site is just a step away.'
+						)
+					) }
+					buttonProps={ {} }
+				>
+					<div>
+						<div className="add-new-site-popover__cta">{ translate( 'Unlock Offer →' ) }</div>
+					</div>
+				</AddNewSiteMenuItem>
+			</AddNewSitePopoverColumn>
+		</>
+	);
+};
+
+export default AddNewSiteWPCOMMenuItems;

--- a/client/lib/wpcom/is-wpcom-environment.ts
+++ b/client/lib/wpcom/is-wpcom-environment.ts
@@ -1,0 +1,7 @@
+import config from '@automattic/calypso-config';
+
+const wpcomEnvironments = [ 'development', 'stage', 'horizon', 'production' ];
+
+const isWPCOMEnvironment = (): boolean => wpcomEnvironments.includes( config( 'env_id' ) );
+
+export default isWPCOMEnvironment;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
