### PR TITLE
A4A: Show a banner based on agency approval status

### DIFF
--- a/client/a8c-for-agencies/components/a4a-agency-approval-notice/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-agency-approval-notice/index.tsx
@@ -1,0 +1,78 @@
+import { useTranslate } from 'i18n-calypso';
+import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { ApprovalStatus } from 'calypso/state/a8c-for-agencies/types';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
+
+const AGENCY_APPROVAL_DISMISS_PREFERENCE = 'a4a-agency-approval-notice-dismissed';
+
+const A4AAgencyApprovalNotice = () => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const agency = useSelector( getActiveAgency );
+
+	const dismissNotice = () => {
+		dispatch( savePreference( AGENCY_APPROVAL_DISMISS_PREFERENCE, true ) );
+		dispatch( recordTracksEvent( 'calypso_a4a_payment_delayed_notice_dismissed' ) );
+	};
+
+	const isDismissed = useSelector( ( state ) =>
+		getPreference( state, AGENCY_APPROVAL_DISMISS_PREFERENCE )
+	);
+
+	if ( isDismissed ) {
+		return null;
+	}
+
+	const availableBannerDetails = {
+		[ ApprovalStatus.PENDING ]: {
+			text: translate(
+				'Your application to Automattic for Agencies is under review. You won’t be able to make any purchases until you have been approved.'
+			),
+			level: 'warning',
+		},
+		[ ApprovalStatus.APPROVED ]: {
+			text: translate(
+				'Welcome to Automattic for Agencies. Your application has been approved! You can now make purchases in the portal.'
+			),
+			level: 'success',
+			// maybe don't show if signup date is older than x days
+		},
+		[ ApprovalStatus.REJECTED ]: {
+			text: translate(
+				'We have not approved your application for the Automattic for Agencies program. Please {{a}}contact support{{/a}} to discuss this further if you think this was done in error.',
+				{
+					components: {
+						a: <a href="#contact-support" />,
+					},
+				}
+			),
+			level: 'error',
+		},
+	};
+
+	if ( ! agency?.approval_status ) {
+		return null;
+	}
+
+	const bannerDetails = availableBannerDetails[ agency?.approval_status ];
+
+	if ( ! bannerDetails ) {
+		return null;
+	}
+
+	return (
+		<LayoutBanner
+			level={ bannerDetails.level as 'warning' | 'success' | 'error' }
+			onClose={ dismissNotice }
+			className="a4a-payment-delayed-notice"
+		>
+			<div>{ bannerDetails.text }</div>
+		</LayoutBanner>
+	);
+};
+
+export default A4AAgencyApprovalNotice;

--- a/client/a8c-for-agencies/components/a4a-agency-approval-notice/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-agency-approval-notice/index.tsx
@@ -27,6 +27,15 @@ const A4AAgencyApprovalNotice = () => {
 		return null;
 	}
 
