### PR TITLE
Stats: fix subscriber list not showing since subscribed date

### DIFF
--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -134,7 +134,6 @@ class StatModuleFollowers extends Component {
 					mainItemLabel={ translate( 'Subscriber' ) }
 					metricLabel={ translate( 'Since' ) }
 					splitHeader
-					useShortNumber
 					showMore={ {
 						url: subscriberManagementUrl,
 						label: this.props.translate( 'Manage subscribers' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/97601

## Proposed Changes

* Remove unnecessary `useShortNumber` from "subscribers" list; the number isn't a number anyway, but a string.

In https://github.com/Automattic/wp-calypso/pull/97289 we made [a change](https://github.com/Automattic/wp-calypso/commit/19f5137e4ad90ace912e2ae8de4b6b302a7826f8#diff-df0a8b3de20cde31320edcbe542bd9b66a758fd192c35503e2ea7465b35c1ecaR108) which moved use of existing `useShortNumber ` prop to shared render function:

https://github.com/Automattic/wp-calypso/blob/607959de352556029ee62a01d4a5094d0faac711/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx#L107-L110

This triggered pre-existing bug, where the subscriber list was requesting component to show "shortened" (i.e. localized) numbers using [`formatNumber`](https://github.com/Automattic/wp-calypso/blob/607959de352556029ee62a01d4a5094d0faac711/packages/components/src/number-formatters/lib/format-number.ts#L27), but where `usePlainCard` was cancelling that prop previously. Formatting numbers for this card doesn't work because for subscribers we show strings like "40 days", not numbers like "40".

The fix is just to remove the prop.

#### Before

<img width="630" alt="Screenshot 2024-12-20 at 16 34 51" src="https://github.com/user-attachments/assets/f7150875-7c9d-4ff2-babc-30b526058c9f" />


#### After

<img width="631" alt="Screenshot 2024-12-20 at 15 58 10" src="https://github.com/user-attachments/assets/3ae6940a-5a8b-44be-9a26-1ef2b1e8d9a6" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Stats -> Subscribers

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
