### PR TITLE
Increase Snackbar Timeout for Theme Activation 

### DIFF
--- a/client/state/themes/actions/activate-theme.js
+++ b/client/state/themes/actions/activate-theme.js
@@ -75,7 +75,7 @@ export function activateTheme( themeId, siteId, options = {} ) {
 							{
 								button: translate( 'View site' ),
 								href: getSiteUrl( getState(), siteId ),
-								duration: 10000,
+								duration: 20000,
 								showDismiss: false,
 							}
 						)

--- a/client/state/themes/actions/activate-theme.js
+++ b/client/state/themes/actions/activate-theme.js
@@ -1,6 +1,7 @@
 import { CALYPSO_CONTACT } from '@automattic/urls';
 import { translate } from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	productsReinstall,
 	productsReinstallNotStarted,
@@ -77,6 +78,14 @@ export function activateTheme( themeId, siteId, options = {} ) {
 								href: getSiteUrl( getState(), siteId ),
 								duration: 20000,
 								showDismiss: false,
+								onClick: () => {
+									dispatch(
+										recordTracksEvent( 'calypso_theme_activated_notice_view_site', {
+											theme: themeId,
+											site: siteId,
+										} )
+									);
+								},
 							}
 						)
 					);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/97091

## Proposed Changes

This PR increases the timeout for the snackbar notification displayed after activating a theme from 10 seconds to 20 seconds. 

Also, it adds the track event to know the number of clicks on the next action ("View site").

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/wp-calypso/issues/97091
* Aligns with user feedback suggesting the current timeout is short and risks being missed: paYJgx-5CF-p2#comment-5604
* To enhance accessibility by providing users with more time to read and interact with the message, addressing concerns related to [WCAG 2.2 Guideline 2.1: Enough Time](https://www.w3.org/WAI/WCAG22/Understanding/enough-time.html).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Theme Showcase
* Activate the Free/Personal/Premium theme
* Upgrade to the required plan if needed
* Make sure the activation snackbar is displayed
* Click "View site" in the snackbar
* Make sure the track event is sent

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?