### PR TITLE
Email stats: use "opens" label instead of "views" for open stats

### DIFF
--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -29,10 +29,12 @@ class StatsGeochart extends Component {
 		postId: PropTypes.number,
 		skipQuery: PropTypes.bool,
 		isLoading: PropTypes.bool,
+		numberLabel: PropTypes.string,
 	};
 
 	static defaultProps = {
 		kind: 'site',
+		numberLabel: '',
 	};
 
 	state = {
@@ -101,7 +103,7 @@ class StatsGeochart extends Component {
 	};
 
 	drawData = () => {
-		const { currentUserCountryCode, data, translate } = this.props;
+		const { currentUserCountryCode, data, translate, numberLabel } = this.props;
 		if ( ! data || ! data.length ) {
 			return;
 		}
@@ -118,7 +120,7 @@ class StatsGeochart extends Component {
 
 		const chartData = new window.google.visualization.DataTable();
 		chartData.addColumn( 'string', translate( 'Country' ).toString() );
-		chartData.addColumn( 'number', translate( 'Views' ).toString() );
+		chartData.addColumn( 'number', numberLabel || translate( 'Views' ).toString() );
 		chartData.addRows( mapData );
 
 		// Note that using raw hex values here is an exception due to

--- a/client/my-sites/stats/stats-email-module/index.jsx
+++ b/client/my-sites/stats/stats-email-module/index.jsx
@@ -39,7 +39,7 @@ class StatsEmailModule extends Component {
 		const moduleStrings = statsStrings()[ path ];
 		// TODO: Support error state in redux store
 		const hasError = false;
-		const metricLabel = statType === 'clicks' ? translate( 'Clicks' ) : null;
+		const metricLabel = statType === 'clicks' ? translate( 'Clicks' ) : translate( 'Opens' );
 
 		return (
 			<>
@@ -59,6 +59,7 @@ class StatsEmailModule extends Component {
 								postId={ postId }
 								query={ query }
 								isLoading={ isLoading }
+								numberLabel={ metricLabel }
 							/>
 						)
 					}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of https://github.com/Automattic/jetpack/issues/40659

## Proposed Changes

* Rename "Views" to "Opens" in email open stats tab

#### Before

<img width="1333" alt="Screenshot 2024-12-23 at 14 35 42" src="https://github.com/user-attachments/assets/301add19-7628-498b-85d7-001d7ca2cbbd" />


#### After

<img width="1288" alt="Screenshot 2024-12-23 at 14 38 46" src="https://github.com/user-attachments/assets/a3cef7c8-3004-4327-86c2-8adc403ba9a3" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See email open stats, e.g. `/stats/email/opens/day/123099561/cicerosletters.wordpress.com`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
