### PR TITLE
Domains Management Revamp: Add DNS Records subpage

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
@@ -18,7 +18,7 @@ import DomainConnectInfoDialog from './domain-connect-info-dialog';
 class DnsRecordsList extends Component {
 	static propTypes = {
 		dns: PropTypes.object.isRequired,
-		selectedDOmain: PropTypes.object.isRequired,
+		selectedDomain: PropTypes.object.isRequired,
 		selectedDomainName: PropTypes.string.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 	};

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -45,6 +45,8 @@ class DnsRecords extends Component {
 		selectedDomainName: PropTypes.string.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 		nameservers: PropTypes.array || null,
+		titleOverride: PropTypes.string,
+		subtitleOverride: PropTypes.string,
 	};
 
 	hasDefaultCnameRecord = () => {
@@ -96,6 +98,7 @@ class DnsRecords extends Component {
 
 	renderHeader = () => {
 		const { domains, translate, selectedSite, currentRoute, selectedDomainName, dns } = this.props;
+		const { showBreadcrumb, titleOverride, subtitleOverride } = this.props.context?.params || {};
 		const selectedDomain = domains?.find( ( domain ) => domain?.name === selectedDomainName );
 
 		const items = [
@@ -166,10 +169,12 @@ class DnsRecords extends Component {
 
 		return (
 			<DomainHeader
-				items={ items }
-				mobileItem={ mobileItem }
+				items={ showBreadcrumb ? items : [] }
+				mobileItem={ showBreadcrumb ? mobileItem : null }
 				buttons={ buttons }
 				mobileButtons={ mobileButtons }
+				titleOverride={ titleOverride }
+				subtitleOverride={ subtitleOverride }
 			/>
 		);
 	};
@@ -256,6 +261,7 @@ class DnsRecords extends Component {
 
 	renderMain() {
 		const { dns, selectedDomainName, selectedSite, translate, domains } = this.props;
+		const { showDetails } = this.props.context?.params || {};
 		const selectedDomain = domains?.find( ( domain ) => domain?.name === selectedDomainName );
 		const headerText = translate( 'DNS Records' );
 
@@ -266,7 +272,7 @@ class DnsRecords extends Component {
 				{ this.renderHeader() }
 				{ selectedDomain?.canManageDnsRecords ? (
 					<>
-						<DnsDetails />
+						{ showDetails && <DnsDetails /> }
 						{ this.renderNotice() }
 						<DnsRecordsList
 							dns={ dns }

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-records-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-records-header.tsx
@@ -1,0 +1,50 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { translate } from 'i18n-calypso';
+import ExternalLink from 'calypso/components/external-link';
+import NavigationHeader from 'calypso/components/navigation-header';
+import { CustomHeaderComponentType } from './custom-header-component-type';
+
+const DNSRecordsHeader: CustomHeaderComponentType = ( {
+	selectedDomainName,
+	selectedSiteSlug,
+} ) => (
+	<NavigationHeader
+		className="navigation-header__breadcrumb"
+		navigationItems={ [
+			{
+				label: selectedDomainName,
+				href: `/domains/manage/all/overview/${ selectedDomainName }/${ selectedSiteSlug }`,
+			},
+			{
+				label: translate( 'DNS records' ),
+			},
+		] }
+		title={ translate( 'DNS records' ) }
+		subtitle={ translate( 'DNS records change how your domain works. {a}Learn more{/a}', {
+			components: {
+				a: (
+					<ExternalLink
+						href={ localizeUrl( 'https://wordpress.com/support/domains/custom-dns/' ) }
+					/>
+				),
+			},
+		} ) }
+	/>
+);
+
+// Override the title and subtitle for the DNS records page
+const dnsRecordsTitle = translate( 'DNS records' );
+const dnsRecordsSubtitle = translate(
+	'DNS records change how your domain works. {{a}}Learn more{{/a}}.',
+	{
+		components: {
+			a: (
+				<ExternalLink href={ localizeUrl( 'https://wordpress.com/support/domains/custom-dns/' ) } />
+			),
+		},
+	}
+);
+
+export default DNSRecordsHeader;
+
+export { dnsRecordsTitle, dnsRecordsSubtitle };

--- a/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
@@ -60,6 +60,67 @@
 	.edit-contact-info-page .contact-details-form-fields {
 		padding: 0;
 	}
+
+    .dns-records {
+        .card.email-setup,
+        .dns-records-list {
+            border: solid 1px $studio-gray-5;
+            border-radius: 4px;
+            box-shadow: none;
+        }
+
+        .dns-records-list {
+            margin-top: 32px;
+
+            .dns-records-list-item__wrapper.is-header {
+                border-bottom-color: $studio-gray-10;
+            }
+
+            .dns-records-list-item__wrapper {
+                padding: 16px 30px 16px 36px;
+
+                &:last-child {
+                    border-bottom: none;
+                }
+            }
+        }
+
+        .button.ellipsis {
+            width: 24px;
+        }
+    }
+
+    .domain__main-placeholder {
+        .vertical-nav {
+            background-color: $studio-white;
+            border: solid 1px $studio-gray-5;
+            border-radius: 4px;
+            margin-top: 32px;
+        }
+
+        .card {
+            background-color: transparent;
+            border-bottom: solid 1px $studio-gray-5;
+            box-shadow: none;
+
+            &:last-child {
+                border-bottom: none;
+            }
+        }
+    }
+
+    .domain__main-placeholder,
+    .dns-records {
+        .navigation-header{
+            border-block-end: none !important;
+            padding-top: 0 !important;
+            padding-bottom: 0;
+
+            .navigation-header__main {
+                padding-inline: 0 !important;
+            }
+        }
+    }
 }
 
 .is-bulk-all-domains-page .layout__content .main {

--- a/client/my-sites/domains/domain-management/subpage-wrapper/subpages.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/subpages.tsx
@@ -1,6 +1,10 @@
 import { translate } from 'i18n-calypso';
 import AddForwardingEmailHeader from './headers/add-fowarding-email-header';
 import { CustomHeaderComponentType } from './headers/custom-header-component-type';
+import DNSRecordsHeader, {
+	dnsRecordsTitle,
+	dnsRecordsSubtitle,
+} from './headers/dns-records-header';
 
 type SubpageWrapperParamsType = {
 	CustomHeader?: CustomHeaderComponentType;
@@ -11,6 +15,7 @@ type SubpageWrapperParamsType = {
 
 // Subpage keys
 export const ADD_FOWARDING_EMAIL = 'add-forwarding-email';
+export const DNS_RECORDS = 'dns-records';
 export const EDIT_CONTACT_INFO = 'edit-contact-info';
 
 // Subpage params map
@@ -19,6 +24,13 @@ const SUBPAGE_TO_PARAMS_MAP: Record< string, SubpageWrapperParamsType > = {
 		CustomHeader: AddForwardingEmailHeader,
 		showFormHeader: true,
 		showPageHeader: false,
+	},
+	[ DNS_RECORDS ]: {
+		CustomHeader: DNSRecordsHeader,
+		titleOverride: dnsRecordsTitle,
+		subtitleOverride: dnsRecordsSubtitle,
+		showBreadcrumb: false,
+		showDetails: false,
 	},
 	[ EDIT_CONTACT_INFO ]: {
 		subPageKey: EDIT_CONTACT_INFO,

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -18,6 +18,7 @@ import {
 } from './domain-management/domain-overview-pane/constants';
 import {
 	ADD_FOWARDING_EMAIL,
+	DNS_RECORDS,
 	EDIT_CONTACT_INFO,
 } from './domain-management/subpage-wrapper/subpages';
 import * as paths from './paths';
@@ -427,6 +428,18 @@ export default function () {
 		navigation,
 		domainManagementController.domainManagementSubpageParams( EDIT_CONTACT_INFO ),
 		domainManagementController.domainManagementEditContactInfo,
+		domainManagementController.domainManagementSubpageView,
+		domainManagementController.domainDashboardLayout,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		paths.domainManagementOverviewRoot() + '/:domain/dns/:site',
+		siteSelection,
+		navigation,
+		domainManagementController.domainManagementSubpageParams( DNS_RECORDS ),
+		domainManagementController.domainManagementDns,
 		domainManagementController.domainManagementSubpageView,
 		domainManagementController.domainDashboardLayout,
 		makeLayout,


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/97279

## Proposed Changes

* Add DNS Records subpage

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
