### PR TITLE
Add E2E tests for Social features in the editor for Simple sites

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-publish-panel-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-publish-panel-component.ts
@@ -31,6 +31,15 @@ export class EditorPublishPanelComponent {
 	}
 
 	/**
+	 * Returns the root element of the toolbar.
+	 */
+	async getRoot() {
+		const editorParent = await this.editor.parent();
+
+		return editorParent.getByRole( 'region', { name: 'Editor publish' } );
+	}
+
+	/**
 	 * Checks whether the Editor Publish panel is open.
 	 *
 	 * This method will wait up to 5 seconds for the panel to be visible.

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -56,6 +56,26 @@ export class EditorSettingsSidebarComponent {
 	//#region Generic methods
 
 	/**
+	 * Returns the root element of the sidebar.
+	 */
+	async getRoot() {
+		const editorParent = await this.editor.parent();
+
+		return editorParent.getByRole( 'region', { name: 'Editor settings' } );
+	}
+
+	/**
+	 * Returns the root element (panel body) of the section.
+	 */
+	async getSection( name: string ) {
+		const sidebar = await this.getRoot();
+
+		return sidebar.locator( '.components-panel__body' ).filter( {
+			has: this.page.locator( `h2.components-panel__body-title button:has-text("${ name }")` ),
+		} );
+	}
+
+	/**
 	 * Clicks a button matching the accessible name.
 	 *
 	 * @param {string} name Accessible name of the button.
@@ -121,10 +141,13 @@ export class EditorSettingsSidebarComponent {
 	 * If the section is already open, this method will pass.
 	 *
 	 * @param {string} name Name of section to be expanded.
+	 *
+	 * @returns The section element.
 	 */
