### PR TITLE
Add DNS Records subpage and add support to custom headers

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -381,7 +381,11 @@ export default {
 
 	domainManagementSubpageParams( subPageKey ) {
 		return ( pageContext, next ) => {
-			pageContext.params = getSubpageParams( subPageKey );
+			pageContext.params = {
+				...pageContext.params,
+				...getSubpageParams( subPageKey ),
+				subPageKey,
+			};
 			next();
 		};
 	},

--- a/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
@@ -18,7 +18,7 @@ import DomainConnectInfoDialog from './domain-connect-info-dialog';
 class DnsRecordsList extends Component {
 	static propTypes = {
 		dns: PropTypes.object.isRequired,
-		selectedDOmain: PropTypes.object.isRequired,
+		selectedDomain: PropTypes.object.isRequired,
 		selectedDomainName: PropTypes.string.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 	};

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -45,6 +45,8 @@ class DnsRecords extends Component {
 		selectedDomainName: PropTypes.string.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 		nameservers: PropTypes.array || null,
+		titleOverride: PropTypes.string,
+		subtitleOverride: PropTypes.string,
 	};
 
 	hasDefaultCnameRecord = () => {
@@ -96,6 +98,11 @@ class DnsRecords extends Component {
 
 	renderHeader = () => {
 		const { domains, translate, selectedSite, currentRoute, selectedDomainName, dns } = this.props;
+		const {
+			showBreadcrumb = true,
+			titleOverride,
+			subtitleOverride,
+		} = this.props.context?.params || {};
 		const selectedDomain = domains?.find( ( domain ) => domain?.name === selectedDomainName );
 
 		const items = [
@@ -166,10 +173,12 @@ class DnsRecords extends Component {
 
 		return (
 			<DomainHeader
-				items={ items }
-				mobileItem={ mobileItem }
+				items={ showBreadcrumb ? items : [] }
+				mobileItem={ showBreadcrumb ? mobileItem : null }
 				buttons={ buttons }
 				mobileButtons={ mobileButtons }
+				titleOverride={ titleOverride }
+				subtitleOverride={ subtitleOverride }
 			/>
 		);
 	};
@@ -256,6 +265,7 @@ class DnsRecords extends Component {
 
 	renderMain() {
 		const { dns, selectedDomainName, selectedSite, translate, domains } = this.props;
+		const { showDetails = true } = this.props.context?.params || {};
 		const selectedDomain = domains?.find( ( domain ) => domain?.name === selectedDomainName );
 		const headerText = translate( 'DNS Records' );
 
@@ -266,7 +276,7 @@ class DnsRecords extends Component {
 				{ this.renderHeader() }
 				{ selectedDomain?.canManageDnsRecords ? (
 					<>
-						<DnsDetails />
+						{ showDetails && <DnsDetails /> }
 						{ this.renderNotice() }
 						<DnsRecordsList
 							dns={ dns }

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/add-fowarding-email-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/add-fowarding-email-header.tsx
@@ -1,0 +1,33 @@
+import { useTranslate } from 'i18n-calypso';
+import NavigationHeader from 'calypso/components/navigation-header';
+import { CustomHeaderComponentType } from './custom-header-component-type';
+
+const AddForwardingEmailHeader: CustomHeaderComponentType = ( {
+	selectedDomainName,
+	selectedSiteSlug,
+} ) => {
+	const translate = useTranslate();
+	return (
+		<>
+			<NavigationHeader
+				className="navigation-header__breadcrumb"
+				navigationItems={ [
+					{
+						label: selectedDomainName,
+						href: `/domains/manage/all/email/${ selectedDomainName }/${ selectedSiteSlug }`,
+					},
+					{
+						label: translate( 'Add email forwarding' ),
+					},
+				] }
+			/>
+			<NavigationHeader
+				className="navigation-header__title"
+				title={ translate( 'Add new email forwarding' ) }
+				subtitle={ translate( 'Seamlessly redirect your messages to where you need them.' ) }
+			/>
+		</>
+	);
+};
+
+export default AddForwardingEmailHeader;

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/custom-header-component-type.ts
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/custom-header-component-type.ts
@@ -1,0 +1,4 @@
+export type CustomHeaderComponentType = React.ComponentType< {
+	selectedDomainName: string;
+	selectedSiteSlug: string;
+} >;

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-records-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-records-header.tsx
@@ -1,0 +1,50 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { translate } from 'i18n-calypso';
+import ExternalLink from 'calypso/components/external-link';
+import NavigationHeader from 'calypso/components/navigation-header';
+import { CustomHeaderComponentType } from './custom-header-component-type';
+
+const DNSRecordsHeader: CustomHeaderComponentType = ( {
+	selectedDomainName,
+	selectedSiteSlug,
+} ) => (
+	<NavigationHeader
+		className="navigation-header__breadcrumb"
+		navigationItems={ [
+			{
+				label: selectedDomainName,
+				href: `/domains/manage/all/overview/${ selectedDomainName }/${ selectedSiteSlug }`,
+			},
+			{
+				label: translate( 'DNS records' ),
+			},
+		] }
+		title={ translate( 'DNS records' ) }
+		subtitle={ translate( 'DNS records change how your domain works. {a}Learn more{/a}', {
+			components: {
+				a: (
+					<ExternalLink
+						href={ localizeUrl( 'https://wordpress.com/support/domains/custom-dns/' ) }
+					/>
+				),
+			},
+		} ) }
+	/>
+);
+
+// Override the title and subtitle for the DNS records page
+const dnsRecordsTitle = translate( 'DNS records' );
+const dnsRecordsSubtitle = translate(
+	'DNS records change how your domain works. {{a}}Learn more{{/a}}.',
+	{
+		components: {
+			a: (
+				<ExternalLink href={ localizeUrl( 'https://wordpress.com/support/domains/custom-dns/' ) } />
+			),
+		},
+	}
+);
+
+export default DNSRecordsHeader;
+
+export { dnsRecordsTitle, dnsRecordsSubtitle };

--- a/client/my-sites/domains/domain-management/subpage-wrapper/index.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/index.tsx
@@ -11,35 +11,43 @@ type SubpageWrapperProps = {
 };
 
 const SubpageWrapper = ( { children, subpageKey, siteName, domainName }: SubpageWrapperProps ) => {
-	const subpageParams = getSubpageParams( subpageKey );
-	if ( ! subpageParams ) {
-		return children;
+	const { CustomHeader, title, subtitle } = getSubpageParams( subpageKey ) || {};
+
+	if ( CustomHeader ) {
+		return (
+			<div className="subpage-wrapper">
+				<CustomHeader selectedDomainName={ domainName } selectedSiteSlug={ siteName } />
+				<div className="subpage-wrapper__content">{ children }</div>
+			</div>
+		);
 	}
 
-	const breadcrumbItems = [
-		{
-			label: domainName,
-			href: domainManagementAllOverview( siteName, domainName ),
-		},
-		{
-			label: subpageParams.title,
-		},
-	];
+	if ( title ) {
+		const breadcrumbItems = [
+			{
+				label: domainName,
+				href: domainManagementAllOverview( siteName, domainName ),
+			},
+			{
+				label: title as string,
+			},
+		];
 
-	return subpageParams ? (
-		<div className="subpage-wrapper">
-			<NavigationHeader
-				className="subpage-wrapper__header"
-				navigationItems={ breadcrumbItems }
-				title={ subpageParams.title }
-				subtitle={ subpageParams.subtitle }
-				alwaysShowTitle
-			/>
-			<div className="subpage-wrapper__content">{ children }</div>
-		</div>
-	) : (
-		<>{ children }</>
-	);
+		return (
+			<div className="subpage-wrapper">
+				<NavigationHeader
+					className="subpage-wrapper__header"
+					navigationItems={ breadcrumbItems }
+					title={ title }
+					subtitle={ subtitle }
+					alwaysShowTitle
+				/>
+				<div className="subpage-wrapper__content">{ children }</div>
+			</div>
+		);
+	}
+
+	return children;
 };
 
 export default SubpageWrapper;

--- a/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
@@ -1,3 +1,4 @@
+@import "@automattic/color-studio/dist/color-variables";
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
@@ -5,6 +6,11 @@
 	display: flex;
 	flex-direction: column;
 	height: 100%;
+
+    .button:not(.is-borderless) {
+        padding: 10px 14px;
+        border-radius: 4px;
+    }
 
 	.subpage-wrapper__header.navigation-header {
 		padding: 24px;
@@ -66,4 +72,98 @@
 			padding: 0;
 		}
 	}
+
+    .dns-records {
+        .card.email-setup,
+        .dns-records-list {
+            border: solid 1px $studio-gray-5;
+            border-radius: 4px;
+            box-shadow: none;
+        }
+
+        .dns-records-list {
+            margin-top: 32px;
+
+            .dns-records-list-item__wrapper.is-header {
+                border-bottom-color: $studio-gray-10;
+            }
+
+            .dns-records-list-item__wrapper {
+                padding: 16px 30px 16px 36px;
+
+                &:last-child {
+                    border-bottom: none;
+                }
+            }
+        }
+
+        .button.ellipsis {
+            width: 24px;
+        }
+    }
+
+    .domain__main-placeholder {
+        .vertical-nav {
+            background-color: $studio-white;
+            border: solid 1px $studio-gray-5;
+            border-radius: 4px;
+            margin-top: 32px;
+        }
+
+        .card {
+            background-color: transparent;
+            border-bottom: solid 1px $studio-gray-5;
+            box-shadow: none;
+
+            &:last-child {
+                border-bottom: none;
+            }
+        }
+    }
+
+    .domain__main-placeholder,
+    .dns-records {
+        .navigation-header{
+            border-block-end: none !important;
+            padding-top: 0 !important;
+            padding-bottom: 0;
+
+            .navigation-header__main {
+                padding-inline: 0 !important;
+            }
+        }
+    }
+}
+
+.is-bulk-all-domains-page .layout__content .main {
+    .navigation-header {
+        &__breadcrumb,
+        &__title {
+            border-block-end: none;
+        }
+
+        &__breadcrumb {
+            @media ( max-width: $break-medium ) {
+                padding-top: 16px;
+            }
+        }
+
+        &__title {
+            padding-bottom: 0;
+            padding-top: 32px;
+
+            .navigation-header__main {
+                max-width: calc(1040px + 92px) !important;
+                margin: 0 auto;
+            }
+
+            @media ( max-width: $break-medium ) {
+                padding-top: 24px;
+
+                .navigation-header__main {
+                    padding-inline: 24px !important;
+                }
+            }
+        }
+    }
 }

--- a/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
@@ -90,6 +90,12 @@
                     border-bottom: none;
                 }
             }
+
+			.dns-records-list-item .dns-records-list-item__menu {
+				.ellipsis-menu__toggle {
+					right: unset;
+				}
+			}
         }
 
         .button.ellipsis {

--- a/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
@@ -7,11 +7,6 @@
 	flex-direction: column;
 	height: 100%;
 
-    .button:not(.is-borderless) {
-        padding: 10px 14px;
-        border-radius: 4px;
-    }
-
 	.subpage-wrapper__header.navigation-header {
 		padding: 24px;
 		border-block-end: 1px solid var(--color-border-secondary);

--- a/client/my-sites/domains/domain-management/subpage-wrapper/subpages.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/subpages.tsx
@@ -1,25 +1,36 @@
 import { __ } from '@wordpress/i18n';
-import CardHeading from 'calypso/components/card-heading';
+import AddForwardingEmailHeader from './headers/add-fowarding-email-header';
+import { CustomHeaderComponentType } from './headers/custom-header-component-type';
+import DNSRecordsHeader, {
+	dnsRecordsTitle,
+	dnsRecordsSubtitle,
+} from './headers/dns-records-header';
 
 type SubpageWrapperParamsType = {
-	subPageKey: string;
-	title: string;
-	subtitle?: string;
+	CustomHeader?: CustomHeaderComponentType;
+	title?: string | React.ReactNode;
+	subtitle?: string | React.ReactNode;
 	[ key: string ]: unknown;
 };
 
 // Subpage keys
 export const ADD_FOWARDING_EMAIL = 'add-forwarding-email';
+export const DNS_RECORDS = 'dns-records';
 export const EDIT_CONTACT_INFO = 'edit-contact-info';
 
 // Subpage params map
 const SUBPAGE_TO_PARAMS_MAP: Record< string, SubpageWrapperParamsType > = {
 	[ ADD_FOWARDING_EMAIL ]: {
-		subPageKey: ADD_FOWARDING_EMAIL,
-		title: __( 'Add new email forwarding' ),
-		subtitle: __( 'Seamlessly redirect your messages to where you need them.' ),
+		CustomHeader: AddForwardingEmailHeader,
+		showFormHeader: true,
 		showPageHeader: false,
-		formHeader: <CardHeading>{ __( 'New email forwarding address' ) }</CardHeading>,
+	},
+	[ DNS_RECORDS ]: {
+		CustomHeader: DNSRecordsHeader,
+		titleOverride: dnsRecordsTitle,
+		subtitleOverride: dnsRecordsSubtitle,
+		showBreadcrumb: false,
+		showDetails: false,
 	},
 	[ EDIT_CONTACT_INFO ]: {
 		subPageKey: EDIT_CONTACT_INFO,

--- a/client/my-sites/domains/domain-management/subpage-wrapper/test/index.test.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/test/index.test.tsx
@@ -4,7 +4,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import SubpageWrapper from '../index';
-import { ADD_FOWARDING_EMAIL } from '../subpages';
+import { ADD_FOWARDING_EMAIL, EDIT_CONTACT_INFO } from '../subpages';
 
 jest.mock( 'component-file-picker', () => () => <div>File Picker</div> );
 
@@ -54,20 +54,16 @@ describe( 'SubpageWrapper', () => {
 
 	it( 'should render breadcrumbs', () => {
 		const { container } = render(
-			<SubpageWrapper
-				subpageKey={ ADD_FOWARDING_EMAIL }
-				siteName="site.com"
-				domainName="domain.com"
-			>
+			<SubpageWrapper subpageKey={ EDIT_CONTACT_INFO } siteName="site.com" domainName="domain.com">
 				<span>Hello</span>
 			</SubpageWrapper>
 		);
 
-		expect( container.querySelector( '.breadcrumbs li:first-child' ).textContent ).toContain(
+		expect( container.querySelector( '.breadcrumbs li:first-child' )?.textContent ).toContain(
 			'domain.com'
 		);
-		expect( container.querySelector( '.breadcrumbs li:last-child' ).textContent ).toContain(
-			'Add new email forwarding'
+		expect( container.querySelector( '.breadcrumbs li:last-child' )?.textContent ).toContain(
+			'Contact information'
 		);
 	} );
 } );

--- a/client/my-sites/domains/domain-management/subpage-wrapper/test/index.test.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/test/index.test.tsx
@@ -6,6 +6,8 @@ import React from 'react';
 import SubpageWrapper from '../index';
 import { ADD_FOWARDING_EMAIL } from '../subpages';
 
+jest.mock( 'component-file-picker', () => () => <div>File Picker</div> );
+
 describe( 'SubpageWrapper', () => {
 	it( 'should render the children', () => {
 		render(

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -18,6 +18,7 @@ import {
 } from './domain-management/domain-overview-pane/constants';
 import {
 	ADD_FOWARDING_EMAIL,
+	DNS_RECORDS,
 	EDIT_CONTACT_INFO,
 } from './domain-management/subpage-wrapper/subpages';
 import * as paths from './paths';
@@ -427,6 +428,18 @@ export default function () {
 		navigation,
 		domainManagementController.domainManagementSubpageParams( EDIT_CONTACT_INFO ),
 		domainManagementController.domainManagementEditContactInfo,
+		domainManagementController.domainManagementSubpageView,
+		domainManagementController.domainDashboardLayout,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		paths.domainManagementOverviewRoot() + '/:domain/dns/:site',
+		siteSelection,
+		navigation,
+		domainManagementController.domainManagementSubpageParams( DNS_RECORDS ),
+		domainManagementController.domainManagementDns,
 		domainManagementController.domainManagementSubpageView,
 		domainManagementController.domainDashboardLayout,
 		makeLayout,

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -194,6 +194,10 @@ export function domainManagementEmail( siteName, domainName ) {
  * @param {string?} relativeTo
  */
 export function domainManagementDns( siteName, domainName, relativeTo = null ) {
+	if ( isUnderDomainManagementOverview( relativeTo ) ) {
+		return domainManagementOverviewRoot() + '/' + domainName + '/dns/' + siteName;
+	}
+
 	return domainManagementEditBase( siteName, domainName, 'dns', relativeTo );
 }
 

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -27,8 +27,8 @@ export default {
 				<EmailForwardsAdd
 					selectedDomainName={ pageContext.params.domain }
 					source={ pageContext.query.source }
+					showFormHeader={ pageContext.params.showFormHeader }
 					showPageHeader={ pageContext.params.showPageHeader }
-					formHeader={ pageContext.params.formHeader }
 				/>
 			</CalypsoShoppingCartProvider>
 		);

--- a/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list.tsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list.tsx
@@ -13,14 +13,14 @@ type Props = {
 	onBeforeAddEmailForwards?: () => void;
 	onAddedEmailForwards: () => void;
 	selectedDomainName: string;
-	formHeader?: React.ReactNode;
+	showFormHeader?: boolean;
 };
 
 const EmailForwardingAddNewCompactList = ( {
 	onAddedEmailForwards,
 	onBeforeAddEmailForwards,
 	selectedDomainName,
-	formHeader,
+	showFormHeader,
 }: Props ) => {
 	const translate = useTranslate();
 
@@ -102,7 +102,7 @@ const EmailForwardingAddNewCompactList = ( {
 							onRemoveEmailForward={ onRemoveEmailForward }
 							onUpdateEmailForward={ onUpdateEmailForward }
 							selectedDomainName={ selectedDomainName }
-							formHeader={ formHeader }
+							showFormHeader={ showFormHeader }
 						/>
 					</div>
 				</Fragment>

--- a/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact.jsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact.jsx
@@ -2,13 +2,13 @@ import { Button, FormInputValidation, FormLabel, Gridicon } from '@automattic/co
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
+import CardHeading from 'calypso/components/card-heading';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import { validateAllFields } from 'calypso/lib/domains/email-forwarding';
 import formState from 'calypso/lib/form-state';
-
 class EmailForwardingAddNewCompact extends Component {
 	static propTypes = {
 		fields: PropTypes.object,
@@ -18,7 +18,7 @@ class EmailForwardingAddNewCompact extends Component {
 		selectedDomainName: PropTypes.string.isRequired,
 		onUpdateEmailForward: PropTypes.func.isRequired,
 		emailForwards: PropTypes.array,
-		formHeader: PropTypes.element,
+		showFormHeader: PropTypes.bool,
 	};
 
 	isMounted = false;
@@ -90,7 +90,7 @@ class EmailForwardingAddNewCompact extends Component {
 	}
 
 	renderFormFields() {
-		const { translate, selectedDomainName, index, fields, formHeader } = this.props;
+		const { translate, selectedDomainName, index, fields, showFormHeader } = this.props;
 		const isValidMailbox = this.isValid( 'mailbox' );
 		const isValidDestination = this.isValid( 'destination' );
 		const { mailbox, destination } = fields;
@@ -99,7 +99,9 @@ class EmailForwardingAddNewCompact extends Component {
 
 		return (
 			<div className="email-forwarding__form-content">
-				{ formHeader ? <>{ formHeader }</> : null }
+				{ showFormHeader ? (
+					<CardHeading>{ translate( 'New email forwarding address' ) }</CardHeading>
+				) : null }
 				<FormFieldset>
 					<FormLabel>{ translate( 'Emails sent to' ) }</FormLabel>
 					<FormTextInputWithAffixes

--- a/client/my-sites/email/email-forwards-add/index.tsx
+++ b/client/my-sites/email/email-forwards-add/index.tsx
@@ -31,8 +31,8 @@ import './style.scss';
 type EmailForwardsAddProps = {
 	selectedDomainName: string;
 	source?: string;
+	showFormHeader?: boolean;
 	showPageHeader?: boolean;
-	formHeader?: React.ReactNode;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -41,8 +41,8 @@ const noop = (): void => {};
 const EmailForwardsAdd = ( {
 	selectedDomainName,
 	source,
+	showFormHeader = false,
 	showPageHeader = true,
-	formHeader,
 }: EmailForwardsAddProps ) => {
 	const currentRoute = useSelector( getCurrentRoute );
 	const selectedSite = useSelector( getSelectedSite );
@@ -104,7 +104,7 @@ const EmailForwardsAdd = ( {
 					onAddedEmailForwards={ onAddedEmailForwards }
 					onBeforeAddEmailForwards={ noop }
 					selectedDomainName={ selectedDomainName }
-					formHeader={ formHeader }
+					showFormHeader={ showFormHeader }
 				/>
 			) }
 		</Card>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/97279

**Should be rebased and merged after completing https://github.com/Automattic/wp-calypso/pull/97696.**

## Proposed Changes

* Added DNS Records subpage.
* Added `CustomHeader` option to the `SubpageWrapper` component.
* Created a custom header for the Add Forwarding Email page (including breadcrumb).
* Update header styles.
* Changes didn't affect visually the Edit Contact Info page.

<img width="1439" alt="Screenshot 2024-12-20 at 09 12 21" src="https://github.com/user-attachments/assets/16962675-ca18-4af1-9ee6-2a3222bfebbe" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of the Domain Management Revamp project: pfuQfP-13x-p2

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/domains/manage?flags=calypso/all-domain-management

**Add Forwarding Email page**
* Click on a domain that doesn't have emails configured
* Click on the Email tab
* Scroll to the bottom of the page and click the Email Forwarding link
* You should be redirected to the Add Forwarding Email page
* Check if the page is rendered as expected
* Make sure the header is also rendered correctly. Test on different screen sizes.
* Perform regression tests on the old page. It should continue working as before without any visual changes

**DNS Records page**
* On the Domains overview, scroll down and expand the DNS Records card.
* Click on Manage
* You should be redirected to the revamped DNS Records page
* Check if the page is rendered as expected. Also, check on multiple screen sizes.
* Perform regression tests on the page, testing all the actions.
* Go to the old version of the page and make sure it's working as expected as well.

**Edit Contact Info page**
* Perform regression tests on the page. You can follow instructions from https://github.com/Automattic/wp-calypso/pull/97562.
* The Edit Contact Info page should look as intended on Miro's PR. No visual change was applied there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?