### PR TITLE
Domain management: Email: Create context menu component

### DIFF
--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -199,6 +199,7 @@ function EmailPlanMailboxesList( {
 								( ! actionPathProps?.disabled && actionPathProps?.path ) || undefined
 							}
 							showIcon={ !! actionPathProps }
+							showContextMenu
 							domain={ domain }
 							disableActions={ isGoogleConfiguring }
 						>

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.scss
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.scss
@@ -23,5 +23,11 @@
 				fill: var(--color-text-inverted);
 			}
 		}
+
+		&[disabled] {
+			svg {
+				fill: var(--color-neutral-20) !important;
+			}
+		}
 	}
 }

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.scss
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.scss
@@ -17,12 +17,12 @@
 		}
 
 		svg {
-			width: 24px;
+			width: 1.5rem;
 			height: auto;
 		}
 
 		svg.gridicons-external {
-			width: 14px;
+			width: 0.875rem;
 		}
 
 		&:hover,

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.scss
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.scss
@@ -12,9 +12,17 @@
 		gap: 0.5rem;
 		align-items: center;
 
+		.label {
+			flex: 1;
+		}
+
 		svg {
 			width: 24px;
 			height: auto;
+		}
+
+		svg.gridicons-external {
+			width: 14px;
 		}
 
 		&:hover,

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.scss
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.scss
@@ -1,0 +1,20 @@
+.email-plan-mailboxes-list__mailbox-context-menu {
+	.button {
+		float: none !important;
+		margin: 0 0 0 1rem !important;
+		padding: 0;
+	}
+}
+
+.email-plan-mailboxes-list__mailbox-context-menu-popover {
+	.popover__menu-item {
+		display: flex;
+		gap: 0.5rem;
+		align-items: center;
+
+		svg {
+			width: 24px;
+			height: auto;
+		}
+	}
+}

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.scss
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.scss
@@ -16,5 +16,12 @@
 			width: 24px;
 			height: auto;
 		}
