### PR TITLE
Goals-first: Remove extra top spacing in the goals step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -129,6 +129,7 @@ button {
 		}
 
 		@include break-xlarge {
+			&.goals,
 			&.domains {
 				margin-top: -60px;
 			}


### PR DESCRIPTION
## Proposed Changes

It seems that we forgot to add the goals step to the list of steps that require top margin tweaking. That was causing a weird extra spacing between the navigation and the heading.

@alshakero let me know if I'm applying the wrong solution here.

| Before | After |
| ------ | ------ |
| <img width="1624" alt="image" src="https://github.com/user-attachments/assets/cf8a7a44-c11c-4f6f-9505-8c59c870def2" /> | <img width="1624" alt="image" src="https://github.com/user-attachments/assets/2606f53f-7848-455e-8aa5-f077152b3f66" /> |