### PR TITLE
A4A > Add site: Enable 'Add new site' component on staging

### DIFF
--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -42,7 +42,8 @@
 		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
 		"a4a-tracking-site-migrations": true,
-		"a4a-product-feedback": true
+		"a4a-product-feedback": true,
+		"a4a-updated-add-new-site": true
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1574

## Proposed Changes

This PR enables the newly built 'Add new site' component on staging.

## Testing Instructions

* Open the A4A live link
* On the Overview page, click the `Add site` button on the top right > Verify the page looks like below:


| Before | After |
|--------|--------|
| <img width="1728" alt="Screenshot 2024-12-20 at 9 21 11 AM" src="https://github.com/user-attachments/assets/0613ed85-9296-4f13-bbc6-39b7afd86523" />| <img width="1728" alt="Screenshot 2024-12-20 at 9 21 18 AM" src="https://github.com/user-attachments/assets/3ecdce38-23d6-466e-be5f-527e46c8a320" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
