### PR TITLE
Enable design-picker/goal-centric in production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -33,7 +33,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
-		"design-picker/goal-centric": false,
+		"design-picker/goal-centric": true,
 		"design-picker/use-assembler-styles": true,
 		"devdocs": false,
 		"external-media": true,

--- a/config/production.json
+++ b/config/production.json
@@ -46,7 +46,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
-		"design-picker/goal-centric": false,
+		"design-picker/goal-centric": true,
 		"desktop-promo": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -44,7 +44,7 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
-		"design-picker/goal-centric": false,
+		"design-picker/goal-centric": true,
 		"desktop-promo": true,
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,


### PR DESCRIPTION
Related to #

Context p1734646506404129-slack-CRWCHQGUB

## Proposed Changes

* Enables the calypso feature flag `design-picker/goal-centric` in production, stage and horizon environments.
 
## Testing Instructions

See https://github.com/Automattic/wp-calypso/pull/96958 for testing instructions