### PR TITLE
Site Migration:  Remove automated-migration/collect-credentials feature flag and references to SOURCE_URL step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -67,7 +67,7 @@ const ImporterMigrateMessage: Step = ( { navigation } ) => {
 	useEffect( () => {
 		recordTracksEvent( 'wpcom_support_free_migration_request_click', {
 			path: window.location.pathname,
-			automated_migration: config.isEnabled( 'automated-migration/collect-credentials' ),
+			automated_migration: true,
 			prevent_ticket_creation: shouldPreventTicketCreation,
 		} );
 		if ( ! shouldPreventTicketCreation ) {
@@ -81,10 +81,7 @@ const ImporterMigrateMessage: Step = ( { navigation } ) => {
 	}, [ shouldPreventTicketCreation, config, fromUrl, siteSlug ] );
 	let whatToExpect: WhatToExpectProps[] = [];
 
-	if (
-		shouldPreventTicketCreation &&
-		config.isEnabled( 'automated-migration/collect-credentials' )
-	) {
+	if ( shouldPreventTicketCreation ) {
 		whatToExpect = [
 			{
 				icon: group,

--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	PLAN_MIGRATION_TRIAL_MONTHLY,
 	PLAN_BUSINESS,
@@ -30,7 +29,6 @@ const {
 	SITE_CREATION_STEP,
 	MIGRATION_UPGRADE_PLAN,
 	MIGRATION_HOW_TO_MIGRATE,
-	MIGRATION_SOURCE_URL,
 	SITE_MIGRATION_INSTRUCTIONS,
 	SITE_MIGRATION_STARTED,
 	SITE_MIGRATION_ASSISTED_MIGRATION,
@@ -46,7 +44,6 @@ const steps = [
 	PROCESSING,
 	MIGRATION_UPGRADE_PLAN,
 	MIGRATION_HOW_TO_MIGRATE,
-	MIGRATION_SOURCE_URL,
 	SITE_MIGRATION_INSTRUCTIONS,
 	SITE_MIGRATION_STARTED,
 	SITE_MIGRATION_ASSISTED_MIGRATION,
@@ -225,7 +222,7 @@ const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject:
 					}
 
 					const destinationStep = migrationDealAccepted
-						? MIGRATION_SOURCE_URL
+						? SITE_MIGRATION_CREDENTIALS
 						: MIGRATION_HOW_TO_MIGRATE;
 
 					return navigateToCheckout( { siteId, siteSlug, plan, from, props, destinationStep } );
@@ -248,27 +245,12 @@ const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject:
 					return navigateWithQueryParams( SITE_MIGRATION_INSTRUCTIONS, [], props );
 				}
 
-				// @deprecated Remove the MIGRATION_SOURCE_URL when SITE_MIGRATION_CREDENTIALS is considered stable.
-				const SOURCE_STEP = config.isEnabled( 'automated-migration/collect-credentials' )
-					? SITE_MIGRATION_CREDENTIALS
-					: MIGRATION_SOURCE_URL;
-
-				return navigateWithQueryParams( SOURCE_STEP, [], props );
+				return navigateWithQueryParams( SITE_MIGRATION_CREDENTIALS, [], props );
 			},
 		},
 		[ SITE_MIGRATION_INSTRUCTIONS.slug ]: {
 			submit: ( props?: ProvidedDependencies ) => {
 				return navigateWithQueryParams( SITE_MIGRATION_STARTED, [], props );
-			},
-		},
-
-		// @deprecated Remove the MIGRATION_SOURCE_URL when SITE_MIGRATION_CREDENTIALS is considered stable.
-		[ MIGRATION_SOURCE_URL.slug ]: {
-			submit: ( props?: ProvidedDependencies ) => {
-				return navigateWithQueryParams( SITE_MIGRATION_ASSISTED_MIGRATION, [], props );
-			},
-			goBack: ( props?: ProvidedDependencies ) => {
-				return navigateWithQueryParams( MIGRATION_HOW_TO_MIGRATE, [], props );
 			},
 		},
 

--- a/client/landing/stepper/declarative-flow/migration/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/test/index.tsx
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import { URLSearchParams } from 'url';
-import config from '@automattic/calypso-config';
 import { isCurrentUserLoggedIn } from '@automattic/data-stores/src/user/selectors';
 import { useIsSiteOwner } from 'calypso/landing/stepper/hooks/use-is-site-owner';
 import { goToCheckout } from 'calypso/landing/stepper/utils/checkout';
@@ -321,7 +320,7 @@ describe( `${ flow.name }`, () => {
 				);
 			} );
 
-			it( 'redirects user from MIGRATION_UPGRADE_PLAN using SOURCE_URL_STEP as destination when they accept the offer', () => {
+			it( 'redirects user from MIGRATION_UPGRADE_PLAN using SITE_MIGRATION_CREDENTIALS as destination when they accept the offer', () => {
 				runNavigation( {
 					from: STEPS.MIGRATION_UPGRADE_PLAN,
 					query: { siteId: 123, siteSlug: 'example.wordpress.com' },
@@ -329,7 +328,7 @@ describe( `${ flow.name }`, () => {
 				} );
 
 				expect( goToCheckout ).toHaveBeenCalledWith( {
-					destination: `/setup/migration/migration-source-url?siteId=123&siteSlug=example.wordpress.com`,
+					destination: `/setup/migration/site-migration-credentials?siteId=123&siteSlug=example.wordpress.com`,
 					extraQueryParams: undefined,
 					flowName: 'migration',
 					siteSlug: 'example.wordpress.com',
@@ -354,23 +353,7 @@ describe( `${ flow.name }`, () => {
 				} );
 			} );
 
-			it( 'redirects user from How To Migrate to MIGRATION_SOURCE_URL when they selects the option "do it for me"', () => {
-				config.disable( 'automated-migration/collect-credentials' );
-
-				const destination = runNavigation( {
-					from: STEPS.MIGRATION_HOW_TO_MIGRATE,
-					query: { siteId: 123, siteSlug: 'example.wordpress.com' },
-					dependencies: { how: HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME },
-				} );
-
-				expect( destination ).toMatchDestination( {
-					step: STEPS.MIGRATION_SOURCE_URL,
-					query: { siteId: 123, siteSlug: 'example.wordpress.com' },
-				} );
-			} );
-
 			it( 'redirects user from How To Migrate > SITE_MIGRATION_CREDENTIALS when they selects the option "do it for me"', () => {
-				config.enable( 'automated-migration/collect-credentials' );
 				const destination = runNavigation( {
 					from: STEPS.MIGRATION_HOW_TO_MIGRATE,
 					query: { siteId: 123, siteSlug: 'example.wordpress.com' },
@@ -495,25 +478,6 @@ describe( `${ flow.name }`, () => {
 			} );
 		} );
 
-		describe( 'MIGRATION_SOURCE_URL', () => {
-			it( 'redirects users from Capture Source URL to Migration assisted', () => {
-				const destination = runNavigation( {
-					from: STEPS.MIGRATION_SOURCE_URL,
-					query: { siteId: 123, siteSlug: 'example.wordpress.com' },
-					dependencies: { from: 'http://oldsite.example.com' },
-				} );
-
-				expect( destination ).toMatchDestination( {
-					step: STEPS.SITE_MIGRATION_ASSISTED_MIGRATION,
-					query: {
-						siteId: 123,
-						siteSlug: 'example.wordpress.com',
-						from: 'http://oldsite.example.com',
-					},
-				} );
-			} );
-		} );
-
 		describe( 'SITE_MIGRATION_OTHER_PLATFORM_DETECTED_IMPORT STEP', () => {
 			it( 'redirects users from SITE_MIGRATION_OTHER_PLATFORM_DETECTED_IMPORT to SITE_MIGRATION_ASSISTED_MIGRATION', () => {
 				runNavigation( {
@@ -542,18 +506,6 @@ describe( `${ flow.name }`, () => {
 	} );
 
 	describe( 'useStepNavigation > goBack', () => {
-		it( 'redirects back user from SOURCE URL > HOW TO MIGRATE', () => {
-			const destination = runNavigationBack( {
-				from: STEPS.MIGRATION_SOURCE_URL,
-				query: { siteId: 123, siteSlug: 'example.wordpress.com' },
-			} );
-
-			expect( destination ).toMatchDestination( {
-				step: STEPS.MIGRATION_HOW_TO_MIGRATE,
-				query: { siteId: 123, siteSlug: 'example.wordpress.com' },
-			} );
-		} );
-
 		it( 'retain user on the step and set the assisted migration modal query param when the modal query param is not set', () => {
 			const destination = runNavigationBack( {
 				from: STEPS.MIGRATION_UPGRADE_PLAN,

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -301,23 +301,16 @@ const siteMigration: Flow = {
 
 					// Do it for me option.
 					if ( providedDependencies?.how === HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME ) {
-						if ( config.isEnabled( 'automated-migration/collect-credentials' ) ) {
-							return navigate(
-								addQueryArgs(
-									{
-										siteSlug,
-										from: fromQueryParam,
-										siteId,
-									},
-									STEPS.SITE_MIGRATION_CREDENTIALS.slug
-								)
-							);
-						}
-
-						return navigate( STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug, {
-							siteId,
-							siteSlug,
-						} );
+						return navigate(
+							addQueryArgs(
+								{
+									siteSlug,
+									from: fromQueryParam,
+									siteId,
+								},
+								STEPS.SITE_MIGRATION_CREDENTIALS.slug
+							)
+						);
 					}
 
 					// Continue with the migration flow.
@@ -346,14 +339,7 @@ const siteMigration: Flow = {
 							providedDependencies?.userAcceptedDeal ||
 							urlQueryParams.get( 'how' ) === HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME
 						) {
-							if ( config.isEnabled( 'automated-migration/collect-credentials' ) ) {
-								redirectAfterCheckout = STEPS.SITE_MIGRATION_CREDENTIALS.slug;
-							} else if ( ! fromQueryParam ) {
-								// If the user selected "Do it for me" but has not given us a source site, we should take them to the source URL step.
-								redirectAfterCheckout = STEPS.SITE_MIGRATION_SOURCE_URL.slug;
-							} else {
-								redirectAfterCheckout = STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug;
-							}
+							redirectAfterCheckout = STEPS.SITE_MIGRATION_CREDENTIALS.slug;
 						}
 
 						const destination = addQueryArgs(

--- a/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import config from '@automattic/calypso-config';
 import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { isCurrentUserLoggedIn } from '@automattic/data-stores/src/user/selectors';
 import { waitFor } from '@testing-library/react';
@@ -178,27 +177,6 @@ describe( 'Hosted site Migration Flow', () => {
 					siteSlug: 'example.wordpress.com',
 				},
 			} );
-		} );
-
-		it( 'migrate redirects from the how-to-migrate (do it for me) page to assisted migration page', () => {
-			config.disable( 'automated-migration/collect-credentials' );
-			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
-
-			runUseStepNavigationSubmit( {
-				currentStep: STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug,
-				dependencies: {
-					destination: 'migrate',
-					how: HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME,
-				},
-			} );
-
-			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug }`,
-				state: {
-					siteSlug: 'example.wordpress.com',
-				},
-			} );
-			config.enable( 'automated-migration/collect-credentials' );
 		} );
 
 		it( 'migrate redirects from the how-to-migrate (do it for me) page to credential collection step', () => {

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import config from '@automattic/calypso-config';
 import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { isCurrentUserLoggedIn } from '@automattic/data-stores/src/user/selectors';
 import { waitFor } from '@testing-library/react';
@@ -223,27 +222,6 @@ describe( 'Site Migration Flow', () => {
 			} );
 		} );
 
-		it( 'migrate redirects from the how-to-migrate (do it for me) page to assisted migration page', () => {
-			config.disable( 'automated-migration/collect-credentials' );
-			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
-
-			runUseStepNavigationSubmit( {
-				currentStep: STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug,
-				dependencies: {
-					destination: 'migrate',
-					how: HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME,
-				},
-			} );
-
-			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug }`,
-				state: {
-					siteSlug: 'example.wordpress.com',
-				},
-			} );
-			config.enable( 'automated-migration/collect-credentials' );
-		} );
-
 		it( 'migrate redirects from the how-to-migrate (do it for me) page to credential collection step', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 
@@ -300,33 +278,6 @@ describe( 'Site Migration Flow', () => {
 				cancelDestination: `/setup/site-migration/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com`,
 				plan: PLAN_MIGRATION_TRIAL_MONTHLY,
 			} );
-		} );
-
-		it( 'redirects the user to the checkout page with the credentials step as success destination', () => {
-			config.enable( 'automated-migration/collect-credentials' );
-			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
-
-			runUseStepNavigationSubmit( {
-				currentURL: `/setup/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com&from=https://site-to-be-migrated.com&how=${ HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME }`,
-				currentStep: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
-				dependencies: {
-					goToCheckout: true,
-					plan: PLAN_MIGRATION_TRIAL_MONTHLY,
-					sendIntentWhenCreatingTrial: true,
-				},
-				cancelDestination: `/setup/site-migration/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com&from=https://site-to-be-migrated.com&how=${ HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME }`,
-			} );
-
-			expect( goToCheckout ).toHaveBeenCalledWith( {
-				destination: `/setup/site-migration/${ STEPS.SITE_MIGRATION_CREDENTIALS.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com`,
-				extraQueryParams: { hosting_intent: HOSTING_INTENT_MIGRATE },
-				flowName: 'site-migration',
-				siteSlug: 'example.wordpress.com',
-				stepName: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
-				cancelDestination: `/setup/site-migration/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com&how=${ HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME }`,
-				plan: PLAN_MIGRATION_TRIAL_MONTHLY,
-			} );
-			config.disable( 'automated-migration/collect-credentials' );
 		} );
 
 		it( 'redirects back to the credentials step when failing to create the ticket', () => {

--- a/config/development.json
+++ b/config/development.json
@@ -35,7 +35,6 @@
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/application-password": true,
-		"automated-migration/collect-credentials": true,
 		"automated-migration/pending-status": true,
 		"bulk-plugin-management": true,
 		"calypso/ai-blogging-prompts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -14,7 +14,6 @@
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
 		"automated-migration/application-password": true,
-		"automated-migration/collect-credentials": true,
 		"automated-migration/pending-status": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-assembler": true,

--- a/config/production.json
+++ b/config/production.json
@@ -25,7 +25,6 @@
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/application-password": true,
-		"automated-migration/collect-credentials": true,
 		"automated-migration/pending-status": true,
 		"bulk-plugin-management": true,
 		"calypso/ai-blogging-prompts": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -24,7 +24,6 @@
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/application-password": true,
-		"automated-migration/collect-credentials": true,
 		"automated-migration/pending-status": true,
 		"bulk-plugin-management": true,
 		"calypso/ai-blogging-prompts": false,

--- a/config/test.json
+++ b/config/test.json
@@ -26,7 +26,6 @@
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/application-password": true,
-		"automated-migration/collect-credentials": true,
 		"automated-migration/pending-status": true,
 		"calypso/all-domain-management": false,
 		"calypsoify/plugins": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -23,7 +23,6 @@
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/application-password": true,
-		"automated-migration/collect-credentials": true,
 		"automated-migration/pending-status": true,
 		"bulk-plugin-management": true,
 		"calypso/ai-blogging-prompts": true,


### PR DESCRIPTION
## Proposed Changes


* Remove all references to  `automated-migration/collect-credentials`  from `/setup/migration` and  `/setup/site-migration` (and hosted-site-migration as consequence) 
* Remove all references to the old `migration-source-url` step, which only captured the user domain. Now, we can capture way more data with the credentials step. 
* Delete the test cases the feature is off


## Why are these changes being made?
* Code cleanup to improve maintenance

## Testing Instructions

- Go to any of our migration flows (e.g./setup/hosted-site-migration) 
- Choose DIFM
- Follow the steps and check if you  can see the credentials setup 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
