### PR TITLE
Gutenberg 19.9: Fix the Site Editor Smoke Test

### DIFF
--- a/packages/calypso-e2e/src/lib/components/full-side-editor-data-views-component.ts
+++ b/packages/calypso-e2e/src/lib/components/full-side-editor-data-views-component.ts
@@ -1,11 +1,6 @@
 import { Page } from 'playwright';
 import { EditorComponent } from './editor-component';
 
-const selectors = {
-	primaryFieldByText: ( primaryFieldText: string ) =>
-		`.dataviews-title-field:has-text("${ primaryFieldText }")`,
-};
-
 /**
  * Represents an instance of the WordPress.com FSE Editor's DataViews.
  * This is used for data layouts (e.g. tables, grids, and lists).
@@ -30,7 +25,6 @@ export class FullSiteEditorDataViewsComponent {
 	 */
 	async clickPrimaryFieldByExactText( primaryFieldText: string ): Promise< void > {
 		const editorParent = await this.editor.parent();
-		const primaryField = editorParent.locator( selectors.primaryFieldByText( primaryFieldText ) );
-		await primaryField.click();
+		await editorParent.getByRole( 'button', { name: primaryFieldText } ).first().click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/full-side-editor-data-views-component.ts
+++ b/packages/calypso-e2e/src/lib/components/full-side-editor-data-views-component.ts
@@ -2,8 +2,8 @@ import { Page } from 'playwright';
 import { EditorComponent } from './editor-component';
 
 const selectors = {
-	primaryFieldByText: ( tableOrGrid: string, primaryFieldText: string ) =>
-		`.dataviews-view-${ tableOrGrid }__primary-field:has-text("${ primaryFieldText }") a`,
+	primaryFieldByText: ( primaryFieldText: string ) =>
+		`.dataviews-title-field:has-text("${ primaryFieldText }")`,
 };
 
 /**
@@ -30,13 +30,7 @@ export class FullSiteEditorDataViewsComponent {
 	 */
 	async clickPrimaryFieldByExactText( primaryFieldText: string ): Promise< void > {
 		const editorParent = await this.editor.parent();
-		const primaryFieldInTable = editorParent.locator(
-			selectors.primaryFieldByText( 'table', primaryFieldText )
-		);
-		const primaryFieldInGrid = editorParent.locator(
-			selectors.primaryFieldByText( 'grid', primaryFieldText )
-		);
-
-		await Promise.race( [ primaryFieldInTable.click(), primaryFieldInGrid.click() ] );
+		const primaryField = editorParent.locator( selectors.primaryFieldByText( primaryFieldText ) );
+		await primaryField.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/full-side-editor-nav-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/full-side-editor-nav-sidebar-component.ts
@@ -1,4 +1,5 @@
 import { Page } from 'playwright';
+import envVariables from '../../env-variables';
 import { EditorComponent } from './editor-component';
 
 const selectors = {
@@ -91,10 +92,15 @@ export class FullSiteEditorNavSidebarComponent {
 	 */
 	async clickNavButtonByExactText( text: string ): Promise< void > {
 		const editorParent = await this.editor.parent();
-		await editorParent
-			.getByLabel( 'Navigation' )
-			.getByRole( 'button', { name: text, exact: true } )
-			.click();
+
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			await editorParent.getByRole( 'button', { name: text, exact: true } ).click();
+		} else {
+			await editorParent
+				.getByLabel( 'Navigation' )
+				.getByRole( 'button', { name: text, exact: true } )
+				.click();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Related to p1735045499308179-slack-C02DQP0FP

## Proposed Changes

This PR fixes an E2E test due to a DataViews HTML markup change in Gutenberg 19.9.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?