### PR TITLE
A4A: Update migration incentive copy

### DIFF
--- a/client/a8c-for-agencies/components/a4a-migration-offer-v3/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v3/index.tsx
@@ -103,7 +103,18 @@ const MigrationOfferV3 = ( { isExpanded, onToggleView }: Props ) => {
 							</Button>
 
 							<span className="a4a-migration-offer-v3__body-actions-footnote">
-								{ translate( '* Offer valid until the end of 2024' ) }
+								{ translate( '* offer valid until %(endDate)s', {
+									args: {
+										endDate: new Date( '2025-01-31T00:00:00' ).toLocaleDateString(
+											translate.localeSlug,
+											{
+												year: 'numeric',
+												month: 'long',
+												day: 'numeric',
+											}
+										),
+									},
+								} ) }
 							</span>
 						</div>
 					</div>

--- a/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
@@ -27,7 +27,7 @@ const MigrationOfferHeader = ( { withIcon }: { withIcon?: boolean } ) => {
 const MigrationOfferBody = () => {
 	const translate = useTranslate();
 	const description = translate(
-		'From now until the end of 2024, you’ll receive $100 for each site you migrate to Pressable or WordPress.com, up to $10,000.* If you’re a WP\u00A0Engine customer, we’ll also credit the costs to set you free. {{a}}Full Terms ↗{{/a}}',
+		'Receive $100 for each site you migrate to Pressable or WordPress.com, up to $10,000.* If you’re a WP\u00A0Engine customer, we’ll also credit the costs to set you free. {{a}}Full Terms ↗{{/a}}',
 		{
 			components: {
 				a: (
@@ -50,7 +50,16 @@ const MigrationOfferBody = () => {
 			</Button>
 			<p className="a4a-migration-offer__asterisk">
 				{ translate(
-					'* The migration limit is $10,000 for WP\u00A0Engine and $3,000 for other hosts.'
+					'* The migration limit is $10,000 for WP\u00A0Engine and $3,000 for other hosts. Offer valid until %(endDate)s',
+					{
+						args: {
+							endDate: new Date( '2025-01-31T00:00:00' ).toLocaleDateString( translate.localeSlug, {
+								year: 'numeric',
+								month: 'long',
+								day: 'numeric',
+							} ),
+						},
+					}
 				) }
 			</p>
 		</>

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-faqs/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-faqs/index.tsx
@@ -80,12 +80,35 @@ export default function MigrationsFAQs() {
 			answer: (
 				<>
 					{ translate(
-						'From now until the end of 2024, you’ll receive $100 for each site you migrate to Pressable or WordPress.com, up to $10,000*. If you’re a WP Engine customer, we’ll also credit the costs to set you free.'
+						'Receive $100 for each site you migrate to Pressable or WordPress.com, up to $10,000.* If you’re a WP\u00A0Engine customer, we’ll also credit the costs to set you free. {{a}}Full Terms ↗{{/a}}',
+						{
+							components: {
+								a: (
+									<a
+										href="https://automattic.com/for-agencies/program-incentives"
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						}
 					) }
 					<br />
 					<br />
 					{ translate(
-						'* The migration limit is $10,000 for WP Engine and $3,000 for other hosts.'
+						'* The migration limit is $10,000 for WP\u00A0Engine and $3,000 for other hosts. Offer valid until %(endDate)s',
+						{
+							args: {
+								endDate: new Date( '2025-01-31T00:00:00' ).toLocaleDateString(
+									translate.localeSlug,
+									{
+										year: 'numeric',
+										month: 'long',
+										day: 'numeric',
+									}
+								),
+							},
+						}
 					) }
 				</>
 			),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1610
Discussion: p1734711558396969-slack-C06JY8QL0TU

## Proposed Changes

* Update migration incentive copy - extend end date to Jan 31, 2025.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check the following locations and make sure the copy has been updated.
  * `/overview`
  
<img width="1313" alt="Screenshot 2024-12-20 at 10 09 07 AM" src="https://github.com/user-attachments/assets/13ef4a92-6a5d-497a-b7ba-ff9c0e8257dc" />

  * `/marketplace/hosting/wpcom`
  
<img width="1691" alt="Screenshot 2024-12-20 at 10 09 54 AM" src="https://github.com/user-attachments/assets/31a6512f-ae55-496a-8350-588dcec3e573" />

  * `/migrations/overview#multiple-sites-migration-offers-faq`
  
<img width="1673" alt="Screenshot 2024-12-20 at 10 12 30 AM" src="https://github.com/user-attachments/assets/0d09f2b7-0e73-47df-bc83-14d2989e5ac0" />

 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?