### PR TITLE
Email stats: update icons

### DIFF
--- a/client/my-sites/stats/stats-email-top-row/index.jsx
+++ b/client/my-sites/stats/stats-email-top-row/index.jsx
@@ -1,6 +1,5 @@
 import { Gridicon } from '@automattic/components';
-import { eye } from '@automattic/components/src/icons';
-import { Icon } from '@wordpress/icons';
+import { Icon, send, seen, link } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
@@ -36,10 +35,10 @@ export default function StatsEmailTopRow( { siteId, postId, statType, className,
 				return (
 					<>
 						<TopCard
-							heading={ translate( 'Recipients' ) }
+							heading={ translate( 'Total emails sent' ) }
 							value={ counts?.total_sends ?? 0 }
 							isLoading={ isRequesting && ! counts?.hasOwnProperty( 'total_sends' ) }
-							icon={ <Gridicon icon="mail" /> }
+							icon={ <Icon icon={ send } /> }
 							emailIsSending={ emailIsSending }
 						/>
 						{ counts?.unique_opens ? (
@@ -47,14 +46,14 @@ export default function StatsEmailTopRow( { siteId, postId, statType, className,
 								heading={ translate( 'Unique opens' ) }
 								value={ counts.unique_opens }
 								isLoading={ isRequesting && ! counts?.hasOwnProperty( 'unique_opens' ) }
-								icon={ <Icon icon={ eye } /> }
+								icon={ <Icon icon={ seen } /> }
 							/>
 						) : null }
 						<TopCard
 							heading={ translate( 'Total opens' ) }
 							value={ counts?.total_opens ?? 0 }
 							isLoading={ isRequesting && ! counts?.hasOwnProperty( 'total_opens' ) }
-							icon={ <Icon icon={ eye } /> }
+							icon={ <Icon icon={ seen } /> }
 						/>
 						<TopCard
 							heading={ translate( 'Open rate' ) }
@@ -72,19 +71,19 @@ export default function StatsEmailTopRow( { siteId, postId, statType, className,
 							heading={ translate( 'Total opens' ) }
 							value={ counts?.total_opens ?? 0 }
 							isLoading={ isRequesting && ! counts?.hasOwnProperty( 'total_opens' ) }
-							icon={ <Gridicon icon="mail" /> }
+							icon={ <Icon icon={ seen } /> }
 						/>
 						<TopCard
 							heading={ translate( 'Total clicks' ) }
 							value={ counts?.total_clicks ?? 0 }
 							isLoading={ isRequesting && ! counts?.hasOwnProperty( 'total_clicks' ) }
-							icon={ <Icon icon={ eye } /> }
+							icon={ <Icon icon={ link } /> }
 						/>
 						<TopCard
 							heading={ translate( 'Click rate' ) }
 							value={ counts?.clicks_rate ? `${ Math.round( counts?.clicks_rate * 100 ) }%` : null }
 							isLoading={ isRequesting && ! counts?.hasOwnProperty( 'clicks_rate' ) }
-							icon={ <Gridicon icon="trending" /> }
+							icon={ <Icon icon={ link } /> }
 						/>
 					</>
 				);

--- a/client/my-sites/stats/stats-email-top-row/index.jsx
+++ b/client/my-sites/stats/stats-email-top-row/index.jsx
@@ -1,4 +1,5 @@
 import { Gridicon } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { Icon, send, seen, link } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -15,6 +16,7 @@ import './style.scss';
 
 export default function StatsEmailTopRow( { siteId, postId, statType, className, post } ) {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 
 	const counts = useSelector( ( state ) =>
 		getEmailStatsNormalizedData( state, siteId, postId, PERIOD_ALL_TIME, statType, '', 'rate' )
@@ -35,7 +37,11 @@ export default function StatsEmailTopRow( { siteId, postId, statType, className,
 				return (
 					<>
 						<TopCard
-							heading={ translate( 'Total emails sent' ) }
+							heading={
+								hasEnTranslation( 'Total emails sent' )
+									? translate( 'Total emails sent' )
+									: translate( 'Recipients' )
+							}
 							value={ counts?.total_sends ?? 0 }
 							isLoading={ isRequesting && ! counts?.hasOwnProperty( 'total_sends' ) }
 							icon={ <Icon icon={ send } /> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of https://github.com/Automattic/jetpack/issues/40659

Designs:
i1: p1HpG7-v7v-p2
i2: p1HpG7-vch-p2

This isn't yet exactly like in designs but nudges us towards [combining the two tabs](https://github.com/Automattic/jetpack/issues/40659) with less changes.

## Proposed Changes

* Update email stats icons; uses WP icons instead of Gridicons

#### Before
<img width="1279" alt="Screenshot 2024-12-23 at 15 22 01" src="https://github.com/user-attachments/assets/d870372d-a597-4caf-9dc1-40cd57644a94" />
<img width="1288" alt="Screenshot 2024-12-23 at 15 22 04" src="https://github.com/user-attachments/assets/f7dcc6e8-3153-438a-9aaa-c9adb5739675" />


#### After
<img width="1266" alt="Screenshot 2024-12-23 at 15 19 57" src="https://github.com/user-attachments/assets/8c0e8d7b-2dd3-483b-a34b-1bce9eb5a0de" />
<img width="1292" alt="Screenshot 2024-12-23 at 15 19 53" src="https://github.com/user-attachments/assets/c9ddd956-fd19-4b75-bd9a-83ad636ff566" />




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See open/click email tabs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?