### PR TITLE
Vdimitrakis/2888 show outperformed in campaign details

### DIFF
--- a/client/data/promote-post/use-promote-post-campaigns-query.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query.ts
@@ -9,6 +9,7 @@ export type CampaignResponse = {
 		title: string;
 	};
 	display_delivery_estimate: string;
+	display_clicks_estimate: string;
 	campaign_id: number;
 	start_date: string;
 	created_at: string;

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -193,33 +193,30 @@ export default function CampaignItemDetails( props: Props ) {
 	} = campaign_stats || {};
 
 	// check if delivery outperformed
+	const calculateOutperformPercentage = ( estimates: string, total: number ): number => {
+		const tempValues = ( estimates || '' ).split( ':' );
+		let median = 0;
+		if ( tempValues && tempValues.length >= 2 ) {
+			const [ minValue, maxValue ] = tempValues.map( Number );
+			median = ( minValue + maxValue ) / 2;
+		}
+		if ( total > median && median > 0 ) {
+			return Math.round( ( ( total - median ) / median ) * 100 );
+		}
+		return 0;
+	};
+
 	// for impressions
-	const deliveryEstimates = ( display_delivery_estimate || '' ).split( ':' );
-	let medianImpressions = 0;
-	if ( deliveryEstimates && deliveryEstimates.length >= 2 ) {
-		const [ minImpressions, maxImpressions ] = deliveryEstimates.map( Number );
-		medianImpressions = ( minImpressions + maxImpressions ) / 2;
-	}
-	let impressionsOutperformedPercentage = 0;
-	if ( impressions_total > medianImpressions && medianImpressions > 0 ) {
-		impressionsOutperformedPercentage = Math.round(
-			( ( impressions_total - medianImpressions ) / medianImpressions ) * 100
-		);
-	}
+	const impressionsOutperformedPercentage = calculateOutperformPercentage(
+		display_delivery_estimate,
+		impressions_total
+	);
 
 	// for clicks
-	const clickEstimates = ( display_clicks_estimate || '' ).split( ':' );
-	let medianClicks = 0;
-	if ( clickEstimates && clickEstimates.length >= 2 ) {
-		const [ minClicks, maxClicks ] = clickEstimates.map( Number );
-		medianClicks = ( minClicks + maxClicks ) / 2;
-	}
-	let clicksOutperformedPercentage = 0;
-	if ( clicks_total > medianClicks && medianClicks > 0 ) {
-		clicksOutperformedPercentage = Math.round(
-			( ( clicks_total - medianClicks ) / medianClicks ) * 100
-		);
-	}
+	const clicksOutperformedPercentage = calculateOutperformPercentage(
+		display_clicks_estimate,
+		clicks_total
+	);
 
 	const { card_name, payment_method, credits, total, orders, payment_links } = billing_data || {};
 	const { title, clickUrl } = content_config || {};

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -174,6 +174,8 @@ export default function CampaignItemDetails( props: Props ) {
 		format,
 		budget_cents,
 		type,
+		display_delivery_estimate,
+		display_clicks_estimate,
 		is_evergreen = false,
 	} = campaign || {};
 
@@ -189,6 +191,35 @@ export default function CampaignItemDetails( props: Props ) {
 		conversion_rate,
 		conversion_last_currency_found,
 	} = campaign_stats || {};
+
+	// check if delivery outperformed
+	// for impressions
+	const deliveryEstimates = ( display_delivery_estimate || '' ).split( ':' );
+	let medianImpressions = 0;
+	if ( deliveryEstimates && deliveryEstimates.length >= 2 ) {
+		const [ minImpressions, maxImpressions ] = deliveryEstimates.map( Number );
+		medianImpressions = ( minImpressions + maxImpressions ) / 2;
+	}
+	let impressionsOutperformedPercentage = 0;
+	if ( impressions_total > medianImpressions && medianImpressions > 0 ) {
+		impressionsOutperformedPercentage = Math.round(
+			( ( impressions_total - medianImpressions ) / medianImpressions ) * 100
+		);
+	}
+
+	// for clicks
+	const clickEstimates = ( display_clicks_estimate || '' ).split( ':' );
+	let medianClicks = 0;
+	if ( clickEstimates && clickEstimates.length >= 2 ) {
+		const [ minClicks, maxClicks ] = clickEstimates.map( Number );
+		medianClicks = ( minClicks + maxClicks ) / 2;
+	}
+	let clicksOutperformedPercentage = 0;
+	if ( clicks_total > medianClicks && medianClicks > 0 ) {
+		clicksOutperformedPercentage = Math.round(
+			( ( clicks_total - medianClicks ) / medianClicks ) * 100
+		);
+	}
 
 	const { card_name, payment_method, credits, total, orders, payment_links } = billing_data || {};
 	const { title, clickUrl } = content_config || {};
