### PR TITLE
Stepper: Switch to new experiment

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -244,7 +244,7 @@ export default {
 			await loadExperimentAssignment( 'calypso_signup_onboarding_aa_test' );
 
 			const stepperOnboardingExperimentAssignment = await loadExperimentAssignment(
-				'calypso_signup_onboarding_stepper_flow_confidence_check'
+				'calypso_signup_onboarding_stepper_flow_confidence_check_2'
 			);
 
 			setReferrerPolicy();


### PR DESCRIPTION
Context: p1734957338210529/1734780289.737499-slack-C073776NJ66

## Proposed Changes

Switches to 22142-explat-experiment.

This is a new iteration of 22142-explat-experiment. We decided to restart the test after this [bug](https://github.com/Automattic/wp-calypso/pull/97738). 

## Why are these changes being made?
Because the original experiment had a flow.

## Testing Instructions

1. Go to the experiment page.
2. Save the bookmarklet.
3. Open an incognito window.
4. Assign yourself to `control`.
5. Go to /start.
6. You should be redirected to /start/user-social?redirected_1220=true..
7. Assign yourself to `treatment`.
8. Go to /start
9. you should be redirected to /setup/onboarding/goals.
10. After deployment, test again and you should be redirect to /setup/onboarding/user.