### PR TITLE
Stats: datetime localization improvements

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -5,6 +5,7 @@ import moment from 'moment';
 import AsyncLoad from 'calypso/components/async-load';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import { getSiteFragment, getStatsDefaultSitePage } from 'calypso/lib/route';
+import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import { getSite, getSiteOption } from 'calypso/state/sites/selectors';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
@@ -63,11 +64,6 @@ function getWordAdsFilters( siteId ) {
 			period: 'year',
 		},
 	];
-}
-
-function getMomentSiteZone( state, siteId ) {
-	const gmtOffset = getSiteOption( state, siteId, 'gmt_offset' );
-	return moment().utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 );
 }
 
 export function redirectToActivity( context ) {

--- a/client/my-sites/stats/hooks/use-moment-site-zone.ts
+++ b/client/my-sites/stats/hooks/use-moment-site-zone.ts
@@ -1,16 +1,24 @@
-import moment, { Moment } from 'moment';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import i18n from 'i18n-calypso';
+import moment from 'moment';
 import { useSelector } from 'calypso/state';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-export function getMomentSiteZone(
-	state: object,
-	siteId: number | null,
-	localizedMoment?: () => Moment
-) {
+export function getMomentSiteZone( state: object, siteId: number | null ) {
+	let localeSlug = i18n.getLocaleSlug();
+	if ( localeSlug === null ) {
+		localeSlug = 'en';
+	}
+
+	const localizedMoment = moment().locale( localeSlug );
+
 	const gmtOffset = getSiteOption( state, siteId, 'gmt_offset' ) as number;
-	return ( localizedMoment || moment )().utcOffset( gmtOffset ?? 0 );
+	if ( Number.isFinite( gmtOffset ) ) {
+		return localizedMoment.utcOffset( gmtOffset );
+	}
+
+	// Falls back to the browser's local timezone if no GMT offset is found
+	return localizedMoment;
 }
 
 /**
@@ -18,6 +26,5 @@ export function getMomentSiteZone(
  */
 export default function useMomentSiteZone() {
 	const siteId = useSelector( getSelectedSiteId );
-	const localizedMoment = useLocalizedMoment();
-	return useSelector( ( state ) => getMomentSiteZone( state, siteId, localizedMoment ) );
+	return useSelector( ( state ) => getMomentSiteZone( state, siteId ) );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76912.

## Proposed Changes

- Drops the duplicated `getMomentSiteZone()` implementation;
- Adds locale information to the`Moment` instance;
- Tries first to use the site timezone;
- Defaults to the user browser timezone instead of `UTC`, if the site timezone isn't available.

The suggestion was to use `withLocalizedMoment()`, but that wouldn't work in the `getMomentSiteZone()` function. It returns a `Moment` instance and not an actual React component to be wrapped by a High-Order Component (HOC).

It was also suggested to use the current user timezone as an intermediate fallback, but this information doesn't actually exist (p1734669805865359-slack-C82FZ5T4G). We only have site and browser timezone information.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR implements the suggestions made on issue #76912, improving how datetime localization is handled.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I'm not aware of an example site that lacks the `gmt_offset` option, so the easiest way to simulate the fallback is to comment the line `return localizedMoment.utcOffset( gmtOffset );`. After that, it's possible to explore datetime information in the chart available at `/stats/day/jetpack.com`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
