### PR TITLE
A4A: Fix for Unintended "Column Order" Selector Opening During Sites Tour

### DIFF
--- a/client/components/guided-tour/step/index.tsx
+++ b/client/components/guided-tour/step/index.tsx
@@ -69,12 +69,16 @@ export function GuidedTourStep( {
 		);
 	}, [ dispatch, tourId, preference, id ] );
 
-	const completeStep = () => {
-		nextStep( currentStep );
-		if ( isLastStep ) {
-			endTour();
-		}
-	};
+	const completeStep = useCallback(
+		( event: MouseEvent | React.MouseEvent< HTMLElement > ) => {
+			event.stopPropagation();
+			nextStep( currentStep );
+			if ( isLastStep ) {
+				endTour();
+			}
+		},
+		[ currentStep, nextStep, isLastStep, endTour ]
+	);
 
 	// Record an event when the tour starts
 	useEffect( () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/97593#issuecomment-2556548023

## Proposed Changes

During the Sites Tour in A4A, when navigating to the next step, an unintended auto-click was occurring on the previous column header, triggering the "Column Order" selector to open. This behavior was unexpected and disrupted the user experience during the tour.

This PR addresses the issue by ensuring that navigation to the next step in the Sites Tour does not trigger clicks on column headers.

| before | after |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/e9b82d4d-3e05-4b18-8a92-6491d843e0a8) | <img width="403" alt="Screenshot 2024-12-23 at 15 07 57" src="https://github.com/user-attachments/assets/d909a9bf-e347-405a-9843-3b768113c919" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://github.com/Automattic/wp-calypso/pull/97593#issuecomment-2557399611

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Prerequisite 

* Go to Developer Console 
* POST to /me/preferences with the following data in `calypso_preferences`

```
{
  "a4a-sites-tour": {"dismiss": false},
}
```

<img width="1432" alt="Screenshot 2024-12-19 at 13 00 01" src="https://github.com/user-attachments/assets/44203af4-48dc-4f3c-99cd-31f8b609419a" />

A4A Live

* Go to /sites?tour=sites-walkthrough
	* Observe the tour starts correctly 
	* Refresh the page after the tour ends
	* Observe the tour does not restart

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
