### PR TITLE
Fix the bug on the Continue button if the user inputs an invalid domain

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
@@ -28,8 +28,15 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
 
-	const { control, errors, accessMethod, isBusy, submitHandler, canBypassVerification } =
-		useCredentialsForm( onSubmit );
+	const {
+		control,
+		errors,
+		accessMethod,
+		isBusy,
+		submitHandler,
+		canBypassVerification,
+		clearErrors,
+	} = useCredentialsForm( onSubmit );
 
 	const queryError = useQuery().get( 'error' ) || null;
 
@@ -59,10 +66,16 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 		return translate( 'Continue' );
 	};
 
+	const onSubmitLocal = ( e: React.FormEvent< HTMLFormElement > ) => {
+		e.preventDefault();
+		clearErrors();
+		submitHandler();
+	};
+
 	const showSpecialInstructions = ! applicationPasswordEnabled || accessMethod === 'backup';
 
 	return (
-		<form className="site-migration-credentials__form" onSubmit={ submitHandler }>
+		<form className="site-migration-credentials__form" onSubmit={ onSubmitLocal }>
 			{ errorMessage && (
 				<Notice
 					className="site-migration-credentials__error-notice"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
@@ -167,6 +167,7 @@ export const useCredentialsForm = (
 		control,
 		handleSubmit,
 		submitHandler,
+		clearErrors,
 		accessMethod,
 		isBusy,
 		canBypassVerification,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #97668

## Proposed Changes

* Fixes for the bug on the Continue button when the user inputs an invalid domain. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* If the user inputs an invalid domain and then clicks on the Continue button, the button is released from the disabled state but clicking on it again would not submit the form again. Causing the user to be stuck in the Authorization step.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link below
* Go through the migration flow until you reach the Authorization step
* Update the source domain in the input to a domain that doesn't exists
* Click on Continue, this check should fail.
* Update the domain again to the correct domain.
* Click on the Continue button again
* You should be redirected to the next step

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