+
+		&:hover,
+		&:focus {
+			svg {
+				fill: var(--color-text-inverted);
+			}
+		}
 	}
 }

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.tsx
@@ -33,7 +33,13 @@ export default function ContextMenu( { className, domain }: Props ) {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const disableItem = ! isDesktop();
 
-	const options = [
+	const viewBillingPaymentsOption = {
+		context: CONTEXT_VIEW_BILLING_PAYMENTS,
+		icon: <Icon icon={ payment } />,
+		label: translate( 'View billing and payments' ),
+	};
+
+	const manageTitanOptions = [
 		{
 			context: TITAN_CONTROL_PANEL_CONTEXT_CONFIGURE_DESKTOP_APP,
 			icon: <Icon icon={ desktop } />,
@@ -63,11 +69,7 @@ export default function ContextMenu( { className, domain }: Props ) {
 			label: translate( 'Set up internal forwarding' ),
 			disabled: disableItem,
 		},
-		{
-			context: CONTEXT_VIEW_BILLING_PAYMENTS,
-			icon: <Icon icon={ payment } />,
-			label: translate( 'View billing and payments' ),
-		},
+		viewBillingPaymentsOption,
 	];
 
 	const onClick = useCallback( ( context: string ) => {
@@ -101,7 +103,7 @@ export default function ContextMenu( { className, domain }: Props ) {
 			popoverClassName={ `${ className }-popover` }
 			position="bottom"
 		>
-			{ options.map( ( option, key ) => (
+			{ manageTitanOptions.map( ( option, key ) => (
 				<PopoverMenuItem
 					key={ key }
 					{ ...option }

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.tsx
@@ -1,0 +1,52 @@
+import { Icon, desktop, mobile, cloudUpload, payment, settings, login } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import './context-menu.scss';
+
+type Props = {
+	className?: string;
+};
+export default function ContextMenu( { className }: Props ) {
+	const translate = useTranslate();
+
+	const options = [
+		{
+			icon: <Icon icon={ desktop } />,
+			label: translate( 'Configure desktop app' ),
+		},
+		{
+			icon: <Icon icon={ mobile } />,
+			label: translate( 'Get mobile app' ),
+		},
+		{
+			icon: <Icon icon={ cloudUpload } />,
+			label: translate( 'Import email data' ),
+		},
+		{
+			icon: <Icon icon={ settings } />,
+			label: translate( 'Configure catch-all email' ),
+		},
+		{
+			icon: <Icon icon={ login } />,
+			label: translate( 'Set up internal forwarding' ),
+		},
+		{
+			icon: <Icon icon={ payment } />,
+			label: translate( 'View billing and payments' ),
+		},
+	];
+
+	return (
+		<EllipsisMenu
+			className={ className }
+			popoverClassName="email-plan-mailboxes-list__mailbox-context-menu-popover"
+		>
+			{ options.map( ( option, key ) => (
+				<PopoverMenuItem key={ key } { ...option }>
+					{ option.label }
+				</PopoverMenuItem>
+			) ) }
+		</EllipsisMenu>
+	);
+}

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.tsx
@@ -1,41 +1,99 @@
+import { isDesktop } from '@automattic/viewport';
 import { Icon, desktop, mobile, cloudUpload, payment, settings, login } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import {
+	TITAN_CONTROL_PANEL_CONTEXT_CONFIGURE_CATCH_ALL_EMAIL,
+	TITAN_CONTROL_PANEL_CONTEXT_CONFIGURE_DESKTOP_APP,
+	TITAN_CONTROL_PANEL_CONTEXT_CONFIGURE_INTERNAL_FORWARDING,
+	TITAN_CONTROL_PANEL_CONTEXT_GET_MOBILE_APP,
+	TITAN_CONTROL_PANEL_CONTEXT_IMPORT_EMAIL_DATA,
+} from 'calypso/lib/titan/constants';
+import { getTitanControlPanelRedirectPath } from 'calypso/my-sites/email/paths';
+import { useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+
 import './context-menu.scss';
+
+const VIEW_BILLING_PAYMENTS = 'view_billing_payments';
 
 type Props = {
 	className?: string;
+	domain?: ResponseDomain;
 };
-export default function ContextMenu( { className }: Props ) {
+export default function ContextMenu( { className, domain }: Props ) {
 	const translate = useTranslate();
+	const currentRoute = useSelector( getCurrentRoute );
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const disableItem = ! isDesktop();
 
 	const options = [
 		{
+			context: TITAN_CONTROL_PANEL_CONTEXT_CONFIGURE_DESKTOP_APP,
 			icon: <Icon icon={ desktop } />,
 			label: translate( 'Configure desktop app' ),
+			disabled: disableItem,
 		},
 		{
+			context: TITAN_CONTROL_PANEL_CONTEXT_GET_MOBILE_APP,
 			icon: <Icon icon={ mobile } />,
 			label: translate( 'Get mobile app' ),
 		},
 		{
+			context: TITAN_CONTROL_PANEL_CONTEXT_IMPORT_EMAIL_DATA,
 			icon: <Icon icon={ cloudUpload } />,
 			label: translate( 'Import email data' ),
+			disabled: disableItem,
 		},
 		{
+			context: TITAN_CONTROL_PANEL_CONTEXT_CONFIGURE_CATCH_ALL_EMAIL,
 			icon: <Icon icon={ settings } />,
 			label: translate( 'Configure catch-all email' ),
+			disabled: disableItem,
 		},
 		{
+			context: TITAN_CONTROL_PANEL_CONTEXT_CONFIGURE_INTERNAL_FORWARDING,
 			icon: <Icon icon={ login } />,
 			label: translate( 'Set up internal forwarding' ),
+			disabled: disableItem,
 		},
 		{
+			context: VIEW_BILLING_PAYMENTS,
 			icon: <Icon icon={ payment } />,
 			label: translate( 'View billing and payments' ),
 		},
 	];
+
+	const onClick = useCallback( ( context: string ) => {
+		recordTracksEvent( 'calypso_email_management_titan_manage_mailboxes_link_click', {
+			context: context,
+		} );
+	}, [] );
+
+	const getPath = useCallback(
+		( context: string ) => {
+			if ( ! domain ) {
+				return '';
+			}
+
+			switch ( context ) {
+				case VIEW_BILLING_PAYMENTS:
+					return `/purchases/subscriptions/${ domain.name }/${ selectedSiteId }`;
+
+				default:
+					return getTitanControlPanelRedirectPath( selectedSiteSlug, domain.name, currentRoute, {
+						context,
+					} );
+			}
+		},
+		[ currentRoute, domain, selectedSiteId, selectedSiteSlug ]
+	);
 
 	return (
 		<EllipsisMenu
@@ -44,7 +102,12 @@ export default function ContextMenu( { className }: Props ) {
 			position="bottom"
 		>
 			{ options.map( ( option, key ) => (
-				<PopoverMenuItem key={ key } { ...option }>
+				<PopoverMenuItem
+					key={ key }
+					{ ...option }
+					onClick={ onClick }
+					href={ getPath( option.context ) }
+				>
 					{ option.label }
 				</PopoverMenuItem>
 			) ) }

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.tsx
@@ -38,7 +38,11 @@ export default function ContextMenu( { className }: Props ) {
 	];
 
 	return (
-		<EllipsisMenu className={ className } popoverClassName={ `${ className }-popover` }>
+		<EllipsisMenu
+			className={ className }
+			popoverClassName={ `${ className }-popover` }
+			position="bottom"
+		>
 			{ options.map( ( option, key ) => (
 				<PopoverMenuItem key={ key } { ...option }>
 					{ option.label }

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.tsx
@@ -38,10 +38,7 @@ export default function ContextMenu( { className }: Props ) {
 	];
 
 	return (
-		<EllipsisMenu
-			className={ className }
-			popoverClassName="email-plan-mailboxes-list__mailbox-context-menu-popover"
-		>
+		<EllipsisMenu className={ className } popoverClassName={ `${ className }-popover` }>
 			{ options.map( ( option, key ) => (
 				<PopoverMenuItem key={ key } { ...option }>
 					{ option.label }

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.tsx
@@ -20,7 +20,7 @@ import type { ResponseDomain } from 'calypso/lib/domains/types';
 
 import './context-menu.scss';
 
-const VIEW_BILLING_PAYMENTS = 'view_billing_payments';
+const CONTEXT_VIEW_BILLING_PAYMENTS = 'view_billing_payments';
 
 type Props = {
 	className?: string;
@@ -64,7 +64,7 @@ export default function ContextMenu( { className, domain }: Props ) {
 			disabled: disableItem,
 		},
 		{
-			context: VIEW_BILLING_PAYMENTS,
+			context: CONTEXT_VIEW_BILLING_PAYMENTS,
 			icon: <Icon icon={ payment } />,
 			label: translate( 'View billing and payments' ),
 		},
@@ -83,7 +83,7 @@ export default function ContextMenu( { className, domain }: Props ) {
 			}
 
 			switch ( context ) {
-				case VIEW_BILLING_PAYMENTS:
+				case CONTEXT_VIEW_BILLING_PAYMENTS:
 					return `/purchases/subscriptions/${ domain.name }/${ selectedSiteId }`;
 
 				default:

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { getGoogleAdminUrl, hasGSuiteWithUs } from 'calypso/lib/gsuite';
 import {
 	TITAN_CONTROL_PANEL_CONTEXT_CONFIGURE_CATCH_ALL_EMAIL,
 	TITAN_CONTROL_PANEL_CONTEXT_CONFIGURE_DESKTOP_APP,
@@ -21,6 +22,7 @@ import type { ResponseDomain } from 'calypso/lib/domains/types';
 import './context-menu.scss';
 
 const CONTEXT_VIEW_BILLING_PAYMENTS = 'view_billing_payments';
+const CONTEXT_GOOGLE_WORKSPACE = 'google_workspace';
 
 type Props = {
 	className?: string;
@@ -33,6 +35,9 @@ export default function ContextMenu( { className, domain }: Props ) {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const disableItem = ! isDesktop();
 
+	/**
+	 * Options
+	 */
 	const viewBillingPaymentsOption = {
 		context: CONTEXT_VIEW_BILLING_PAYMENTS,
 		icon: <Icon icon={ payment } />,
@@ -72,6 +77,20 @@ export default function ContextMenu( { className, domain }: Props ) {
 		viewBillingPaymentsOption,
 	];
 
+	const manageGoogleOptions = [
+		{
+			context: CONTEXT_GOOGLE_WORKSPACE,
+			icon: <Icon icon={ settings } />,
+			label: translate( 'Manage Google Workspace' ),
+		},
+		viewBillingPaymentsOption,
+	];
+
+	const contextMenuOptions = hasGSuiteWithUs( domain ) ? manageGoogleOptions : manageTitanOptions;
+
+	/**
+	 * Callbacks
+	 */
 	const onClick = useCallback( ( context: string ) => {
 		recordTracksEvent( 'calypso_email_management_titan_manage_mailboxes_link_click', {
 			context: context,
@@ -88,6 +107,9 @@ export default function ContextMenu( { className, domain }: Props ) {
 				case CONTEXT_VIEW_BILLING_PAYMENTS:
 					return `/purchases/subscriptions/${ domain.name }/${ selectedSiteId }`;
 
+				case CONTEXT_GOOGLE_WORKSPACE:
+					return getGoogleAdminUrl( domain.name );
+
 				default:
 					return getTitanControlPanelRedirectPath( selectedSiteSlug, domain.name, currentRoute, {
 						context,
@@ -97,13 +119,16 @@ export default function ContextMenu( { className, domain }: Props ) {
 		[ currentRoute, domain, selectedSiteId, selectedSiteSlug ]
 	);
 
+	/**
+	 * Template render
+	 */
 	return (
 		<EllipsisMenu
 			className={ className }
 			popoverClassName={ `${ className }-popover` }
 			position="bottom"
 		>
-			{ manageTitanOptions.map( ( option, key ) => (
+			{ contextMenuOptions.map( ( option, key ) => (
 				<PopoverMenuItem
 					key={ key }
 					{ ...option }

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.tsx
@@ -50,29 +50,34 @@ export default function ContextMenu( { className, domain }: Props ) {
 			icon: <Icon icon={ desktop } />,
 			label: translate( 'Configure desktop app' ),
 			disabled: disableItem,
+			isExternalLink: true,
 		},
 		{
 			context: TITAN_CONTROL_PANEL_CONTEXT_GET_MOBILE_APP,
 			icon: <Icon icon={ mobile } />,
 			label: translate( 'Get mobile app' ),
+			isExternalLink: true,
 		},
 		{
 			context: TITAN_CONTROL_PANEL_CONTEXT_IMPORT_EMAIL_DATA,
 			icon: <Icon icon={ cloudUpload } />,
 			label: translate( 'Import email data' ),
 			disabled: disableItem,
+			isExternalLink: true,
 		},
 		{
 			context: TITAN_CONTROL_PANEL_CONTEXT_CONFIGURE_CATCH_ALL_EMAIL,
 			icon: <Icon icon={ settings } />,
 			label: translate( 'Configure catch-all email' ),
 			disabled: disableItem,
+			isExternalLink: true,
 		},
 		{
 			context: TITAN_CONTROL_PANEL_CONTEXT_CONFIGURE_INTERNAL_FORWARDING,
 			icon: <Icon icon={ login } />,
 			label: translate( 'Set up internal forwarding' ),
 			disabled: disableItem,
+			isExternalLink: true,
 		},
 		viewBillingPaymentsOption,
 	];
@@ -82,6 +87,7 @@ export default function ContextMenu( { className, domain }: Props ) {
 			context: CONTEXT_GOOGLE_WORKSPACE,
 			icon: <Icon icon={ settings } />,
 			label: translate( 'Manage Google Workspace' ),
+			isExternalLink: true,
 		},
 		viewBillingPaymentsOption,
 	];
@@ -135,7 +141,7 @@ export default function ContextMenu( { className, domain }: Props ) {
 					onClick={ onClick }
 					href={ getPath( option.context ) }
 				>
-					{ option.label }
+					<span className="label">{ option.label }</span>
 				</PopoverMenuItem>
 			) ) }
 		</EllipsisMenu>

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/list-header.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/list-header.tsx
@@ -4,6 +4,7 @@ import React, { useCallback } from 'react';
 import SectionHeader from 'calypso/components/section-header';
 import { EMAIL_ACCOUNT_TYPE_FORWARD } from 'calypso/lib/emails/email-provider-constants';
 import EmailTypeIcon from '../email-type-icon';
+import ContextMenu from './context-menu';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
 type Props = React.PropsWithChildren< {
@@ -12,6 +13,7 @@ type Props = React.PropsWithChildren< {
 	addMailboxPath?: string;
 	domain?: ResponseDomain;
 	showIcon?: boolean;
+	showContextMenu?: boolean;
 	disableActions?: boolean;
 } >;
 const MailboxListHeader = ( {
@@ -21,6 +23,7 @@ const MailboxListHeader = ( {
 	addMailboxPath,
 	domain,
 	showIcon,
+	showContextMenu = false,
 	disableActions,
 }: Props ) => {
 	const translate = useTranslate();
@@ -63,6 +66,12 @@ const MailboxListHeader = ( {
 					<Button href={ addMailboxPath } variant="link" disabled={ !! disableActions }>
 						{ translate( 'Add mailbox' ) }
 					</Button>
+				) }
+				{ showContextMenu && (
+					<ContextMenu
+						domain={ domain }
+						className="email-plan-mailboxes-list__mailbox-context-menu"
+					/>
 				) }
 			</SectionHeader>
 			{ children }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/97284

## Proposed Changes

* Creates context menu component
* Updates Header component to support the context menu
* Integrates context menu

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Domain Management Revamp

## Testing Instructions

* Go to `/domains/manage?flags=calypso/all-domain-management`
* Ensure you have WP (titan) and Google domain created
* Select WP domain and select Email tab
* Check the context menu options, check if the links property works
<img width="1094" alt="Screenshot 2024-12-24 at 00 17 28" src="https://github.com/user-attachments/assets/a20eae81-339a-4d01-a688-3db49fa89397" />

* Select google domain
* Check the context menu options, check if the links property works
<img width="1095" alt="Screenshot 2024-12-24 at 00 17 09" src="https://github.com/user-attachments/assets/16164012-4def-43a9-b103-1828ef2dd7cd" />

| Current options | and links |
|--------|--------|
| <img width="865" alt="1" src="https://github.com/user-attachments/assets/753e4378-f435-4545-b1d1-285334c859f6" /> | <img width="977" alt="2" src="https://github.com/user-attachments/assets/39243250-cc2a-4034-95ad-11c40e5d21c8" /> | 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
