### PR TITLE
Stats: Show 'sending email' notice

### DIFF
--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -251,7 +251,7 @@ class StatsEmailDetail extends Component {
 									siteId={ siteId }
 									postId={ postId }
 									statType={ statType }
-									date={ date }
+									post={ post }
 								/>
 
 								<StatsPeriodHeader>

--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -247,7 +247,12 @@ class StatsEmailDetail extends Component {
 							<div className="stats__email-wrapper">
 								<h3 className="highlight-cards-heading">{ this.getTitle( statType ) }</h3>
 
-								<StatsEmailTopRow siteId={ siteId } postId={ postId } statType={ statType } />
+								<StatsEmailTopRow
+									siteId={ siteId }
+									postId={ postId }
+									statType={ statType }
+									date={ date }
+								/>
 
 								<StatsPeriodHeader>
 									<StatsPeriodNavigation

--- a/client/my-sites/stats/stats-email-top-row/index.jsx
+++ b/client/my-sites/stats/stats-email-top-row/index.jsx
@@ -3,6 +3,7 @@ import { eye } from '@automattic/components/src/icons';
 import { Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import moment from 'moment';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { PERIOD_ALL_TIME } from 'calypso/state/stats/emails/constants';
@@ -13,7 +14,7 @@ import {
 import TopCard from './top-card';
 import './style.scss';
 
-export default function StatsEmailTopRow( { siteId, postId, statType, className } ) {
+export default function StatsEmailTopRow( { siteId, postId, statType, className, date } ) {
 	const translate = useTranslate();
 
 	const counts = useSelector( ( state ) =>
@@ -22,6 +23,16 @@ export default function StatsEmailTopRow( { siteId, postId, statType, className 
 	const isRequesting = useSelector( ( state ) =>
 		isRequestingEmailStats( state, siteId, postId, PERIOD_ALL_TIME, statType )
 	);
+
+	/**
+	 * Only show some email stats if post published more than 5 minutes ago.
+	 * As part of this, we fix the date sometimes object having wrong time of day
+	 * and normalize to utc to account for time zones differences.
+	 */
+	const correctedPostDateWithTime = moment.parseZone( date._i ).utc();
+	const now = moment().utc();
+	const minutesSincePublishing = now.diff( correctedPostDateWithTime, 'minutes' );
+	const emailIsSending = minutesSincePublishing < 5;
 
 	const boxes = useMemo( () => {
 		switch ( statType ) {
@@ -33,6 +44,7 @@ export default function StatsEmailTopRow( { siteId, postId, statType, className 
 							value={ counts?.total_sends ?? 0 }
 							isLoading={ isRequesting && ! counts?.hasOwnProperty( 'total_sends' ) }
 							icon={ <Gridicon icon="mail" /> }
+							emailIsSending={ emailIsSending }
 						/>
 						{ counts?.unique_opens ? (
 							<TopCard
@@ -53,6 +65,7 @@ export default function StatsEmailTopRow( { siteId, postId, statType, className 
 							value={ counts?.opens_rate ? `${ Math.round( counts?.opens_rate * 100 ) }%` : null }
 							isLoading={ isRequesting && ! counts?.hasOwnProperty( 'opens_rate' ) }
 							icon={ <Gridicon icon="trending" /> }
+							emailIsSending={ emailIsSending }
 						/>
 					</>
 				);
@@ -82,7 +95,7 @@ export default function StatsEmailTopRow( { siteId, postId, statType, className 
 			default:
 				return null;
 		}
-	}, [ statType, counts, translate, isRequesting ] );
+	}, [ statType, counts, translate, isRequesting, emailIsSending ] );
 
 	return (
 		<div className={ clsx( 'stats-email-open-top-row', className ?? null ) }>

--- a/client/my-sites/stats/stats-email-top-row/index.jsx
+++ b/client/my-sites/stats/stats-email-top-row/index.jsx
@@ -14,7 +14,7 @@ import {
 import TopCard from './top-card';
 import './style.scss';
 
-export default function StatsEmailTopRow( { siteId, postId, statType, className, date } ) {
+export default function StatsEmailTopRow( { siteId, postId, statType, className, post } ) {
 	const translate = useTranslate();
 
 	const counts = useSelector( ( state ) =>
@@ -25,14 +25,10 @@ export default function StatsEmailTopRow( { siteId, postId, statType, className,
 	);
 
 	/**
-	 * Only show some email stats if post published more than 5 minutes ago.
-	 * As part of this, we fix the date sometimes object having wrong time of day
-	 * and normalize to utc to account for time zones differences.
+	 * Only show email stats if post was published more than 5 minutes ago.
 	 */
-	const correctedPostDateWithTime = moment.parseZone( date._i ).utc();
-	const now = moment().utc();
-	const minutesSincePublishing = now.diff( correctedPostDateWithTime, 'minutes' );
-	const emailIsSending = minutesSincePublishing < 5;
+	const now = moment();
+	const emailIsSending = post?.date ? now.diff( moment( post?.date ), 'minutes' ) < 5 : false;
 
 	const boxes = useMemo( () => {
 		switch ( statType ) {

--- a/client/my-sites/stats/stats-email-top-row/style.scss
+++ b/client/my-sites/stats/stats-email-top-row/style.scss
@@ -9,7 +9,7 @@ $vertical-margin: 32px;
 	color: var(--studio-gray-100);
 	font-size: $font-body-small;
 	margin-bottom: $vertical-margin;
-	.sending-email .highlight-card-count-value {
+	.is-sending-email .highlight-card-count-value {
 		font-size: $font-body-small;
 		font-style: italic;
 		font-family: $sans;

--- a/client/my-sites/stats/stats-email-top-row/style.scss
+++ b/client/my-sites/stats/stats-email-top-row/style.scss
@@ -9,6 +9,12 @@ $vertical-margin: 32px;
 	color: var(--studio-gray-100);
 	font-size: $font-body-small;
 	margin-bottom: $vertical-margin;
+	.sending-email .highlight-card-count-value {
+		font-size: $font-body-small;
+		font-style: italic;
+		font-family: $sans;
+		padding-top: 10px;
+	}
 }
 
 .stats__email-detail {

--- a/client/my-sites/stats/stats-email-top-row/top-card.jsx
+++ b/client/my-sites/stats/stats-email-top-row/top-card.jsx
@@ -36,7 +36,7 @@ const TopCard = ( { heading, icon, value, isLoading, emailIsSending = false } ) 
 		<Card className="highlight-card">
 			<div className="highlight-card-icon">{ icon }</div>
 			<div className="highlight-card-heading">{ heading }</div>
-			<div className={ `highlight-card-count ${ emailIsSending ? 'sending-email' : '' }` }>
+			<div className={ `highlight-card-count ${ emailIsSending ? 'is-sending-email' : '' }` }>
 				<TopCardValue
 					value={ emailIsSending ? translate( 'Still sending emails.' ) : value }
 					isLoading={ isLoading }

--- a/client/my-sites/stats/stats-email-top-row/top-card.jsx
+++ b/client/my-sites/stats/stats-email-top-row/top-card.jsx
@@ -1,4 +1,5 @@
 import { Card, ShortenedNumber, Spinner } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 
 /* This is a very stripped down version of HighlightCard
  * HighlightCard doesn't support non-numeric values
@@ -29,13 +30,17 @@ const TopCardValue = ( { value, isLoading } ) => {
 	);
 };
 
-const TopCard = ( { heading, icon, value, isLoading } ) => {
+const TopCard = ( { heading, icon, value, isLoading, emailIsSending = false } ) => {
+	const translate = useTranslate();
 	return (
 		<Card className="highlight-card">
 			<div className="highlight-card-icon">{ icon }</div>
 			<div className="highlight-card-heading">{ heading }</div>
-			<div className="highlight-card-count">
-				<TopCardValue value={ value } isLoading={ isLoading } />
+			<div className={ `highlight-card-count ${ emailIsSending ? 'sending-email' : '' }` }>
+				<TopCardValue
+					value={ emailIsSending ? translate( 'Still sending emails.' ) : value }
+					isLoading={ isLoading }
+				/>
 			</div>
 		</Card>
 	);


### PR DESCRIPTION
Resolves: https://github.com/Automattic/wp-calypso/issues/87174
Addresses: https://github.com/Automattic/jetpack/issues/40524
Related designs and P2:  p1HpG7-v7v-p2

## Proposed Changes

Context: If users publish a post and then go to the newsletter stats page too quickly, they will see stats showing a small number of emails sent, which has proven confusing. 

Changes: 
- We now show "Still sending emails" notice in place of stats for the first 5 minutes after a post is published.

The stats now look like this for the first 5 minutes after publishing a post:
<img width="1217" alt="still-sending-emails" src="https://github.com/user-attachments/assets/d674512e-c612-4782-9610-1706ebb329c3" />

## Testing Instructions

- Check this out and go to a test site where you have some subscribers.
- Publish a post. If necessary, be sure to set it to send emails to subscribers.
- Go to Stats > Subscribers > Emails > the individual page for this post (or go directly to http://calypso.localhost:3000/stats/email/opens/day/[POSTID]/[YOURWEBSITEURL])
- Confirm you see "Still sending emails." for the first five minutes,.
- After 5 minutes, confirm you see numbers (if you publish on a site or in a way where no emails are sent, you'll just see 0 after 5 minutes). 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?