### PR TITLE
Stats: rename 'Subscribers' to 'Newsletters'

### DIFF
--- a/client/blocks/stats-navigation/constants.ts
+++ b/client/blocks/stats-navigation/constants.ts
@@ -67,11 +67,9 @@ const insights = {
 	paywall: true,
 } as NavItem;
 
-// TODO: Consider adding subscriber counts into this nav item in the future.
-// See client/blocks/subscribers-count/index.jsx.
 const subscribers = {
 	get label() {
-		return translate( 'Subscribers' );
+		return translate( 'Newsletter' );
 	},
 	path: '/stats/subscribers',
 	showIntervals: false,

--- a/client/my-sites/stats/pages/shared/helpers.tsx
+++ b/client/my-sites/stats/pages/shared/helpers.tsx
@@ -44,7 +44,7 @@ function getSiteFilters( siteId: number ): SiteFilterType[] {
 			id: 'stats-insights',
 		},
 		{
-			title: i18n.translate( 'Newsletters' ),
+			title: i18n.translate( 'Newsletter' ),
 			path: '/stats/subscribers/' + siteId,
 			id: 'stats-subscribers',
 			period: 'day', // default period for Subscribers

--- a/client/my-sites/stats/pages/shared/helpers.tsx
+++ b/client/my-sites/stats/pages/shared/helpers.tsx
@@ -44,7 +44,7 @@ function getSiteFilters( siteId: number ): SiteFilterType[] {
 			id: 'stats-insights',
 		},
 		{
-			title: i18n.translate( 'Subscribers' ),
+			title: i18n.translate( 'Newsletters' ),
 			path: '/stats/subscribers/' + siteId,
 			id: 'stats-subscribers',
 			period: 'day', // default period for Subscribers

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -125,15 +125,10 @@ export default function SubscribersChartSection( {
 	const hasAddedPaidSubscriptionProduct = products && products.length > 0;
 	const chartData = transformData( data?.data || [], hasAddedPaidSubscriptionProduct );
 
-	const subscribers = {
-		label: 'Subscribers',
-		path: `/stats/subscribers/`,
-	};
-
 	const slugPath = slug ? `/${ slug }` : '';
-	const pathTemplate = `${ subscribers.path }{{ interval }}${ slugPath }`;
+	const pathTemplate = `/stats/subscribers/{{ interval }}${ slugPath }`;
 
-	const subscribersUrl = isOdysseyStats
+	const manageSubscribersUrl = isOdysseyStats
 		? `https://cloud.jetpack.com/subscribers/${ slug }`
 		: `/subscribers/${ slug }`;
 
@@ -144,7 +139,7 @@ export default function SubscribersChartSection( {
 				<h1 className="highlight-cards-heading">
 					{ translate( 'Subscribers' ) }{ ' ' }
 					<small>
-						<a className="highlight-cards-heading-wrapper" href={ subscribersUrl }>
+						<a className="highlight-cards-heading-wrapper" href={ manageSubscribersUrl }>
 							{ translate( 'View all subscribers' ) }
 						</a>
 					</small>

--- a/packages/calypso-e2e/src/lib/pages/stats-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/stats-page.ts
@@ -82,7 +82,7 @@ export class StatsPage {
 		if ( name === 'Insights' ) {
 			await this.page.waitForURL( /stats\/insights/ );
 		}
-		if ( name === 'Subscribers' ) {
+		if ( name === 'Newsletter' ) {
 			await this.page.waitForURL( /stats\/subscribers/ );
 		}
 		if ( name === 'Store' ) {

--- a/packages/calypso-e2e/src/lib/pages/stats-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/stats-page.ts
@@ -3,7 +3,7 @@ import { envVariables } from '../..';
 import { getCalypsoURL } from '../../data-helper';
 import { clickNavTab } from '../../element-helper';
 
-export type StatsTabs = 'Traffic' | 'Insights' | 'Subscribers' | 'Store';
+export type StatsTabs = 'Traffic' | 'Insights' | 'Newsletter' | 'Store';
 type TrafficActivityType = 'Views' | 'Visitors' | 'Likes' | 'Comments';
 type StoreActivityType = 'Gross Sales' | 'Net sales' | 'Orders' | 'Avg. Order Value';
 // Discriminated Union type.

--- a/test/e2e/specs/stats/stats.ts
+++ b/test/e2e/specs/stats/stats.ts
@@ -90,9 +90,9 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 		} );
 	} );
 
-	describe( 'Subscribers', function () {
-		it( 'Click on Subscribers tab', async function () {
-			await statsPage.clickTab( 'Subscribers' );
+	describe( 'Newsletter', function () {
+		it( 'Click on Newsletter tab', async function () {
+			await statsPage.clickTab( 'Newsletter' );
 		} );
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack/issues/40537

Designs p1HpG7-vch-p2

## Proposed Changes

* Now that "Subscribers" tab contains more than just subscribers (i.e. emails), let's rename it to match product's name.

Before
<img width="551" alt="image" src="https://github.com/user-attachments/assets/8567f049-f973-47cf-843d-fe0861d4c6ae" />

After
<img width="693" alt="Screenshot 2024-12-23 at 14 53 51" src="https://github.com/user-attachments/assets/9634b091-e1f3-45fa-aa7e-ce9ed661d5e4" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head over to Stats and see new tab name. URL still stays the same to make the change simpler.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
