### PR TITLE
i18n: Introduce `fixMe` method to `i18n-calypso`

### DIFF
--- a/packages/i18n-calypso/CHANGELOG.md
+++ b/packages/i18n-calypso/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.1.0
+
+- Add new `fixMe` method for conditionally loading a copy given a respective translation exists
+
 ## 7.0.0
 
 - Update React peer dependency to v18.

--- a/packages/i18n-calypso/README.md
+++ b/packages/i18n-calypso/README.md
@@ -219,9 +219,29 @@ i18n.numberFormat( 2500.1, 2 ); // '2.500,10'
 i18n.numberFormat( 2500.33, { decimals: 3, thousandsSep: '*', decPoint: '@' } ); // '2*500@330'
 ```
 
+## fixMe Method
+
+Using the method `fixMe` you can apply a translation (`newCopy` parameter) only when a certain text has been translated or the locale is English (`en`, `en-gb`), otherwise apply the fallback translation (`oldCopy` parameter). This is a common pattern in the codebase for new translations that we need to ship straight away, and the function is meant to save a few inline conditions.
+
+Important: Due to the way our string extraction mechanism works, always pass `i18n.translate( '...' )` for `newCopy` parameter as otherwise the new string will not be picked up for translation.
+
+### Usage
+
+```js
+const i18n = require( 'i18n-calypso' );
+
+i18n.fixMe( {
+	text: 'new copy',
+	newCopy: i18n.translate( 'new copy' ),
+	oldCopy: i18n.translate( 'old copy' ),
+} );
+```
+
 ## hasTranslation Method
 
 Using the method `hasTranslation` you can check whether a translation for a given string exists. As the `translate()` function will always return screen text that can be displayed (will supply the source text if no translation exists), it is unsuitable to determine whether text is translated. Other factors are optional [key hashing](#key-hashing) as well as purposeful translation to the source text.
+
+Important: For most current usages in Calypso, where we conditionally render a new copy when a translation exists (otherwise a fallback), it's best to use `fixMe` method instead (above). It encapsulates a few of the conditions that would otherwise be necessary.
 
 ### Usage
 

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "i18n-calypso",
-	"version": "7.0.0",
+	"version": "7.1.0",
 	"description": "I18n JavaScript library on top of Tannin originally used in Calypso.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -346,6 +346,27 @@ I18N.prototype.hasTranslation = function () {
 };
 
 /**
+ * Returns `translation` if given `text` is translated or locale is English, otherwise returns the `fallback`.
+ * @param {Object} options
+ * @param {string} options.text - The text to check for translation.
+ * @param {string | Object} options.translation - The translation to return if the text is translated.
+ * @param {string | Object} options.fallback - The fallback to return if the text is not translated.
+ */
+I18N.prototype.fixMe = function ( { text, translation, fallback } ) {
+	if ( typeof text !== 'string' || ! translation || ! fallback ) {
+		throw new Error(
+			'fixMe() requires an object with proper text, translation, and fallback properties'
+		);
+	}
+
+	if ( [ 'en', 'en-gb' ].includes( this.getLocale() ) || this.hasTranslation( text ) ) {
+		return translation;
+	}
+
+	return fallback;
+};
+
+/**
  * Exposes single translation method.
  * See sibling README
  * @returns {string | Object | undefined} translated text or an object containing React children that can be inserted into a parent component

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -347,6 +347,13 @@ I18N.prototype.hasTranslation = function () {
 
 /**
  * Returns `translation` if given `text` is translated or locale is English, otherwise returns the `fallback`.
+ * ------------------
+ * Important - Usage:
+ * ------------------
+ * `translation` prop should be an actual `i18n.translate()` call from the consuming end.
+ * This is the only way currently to ensure that it is picked up by our string extraction mechanism
+ * and propagate into GlotPress for translation.
+ * ------------------
  * @param {Object} options
  * @param {string} options.text - The text to check for translation.
  * @param {string | Object} options.translation - The translation to return if the text is translated.

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -361,7 +361,8 @@ I18N.prototype.hasTranslation = function () {
  */
 I18N.prototype.fixMe = function ( { text, newCopy, oldCopy } ) {
 	if ( typeof text !== 'string' ) {
-		throw new Error( 'fixMe() requires an object with proper text property' );
+		warn( 'fixMe() requires an object with a proper text property (string)' );
+		return null;
 	}
 
 	if ( [ 'en', 'en-gb' ].includes( this.getLocaleSlug() ) || this.hasTranslation( text ) ) {

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -346,29 +346,29 @@ I18N.prototype.hasTranslation = function () {
 };
 
 /**
- * Returns `translation` if given `text` is translated or locale is English, otherwise returns the `fallback`.
+ * Returns `newCopy` if given `text` is translated or locale is English, otherwise returns the `oldCopy`.
  * ------------------
  * Important - Usage:
  * ------------------
- * `translation` prop should be an actual `i18n.translate()` call from the consuming end.
+ * `newCopy` prop should be an actual `i18n.translate()` call from the consuming end.
  * This is the only way currently to ensure that it is picked up by our string extraction mechanism
  * and propagate into GlotPress for translation.
  * ------------------
  * @param {Object} options
  * @param {string} options.text - The text to check for translation.
- * @param {string | Object} options.translation - The translation to return if the text is translated.
- * @param {string | Object | undefined } options.fallback - The fallback to return if the text is not translated.
+ * @param {string | Object} options.newCopy - The translation to return if the text is translated.
+ * @param {string | Object | undefined } options.oldCopy - The fallback to return if the text is not translated.
  */
-I18N.prototype.fixMe = function ( { text, translation, fallback } ) {
-	if ( typeof text !== 'string' || ! translation ) {
-		throw new Error( 'fixMe() requires an object with proper text and translation properties' );
+I18N.prototype.fixMe = function ( { text, newCopy, oldCopy } ) {
+	if ( typeof text !== 'string' ) {
+		throw new Error( 'fixMe() requires an object with proper text property' );
 	}
 
 	if ( [ 'en', 'en-gb' ].includes( this.getLocaleSlug() ) || this.hasTranslation( text ) ) {
-		return translation;
+		return newCopy;
 	}
 
-	return fallback;
+	return oldCopy;
 };
 
 /**

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -364,7 +364,7 @@ I18N.prototype.fixMe = function ( { text, translation, fallback } ) {
 		throw new Error( 'fixMe() requires an object with proper text and translation properties' );
 	}
 
-	if ( [ 'en', 'en-gb' ].includes( this.getLocale() ) || this.hasTranslation( text ) ) {
+	if ( [ 'en', 'en-gb' ].includes( this.getLocaleSlug() ) || this.hasTranslation( text ) ) {
 		return translation;
 	}
 

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -357,13 +357,11 @@ I18N.prototype.hasTranslation = function () {
  * @param {Object} options
  * @param {string} options.text - The text to check for translation.
  * @param {string | Object} options.translation - The translation to return if the text is translated.
- * @param {string | Object} options.fallback - The fallback to return if the text is not translated.
+ * @param {string | Object | undefined } options.fallback - The fallback to return if the text is not translated.
  */
 I18N.prototype.fixMe = function ( { text, translation, fallback } ) {
-	if ( typeof text !== 'string' || ! translation || ! fallback ) {
-		throw new Error(
-			'fixMe() requires an object with proper text, translation, and fallback properties'
-		);
+	if ( typeof text !== 'string' || ! translation ) {
+		throw new Error( 'fixMe() requires an object with proper text and translation properties' );
 	}
 
 	if ( [ 'en', 'en-gb' ].includes( this.getLocale() ) || this.hasTranslation( text ) ) {

--- a/packages/i18n-calypso/src/index.js
+++ b/packages/i18n-calypso/src/index.js
@@ -27,3 +27,4 @@ export const stateObserver = i18n.stateObserver;
 export const on = i18n.on.bind( i18n );
 export const off = i18n.off.bind( i18n );
 export const emit = i18n.emit.bind( i18n );
+export const fixMe = i18n.fixMe.bind( i18n );

--- a/packages/i18n-calypso/test/index.js
+++ b/packages/i18n-calypso/test/index.js
@@ -292,7 +292,7 @@ describe( 'I18n', function () {
 		} );
 
 		it( 'should return translation if locale is en', () => {
-			i18n.getLocale = jest.fn().mockReturnValue( 'en' );
+			i18n.getLocaleSlug = jest.fn().mockReturnValue( 'en' );
 			const result = i18n.fixMe( {
 				text: 'hello',
 				translation: 'hello',
@@ -302,7 +302,7 @@ describe( 'I18n', function () {
 		} );
 
 		it( 'should return translation if locale is en-gb', () => {
-			i18n.getLocale = jest.fn().mockReturnValue( 'en-gb' );
+			i18n.getLocaleSlug = jest.fn().mockReturnValue( 'en-gb' );
 			const result = i18n.fixMe( {
 				text: 'hello',
 				translation: 'hello',
@@ -322,7 +322,7 @@ describe( 'I18n', function () {
 		} );
 
 		it( 'should return fallback if text does not have a translation and locale is not English', () => {
-			i18n.getLocale = jest.fn().mockReturnValue( 'fr' );
+			i18n.getLocaleSlug = jest.fn().mockReturnValue( 'fr' );
 			i18n.hasTranslation = jest.fn().mockReturnValue( false );
 			const result = i18n.fixMe( {
 				text: 'hello',

--- a/packages/i18n-calypso/test/index.js
+++ b/packages/i18n-calypso/test/index.js
@@ -19,6 +19,7 @@ describe( 'I18n', function () {
 	} );
 
 	afterEach( function () {
+		jest.clearAllMocks();
 		i18n.configure(); // ensure everything is reset
 	} );
 
@@ -280,6 +281,55 @@ describe( 'I18n', function () {
 			expect( translate( 'red' ) ).toBe( 'edra' );
 			expect( translate( 'grey' ) ).toBe( 'reyga' );
 			expect( translate( 'green', { context: 'color' } ) ).toBe( 'cursus' );
+		} );
+	} );
+
+	describe( 'fixMe', () => {
+		it( 'should throw an error if text, translation, or fallback are missing', () => {
+			expect( () => i18n.fixMe( {} ) ).toThrow(
+				'fixMe() requires an object with proper text, translation, and fallback properties'
+			);
+		} );
+
+		it( 'should return translation if locale is en', () => {
+			i18n.getLocale = jest.fn().mockReturnValue( 'en' );
+			const result = i18n.fixMe( {
+				text: 'hello',
+				translation: 'hello',
+				fallback: 'hi',
+			} );
+			expect( result ).toBe( 'hello' );
+		} );
+
+		it( 'should return translation if locale is en-gb', () => {
+			i18n.getLocale = jest.fn().mockReturnValue( 'en-gb' );
+			const result = i18n.fixMe( {
+				text: 'hello',
+				translation: 'hello',
+				fallback: 'hi',
+			} );
+			expect( result ).toBe( 'hello' );
+		} );
+
+		it( 'should return translation if text has a translation', () => {
+			i18n.hasTranslation = jest.fn().mockReturnValue( true );
+			const result = i18n.fixMe( {
+				text: 'hello',
+				translation: 'bonjour',
+				fallback: 'hi',
+			} );
+			expect( result ).toBe( 'bonjour' );
+		} );
+
+		it( 'should return fallback if text does not have a translation and locale is not English', () => {
+			i18n.getLocale = jest.fn().mockReturnValue( 'fr' );
+			i18n.hasTranslation = jest.fn().mockReturnValue( false );
+			const result = i18n.fixMe( {
+				text: 'hello',
+				translation: 'bonjour',
+				fallback: 'hi',
+			} );
+			expect( result ).toBe( 'hi' );
 		} );
 	} );
 } );

--- a/packages/i18n-calypso/test/index.js
+++ b/packages/i18n-calypso/test/index.js
@@ -285,9 +285,9 @@ describe( 'I18n', function () {
 	} );
 
 	describe( 'fixMe', () => {
-		it( 'should throw an error if text, translation, or fallback are missing', () => {
+		it( 'should throw an error if text or translation are missing', () => {
 			expect( () => i18n.fixMe( {} ) ).toThrow(
-				'fixMe() requires an object with proper text, translation, and fallback properties'
+				'fixMe() requires an object with proper text and translation properties'
 			);
 		} );
 

--- a/packages/i18n-calypso/test/index.js
+++ b/packages/i18n-calypso/test/index.js
@@ -285,10 +285,9 @@ describe( 'I18n', function () {
 	} );
 
 	describe( 'fixMe', () => {
-		it( 'should throw an error if text is missing', () => {
-			expect( () => i18n.fixMe( {} ) ).toThrow(
-				'fixMe() requires an object with proper text property'
-			);
+		it( 'should return null if text is missing or wrong type', () => {
+			const result = i18n.fixMe( {} );
+			expect( result ).toBe( null );
 		} );
 
 		it( 'should return newCopy if locale is en', () => {

--- a/packages/i18n-calypso/test/index.js
+++ b/packages/i18n-calypso/test/index.js
@@ -285,49 +285,49 @@ describe( 'I18n', function () {
 	} );
 
 	describe( 'fixMe', () => {
-		it( 'should throw an error if text or translation are missing', () => {
+		it( 'should throw an error if text is missing', () => {
 			expect( () => i18n.fixMe( {} ) ).toThrow(
-				'fixMe() requires an object with proper text and translation properties'
+				'fixMe() requires an object with proper text property'
 			);
 		} );
 
-		it( 'should return translation if locale is en', () => {
+		it( 'should return newCopy if locale is en', () => {
 			i18n.getLocaleSlug = jest.fn().mockReturnValue( 'en' );
 			const result = i18n.fixMe( {
 				text: 'hello',
-				translation: 'hello',
-				fallback: 'hi',
+				newCopy: 'hello',
+				oldCopy: 'hi',
 			} );
 			expect( result ).toBe( 'hello' );
 		} );
 
-		it( 'should return translation if locale is en-gb', () => {
+		it( 'should return newCopy if locale is en-gb', () => {
 			i18n.getLocaleSlug = jest.fn().mockReturnValue( 'en-gb' );
 			const result = i18n.fixMe( {
 				text: 'hello',
-				translation: 'hello',
-				fallback: 'hi',
+				newCopy: 'hello',
+				oldCopy: 'hi',
 			} );
 			expect( result ).toBe( 'hello' );
 		} );
 
-		it( 'should return translation if text has a translation', () => {
+		it( 'should return newCopy if text has a translation', () => {
 			i18n.hasTranslation = jest.fn().mockReturnValue( true );
 			const result = i18n.fixMe( {
 				text: 'hello',
-				translation: 'bonjour',
-				fallback: 'hi',
+				newCopy: 'bonjour',
+				oldCopy: 'hi',
 			} );
 			expect( result ).toBe( 'bonjour' );
 		} );
 
-		it( 'should return fallback if text does not have a translation and locale is not English', () => {
+		it( 'should return oldCopy if text does not have a translation and locale is not English', () => {
 			i18n.getLocaleSlug = jest.fn().mockReturnValue( 'fr' );
 			i18n.hasTranslation = jest.fn().mockReturnValue( false );
 			const result = i18n.fixMe( {
 				text: 'hello',
-				translation: 'bonjour',
-				fallback: 'hi',
+				newCopy: 'bonjour',
+				oldCopy: 'hi',
 			} );
 			expect( result ).toBe( 'hi' );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/654
Props to @sdnunca for suggesting direction with `fixMe` method

## Proposed Changes

Introduces a `fixMe` method to `i18n-calypso` that resembles the wpcom `fixMe__` utility.

- This is meant to replace a lot of the `hasTranslation` checks in Calypso that are usually accompanied with a `locale === 'en'` check. 
- The method accepts a `text`, `newCopy`, and `oldCopy` (fallback) properties.
    - `text` is a plain string that will internally be checked for existing translations
    - `newCopy` is the actual translation object/string to use if a translation exists or the locale is `en` or `en-gb`
    - `oldCopy` is the fallback translation to return to if the above conditions are not met

### Usage

The key to using this method is to pass an actual `translate` call for the `translation` prop e.g.

```
fixMe( { 
    text: 'foo', 
    newCopy: translate( 'foo' ), 
    oldCopy: translate( 'bar' ) 
} )
```

This is the only way currently to ensure that `foo` is picked up by the string extraction mechanism and propagate into GlotPress for translation when none exists. 

When translations are done, the follow-up would be the removal of this call and replacement with the translation call (`translate( 'foo' )` above).


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/654.  `hasTranslation` calls are almost always accompanied by a `locale === 'en'` checks, which this method will effectively replace.

## TODO

- [x] Update `i18n-calypso` docs with mention and usage of `fixMe`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review and automated tests

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?