### PR TITLE
Sites Dashboard: Fix header style in the list view

### DIFF
--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -44,7 +44,7 @@
 		white-space: nowrap;
 	}
 
-	.a4a-layout__viewport {
+	.multi-sites-dashboard-layout__viewport {
 		margin-inline-start: 0;
 	}
 

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -209,7 +209,7 @@
 			.sites-overview {
 				padding: 0;
 
-				.a4a-layout__viewport {
+				.multi-sites-dashboard-layout__viewport {
 					padding-inline: 16px;
 				}
 

--- a/client/layout/multi-sites-dashboard/header.tsx
+++ b/client/layout/multi-sites-dashboard/header.tsx
@@ -67,7 +67,7 @@ export default function LayoutHeader( { showStickyContent, children, className }
 	const [ divRef, hasCrossed ] = useDetectWindowBoundary();
 
 	const outerDivProps = divRef ? { ref: divRef as React.RefObject< HTMLDivElement > } : {};
-	const wrapperClass = clsx( className, 'a4a-layout__viewport' );
+	const wrapperClass = clsx( className, 'multi-sites-dashboard-layout__viewport' );
 
 	const [ minHeaderHeight, setMinHeaderHeight ] = useState( 0 );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10138

## Proposed Changes

This PR fixes header style in the list view.

| before | after |
|--------|--------|
| <img width="421" alt="Screenshot 2024-12-24 at 11 15 37" src="https://github.com/user-attachments/assets/88ecaa0e-d965-4872-8c50-9f83b82f8909" /> | <img width="409" alt="Screenshot 2024-12-24 at 11 27 48" src="https://github.com/user-attachments/assets/b67bb870-5b10-4d59-8193-0a3457c3a76b" /> | 

This was due to missing class updates. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select any site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