-	async expandSection( name: string ): Promise< void > {
+	async expandSection( name: string ) {
+		const section = await this.getSection( name );
 		if ( await this.targetIsOpen( selectors.section( name ) ) ) {
-			return;
+			return section;
 		}
 
 		const editorParent = await this.editor.parent();
@@ -135,6 +158,8 @@ export class EditorSettingsSidebarComponent {
 			`${ selectors.section( name ) }[aria-expanded="true"]`
 		);
 		await expandedLocator.waitFor();
+
+		return section;
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -515,6 +515,22 @@ export class EditorPage {
 	//#region Settings Sidebar
 
 	/**
+	 * Returns the locator for the root element of the settings sidebar.
+	 */
+	async getSettingsRoot() {
+		return await this.editorSettingsSidebarComponent.getRoot();
+	}
+
+	/**
+	 * Returns the locator of a section (panel body) settings sidebar.
+	 *
+	 * @param {string} name Name of the section.
+	 */
+	async getSettingsSection( name: string ) {
+		return await this.editorSettingsSidebarComponent.getSection( name );
+	}
+
+	/**
 	 * Opens the Settings sidebar.
 	 */
 	async openSettings( target: EditorToolbarSettingsButton = 'Settings' ): Promise< void > {
@@ -538,8 +554,8 @@ export class EditorPage {
 	 *
 	 * @param {string} name Name of the section to expand.
 	 */
-	async expandSection( name: string ): Promise< void > {
-		await this.editorSettingsSidebarComponent.expandSection( name );
+	async expandSection( name: string ) {
+		return await this.editorSettingsSidebarComponent.expandSection( name );
 	}
 
 	/**
@@ -681,6 +697,13 @@ export class EditorPage {
 	//#endregion
 
 	//#region Publish, Draft & Schedule
+
+	/**
+	 * Returns the locator for the root element of the publish toolbar.
+	 */
+	async getPublishPanelRoot() {
+		return await this.editorPublishPanelComponent.getRoot();
+	}
 
 	/**
 	 * Publishes the post or page and returns the resulting URL.

--- a/packages/calypso-e2e/src/lib/utils/index.ts
+++ b/packages/calypso-e2e/src/lib/utils/index.ts
@@ -2,6 +2,7 @@
 export * from './validate-translations';
 export * from './get-test-account-by-feature';
 export * from './translate';
+export * from './social-connections-manager';
 
 // Other items are exported for unit testing, we only care about the manager class.
 export { EditorTracksEventManager } from './editor-tracks-event-manager';

--- a/packages/calypso-e2e/src/lib/utils/social-connections-manager.ts
+++ b/packages/calypso-e2e/src/lib/utils/social-connections-manager.ts
@@ -1,0 +1,112 @@
+import { Page } from 'playwright';
+
+/**
+ * A class to help manage social connections in the UI.
+ */
+export class SocialConnectionsManager {
+	/**
+	 * Constructor to set the props
+	 */
+	constructor(
+		private page: Page,
+		private siteId: number
+	) {
+		// Ensure the methods are bound to the class.
+		this.isTargetUrl = this.isTargetUrl.bind( this );
+	}
+
+	/**
+	 * Get the patterns for the social connections URLs
+	 */
+	get patterns() {
+		return {
+			CONNECTION_TESTS: new RegExp(
+				// The request that deals with connection test results
+				`wpcom/v2/sites/${ this.siteId }/publicize/connection-test-results`
+			),
+			GET_POST: new RegExp(
+				// The request that gets the post data in the editor
+				`wp/v2/sites/${ this.siteId }/posts/[0-9]+`
+			),
+			POST_AUTOSAVES: new RegExp(
+				// The request that deals with post autosaves in the editor
+				`wp/v2/sites/${ this.siteId }/posts/[0-9]+/autosaves`
+			),
+		};
+	}
+
+	/**
+	 * Get the test connections
+	 */
+	get testConnections() {
+		return [
+			{
+				connection_id: '123456',
+				display_name: 'Tumblr Test Connection',
+				service_name: 'tumblr',
+			},
+			{
+				connection_id: '654321',
+				display_name: 'Bluesky Test Connection',
+				service_name: 'bluesky',
+			},
+		];
+	}
+
+	/**
+	 * Whether the URL is the one we want to intercept
+	 */
+	isTargetUrl( url: URL ) {
+		const { GET_POST, POST_AUTOSAVES, CONNECTION_TESTS } = this.patterns;
+
+		// We don't want to intercept autosave requests.
+		if ( GET_POST.test( url.pathname ) && ! POST_AUTOSAVES.test( url.pathname ) ) {
+			return true;
+		}
+
+		return CONNECTION_TESTS.test( url.pathname );
+	}
+
+	/**
+	 * Intercept the requests and to modify the response
+	 */
+	async interceptRequests() {
+		await this.page.route( this.isTargetUrl, async ( route ) => {
+			// Fetch original response.
+			const response = await route.fetch();
+
+			const result = await response.json();
+
+			const url = route.request().url();
+
+			if ( this.patterns.GET_POST.test( url ) ) {
+				// For posts, add a test connection to post attributes.
+				result.body.jetpack_publicize_connections.push( ...this.testConnections );
+			} else if ( this.patterns.CONNECTION_TESTS.test( url ) ) {
+				// For connection tests, add a test connection to the body.
+				result.body.push( ...this.testConnections );
+			}
+
+			await route.fulfill( {
+				response,
+				body: JSON.stringify( result ),
+			} );
+		} );
+	}
+
+	/**
+	 * Clear the intercepts
+	 */
+	async clearIntercepts() {
+		await this.page.unroute( this.isTargetUrl );
+	}
+
+	/**
+	 * Wait for the connection test results response.
+	 */
+	async waitForConnectionTests() {
+		await this.page.waitForResponse( ( response ) => {
+			return this.patterns.CONNECTION_TESTS.test( response.url() );
+		} );
+	}
+}

--- a/test/e2e/specs/jetpack/social__editor-simple-sites.ts
+++ b/test/e2e/specs/jetpack/social__editor-simple-sites.ts
@@ -1,0 +1,202 @@
+/**
+ * @group jetpack-wpcom-integration
+ */
+
+import {
+	DataHelper,
+	EditorPage,
+	SecretsManager,
+	SocialConnectionsManager,
+	TestAccount,
+	TestAccountName,
+} from '@automattic/calypso-e2e';
+import { Browser, Page } from 'playwright';
+
+declare const browser: Browser;
+
+const features = {
+	resharing: false,
+	manualSharing: true,
+	mediaSharing: false,
+	socialImageGenerator: false,
+};
+
+const testCases: Array< {
+	plan: string;
+	testAccountName: TestAccountName;
+	features: Record<
+		'resharing' | 'manualSharing' | 'mediaSharing' | 'socialImageGenerator',
+		boolean
+	>;
+} > = [
+	{
+		plan: 'Free',
+		testAccountName: 'simpleSiteFreePlanUser',
+		features,
+	},
+	{
+		plan: 'Personal',
+		testAccountName: 'simpleSitePersonalPlanUser',
+		features,
+	},
+];
+
+/**
+ * Tests features offered by Jetpack Social on a Simple site with Free plan.
+ *
+ * Keywords: Social, Jetpack, Publicize
+ */
+describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () {
+	for ( const { plan, testAccountName, features } of testCases ) {
+		describe( DataHelper.createSuiteTitle( `For Simple sites with ${ plan } plan` ), function () {
+			let page: Page;
+			let editorPage: EditorPage;
+			let socialConnectionsManager: SocialConnectionsManager;
+
+			const credentials = SecretsManager.secrets.testAccounts[ testAccountName ];
+			const siteSlug = credentials.testSites?.primary?.url;
+			const siteId = credentials.testSites?.primary?.id;
+
+			beforeAll( async () => {
+				page = await browser.newPage();
+				editorPage = new EditorPage( page );
+				socialConnectionsManager = new SocialConnectionsManager( page, siteId! );
+
+				const testAccount = new TestAccount( testAccountName );
+				await testAccount.authenticate( page );
+			} );
+
+			beforeEach( async () => {
+				await editorPage.visit( 'post', { siteSlug } );
+			} );
+
+			afterEach( async () => {
+				await socialConnectionsManager.clearIntercepts();
+			} );
+
+			test( 'Should verify that auto-sharing is available for new posts', async function () {
+				await socialConnectionsManager.interceptRequests();
+
+				await Promise.all( [
+					// Open the Jetpack sidebar.
+					editorPage.openSettings( 'Jetpack' ),
+					// Wait for the connection test results to finish
+					socialConnectionsManager.waitForConnectionTests(),
+				] );
+
+				// Expand the Publicize panel.
+				const section = await editorPage.expandSection( 'Share this post' );
+
+				// Verify that the toggle is enabled.
+				const toggle = section.getByLabel( 'Share when publishing' );
+				expect( await toggle.isChecked() ).toBe( true );
+
+				// Verify that the message box is editable.
+				const messageBox = section.getByRole( 'textbox', { name: 'Message' } );
+				expect( await messageBox.isEditable() ).toBe( true );
+
+				// Verify whether the media button is available.
+				const mediaButton = section.getByRole( 'button', { name: 'Choose Media' } );
+				expect( await mediaButton.isVisible() ).toBe( features.mediaSharing );
+			} );
+
+			test( `Should verify that resharing ${
+				features.resharing ? 'IS' : 'is NOT'
+			} available`, async function () {
+				// Open the Jetpack sidebar.
+				await editorPage.openSettings( 'Jetpack' );
+
+				// Expand the Publicize panel.
+				let section = await editorPage.expandSection( 'Share this post' );
+
+				// Verify that resharing button is not visible on new posts.
+				const reshareButton = section.getByRole( 'button', { name: 'Share post' } );
+				expect( await reshareButton.isVisible() ).toBe( false );
+
+				// Set a title for the post
+				await editorPage.enterTitle( DataHelper.getRandomPhrase() );
+				// Publish the post.
+				await editorPage.publish();
+				await editorPage.closeAllPanels();
+
+				// Open the Jetpack sidebar.
+				await editorPage.openSettings( 'Jetpack' );
+
+				// Expand the Publicize panel.
+				section = await editorPage.expandSection( 'Share this post' );
+
+				// Verify whether the toggle is visible.
+				const toggle = section.getByLabel( 'Share when publishing' );
+				expect( await toggle.isVisible() ).toBe( features.resharing );
+
+				// Verify whether the upgrade nudge/link is visible.
+				if ( ! features.resharing ) {
+					const upgradeLink = section.getByRole( 'link', { name: 'Upgrade now' } );
+					// The upgrade CTA is a button instead of a link until some API call finishes to get the checkout URL, which makes it a link.
+					// So, we need to wait for the link to appear.
+					await upgradeLink.waitFor();
+				}
+
+				const content = await section.textContent();
+
+				const message = 'To re-share a post, you need to upgrade to the WordPress.com Premium plan';
+
+				expect( content?.includes( message ) ).toBe( ! features.resharing );
+			} );
+
+			test( `Should verify that manual sharing ${
+				features.manualSharing ? 'IS' : 'is NOT'
+			} available`, async function () {
+				// Open the Jetpack sidebar.
+				await editorPage.openSettings( 'Jetpack' );
+
+				// Expand the Publicize panel.
+				let section = await editorPage.expandSection( 'Share this post' );
+
+				// Verify that manual sharing is NOT available before publishing.
+				let manualSharing = section.getByRole( 'paragraph', { name: 'Manual sharing' } );
+				expect( await manualSharing.isVisible() ).toBe( false );
+
+				// Set a title for the post
+				await editorPage.enterTitle( DataHelper.getRandomPhrase() );
+				// Publish the post.
+				await editorPage.publish();
+
+				// Verify whether the manual sharing is available on post publish panel
+				manualSharing = ( await editorPage.getPublishPanelRoot() ).getByRole( 'button', {
+					name: 'Manual sharing',
+				} );
+
+				// For some reason the manual sharing is not visible on the post publish panel for Simple sites with personal plan.
+				const isPostPublishManualSharingVisible = features.manualSharing && plan !== 'Personal';
+
+				expect( await manualSharing.isVisible() ).toBe( isPostPublishManualSharingVisible );
+
+				// Close the post publish panel.
+				await editorPage.closeAllPanels();
+
+				// Open the Jetpack sidebar.
+				await editorPage.openSettings( 'Jetpack' );
+
+				// Expand the Publicize panel.
+				section = await editorPage.expandSection( 'Share this post' );
+
+				// Verify whether manual sharing is available in the Jetpack sidebar.
+				manualSharing = section.getByText( 'Manual sharing' );
+				expect( await manualSharing.isVisible() ).toBe( features.manualSharing );
+			} );
+
+			test( `Should verify that Social Image Generator ${
+				features.socialImageGenerator ? 'IS' : 'is NOT'
+			} available`, async function () {
+				// Open the Jetpack sidebar.
+				await editorPage.openSettings( 'Jetpack' );
+
+				const section = await editorPage.getSettingsSection( 'Social Image Generator' );
+
+				// Verify whether the Social Image Generator panel exists.
+				expect( await section.isVisible() ).toBe( features.socialImageGenerator );
+			} );
+		} );
+	}
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Add E2E tests for Social features in the editor for Simple sites

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To increase E2E test coverage for Social features on WPCOM

For reference, the tests are related to these features

<img width="290" alt="Screenshot 2024-12-24 at 4 07 24 PM" src="https://github.com/user-attachments/assets/db13b870-8cd7-44c0-a453-2a5ac9ae793a" />

<img width="311" alt="Screenshot 2024-12-24 at 4 06 07 PM" src="https://github.com/user-attachments/assets/dcd40ddf-57a2-457d-91ac-1f5094bc41ab" />

Media sharing feature not available yet on WPCOM
<img width="286" alt="image" src="https://github.com/user-attachments/assets/f6c979f8-e591-4e48-976a-6a173345bdf4" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Just check if the CI is happy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
