### PR TITLE
Stepper vs start: Fix double redirect

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -32,6 +32,8 @@ import {
 	clearSignupDestinationCookie,
 	getSignupCompleteFlowName,
 	wasSignupCheckoutPageUnloaded,
+	setHasRedirectedForExperiment,
+	getHasRedirectedForExperiment,
 } from './storageUtils';
 import {
 	getStepUrl,
@@ -239,9 +241,18 @@ export default {
 
 		store.set( 'signup-locale', localeFromParams );
 
+		const hasRedirected =
+			context.querystring?.includes( 'redirected_1220=true' ) ||
+			// Check the URL as well because sometimes the context.querystring lags behind the URL.
+			new URLSearchParams( window.location.search ).has( 'redirected_1220' ) ||
+			// Check session storage in case the query parma was omitted.
+			getHasRedirectedForExperiment();
+
 		const isOnboardingFlow = flowName === 'onboarding';
-		if ( isOnboardingFlow && ! context.querystring?.includes( 'redirected_1220=true' ) ) {
+
+		if ( isOnboardingFlow && ! hasRedirected ) {
 			await loadExperimentAssignment( 'calypso_signup_onboarding_aa_test' );
+			setHasRedirectedForExperiment();
 
 			const stepperOnboardingExperimentAssignment = await loadExperimentAssignment(
 				'calypso_signup_onboarding_stepper_flow_confidence_check_2'

--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -60,6 +60,22 @@ export const setSignupCheckoutPageUnloaded = ( value ) =>
 	);
 export const getSignupCompleteFlowName = () =>
 	ignoreFatalsForStorage( () => sessionStorage?.getItem( 'wpcom_signup_complete_flow_name' ) );
+
+export const getHasRedirectedForExperiment = () =>
+	ignoreFatalsForStorage( () =>
+		sessionStorage?.getItem(
+			'wpcom_redirected_calypso_signup_onboarding_stepper_flow_confidence_check_2'
+		)
+	);
+
+export const setHasRedirectedForExperiment = () =>
+	ignoreFatalsForStorage( () =>
+		sessionStorage?.setItem(
+			'wpcom_redirected_calypso_signup_onboarding_stepper_flow_confidence_check_2',
+			'1'
+		)
+	);
+
 export const setSignupCompleteFlowName = ( value ) =>
 	ignoreFatalsForStorage( () =>
 		sessionStorage?.setItem( 'wpcom_signup_complete_flow_name', value )


### PR DESCRIPTION

## Proposed Changes

In some cases, i.e after login, the query parameters are omitted from the flow URL. This resulted in another redirect because redirect_1220 parameter was gone. This removes the dependency on the query parameter.


## Why are these changes being made?
To fix e2e tests.

## Testing Instructions

Prelease tests should pass. I'll run them once the live link builds.
