### PR TITLE
Experiment: Fix Stepper redirect

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -266,6 +266,9 @@ export default {
 			}
 
 			window.location.replace( url );
+			// skip the rest to avoid the `page.redirect` call below.
+			next();
+			return;
 		}
 
 		// const isOnboardingFlow = flowName === 'onboarding';


### PR DESCRIPTION
## Proposed Changes

This fixes the redirect for the Stepper branch of 22137-explat-experiment. 

## Why are these changes being made?
Because the redirect was adding an extraneous segment to the URL causing all path-oriented events to fail.

## Testing Instructions

1. While incognito, assign yourself to treatment.
2. Unproxy yourself.
3. Go to /start.
4. You should be redirected to /setup/onboarding. Not /setup/onboarding/user-social.

