### PR TITLE
Reader: Use dropdown for email delivery frequency

### DIFF
--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -1,4 +1,4 @@
-import { SegmentedControl } from '@automattic/components';
+import { Reader } from '@automattic/data-stores';
 import { Button, ToggleControl } from '@wordpress/components';
 import { Icon, settings } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
@@ -8,6 +8,7 @@ import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
 import Settings from 'calypso/assets/images/icons/settings.svg';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import FormSelect from 'calypso/components/forms/form-select';
 import SVGIcon from 'calypso/components/svg-icon';
 import ReaderPopover from 'calypso/reader/components/reader-popover';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -44,6 +45,24 @@ class ReaderSiteNotificationSettings extends Component {
 	iconRef = createRef();
 	spanRef = createRef();
 
+	getAvailableFrequencies = () => {
+		const { translate } = this.props;
+		return [
+			{
+				value: Reader.EmailDeliveryFrequency.Instantly,
+				label: translate( 'Instantly' ),
+			},
+			{
+				value: Reader.EmailDeliveryFrequency.Daily,
+				label: translate( 'Daily' ),
+			},
+			{
+				value: Reader.EmailDeliveryFrequency.Weekly,
+				label: translate( 'Weekly' ),
+			},
+		];
+	};
+
 	togglePopoverVisibility = () => {
 		this.setState( { showPopover: ! this.state.showPopover } );
 	};
@@ -52,7 +71,7 @@ class ReaderSiteNotificationSettings extends Component {
 		this.setState( { showPopover: false } );
 	};
 
-	setSelected = ( text ) => () => {
+	setSelected = ( text ) => {
 		const { siteId } = this.props;
 		this.props.updateNewPostEmailSubscription( siteId, text );
 
@@ -108,12 +127,18 @@ class ReaderSiteNotificationSettings extends Component {
 	render() {
 		const {
 			translate,
+			emailDeliveryFrequency,
 			sendNewCommentsByEmail,
 			sendNewPostsByEmail,
 			sendNewPostsByNotification,
 			isEmailBlocked,
 			subscriptionId,
 		} = this.props;
+
+		const availableFrequencies = this.getAvailableFrequencies();
+		const selectedFrequency = availableFrequencies.find(
+			( option ) => option.value === emailDeliveryFrequency
+		);
 
 		if ( ! this.props.siteId ) {
 			return null;
@@ -198,27 +223,20 @@ class ReaderSiteNotificationSettings extends Component {
 					</div>
 
 					{ ! isEmailBlocked && sendNewPostsByEmail && (
-						<SegmentedControl>
-							<SegmentedControl.Item
-								selected={ this.props.emailDeliveryFrequency === 'instantly' }
-								onClick={ this.setSelected( 'instantly' ) }
+						<div className="reader-site-notification-settings__popout-select">
+							<FormSelect
+								value={ selectedFrequency?.value }
+								onChange={ ( event ) => this.setSelected( event.target.value ) }
 							>
-								{ translate( 'Instantly' ) }
-							</SegmentedControl.Item>
-							<SegmentedControl.Item
-								selected={ this.props.emailDeliveryFrequency === 'daily' }
-								onClick={ this.setSelected( 'daily' ) }
-							>
-								{ translate( 'Daily' ) }
-							</SegmentedControl.Item>
-							<SegmentedControl.Item
-								selected={ this.props.emailDeliveryFrequency === 'weekly' }
-								onClick={ this.setSelected( 'weekly' ) }
-							>
-								{ translate( 'Weekly' ) }
-							</SegmentedControl.Item>
-						</SegmentedControl>
+								{ availableFrequencies.map( ( option ) => (
+									<option key={ option.value } value={ option.value }>
+										{ option.label }
+									</option>
+								) ) }
+							</FormSelect>
+						</div>
 					) }
+
 					{ ! isEmailBlocked && (
 						<div className="reader-site-notification-settings__popout-toggle">
 							<ToggleControl

--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -32,31 +32,28 @@
 	}
 }
 
-.reader-popover.popover.is-bottom .popover__arrow::before,
-.reader-popover.popover.is-bottom-left .popover__arrow::before,
-.reader-popover.popover.is-bottom-right .popover__arrow::before {
-	border: 10px solid var(--color-surface);
-	border-bottom-style: solid;
-	border-left-color: transparent;
-	border-right-color: transparent;
-	border-top: none;
-}
+.reader-site-notification-settings__popout.reader-popover.popover {
+	&.is-bottom .popover__arrow::before,
+	&.is-bottom-left .popover__arrow::before,
+	&.is-bottom-right .popover__arrow::before {
+		border: 10px solid var(--color-surface);
+		border-bottom-style: solid;
+		border-left-color: transparent;
+		border-right-color: transparent;
+		border-top: none;
+	}
 
-.reader-popover.popover .popover__inner {
-	background: var(--color-surface);
+	.popover__inner {
+		background: var(--color-surface);
+	}
 }
 
 .reader-popover__wrapper {
-	.segmented-control {
-		background: inherit;
-		padding: 0 12px 10px 16px;
-	}
+	.reader-site-notification-settings__popout-select {
+		padding-top: 0;
 
-	.segmented-control__link {
-		background: var(--color-surface);
-
-		span {
-			font-size: $font-body-extra-small;
+		.form-select:only-of-type {
+			max-width: 100%;
 		}
 	}
 
@@ -77,10 +74,12 @@
 		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		line-height: 1.25rem;
 		height: 1.25rem;
+		margin: 0;
 	}
 }
 
 .reader-site-notification-settings__popout-toggle,
+.reader-site-notification-settings__popout-select,
 .reader-site-notification-settings__popout-instructions {
 	color: var(--color-neutral-70);
 	font-size: $font-body-small;

--- a/client/blocks/reader-site-subscription/styles.scss
+++ b/client/blocks/reader-site-subscription/styles.scss
@@ -83,8 +83,6 @@
 			}
 
 			&__control {
-				width: fit-content;
-
 				.segmented-control__link {
 					padding: 10px 25px;
 				}

--- a/client/landing/subscriptions/components/settings/site-settings/delivery-frequency-input.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/delivery-frequency-input.tsx
@@ -1,26 +1,8 @@
-import { SegmentedControl } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
-
-type DeliveryFrequencyOptionProps = {
-	children: React.ReactNode;
-	value: Reader.EmailDeliveryFrequency;
-	selected: boolean;
-	onChange: ( value: Reader.EmailDeliveryFrequency ) => void;
-};
-
-const DeliveryFrequencyOption = ( {
-	children,
-	selected,
-	value,
-	onChange,
-}: DeliveryFrequencyOptionProps ) => (
-	<SegmentedControl.Item selected={ selected } onClick={ () => onChange( value ) }>
-		{ children }
-	</SegmentedControl.Item>
-);
+import { ChangeEvent, useMemo } from 'react';
+import FormSelect from 'calypso/components/forms/form-select';
 
 type DeliveryFrequencyInputProps = {
 	onChange: ( value: Reader.EmailDeliveryFrequency ) => void;
@@ -29,7 +11,7 @@ type DeliveryFrequencyInputProps = {
 };
 
 type DeliveryFrequencyKeyLabel = {
-	key: Reader.EmailDeliveryFrequency;
+	value: Reader.EmailDeliveryFrequency;
 	label: string;
 };
 
@@ -43,19 +25,24 @@ const DeliveryFrequencyInput = ( {
 	const availableFrequencies = useMemo< DeliveryFrequencyKeyLabel[] >(
 		() => [
 			{
-				key: Reader.EmailDeliveryFrequency.Instantly,
+				value: Reader.EmailDeliveryFrequency.Instantly,
 				label: translate( 'Instantly' ),
 			},
 			{
-				key: Reader.EmailDeliveryFrequency.Daily,
+				value: Reader.EmailDeliveryFrequency.Daily,
 				label: translate( 'Daily' ),
 			},
 			{
-				key: Reader.EmailDeliveryFrequency.Weekly,
+				value: Reader.EmailDeliveryFrequency.Weekly,
 				label: translate( 'Weekly' ),
 			},
 		],
 		[ translate ]
+	);
+
+	const selectedFrequency = useMemo< DeliveryFrequencyKeyLabel | undefined >(
+		() => availableFrequencies.find( ( option ) => option.value === selectedValue ),
+		[ selectedValue, availableFrequencies ]
 	);
 
 	return (
@@ -67,22 +54,21 @@ const DeliveryFrequencyInput = ( {
 			{ ! isLoggedIn && (
 				<p className="setting-item__label">{ translate( 'Email me new posts' ) }</p>
 			) }
-			<SegmentedControl
+			<FormSelect
 				className={ clsx( 'delivery-frequency-input__control', {
 					'is-loading': isUpdating,
 				} ) }
+				value={ selectedFrequency?.value }
+				onChange={ ( event: ChangeEvent< HTMLSelectElement > ) =>
+					onChange( event.target.value as Reader.EmailDeliveryFrequency )
+				}
 			>
-				{ availableFrequencies.map( ( { key, label }, index ) => (
-					<DeliveryFrequencyOption
-						selected={ selectedValue === key }
-						value={ key }
-						onChange={ onChange }
-						key={ index }
-					>
-						{ label }
-					</DeliveryFrequencyOption>
+				{ availableFrequencies.map( ( option ) => (
+					<option key={ option.value } value={ option.value }>
+						{ option.label }
+					</option>
 				) ) }
-			</SegmentedControl>
+			</FormSelect>
 		</div>
 	);
 };

--- a/client/landing/subscriptions/components/settings/styles.scss
+++ b/client/landing/subscriptions/components/settings/styles.scss
@@ -51,10 +51,5 @@
 				text-decoration: underline;
 			}
 		}
-
-		.segmented-control__item.is-selected .segmented-control__link {
-			background-color: $studio-gray-90;
-			color: $studio-white;
-		}
 	}
 }

--- a/client/reader/site-subscriptions-manager/style.scss
+++ b/client/reader/site-subscriptions-manager/style.scss
@@ -142,6 +142,10 @@ hr.subscriptions__separator {
 				margin-bottom: 16px;
 			}
 		}
+
+		.delivery-frequency-input__control {
+			max-width: 100%;
+		}
 	}
 
 	.site-settings-popover__unsubscribe-button.components-button.has-icon:not(:last-child) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/96584

## Proposed Changes

This PR updates the email frequency component to use dropdown instead of segment controls. There are 3 affected areas:

/read/feeds/:feedId
| Current | Proposal | Proposal (expanded) |
| --- | --- | --- |
| ![Screenshot 2024-12-24 at 2 58 10 PM](https://github.com/user-attachments/assets/b8b5eee7-2b73-4ff1-a607-be16116ebfec) | ![Screenshot 2024-12-24 at 2 58 21 PM](https://github.com/user-attachments/assets/fb3039c7-1457-42c3-8441-a27e6ea56704) |  ![Screenshot 2024-12-24 at 2 58 16 PM](https://github.com/user-attachments/assets/e3835f96-8643-4a87-9aac-35a2505a9cc7) |

/read/subscriptions/:subscriptionId
| Current | Proposal | Proposal (expanded) |
| --- | --- | --- |
| ![Screenshot 2024-12-24 at 2 58 33 PM](https://github.com/user-attachments/assets/c3446f16-050b-43cb-a4d0-ba76a8477e41) | ![Screenshot 2024-12-24 at 2 58 40 PM](https://github.com/user-attachments/assets/bf3656d3-7722-44dc-a456-ae487363740d) | ![Screenshot 2024-12-24 at 2 58 45 PM](https://github.com/user-attachments/assets/df0ced1a-0359-4c49-ab06-9ae095572c76)|

/read/subscriptions

| Current | Proposal | Proposal (expanded) |
| --- | --- | --- |
| ![Screenshot 2024-12-24 at 2 59 12 PM](https://github.com/user-attachments/assets/fd88acae-9543-48e1-aba5-3a479a813ced) | ![Screenshot 2024-12-24 at 2 59 19 PM](https://github.com/user-attachments/assets/f3a106b6-fa60-4265-9d4b-cb58f5b6844c) | ![Screenshot 2024-12-24 at 2 59 26 PM](https://github.com/user-attachments/assets/b9ce54a9-3abe-4f0b-8a82-3467c61b3dc0) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Contributes to the overall polish of WordPress.com.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /read/subscriptions
* Click on the ellipsis icon and ensure that the email frequency setting has been updated to dropdown
* Ensure that setting can be updated properly
* Click on any site title to land on the /read/subscriptions/:subscriptionId page
* Ensure that the email frequency setting has been updated to dropdown and can be updated properly
* Click on the site icon to land on the /read/feeds/:feedId page
* Click on the settings icon and ensure that the email frequency setting has been updated to dropdown and can be updated properly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
