### PR TITLE
Enable Bulk Plugin Management: Improve DataViews CSS

### DIFF
--- a/client/components/dataviews/style.scss
+++ b/client/components/dataviews/style.scss
@@ -73,30 +73,9 @@
 		}
 	}
 
-	.components-checkbox-control__input[type='checkbox']:focus {
-		box-shadow:
-			0 0 0 var( --studio-jetpack-green-50 ) #fff,
-			0 0 0 calc( 2 * var( --studio-jetpack-green-50 ) ) var( --studio-jetpack-green-50 );
-		outline: 2px solid transparent;
-		outline-offset: 2px;
-	}
-
-	.components-checkbox-control__input[type='checkbox']:checked,
-	.components-checkbox-control__input[type='checkbox']:indeterminate {
-		background: var( --wp-components-color-accent, var( --studio-jetpack-green-50 ) );
-		border-color: var( --wp-components-color-accent, var( --studio-jetpack-green-50 ) );
-	}
-
 	.components-search-control input[type='search'].components-search-control__input {
 		background: var( --studio-white );
 		border: 1px solid var( --color-neutral-5 );
-	}
-
-	.dataviews-bulk-edit-button.components-button.is-tertiary:active:not( :disabled ),
-	.dataviews-bulk-edit-button.components-button.is-tertiary:hover:not( :disabled ) {
-		box-shadow: none;
-		background-color: transparent;
-		color: var( --studio-jetpack-green-50 );
 	}
 
 	thead .dataviews-view-table__row th {
@@ -213,22 +192,5 @@
 		z-index: 1;
 		background: linear-gradient( 90deg, rgba( 255, 255, 255, 0 ) 0, rgb( 255, 255, 255 ) 25% );
 		padding-left: 48px;
-	}
-}
-
-// TODO: remove when this is implemented upstream.
-//
-// This reverts to core styles that are overriden by wp-calypso (this same file, line 21),
-// which need to be removed in a follow-up.
-// Follow-up issue: https://github.com/Automattic/dotcom-forge/issues/9554
-body.is-section-plugins .plugin-management-wrapper {
-	--wp-components-color-accent: var( --color-accent );
-}
-body.is-section-plugins .plugin-management-wrapper,
-.is-section-jetpack-cloud-plugin-management {
-	.dataviews-wrapper .dataviews-view-table .dataviews-view-table__row {
-		.dataviews-view-table-selection-checkbox {
-			padding-left: 0;
-		}
 	}
 }

