### PR TITLE
Migration flow: rename fallback migration in <StepContainer>

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/index.tsx
@@ -30,7 +30,7 @@ const SiteMigrationFallbackCredentials: Step = function ( { navigation } ) {
 		<>
 			<DocumentHead title={ translate( 'Tell us about your WordPress site' ) } />
 			<StepContainer
-				stepName="site-migration-credentials"
+				stepName="site-migration-fallback-credentials"
 				flowName="site-migration"
 				goBack={ navigation?.goBack }
 				goNext={ navigation?.submit }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/97671

## Proposed Changes

Rename the stepName property from `site-migration-credentials` to `site-migration-fallback-credentials`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The current stepName was carried over from the original credentials step. This is causing an inability to create good funnels, since `stepName` is the name of the step in the `calypso_signup_step_start` track event.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply this branch or use the Calypso live link below
1. Go through the migration flow
1. Once you get to the authorization screen click on `Share credentials instead` <img width="844" alt="image" src="https://github.com/user-attachments/assets/9e1f95fa-32ae-4ff4-abae-4891121e525a" />
1. Verify that the `calypso_signup_step_start` event has `site-migration-fallback-credentials` as the value for the `step` property 
<img width="647" alt="image" src="https://github.com/user-attachments/assets/660af2ae-595c-49f2-9cad-b8065fa4bcea" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
