### PR TITLE
A4A: disable global notifications

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -338,6 +338,8 @@ class Layout extends Component {
 			// There is a custom command palette in the "Switch site" page, so we disable it.
 			config.isEnabled( 'yolo/command-palette' ) && this.props.currentRoute !== '/switch-site';
 
+		const shouldDisableGlobalNotifications = this.props.disableGlobalNotifications;
+
 		return (
 			<div className={ sectionClass }>
 				<WhatsNewLoader
@@ -427,7 +429,7 @@ class Layout extends Component {
 				{ config.isEnabled( 'legal-updates-banner' ) && (
 					<AsyncLoad require="calypso/blocks/legal-updates-banner" placeholder={ null } />
 				) }
-				<GlobalNotifications />
+				{ ! shouldDisableGlobalNotifications && <GlobalNotifications /> }
 				{ shouldEnableCommandPalette && (
 					<AsyncLoad require="calypso/layout/command-palette" placeholder={ null } />
 				) }
@@ -475,6 +477,8 @@ export default withCurrentRoute(
 				[ 'signup', 'jetpack-connect' ].includes( sectionName ) );
 		const isFromAutomatticForAgenciesPlugin =
 			'automattic-for-agencies-client' === currentQuery?.from;
+		// Currently, we only want to disable global notifications for A4A.
+		const disableGlobalNotifications = isA8CForAgencies();
 		const masterbarIsHidden =
 			! masterbarIsVisible( state ) ||
 			noMasterbarForSection ||
@@ -545,6 +549,7 @@ export default withCurrentRoute(
 			isGlobalSidebarCollapsed: shouldShowCollapsedGlobalSidebar && ! sidebarIsHidden,
 			isUnifiedSiteSidebarVisible: shouldShowUnifiedSiteSidebar && ! sidebarIsHidden,
 			isNewUser: isUserNewerThan( WEEK_IN_MILLISECONDS )( state ),
+			disableGlobalNotifications,
 		};
 	} )( Layout )
 );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -338,8 +338,6 @@ class Layout extends Component {
 			// There is a custom command palette in the "Switch site" page, so we disable it.
 			config.isEnabled( 'yolo/command-palette' ) && this.props.currentRoute !== '/switch-site';
 
-		const shouldDisableGlobalNotifications = this.props.disableGlobalNotifications;
-
 		return (
 			<div className={ sectionClass }>
 				<WhatsNewLoader
@@ -429,7 +427,7 @@ class Layout extends Component {
 				{ config.isEnabled( 'legal-updates-banner' ) && (
 					<AsyncLoad require="calypso/blocks/legal-updates-banner" placeholder={ null } />
 				) }
-				{ ! shouldDisableGlobalNotifications && <GlobalNotifications /> }
+				{ ! isA8CForAgencies() && <GlobalNotifications /> }
 				{ shouldEnableCommandPalette && (
 					<AsyncLoad require="calypso/layout/command-palette" placeholder={ null } />
 				) }
@@ -477,8 +475,6 @@ export default withCurrentRoute(
 				[ 'signup', 'jetpack-connect' ].includes( sectionName ) );
 		const isFromAutomatticForAgenciesPlugin =
 			'automattic-for-agencies-client' === currentQuery?.from;
-		// Currently, we only want to disable global notifications for A4A.
-		const disableGlobalNotifications = isA8CForAgencies();
 		const masterbarIsHidden =
 			! masterbarIsVisible( state ) ||
 			noMasterbarForSection ||
@@ -549,7 +545,6 @@ export default withCurrentRoute(
 			isGlobalSidebarCollapsed: shouldShowCollapsedGlobalSidebar && ! sidebarIsHidden,
 			isUnifiedSiteSidebarVisible: shouldShowUnifiedSiteSidebar && ! sidebarIsHidden,
 			isNewUser: isUserNewerThan( WEEK_IN_MILLISECONDS )( state ),
-			disableGlobalNotifications,
 		};
 	} )( Layout )
 );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pfSQfS-Bd-p2

## Proposed Changes

In Automattic for Agencies we currently don't have a **masterbar** and don't wire up WPCOM notification bar for our clients. Thus, to improve overall performance and reduce number of unnecessary calls we want to remove Global Notifications for now.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
To reduce number of redundant calls of improve page load time.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check live links bellow and inspect dev console Network tab
- For A4A, no `notifications` calls should be present
- For Jetpack Cloud and Wordpress.com all should work as before and Wordpress.com masterbar should work properly

<img width="443" alt="Screenshot 2024-12-20 at 9 07 41 AM" src="https://github.com/user-attachments/assets/9a9399a0-5b65-4f82-b2c0-44441d672803" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?