### PR TITLE
Jetpack Checkout: add note after purchasing a Jetpack license

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-license-key-clipboard.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-license-key-clipboard.tsx
@@ -74,6 +74,9 @@ const JetpackLicenseKeyClipboard: React.FC< JetpackLicenseKeyProps > = ( {
 						{ copied ? translate( 'Copied!' ) : translate( 'Copy', { context: 'verb' } ) }
 					</ClipboardButton>
 				</div>
+				<div className="jetpack-license-key-clipboard__helper-text">
+					{ translate( 'We sent the license key to your email inbox too.' ) }
+				</div>
 			</div>
 		</>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -702,6 +702,12 @@
 
 .jetpack-license-key-clipboard {
 	margin-top: 40px;
+
+	.jetpack-license-key-clipboard__helper-text {
+		color: var(--color-neutral-60);
+		font-size: 0.875rem;
+		margin-top: 8px;
+	}
 }
 
 .jetpack-license-key-clipboard__container {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-backup-team/issues/601

## Proposed Changes

* Add note after purchasing a Jetpack license

| Before | After |
|---|---|
| ![CleanShot 2024-12-20 at 20 56 00@2x](https://github.com/user-attachments/assets/33eb889a-bfe0-4885-b8f7-a79bced9a588) | ![CleanShot 2024-12-20 at 20 55 31@2x](https://github.com/user-attachments/assets/4c24338d-33c1-4236-9ecf-6ac00f0862f1) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://github.com/Automattic/jetpack-backup-team/issues/601

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://cloud.jetpack.com/pricing
* Purchase a Jetpack VaultPress Backup plan
* When it prompts you to select a site to apply the plan, select `I don't see my site. Let me configure it manually`.
  ![CleanShot 2024-12-20 at 20 59 55@2x](https://github.com/user-attachments/assets/6f68eadd-75e7-48ee-8011-c00398d221fa)
* When you are on the `Ok, let's install Jetpack (...)` screen, copy the URL and now replace `wordpress.com` with your Calypso Blue live branch domain
* Ensure you see the new note below the license key (as shared in the screenshot above).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
