### PR TITLE
Backup: fix retention settings radio styles

### DIFF
--- a/client/components/backup-retention-management/retention-options/retention-option-card.tsx
+++ b/client/components/backup-retention-management/retention-options/retention-option-card.tsx
@@ -48,7 +48,7 @@ const RetentionOptionCard: FunctionComponent< RetentionOptionCardProps > = ( {
 			<div className="retention-option__headline">
 				<div className="headline__label">{ RETENTION_OPTIONS_LABELS[ value ] }</div>
 				<input
-					className="headline__input components-radio-control__input"
+					className="components-radio-control__input"
 					type="radio"
 					name="storage_option"
 					value={ value }

--- a/client/components/backup-retention-management/style.scss
+++ b/client/components/backup-retention-management/style.scss
@@ -2,6 +2,7 @@
 @import "@wordpress/base-styles/mixins";
 
 .backup-retention-management {
+	--color-accent: var(--studio-jetpack-green-50);
 	box-sizing: border-box;
 	margin: auto;
 	margin-top: 1px;
@@ -142,41 +143,8 @@
 			color: var(--studio-gray-80);
 		}
 
-		&__headline	.headline__input {
-			-webkit-appearance: none;
-			appearance: none;
-			margin: 0;
-			padding: 0;
-			width: 20px;
-			height: 20px;
-			border-width: 1px;
-			border-color: var(--studio-gray-40);
-
-			&:focus {
-				box-shadow: none;
-			}
-
-			&::before {
-				content: none;
-			}
-
-			&::after {
-				content: "";
-				display: block;
-				border-radius: 50%;
-				width: 10px;
-				height: 10px;
-				margin: 1px;
-			}
-
-			&:checked {
-				&::after {
-					border: 3px solid #fff;
-				}
-
-				border-color: var(--studio-jetpack-green-50);
-				background: var(--studio-jetpack-green-50);
-			}
+		&__headline .components-radio-control__input[type="radio"]:focus {
+			box-shadow: none;
 		}
 
 		&__space-needed {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fix the retention settings radio styles, which appear slightly distorted, and start relying on core component styles.

| Before | After |
|---|---|
| ![CleanShot 2024-12-20 at 13 30 18@2x](https://github.com/user-attachments/assets/4695e4a1-892a-4806-abec-43415e05c0ef) | ![CleanShot 2024-12-20 at 13 30 29@2x](https://github.com/user-attachments/assets/4a611024-e514-4f19-b3ad-0f284be72818) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

UI improvement

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Jetpack Cloud Live Branch
* Pick a site with a Jetpack VaultPress Backup plan (it should have a storage limit, and the user should not be an agency)
* Navigate to Settings page
* Ensure the radio buttons now looks good as the screenshots shared above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
