### PR TITLE
A4A: Add the missing styles to LayoutBanner and LayoutStepper components.

### DIFF
--- a/client/a8c-for-agencies/components/layout/banner.tsx
+++ b/client/a8c-for-agencies/components/layout/banner.tsx
@@ -5,6 +5,8 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 
+import './style.scss';
+
 type Props = {
 	actions?: React.ReactNode[];
 	className?: string;

--- a/client/a8c-for-agencies/components/layout/stepper.tsx
+++ b/client/a8c-for-agencies/components/layout/stepper.tsx
@@ -2,6 +2,8 @@ import { Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import { Fragment } from 'react';
 
+import './style.scss';
+
 type Props = {
 	steps: string[];
 	current: number;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR fixes a regression produced by the A4A Layout extraction work: https://github.com/Automattic/wp-calypso/pull/97542. After that extraction, we don't import the `styles.scss` file for some A4A components, so the issue is because of those missing styles.

- LayoutStepper
- LayoutBanner

Just importing the `styles.scss` in the component fixes the issue:

Before:
![image](https://github.com/user-attachments/assets/3ec0d022-2a4b-4b1d-8cc3-4846b3770062)

After:
<img width="677" alt="image" src="https://github.com/user-attachments/assets/e4c3dae3-4b6b-460a-b894-690eb6a34011" />

Also, the same issue happens with the `LayoutBanner`, after the Layout style extraction, this component doesn't import the `style.scss` file.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code
- Go to `/purchases/licenses` and Assign a license.
   - Check trunk, you will see the steps with the missed styles.
   - Check this branch, you will see the steps correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
