### PR TITLE
Fix e2e tests

### DIFF
--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -163,6 +163,9 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 		} );
 
 		it( 'Land in Home dashboard', async function () {
+			// dirty hack to wait for the launchpad to load.
+			// Stepper has a quirk where it redirects twice. Playwright hooks to the first one and thinks it was aborted.
+			await new Promise( ( resolve ) => setTimeout( resolve, 5000 ) );
 			await page.waitForURL(
 				DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.blogid }` ),
 				{ timeout: 30 * 1000 }

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -26,7 +26,7 @@ import {
 	PurchasesPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { apiCloseAccount } from '../shared';
+import { apiCloseAccount, fixme_retry } from '../shared';
 
 declare const browser: Browser;
 
@@ -165,10 +165,11 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 		it( 'Land in Home dashboard', async function () {
 			// dirty hack to wait for the launchpad to load.
 			// Stepper has a quirk where it redirects twice. Playwright hooks to the first one and thinks it was aborted.
-			await new Promise( ( resolve ) => setTimeout( resolve, 5000 ) );
-			await page.waitForURL(
-				DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.blogid }` ),
-				{ timeout: 30 * 1000 }
+			await fixme_retry( () =>
+				page.waitForURL(
+					DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.blogid }` ),
+					{ timeout: 30 * 1000 }
+				)
 			);
 		} );
 

--- a/test/e2e/specs/onboarding/onboarding__write.ts
+++ b/test/e2e/specs/onboarding/onboarding__write.ts
@@ -15,7 +15,7 @@ import {
 	EditorPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { apiCloseAccount } from '../shared';
+import { apiCloseAccount, fixme_retry } from '../shared';
 
 declare const browser: Browser;
 
@@ -99,8 +99,7 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 		it( 'Launchpad is shown', async function () {
 			// dirty hack to wait for the launchpad to load.
 			// Stepper has a quirk where it redirects twice. Playwright hooks to the first one and thinks it was aborted.
-			await new Promise( ( resolve ) => setTimeout( resolve, 5000 ) );
-			await page.waitForURL( /launchpad/, { timeout: 30000, waitUntil: 'load' } );
+			await fixme_retry( () => page.waitForURL( /launchpad/ ) );
 		} );
 
 		it( 'Write first post', async function () {
@@ -144,8 +143,7 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 		it( 'Launchpad is shown', async function () {
 			// dirty hack to wait for the launchpad to load.
 			// Stepper has a quirk where it redirects twice. Playwright hooks to the first one and thinks it was aborted.
-			await new Promise( ( resolve ) => setTimeout( resolve, 5000 ) );
-			await page.waitForURL( /launchpad/ );
+			await fixme_retry( () => page.waitForURL( /launchpad/ ) );
 		} );
 
 		it( 'Launch site', async function () {

--- a/test/e2e/specs/onboarding/onboarding__write.ts
+++ b/test/e2e/specs/onboarding/onboarding__write.ts
@@ -97,7 +97,10 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 		let editorPage: EditorPage;
 
 		it( 'Launchpad is shown', async function () {
-			await page.waitForURL( /launchpad/, { timeout: 30000 } );
+			// dirty hack to wait for the launchpad to load.
+			// Stepper has a quirk where it redirects twice. Playwright hooks to the first one and thinks it was aborted.
+			await new Promise( ( resolve ) => setTimeout( resolve, 5000 ) );
+			await page.waitForURL( /launchpad/, { timeout: 30000, waitUntil: 'load' } );
 		} );
 
 		it( 'Write first post', async function () {
@@ -139,6 +142,9 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 
 	describe( 'Launchpad', function () {
 		it( 'Launchpad is shown', async function () {
+			// dirty hack to wait for the launchpad to load.
+			// Stepper has a quirk where it redirects twice. Playwright hooks to the first one and thinks it was aborted.
+			await new Promise( ( resolve ) => setTimeout( resolve, 5000 ) );
 			await page.waitForURL( /launchpad/ );
 		} );
 

--- a/test/e2e/specs/shared/index.ts
+++ b/test/e2e/specs/shared/index.ts
@@ -1,2 +1,18 @@
 export * from './api-close-account';
 export * from './api-delete-site';
+
+/**
+ * This is a fix for e2e test that was deployed on Christmas eve as an emergency fix. Please remove and fix the root cause.
+ * @param callback the attempt callback
+ * @param retries number of retries.
+ */
+export async function fixme_retry( callback: () => unknown, retries: number = 5 ) {
+	let count = retries;
+	try {
+		return await callback();
+	} catch ( e ) {
+		if ( ! --count ) {
+			throw e;
+		}
+	}
+}

--- a/test/e2e/specs/shared/index.ts
+++ b/test/e2e/specs/shared/index.ts
@@ -8,11 +8,14 @@ export * from './api-delete-site';
  */
 export async function fixme_retry( callback: () => unknown, retries: number = 5 ) {
 	let count = retries;
-	try {
-		return await callback();
-	} catch ( e ) {
-		if ( ! --count ) {
-			throw e;
+	while ( count-- ) {
+		try {
+			return await callback();
+		} catch ( e ) {
+			if ( ! --count ) {
+				throw e;
+			}
+			await new Promise( ( r ) => setTimeout( r, 1000 ) );
 		}
 	}
 }


### PR DESCRIPTION
Stepper has a quirk where it redirects more than once due to window.location calls inside react re-renders. This breaks e2e tests because Playwright hooks to the first redirect and thinks it was aborted. This makes Playwright check 5 times before giving up on the page load check.


## Testing Instructions
1. Go to Teamcity prerelease tests.
2. Run them against the Calypso live URL of this branch.

