### PR TITLE
Add currency to pricing page and checkout page view tracks

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-record-checkout-loaded.ts
+++ b/client/my-sites/checkout/src/hooks/use-record-checkout-loaded.ts
@@ -25,6 +25,7 @@ export default function useRecordCheckoutLoaded( {
 } ): void {
 	const reduxDispatch = useDispatch();
 	const hasRecordedCheckoutLoad = useRef( false );
+	const { currency } = responseCart;
 	if ( ! isLoading && ! hasRecordedCheckoutLoad.current ) {
 		debug( 'composite checkout has loaded' );
 		reduxDispatch(
@@ -35,6 +36,7 @@ export default function useRecordCheckoutLoaded( {
 				product_slug: productAliasFromUrl,
 				is_composite: true,
 				checkout_flow: checkoutFlow,
+				currency,
 			} )
 		);
 		reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_loaded', {} ) );


### PR DESCRIPTION
## Proposed Changes

* Add currency prop to page views on the pricing page and checkout

## Why are these changes being made?

We don't currently have currency tracked on these page views

## Testing Instructions

1. Open the Calypso Blue live link
2. Go to `/checkout/jetpack/jetpack_complete`
3. In tracks vigilante, or wherever you look at tracks, find the `calypso_checkout_page_view` event and ensure the currency prop is present
![Screenshot 2024-12-20 at 12 01 03 PM](https://github.com/user-attachments/assets/6d335e42-afa6-4c0d-b6b1-2c00ad735bb4)
4. Open the Calypso Green live link
5. Go to `/pricing`
6. Find the `calypso_jetpack_pricing_page_visit` event and ensure `currency` is tracked
![Screenshot 2024-12-20 at 12 03 00 PM](https://github.com/user-attachments/assets/8f70c7bc-8340-42c7-8351-22e350d73be6)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
