### PR TITLE
Reader: enable pagination controls for Recent Feed

### DIFF
--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -184,16 +184,6 @@ body.is-reader-full-post {
 				padding: $recent-feed-spacing;
 			}
 		}
-
-		// This is a temporary fix to disable the pagination page selector because of this issue: Automattic/loop#247
-		// Once that issue is fixed, this code should be removed.
-		.dataviews-pagination__page-select {
-			display: none;
-
-			& + div {
-				margin-left: auto;
-			}
-		}
 	}
 
 	&__post-column {

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -427,7 +427,7 @@ function get_page_handle( streamType, action, data ) {
 
 export function handlePage( action, data ) {
 	const { posts, sites, cards } = data;
-	const { streamKey, query, isPoll, gap, streamType } = action.payload;
+	const { streamKey, query, isPoll, gap, streamType, page, perPage } = action.payload;
 	const pageHandle = get_page_handle( streamType, action, data );
 	const { dateProperty } = streamApis[ streamType ];
 
@@ -502,6 +502,8 @@ export function handlePage( action, data ) {
 				gap,
 				totalItems,
 				totalPages,
+				page,
+				perPage,
 			} )
 		);
 	}

--- a/client/state/reader/streams/actions.js
+++ b/client/state/reader/streams/actions.js
@@ -47,7 +47,16 @@ export function requestPage( {
 	};
 }
 