--- a/client/components/dataviews/style.scss
+++ b/client/components/dataviews/style.scss
@@ -79,7 +79,7 @@
 	}
 
 	thead .dataviews-view-table__row th {
-		span,
+		span.dataviews-view-table-header,
 		button {
 			font-size: rem( 11px );
 			font-weight: 500;

--- a/client/components/dataviews/style.scss
+++ b/client/components/dataviews/style.scss
@@ -1,13 +1,13 @@
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/mixins";
-@import "@wordpress/dataviews/build-style/style.css";
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/dataviews/build-style/style.css';
 
 .dataviews-wrapper {
 	// Maybe move upstream to the gutenberg repository
 	width: 100%;
 
 	tr.dataviews-view-table__row {
-		background: var(--studio-white);
+		background: var( --studio-white );
 
 		.components-checkbox-control__input {
 			opacity: 0;
@@ -15,15 +15,6 @@
 		.components-checkbox-control__input:checked,
 		.components-checkbox-control__input:indeterminate {
 			opacity: 1;
-		}
-
-		.dataviews-view-table-selection-checkbox {
-			padding-left: 12px;
-			&.is-selected {
-				.components-checkbox-control__input {
-					opacity: 1;
-				}
-			}
 		}
 
 		&:hover {
@@ -34,23 +25,23 @@
 		}
 
 		th {
-			border-bottom: 1px solid var(--color-neutral-5);
-			font-size: rem(13px);
+			border-bottom: 1px solid var( --color-neutral-5 );
+			font-size: rem( 13px );
 			font-weight: 400;
 			vertical-align: middle;
 		}
 
 		td {
-			border-bottom: 1px solid var(--color-neutral-5);
+			border-bottom: 1px solid var( --color-neutral-5 );
 			vertical-align: middle;
 
-			&:has(.sites-dataviews__site) {
+			&:has( .sites-dataviews__site ) {
 				width: 20%;
 			}
 		}
 
 		.dataviews-view-table__cell-content-wrapper {
-			font-size: rem(13px);
+			font-size: rem( 13px );
 		}
 
 		.dataviews-view-table__checkbox-column,
@@ -58,8 +49,8 @@
 			label.components-checkbox-control__label {
 				display: none;
 			}
-			&[type="checkbox"] {
-				border-color: var(--color-neutral-5);
+			&[type='checkbox'] {
+				border-color: var( --color-neutral-5 );
 			}
 		}
 
@@ -70,10 +61,10 @@
 
 	ul.dataviews-view-list {
 		li:hover {
-			background: var(--color-neutral-0);
+			background: var( --color-neutral-0 );
 		}
 		.is-selected {
-			background-color: var(--color-neutral-0);
+			background-color: var( --color-neutral-0 );
 		}
 
 		// Needs to be moved upstream to the gutenberg repository.
@@ -82,37 +73,39 @@
 		}
 	}
 
-	.components-checkbox-control__input[type="checkbox"]:focus {
-		box-shadow: 0 0 0 var(--studio-jetpack-green-50) #fff, 0 0 0 calc(2* var(--studio-jetpack-green-50)) var(--studio-jetpack-green-50);
+	.components-checkbox-control__input[type='checkbox']:focus {
+		box-shadow:
+			0 0 0 var( --studio-jetpack-green-50 ) #fff,
+			0 0 0 calc( 2 * var( --studio-jetpack-green-50 ) ) var( --studio-jetpack-green-50 );
 		outline: 2px solid transparent;
 		outline-offset: 2px;
 	}
 
-	.components-checkbox-control__input[type="checkbox"]:checked,
-	.components-checkbox-control__input[type="checkbox"]:indeterminate {
-		background: var(--wp-components-color-accent, var(--studio-jetpack-green-50));
-		border-color: var(--wp-components-color-accent, var(--studio-jetpack-green-50));
+	.components-checkbox-control__input[type='checkbox']:checked,
+	.components-checkbox-control__input[type='checkbox']:indeterminate {
+		background: var( --wp-components-color-accent, var( --studio-jetpack-green-50 ) );
+		border-color: var( --wp-components-color-accent, var( --studio-jetpack-green-50 ) );
 	}
 
-	.components-search-control input[type="search"].components-search-control__input {
-		background: var(--studio-white);
-		border: 1px solid var(--color-neutral-5);
+	.components-search-control input[type='search'].components-search-control__input {
+		background: var( --studio-white );
+		border: 1px solid var( --color-neutral-5 );
 	}
 
-	.dataviews-bulk-edit-button.components-button.is-tertiary:active:not(:disabled),
-	.dataviews-bulk-edit-button.components-button.is-tertiary:hover:not(:disabled) {
+	.dataviews-bulk-edit-button.components-button.is-tertiary:active:not( :disabled ),
+	.dataviews-bulk-edit-button.components-button.is-tertiary:hover:not( :disabled ) {
 		box-shadow: none;
 		background-color: transparent;
-		color: var(--studio-jetpack-green-50);
+		color: var( --studio-jetpack-green-50 );
 	}
 
 	thead .dataviews-view-table__row th {
 		span,
 		button {
-			font-size: rem(11px);
+			font-size: rem( 11px );
 			font-weight: 500;
 			line-height: 20px;
-			color: var(--color-accent-80);
+			color: var( --color-accent-80 );
 			text-transform: uppercase;
 		}
 
@@ -128,14 +121,14 @@
 		justify-content: end;
 		flex-wrap: nowrap;
 
-		@media (min-width: 1080px) {
+		@media ( min-width: 1080px ) {
 			.site-actions__actions-large-screen {
 				float: none;
 				margin-inline-end: 20px;
 			}
 		}
 
-		> *:not(:last-child) {
+		> *:not( :last-child ) {
 			margin-inline-end: 10px;
 		}
 
@@ -149,14 +142,14 @@
 
 		&.sites-dataviews__actions-error {
 			svg {
-				color: var(--color-accent-5);
+				color: var( --color-accent-5 );
 			}
 		}
 	}
 
 	// Color overrides for focus states of Action button
-	.components-button:focus:not(:disabled) {
-		--wp-components-color-accent: var(--color-primary-light);
+	.components-button:focus:not( :disabled ) {
+		--wp-components-color-accent: var( --color-primary-light );
 	}
 }
 
@@ -166,7 +159,7 @@
 // when no field is hidable.
 // This has been fixed upstream as of
 // https://github.com/WordPress/gutenberg/pull/64711
-.dataviews-settings-section:has(.dataviews-settings-section__content:empty) {
+.dataviews-settings-section:has( .dataviews-settings-section__content:empty ) {
 	display: none;
 }
 
@@ -176,7 +169,9 @@
 // It shouldn't be visible when there are no sortable fields.
 // Fixed at https://github.com/WordPress/gutenberg/issues/64816
 .is-section-a8c-for-agencies-team .dataviews-settings-section__content .is-divided-in-two,
-.is-section-a8c-for-agencies-sites.modal-open .dataviews-settings-section__content .is-divided-in-two,
+.is-section-a8c-for-agencies-sites.modal-open
+	.dataviews-settings-section__content
+	.is-divided-in-two,
 .is-section-a8c-for-agencies-referrals .dataviews-settings-section__content .is-divided-in-two,
 .is-section-a8c-for-agencies-client .dataviews-settings-section__content .is-divided-in-two {
 	display: none !important;
@@ -216,7 +211,7 @@
 		position: sticky;
 		right: 0;
 		z-index: 1;
-		background: linear-gradient(90deg, rgba(255, 255, 255, 0) 0, rgb(255, 255, 255) 25%);
+		background: linear-gradient( 90deg, rgba( 255, 255, 255, 0 ) 0, rgb( 255, 255, 255 ) 25% );
 		padding-left: 48px;
 	}
 }
@@ -227,14 +222,13 @@
 // which need to be removed in a follow-up.
 // Follow-up issue: https://github.com/Automattic/dotcom-forge/issues/9554
 body.is-section-plugins .plugin-management-wrapper {
-    --wp-components-color-accent: var(--color-accent);
+	--wp-components-color-accent: var( --color-accent );
 }
 body.is-section-plugins .plugin-management-wrapper,
 .is-section-jetpack-cloud-plugin-management {
-
-    .dataviews-wrapper .dataviews-view-table .dataviews-view-table__row {
-		.dataviews-view-table-selection-checkbox{
+	.dataviews-wrapper .dataviews-view-table .dataviews-view-table__row {
+		.dataviews-view-table-selection-checkbox {
 			padding-left: 0;
 		}
-    }
+	}
 }

--- a/client/my-sites/plugins/plugin-icon/plugin-icon.tsx
+++ b/client/my-sites/plugins/plugin-icon/plugin-icon.tsx
@@ -7,9 +7,10 @@ interface PluginIconProps {
 	className?: string;
 	image?: string;
 	isPlaceholder?: boolean;
+	size?: number;
 }
 
-const PluginIcon = ( { className, image, isPlaceholder }: PluginIconProps ) => {
+const PluginIcon = ( { className, image, isPlaceholder, size = 48 }: PluginIconProps ) => {
 	const classes = clsx(
 		{
 			'plugin-icon': true,
@@ -19,12 +20,17 @@ const PluginIcon = ( { className, image, isPlaceholder }: PluginIconProps ) => {
 		className
 	);
 
+	const style = {
+		width: size,
+		height: size,
+	};
+
 	return (
-		<div className={ classes }>
+		<div className={ classes } style={ style }>
 			{ isPlaceholder || ! image ? (
-				<Gridicon icon="plugins" />
+				<Gridicon icon="plugins" size={ size } />
 			) : (
-				<img className="plugin-icon__img" src={ image } alt="plugin-icon" />
+				<img className="plugin-icon__img" src={ image } alt="plugin-icon" style={ style } />
 			) }
 		</div>
 	);

--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -27,11 +27,6 @@ body.is-section-plugins .plugin-management-wrapper.is-bulk-plugin-management,
 
 		.dataviews-view-table {
 			.dataviews-view-table__row {
-				.plugin-icon {
-					max-width: 35px;
-					max-height: 35px;
-				}
-
 				td:nth-child( 2 ) {
 					white-space: break-spaces;
 				}

--- a/client/my-sites/plugins/plugins-list/use-fields.tsx
+++ b/client/my-sites/plugins/plugins-list/use-fields.tsx
@@ -90,9 +90,14 @@ export function useFields(
 								className="plugin-name-button"
 							>
 								{ item.icon ? (
-									<PluginIcon image={ item.icon } size={ 35 } />
+									<PluginIcon className="plugin-icon" image={ item.icon } size={ 35 } />
 								) : (
-									<Icon size={ 32 } icon={ plugins } className="plugin-icon" />
+									<Icon
+										size={ 32 }
+										icon={ plugins }
+										className="plugin-icon"
+										style={ { maxWidth: '35px', maxHeight: '35px' } }
+									/>
 								) }
 								{ item.name }
 							</Button>

--- a/client/my-sites/plugins/plugins-list/use-fields.tsx
+++ b/client/my-sites/plugins/plugins-list/use-fields.tsx
@@ -3,6 +3,7 @@ import { Operator } from '@wordpress/dataviews';
 import { Icon, plugins } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { PLUGINS_STATUS } from 'calypso/state/plugins/installed/status/constants';
@@ -88,8 +89,11 @@ export function useFields(
 								} }
 								className="plugin-name-button"
 							>
-								{ item.icon && <img className="plugin-icon" alt={ item.name } src={ item.icon } /> }
-								{ ! item.icon && <Icon size={ 32 } icon={ plugins } className="plugin-icon" /> }
+								{ item.icon ? (
+									<PluginIcon image={ item.icon } size={ 35 } />
+								) : (
+									<Icon size={ 32 } icon={ plugins } className="plugin-icon" />
+								) }
 								{ item.name }
 							</Button>
 							{ pluginActionStatus }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9554

## Proposed Changes

- [x] Make a new prop at the PluginIcon component, and use that instead of style overrides. [Source](https://github.com/Automattic/wp-calypso/pull/95561#discussion_r1816786001). 
  - This PR introduces a new `size` prop on the `<PluginIcon>` component, and uses it to size the plugin icons in the DataViews table. As the `<PluginIcon>` component is used in multiple places, I checked for regressions on other plugins pages.
- [x] Propose a removal [of this CSS property](https://github.com/Automattic/wp-calypso/blob/trunk/client/components/dataviews/style.scss#L21) internally since it's not a problem with the core component. [Source](https://github.com/Automattic/wp-calypso/pull/95561#discussion_r1816790037).
  - This PR removes this override internally, I found no regressions across all 3 pages.
- [x] Make sure the `--wp-components-color-accent: var(--color-accent);` is defined correctly so we don't need to redefine it on the [DataViews Calypso wrapper file](https://github.com/Automattic/wp-calypso/blob/trunk/client/components/dataviews/style.scss).
  - Jetpack specific style overrides have been recreated [here](https://github.com/Automattic/wp-calypso/blob/aa9c4837ef0d81775a5298b0c8a47578153c2fa8/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss#L14), so this PR removes the duplicated CSS from the [dataviews styles](https://github.com/Automattic/wp-calypso/pull/97737/files#diff-9950890eeef134bd0b0662a983b25d3f1f9c99747b74d853ea1fde9b88f54d0c).
- [x] Remover checkboxes overrides on Dotcom. [Source](https://github.com/Automattic/wp-calypso/pull/95561#discussion_r1816797332).
  - This was fixed by narrowing the scope of [this selector](https://github.com/Automattic/wp-calypso/pull/97737/files#diff-9950890eeef134bd0b0662a983b25d3f1f9c99747b74d853ea1fde9b88f54d0cR82).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is a follow-up of https://github.com/Automattic/wp-calypso/pull/95561

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**On WPCOM and JP manage**
- Go to `/plugins/manage`
- Check the select all checkbox in the table header
- Check that the checkbox style is fixed
- Check the plugin icon styles for regressions
- Check the highlight color for regressions
- Check for any other possible regressions

**On A4A**
- Go to `/sites`
- Check for regressions

| Page | Staging | This branch |
|--------|--------|--------|
| WPCOM | ![CleanShot 2024-12-23 at 12 00 58@2x](https://github.com/user-attachments/assets/72cc0aa7-1948-4f86-9de3-e32ad5489a80) | ![CleanShot 2024-12-23 at 12 00 42@2x](https://github.com/user-attachments/assets/ab912250-328c-481b-bb83-187d30336b11) |
| JP manage | ![CleanShot 2024-12-23 at 12 06 15@2x](https://github.com/user-attachments/assets/f281da44-5da7-4a12-818a-747f1acc105f) | ![CleanShot 2024-12-23 at 12 06 30@2x](https://github.com/user-attachments/assets/9d8d8f44-9628-4e58-a506-ad62a6583760) |
| A4A (no changes) |  ![CleanShot 2024-12-23 at 12 04 50@2x](https://github.com/user-attachments/assets/861cf510-7fd9-4716-819b-50bbfcc70015) | ![CleanShot 2024-12-23 at 12 04 38@2x](https://github.com/user-attachments/assets/ac6d2b61-94a2-44d7-b8b1-ea9954aac10e) |