### PR TITLE
Design Picker: Fix try before you buy on Free plans.

### DIFF
--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -86,7 +86,7 @@ export default function PremiumGlobalStylesUpgradeModal( {
 							{ description ?? (
 								<>
 									<p>{ translations.description }</p>
-									<p>{ tryStyle ? translations.promotion : translations.promotionNoTry }</p>
+									<p>{ translations.promotion }</p>
 								</>
 							) }
 							{ featureList }

--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -19,7 +19,7 @@ export interface PremiumGlobalStylesUpgradeModalProps {
 	checkout: () => void;
 	closeModal: () => void;
 	isOpen: boolean;
-	tryStyle: () => void;
+	tryStyle?: ( () => void ) | undefined;
 	/** Now we have 3 types of global styles including style variations, color variations, and font variations */
 	numOfSelectedGlobalStyles?: number;
 }
@@ -29,7 +29,7 @@ export default function PremiumGlobalStylesUpgradeModal( {
 	checkout,
 	closeModal,
 	isOpen,
-	tryStyle,
+	tryStyle = undefined,
 	numOfSelectedGlobalStyles = 1,
 }: PremiumGlobalStylesUpgradeModalProps ) {
 	const translate = useTranslate();
@@ -86,14 +86,20 @@ export default function PremiumGlobalStylesUpgradeModal( {
 							{ description ?? (
 								<>
 									<p>{ translations.description }</p>
-									<p>{ translations.promotion }</p>
+									<p>{ tryStyle ? translations.promotion : translations.promotionNoTry }</p>
 								</>
 							) }
 							{ featureList }
 							<div className="upgrade-modal__actions bundle">
-								<Button className="upgrade-modal__cancel" onClick={ () => tryStyle() }>
-									{ translations.cancel }
-								</Button>
+								{ tryStyle ? (
+									<Button className="upgrade-modal__cancel" onClick={ () => tryStyle() }>
+										{ translations.try }
+									</Button>
+								) : (
+									<Button className="upgrade-modal__cancel" onClick={ closeModal }>
+										{ translations.cancel }
+									</Button>
+								) }
 								<Button
 									className="upgrade-modal__upgrade-plan"
 									primary

--- a/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
@@ -57,11 +57,6 @@ const useGlobalStylesUpgradeTranslations = ( { numOfSelectedGlobalStyles = 1 }: 
 			'Upgrade now to unlock your premium styles and get access to tons of other features. Or you can decide later and try them out first.',
 			{ count: numOfSelectedGlobalStyles }
 		),
-		promotionNoTry: translate(
-			'Upgrade now to unlock your premium style and get access to tons of other features.',
-			'Upgrade now to unlock your premium styles and get access to tons of other features.',
-			{ count: numOfSelectedGlobalStyles }
-		),
 		try: translate( 'Decide later' ),
 		cancel: translate( 'Cancel' ),
 		upgrade: translate( 'Upgrade plan' ),

--- a/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
@@ -57,7 +57,13 @@ const useGlobalStylesUpgradeTranslations = ( { numOfSelectedGlobalStyles = 1 }: 
 			'Upgrade now to unlock your premium styles and get access to tons of other features. Or you can decide later and try them out first.',
 			{ count: numOfSelectedGlobalStyles }
 		),
-		cancel: translate( 'Decide later' ),
+		promotionNoTry: translate(
+			'Upgrade now to unlock your premium style and get access to tons of other features.',
+			'Upgrade now to unlock your premium styles and get access to tons of other features.',
+			{ count: numOfSelectedGlobalStyles }
+		),
+		try: translate( 'Decide later' ),
+		cancel: translate( 'Cancel' ),
 		upgrade: translate( 'Upgrade plan' ),
 		upgradeWithPlan: translate( 'Get %(planTitle)s plan', {
 			args: { planTitle },

--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -466,7 +466,6 @@ export const ThemeUpgradeModal = ( {
 	const getPersonalPlanFeatureList = () => {
 		return getPlanFeaturesObject( [
 			WPCOM_FEATURES_PREMIUM_THEMES_LIMITED,
-			FEATURE_STYLE_CUSTOMIZATION,
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_AD_FREE_EXPERIENCE,
 			FEATURE_FAST_DNS,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -21,7 +21,6 @@ import {
 	useDesignPickerFilters,
 	getDesignPreviewUrl,
 	isAssemblerDesign,
-	PERSONAL_THEME,
 } from '@automattic/design-picker';
 import { useLocale, useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer, DESIGN_FIRST_FLOW, ONBOARDING_FLOW } from '@automattic/onboarding';
@@ -631,11 +630,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				} )
 			);
 
-			if ( selectedDesign?.design_tier === PERSONAL_THEME ) {
-				closePremiumGlobalStylesModal();
-			} else {
-				pickDesign();
-			}
+			pickDesign();
 		}
 	}
 
@@ -778,10 +773,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			return () => pickDesign();
 		}
 
-		const isPersonalDesign = selectedDesign?.design_tier === PERSONAL_THEME;
 		if ( isLockedTheme ) {
-			// For personal themes we favor the GS Upgrade Modal over the Plan Upgrade Modal.
-			return isPersonalDesign && shouldUnlockGlobalStyles ? unlockPremiumGlobalStyles : upgradePlan;
+			// If the theme is locked, we should show the plan upgrade modal.
+			return upgradePlan;
 		}
 
 		return shouldUnlockGlobalStyles ? unlockPremiumGlobalStyles : () => pickDesign();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -21,6 +21,7 @@ import {
 	useDesignPickerFilters,
 	getDesignPreviewUrl,
 	isAssemblerDesign,
+	PERSONAL_THEME,
 } from '@automattic/design-picker';
 import { useLocale, useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer, DESIGN_FIRST_FLOW, ONBOARDING_FLOW } from '@automattic/onboarding';
@@ -773,9 +774,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			return () => pickDesign();
 		}
 
+		const isPersonalDesign = selectedDesign?.design_tier === PERSONAL_THEME;
 		if ( isLockedTheme ) {
-			// If the theme is locked, we should show the plan upgrade modal.
-			return upgradePlan;
+			// For personal themes we favor the GS Upgrade Modal over the Plan Upgrade Modal.
+			return isPersonalDesign && shouldUnlockGlobalStyles ? unlockPremiumGlobalStyles : upgradePlan;
 		}
 
 		return shouldUnlockGlobalStyles ? unlockPremiumGlobalStyles : () => pickDesign();
@@ -857,8 +859,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					checkout={ handleCheckoutForPremiumGlobalStyles }
 					closeModal={ closePremiumGlobalStylesModal }
 					isOpen={ showPremiumGlobalStylesModal }
-					tryStyle={ tryPremiumGlobalStyles }
 					numOfSelectedGlobalStyles={ numOfSelectedGlobalStyles }
+					{ ...( ! isLockedTheme && { tryStyle: tryPremiumGlobalStyles } ) }
 				/>
 				<AsyncLoad
 					require="@automattic/design-preview"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Users on the Free plan will not see the try before you buy option on Personal or higher themes.
* Instead they will be given the option to cancel, which will close the modal.
* Copy has been updated to avoid confusion. 
* Removed the Customization feature from the feature list.

| Before | After |
|---|---|
| ![Screenshot 2024-12-20 at 17 41 24](https://github.com/user-attachments/assets/3e8e65af-8b40-4fcb-8ea4-894efd9c65c3) | ![Screenshot 2024-12-20 at 17 40 36](https://github.com/user-attachments/assets/577e613d-1c4b-430e-bb9c-5ec388134913) |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Users on the Free plan are seeing the Global Styles update modal with the try before you buy option on Personal themes. We do not support try before you buy on themes, yet we're showing the option, even though clicking on the button doesn't do anything.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link
* Create a new free site
* Go to the Design Picker and pick a Personal theme
* Apply a style variation and click continue.
* The upgrade modal shouldn't reference try before you buy.
* Create a site on a Personal plan
* The upgrade modal should reference try before you buy and should work as expected.
* Check for other possible regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