+	// If approved, only show banner for 1 week after signup
+	if (
+		agency?.approval_status === ApprovalStatus.APPROVED &&
+		agency?.created_at &&
+		new Date( agency.created_at ) < new Date( Date.now() - 7 * 24 * 60 * 60 * 1000 ) // 7 days
+	) {
+		return null;
+	}
+
 	const availableBannerDetails = {
 		[ ApprovalStatus.PENDING ]: {
 			text: translate(
@@ -41,7 +50,6 @@ const A4AAgencyApprovalNotice = () => {
 			),
 			level: 'success',
 			hideCloseButton: false,
-			// maybe don't show if signup date is older than x days
 		},
 		[ ApprovalStatus.REJECTED ]: {
 			text: translate(

--- a/client/a8c-for-agencies/components/a4a-agency-approval-notice/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-agency-approval-notice/index.tsx
@@ -36,6 +36,10 @@ const A4AAgencyApprovalNotice = () => {
 		return null;
 	}
 
+	if ( ! agency?.approval_status ) {
+		return null;
+	}
+
 	const availableBannerDetails = {
 		[ ApprovalStatus.PENDING ]: {
 			text: translate(
@@ -64,10 +68,6 @@ const A4AAgencyApprovalNotice = () => {
 			hideCloseButton: true,
 		},
 	};
-
-	if ( ! agency?.approval_status ) {
-		return null;
-	}
 
 	const bannerDetails = availableBannerDetails[ agency?.approval_status ];
 

--- a/client/a8c-for-agencies/components/a4a-agency-approval-notice/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-agency-approval-notice/index.tsx
@@ -3,9 +3,10 @@ import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { ApprovalStatus } from 'calypso/state/a8c-for-agencies/types';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
+
+import './style.scss';
 
 const AGENCY_APPROVAL_DISMISS_PREFERENCE = 'a4a-agency-approval-notice-dismissed';
 
@@ -16,7 +17,6 @@ const A4AAgencyApprovalNotice = () => {
 
 	const dismissNotice = () => {
 		dispatch( savePreference( AGENCY_APPROVAL_DISMISS_PREFERENCE, true ) );
-		dispatch( recordTracksEvent( 'calypso_a4a_payment_delayed_notice_dismissed' ) );
 	};
 
 	const isDismissed = useSelector( ( state ) =>
@@ -33,12 +33,14 @@ const A4AAgencyApprovalNotice = () => {
 				'Your application to Automattic for Agencies is under review. You won’t be able to make any purchases until you have been approved.'
 			),
 			level: 'warning',
+			hideCloseButton: true,
 		},
 		[ ApprovalStatus.APPROVED ]: {
 			text: translate(
 				'Welcome to Automattic for Agencies. Your application has been approved! You can now make purchases in the portal.'
 			),
 			level: 'success',
+			hideCloseButton: false,
 			// maybe don't show if signup date is older than x days
 		},
 		[ ApprovalStatus.REJECTED ]: {
@@ -51,6 +53,7 @@ const A4AAgencyApprovalNotice = () => {
 				}
 			),
 			level: 'error',
+			hideCloseButton: true,
 		},
 	};
 
@@ -68,7 +71,8 @@ const A4AAgencyApprovalNotice = () => {
 		<LayoutBanner
 			level={ bannerDetails.level as 'warning' | 'success' | 'error' }
 			onClose={ dismissNotice }
-			className="a4a-payment-delayed-notice"
+			className="a4a-agency-approval-notice"
+			hideCloseButton={ bannerDetails.hideCloseButton }
 		>
 			<div>{ bannerDetails.text }</div>
 		</LayoutBanner>

--- a/client/a8c-for-agencies/components/a4a-agency-approval-notice/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-agency-approval-notice/index.tsx
@@ -5,6 +5,7 @@ import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors
 import { ApprovalStatus } from 'calypso/state/a8c-for-agencies/types';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
+import { CONTACT_URL_HASH_FRAGMENT } from '../a4a-contact-support-widget';
 
 import './style.scss';
 
@@ -36,10 +37,6 @@ const A4AAgencyApprovalNotice = () => {
 		return null;
 	}
 
-	if ( ! agency?.approval_status ) {
-		return null;
-	}
-
 	const availableBannerDetails = {
 		[ ApprovalStatus.PENDING ]: {
 			text: translate(
@@ -60,7 +57,7 @@ const A4AAgencyApprovalNotice = () => {
 				'We have not approved your application for the Automattic for Agencies program. Please {{a}}contact support{{/a}} to discuss this further if you think this was done in error.',
 				{
 					components: {
-						a: <a href="#contact-support" />,
+						a: <a href={ CONTACT_URL_HASH_FRAGMENT } />,
 					},
 				}
 			),
@@ -69,7 +66,9 @@ const A4AAgencyApprovalNotice = () => {
 		},
 	};
 
-	const bannerDetails = availableBannerDetails[ agency?.approval_status ];
+	const bannerDetails = agency?.approval_status
+		? availableBannerDetails[ agency.approval_status ]
+		: null;
 
 	if ( ! bannerDetails ) {
 		return null;

--- a/client/a8c-for-agencies/components/a4a-agency-approval-notice/style.scss
+++ b/client/a8c-for-agencies/components/a4a-agency-approval-notice/style.scss
@@ -1,0 +1,3 @@
+.a4a-agency-approval-notice {
+	margin-block-end: 24px;
+}

--- a/client/a8c-for-agencies/components/a4a-agency-approval-notice/style.scss
+++ b/client/a8c-for-agencies/components/a4a-agency-approval-notice/style.scss
@@ -1,3 +1,7 @@
 .a4a-agency-approval-notice {
 	margin-block-end: 24px;
 }
+
+.sites-dashboard .a4a-agency-approval-notice {
+    padding: 0;
+}

--- a/client/a8c-for-agencies/components/a4a-agency-approval-notice/style.scss
+++ b/client/a8c-for-agencies/components/a4a-agency-approval-notice/style.scss
@@ -3,5 +3,5 @@
 }
 
 .sites-dashboard .a4a-agency-approval-notice {
-    padding: 0;
+	padding: 0;
 }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -4,6 +4,7 @@ import { getQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useContext, useEffect, useRef, useState } from 'react';
+import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
@@ -222,6 +223,7 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 		>
 			{ isClient ? null : (
 				<LayoutTop>
+					<A4AAgencyApprovalNotice />
 					<LayoutHeader>
 						<Breadcrumb
 							items={ [

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/index.tsx
@@ -2,6 +2,7 @@ import page from '@automattic/calypso-router';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
+import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import PressableUsageLimitNotice from 'calypso/a8c-for-agencies/components/pressable-usage-limit-notice';
@@ -89,6 +90,7 @@ function HostingOverviewV3( { section }: SectionProps ) {
 		>
 			<LayoutTop>
 				<PressableUsageLimitNotice />
+				<A4AAgencyApprovalNotice />
 				<LayoutHeader>
 					<Breadcrumb
 						items={ [

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
@@ -3,6 +3,7 @@ import { useBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
+import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
@@ -85,6 +86,7 @@ function ProductsOverview( { siteId, suggestedProduct, productBrand, searchQuery
 			withBorder
 		>
 			<LayoutTop withNavigation>
+				<A4AAgencyApprovalNotice />
 				<LayoutHeader showStickyContent={ showStickyContent }>
 					<Breadcrumb
 						items={ [

--- a/client/a8c-for-agencies/sections/overview/overview.tsx
+++ b/client/a8c-for-agencies/sections/overview/overview.tsx
@@ -1,4 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
+import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
 import ContentSidebar from 'calypso/a8c-for-agencies/components/content-sidebar';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
@@ -23,6 +24,7 @@ export default function Overview() {
 	return (
 		<Layout title={ title } wide>
 			<LayoutTop>
+				<A4AAgencyApprovalNotice />
 				<PressableUsageLimitNotice />
 				<LayoutHeader className="a4a-overview-header">
 					<Title>{ title }</Title>

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/index.tsx
@@ -1,6 +1,7 @@
 import { Card } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import LayoutStepper from 'calypso/a8c-for-agencies/components/layout/stepper';
@@ -53,6 +54,7 @@ export default function PaymentMethodAdd( { withAssignLicense, isClientCheckout 
 			{ !! stepper && <LayoutStepper steps={ stepper.steps } current={ stepper.current } /> }
 
 			<LayoutTop>
+				<A4AAgencyApprovalNotice />
 				<LayoutHeader>
 					{ ! stepper && ! isClientCheckout && (
 						<Breadcrumb

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -3,6 +3,7 @@ import { isWithinBreakpoint } from '@automattic/viewport';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { useContext, useEffect, useCallback, useState, useRef } from 'react';
+import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
 import {
 	DATAVIEWS_LIST,
 	DATAVIEWS_TABLE,
@@ -246,6 +247,7 @@ export default function SitesDashboard() {
 			<LayoutColumn className="sites-overview" wide>
 				<LayoutTop withNavigation={ navItems.length > 1 }>
 					<ProvisioningSiteNotification />
+					<A4AAgencyApprovalNotice />
 
 					<LayoutHeader>
 						<Title>{ translate( 'Sites' ) }</Title>

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -97,6 +97,7 @@ export interface Agency {
 		label: string;
 		features: string[];
 	};
+	approval_status: ApprovalStatus | '';
 }
 
 export interface AgencyStore {
@@ -124,4 +125,10 @@ interface CombinedStore {
  */
 export interface A4AStore {
 	a8cForAgencies: CombinedStore;
+}
+
+export enum ApprovalStatus {
+	PENDING = 'pending',
+	APPROVED = 'approved',
+	REJECTED = 'rejected',
 }

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -98,6 +98,7 @@ export interface Agency {
 		features: string[];
 	};
 	approval_status: ApprovalStatus | '';
+	created_at: string;
 }
 
 export interface AgencyStore {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1608
PT: pfunGA-3ie-p2

## Proposed Changes

* We're introducing the ability flag new agencies for review. This change show a banner based on that agency approval status.

Note: There's [an existing issue](https://github.com/Automattic/automattic-for-agencies-dev/issues/1314) for a layout bug when these banners are displayed on mobile screen sizes.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To better inform users about their approval status.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Also apply this backend PR (169166-ghe-Automattic/wpcom)
* As described in the backend PR, update the blog option for your agency and test the values `pending`, `approved`, and `rejected`.
* Test the following pages to make sure the banner is shown properly (`/overview`; `/marketplace/hosting/wpcom` - including hosting, products, and checkout pages;  `/sites`; `/purchases/payment-methods/add`)

**Pending**
* There should not be a close button shown 
<img width="1706" alt="Screenshot 2024-12-20 at 1 48 49 PM" src="https://github.com/user-attachments/assets/eeb22871-653a-4041-82e3-3efa8221c7b6" />

**Rejected**
* There should not be a close button shown 
* The "contact us" link should open the contact form modal
<img width="1706" alt="Screenshot 2024-12-20 at 1 49 14 PM" src="https://github.com/user-attachments/assets/067a21d2-76df-4f4f-bcf1-223ef832a5ab" />

**Approved**
* You might need to hard code `created_at` field, as described in the backend PR if your agency is older than 1 week.
* There should be a close button shown 
* After closing and refreshing the banner should not show again
* On the backend hard code the `created_at` value to be older than 1 week. The banner should no longer be shown in this case
<img width="1708" alt="Screenshot 2024-12-20 at 1 48 02 PM" src="https://github.com/user-attachments/assets/817d9f4d-92c3-4ce2-b758-398b3334daba" />

---

Note: You can clear the Calypso preference after closing the banner if need from the UI.

<img width="1140" alt="Screenshot 2024-12-20 at 1 43 35 PM" src="https://github.com/user-attachments/assets/0d45b89b-5a00-41ec-82a0-b11b9e22fe78" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?