### PR TITLE
Theme Card: Remove the description popover

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -340,8 +340,7 @@ export class Theme extends Component {
 
 	render() {
 		const { selectedStyleVariation, theme } = this.props;
-		const { name, description, style_variations = [], isCustomGeneratedTheme } = theme;
-		const themeDescription = decodeEntities( description );
+		const { name, style_variations = [] } = theme;
 
 		if ( this.props.isPlaceholder ) {
 			return this.renderPlaceholder();
@@ -351,7 +350,6 @@ export class Theme extends Component {
 			<ThemeCard
 				ref={ this.props.bookmarkRef }
 				name={ name }
-				description={ themeDescription }
 				image={ this.renderScreenshot() }
 				imageClickUrl={ this.props.screenshotClickUrl }
 				imageActionLabel={ this.props.actionLabel }
@@ -363,7 +361,6 @@ export class Theme extends Component {
 				isActive={ this.props.active }
 				isLoading={ this.props.loading }
 				isSoftLaunched={ this.props.softLaunched }
-				isShowDescriptionOnImageHover={ ! isCustomGeneratedTheme }
 				onClick={ this.setBookmark }
 				onImageClick={ this.onScreenshotClick }
 				onStyleVariationClick={ this.onStyleVariationClick }

--- a/packages/design-picker/src/components/theme-card/index.stories.tsx
+++ b/packages/design-picker/src/components/theme-card/index.stories.tsx
@@ -24,9 +24,6 @@ const Image = () => (
 const defaultArgs = {
 	name: 'Stewart',
 	image: <Image></Image>,
-	isShowDescriptionOnImageHover: true,
-	description:
-		'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
 };
 
 export const NotActive: ThemeCardStory = Template.bind( {} );

--- a/packages/design-picker/src/components/theme-card/index.tsx
+++ b/packages/design-picker/src/components/theme-card/index.tsx
@@ -1,7 +1,7 @@
-import { Card, Popover } from '@automattic/components';
+import { Card } from '@automattic/components';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
-import { forwardRef, useMemo, useRef, useState } from 'react';
+import { forwardRef, useMemo } from 'react';
 import StyleVariationBadges from '../style-variation-badges';
 import type { StyleVariation } from '../../types';
 import type { Ref } from 'react';
@@ -10,7 +10,6 @@ import './style.scss';
 interface ThemeCardProps {
 	className?: string;
 	name: string;
-	description?: string;
 	image: React.ReactNode;
 	imageClickUrl?: string;
 	imageActionLabel?: string;
@@ -21,7 +20,6 @@ interface ThemeCardProps {
 	optionsMenu?: React.ReactNode;
 	isActive?: boolean;
 	isLoading?: boolean;
-	isShowDescriptionOnImageHover?: boolean;
 	isSoftLaunched?: boolean;
 	onClick?: () => void;
 	onImageClick?: () => void;
@@ -56,7 +54,6 @@ const ThemeCard = forwardRef(
 		{
 			className,
 			name,
-			description,
 			image,
 			imageClickUrl,
 			imageActionLabel,
@@ -67,7 +64,6 @@ const ThemeCard = forwardRef(
 			optionsMenu,
 			isActive,
 			isLoading,
-			isShowDescriptionOnImageHover,
 			isSoftLaunched,
 			onClick,
 			onImageClick,
@@ -77,8 +73,6 @@ const ThemeCard = forwardRef(
 		forwardedRef: Ref< any > // eslint-disable-line @typescript-eslint/no-explicit-any
 	) => {
 		const e2eName = useMemo( () => name?.toLowerCase?.().replace( /\s+/g, '-' ), [ name ] );
-		const imageRef = useRef< HTMLAnchorElement >( null );
-		const [ isShowTooltip, setIsShowTooltip ] = useState( false );
 
 		const isActionable = imageClickUrl || onImageClick;
 		const themeClasses = clsx( 'theme-card', {
@@ -99,7 +93,6 @@ const ThemeCard = forwardRef(
 					{ banner && <div className="theme-card__banner">{ banner }</div> }
 					<div className="theme-card__image-container">
 						<a
-							ref={ imageRef }
 							className="theme-card__image"
 							href={ imageClickUrl || '#' }
 							aria-label={ name }
@@ -110,8 +103,6 @@ const ThemeCard = forwardRef(
 
 								onImageClick?.();
 							} }
-							onMouseEnter={ () => setIsShowTooltip( true ) }
-							onMouseLeave={ () => setIsShowTooltip( false ) }
 						>
 							{ isActionable && imageActionLabel && (
 								<div className="theme-card__image-label">{ imageActionLabel }</div>
@@ -123,16 +114,6 @@ const ThemeCard = forwardRef(
 						<div className="theme-card__loading">
 							<div className="theme-card__loading-dot" />
 						</div>
-					) }
-					{ isShowDescriptionOnImageHover && description && (
-						<Popover
-							className="theme-card__tooltip"
-							context={ imageRef.current }
-							isVisible={ isShowTooltip }
-							showDelay={ 1000 }
-						>
-							{ description }
-						</Popover>
 					) }
 					{ isSoftLaunched && (
 						<div className="theme-card__info-soft-launched">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/97380
Fixes https://github.com/Automattic/wp-calypso/issues/94311

## Proposed Changes

This PR removes the theme card description popover since they can be quite verbose to fit in a popover.

![image](https://github.com/user-attachments/assets/e89b27a4-1a14-481a-bee8-531b017cbd8c)

![image](https://github.com/user-attachments/assets/a5cc0ca1-6eda-44f3-9af8-913af6589c95)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Contributes to the overall WordPress.com polish. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /themes.
* Hover on any theme card.
* Ensure that no popover is shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
