### PR TITLE
Goals first: Enable back button in the login step for the DIFM and Import flows

### DIFF
--- a/client/landing/stepper/declarative-flow/hosted-site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/hosted-site-migration-flow.ts
@@ -1,4 +1,5 @@
 import { HOSTED_SITE_MIGRATION_FLOW } from '@automattic/onboarding';
+import { useSearchParams } from 'react-router-dom';
 import { type Flow } from './internals/types';
 import siteMigration from './site-migration-flow';
 
@@ -6,6 +7,16 @@ const hostedSiteMigrationFlow: Flow = {
 	...siteMigration,
 	variantSlug: HOSTED_SITE_MIGRATION_FLOW,
 	isSignupFlow: true,
+	useLoginParams() {
+		const [ searchParams ] = useSearchParams();
+		const backUrl = searchParams.get( 'back_url' );
+
+		return {
+			extraQueryParams: {
+				...( backUrl ? { back_url: backUrl } : {} ),
+			},
+		};
+	},
 };
 
 export default hostedSiteMigrationFlow;

--- a/client/landing/stepper/declarative-flow/hosted-site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/hosted-site-migration-flow.ts
@@ -9,11 +9,11 @@ const hostedSiteMigrationFlow: Flow = {
 	isSignupFlow: true,
 	useLoginParams() {
 		const [ searchParams ] = useSearchParams();
-		const backUrl = searchParams.get( 'back_url' );
+		const backTo = searchParams.get( 'back_to' );
 
 		return {
 			extraQueryParams: {
-				...( backUrl ? { back_url: backUrl } : {} ),
+				...( backTo ? { back_to: backTo } : {} ),
 			},
 		};
 	},

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -122,6 +122,11 @@ const onboarding: Flow = {
 		const submit = async ( providedDependencies: ProvidedDependencies = {} ) => {
 			switch ( currentStepSlug ) {
 				case 'goals': {
+					const goalsUrl =
+						locale && locale !== 'en'
+							? `/setup/onboarding/goals/${ locale }`
+							: '/setup/onboarding/goals';
+
 					const { intent } = providedDependencies;
 
 					switch ( intent ) {
@@ -130,7 +135,11 @@ const onboarding: Flow = {
 								locale && locale !== 'en'
 									? `/setup/hosted-site-migration/${ locale }`
 									: '/setup/hosted-site-migration';
-							return window.location.assign( migrationFlowLink );
+							return window.location.assign(
+								addQueryArgs( migrationFlowLink, {
+									back_url: goalsUrl,
+								} )
+							);
 						}
 
 						case SiteIntent.DIFM: {
@@ -139,7 +148,11 @@ const onboarding: Flow = {
 									? `/start/do-it-for-me/${ locale }`
 									: '/start/do-it-for-me';
 
-							return window.location.assign( difmFlowLink );
+							return window.location.assign(
+								addQueryArgs( difmFlowLink, {
+									back_url: goalsUrl,
+								} )
+							);
 						}
 
 						default: {

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -137,7 +137,7 @@ const onboarding: Flow = {
 									: '/setup/hosted-site-migration';
 							return window.location.assign(
 								addQueryArgs( migrationFlowLink, {
-									back_url: goalsUrl,
+									back_to: goalsUrl,
 								} )
 							);
 						}
@@ -150,7 +150,7 @@ const onboarding: Flow = {
 
 							return window.location.assign(
 								addQueryArgs( difmFlowLink, {
-									back_url: goalsUrl,
+									back_to: goalsUrl,
 								} )
 							);
 						}

--- a/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
@@ -49,7 +49,9 @@ describe( 'Onboarding Flow', () => {
 				},
 			} );
 
-			expect( window.location.assign ).toHaveBeenCalledWith( '/setup/hosted-site-migration' );
+			expect( window.location.assign ).toHaveBeenCalledWith(
+				'/setup/hosted-site-migration?back_to=%2Fsetup%2Fonboarding%2Fgoals'
+			);
 		} );
 
 		it( 'should redirect to DIFM flow when intent is DIFM', async () => {
@@ -62,7 +64,9 @@ describe( 'Onboarding Flow', () => {
 				},
 			} );
 
-			expect( window.location.assign ).toHaveBeenCalledWith( '/start/do-it-for-me' );
+			expect( window.location.assign ).toHaveBeenCalledWith(
+				'/start/do-it-for-me?back_to=%2Fsetup%2Fonboarding%2Fgoals'
+			);
 		} );
 
 		it( 'should navigate to designSetup step for other intents', async () => {

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -9,6 +9,7 @@ import { usePresalesChat } from 'calypso/lib/presales-chat';
 import flows from 'calypso/signup/config/flows';
 import NavigationLink from 'calypso/signup/navigation-link';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { isReskinnedFlow } from '../is-flow';
 import './style.scss';
 
@@ -67,7 +68,7 @@ class StepWrapper extends Component {
 				backUrl={ this.props.backUrl }
 				rel={ this.props.isExternalBackUrl ? 'external' : '' }
 				labelText={ this.props.backLabelText }
-				allowBackFirstStep={ this.props.allowBackFirstStep }
+				allowBackFirstStep={ this.props.allowBackFirstStep || !! this.props.backUrl }
 				backIcon={ isReskinnedFlow( this.props.flowName ) ? 'chevron-left' : undefined }
 				queryParams={ this.props.queryParams }
 			/>
@@ -265,8 +266,14 @@ class StepWrapper extends Component {
 	}
 }
 
-export default connect( ( state ) => {
+export default connect( ( state, ownProps ) => {
+	const backToParam = getCurrentQueryArguments( state )?.back_to?.toString();
+	const backTo = backToParam?.startsWith( '/' ) ? backToParam : undefined;
+
+	const backUrl = ownProps.backUrl ?? backTo;
+
 	return {
+		backUrl,
 		userLoggedIn: isUserLoggedIn( state ),
 	};
 } )( localize( StepWrapper ) );

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -57,7 +57,7 @@
 	@mixin unstick {
 		position: absolute;
 		top: 9px;
-		left: 11px;
+		left: 56px;
 		right: 16px;
 		padding: 0;
 		border: none;

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -753,13 +753,11 @@ export class UserStep extends Component {
 			return null;
 		}
 
-		const backUrl = this.props.backUrl?.startsWith( '/' ) ? this.props.backUrl : undefined;
-
 		// TODO: decouple hideBack flag from the flow name.
 		return (
 			<StepWrapper
-				backUrl={ backUrl }
-				allowBackFirstStep={ !! backUrl }
+				backUrl={ this.props.backUrl }
+				allowBackFirstStep={ !! this.props.backUrl }
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				headerText={ this.getHeaderText() }
@@ -777,8 +775,10 @@ export class UserStep extends Component {
 const ConnectedUser = connect(
 	( state ) => {
 		const oauth2Client = getCurrentOAuth2Client( state );
+		const backUrl = get( getCurrentQueryArguments( state ), 'back_url' );
+
 		return {
-			backUrl: get( getCurrentQueryArguments( state ), 'back_url' ),
+			backUrl: backUrl?.startsWith( '/' ) ? backUrl : undefined,
 			oauth2Client: oauth2Client,
 			suggestedUsername: getSuggestedUsername( state ),
 			wccomFrom: getWccomFrom( state ),

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -753,9 +753,13 @@ export class UserStep extends Component {
 			return null;
 		}
 
+		const backUrl = this.props.backUrl?.startsWith( '/' ) ? this.props.backUrl : undefined;
+
 		// TODO: decouple hideBack flag from the flow name.
 		return (
 			<StepWrapper
+				backUrl={ backUrl }
+				allowBackFirstStep={ !! backUrl }
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				headerText={ this.getHeaderText() }
@@ -774,6 +778,7 @@ const ConnectedUser = connect(
 	( state ) => {
 		const oauth2Client = getCurrentOAuth2Client( state );
 		return {
+			backUrl: get( getCurrentQueryArguments( state ), 'back_url' ),
 			oauth2Client: oauth2Client,
 			suggestedUsername: getSuggestedUsername( state ),
 			wccomFrom: getWccomFrom( state ),

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -756,8 +756,6 @@ export class UserStep extends Component {
 		// TODO: decouple hideBack flag from the flow name.
 		return (
 			<StepWrapper
-				backUrl={ this.props.backUrl }
-				allowBackFirstStep={ !! this.props.backUrl }
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				headerText={ this.getHeaderText() }
@@ -775,10 +773,8 @@ export class UserStep extends Component {
 const ConnectedUser = connect(
 	( state ) => {
 		const oauth2Client = getCurrentOAuth2Client( state );
-		const backUrl = get( getCurrentQueryArguments( state ), 'back_url' );
 
 		return {
-			backUrl: backUrl?.startsWith( '/' ) ? backUrl : undefined,
 			oauth2Client: oauth2Client,
 			suggestedUsername: getSuggestedUsername( state ),
 			wccomFrom: getWccomFrom( state ),


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/97706.

## Proposed Changes

Title. I'm not sure if the chosen approach here is the best - please let me know if there's a better way of achieving it for both flows.

## Why are these changes being made?

Continuity, UX.

## Testing Instructions

Enter `/setup/onboarding` and click the DIFM link. You should be redirected to the login screen with the back button enabled and that button should send you back to the goals screen.

Do the same for the import link in the goals step.