### PR TITLE
Revert "Start vs Stepper: do not double redirect"

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -239,13 +239,8 @@ export default {
 
 		store.set( 'signup-locale', localeFromParams );
 
-		const hasRedirected =
-			context.querystring?.includes( 'redirected_1220=true' ) ||
-			// Check the URL as well because sometimes the context.querystring lags behind the URL.
-			new URLSearchParams( window.location.search ).has( 'redirected_1220' );
-
 		const isOnboardingFlow = flowName === 'onboarding';
-		if ( isOnboardingFlow && ! hasRedirected ) {
+		if ( isOnboardingFlow && ! context.querystring?.includes( 'redirected_1220=true' ) ) {
 			await loadExperimentAssignment( 'calypso_signup_onboarding_aa_test' );
 
 			const stepperOnboardingExperimentAssignment = await loadExperimentAssignment(


### PR DESCRIPTION
Reverts Automattic/wp-calypso#97752

Pre-release tests are failing.