### PR TITLE
Allow opening site previews in a new tab with Cmd+click or middle click

### DIFF
--- a/client/sites/components/sites-dashboard.tsx
+++ b/client/sites/components/sites-dashboard.tsx
@@ -89,7 +89,7 @@ const getFieldsByBreakpoint = ( selectedSite: boolean, isDesktop: boolean ) => {
 	return isDesktop ? desktopFields : mobileFields;
 };
 
-export function showSitesPage( route: string ) {
+export function showSitesPage( route: string, openInNewTab = false ) {
 	const currentParams = new URL( window.location.href ).searchParams;
 	const newUrl = new URL( route, window.location.origin );
 
@@ -103,7 +103,17 @@ export function showSitesPage( route: string ) {
 		}
 	} );
 
-	pagejs.show( newUrl.toString().replace( window.location.origin, '' ) );
+	if ( openInNewTab ) {
+		const newWindow = window.open(
+			newUrl.toString().replace( window.location.origin, '' ),
+			'_blank'
+		);
+		if ( newWindow ) {
+			newWindow.opener = null;
+		}
+	} else {
+		pagejs.show( newUrl.toString().replace( window.location.origin, '' ) );
+	}
 }
 
 const SitesDashboard = ( {
@@ -336,14 +346,16 @@ const SitesDashboard = ( {
 
 	const openSitePreviewPane = (
 		site: SiteExcerptData,
-		source: 'site_field' | 'action' | 'list_row_click' | 'environment_switcher'
+		source: 'site_field' | 'action' | 'list_row_click' | 'environment_switcher',
+		openInNewTab?: boolean
 	) => {
 		recordTracksEvent( 'calypso_sites_dashboard_open_site_preview_pane', {
 			site_id: site.ID,
 			source,
 		} );
 		showSitesPage(
-			`/${ FEATURE_TO_ROUTE_MAP[ initialSiteFeature ].replace( ':site', site.slug ) }`
+			`/${ FEATURE_TO_ROUTE_MAP[ initialSiteFeature ].replace( ':site', site.slug ) }`,
+			openInNewTab
 		);
 	};
 

--- a/client/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
@@ -29,7 +29,8 @@ type Props = {
 	site: SiteExcerptData;
 	openSitePreviewPane?: (
 		site: SiteExcerptData,
-		source: 'site_field' | 'action' | 'list_row_click' | 'environment_switcher'
+		source: 'site_field' | 'action' | 'list_row_click' | 'environment_switcher',
+		openInNewTab?: boolean
 	) => void;
 };
 
@@ -77,17 +78,27 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 	const isAdmin = useSelector( ( state ) => canCurrentUser( state, site.ID, 'manage_options' ) );
 
 	const onSiteClick = ( event: React.MouseEvent ) => {
+		event.preventDefault();
+
+		let openInNewTab = false;
+		if ( event.ctrlKey || event.metaKey ) {
+			openInNewTab = true;
+		}
+		// Support middle click to open in new tab
+		if ( event.button === 1 ) {
+			openInNewTab = true;
+		}
+
 		if (
 			isAdmin &&
 			! isP2Site &&
 			! isNotAtomicJetpack( site ) &&
 			! isDisconnectedJetpackAndNotAtomic( site )
 		) {
-			openSitePreviewPane && openSitePreviewPane( site, 'site_field' );
+			openSitePreviewPane && openSitePreviewPane( site, 'site_field', openInNewTab );
 		} else {
-			navigate( adminUrl );
+			navigate( adminUrl, openInNewTab );
 		}
-		event.preventDefault();
 	};
 
 	const isMigrationPending = getMigrationStatus( site ) === 'pending';
@@ -97,6 +108,7 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 		<Button
 			className="sites-dataviews__site"
 			onClick={ onSiteClick }
+			onAuxClick={ onSiteClick }
 			borderless
 			disabled={ site.is_deleted }
 		>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9969

## Proposed Changes

This PR allows opening site previews in a new tab with Cmd+click or middle click.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://github.com/Automattic/dotcom-forge/issues/9969

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Cmd+click any site
* Observe the site opens in a new window

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
