### PR TITLE
Email stats: hide when post was not sent

### DIFF
--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -18,6 +18,7 @@ type PostThumbnail = {
 
 type Post = {
 	date: string | null;
+	dont_email_post_to_subs: boolean | null;
 	title: string;
 	type: string | null;
 	like_count: number | null;
@@ -80,10 +81,11 @@ export default function PostDetailHighlightsSection( {
 	);
 
 	// postId > 0: Show the tabs for posts except for the Home Page (postId = 0).
-	// TODO: remove the (post?.date && new Date(post?.date) >= new Date("2023-05-30")) check when the Newsletter Stats data is backfilled.
 	const isEmailTabsAvailable =
 		postId > 0 &&
+		! post?.dont_email_post_to_subs &&
 		post?.date &&
+		// The Newsletter Stats data was never backfilled (internal ref pdDOJh-1Uy-p2).
 		new Date( post?.date ) >= new Date( '2023-05-30' ) &&
 		supportsEmailStats;
 

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -106,6 +106,10 @@ class StatsPostDetail extends Component {
 		return null;
 	}
 
+	hasDontSendEmailPostToSubs( metadata ) {
+		return metadata?.some( ( { key } ) => key === '_jetpack_dont_email_post_to_subs' );
+	}
+
 	getPost() {
 		const { isPostHomepage, post, postFallback, countLikes } = this.props;
 
@@ -120,6 +124,7 @@ class StatsPostDetail extends Component {
 			return {
 				...postBase,
 				date: post?.date,
+				dont_email_post_to_subs: this.hasDontSendEmailPostToSubs( post?.metadata ),
 				post_thumbnail: post?.post_thumbnail,
 				comment_count: post?.discussion?.comment_count,
 				type: post?.type,
@@ -131,6 +136,7 @@ class StatsPostDetail extends Component {
 			return {
 				...postBase,
 				date: postFallback?.post_date_gmt,
+				dont_email_post_to_subs: this.hasDontSendEmailPostToSubs( post?.metadata ),
 				post_thumbnail: null,
 				comment_count: parseInt( postFallback?.comment_count, 10 ),
 				type: postFallback?.post_type,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack/issues/40724

Depends on https://github.com/Automattic/jetpack/pull/40723 merged and deployed to WP.com.

## Proposed Changes

* Hide email open/click tabs for individual post stats when post wasn't even sent as email.

This is different from Newsletters being disabled for the site entirely; I'll do a follow up PR to hide tabs in that case, too.

Alternatively we could keep showing tabs, but indicate somehow that the post wasn't sent as an email.

Post that wasn't sent as an email

<img width="891" alt="Screenshot 2024-12-23 at 14 08 13" src="https://github.com/user-attachments/assets/db99c7ec-b18b-4fb5-9eb3-2173553c3314" />

Post that was sent as an email

<img width="984" alt="Screenshot 2024-12-23 at 14 08 38" src="https://github.com/user-attachments/assets/c0eb24fb-7fcb-4cd8-b72a-96fd2776b00c" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply [PR](https://github.com/Automattic/jetpack/pull/40723) at your sandbox
* Create a new post and set "post only" from "newsletter" sidebar (icon in the header) and another post with "email and post" option
* Open stats individual posts view in Calypso at /stats/post/[POST ID]/[SITE ID]
* See how tabs  are hidden for "post only" version

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
