### PR TITLE
Stats: Remove subscriber highlight card stats

### DIFF
--- a/client/my-sites/stats/pages/subscribers/index.tsx
+++ b/client/my-sites/stats/pages/subscribers/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
@@ -21,7 +20,6 @@ import StatsModulePlaceholder from '../../stats-module/placeholder';
 import PageViewTracker from '../../stats-page-view-tracker';
 import SubscribersChartSection, { PeriodType } from '../../stats-subscribers-chart-section';
 import SubscribersHighlightSection from '../../stats-subscribers-highlight-section';
-import SubscribersOverview from '../../stats-subscribers-overview';
 import type { Moment } from 'moment';
 
 interface StatsSubscribersPageProps {
@@ -47,7 +45,6 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
-	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const { supportsEmailStats, supportsSubscriberChart } = useSelector( ( state ) =>
 		getEnvStatsFeatureSupportChecks( state, siteId )
 	);
@@ -83,12 +80,6 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 	// Necessary to properly configure the fixed navigation headers.
 	// sessionStorage.setItem( 'jp-stats-last-tab', 'subscribers' );
 
-	// Check if the site has any paid subscription products added.
-	const products = useSelector( ( state ) => state.memberships?.productList?.items[ siteId ?? 0 ] );
-	// Odyssey Stats doesn't support the membership API endpoint yet.
-	// Products with an `undefined` value rather than an empty array means the API call has not been completed yet.
-	const hasAddedPaidSubscriptionProduct = ! isOdysseyStats && products && products.length > 0;
-
 	const summaryUrl = `/stats/${ period?.period }/emails/${ siteSlug }?startDate=${ period?.startOf?.format(
 		'YYYY-MM-DD'
 	) }`;
@@ -120,7 +111,6 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 										slug={ siteSlug }
 										period={ period.period }
 									/>
-									{ hasAddedPaidSubscriptionProduct && <SubscribersOverview siteId={ siteId } /> }
 								</>
 							) }
 							<div className={ statsModuleListClass }>


### PR DESCRIPTION
## Summary

Removes cards on Stats > Subscribers page that show subscribers numbers for 30 days ago / 60 days ago / 90 days ago, along with any code that was only being used for these.

Addresses: https://github.com/Automattic/jetpack/issues/40524
Based on designs at: p1HpG7-v7v-p2

*Before:*
<img width="1221" alt="subscribers-stats-before" src="https://github.com/user-attachments/assets/b46a2511-1f4f-4c74-b2e6-a9e85959538e" />

*After:*
<img width="1208" alt="subscriber-stats-after" src="https://github.com/user-attachments/assets/4a0439e3-c8d5-4f6a-9a2b-937bb504dc75" />

## Testing Instructions

Navigate to Stats > Subscribers page and confirm the cards above are removed below the chart.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?