### PR TITLE
Stepper: Fix the styles of the user step

### DIFF
--- a/client/components/logged-out-form/footer.scss
+++ b/client/components/logged-out-form/footer.scss
@@ -1,4 +1,4 @@
-.logged-out-form__footer {
+.card.logged-out-form__footer {
 	box-shadow: none;
 	background: none;
 	margin: 16px -16px -16px;

--- a/client/components/logged-out-form/style.scss
+++ b/client/components/logged-out-form/style.scss
@@ -1,4 +1,4 @@
-.logged-out-form {
+.card.logged-out-form {
 	margin: 0 auto 16px;
 	max-width: 360px;
 	padding: 16px;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -399,8 +399,8 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 	$gray-50: #646970;
 	$breakpoint-mobile: 660px;
 
-	--color-accent: #117ac9;
-	--color-accent-60: #0e64a5;
+	--color-accent: var(--studio-wordpress-blue-50);
+	--color-accent-60: var(--studio-wordpress-blue-60);
 
 	.signup-header {
 		.wordpress-logo {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/97570

## Proposed Changes

* Fix the styles of the user step by increasing the CSS priority and the styles should be the same as [the user step on the signup flow](https://wordpress.com/start/user-social).

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/ad0fb801-d056-41c5-9bde-fc6ec15ba0ef) | ![image](https://github.com/user-attachments/assets/9e783a1b-a7c5-4ca8-8461-41aceaee0acb) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/wp-calypso/issues/97570

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log out
* Go to /setup/onboarding
* Select any goals
* Select any designs
* On the Account screen,
  * Click "Continue with email"
  * Ensure the styles look good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
