### PR TITLE
Email Stats: Add Opens and Clicks tooltips

### DIFF
--- a/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
@@ -87,7 +87,7 @@ const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
 							const hasUniques = hasUniqueMetrics( opensUnique, opens );
 							return (
 								<TooltipWrapper
-									value={ hasUniques ? `${ item.opens_rate }%` : '-' }
+									value={ hasUniques ? `${ item.opens_rate }%` : '—' }
 									item={ item }
 									renderContent={ ( item ) => createOpensTooltipContent( item, translate ) }
 								/>
@@ -110,7 +110,7 @@ const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
 						const hasUniques = hasUniqueMetrics( clicksUnique, clicks );
 						return (
 							<TooltipWrapper
-								value={ hasUniques ? `${ item.clicks_rate }%` : translate( '-' ) }
+								value={ hasUniques ? `${ item.clicks_rate }%` : '—' }
 								item={ item }
 								renderContent={ ( item ) => createClicksTooltipContent( item, translate ) }
 							/>

--- a/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
@@ -82,14 +82,14 @@ const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
 					additionalColumns={ {
 						header: <span>{ translate( 'Opens' ) }</span>,
 						body: ( item: EmailStatsItem ) => {
-							const opensUnique = parseInt( item.unique_opens, 10 );
-							const opens = parseInt( item.opens, 10 );
+							const opensUnique = parseInt( String( item.unique_opens ), 10 );
+							const opens = parseInt( String( item.opens ), 10 );
 							const hasUniques = hasUniqueMetrics( opensUnique, opens );
 							return (
 								<TooltipWrapper
 									value={ hasUniques ? `${ item.opens_rate }%` : '—' }
 									item={ item }
-									renderContent={ ( item ) => createOpensTooltipContent( item, translate ) }
+									renderContent={ createOpensTooltipContent }
 								/>
 							);
 						},
@@ -105,14 +105,14 @@ const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
 						if ( ! item?.opens ) {
 							return value;
 						}
-						const clicksUnique = parseInt( item.unique_clicks, 10 );
-						const clicks = parseInt( item.clicks, 10 );
+						const clicksUnique = parseInt( String( item.unique_clicks ), 10 );
+						const clicks = parseInt( String( item.clicks ), 10 );
 						const hasUniques = hasUniqueMetrics( clicksUnique, clicks );
 						return (
 							<TooltipWrapper
 								value={ hasUniques ? `${ item.clicks_rate }%` : '—' }
 								item={ item }
-								renderContent={ ( item ) => createClicksTooltipContent( item, translate ) }
+								renderContent={ createClicksTooltipContent }
 							/>
 						);
 					} }

--- a/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
@@ -19,6 +19,13 @@ import { useShouldGateStats } from '../../../hooks/use-should-gate-stats';
 import StatsModule from '../../../stats-module';
 import { StatsEmptyActionEmail } from '../shared';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
+import {
+	TooltipWrapper,
+	createOpensTooltipContent,
+	createClicksTooltipContent,
+	hasUniqueMetrics,
+	EmailStatsItem,
+} from './tooltips';
 import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
 
 const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
@@ -74,7 +81,25 @@ const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
 					}
 					additionalColumns={ {
 						header: <span>{ translate( 'Opens' ) }</span>,
-						body: ( item: { opens_rate: number } ) => <span>{ `${ item.opens_rate }%` }</span>,
+						body: ( item: EmailStatsItem ) => {
+							const opensUnique = parseInt( item.unique_opens, 10 );
+							const opens = parseInt( item.opens, 10 );
+							const hasUniques = hasUniqueMetrics( opensUnique, opens );
+							return (
+								<TooltipWrapper
+									value={
+										hasUniques
+											? `${ item.opens_rate }%`
+											: translate(
+													/* translators: Shown in a table column when email open rate data is not available */
+													'n/a'
+											  )
+									}
+									item={ item }
+									renderContent={ ( item ) => createOpensTooltipContent( item, translate ) }
+								/>
+							);
+						},
 					} }
 					moduleStrings={ moduleStrings }
 					period={ period }
@@ -83,8 +108,28 @@ const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
 					mainItemLabel={ translate( 'Latest Emails' ) }
 					metricLabel={ translate( 'Clicks' ) }
 					valueField="clicks_rate"
-					formatValue={ ( value: number ) => `${ value }%` }
-					showSummaryLink
+					formatValue={ ( value: number, item: EmailStatsItem ) => {
+						if ( ! item?.opens ) {
+							return value;
+						}
+						const clicksUnique = parseInt( item.unique_clicks, 10 );
+						const clicks = parseInt( item.clicks, 10 );
+						const hasUniques = hasUniqueMetrics( clicksUnique, clicks );
+						return (
+							<TooltipWrapper
+								value={
+									hasUniques
+										? `${ item.clicks_rate }%`
+										: translate(
+												/* translators: Shown in a table column when email click rate data is not available */
+												'n/a'
+										  )
+								}
+								item={ item }
+								renderContent={ ( item ) => createClicksTooltipContent( item, translate ) }
+							/>
+						);
+					} }
 					className={ className }
 					hasNoBackground
 					skipQuery

--- a/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
@@ -87,14 +87,7 @@ const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
 							const hasUniques = hasUniqueMetrics( opensUnique, opens );
 							return (
 								<TooltipWrapper
-									value={
-										hasUniques
-											? `${ item.opens_rate }%`
-											: translate(
-													/* translators: Shown in a table column when email open rate data is not available */
-													'n/a'
-											  )
-									}
+									value={ hasUniques ? `${ item.opens_rate }%` : '-' }
 									item={ item }
 									renderContent={ ( item ) => createOpensTooltipContent( item, translate ) }
 								/>
@@ -117,14 +110,7 @@ const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
 						const hasUniques = hasUniqueMetrics( clicksUnique, clicks );
 						return (
 							<TooltipWrapper
-								value={
-									hasUniques
-										? `${ item.clicks_rate }%`
-										: translate(
-												/* translators: Shown in a table column when email click rate data is not available */
-												'n/a'
-										  )
-								}
+								value={ hasUniques ? `${ item.clicks_rate }%` : translate( '-' ) }
 								item={ item }
 								renderContent={ ( item ) => createClicksTooltipContent( item, translate ) }
 							/>

--- a/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
@@ -21,8 +21,8 @@ import { StatsEmptyActionEmail } from '../shared';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
 import {
 	TooltipWrapper,
-	createOpensTooltipContent,
-	createClicksTooltipContent,
+	OpensTooltipContent,
+	ClicksTooltipContent,
 	hasUniqueMetrics,
 	EmailStatsItem,
 } from './tooltips';
@@ -89,7 +89,7 @@ const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
 								<TooltipWrapper
 									value={ hasUniques ? `${ item.opens_rate }%` : '—' }
 									item={ item }
-									renderContent={ createOpensTooltipContent }
+									TooltipContent={ OpensTooltipContent }
 								/>
 							);
 						},
@@ -112,7 +112,7 @@ const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
 							<TooltipWrapper
 								value={ hasUniques ? `${ item.clicks_rate }%` : '—' }
 								item={ item }
-								renderContent={ createClicksTooltipContent }
+								TooltipContent={ ClicksTooltipContent }
 							/>
 						);
 					} }

