### PR TITLE
Add additional props to relevant track events

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -138,6 +138,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		} else {
 			recordTracksEvent( 'calypso_signup_free_plan_select', {
 				from_section: 'default',
+				flow: flowName,
 			} );
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util.ts
@@ -90,6 +90,7 @@ export const buildUpgradeFunction = (
 	} else {
 		recordTracksEvent( 'calypso_signup_free_plan_select', {
 			from_section: stepSectionName ? stepSectionName : 'default',
+			flow: flowName,
 		} );
 	}
 

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -2,7 +2,7 @@ import { OnboardSelect, Onboard } from '@automattic/data-stores';
 import { ONBOARDING_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { pathToUrl } from 'calypso/lib/url';
 import {
@@ -10,7 +10,10 @@ import {
 	setSignupCompleteFlowName,
 	setSignupCompleteSlug,
 } from 'calypso/signup/storageUtils';
-import { STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT } from '../constants';
+import {
+	STEPPER_TRACKS_EVENT_SIGNUP_START,
+	STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
+} from '../constants';
 import { useFlowLocale } from '../hooks/use-flow-locale';
 import { useQuery } from '../hooks/use-query';
 import { ONBOARD_STORE } from '../stores';
@@ -38,6 +41,19 @@ const onboarding: Flow = {
 	name: ONBOARDING_FLOW,
 	isSignupFlow: true,
 	__experimentalUseBuiltinAuth: true,
+	useTracksEventProps() {
+		const isGoalsAtFrontExperiment = useGoalsFirstExperiment()[ 1 ];
+
+		return useMemo(
+			() => ( {
+				[ STEPPER_TRACKS_EVENT_SIGNUP_START ]: {
+					is_goals_first: isGoalsAtFrontExperiment.toString(),
+					...( isGoalsAtFrontExperiment && { step: 'goals' } ),
+				},
+			} ),
+			[ isGoalsAtFrontExperiment ]
+		);
+	},
 	useSteps() {
 		// We have already checked the value has loaded in useAssertConditions
 		const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();

--- a/client/landing/stepper/hooks/use-record-signup-complete.ts
+++ b/client/landing/stepper/hooks/use-record-signup-complete.ts
@@ -10,19 +10,28 @@ import type { UserSelect, OnboardSelect } from '@automattic/data-stores';
 export const useRecordSignupComplete = ( flow: string | null ) => {
 	const site = useSite();
 	const siteId = site?.ID || null;
-	const theme = site?.options?.theme_slug || '';
-	const { userId, domainCartItem, planCartItem, selectedDomain, signupDomainOrigin } = useSelect(
-		( select ) => {
-			return {
-				userId: ( select( USER_STORE ) as UserSelect ).getCurrentUser()?.ID,
-				domainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem(),
-				planCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
-				selectedDomain: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDomain(),
-				signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
-			};
-		},
-		[]
-	);
+
+	const {
+		userId,
+		domainCartItem,
+		planCartItem,
+		selectedDomain,
+		signupDomainOrigin,
+		goals,
+		selectedDesign,
+	} = useSelect( ( select ) => {
+		return {
+			userId: ( select( USER_STORE ) as UserSelect ).getCurrentUser()?.ID,
+			domainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem(),
+			planCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
+			selectedDomain: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDomain(),
+			signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
+			goals: ( select( ONBOARD_STORE ) as OnboardSelect ).getGoals(),
+			selectedDesign: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
+		};
+	}, [] );
+
+	const theme = site?.options?.theme_slug || selectedDesign?.slug || '';
 
 	return useCallback(
 		( signupCompletionState: Record< string, unknown > ) => {
@@ -61,6 +70,7 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 						hasPaidDomainItem && domainCartItem ? isDomainTransfer( domainCartItem ) : undefined,
 					signupDomainOrigin: signupDomainOrigin ?? SIGNUP_DOMAIN_ORIGIN.NOT_SET,
 					framework: 'stepper',
+					goals: goals.length && goals?.join( ',' ),
 				},
 				true
 			);
@@ -74,6 +84,7 @@ export const useRecordSignupComplete = ( flow: string | null ) => {
 			siteId,
 			theme,
 			userId,
+			goals,
 		]
 	);
 };

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -54,6 +54,7 @@ export function recordSignupComplete(
 		signupDomainOrigin,
 		elapsedTimeSinceStart = null,
 		framework,
+		goals,
 	},
 	now
 ) {
@@ -80,6 +81,7 @@ export function recordSignupComplete(
 				isMapping,
 				signupDomainOrigin,
 				framework,
+				goals,
 			},
 			true
 		);
@@ -106,6 +108,7 @@ export function recordSignupComplete(
 		is_mapping: isMapping,
 		signup_domain_origin: signupDomainOrigin,
 		framework,
+		goals,
 	} );
 
 	// Google Analytics


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/97576

## Proposed Changes

* add `is_goals_first` and `goals` step to the `calypso_setup_start` event
* add flow prop to `calypso_signup_free_plan_select`
* add list of goals and also theme to `calypso_signup_complete`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To help accurately segment users of this event

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding` 
* Check console log for events fired
* check the events for the new props.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
