### PR TITLE
Me: Fix Background Height of Emptier Pages

### DIFF
--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -1,11 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.is-section-me.is-global-sidebar-visible .purchases__cancel.main,
-.is-section-me.is-global-sidebar-visible .purchases__cancel-domain.main {
-	height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
-}
-
 .cancel-purchase__wrapper-card {
 	padding: 32px;
 	padding-top: 12px;

--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -38,6 +38,7 @@ body.is-section-me {
 				background: var(--color-surface);
 				border-radius: 8px; /* stylelint-disable-line scales/radii */
 				box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
+				height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
 				overflow-y: auto;
 				overflow-x: hidden;
 				max-width: none;


### PR DESCRIPTION
## Proposed Changes

Some of the pages on `/me` have looked quite odd for a while now because their height doesn't expand to the full screen, which has a weird effect when switching between pages. 

## Why are these changes being made?

This line of code was removed in #94180 because it was considered unnecessary, but that was wrong - the code was preventing this issue from occurring. I have tried repeatedly to reproduce the bug that it was removed to fix (#94167), but I can't do so now.  

## Testing Instructions

Navigate some pages through `/me` and verify:

1) The background is the full height of the screen.
2) You can't reproduce #94180 - there should be sufficient padding on screens like `/me/privacy` at all screen sizes.

| Before | After |
|--------|--------|
| <img width="1665" alt="Screenshot 2024-12-23 at 21 44 27" src="https://github.com/user-attachments/assets/8d9bbf51-c7e2-4070-9104-007db062286a" /> | <img width="1658" alt="Screenshot 2024-12-23 at 21 44 17" src="https://github.com/user-attachments/assets/6d6fcb55-c790-4140-9a6b-a55289a933aa" /> | 

cc @eoigal, @Addison-Stavlo, @fushar 