### PR TITLE
Enable Bulk Plugin Management: Fix the table row border styles

### DIFF
--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -1,96 +1,108 @@
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/mixins";
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 body.is-section-plugins .plugin-management-wrapper.is-bulk-plugin-management {
-    display: flex;
-    flex-direction: column;
-    flex-wrap: nowrap;
+	display: flex;
+	flex-direction: column;
+	flex-wrap: nowrap;
 
 	.navigation-header {
-		border-block-end: 1px solid var(--color-border-secondary);
+		border-block-end: 1px solid var( --color-border-secondary );
 		padding-inline: 48px;
-    
-        @media (max-width: 430px) {
-            padding-inline: 24px;
-        }
 
-        .navigation-header__main {
-            margin: auto;
-        }
+		@media ( max-width: 430px ) {
+			padding-inline: 24px;
+		}
+
+		.navigation-header__main {
+			margin: auto;
+		}
 	}
 }
 
 body.is-section-plugins .plugin-management-wrapper.is-bulk-plugin-management,
 .is-section-jetpack-cloud-plugin-management .plugin-management-wrapper.is-bulk-plugin-management {
-    .dataviews-wrapper {
-        margin: auto;
+	.dataviews-wrapper {
+		margin: auto;
 
-        .dataviews-view-table {
-            .dataviews-view-table__row {
-                .plugin-icon {
-                    max-width: 35px;
-                    max-height: 35px;
-                }
+		.dataviews-view-table {
+			.dataviews-view-table__row {
+				.plugin-icon {
+					max-width: 35px;
+					max-height: 35px;
+				}
 
-                td:nth-child(2) {
-                    white-space: break-spaces;
-                }
-            }
-        }
-    }
+				td:nth-child( 2 ) {
+					white-space: break-spaces;
+				}
 
-    .dataviews-pagination {
-        padding: 12px 16px 12px 16px;
-    }
+				th,
+				td {
+					border-bottom: none;
+				}
+			}
+		}
+	}
 
-    .plugin-name-button {
-        padding: 0;
+	.dataviews-pagination {
+		padding: 12px 16px 12px 16px;
+	}
+
+	.plugin-name-button {
+		padding: 0;
 		text-align: start;
 		height: auto;
-    }
+	}
 }
 
 .is-section-jetpack-cloud-plugin-management {
-    --wp-admin-theme-color: var(--studio-jetpack-green-50);
-    height: 100%;
-    overflow: hidden;
+	--wp-admin-theme-color: var( --studio-jetpack-green-50 );
+	height: 100%;
+	overflow: hidden;
 
-    .plugin-management-wrapper {
-        height: calc(100vh - 50px);
+	.plugin-management-wrapper {
+		height: calc( 100vh - 50px );
 		display: flex;
 		flex-direction: column;
-		min-height: calc(100vh - 64px);
+		min-height: calc( 100vh - 64px );
 	}
 
-    .select-partner-key {
-        padding: 0 40px;
-    }
+	.select-partner-key {
+		padding: 0 40px;
+	}
 
-    .dataviews-wrapper {
-        button {
-            border: none;
-            background-color: transparent;
+	.dataviews-wrapper {
+		button {
+			border: none;
+			background-color: transparent;
 
-            &:hover {
-                background-color: var(--color-background-alt);
-            }
-        }
+			&:hover {
+				background-color: var( --color-background-alt );
+			}
+		}
 
-        thead .dataviews-view-table__row button {
-            &:focus {
-                box-shadow: none;
-            }
-        }
-    }
+		thead .dataviews-view-table__row button {
+			&:focus {
+				box-shadow: none;
+			}
+		}
 
-    .layout__primary,
-    .plugins-overview__container {
-        height: 100%;
-    }
+		.dataviews-view-table__row {
+			th,
+			td {
+				border-bottom: none;
+			}
+		}
+	}
 
-    .layout__content {
-        height: 100%;
-    }
+	.layout__primary,
+	.plugins-overview__container {
+		height: 100%;
+	}
+
+	.layout__content {
+		height: 100%;
+	}
 
 	.plugins__top-container-jc,
 	.plugins__main-content-jc {
@@ -105,13 +117,13 @@ body.is-section-plugins .plugin-management-wrapper.is-bulk-plugin-management,
 }
 
 .sites-manage-plugin-status-button {
-    padding: 0;
-    display: contents;
+	padding: 0;
+	display: contents;
 }
 
 .sites-manage-plugin-button {
-    margin-left: -12px;
-    font-size: inherit;
-    color: inherit;
-    cursor: pointer;
+	margin-left: -12px;
+	font-size: inherit;
+	color: inherit;
+	cursor: pointer;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9922

## Proposed Changes

Update the table row borders only on Jetpack manage and WPCOM.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/96592.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Prerequisites**
- Sign up for A4A at https://agencies.automattic.com/signup with your A8C account
- Sign up for Jetpack Manage at https://cloud.jetpack.com/manage/signup with your A8C account

**Testing steps**
Locally, you can start the different environments using these commands:
```
yarn start-a8c-for-agencies
yarn start-jetpack-cloud
```
Alternatively, you can also start the three environments on different ports:
```bash
yarn start # starts Calypso on port 3000
yarn start-jetpack-cloud-p # starts JP Cloud on port 3001
yarn start-a8c-for-agencies-p # starts A4A on port 3002
```

On WPCOM and Jetpack manage, check that the table rows now have the updated borders. On A4A, the sites table should have the original border styles.

On Calypso:
- Visit `http://calypso.localhost:3000/plugins/manage` and check the updated styles

On Jetpack manage:
- Visit `http://jetpack.cloud.localhost:3001/plugins/manage` and check the updated styles

On A4A agencies:
- Visit `http://agencies.localhost:3002/sites` and check for regressions

| Place | Before | After |
|--------|--------|--------|
| WPCOM | ![CleanShot 2024-12-20 at 11 36 48@2x](https://github.com/user-attachments/assets/385b6a56-89db-49bd-8ed7-81c0a711a5b1) | ![CleanShot 2024-12-20 at 11 27 38@2x](https://github.com/user-attachments/assets/0ee9e662-1189-4fd7-aad4-c48aa5a91740) |
| JP manage | ![CleanShot 2024-12-20 at 11 37 00@2x](https://github.com/user-attachments/assets/1b0905cd-f569-476f-b57f-4e0f284f6470) | ![CleanShot 2024-12-20 at 11 30 06@2x](https://github.com/user-attachments/assets/de91fdff-c426-406b-8ab0-fe069b9b1132) |
| A4A (no change) | ![CleanShot 2024-12-20 at 11 37 07@2x](https://github.com/user-attachments/assets/82184372-8326-4e82-9a85-dc4c848c6beb) | ![CleanShot 2024-12-20 at 11 27 20@2x](https://github.com/user-attachments/assets/c1a8dced-a6d3-4813-9f0b-6edf9e577197) |