@@ -822,17 +853,49 @@ export default function CampaignItemDetails( props: Props ) {
 											<span className="campaign-item-details__label">
 												{ translate( 'Clicks' ) }
 											</span>
-											<span className="campaign-item-details__text wp-brand-font">
-												{ ! isLoading ? clicksFormatted : <FlexibleSkeleton /> }
+											<span className="campaign-item-details__text">
+												<span className="wp-brand-font">
+													{ ! isLoading ? clicksFormatted : <FlexibleSkeleton /> }
+												</span>
+												{ !! clicksOutperformedPercentage && (
+													<span className="campaign-item-details__outperformed">
+														{ translate( 'Outperformed' ) }
+													</span>
+												) }
 											</span>
+											{ !! clicksOutperformedPercentage && (
+												<span>
+													{ translate( '%(percentage)s% more than estimated', {
+														args: {
+															percentage: clicksOutperformedPercentage,
+														},
+													} ) }
+												</span>
+											) }
 										</div>
 										<div>
 											<span className="campaign-item-details__label">
 												{ translate( 'People reached' ) }
 											</span>
-											<span className="campaign-item-details__text wp-brand-font">
-												{ ! isLoading ? impressionsTotal : <FlexibleSkeleton /> }
+											<span className="campaign-item-details__text">
+												<span className="wp-brand-font">
+													{ ! isLoading ? impressionsTotal : <FlexibleSkeleton /> }
+												</span>
+												{ !! impressionsOutperformedPercentage && (
+													<span className="campaign-item-details__outperformed">
+														{ translate( 'Outperformed' ) }
+													</span>
+												) }
 											</span>
+											{ !! impressionsOutperformedPercentage && (
+												<span>
+													{ translate( '%(percentage)s% more than estimated', {
+														args: {
+															percentage: impressionsOutperformedPercentage,
+														},
+													} ) }
+												</span>
+											) }
 										</div>
 										{ isWooStore && status !== 'created' && (
 											<>

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -177,8 +177,8 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 
 			.campaign-item-details__outperformed {
 				display: inline-block;
-				font-size: 0.875rem;
-				line-height: 0.875;
+				font-size: 0.75rem;
+				line-height: 0.75;
 				font-weight: 500;
 				border: 1px solid var(--studio-celadon-0);
 				color: var(--studio-celadon-50);

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -1,5 +1,6 @@
 @import "@automattic/color-studio/dist/color-variables";
 @import "@wordpress/base-styles/breakpoints";
+@import "@automattic/typography/styles/variables";
 @import "../../style";
 
 body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
@@ -163,6 +164,31 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 			.campaign-item-details__text {
 				color: var(--studio-gray-100);
 				line-height: 1.25;
+			}
+
+			.campaign-item-details__text {
+				display: flex;
+				align-items: center;
+				@media (max-width: $break-medium) {
+					flex-direction: column;
+					align-items: start;
+				}
+			}
+
+			.campaign-item-details__outperformed {
+				display: inline-block;
+				font-size: 0.875rem;
+				line-height: 0.875;
+				font-weight: 500;
+				border: 1px solid var(--studio-celadon-0);
+				color: var(--studio-celadon-50);
+				padding: 5px 10px;
+				border-radius: 4px;
+				margin-left: 12px;
+				@media (max-width: $break-medium) {
+					margin-left: 0;
+					margin-top: 8px;
+				}
 			}
 		}
 


### PR DESCRIPTION
Related to #

2888-gh-tumblr/a8c-dsp

## Proposed Changes

We want to display an outperformed UI element when the campaign has delivered more impressions or clicks than promised

the figma screenshot below is for reference

<img width="718" alt="Screenshot 2024-12-20 at 6 05 36 PM" src="https://github.com/user-attachments/assets/995c418b-313e-4221-b5f2-8d5f64acf793" />

(please note we don't use visitors - we use clicks instead) 

below is the screenshot from a browser with actual data
(I have a campaign that has delivered more than promised so it was easy for me to test this)


<img width="731" alt="Screenshot 2024-12-20 at 6 13 26 PM" src="https://github.com/user-attachments/assets/e3b71391-323c-4d48-a8e7-43f6d05059a2" />


## Testing Instructions

Please checkout the branch (or you can use the live preview link if you have some campaigns that have overdelivered) 

go to the campaigns advertising page (tools->advertising-> campaigns) and find a campaign that has clicks and impressions

you should see the above elements and a percentage of the overdelivery

(if you cant spot a campaign with more results than promised. you can try to checkout branch, bridge connections to your local DSP and fake the numbers) 

I am using the display_delivery_estimate and display_clicks_estimate to calculate the logic (or you can fake impressions_total and clicks_total to a very high number)

do a CR

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
