### PR TITLE
Goals first: Use actual experiment checks within useGoalsFirstExperiment

### DIFF
--- a/client/landing/stepper/declarative-flow/helpers/use-goals-first-experiment.ts
+++ b/client/landing/stepper/declarative-flow/helpers/use-goals-first-experiment.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { useExperiment } from 'calypso/lib/explat';
 import { getFlowFromURL } from '../../utils/get-flow-from-url';
 
-export const EXPERIMENT_NAME = 'calypso_onboarding_goals_first_holdout_20250106';
+export const EXPERIMENT_NAME = 'calypso_signup_onboarding_goals_first_flow_holdout_20241220';
 
 /**
  * Check whether the user should have the "goals first" onboarding experience.
@@ -18,14 +18,13 @@ export function useGoalsFirstExperiment(): [ boolean, boolean ] {
 	} );
 
 	/**
-	 * If the user is not eligible, we'll treat them as if they were in the holdout group
-	 * so we can provide the existing experience.
+	 * If the user is not eligible, we'll treat them as if they were in the
+	 * holdout/control group so we can provide the existing experience.
 	 *
 	 * This fallback is necessary because experimentAssignment returns null when the user
-	 * is not eligible, and we're using this hook within steps that are used by other
-	 * flows.
+	 * is not eligible, and we're using this hook within steps that are used by other flows.
 	 */
-	const variationName = experimentAssignment?.variationName ?? 'holdout';
+	const variationName = experimentAssignment?.variationName ?? 'control';
 
-	return [ isLoading, variationName === 'control' ];
+	return [ isLoading, variationName === 'treatment' ];
 }

--- a/client/landing/stepper/declarative-flow/helpers/use-goals-first-experiment.ts
+++ b/client/landing/stepper/declarative-flow/helpers/use-goals-first-experiment.ts
@@ -1,37 +1,31 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { ONBOARDING_FLOW } from '@automattic/onboarding';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
+import { useExperiment } from 'calypso/lib/explat';
 import { getFlowFromURL } from '../../utils/get-flow-from-url';
+
+export const EXPERIMENT_NAME = 'calypso_onboarding_goals_first_holdout_20250106';
 
 /**
  * Check whether the user should have the "goals first" onboarding experience.
- * Returns [ isLoading, isGoalsAtFrontExperiment ]
  *
- * The experience is currently gated behind a feature flag which is loaded immediately,
- * but we want to code as if loading time might be involved. So this hook has a fake
- * timer.
- * Note: It's important that there be no timer in the production experience
- * i.e. when the feature flag is disabled.
+ * Returns [ isLoading, isGoalsAtFrontExperiment ]
  */
 export function useGoalsFirstExperiment(): [ boolean, boolean ] {
 	const flow = useMemo( () => getFlowFromURL(), [] );
-	const isEligible = isEnabled( 'onboarding/goals-first' ) && flow === ONBOARDING_FLOW;
 
-	const [ isLoading, setIsLoading ] = useState( true );
-	useEffect( () => {
-		if ( ! isEligible ) {
-			return;
-		}
+	const [ isLoading, experimentAssignment ] = useExperiment( EXPERIMENT_NAME, {
+		isEligible: flow === ONBOARDING_FLOW,
+	} );
 
-		const id = setTimeout( () => setIsLoading( false ), 700 );
-		return () => {
-			clearTimeout( id );
-		};
-	}, [ isEligible ] );
+	/**
+	 * If the user is not eligible, we'll treat them as if they were in the holdout group
+	 * so we can provide the existing experience.
+	 *
+	 * This fallback is necessary because experimentAssignment returns null when the user
+	 * is not eligible, and we're using this hook within steps that are used by other
+	 * flows.
+	 */
+	const variationName = experimentAssignment?.variationName ?? 'holdout';
 
-	if ( ! isEligible ) {
-		return [ false, false ];
-	}
-
-	return [ isLoading, true ];
+	return [ isLoading, variationName === 'control' ];
 }

--- a/client/landing/stepper/declarative-flow/internals/components/boot/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/boot/index.tsx
@@ -1,4 +1,5 @@
 import { useLocale } from '@automattic/i18n-utils';