-export function receivePage( { streamKey, pageHandle, streamItems, gap, totalItems, totalPages } ) {
+export function receivePage( {
+	streamKey,
+	pageHandle,
+	streamItems,
+	gap,
+	totalItems,
+	totalPages,
+	page,
+	perPage,
+} ) {
 	return {
 		type: READER_STREAMS_PAGE_RECEIVE,
 		payload: {
@@ -57,6 +66,8 @@ export function receivePage( { streamKey, pageHandle, streamItems, gap, totalIte
 			gap,
 			totalItems,
 			totalPages,
+			page,
+			perPage,
 		},
 	};
 }

--- a/client/state/reader/streams/reducer.js
+++ b/client/state/reader/streams/reducer.js
@@ -36,14 +36,53 @@ export const items = ( state = [], action ) => {
 	let gap;
 	let newState;
 	let newXPosts;
+	let perPage;
+	let page;
 
 	switch ( action.type ) {
 		case READER_STREAMS_PAGE_RECEIVE:
 			gap = action.payload.gap;
 			streamItems = action.payload.streamItems;
+			perPage = action.payload.perPage;
+			page = action.payload.page;
 
 			if ( ! Array.isArray( streamItems ) ) {
 				return state;
+			}
+
+			// For the Recent feeds, we need to pad the stream with empty items
+			// for the DataViews pagination to work correctly
+			// see Automattic/loop#238
+			if (
+				action.payload.streamKey.startsWith( 'recent' ) &&
+				streamItems.length > 0 &&
+				perPage &&
+				page > 1
+			) {
+				// Calculate where new items should start
+				const startIndex = ( page - 1 ) * perPage;
+				const existingLength = state.length;
+				const paddingNeeded = startIndex - existingLength;
+
+				// Case 1: Need to add padding before new items
+				if ( paddingNeeded > 0 ) {
+					const paddingItems = Array( paddingNeeded )
+						.fill( undefined )
+						.map( ( _, index ) => ( {
+							isPadding: true,
+							postId: `padding-${ index }`,
+						} ) );
+
+					return combineXPosts( [ ...state, ...paddingItems, ...streamItems ] );
+				}
+
+				// Case 2: Replace existing items at correct index
+				const updatedState = [ ...state ];
+				streamItems.forEach( ( item, index ) => {
+					updatedState[ startIndex + index ] = item;
+				} );
+
+				return combineXPosts( updatedState );
 			}
 
 			if ( gap ) {

--- a/client/state/reader/streams/reducer.js
+++ b/client/state/reader/streams/reducer.js
@@ -38,6 +38,7 @@ export const items = ( state = [], action ) => {
 	let newXPosts;
 	let perPage;
 	let page;
+	let streamKey;
 
 	switch ( action.type ) {
 		case READER_STREAMS_PAGE_RECEIVE:
@@ -45,6 +46,7 @@ export const items = ( state = [], action ) => {
 			streamItems = action.payload.streamItems;
 			perPage = action.payload.perPage;
 			page = action.payload.page;
+			streamKey = action.payload.streamKey;
 
 			if ( ! Array.isArray( streamItems ) ) {
 				return state;
@@ -53,12 +55,7 @@ export const items = ( state = [], action ) => {
 			// For the Recent feeds, we need to pad the stream with empty items
 			// for the DataViews pagination to work correctly
 			// see Automattic/loop#238
-			if (
-				action.payload?.streamKey?.startsWith( 'recent' ) &&
-				streamItems.length > 0 &&
-				perPage &&
-				page > 1
-			) {
+			if ( streamKey?.startsWith( 'recent' ) && streamItems.length > 0 && perPage && page > 1 ) {
 				// Calculate where new items should start
 				const startIndex = ( page - 1 ) * perPage;
 				const existingLength = state.length;

--- a/client/state/reader/streams/reducer.js
+++ b/client/state/reader/streams/reducer.js
@@ -54,7 +54,7 @@ export const items = ( state = [], action ) => {
 			// for the DataViews pagination to work correctly
 			// see Automattic/loop#238
 			if (
-				action.payload?.streamKey.startsWith( 'recent' ) &&
+				action.payload?.streamKey?.startsWith( 'recent' ) &&
 				streamItems.length > 0 &&
 				perPage &&
 				page > 1

--- a/client/state/reader/streams/reducer.js
+++ b/client/state/reader/streams/reducer.js
@@ -54,7 +54,7 @@ export const items = ( state = [], action ) => {
 			// for the DataViews pagination to work correctly
 			// see Automattic/loop#238
 			if (
-				action.payload.streamKey.startsWith( 'recent' ) &&
+				action.payload?.streamKey.startsWith( 'recent' ) &&
 				streamItems.length > 0 &&
 				perPage &&
 				page > 1


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/loop#238
Fixes Automattic/loop#247

## Proposed Changes

"Pads" the stream item results so the correct number of items are present for the DataViews pagination to work correctly.

https://github.com/user-attachments/assets/0697fcca-6bef-4b26-a0b9-8c8518486e38

There were two solutions I explored in fixing this issue:

1. "Padding" the state with empty items so DataViews had the correct number of items for pagination to work correctly.
2. Requesting enough items from the API so DataViews had the correct number of items for pagination to work correctly.

See "Why are these changes being made" for an explanation of the issue.

I implemented approach 1 because it provided the best UX. The major downside is the additional code/types to handle a stream including "padding" items.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The DataViews component has its own pagination implementation. In order for this pagination to work correctly, however, it needs all the items for a given page and page size passed to it as a prop.
  * For example, if page `4` is selected in the DataViews component with a page size of `10`, DataViews needs its `items` prop to have `40` or more items in it for the pagination logic to work correctly.
* Our current way of requesting pages from the `/read/streams/following` endpoint would request a single page at a time of a given size and add those results to the store.
* This causes an issue with the DataViews pagination highlighted in this slack convo: p1733503754426959-slack-C03NLNTPZ2T where if a user selected pages out of order then the DataViews pagination would break.
  * As an example, if a user selects page `4` after initial load the endpoint would return page `4 `of the results and those items would be stored in the store. With a page size of `10`, this would mean that the store had `20` items in it: page `1` (from initial load) and page `4`.
  * Those `20` items would be passed to DataViews and when it tried to render page `4` with a page size of `10` with only `20` items, it would break.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the Reader (`/read`)
* Use the pagination controls for different feeds
* Make sure the items are in the correct chronological order
* Generally try to break the pagination

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
