### PR TITLE
Apply new badge styles to en locale for designSetup step

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/index.js
+++ b/client/components/theme-tier/theme-tier-badge/index.js
@@ -1,6 +1,6 @@
 import { BUNDLED_THEME, DOT_ORG_THEME, MARKETPLACE_THEME } from '@automattic/design-picker';
 import clsx from 'clsx';
-import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
+import useIsUpdatedBadgeDesign from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-is-updated-badge-design';
 import { useSelector } from 'calypso/state';
 import { useIsThemeAllowedOnSite } from 'calypso/state/themes/hooks/use-is-theme-allowed-on-site';
 import { useThemeTierForTheme } from 'calypso/state/themes/hooks/use-theme-tier-for-theme';
@@ -31,10 +31,9 @@ export default function ThemeTierBadge( {
 	);
 	const themeTier = useThemeTierForTheme( themeId );
 	const isThemeAllowed = useIsThemeAllowedOnSite( siteId, themeId );
-	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
-
+	const isUpdatedBadgeDesign = useIsUpdatedBadgeDesign();
 	const getBadge = () => {
-		if ( isGoalsAtFrontExperiment && 'free' === themeTier?.slug ) {
+		if ( isUpdatedBadgeDesign && 'free' === themeTier?.slug ) {
 			return <ThemeTierFreeBadge />;
 		}
 
@@ -51,7 +50,7 @@ export default function ThemeTierBadge( {
 		}
 
 		if (
-			! isGoalsAtFrontExperiment &&
+			! isUpdatedBadgeDesign &&
 			( 'partner' === themeTier?.slug || MARKETPLACE_THEME === themeType )
 		) {
 			return <ThemeTierPartnerBadge />;

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
@@ -3,7 +3,7 @@ import { BundledBadge, PremiumBadge } from '@automattic/components';
 import { createInterpolateElement } from '@wordpress/element';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
+import useIsUpdatedBadgeDesign from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-is-updated-badge-design';
 import { useBundleSettingsByTheme } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
 import { useSelector } from 'calypso/state';
 import { canUseTheme } from 'calypso/state/themes/selectors';
@@ -20,7 +20,7 @@ export default function ThemeTierBundledBadge() {
 	const isThemeIncluded = useSelector(
 		( state ) => siteId && canUseTheme( state, siteId, themeId )
 	);
-	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
+	const isUpdatedBadgeDesign = useIsUpdatedBadgeDesign();
 
 	if ( ! bundleSettings ) {
 		return;
@@ -48,7 +48,7 @@ export default function ThemeTierBundledBadge() {
 		</>
 	);
 
-	const labelText = isGoalsAtFrontExperiment
+	const labelText = isUpdatedBadgeDesign
 		? translate( 'Available on %(businessPlanName)s', {
 				args: {
 					businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
@@ -61,19 +61,19 @@ export default function ThemeTierBundledBadge() {
 			{ showUpgradeBadge && ! isThemeIncluded && (
 				<PremiumBadge
 					className={ clsx( 'theme-tier-badge__content', {
-						'theme-tier-badge__without-background': isGoalsAtFrontExperiment,
+						'theme-tier-badge__without-background': isUpdatedBadgeDesign,
 					} ) }
 					focusOnShow={ false }
 					labelText={ labelText }
 					tooltipClassName="theme-tier-badge-tooltip"
 					tooltipContent={ tooltipContent }
 					tooltipPosition="top"
-					shouldHideTooltip={ isGoalsAtFrontExperiment }
-					isClickable={ ! isGoalsAtFrontExperiment }
+					shouldHideTooltip={ isUpdatedBadgeDesign }
+					isClickable={ ! isUpdatedBadgeDesign }
 				/>
 			) }
 
-			{ ! isGoalsAtFrontExperiment && (
+			{ ! isUpdatedBadgeDesign && (
 				<BundledBadge
 					className="theme-tier-badge__content"
 					color={ bundleSettings.color }

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
@@ -4,7 +4,7 @@ import { Plans } from '@automattic/data-stores';
 import { createInterpolateElement } from '@wordpress/element';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
+import useIsUpdatedBadgeDesign from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-is-updated-badge-design';
 import { useSelector } from 'calypso/state';
 import { useThemeTierForTheme } from 'calypso/state/themes/hooks/use-theme-tier-for-theme';
 import { getMarketplaceThemeSubscriptionPrices } from 'calypso/state/themes/selectors';
@@ -28,10 +28,10 @@ export default function ThemeTierPlanUpgradeBadge( { showPartnerPrice } ) {
 	// Using API plans because the updated getTitle() method doesn't take the experiment assignment into account.
 	const plans = Plans.usePlans( { coupon: undefined } );
 	const planName = plans?.data?.[ mappedPlan.getStoreSlug() ]?.productNameShort;
-	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
+	const isUpdatedBadgeDesign = useIsUpdatedBadgeDesign();
 
 	const getLabel = () => {
-		if ( ! isGoalsAtFrontExperiment ) {
+		if ( ! isUpdatedBadgeDesign ) {
 			return translate( 'Upgrade' );
 		}
 
@@ -72,15 +72,15 @@ export default function ThemeTierPlanUpgradeBadge( { showPartnerPrice } ) {
 	return (
 		<PremiumBadge
 			className={ clsx( 'theme-tier-badge__content', {
-				'theme-tier-badge__without-background': isGoalsAtFrontExperiment,
+				'theme-tier-badge__without-background': isUpdatedBadgeDesign,
 			} ) }
 			focusOnShow={ false }
 			labelText={ getLabel() }
 			tooltipClassName="theme-tier-badge-tooltip"
 			tooltipContent={ tooltipContent }
 			tooltipPosition="top"
-			shouldHideTooltip={ isGoalsAtFrontExperiment }
-			isClickable={ ! isGoalsAtFrontExperiment }
+			shouldHideTooltip={ isUpdatedBadgeDesign }
+			isClickable={ ! isUpdatedBadgeDesign }
 		/>
 	);
 }

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
@@ -36,12 +36,24 @@ export default function ThemeTierPlanUpgradeBadge( { showPartnerPrice } ) {
 		}
 
 		if ( showPartnerPrice && subscriptionPrices.month ) {
-			return translate( 'Available on %(planName)s plus %(price)s/month', {
+			const fullLabel = translate( 'Available on %(planName)s plus %(price)s/month', {
 				args: {
 					planName: planName,
 					price: subscriptionPrices.month,
 				},
 			} );
+
+			// Use shorter version if full label is too long
+			const MAX_LABEL_LENGTH = 45;
+			return fullLabel.length > MAX_LABEL_LENGTH
+				? /* translators: This is a shorter version of the text "Available on %(planName)s plus %(price)s/month". */
+				  translate( '%(planName)s + %(price)s/mo', {
+						args: {
+							planName: planName,
+							price: subscriptionPrices.month,
+						},
+				  } )
+				: fullLabel;
 		}
 
 		return translate( 'Available on %(planName)s', {

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -30,7 +30,6 @@ exports[`Theme rendering should match snapshot 1`] = `
     >
       <h2
         class="theme-card__info-title"
-        title="Twenty Seventeen"
       >
         <span>
           Twenty Seventeen

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -30,6 +30,7 @@ exports[`Theme rendering should match snapshot 1`] = `
     >
       <h2
         class="theme-card__info-title"
+        title="Twenty Seventeen"
       >
         <span>
           Twenty Seventeen

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-is-updated-badge-design.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-is-updated-badge-design.tsx
@@ -11,7 +11,7 @@ const useIsUpdatedBadgeDesign = () => {
 
 	const step = useMemo( () => getStepFromURL(), [] );
 
-	return isEligible ? step === 'designSetup' : false;
+	return isEligible ? step?.toLowerCase() === 'designsetup' : false;
 };
 
 export default useIsUpdatedBadgeDesign;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-is-updated-badge-design.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-is-updated-badge-design.tsx
@@ -4,6 +4,7 @@ import { getStepFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url'
 
 const useIsUpdatedBadgeDesign = () => {
 	const step = useMemo( () => getStepFromURL(), [] );
+	// TODO: Remove this after translations are completed
 	const hasEnTranslation = useHasEnTranslation();
 	const isEligible = hasEnTranslation( '%(planName)s + %(price)s/mo' );
 	return isEligible ? step?.toLowerCase() === 'designsetup' : false;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-is-updated-badge-design.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-is-updated-badge-design.tsx
@@ -1,0 +1,17 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { useMemo } from 'react';
+import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
+import { getStepFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
+
+const useIsUpdatedBadgeDesign = () => {
+	// TODO: Remove the locale and isGoalsAtFrontExperiment check after translations are complete.
+	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
+	const locale = useLocale();
+	const isEligible = isGoalsAtFrontExperiment || locale === 'en';
+
+	const step = useMemo( () => getStepFromURL(), [] );
+
+	return isEligible ? step === 'designSetup' : false;
+};
+
+export default useIsUpdatedBadgeDesign;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-is-updated-badge-design.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-is-updated-badge-design.tsx
@@ -1,16 +1,11 @@
-import { useLocale } from '@automattic/i18n-utils';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useMemo } from 'react';
-import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
 import { getStepFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
 
 const useIsUpdatedBadgeDesign = () => {
-	// TODO: Remove the locale and isGoalsAtFrontExperiment check after translations are complete.
-	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
-	const locale = useLocale();
-	const isEligible = isGoalsAtFrontExperiment || locale === 'en';
-
 	const step = useMemo( () => getStepFromURL(), [] );
-
+	const hasEnTranslation = useHasEnTranslation();
+	const isEligible = hasEnTranslation( '%(planName)s + %(price)s/mo' );
 	return isEligible ? step?.toLowerCase() === 'designsetup' : false;
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -89,6 +89,7 @@ import { getCategorizationOptions } from './categories';
 import { STEP_NAME } from './constants';
 import DesignPickerDesignTitle from './design-picker-design-title';
 import { EligibilityWarningsModal } from './eligibility-warnings-modal';
+import useIsUpdatedBadgeDesign from './hooks/use-is-updated-badge-design';
 import useRecipe from './hooks/use-recipe';
 import useTrackFilters from './hooks/use-track-filters';
 import getThemeIdFromDesign from './utils/get-theme-id-from-design';
@@ -124,6 +125,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	const [ isGoalsAtFrontExperimentLoading, isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 	const isSiteRequired = flow !== ONBOARDING_FLOW || ! isGoalsAtFrontExperiment;
+
+	const isUpdatedBadgeDesign = useIsUpdatedBadgeDesign();
 
 	const { isEligible } = useIsBigSkyEligible();
 	const isBigSkyEligible = isEligible && isGoalCentricFeature;
@@ -962,10 +965,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				categorization={ categorization }
 				isPremiumThemeAvailable={ isPremiumThemeAvailable }
 				shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
-				// We may want to modify the ThemeCard component once the experiment is completed
+				// TODO: Update the ThemeCard component once the new design is rolled out completely
 				// to avoid passing the getBadge and getOptionsMenu prop conditionally down the component tree.
-				getBadge={ isGoalsAtFrontExperiment ? undefined : getBadge }
-				getOptionsMenu={ isGoalsAtFrontExperiment ? getBadge : undefined }
+				getBadge={ isUpdatedBadgeDesign ? undefined : getBadge }
+				getOptionsMenu={ isUpdatedBadgeDesign ? getBadge : undefined }
 				oldHighResImageLoading={ oldHighResImageLoading }
 				siteActiveTheme={ siteActiveTheme?.[ 0 ]?.stylesheet ?? null }
 				showActiveThemeBadge={ intent !== 'build' }

--- a/client/landing/stepper/utils/get-flow-from-url.ts
+++ b/client/landing/stepper/utils/get-flow-from-url.ts
@@ -6,3 +6,9 @@ export const getFlowFromURL = () => {
 	const fromQuery = new URLSearchParams( window.location.search ).get( 'flow' );
 	return fromPath || fromQuery;
 };
+
+export const getStepFromURL = () => {
+	const fromPath = matchPath( { path: '/setup/:flow/:step' }, window.location.pathname )?.params
+		?.step;
+	return fromPath;
+};

--- a/packages/design-picker/src/components/theme-card/index.tsx
+++ b/packages/design-picker/src/components/theme-card/index.tsx
@@ -143,7 +143,7 @@ const ThemeCard = forwardRef(
 						</div>
 					) }
 					<div className={ themeInfoClasses }>
-						<h2 className="theme-card__info-title" title={ name }>
+						<h2 className="theme-card__info-title">
 							<span>{ name }</span>
 						</h2>
 						{ ! optionsMenu && styleVariations.length > 0 && (

--- a/packages/design-picker/src/components/theme-card/index.tsx
+++ b/packages/design-picker/src/components/theme-card/index.tsx
@@ -86,7 +86,8 @@ const ThemeCard = forwardRef(
 			'theme-card--is-actionable': isActionable,
 		} );
 		const themeInfoClasses = clsx( 'theme-card__info', {
-			'theme-card__info--has-style-variations': styleVariations.length > 0,
+			// Only show style variations when there is both a badge and variations.
+			'theme-card__info--has-style-variations': badge && styleVariations.length > 0,
 		} );
 
 		return (
@@ -142,7 +143,7 @@ const ThemeCard = forwardRef(
 						</div>
 					) }
 					<div className={ themeInfoClasses }>
-						<h2 className="theme-card__info-title">
+						<h2 className="theme-card__info-title" title={ name }>
 							<span>{ name }</span>
 						</h2>
 						{ ! optionsMenu && styleVariations.length > 0 && (

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -26,6 +26,8 @@ $theme-card-info-margin-top: 16px;
 	}
 
 	.theme-card__info-badge-container {
+		position: absolute;
+		bottom: 0;
 		display: flex;
 		flex-basis: 100%;
 	}
@@ -221,13 +223,6 @@ $theme-card-info-margin-top: 16px;
 	text-rendering: optimizeLegibility;
 	-webkit-font-smoothing: antialiased;
 
-	&:not(&--has-style-variations) {
-		.theme-card__info-options,
-		.theme-card__info-options .theme__more-button {
-			top: 0;
-		}
-	}
-
 	&-badge {
 		border-radius: 20px;  /* stylelint-disable-line scales/radii */
 		flex: 0 0 auto;
@@ -274,6 +269,7 @@ $theme-card-info-margin-top: 16px;
 	position: relative;
 	white-space: nowrap;
 	width: 0;
+	text-overflow: ellipsis;
 }
 
 .theme-card__info-style-variations {
@@ -296,9 +292,8 @@ $theme-card-info-margin-top: 16px;
 	border: 0;
 	display: flex;
 	flex: 0 0 auto;
-	position: absolute;
-	right: 0;
 	transition: all 0.1s ease-in-out;
+	align-self: center;
 
 	&:hover {
 		background-color: initial;


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/97717 and https://github.com/Automattic/wp-calypso/issues/97686

## Proposed Changes

> [!NOTE]  
> New badge styles are only on locale `en` for code simplicity until we get the latest translations.

* Apply the new badge style updates to design picker in onboarding flows for locale `en`
* Allow /setup/onboarding with `flags=onboarding/goals-first` to continue to see the changes (not released to public yet)
* Use `hasEnTranslation` check while we wait for translations to complete because `designSetup` is in production for other onboarding-related flows
* Added a shorter copy for when the badges overflow

![badge long@2x](https://github.com/user-attachments/assets/986f481c-9e09-43ac-a6f9-acf7ab05c2bc)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On en locale, go to /setup/onboarding
* After getting to the launchpad, go to the select a design step
* It should reflect the new badge changes
* Make sure nothing changes in the theme showcase /themes

| Old | New (en locale) |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/917cb48c-4e66-42d0-b021-9fd7c75ed174"> | <img src="https://github.com/user-attachments/assets/7a5da473-5aea-4db6-8867-ab8636e7f849"> |
| <img src="https://github.com/user-attachments/assets/c307ad44-8468-4694-80d9-325e5512f502"> | <img src="https://github.com/user-attachments/assets/4420a7bc-021b-454b-afbe-3e5f1e6b02df"> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
