### PR TITLE
Remove DataViewsPaginationInfo from Dotcom

### DIFF
--- a/client/sites/components/sites-dataviews/utils.ts
+++ b/client/sites/components/sites-dataviews/utils.ts
@@ -1,4 +1,3 @@
-import { DataViewsPaginationInfo } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import { DUMMY_DATA_VIEW_PREFIX } from './constants';
 import type { SiteExcerptData } from '@automattic/sites';
 
@@ -14,7 +13,10 @@ export function mapFieldIdToSortKey( fieldId: string ) {
 export function getSitesPagination(
 	allSites: SiteExcerptData[],
 	perPage: number
-): DataViewsPaginationInfo {
+): {
+	totalItems: number;
+	totalPages: number;
+} {
 	const totalItems = allSites.length;
 	const totalPages = Math.ceil( totalItems / perPage );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 
- https://github.com/Automattic/dotcom-forge/issues/10138

## Proposed Changes

This PR removes `DataViewsPaginationInfo` from Dotcom to decouple from A4A. 

While this type should ideally be shared from Core, it doesn't seem worth it to create an interface that much.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- https://github.com/Automattic/dotcom-forge/issues/10138
- Please refer to the Project Thread pbxlJb-6J5-p2 and the proposal post pfYzsZ-Y4-p2 for more context.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test /sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
