### PR TITLE
Update theme badge labels

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/index.js
+++ b/client/components/theme-tier/theme-tier-badge/index.js
@@ -51,7 +51,10 @@ export default function ThemeTierBadge( {
 			return <ThemeTierCommunityBadge />;
 		}
 
-		if ( 'partner' === themeTier?.slug || MARKETPLACE_THEME === themeType ) {
+		if (
+			! ( isGoalsAtFrontExperiment && ! user ) &&
+			( 'partner' === themeTier?.slug || MARKETPLACE_THEME === themeType )
+		) {
 			return <ThemeTierPartnerBadge />;
 		}
 

--- a/client/components/theme-tier/theme-tier-badge/index.js
+++ b/client/components/theme-tier/theme-tier-badge/index.js
@@ -8,6 +8,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { ThemeTierBadgeContextProvider } from './theme-tier-badge-context';
 import ThemeTierBundledBadge from './theme-tier-bundled-badge';
 import ThemeTierCommunityBadge from './theme-tier-community-badge';
+import ThemeTierFreeBadge from './theme-tier-free-badge';
 import ThemeTierPartnerBadge from './theme-tier-partner-badge';
 import ThemeTierStyleVariationBadge from './theme-tier-style-variation-badge';
 import ThemeTierUpgradeBadge from './theme-tier-upgrade-badge';
@@ -30,6 +31,10 @@ export default function ThemeTierBadge( {
 	const isThemeAllowed = useIsThemeAllowedOnSite( siteId, themeId );
 
 	const getBadge = () => {
+		if ( 'free' === themeTier?.slug ) {
+			return <ThemeTierFreeBadge />;
+		}
+
 		if ( BUNDLED_THEME === themeType ) {
 			return <ThemeTierBundledBadge />;
 		}

--- a/client/components/theme-tier/theme-tier-badge/index.js
+++ b/client/components/theme-tier/theme-tier-badge/index.js
@@ -1,6 +1,8 @@
 import { BUNDLED_THEME, DOT_ORG_THEME, MARKETPLACE_THEME } from '@automattic/design-picker';
 import clsx from 'clsx';
+import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
 import { useSelector } from 'calypso/state';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { useIsThemeAllowedOnSite } from 'calypso/state/themes/hooks/use-is-theme-allowed-on-site';
 import { useThemeTierForTheme } from 'calypso/state/themes/hooks/use-theme-tier-for-theme';
 import { getThemeType, isThemePurchased } from 'calypso/state/themes/selectors';
@@ -29,9 +31,11 @@ export default function ThemeTierBadge( {
 	);
 	const themeTier = useThemeTierForTheme( themeId );
 	const isThemeAllowed = useIsThemeAllowedOnSite( siteId, themeId );
+	const user = useSelector( getCurrentUser );
+	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 
 	const getBadge = () => {
-		if ( 'free' === themeTier?.slug ) {
+		if ( isGoalsAtFrontExperiment && ! user && 'free' === themeTier?.slug ) {
 			return <ThemeTierFreeBadge />;
 		}
 

--- a/client/components/theme-tier/theme-tier-badge/index.js
+++ b/client/components/theme-tier/theme-tier-badge/index.js
@@ -22,6 +22,7 @@ export default function ThemeTierBadge( {
 	isLockedStyleVariation,
 	showUpgradeBadge = true,
 	themeId,
+	showPartnerPrice = false,
 } ) {
 	const siteId = useSelector( getSelectedSiteId );
 	const themeType = useSelector( ( state ) => getThemeType( state, themeId ) );
@@ -60,7 +61,7 @@ export default function ThemeTierBadge( {
 			return null;
 		}
 
-		return <ThemeTierUpgradeBadge />;
+		return <ThemeTierUpgradeBadge showPartnerPrice={ showPartnerPrice } />;
 	};
 
 	const badge = getBadge();

--- a/client/components/theme-tier/theme-tier-badge/index.js
+++ b/client/components/theme-tier/theme-tier-badge/index.js
@@ -2,7 +2,6 @@ import { BUNDLED_THEME, DOT_ORG_THEME, MARKETPLACE_THEME } from '@automattic/des
 import clsx from 'clsx';
 import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
 import { useSelector } from 'calypso/state';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { useIsThemeAllowedOnSite } from 'calypso/state/themes/hooks/use-is-theme-allowed-on-site';
 import { useThemeTierForTheme } from 'calypso/state/themes/hooks/use-theme-tier-for-theme';
 import { getThemeType, isThemePurchased } from 'calypso/state/themes/selectors';
@@ -31,11 +30,10 @@ export default function ThemeTierBadge( {
 	);
 	const themeTier = useThemeTierForTheme( themeId );
 	const isThemeAllowed = useIsThemeAllowedOnSite( siteId, themeId );
-	const user = useSelector( getCurrentUser );
 	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 
 	const getBadge = () => {
-		if ( isGoalsAtFrontExperiment && ! user && 'free' === themeTier?.slug ) {
+		if ( isGoalsAtFrontExperiment && 'free' === themeTier?.slug ) {
 			return <ThemeTierFreeBadge />;
 		}
 
@@ -52,7 +50,7 @@ export default function ThemeTierBadge( {
 		}
 
 		if (
-			! ( isGoalsAtFrontExperiment && ! user ) &&
+			! isGoalsAtFrontExperiment &&
 			( 'partner' === themeTier?.slug || MARKETPLACE_THEME === themeType )
 		) {
 			return <ThemeTierPartnerBadge />;

--- a/client/components/theme-tier/theme-tier-badge/style.scss
+++ b/client/components/theme-tier/theme-tier-badge/style.scss
@@ -10,10 +10,6 @@
 	overflow: hidden;
 	white-space: nowrap;
 
-	&.theme-tier-badge--free .badge {
-		line-height: 20px;
-	}
-
 	.theme-tier-badge__content {
 		margin: 0 8px 4px 0;
 		max-width: 100%;
@@ -28,22 +24,19 @@
 			overflow: hidden;
 			text-overflow: ellipsis;
 		}
+	}
 
-		&.theme-tier-badge__without-background {
-			background: transparent;
-			padding: 0;
-			color: var(--studio-gray-80);
-			margin: 0;
-
-			.premium-badge__logo {
-				margin-top: 0;
-			}
-		}
+	&__without-background.theme-tier-badge__content {
+		background: transparent;
+		padding: 0;
+		color: var(--studio-gray-80);
+		margin: 0;
 	}
 
 	.badge--info {
 		color: var(--studio-wordpress-blue);
 		background-color: #EBEEFC; /* 50% of wordpress-blue-10 */
+		font-family: $sans;
 	}
 }
 

--- a/client/components/theme-tier/theme-tier-badge/style.scss
+++ b/client/components/theme-tier/theme-tier-badge/style.scss
@@ -26,8 +26,14 @@
 		}
 	}
 
-	.badge--info-blue {
-		background-color: var(--studio-wordpress-blue);
+	&__without-background{
+		background: transparent;
+		padding: 0;
+		color: var(--studio-gray-80);
+	}
+
+	.badge--info {
+		color: var(--studio-wordpress-blue);
 	}
 }
 

--- a/client/components/theme-tier/theme-tier-badge/style.scss
+++ b/client/components/theme-tier/theme-tier-badge/style.scss
@@ -10,10 +10,6 @@
 	overflow: hidden;
 	white-space: nowrap;
 
-	&.theme-tier-badge--free .badge {
-		font-size: $font-body-extra-small;
-	}
-
 	.theme-tier-badge__content {
 		margin: 0 8px 4px 0;
 		max-width: 100%;
@@ -30,18 +26,16 @@
 		}
 	}
 
-	&__without-background {
+	&__without-background.theme-tier-badge__content {
 		background: transparent;
 		padding: 0;
 		color: var(--studio-gray-80);
-
-		.premium-badge__logo {
-			margin-top: 0;
-		}
+		margin: 0;
 	}
 
 	.badge--info {
 		color: var(--studio-wordpress-blue);
+		background-color: #EBEEFC; /* 50% of wordpress-blue-10 */
 	}
 }
 

--- a/client/components/theme-tier/theme-tier-badge/style.scss
+++ b/client/components/theme-tier/theme-tier-badge/style.scss
@@ -25,6 +25,10 @@
 			text-overflow: ellipsis;
 		}
 	}
+
+	.badge--info-blue {
+		background-color: var(--studio-wordpress-blue);
+	}
 }
 
 .theme-tier-badge-tooltip,

--- a/client/components/theme-tier/theme-tier-badge/style.scss
+++ b/client/components/theme-tier/theme-tier-badge/style.scss
@@ -10,6 +10,10 @@
 	overflow: hidden;
 	white-space: nowrap;
 
+	&.theme-tier-badge--free .badge {
+		font-size: $font-body-extra-small;
+	}
+
 	.theme-tier-badge__content {
 		margin: 0 8px 4px 0;
 		max-width: 100%;

--- a/client/components/theme-tier/theme-tier-badge/style.scss
+++ b/client/components/theme-tier/theme-tier-badge/style.scss
@@ -10,6 +10,10 @@
 	overflow: hidden;
 	white-space: nowrap;
 
+	&.theme-tier-badge--free .badge {
+		line-height: 20px;
+	}
+
 	.theme-tier-badge__content {
 		margin: 0 8px 4px 0;
 		max-width: 100%;

--- a/client/components/theme-tier/theme-tier-badge/style.scss
+++ b/client/components/theme-tier/theme-tier-badge/style.scss
@@ -26,10 +26,14 @@
 		}
 	}
 
-	&__without-background{
+	&__without-background {
 		background: transparent;
 		padding: 0;
 		color: var(--studio-gray-80);
+
+		.premium-badge__logo {
+			margin-top: 0;
+		}
 	}
 
 	.badge--info {

--- a/client/components/theme-tier/theme-tier-badge/style.scss
+++ b/client/components/theme-tier/theme-tier-badge/style.scss
@@ -24,13 +24,17 @@
 			overflow: hidden;
 			text-overflow: ellipsis;
 		}
-	}
 
-	&__without-background.theme-tier-badge__content {
-		background: transparent;
-		padding: 0;
-		color: var(--studio-gray-80);
-		margin: 0;
+		&.theme-tier-badge__without-background {
+			background: transparent;
+			padding: 0;
+			color: var(--studio-gray-80);
+			margin: 0;
+
+			.premium-badge__logo {
+				margin-top: 0;
+			}
+		}
 	}
 
 	.badge--info {

--- a/client/components/theme-tier/theme-tier-badge/style.scss
+++ b/client/components/theme-tier/theme-tier-badge/style.scss
@@ -31,6 +31,10 @@
 		padding: 0;
 		color: var(--studio-gray-80);
 		margin: 0;
+
+		.design-picker-design-title__container & {
+			color: var(--studio-white);
+		}
 	}
 
 	.badge--info {

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
@@ -67,11 +67,12 @@ export default function ThemeTierBundledBadge() {
 						'theme-tier-badge__without-background': isGoalsAtFrontExperiment && ! user,
 					} ) }
 					focusOnShow={ false }
-					isClickable
 					labelText={ labelText }
 					tooltipClassName="theme-tier-badge-tooltip"
 					tooltipContent={ tooltipContent }
 					tooltipPosition="top"
+					shouldHideTooltip={ isGoalsAtFrontExperiment && ! user }
+					isClickable={ ! ( isGoalsAtFrontExperiment && ! user ) }
 				/>
 			) }
 

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
@@ -6,7 +6,6 @@ import { useTranslate } from 'i18n-calypso';
 import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
 import { useBundleSettingsByTheme } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
 import { useSelector } from 'calypso/state';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { canUseTheme } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ThemeTierBadgeCheckoutLink from './theme-tier-badge-checkout-link';
@@ -21,7 +20,6 @@ export default function ThemeTierBundledBadge() {
 	const isThemeIncluded = useSelector(
 		( state ) => siteId && canUseTheme( state, siteId, themeId )
 	);
-	const user = useSelector( getCurrentUser );
 	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 
 	if ( ! bundleSettings ) {
@@ -50,33 +48,32 @@ export default function ThemeTierBundledBadge() {
 		</>
 	);
 
-	const labelText =
-		isGoalsAtFrontExperiment && ! user
-			? translate( 'Available on %(businessPlanName)s', {
-					args: {
-						businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
-					},
-			  } )
-			: translate( 'Upgrade' );
+	const labelText = isGoalsAtFrontExperiment
+		? translate( 'Available on %(businessPlanName)s', {
+				args: {
+					businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+				},
+		  } )
+		: translate( 'Upgrade' );
 
 	return (
 		<div className="theme-tier-badge">
 			{ showUpgradeBadge && ! isThemeIncluded && (
 				<PremiumBadge
 					className={ clsx( 'theme-tier-badge__content', {
-						'theme-tier-badge__without-background': isGoalsAtFrontExperiment && ! user,
+						'theme-tier-badge__without-background': isGoalsAtFrontExperiment,
 					} ) }
 					focusOnShow={ false }
 					labelText={ labelText }
 					tooltipClassName="theme-tier-badge-tooltip"
 					tooltipContent={ tooltipContent }
 					tooltipPosition="top"
-					shouldHideTooltip={ isGoalsAtFrontExperiment && ! user }
-					isClickable={ ! ( isGoalsAtFrontExperiment && ! user ) }
+					shouldHideTooltip={ isGoalsAtFrontExperiment }
+					isClickable={ ! isGoalsAtFrontExperiment }
 				/>
 			) }
 
-			{ ! ( isGoalsAtFrontExperiment && ! user ) && (
+			{ ! isGoalsAtFrontExperiment && (
 				<BundledBadge
 					className="theme-tier-badge__content"
 					color={ bundleSettings.color }

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
@@ -76,15 +76,17 @@ export default function ThemeTierBundledBadge() {
 				/>
 			) }
 
-			<BundledBadge
-				className="theme-tier-badge__content"
-				color={ bundleSettings.color }
-				icon={ <BadgeIcon /> }
-				isClickable={ false }
-				shouldHideTooltip
-			>
-				{ bundleName }
-			</BundledBadge>
+			{ ! ( isGoalsAtFrontExperiment && ! user ) && (
+				<BundledBadge
+					className="theme-tier-badge__content"
+					color={ bundleSettings.color }
+					icon={ <BadgeIcon /> }
+					isClickable={ false }
+					shouldHideTooltip
+				>
+					{ bundleName }
+				</BundledBadge>
+			) }
 		</div>
 	);
 }

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
@@ -1,9 +1,12 @@
 import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
 import { BundledBadge, PremiumBadge } from '@automattic/components';
 import { createInterpolateElement } from '@wordpress/element';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
 import { useBundleSettingsByTheme } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
 import { useSelector } from 'calypso/state';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { canUseTheme } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ThemeTierBadgeCheckoutLink from './theme-tier-badge-checkout-link';
@@ -18,6 +21,8 @@ export default function ThemeTierBundledBadge() {
 	const isThemeIncluded = useSelector(
 		( state ) => siteId && canUseTheme( state, siteId, themeId )
 	);
+	const user = useSelector( getCurrentUser );
+	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 
 	if ( ! bundleSettings ) {
 		return;
@@ -45,14 +50,25 @@ export default function ThemeTierBundledBadge() {
 		</>
 	);
 
+	const labelText =
+		isGoalsAtFrontExperiment && ! user
+			? translate( 'Available on %(businessPlanName)s', {
+					args: {
+						businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+					},
+			  } )
+			: translate( 'Upgrade' );
+
 	return (
 		<div className="theme-tier-badge">
 			{ showUpgradeBadge && ! isThemeIncluded && (
 				<PremiumBadge
-					className="theme-tier-badge__content"
+					className={ clsx( 'theme-tier-badge__content', {
+						'theme-tier-badge__without-background': isGoalsAtFrontExperiment && ! user,
+					} ) }
 					focusOnShow={ false }
 					isClickable
-					labelText={ translate( 'Upgrade' ) }
+					labelText={ labelText }
 					tooltipClassName="theme-tier-badge-tooltip"
 					tooltipContent={ tooltipContent }
 					tooltipPosition="top"

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-free-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-free-badge.js
@@ -1,0 +1,8 @@
+import { Badge } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+
+export default function ThemeTierFreeBadge() {
+	const translate = useTranslate();
+
+	return <Badge type="info-blue">{ translate( 'Free' ) }</Badge>;
+}

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-free-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-free-badge.js
@@ -4,5 +4,5 @@ import { useTranslate } from 'i18n-calypso';
 export default function ThemeTierFreeBadge() {
 	const translate = useTranslate();
 
-	return <Badge type="info-blue">{ translate( 'Free' ) }</Badge>;
+	return <Badge type="info">{ translate( 'Free' ) }</Badge>;
 }

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
@@ -5,8 +5,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
-import { useSelector } from 'calypso/state';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { useThemeTierForTheme } from 'calypso/state/themes/hooks/use-theme-tier-for-theme';
 import { THEME_TIERS } from '../constants';
 import ThemeTierBadgeCheckoutLink from './theme-tier-badge-checkout-link';
@@ -26,15 +24,13 @@ export default function ThemeTierPlanUpgradeBadge() {
 	const plans = Plans.usePlans( { coupon: undefined } );
 	const planName = plans?.data?.[ mappedPlan.getStoreSlug() ]?.productNameShort;
 	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
-	const user = useSelector( getCurrentUser );
-	const labelText =
-		isGoalsAtFrontExperiment && ! user
-			? translate( 'Available on %(planName)s', {
-					args: {
-						planName: planName,
-					},
-			  } )
-			: translate( 'Upgrade' );
+	const labelText = isGoalsAtFrontExperiment
+		? translate( 'Available on %(planName)s', {
+				args: {
+					planName: planName,
+				},
+		  } )
+		: translate( 'Upgrade' );
 
 	const tooltipContent = (
 		<>
@@ -57,15 +53,15 @@ export default function ThemeTierPlanUpgradeBadge() {
 	return (
 		<PremiumBadge
 			className={ clsx( 'theme-tier-badge__content', {
-				'theme-tier-badge__without-background': isGoalsAtFrontExperiment && ! user,
+				'theme-tier-badge__without-background': isGoalsAtFrontExperiment,
 			} ) }
 			focusOnShow={ false }
 			labelText={ labelText }
 			tooltipClassName="theme-tier-badge-tooltip"
 			tooltipContent={ tooltipContent }
 			tooltipPosition="top"
-			shouldHideTooltip={ isGoalsAtFrontExperiment && ! user }
-			isClickable={ ! ( isGoalsAtFrontExperiment && ! user ) }
+			shouldHideTooltip={ isGoalsAtFrontExperiment }
+			isClickable={ ! isGoalsAtFrontExperiment }
 		/>
 	);
 }

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
@@ -2,14 +2,18 @@ import { getPlan } from '@automattic/calypso-products';
 import { PremiumBadge } from '@automattic/components';
 import { Plans } from '@automattic/data-stores';
 import { createInterpolateElement } from '@wordpress/element';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
+import { useSelector } from 'calypso/state';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { useThemeTierForTheme } from 'calypso/state/themes/hooks/use-theme-tier-for-theme';
 import { THEME_TIERS } from '../constants';
 import ThemeTierBadgeCheckoutLink from './theme-tier-badge-checkout-link';
 import { useThemeTierBadgeContext } from './theme-tier-badge-context';
 import ThemeTierTooltipTracker from './theme-tier-tooltip-tracker';
 
-export default function ThemeTierUpgradeBadge() {
+export default function ThemeTierPlanUpgradeBadge() {
 	const translate = useTranslate();
 	const { themeId } = useThemeTierBadgeContext();
 	const themeTier = useThemeTierForTheme( themeId );
@@ -21,6 +25,16 @@ export default function ThemeTierUpgradeBadge() {
 	// Using API plans because the updated getTitle() method doesn't take the experiment assignment into account.
 	const plans = Plans.usePlans( { coupon: undefined } );
 	const planName = plans?.data?.[ mappedPlan.getStoreSlug() ]?.productNameShort;
+	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
+	const user = useSelector( getCurrentUser );
+	const labelText =
+		isGoalsAtFrontExperiment && ! user
+			? translate( 'Available on %(planName)s', {
+					args: {
+						planName: planName,
+					},
+			  } )
+			: translate( 'Upgrade' );
 
 	const tooltipContent = (
 		<>
@@ -42,10 +56,12 @@ export default function ThemeTierUpgradeBadge() {
 
 	return (
 		<PremiumBadge
-			className="theme-tier-badge__content"
+			className={ clsx( 'theme-tier-badge__content', {
+				'theme-tier-badge__without-background': isGoalsAtFrontExperiment && ! user,
+			} ) }
 			focusOnShow={ false }
 			isClickable
-			labelText={ translate( 'Upgrade' ) }
+			labelText={ labelText }
 			tooltipClassName="theme-tier-badge-tooltip"
 			tooltipContent={ tooltipContent }
 			tooltipPosition="top"

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
@@ -60,11 +60,12 @@ export default function ThemeTierPlanUpgradeBadge() {
 				'theme-tier-badge__without-background': isGoalsAtFrontExperiment && ! user,
 			} ) }
 			focusOnShow={ false }
-			isClickable
 			labelText={ labelText }
 			tooltipClassName="theme-tier-badge-tooltip"
 			tooltipContent={ tooltipContent }
 			tooltipPosition="top"
+			shouldHideTooltip={ isGoalsAtFrontExperiment && ! user }
+			isClickable={ ! ( isGoalsAtFrontExperiment && ! user ) }
 		/>
 	);
 }

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
@@ -5,13 +5,15 @@ import { createInterpolateElement } from '@wordpress/element';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
+import { useSelector } from 'calypso/state';
 import { useThemeTierForTheme } from 'calypso/state/themes/hooks/use-theme-tier-for-theme';
+import { getMarketplaceThemeSubscriptionPrices } from 'calypso/state/themes/selectors';
 import { THEME_TIERS } from '../constants';
 import ThemeTierBadgeCheckoutLink from './theme-tier-badge-checkout-link';
 import { useThemeTierBadgeContext } from './theme-tier-badge-context';
 import ThemeTierTooltipTracker from './theme-tier-tooltip-tracker';
 
-export default function ThemeTierPlanUpgradeBadge() {
+export default function ThemeTierPlanUpgradeBadge( { showPartnerPrice } ) {
 	const translate = useTranslate();
 	const { themeId } = useThemeTierBadgeContext();
 	const themeTier = useThemeTierForTheme( themeId );
@@ -19,18 +21,35 @@ export default function ThemeTierPlanUpgradeBadge() {
 	const tierMinimumUpsellPlan = THEME_TIERS[ themeTier?.slug ]?.minimumUpsellPlan;
 	const mappedPlan = getPlan( tierMinimumUpsellPlan );
 	const planPathSlug = mappedPlan?.getPathSlug();
+	const subscriptionPrices = useSelector( ( state ) =>
+		getMarketplaceThemeSubscriptionPrices( state, themeId )
+	);
 
 	// Using API plans because the updated getTitle() method doesn't take the experiment assignment into account.
 	const plans = Plans.usePlans( { coupon: undefined } );
 	const planName = plans?.data?.[ mappedPlan.getStoreSlug() ]?.productNameShort;
 	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
-	const labelText = isGoalsAtFrontExperiment
-		? translate( 'Available on %(planName)s', {
+
+	const getLabel = () => {
+		if ( ! isGoalsAtFrontExperiment ) {
+			return translate( 'Upgrade' );
+		}
+
+		if ( showPartnerPrice && subscriptionPrices.month ) {
+			return translate( 'Available on %(planName)s plus %(price)s/month', {
 				args: {
 					planName: planName,
+					price: subscriptionPrices.month,
 				},
-		  } )
-		: translate( 'Upgrade' );
+			} );
+		}
+
+		return translate( 'Available on %(planName)s', {
+			args: {
+				planName: planName,
+			},
+		} );
+	};
 
 	const tooltipContent = (
 		<>
@@ -56,7 +75,7 @@ export default function ThemeTierPlanUpgradeBadge() {
 				'theme-tier-badge__without-background': isGoalsAtFrontExperiment,
 			} ) }
 			focusOnShow={ false }
-			labelText={ labelText }
+			labelText={ getLabel() }
 			tooltipClassName="theme-tier-badge-tooltip"
 			tooltipContent={ tooltipContent }
 			tooltipPosition="top"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
@@ -16,6 +16,7 @@ const DesignPickerDesignTitle: FC< Props > = ( { designTitle, selectedDesign } )
 			className="design-picker-design-title__theme-tier-badge"
 			isLockedStyleVariation={ false }
 			themeId={ selectedDesign.slug }
+			showPartnerPrice
 		/>
 	</div>
 );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -54,6 +54,7 @@ import { navigate } from 'calypso/lib/navigate';
 import { urlToSlug } from 'calypso/lib/url';
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { getEligibility } from 'calypso/state/automated-transfer/selectors';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import {
 	getProductBillingSlugByThemeId,
 	getProductsByBillingSlug,
@@ -104,6 +105,7 @@ import type { Design, StyleVariation } from '@automattic/design-picker';
 import type { GlobalStylesObject } from '@automattic/global-styles';
 import type { AnyAction } from 'redux';
 import type { ThunkAction } from 'redux-thunk';
+
 const SiteIntent = Onboard.SiteIntent;
 
 const EMPTY_ARRAY: Design[] = [];
@@ -135,6 +137,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const translate = useTranslate();
 	const locale = useLocale();
 	const hasEnTranslation = useHasEnTranslation();
+
+	const user = useSelector( getCurrentUser );
 
 	const { intent, goals } = useSelect( ( select ) => {
 		const onboardStore = select( ONBOARD_STORE ) as OnboardSelect;
@@ -971,7 +975,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				categorization={ categorization }
 				isPremiumThemeAvailable={ isPremiumThemeAvailable }
 				shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
-				getBadge={ getBadge }
+				// We may want to modify the ThemeCard component once the experiment is completed
+				// to avoid passing the getBadge and getOptionsMenu prop conditionally down the component tree.
+				getBadge={ isGoalsAtFrontExperiment && ! user ? undefined : getBadge }
+				getOptionsMenu={ isGoalsAtFrontExperiment && ! user ? getBadge : undefined }
 				oldHighResImageLoading={ oldHighResImageLoading }
 				siteActiveTheme={ siteActiveTheme?.[ 0 ]?.stylesheet ?? null }
 				showActiveThemeBadge={ intent !== 'build' }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -54,7 +54,6 @@ import { navigate } from 'calypso/lib/navigate';
 import { urlToSlug } from 'calypso/lib/url';
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { getEligibility } from 'calypso/state/automated-transfer/selectors';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import {
 	getProductBillingSlugByThemeId,
 	getProductsByBillingSlug,
@@ -137,8 +136,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const translate = useTranslate();
 	const locale = useLocale();
 	const hasEnTranslation = useHasEnTranslation();
-
-	const user = useSelector( getCurrentUser );
 
 	const { intent, goals } = useSelect( ( select ) => {
 		const onboardStore = select( ONBOARD_STORE ) as OnboardSelect;
@@ -977,8 +974,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
 				// We may want to modify the ThemeCard component once the experiment is completed
 				// to avoid passing the getBadge and getOptionsMenu prop conditionally down the component tree.
-				getBadge={ isGoalsAtFrontExperiment && ! user ? undefined : getBadge }
-				getOptionsMenu={ isGoalsAtFrontExperiment && ! user ? getBadge : undefined }
+				getBadge={ isGoalsAtFrontExperiment ? undefined : getBadge }
+				getOptionsMenu={ isGoalsAtFrontExperiment ? getBadge : undefined }
 				oldHighResImageLoading={ oldHighResImageLoading }
 				siteActiveTheme={ siteActiveTheme?.[ 0 ]?.stylesheet ?? null }
 				showActiveThemeBadge={ intent !== 'build' }

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -27,7 +27,7 @@
 			right: 4px;
 			height: 36px;
 			border-radius: 4px;
-			background-color: var(--studio-gray-0);
+			background-color: #EDEDEF; /* 50% of gray-5 */
 		}
 
 		&.is-pressed {

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -30,6 +30,14 @@
 			background-color: #EDEDEF; /* 50% of gray-5 */
 		}
 
+		&:not([class*="is-pressed"]):hover {
+			color: var(--studio-gray-100);
+		}
+
+		&:not([class*="is-pressed"]):hover::before{
+			background-color: var(--studio-gray-5);
+		}
+
 		&.is-pressed {
 			&::before {
 				background-color: var(--studio-wordpress-blue);
@@ -46,12 +54,17 @@
 	}
 
 	button.components-button.responsive-toolbar-group__menu-item {
-		height: 36px;
+		height: 40px;
 		padding: 8px 12px;
 		border-radius: 4px;
 		line-height: 20px;
-		background-color: var(--studio-gray-0);
+		background-color: #EDEDEF; /* 50% of gray-5 */
 		font-size: rem(13px);
+
+		&:not(.responsive-toolbar-group__more-item):not([class*="is-selected"]):hover {
+			color: var(--studio-gray-100);
+			background-color: var(--studio-gray-5);
+		}
 
 		&:not(:first-child) {
 			margin-top: 8px;

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -381,6 +381,11 @@
 			opacity: 1;
 		}
 	}
+
+	.theme-tier-badge--free .badge {
+		font-size: $font-body-extra-small;
+		height: 20px;
+	}
 }
 
 .design-picker.design-picker__unified {

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -384,7 +384,6 @@
 
 	.theme-tier-badge--free .badge {
 		font-size: $font-body-extra-small;
-		height: 20px;
 	}
 }
 

--- a/packages/design-picker/src/components/theme-card/index.tsx
+++ b/packages/design-picker/src/components/theme-card/index.tsx
@@ -15,7 +15,7 @@ interface ThemeCardProps {
 	imageClickUrl?: string;
 	imageActionLabel?: string;
 	banner?: React.ReactNode;
-	badge: React.ReactNode;
+	badge?: React.ReactNode;
 	styleVariations: StyleVariation[];
 	selectedStyleVariation?: StyleVariation;
 	optionsMenu?: React.ReactNode;
@@ -155,7 +155,7 @@ const ThemeCard = forwardRef(
 								/>
 							</div>
 						) }
-						{ ! isActive && <>{ badge }</> }
+						{ ! isActive && badge && <>{ badge }</> }
 						{ optionsMenu && <div className="theme-card__info-options">{ optionsMenu }</div> }
 						{ isActive && <ActiveBadge /> }
 					</div>

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -296,7 +296,6 @@ $theme-card-info-margin-top: 16px;
 	border: 0;
 	display: flex;
 	flex: 0 0 auto;
-	height: 20px;
 	position: absolute;
 	right: 0;
 	transition: all 0.1s ease-in-out;

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -108,7 +108,8 @@ interface DesignCardProps {
 	shouldLimitGlobalStyles?: boolean;
 	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
-	getBadge: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
+	getBadge?: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
+	getOptionsMenu?: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
 	oldHighResImageLoading?: boolean; // Temporary for A/B test.
 	isActive: boolean;
 }
@@ -122,6 +123,7 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 	onChangeVariation,
 	onPreview,
 	getBadge,
+	getOptionsMenu,
 	oldHighResImageLoading,
 	isActive,
 } ) => {
@@ -157,7 +159,8 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 					oldHighResImageLoading={ oldHighResImageLoading }
 				/>
 			}
-			badge={ getBadge( design.slug, isLocked ) }
+			optionsMenu={ getOptionsMenu && getOptionsMenu( design.slug, isLocked ) }
+			badge={ getBadge && getBadge( design.slug, isLocked ) }
 			styleVariations={ style_variations }
 			selectedStyleVariation={ selectedStyleVariation }
 			onStyleVariationClick={ ( variation ) => {
@@ -185,7 +188,8 @@ interface DesignCardGroup {
 	showNoResults?: boolean;
 	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
-	getBadge: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
+	getBadge?: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
+	getOptionsMenu?: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
 }
 
 const DesignCardGroup = ( {
@@ -203,6 +207,7 @@ const DesignCardGroup = ( {
 	onChangeVariation,
 	onPreview,
 	getBadge,
+	getOptionsMenu,
 }: DesignCardGroup ) => {
 	const translate = useTranslate();
 	const [ isCollapsed, setIsCollapsed ] = useState( !! categoryName || false );
@@ -223,6 +228,7 @@ const DesignCardGroup = ( {
 						onChangeVariation={ onChangeVariation }
 						onPreview={ onPreview }
 						getBadge={ getBadge }
+						getOptionsMenu={ getOptionsMenu }
 						oldHighResImageLoading={ oldHighResImageLoading }
 						isActive={ showActiveThemeBadge && design.recipe?.stylesheet === siteActiveTheme }
 					/>
@@ -286,7 +292,8 @@ interface DesignPickerProps {
 	categorization?: Categorization;
 	isPremiumThemeAvailable?: boolean;
 	shouldLimitGlobalStyles?: boolean;
-	getBadge: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
+	getBadge?: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
+	getOptionsMenu?: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
 	oldHighResImageLoading?: boolean; // Temporary for A/B test
 	siteActiveTheme?: string | null;
 	showActiveThemeBadge?: boolean;
@@ -305,6 +312,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	isPremiumThemeAvailable,
 	shouldLimitGlobalStyles,
 	getBadge,
+	getOptionsMenu,
 	oldHighResImageLoading,
 	siteActiveTheme = null,
 	showActiveThemeBadge = false,
@@ -366,6 +374,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 		onChangeVariation,
 		onPreview,
 		getBadge,
+		getOptionsMenu,
 		oldHighResImageLoading,
 		showActiveThemeBadge,
 		siteActiveTheme,
@@ -477,7 +486,8 @@ export interface UnifiedDesignPickerProps {
 	heading?: React.ReactNode;
 	isPremiumThemeAvailable?: boolean;
 	shouldLimitGlobalStyles?: boolean;
-	getBadge: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
+	getBadge?: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
+	getOptionsMenu?: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
 	oldHighResImageLoading?: boolean; // Temporary for A/B test
 	siteActiveTheme?: string | null;
 	showActiveThemeBadge?: boolean;
@@ -498,6 +508,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	isPremiumThemeAvailable,
 	shouldLimitGlobalStyles,
 	getBadge,
+	getOptionsMenu,
 	oldHighResImageLoading,
 	siteActiveTheme = null,
 	showActiveThemeBadge = false,
@@ -525,6 +536,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					isPremiumThemeAvailable={ isPremiumThemeAvailable }
 					shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
 					getBadge={ getBadge }
+					getOptionsMenu={ getOptionsMenu }
 					oldHighResImageLoading={ oldHighResImageLoading }
 					siteActiveTheme={ siteActiveTheme }
 					showActiveThemeBadge={ showActiveThemeBadge }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Requirements updated on this Slack convo: p1734630014796709-slack-C085HCWCEDN 

- Only apply the changes for logged-out users belonging to the new goals flow
- Free themes: Show free blue badge.
- Premium themes: any theme that’s not free should show “Available on {Plan name}” where plan name is the name of the plan it’s available on (eg Available on Personal, ... Available on Commerce, etc.). 
- Don't show the WooCommerce badge
- Remove the theme color picker and add the badge on its place

Tasks:

- Closes https://github.com/Automattic/wp-calypso/issues/97295
- Related to https://github.com/Automattic/wp-calypso/issues/93931


## Proposed Changes

* We're only changing the logged-out view and users who belongs to the `isGoalsAtFrontExperiment` experiment
* 1 - We're positioning the badge at the bottom right of the theme block ([from this task](https://github.com/Automattic/wp-calypso/issues/93931))
* 1 - We're hiding it's background and spacing
* 1 - We're removing the tooltip and it's not clicable anymore ([from this task](https://github.com/Automattic/wp-calypso/issues/95471))
* 2 - Adding free blue badge for themes that are free
* 3 - Removing WooCommerce badge for Business plan with it.
* 3 - Removed the theme color picker and add the badge on its place

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/ddcb4942-3f9e-4adc-aa56-9de8ae6d65a4" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We're improving the onboarding experience and this task is part of this project: pet6gk-1Oz-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the new goals onboarding: http://calypso.localhost:3000/setup/onboarding/goals?flags=onboarding/goals-first
* Ensure the changes above only happen to logged-out users who belong to the experiment.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?