### PR TITLE
Stay on same tab when switching domains

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain-dashboard-layout.tsx
+++ b/client/my-sites/domains/domain-management/components/domain-dashboard-layout.tsx
@@ -6,6 +6,7 @@ import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
 type DomainDashboardLayoutProps = {
 	innerContent: React.ReactNode;
 	selectedDomainName: string;
+	selectedFeature: string;
 };
 
 function DomainDashboardLayout( props: DomainDashboardLayoutProps ) {
@@ -17,6 +18,7 @@ function DomainDashboardLayout( props: DomainDashboardLayoutProps ) {
 					analyticsTitle="Domain Management > All Domains"
 					sidebarMode
 					selectedDomainName={ props.selectedDomainName }
+					selectedFeature={ props.selectedFeature }
 				/>
 			</LayoutColumn>
 			<LayoutColumn className="domains-overview__details" wide>

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -329,11 +329,13 @@ export default {
 	// The main layout that wraps all the domain management pages.
 	domainDashboardLayout( pageContext, next ) {
 		const selectedDomainName = decodeURIComponentIfValid( pageContext.params.domain );
+		const selectedFeature = pageContext.primary?.props?.selectedFeature;
 
 		pageContext.primary = (
 			<DomainManagement.DomainDashboardLayout
 				innerContent={ pageContext.primary }
 				selectedDomainName={ selectedDomainName }
+				selectedFeature={ selectedFeature }
 			/>
 		);
 

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -29,6 +29,7 @@ interface BulkAllDomainsProps {
 	analyticsTitle: string;
 	sidebarMode?: boolean;
 	selectedDomainName?: string;
+	selectedFeature?: string;
 }
 
 export default function BulkAllDomains( props: BulkAllDomainsProps ) {
@@ -443,6 +444,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 						deleteBulkActionStatus={ deleteBulkActionStatus }
 						sidebarMode={ props.sidebarMode }
 						selectedDomainName={ props.selectedDomainName }
+						selectedFeature={ props.selectedFeature }
 					/>
 				) : (
 					<div className="bulk-domains-empty-state">

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -50,8 +50,13 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 		sslStatus,
 		hasWpcomManagedSslCert,
 	} = useDomainRow( domain );
-	const { canSelectAnyDomains, domainsTableColumns, isCompact, currentlySelectedDomainName } =
-		useDomainsTable();
+	const {
+		canSelectAnyDomains,
+		domainsTableColumns,
+		isCompact,
+		currentlySelectedDomainName,
+		selectedFeature,
+	} = useDomainsTable();
 
 	const renderSiteCell = () => {
 		if ( site && currentDomainData ) {
@@ -75,7 +80,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 		currentDomainData && getDomainTypeText( currentDomainData, __, domainInfoContext.DOMAIN_ROW );
 
 	const domainManagementLink = isManageableDomain
-		? getDomainManagementLink( domain, siteSlug, isAllSitesView )
+		? getDomainManagementLink( domain, siteSlug, isAllSitesView, selectedFeature )
 		: '';
 
 	const renderOwnerCell = () => {

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -126,6 +126,7 @@ type Value = {
 	currentUserCanBulkUpdateContactInfo: boolean;
 	isCompact: boolean;
 	currentlySelectedDomainName?: string;
+	selectedFeature?: string;
 };
 
 export const DomainsTableStateContext = createContext< Value | undefined >( undefined );
@@ -149,6 +150,7 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 		currentUserCanBulkUpdateContactInfo = false,
 		sidebarMode = false,
 		selectedDomainName,
+		selectedFeature,
 	} = props;
 
 	const [ { sortKey, sortDirection }, setSort ] = useState< {
@@ -450,6 +452,7 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 		currentUserCanBulkUpdateContactInfo,
 		isCompact,
 		currentlySelectedDomainName: selectedDomainName,
+		selectedFeature,
 	};
 
 	return value;

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -70,6 +70,7 @@ interface BaseDomainsTableProps {
 	currentUserCanBulkUpdateContactInfo?: boolean;
 	sidebarMode?: boolean;
 	selectedDomainName?: string;
+	selectedFeature?: string;
 }
 
 export type DomainsTableProps =

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -8,7 +8,8 @@ export const emailManagementAllSitesPrefix = '/email/all';
 export function domainManagementLink(
 	{ domain, type }: Pick< ResponseDomain, 'domain' | 'type' >,
 	siteSlug: string,
-	isAllSitesView: boolean
+	isAllSitesView: boolean,
+	feature?: string
 ) {
 	const viewSlug = domainManagementViewSlug( type );
 
@@ -22,6 +23,10 @@ export function domainManagementLink(
 	const isAllDomainManagementEnabled = config.isEnabled( 'calypso/all-domain-management' );
 
 	if ( isAllDomainManagementEnabled && isAllSitesView ) {
+		if ( feature && 'email-management' === feature ) {
+			return `/domains/manage/all/email/${ domain }/${ siteSlug }`;
+		}
+
 		return `/domains/manage/all/overview/${ domain }/${ siteSlug }`;
 	}
 

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -25,11 +25,11 @@ export function domainManagementLink(
 	if ( isAllDomainManagementEnabled && isAllSitesView ) {
 		switch ( feature ) {
 			case 'email-management':
-				return `/domains/manage/all/email/${ domain }/${ siteSlug }`;
+				return `${ domainManagementAllRoot() }/email/${ domain }/${ siteSlug }`;
 
 			case 'domain-overview':
 			default:
-				return `/domains/manage/all/overview/${ domain }/${ siteSlug }`;
+				return `${ domainManagementAllRoot() }/overview/${ domain }/${ siteSlug }`;
 		}
 	}
 

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -23,11 +23,14 @@ export function domainManagementLink(
 	const isAllDomainManagementEnabled = config.isEnabled( 'calypso/all-domain-management' );
 
 	if ( isAllDomainManagementEnabled && isAllSitesView ) {
-		if ( feature && 'email-management' === feature ) {
-			return `/domains/manage/all/email/${ domain }/${ siteSlug }`;
-		}
+		switch ( feature ) {
+			case 'email-management':
+				return `/domains/manage/all/email/${ domain }/${ siteSlug }`;
 
-		return `/domains/manage/all/overview/${ domain }/${ siteSlug }`;
+			case 'domain-overview':
+			default:
+				return `/domains/manage/all/overview/${ domain }/${ siteSlug }`;
+		}
 	}
 
 	if ( isAllSitesView ) {


### PR DESCRIPTION
Closes #97446.

TODO:
- [x] Make it work with subpages like Email Forwarding (maybe? Check with Imran)
- [x] Is the Emails tab always guaranteed to be there for all sites? If not, account for that.
- [ ] Add tests as needed
- [ ] Nice to have: Make it scalable for any other tabs that may be added

## Proposed Changes

Add `selectedFeature` prop to ensure UI stays on same tab when switching domains.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the `calypso/all-domain-management` flag.
* On `/domains/manage`, select a domain.
* Click on the _Emails_ tab.
* Switch to a new domain.
* Ensure the _Emails_ tab is still selected.
* Click on the _Overview_ tab.
* Switch to a new domain.
* Ensure the _Overview_ tab is still selected.
* Disable the `calypso/all-domain-management` flag.
* Click on different domains and ensure the functionality still works as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
