### PR TITLE
Add `README.md` file to the 'Add New Site' component

### DIFF
--- a/client/components/add-new-site/README.md
+++ b/client/components/add-new-site/README.md
@@ -1,0 +1,54 @@
+# AddNewSite
+
+This is a [`AddNewSite` component](../../components/add-new-site/index.tsx)
+
+## Overview
+
+The [AddNewSite](../../components/add-new-site/index.tsx) component is designed with a focus on modularity and environment agnosticism. Our approach centralizes component functionality to ensure a single implementation serves all environments. Environment-specific behaviors are managed internally using the env the component is rendered on, keeping the component adaptable and reusable across different contexts. Additionally, the component leverages asynchronous loading for dynamic content, ensuring that environment-specific data is fetched and rendered only when needed. This strategy optimizes performance and guarantees the most relevant data is presented to the user. For more details, refer to [PR #97499](https://github.com/Automattic/wp-calypso/pull/97499).
+
+## Usage
+
+```jsx
+import React from 'react';
+import AddNewSite from 'calypso/components/add-new-site';
+
+const App = () => {
+	return <AddNewSite />;
+};
+
+export default App;
+```
+
+## Props
+
+The Add New Site component does not accept any props.
+
+## Components
+
+The Add New Site component is composed of several subcomponents:
+
+- [AddNewSiteButton](../../components/add-new-site/button.tsx): Renders the button to open the "Add New Site" menu.
+
+- [AddNewSitePopover](../../components/add-new-site/popover.tsx): Renders the popover menu
+
+- [AddNewSitePopoverColumn](../../components/add-new-site/popover-column.tsx): Renders the flex column for the popover menu
+
+- [AddNewSiteMenuItem](../../components/add-new-site/menu-item.tsx): Renders the menu item within the popover.
+
+## Context
+
+The Add New Site component uses the AddNewSiteContext to manage the state of the modal type and visibility. The context provides the following values:
+
+| Value               | Type     | Description                             |
+| ------------------- | -------- | --------------------------------------- |
+| visibleModalType    | string   | The type of the currently visible modal |
+| setVisibleModalType | function | Function to set the visible modal type  |
+
+## Async Loading
+
+The [AddNewSite](../../components/add-new-site/index.tsx) component utilizes asynchronous loading to fetch and render content dynamically via the [AddNewSiteContent](../../components/add-new-site/content/index.tsx) component. This approach ensures that environment-specific data is loaded and displayed appropriately. It is essential to always implement asynchronous loading to:
+
+- Optimize performance by fetching data only when required.
+- Ensure that environment-specific content is accurate and up-to-date.
+
+By adhering to this practice, the [AddNewSite](../../components/add-new-site/index.tsx) component remains both efficient and versatile in various deployment contexts.

--- a/client/components/add-new-site/README.md
+++ b/client/components/add-new-site/README.md
@@ -4,7 +4,7 @@ This is a [`AddNewSite` component](../../components/add-new-site/index.tsx)
 
 ## Overview
 
-The [AddNewSite](../../components/add-new-site/index.tsx) component is designed with a focus on modularity and environment agnosticism. Our approach centralizes component functionality to ensure a single implementation serves all environments. Environment-specific behaviors are managed internally using the env the component is rendered on, keeping the component adaptable and reusable across different contexts. Additionally, the component leverages asynchronous loading for dynamic content, ensuring that environment-specific data is fetched and rendered only when needed. This strategy optimizes performance and guarantees the most relevant data is presented to the user. For more details, refer to [PR #97499](https://github.com/Automattic/wp-calypso/pull/97499).
+The [AddNewSite](../../components/add-new-site/index.tsx) component is designed with a focus on modularity and environment agnosticism. Our approach centralizes component functionality to ensure a single implementation serves all environments. Environment-specific behaviors are managed internally using the environment the component is rendered in, keeping the component adaptable and reusable across different contexts. Additionally, the component leverages asynchronous loading for dynamic content, ensuring that environment-specific data is fetched and rendered only when needed. This strategy optimizes performance and guarantees the most relevant data is presented to the user. For more details, refer to [PR #97499](https://github.com/Automattic/wp-calypso/pull/97499).
 
 ## Usage
 


### PR DESCRIPTION
## Proposed Changes

This PR adds the README.md file to the 'Add New Site' component

## Testing Instructions

* Check the README.md [file](https://github.com/Automattic/wp-calypso/blob/38133654e34ae4765c2f74591eb25e51a30fb59c/client/components/add-new-site/README.md) and verify it makes sense.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
