### PR TITLE
Domain Step: Fix the back button on the first click

### DIFF
--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -105,7 +105,7 @@ const StepContainer: React.FC< Props > = ( {
 		}
 	};
 
-	function BackButton() {
+	function renderBackButton() {
 		// Hide back button if goBack is falsy, it won't do anything in that case.
 		if ( shouldHideNavButtons || ( ! goBack && ! backUrl ) ) {
 			return null;
@@ -123,7 +123,7 @@ const StepContainer: React.FC< Props > = ( {
 		);
 	}
 
-	function SkipButton() {
+	function renderSkipButton() {
 		const skipAction = onSkip ?? goNext;
 
 		if ( shouldHideNavButtons || ! skipAction ) {
@@ -149,7 +149,7 @@ const StepContainer: React.FC< Props > = ( {
 		);
 	}
 
-	function NextButton() {
+	function renderNextButton() {
 		if ( shouldHideNavButtons || ! goNext ) {
 			return null;
 		}
@@ -183,9 +183,9 @@ const StepContainer: React.FC< Props > = ( {
 					'has-sticky-nav-buttons-padding': hasStickyNavButtonsPadding,
 				} ) }
 			>
-				{ ! hideBack && <BackButton /> }
-				{ ! hideSkip && skipButtonAlign === 'top' && <SkipButton /> }
-				{ ! hideNext && <NextButton /> }
+				{ ! hideBack && renderBackButton() }
+				{ ! hideSkip && skipButtonAlign === 'top' && renderSkipButton() }
+				{ ! hideNext && renderNextButton() }
 				{ customizedActionButtons }
 			</ActionButtons>
 			{ ! hideFormattedHeader && (
@@ -216,7 +216,7 @@ const StepContainer: React.FC< Props > = ( {
 			{ ! hideSkip && skipButtonAlign === 'bottom' && (
 				<div className="step-container__buttons">
 					{ isLargeSkipLayout && <hr className="step-container__skip-hr" /> }
-					<SkipButton />
+					{ renderSkipButton() }
 				</div>
 			) }
 			{ showJetpackPowered && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fix the issue that the first click of the back button on the Domain step didn't work. The reason is the `<BackButon />` was an inline component of the `<StepContainer />`. When you clicked the back button at the first time, it would trigger the state update and cause the component re-render. As a result, the `goBack` function wouldn't be called so that the page kept in the Domain step

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/onboarding
* Select any goals
* Select any designs
* On the Domains screen, click the back button
* Ensure you go back to the Design Picker screen immediately

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