--- a/client/my-sites/stats/features/modules/stats-emails/tooltips.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/tooltips.tsx
@@ -74,7 +74,7 @@ export const createOpensTooltipContent = (
 					? translate( 'Unique opens: %(uniqueOpens)d (%(openRate).2f%%)', {
 							args: { uniqueOpens: opensUnique, openRate: opensRate },
 					  } )
-					: translate( 'Unique opens: -' ) }
+					: translate( 'Unique opens: —' ) }
 			</div>
 		</div>
 	);
@@ -107,7 +107,7 @@ export const createClicksTooltipContent = (
 					? translate( 'Unique clicks: %(uniqueClicks)d (%(clickRate).2f%%)', {
 							args: { uniqueClicks: clicksUnique, clickRate: clicksRate },
 					  } )
-					: translate( 'Unique clicks: -' ) }
+					: translate( 'Unique clicks: —' ) }
 			</div>
 		</div>
 	);

--- a/client/my-sites/stats/features/modules/stats-emails/tooltips.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/tooltips.tsx
@@ -60,7 +60,7 @@ export const createOpensTooltipContent = (
 	return (
 		<div className="stats-email__tooltip">
 			<div>
-				{ translate( 'Subscribers reached: %(sends)d', {
+				{ translate( 'Recipients: %(sends)d', {
 					args: { sends: totalSends },
 				} ) }
 			</div>
@@ -74,7 +74,7 @@ export const createOpensTooltipContent = (
 					? translate( 'Unique opens: %(uniqueOpens)d (%(openRate).2f%%)', {
 							args: { uniqueOpens: opensUnique, openRate: opensRate },
 					  } )
-					: translate( 'Unique opens: n/a' ) }
+					: translate( 'Unique opens: -' ) }
 			</div>
 		</div>
 	);
@@ -93,7 +93,7 @@ export const createClicksTooltipContent = (
 	return (
 		<div className="stats-email__tooltip">
 			<div>
-				{ translate( 'Subscribers reached: %(sends)d', {
+				{ translate( 'Recipients: %(sends)d', {
 					args: { sends: totalSends },
 				} ) }
 			</div>
@@ -107,7 +107,7 @@ export const createClicksTooltipContent = (
 					? translate( 'Unique clicks: %(uniqueClicks)d (%(clickRate).2f%%)', {
 							args: { uniqueClicks: clicksUnique, clickRate: clicksRate },
 					  } )
-					: translate( 'Unique clicks: n/a' ) }
+					: translate( 'Unique clicks: -' ) }
 			</div>
 		</div>
 	);

--- a/client/my-sites/stats/features/modules/stats-emails/tooltips.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/tooltips.tsx
@@ -1,0 +1,114 @@
+import { Tooltip } from '@automattic/components';
+import { TranslateResult } from 'i18n-calypso';
+import React, { useRef, useState } from 'react';
+
+export interface EmailStatsItem {
+	unique_opens: number;
+	opens: number;
+	opens_rate: number;
+	unique_clicks: number;
+	clicks: number;
+	clicks_rate: number;
+	total_sends: number;
+}
+
+interface TooltipWrapperProps {
+	value: string;
+	item: EmailStatsItem;
+	renderContent: ( item: EmailStatsItem ) => React.ReactNode;
+}
+
+export const TooltipWrapper: React.FC< TooltipWrapperProps > = ( {
+	value,
+	item,
+	renderContent,
+} ) => {
+	const triggerRef = useRef< HTMLSpanElement >( null );
+	const [ showTooltip, setShowTooltip ] = useState( false );
+
+	return (
+		<span className="stats-email__tooltip-wrapper">
+			<span
+				ref={ triggerRef }
+				className="stats-email__tooltip-trigger"
+				onMouseEnter={ () => setShowTooltip( true ) }
+				onMouseLeave={ () => setShowTooltip( false ) }
+			>
+				{ value }
+			</span>
+			<Tooltip position="top" context={ triggerRef.current } isVisible={ showTooltip }>
+				{ renderContent( item ) }
+			</Tooltip>
+		</span>
+	);
+};
+
+export const hasUniqueMetrics = ( uniqueValue: number, totalValue: number ) => {
+	return uniqueValue > 0 && totalValue > 0;
+};
+
+export const createOpensTooltipContent = (
+	item: any,
+	translate: ( text: string, options?: { args: Record< string, any > } ) => TranslateResult
+) => {
+	const opensUnique = parseInt( item.unique_opens, 10 );
+	const opens = parseInt( item.opens, 10 );
+	const opensRate = parseFloat( item.opens_rate );
+	const totalSends = parseInt( item.total_sends, 10 );
+	const hasUniques = hasUniqueMetrics( opensUnique, opens );
+
+	return (
+		<div className="stats-email__tooltip">
+			<div>
+				{ translate( 'Subscribers reached: %(sends)d', {
+					args: { sends: totalSends },
+				} ) }
+			</div>
+			<div>
+				{ translate( 'Total opens: %(opens)d', {
+					args: { opens },
+				} ) }
+			</div>
+			<div>
+				{ hasUniques
+					? translate( 'Unique opens: %(uniqueOpens)d (%(openRate).2f%%)', {
+							args: { uniqueOpens: opensUnique, openRate: opensRate },
+					  } )
+					: translate( 'Unique opens: n/a' ) }
+			</div>
+		</div>
+	);
+};
+
+export const createClicksTooltipContent = (
+	item: any,
+	translate: ( text: string, options?: { args: Record< string, any > } ) => TranslateResult
+) => {
+	const clicksUnique = parseInt( item.unique_clicks, 10 );
+	const clicks = parseInt( item.clicks, 10 );
+	const clicksRate = parseFloat( item.clicks_rate );
+	const totalSends = parseInt( item.total_sends, 10 );
+	const hasUniques = hasUniqueMetrics( clicksUnique, clicks );
+
+	return (
+		<div className="stats-email__tooltip">
+			<div>
+				{ translate( 'Subscribers reached: %(sends)d', {
+					args: { sends: totalSends },
+				} ) }
+			</div>
+			<div>
+				{ translate( 'Total clicks: %(clicks)d', {
+					args: { clicks },
+				} ) }
+			</div>
+			<div>
+				{ hasUniques
+					? translate( 'Unique clicks: %(uniqueClicks)d (%(clickRate).2f%%)', {
+							args: { uniqueClicks: clicksUnique, clickRate: clicksRate },
+					  } )
+					: translate( 'Unique clicks: n/a' ) }
+			</div>
+		</div>
+	);
+};

--- a/client/my-sites/stats/features/modules/stats-emails/tooltips.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/tooltips.tsx
@@ -1,5 +1,5 @@
 import { Tooltip } from '@automattic/components';
-import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import React, { useRef, useState } from 'react';
 
 export interface EmailStatsItem {
@@ -15,20 +15,16 @@ export interface EmailStatsItem {
 interface TooltipWrapperProps {
 	value: string;
 	item: EmailStatsItem;
-	renderContent: (
-		item: EmailStatsItem,
-		translate: ( text: string, options?: { args: Record< string, any > } ) => TranslateResult
-	) => React.ReactNode;
+	TooltipContent: React.ComponentType< { item: EmailStatsItem } >;
 }
 
 export const TooltipWrapper: React.FC< TooltipWrapperProps > = ( {
 	value,
 	item,
-	renderContent,
+	TooltipContent,
 } ) => {
 	const triggerRef = useRef< HTMLSpanElement >( null );
 	const [ showTooltip, setShowTooltip ] = useState( false );
-	const translate = useTranslate();
 
 	return (
 		<span className="stats-email__tooltip-wrapper">
@@ -41,7 +37,7 @@ export const TooltipWrapper: React.FC< TooltipWrapperProps > = ( {
 				{ value }
 			</span>
 			<Tooltip position="top" context={ triggerRef.current } isVisible={ showTooltip }>
-				{ renderContent( item, translate ) }
+				<TooltipContent item={ item } />
 			</Tooltip>
 		</span>
 	);
@@ -51,10 +47,8 @@ export const hasUniqueMetrics = ( uniqueValue: number, totalValue: number ) => {
 	return uniqueValue > 0 && totalValue > 0;
 };
 
-export const createOpensTooltipContent = (
-	item: EmailStatsItem,
-	translate: ( text: string, options?: { args: Record< string, any > } ) => TranslateResult
-) => {
+export const OpensTooltipContent: React.FC< { item: EmailStatsItem } > = ( { item } ) => {
+	const translate = useTranslate();
 	const opensUnique = parseInt( String( item.unique_opens ), 10 );
 	const opens = parseInt( String( item.opens ), 10 );
 	const opensRate = parseFloat( String( item.opens_rate ) );
@@ -84,10 +78,8 @@ export const createOpensTooltipContent = (
 	);
 };
 
-export const createClicksTooltipContent = (
-	item: EmailStatsItem,
-	translate: ( text: string, options?: { args: Record< string, any > } ) => TranslateResult
-) => {
+export const ClicksTooltipContent: React.FC< { item: EmailStatsItem } > = ( { item } ) => {
+	const translate = useTranslate();
 	const clicksUnique = parseInt( String( item.unique_clicks ), 10 );
 	const clicks = parseInt( String( item.clicks ), 10 );
 	const clicksRate = parseFloat( String( item.clicks_rate ) );

--- a/client/my-sites/stats/features/modules/stats-emails/tooltips.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/tooltips.tsx
@@ -1,5 +1,5 @@
 import { Tooltip } from '@automattic/components';
-import { TranslateResult } from 'i18n-calypso';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
 import React, { useRef, useState } from 'react';
 
 export interface EmailStatsItem {
@@ -15,7 +15,10 @@ export interface EmailStatsItem {
 interface TooltipWrapperProps {
 	value: string;
 	item: EmailStatsItem;
-	renderContent: ( item: EmailStatsItem ) => React.ReactNode;
+	renderContent: (
+		item: EmailStatsItem,
+		translate: ( text: string, options?: { args: Record< string, any > } ) => TranslateResult
+	) => React.ReactNode;
 }
 
 export const TooltipWrapper: React.FC< TooltipWrapperProps > = ( {
@@ -25,6 +28,7 @@ export const TooltipWrapper: React.FC< TooltipWrapperProps > = ( {
 } ) => {
 	const triggerRef = useRef< HTMLSpanElement >( null );
 	const [ showTooltip, setShowTooltip ] = useState( false );
+	const translate = useTranslate();
 
 	return (
 		<span className="stats-email__tooltip-wrapper">
@@ -37,7 +41,7 @@ export const TooltipWrapper: React.FC< TooltipWrapperProps > = ( {
 				{ value }
 			</span>
 			<Tooltip position="top" context={ triggerRef.current } isVisible={ showTooltip }>
-				{ renderContent( item ) }
+				{ renderContent( item, translate ) }
 			</Tooltip>
 		</span>
 	);
@@ -48,13 +52,13 @@ export const hasUniqueMetrics = ( uniqueValue: number, totalValue: number ) => {
 };
 
 export const createOpensTooltipContent = (
-	item: any,
+	item: EmailStatsItem,
 	translate: ( text: string, options?: { args: Record< string, any > } ) => TranslateResult
 ) => {
-	const opensUnique = parseInt( item.unique_opens, 10 );
-	const opens = parseInt( item.opens, 10 );
-	const opensRate = parseFloat( item.opens_rate );
-	const totalSends = parseInt( item.total_sends, 10 );
+	const opensUnique = parseInt( String( item.unique_opens ), 10 );
+	const opens = parseInt( String( item.opens ), 10 );
+	const opensRate = parseFloat( String( item.opens_rate ) );
+	const totalSends = parseInt( String( item.total_sends ), 10 );
 	const hasUniques = hasUniqueMetrics( opensUnique, opens );
 
 	return (
@@ -81,13 +85,13 @@ export const createOpensTooltipContent = (
 };
 
 export const createClicksTooltipContent = (
-	item: any,
+	item: EmailStatsItem,
 	translate: ( text: string, options?: { args: Record< string, any > } ) => TranslateResult
 ) => {
-	const clicksUnique = parseInt( item.unique_clicks, 10 );
-	const clicks = parseInt( item.clicks, 10 );
-	const clicksRate = parseFloat( item.clicks_rate );
-	const totalSends = parseInt( item.total_sends, 10 );
+	const clicksUnique = parseInt( String( item.unique_clicks ), 10 );
+	const clicks = parseInt( String( item.clicks ), 10 );
+	const clicksRate = parseFloat( String( item.clicks_rate ) );
+	const totalSends = parseInt( String( item.total_sends ), 10 );
 	const hasUniques = hasUniqueMetrics( clicksUnique, clicks );
 
 	return (

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -152,7 +152,14 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 							const hasUniquesData = opensUnique > 0 || opens === 0;
 							return (
 								<TooltipWrapper
-									value={ hasUniquesData ? `${ item.opens_rate }%` : 'n/a' }
+									value={
+										hasUniquesData
+											? `${ item.opens_rate }%`
+											: translate(
+													/* translators: Shown in a table column when email open rate data is not available */
+													'n/a'
+											  )
+									}
 									item={ item }
 									renderContent={ renderOpensTooltipContent }
 								/>
@@ -175,7 +182,14 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 							const hasUniquesData = clicksUnique > 0 || clicks === 0;
 							return (
 								<TooltipWrapper
-									value={ hasUniquesData ? `${ item.clicks_rate }%` : 'n/a' }
+									value={
+										hasUniquesData
+											? `${ item.clicks_rate }%`
+											: translate(
+													/* translators: Shown in a table column when email click rate data is not available */
+													'n/a'
+											  )
+									}
 									item={ item }
 									renderContent={ renderClicksTooltipContent }
 								/>

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -1,4 +1,6 @@
+import { Tooltip } from '@automattic/components';
 import { localize } from 'i18n-calypso';
+import { useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
@@ -12,6 +14,30 @@ import '../summary/style.scss';
 import '../stats-module/summary-nav.scss';
 
 const StatsStrings = statsStringsFactory();
+
+const TooltipWrapper = ( { value, item, renderContent } ) => {
+	const triggerRef = useRef( null );
+	const [ showTooltip, setShowTooltip ] = useState( false );
+
+	const formattedValue =
+		typeof value === 'number' ? Number( value ).toFixed( 2 ) : value.replace( '%', '' ).trim();
+
+	return (
+		<span className="stats-email__tooltip-wrapper">
+			<span
+				ref={ triggerRef }
+				className="stats-email__tooltip-trigger"
+				onMouseEnter={ () => setShowTooltip( true ) }
+				onMouseLeave={ () => setShowTooltip( false ) }
+			>
+				{ `${ formattedValue }%` }
+			</span>
+			<Tooltip position="top" context={ triggerRef.current } isVisible={ showTooltip }>
+				{ renderContent( item ) }
+			</Tooltip>
+		</span>
+	);
+};
 
 const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 	// Navigation settings. One of the following, depending on the summary view.
@@ -36,6 +62,46 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 		backLink += domain;
 	}
 	const navigationItems = [ { label: backLabel, href: backLink }, { label: title } ];
+
+	const renderTooltipContent = ( item ) => {
+		const opensUnique = parseInt( item.opens_unique, 10 ) || 0;
+		const clicksUnique = parseInt( item.clicks_unique, 10 ) || 0;
+		const opens = parseInt( item.opens, 10 ) || 0;
+		const clicks = parseInt( item.clicks, 10 ) || 0;
+		const opensRate = parseFloat( item.opens_rate ) || 0;
+		const clicksRate = parseFloat( item.clicks_rate ) || 0;
+
+		return (
+			<div className="stats-email__tooltip">
+				<div>{ translate( 'Total Opens: %(opens)d', { args: { opens } } ) }</div>
+				<div>
+					{ translate( 'Unique Opens: %(uniqueOpens)d', {
+						args: { uniqueOpens: opensUnique },
+					} ) }
+				</div>
+				<div>
+					{ translate( 'Open Rate: %(openRate).2f%%', {
+						args: { openRate: opensRate },
+					} ) }
+				</div>
+				<div>
+					{ translate( 'Total Clicks: %(clicks)d', {
+						args: { clicks },
+					} ) }
+				</div>
+				<div>
+					{ translate( 'Unique Clicks: %(uniqueClicks)d', {
+						args: { uniqueClicks: clicksUnique },
+					} ) }
+				</div>
+				<div>
+					{ translate( 'Click Rate: %(clickRate).2f%%', {
+						args: { clickRate: clicksRate },
+					} ) }
+				</div>
+			</div>
+		);
+	};
 
 	return (
 		<Main className="has-fixed-nav" wideLayout>
@@ -64,9 +130,11 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 							</>
 						),
 						body: ( item ) => (
-							<>
-								<span>{ `${ item.opens_rate }%` }</span>
-							</>
+							<TooltipWrapper
+								value={ `${ item.opens_rate }%` }
+								item={ item }
+								renderContent={ renderTooltipContent }
+							/>
 						),
 					} }
 					path="emails"
@@ -78,7 +146,18 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 					hideSummaryLink
 					metricLabel={ translate( 'Clicks' ) }
 					valueField="clicks_rate"
-					formatValue={ ( value ) => `${ value }%` }
+					formatValue={ ( value, item ) => {
+						if ( item?.opens !== undefined ) {
+							return (
+								<TooltipWrapper
+									value={ `${ value }%` }
+									item={ item }
+									renderContent={ renderTooltipContent }
+								/>
+							);
+						}
+						return <span>{ `${ value }%` }</span>;
+					} }
 					listItemClassName="stats__summary--narrow-mobile"
 				/>
 				<JetpackColophon />

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -74,14 +74,7 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 							const hasUniquesData = opensUnique > 0 || opens === 0;
 							return (
 								<TooltipWrapper
-									value={
-										hasUniquesData
-											? `${ item.opens_rate }%`
-											: translate(
-													/* translators: Shown in a table column when email open rate data is not available */
-													'n/a'
-											  )
-									}
+									value={ hasUniquesData ? `${ item.opens_rate }%` : '-' }
 									item={ item }
 									renderContent={ createOpensTooltipContent }
 								/>
@@ -104,14 +97,7 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 							const hasUniquesData = clicksUnique > 0 || clicks === 0;
 							return (
 								<TooltipWrapper
-									value={
-										hasUniquesData
-											? `${ item.clicks_rate }%`
-											: translate(
-													/* translators: Shown in a table column when email click rate data is not available */
-													'n/a'
-											  )
-									}
+									value={ hasUniquesData ? `${ item.clicks_rate }%` : '-' }
 									item={ item }
 									renderContent={ createClicksTooltipContent }
 								/>

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -74,7 +74,7 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 							const hasUniquesData = opensUnique > 0 || opens === 0;
 							return (
 								<TooltipWrapper
-									value={ hasUniquesData ? `${ item.opens_rate }%` : '-' }
+									value={ hasUniquesData ? `${ item.opens_rate }%` : '—' }
 									item={ item }
 									renderContent={ createOpensTooltipContent }
 								/>
@@ -97,7 +97,7 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 							const hasUniquesData = clicksUnique > 0 || clicks === 0;
 							return (
 								<TooltipWrapper
-									value={ hasUniquesData ? `${ item.clicks_rate }%` : '-' }
+									value={ hasUniquesData ? `${ item.clicks_rate }%` : '—' }
 									item={ item }
 									renderContent={ createClicksTooltipContent }
 								/>

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -7,8 +7,8 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import {
 	TooltipWrapper,
-	createOpensTooltipContent,
-	createClicksTooltipContent,
+	OpensTooltipContent,
+	ClicksTooltipContent,
 } from '../features/modules/stats-emails/tooltips';
 import StatsModule from '../stats-module';
 import PageViewTracker from '../stats-page-view-tracker';
@@ -76,7 +76,7 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 								<TooltipWrapper
 									value={ hasUniquesData ? `${ item.opens_rate }%` : '—' }
 									item={ item }
-									renderContent={ createOpensTooltipContent }
+									TooltipContent={ OpensTooltipContent }
 								/>
 							);
 						},
@@ -99,7 +99,7 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 								<TooltipWrapper
 									value={ hasUniquesData ? `${ item.clicks_rate }%` : '—' }
 									item={ item }
-									renderContent={ createClicksTooltipContent }
+									TooltipContent={ ClicksTooltipContent }
 								/>
 							);
 						}

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -64,40 +64,38 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 	const navigationItems = [ { label: backLabel, href: backLink }, { label: title } ];
 
 	const renderTooltipContent = ( item ) => {
-		const opensUnique = parseInt( item.opens_unique, 10 ) || 0;
-		const clicksUnique = parseInt( item.clicks_unique, 10 ) || 0;
-		const opens = parseInt( item.opens, 10 ) || 0;
-		const clicks = parseInt( item.clicks, 10 ) || 0;
-		const opensRate = parseFloat( item.opens_rate ) || 0;
-		const clicksRate = parseFloat( item.clicks_rate ) || 0;
+		const opensUnique = parseInt( item.opens_unique, 10 );
+		const clicksUnique = parseInt( item.clicks_unique, 10 );
+		const opens = parseInt( item.opens, 10 );
+		const clicks = parseInt( item.clicks, 10 );
+		const opensRate = parseFloat( item.opens_rate );
+		const clicksRate = parseFloat( item.clicks_rate );
+		const totalSends = parseInt( item.total_sends, 10 );
 
 		return (
 			<div className="stats-email__tooltip">
-				<div>{ translate( 'Total Opens: %(opens)d', { args: { opens } } ) }</div>
 				<div>
-					{ translate( 'Unique Opens: %(uniqueOpens)d', {
-						args: { uniqueOpens: opensUnique },
+					{ translate( 'Subscribers reached: %(sends)d', {
+						args: { sends: totalSends },
 					} ) }
 				</div>
 				<div>
-					{ translate( 'Open Rate: %(openRate).2f%%', {
-						args: { openRate: opensRate },
-					} ) }
+					{ opensUnique
+						? translate( 'Unique opens: %(uniqueOpens)d (%(openRate).2f%%)', {
+								args: { uniqueOpens: opensUnique, openRate: opensRate },
+						  } )
+						: translate( 'Opens: %(opens)d)', {
+								args: { opens },
+						  } ) }
 				</div>
 				<div>
-					{ translate( 'Total Clicks: %(clicks)d', {
-						args: { clicks },
-					} ) }
-				</div>
-				<div>
-					{ translate( 'Unique Clicks: %(uniqueClicks)d', {
-						args: { uniqueClicks: clicksUnique },
-					} ) }
-				</div>
-				<div>
-					{ translate( 'Click Rate: %(clickRate).2f%%', {
-						args: { clickRate: clicksRate },
-					} ) }
+					{ clicksUnique
+						? translate( 'Unique clicks: %(uniqueClicks)d (%(clickRate).2f%%)', {
+								args: { uniqueClicks: clicksUnique, clickRate: clicksRate },
+						  } )
+						: translate( 'Clicks: %(clicks)d ', {
+								args: { clicks },
+						  } ) }
 				</div>
 			</div>
 		);

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -1,12 +1,15 @@
-import { Tooltip } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import {
+	TooltipWrapper,
+	createOpensTooltipContent,
+	createClicksTooltipContent,
+} from '../features/modules/stats-emails/tooltips';
 import StatsModule from '../stats-module';
 import PageViewTracker from '../stats-page-view-tracker';
 import statsStringsFactory from '../stats-strings';
@@ -14,27 +17,6 @@ import '../summary/style.scss';
 import '../stats-module/summary-nav.scss';
 
 const StatsStrings = statsStringsFactory();
-
-const TooltipWrapper = ( { value, item, renderContent } ) => {
-	const triggerRef = useRef( null );
-	const [ showTooltip, setShowTooltip ] = useState( false );
-
-	return (
-		<span className="stats-email__tooltip-wrapper">
-			<span
-				ref={ triggerRef }
-				className="stats-email__tooltip-trigger"
-				onMouseEnter={ () => setShowTooltip( true ) }
-				onMouseLeave={ () => setShowTooltip( false ) }
-			>
-				{ value }
-			</span>
-			<Tooltip position="top" context={ triggerRef.current } isVisible={ showTooltip }>
-				{ renderContent( item ) }
-			</Tooltip>
-		</span>
-	);
-};
 
 const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 	// Navigation settings. One of the following, depending on the summary view.
@@ -59,66 +41,6 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 		backLink += domain;
 	}
 	const navigationItems = [ { label: backLabel, href: backLink }, { label: title } ];
-
-	const renderOpensTooltipContent = ( item ) => {
-		const opensUnique = parseInt( item.unique_opens, 10 );
-		const opens = parseInt( item.opens, 10 );
-		const opensRate = parseFloat( item.opens_rate );
-		const totalSends = parseInt( item.total_sends, 10 );
-		const hasUniquesData = opensUnique > 0 && opens > 0;
-
-		return (
-			<div className="stats-email__tooltip">
-				<div>
-					{ translate( 'Subscribers reached: %(sends)d', {
-						args: { sends: totalSends },
-					} ) }
-				</div>
-				<div>
-					{ translate( 'Total opens: %(opens)d', {
-						args: { opens },
-					} ) }
-				</div>
-				<div>
-					{ hasUniquesData
-						? translate( 'Unique opens: %(uniqueOpens)d (%(openRate).2f%%)', {
-								args: { uniqueOpens: opensUnique, openRate: opensRate },
-						  } )
-						: translate( 'Unique opens: n/a' ) }
-				</div>
-			</div>
-		);
-	};
-
-	const renderClicksTooltipContent = ( item ) => {
-		const clicksUnique = parseInt( item.unique_clicks, 10 );
-		const clicks = parseInt( item.clicks, 10 );
-		const clicksRate = parseFloat( item.clicks_rate );
-		const totalSends = parseInt( item.total_sends, 10 );
-		const hasUniquesData = clicksUnique > 0 && clicks > 0;
-
-		return (
-			<div className="stats-email__tooltip">
-				<div>
-					{ translate( 'Subscribers reached: %(sends)d', {
-						args: { sends: totalSends },
-					} ) }
-				</div>
-				<div>
-					{ translate( 'Total clicks: %(clicks)d', {
-						args: { clicks },
-					} ) }
-				</div>
-				<div>
-					{ hasUniquesData
-						? translate( 'Unique clicks: %(uniqueClicks)d (%(clickRate).2f%%)', {
-								args: { uniqueClicks: clicksUnique, clickRate: clicksRate },
-						  } )
-						: translate( 'Unique clicks: n/a' ) }
-				</div>
-			</div>
-		);
-	};
 
 	return (
 		<Main className="has-fixed-nav" wideLayout>
@@ -161,7 +83,7 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 											  )
 									}
 									item={ item }
-									renderContent={ renderOpensTooltipContent }
+									renderContent={ createOpensTooltipContent }
 								/>
 							);
 						},
@@ -191,7 +113,7 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 											  )
 									}
 									item={ item }
-									renderContent={ renderClicksTooltipContent }
+									renderContent={ createClicksTooltipContent }
 								/>
 							);
 						}

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -64,8 +64,8 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 	const navigationItems = [ { label: backLabel, href: backLink }, { label: title } ];
 
 	const renderTooltipContent = ( item ) => {
-		const opensUnique = parseInt( item.opens_unique, 10 );
-		const clicksUnique = parseInt( item.clicks_unique, 10 );
+		const uniqueOpens = parseInt( item.unique_opens, 10 );
+		const uniqueClicks = parseInt( item.unique_clicks, 10 );
 		const opens = parseInt( item.opens, 10 );
 		const clicks = parseInt( item.clicks, 10 );
 		const opensRate = parseFloat( item.opens_rate );
@@ -80,18 +80,18 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 					} ) }
 				</div>
 				<div>
-					{ opensUnique
+					{ uniqueOpens
 						? translate( 'Unique opens: %(uniqueOpens)d (%(openRate).2f%%)', {
-								args: { uniqueOpens: opensUnique, openRate: opensRate },
+								args: { uniqueOpens: uniqueOpens, openRate: opensRate },
 						  } )
 						: translate( 'Opens: %(opens)d)', {
 								args: { opens },
 						  } ) }
 				</div>
 				<div>
-					{ clicksUnique
+					{ uniqueClicks
 						? translate( 'Unique clicks: %(uniqueClicks)d (%(clickRate).2f%%)', {
-								args: { uniqueClicks: clicksUnique, clickRate: clicksRate },
+								args: { uniqueClicks: uniqueClicks, clickRate: clicksRate },
 						  } )
 						: translate( 'Clicks: %(clicks)d ', {
 								args: { clicks },

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -19,9 +19,6 @@ const TooltipWrapper = ( { value, item, renderContent } ) => {
 	const triggerRef = useRef( null );
 	const [ showTooltip, setShowTooltip ] = useState( false );
 
-	const formattedValue =
-		typeof value === 'number' ? Number( value ).toFixed( 2 ) : value.replace( '%', '' ).trim();
-
 	return (
 		<span className="stats-email__tooltip-wrapper">
 			<span
@@ -30,7 +27,7 @@ const TooltipWrapper = ( { value, item, renderContent } ) => {
 				onMouseEnter={ () => setShowTooltip( true ) }
 				onMouseLeave={ () => setShowTooltip( false ) }
 			>
-				{ `${ formattedValue }%` }
+				{ value }
 			</span>
 			<Tooltip position="top" context={ triggerRef.current } isVisible={ showTooltip }>
 				{ renderContent( item ) }
@@ -63,14 +60,12 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 	}
 	const navigationItems = [ { label: backLabel, href: backLink }, { label: title } ];
 
-	const renderTooltipContent = ( item ) => {
-		const uniqueOpens = parseInt( item.unique_opens, 10 );
-		const uniqueClicks = parseInt( item.unique_clicks, 10 );
+	const renderOpensTooltipContent = ( item ) => {
+		const opensUnique = parseInt( item.unique_opens, 10 );
 		const opens = parseInt( item.opens, 10 );
-		const clicks = parseInt( item.clicks, 10 );
 		const opensRate = parseFloat( item.opens_rate );
-		const clicksRate = parseFloat( item.clicks_rate );
 		const totalSends = parseInt( item.total_sends, 10 );
+		const hasUniquesData = opensUnique > 0 && opens > 0;
 
 		return (
 			<div className="stats-email__tooltip">
@@ -80,22 +75,46 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 					} ) }
 				</div>
 				<div>
-					{ uniqueOpens
-						? translate( 'Unique opens: %(uniqueOpens)d (%(openRate).2f%%)', {
-								args: { uniqueOpens: uniqueOpens, openRate: opensRate },
-						  } )
-						: translate( 'Opens: %(opens)d)', {
-								args: { opens },
-						  } ) }
+					{ translate( 'Total opens: %(opens)d', {
+						args: { opens },
+					} ) }
 				</div>
 				<div>
-					{ uniqueClicks
-						? translate( 'Unique clicks: %(uniqueClicks)d (%(clickRate).2f%%)', {
-								args: { uniqueClicks: uniqueClicks, clickRate: clicksRate },
+					{ hasUniquesData
+						? translate( 'Unique opens: %(uniqueOpens)d (%(openRate).2f%%)', {
+								args: { uniqueOpens: opensUnique, openRate: opensRate },
 						  } )
-						: translate( 'Clicks: %(clicks)d ', {
-								args: { clicks },
-						  } ) }
+						: translate( 'Unique opens: n/a' ) }
+				</div>
+			</div>
+		);
+	};
+
+	const renderClicksTooltipContent = ( item ) => {
+		const clicksUnique = parseInt( item.unique_clicks, 10 );
+		const clicks = parseInt( item.clicks, 10 );
+		const clicksRate = parseFloat( item.clicks_rate );
+		const totalSends = parseInt( item.total_sends, 10 );
+		const hasUniquesData = clicksUnique > 0 && clicks > 0;
+
+		return (
+			<div className="stats-email__tooltip">
+				<div>
+					{ translate( 'Subscribers reached: %(sends)d', {
+						args: { sends: totalSends },
+					} ) }
+				</div>
+				<div>
+					{ translate( 'Total clicks: %(clicks)d', {
+						args: { clicks },
+					} ) }
+				</div>
+				<div>
+					{ hasUniquesData
+						? translate( 'Unique clicks: %(uniqueClicks)d (%(clickRate).2f%%)', {
+								args: { uniqueClicks: clicksUnique, clickRate: clicksRate },
+						  } )
+						: translate( 'Unique clicks: n/a' ) }
 				</div>
 			</div>
 		);
@@ -127,13 +146,18 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 								<span>{ translate( 'Opens' ) }</span>
 							</>
 						),
-						body: ( item ) => (
-							<TooltipWrapper
-								value={ `${ item.opens_rate }%` }
-								item={ item }
-								renderContent={ renderTooltipContent }
-							/>
-						),
+						body: ( item ) => {
+							const opensUnique = parseInt( item.unique_opens, 10 );
+							const opens = parseInt( item.opens, 10 );
+							const hasUniquesData = opensUnique > 0 || opens === 0;
+							return (
+								<TooltipWrapper
+									value={ hasUniquesData ? `${ item.opens_rate }%` : 'n/a' }
+									item={ item }
+									renderContent={ renderOpensTooltipContent }
+								/>
+							);
+						},
 					} }
 					path="emails"
 					moduleStrings={ { ...StatsStrings.emails, title: '' } }
@@ -145,16 +169,19 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 					metricLabel={ translate( 'Clicks' ) }
 					valueField="clicks_rate"
 					formatValue={ ( value, item ) => {
-						if ( item?.opens !== undefined ) {
+						if ( item?.clicks !== undefined ) {
+							const clicksUnique = parseInt( item.unique_clicks, 10 );
+							const clicks = parseInt( item.clicks, 10 );
+							const hasUniquesData = clicksUnique > 0 || clicks === 0;
 							return (
 								<TooltipWrapper
-									value={ `${ value }%` }
+									value={ hasUniquesData ? `${ item.clicks_rate }%` : 'n/a' }
 									item={ item }
-									renderContent={ renderTooltipContent }
+									renderContent={ renderClicksTooltipContent }
 								/>
 							);
 						}
-						return <span>{ `${ value }%` }</span>;
+						return <span>{ value }</span>;
 					} }
 					listItemClassName="stats__summary--narrow-mobile"
 				/>

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -974,7 +974,19 @@ export const normalizers = {
 		const emailsData = get( data, [ 'posts' ], [] );
 
 		return emailsData.map(
-			( { id, href, date, title, type, opens, clicks, opens_rate, clicks_rate } ) => {
+			( {
+				id,
+				href,
+				date,
+				title,
+				type,
+				opens,
+				clicks,
+				opens_rate,
+				clicks_rate,
+				opens_unique,
+				clicks_unique,
+			} ) => {
 				const detailPage = site ? `/stats/email/opens/day/${ id }/${ site.slug }` : null;
 				return {
 					id,
@@ -982,11 +994,13 @@ export const normalizers = {
 					date,
 					label: title,
 					type,
-					value: clicks || '0',
+					value: clicks_rate || '0',
 					opens: opens || '0',
 					clicks: clicks || '0',
 					opens_rate: opens_rate || '0',
 					clicks_rate: clicks_rate || '0',
+					opens_unique: opens_unique || '0',
+					clicks_unique: clicks_unique || '0',
 					page: detailPage,
 					actions: [
 						{

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -986,6 +986,7 @@ export const normalizers = {
 				clicks_rate,
 				opens_unique,
 				clicks_unique,
+				total_sends,
 			} ) => {
 				const detailPage = site ? `/stats/email/opens/day/${ id }/${ site.slug }` : null;
 				return {
@@ -1001,6 +1002,7 @@ export const normalizers = {
 					clicks_rate: clicks_rate || '0',
 					opens_unique: opens_unique || '0',
 					clicks_unique: clicks_unique || '0',
+					total_sends: total_sends || '0',
 					page: detailPage,
 					actions: [
 						{

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -984,8 +984,8 @@ export const normalizers = {
 				clicks,
 				opens_rate,
 				clicks_rate,
-				opens_unique,
-				clicks_unique,
+				unique_opens,
+				unique_clicks,
 				total_sends,
 			} ) => {
 				const detailPage = site ? `/stats/email/opens/day/${ id }/${ site.slug }` : null;
@@ -1000,8 +1000,8 @@ export const normalizers = {
 					clicks: clicks || '0',
 					opens_rate: opens_rate || '0',
 					clicks_rate: clicks_rate || '0',
-					opens_unique: opens_unique || '0',
-					clicks_unique: clicks_unique || '0',
+					unique_opens: unique_opens || '0',
+					unique_clicks: unique_clicks || '0',
 					total_sends: total_sends || '0',
 					page: detailPage,
 					actions: [

--- a/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx
+++ b/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx
@@ -109,7 +109,7 @@ const HorizontalBarListItem = ( {
 			return <ShortenedNumber value={ value } />;
 		}
 		if ( formatValue ) {
-			return formatValue( value );
+			return formatValue( value, data );
 		}
 		return usePlainCard ? value : numberFormat( value, 0 );
 	};
@@ -193,6 +193,7 @@ const HorizontalBarListItem = ( {
 									isStatic={ isStatic }
 									usePlainCard={ usePlainCard }
 									isLinkUnderlined={ isLinkUnderlined }
+									formatValue={ formatValue }
 								/>
 							);
 						} ) }

--- a/packages/components/src/horizontal-bar-list/types.ts
+++ b/packages/components/src/horizontal-bar-list/types.ts
@@ -32,7 +32,10 @@ export type HorizontalBarListItemProps = {
 	 * @property {boolean} hasNoBackground - don't render the background bar and adjust indentation
 	 */
 	hasNoBackground?: boolean;
-	formatValue?: ( value: number ) => string;
+	/**
+	 * @property {Function} formatValue - function to format the value display. Can optionally receive the full item data.
+	 */
+	formatValue?: ( value: number, item?: StatDataObject ) => React.ReactNode;
 };
 
 type StatDataObject = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/97638

## Proposed Changes

This PR proposes rendering n/a when unique clicks data is unavailable (e.g., when we have clicks but not unique clicks data). It also adds tooltips to display subscribers reached, along with total and unique values.

<img width="348" alt="Screenshot 2024-12-27 at 10 34 36 AM" src="https://github.com/user-attachments/assets/04f36941-7a85-4b29-829d-7c639fabfdf9" />


<img width="255" alt="Screenshot 2024-12-27 at 7 31 06 AM" src="https://github.com/user-attachments/assets/0b754658-c76f-43bc-823b-61e925ebb7c9" />


https://github.com/user-attachments/assets/fafc6e9b-03dc-4f6f-96ec-c1c14c38f42a



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check https://wordpress.com/stats/day/emails/<your_site>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