+import { ONBOARDING_FLOW } from '@automattic/onboarding';
 import {
 	type ComponentProps,
 	Suspense,
@@ -7,8 +8,11 @@ import {
 	useTransition,
 	type FC,
 	type PropsWithChildren,
+	useMemo,
 } from 'react';
 import { useFlowLocale } from 'calypso/landing/stepper/hooks/use-flow-locale';
+import { getFlowFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
+import { useGoalsFirstExperiment } from '../../../helpers/use-goals-first-experiment';
 
 interface Props extends PropsWithChildren {
 	fallback: ComponentProps< typeof Suspense >[ 'fallback' ];
@@ -22,13 +26,20 @@ export const Boot: FC< Props > = ( { children, fallback } ) => {
 	const locale = useLocale();
 	const newLocale = useFlowLocale();
 
+	const [ isLoadingGoalsFirst ] = useGoalsFirstExperiment();
+	const flowName = useMemo( () => getFlowFromURL(), [] );
+
 	useEffect( () => {
-		if ( ! isReady && newLocale === locale ) {
+		if (
+			! isReady &&
+			newLocale === locale &&
+			( flowName !== ONBOARDING_FLOW || ! isLoadingGoalsFirst )
+		) {
 			setTransition( () => {
 				setIsReady( true );
 			} );
 		}
-	}, [ locale, newLocale, isReady ] );
+	}, [ locale, newLocale, isReady, isLoadingGoalsFirst, flowName ] );
 
 	// Continue to show the fallback UI while we are still loading the new locale or when we're first transitioning to the new locale (i.e. the transition is still in process)
 	if ( ! isReady || isPending ) {

--- a/config/development.json
+++ b/config/development.json
@@ -166,7 +166,6 @@
 		"onboarding/trail-map-feature-grid-structure": false,
 		"onboarding/trail-map-feature-grid": false,
 		"onboarding/user-on-stepper-hosting": true,
-		"onboarding/goals-first": true,
 		"p2/p2-plus": true,
 		"p2-enabled": false,
 		"page/export": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -134,7 +134,6 @@
 		"onboarding/trail-map-feature-grid-copy": false,
 		"onboarding/trail-map-feature-grid-structure": false,
 		"onboarding/trail-map-feature-grid": false,
-		"onboarding/goals-first": true,
 		"p2/p2-plus": true,
 		"p2-enabled": true,
 		"page/export": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -133,7 +133,6 @@
 		"onboarding/trail-map-feature-grid-structure": false,
 		"onboarding/trail-map-feature-grid": false,
 		"onboarding/user-on-stepper-hosting": true,
-		"onboarding/goals-first": true,
 		"p2/p2-plus": true,
 		"p2-enabled": false,
 		"performance-profiler/llm": true,

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -5,7 +5,8 @@ import type { SiteDetails, NewSiteResponse } from '../../../types/rest-api-clien
 /**
  * The plans page URL regex.
  */
-export const plansPageUrl = /.*start\/plans|start\/with-theme\/plans-theme-preselected.*/;
+export const plansPageUrl =
+	/.*setup\/onboarding\/plans|start\/plans|start\/with-theme\/plans-theme-preselected.*/;
 
 /**
  * Represents the Signup > Pick a Plan page.

--- a/packages/calypso-e2e/src/lib/pages/site-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/site-settings-page.ts
@@ -1,11 +1,6 @@
 import { Page } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
 
-const selectors = {
-	// Launch site
-	launchSiteButton: 'a:text("Launch site")',
-};
-
 /**
  * Represents the Sites > Site > Settings page.
  */
@@ -28,7 +23,6 @@ export class SiteSettingsPage {
 	 */
 	async visit( siteSlug: string ): Promise< void > {
 		await this.page.goto( getCalypsoURL( `sites/settings/site/${ siteSlug }` ), {
-			waitUntil: 'networkidle',
 			timeout: 20 * 1000,
 		} );
 	}
@@ -37,9 +31,7 @@ export class SiteSettingsPage {
 	 * Start the site launch process.
 	 */
 	async launchSite(): Promise< void > {
-		await Promise.all( [
-			this.page.waitForNavigation(),
-			this.page.click( selectors.launchSiteButton ),
-		] );
+		const launchSite = this.page.getByRole( 'link', { name: 'Launch site' } );
+		await launchSite.click();
 	}
 }

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -35,7 +35,7 @@ declare const browser: Browser;
  *
  * Keywords: Onboarding, Store Checkout, Coupon, Signup, Plan, Subscription, Cancel
  */
-describe.skip( 'Lifecyle: Signup, onboard, launch and cancel subscription', function () {
+describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function () {
 	const planName = 'Personal';
 	const testUser = DataHelper.getNewTestUser( {
 		usernamePrefix: 'ftmepersonal',

--- a/test/e2e/specs/onboarding/onboarding__write.ts
+++ b/test/e2e/specs/onboarding/onboarding__write.ts
@@ -19,7 +19,7 @@ import { apiCloseAccount, fixme_retry } from '../shared';
 
 declare const browser: Browser;
 
-describe.skip( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () {
+describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () {
 	const blogName = DataHelper.getBlogName();
 	const testUser = DataHelper.getNewTestUser( {
 		usernamePrefix: 'signupfree',


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/96179.
Closes #98001

## Proposed Changes

Remove the flag `onboarding/goals-first` and use the actual experiment name and variant names.