### PR TITLE
Start vs Stepper: do not double redirect

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -239,8 +239,13 @@ export default {
 
 		store.set( 'signup-locale', localeFromParams );
 
+		const hasRedirected =
+			context.querystring?.includes( 'redirected_1220=true' ) ||
+			// Check the URL as well because sometimes the context.querystring lags behind the URL.
+			new URLSearchParams( window.location.search ).has( 'redirected_1220' );
+
 		const isOnboardingFlow = flowName === 'onboarding';
-		if ( isOnboardingFlow && ! context.querystring?.includes( 'redirected_1220=true' ) ) {
+		if ( isOnboardingFlow && ! hasRedirected ) {
 			await loadExperimentAssignment( 'calypso_signup_onboarding_aa_test' );
 
 			const stepperOnboardingExperimentAssignment = await loadExperimentAssignment(


### PR DESCRIPTION
## Proposed Changes

To prevent a redirect loop, we rely on the query string to determine if the user had already been redirected. But since `querystring` lags a bit, we were redirecting twice. 

Because when we redirect in `controller.js`, the `context.querystring` doesn't contain the query values, I couldn't investigate why that is the case. The good news is that `location.pathname` does have them, so this PR uses it as a harmless backup. 

## Why are these changes being made?
To prevent excessive redirects.

## Testing Instructions

1. Open DevTools > Network. 
2. **Filter by Doc.**
3. Go to /start.
4. Assuming you're assigned to /start, you should land at /start?redirect_1220=true.
5. When you signup and make to the domains page, the DevTools should show a single instance of loading /domains.

## Before and after

### Before
<img width="931" alt="image" src="https://github.com/user-attachments/assets/a0dd224d-7d78-41d9-a8f8-f133cc9b64c6" />

### After
<img width="924" alt="image" src="https://github.com/user-attachments/assets/51a18e05-c0c3-4639-b03e-4a204536be92" />

