### PR TITLE
Checkout page - Fix vat checkbox and border color when checked

### DIFF
--- a/client/my-sites/checkout/src/components/vat-form/style.css
+++ b/client/my-sites/checkout/src/components/vat-form/style.css
@@ -16,3 +16,7 @@
 .vat-form__row input[type="checkbox"]:disabled {
 	opacity: 0.5;
 }
+
+.is-section-checkout .components-checkbox-control__input[type=checkbox]:checked {
+	--wp-admin-theme-color: var(--studio-wordpress-blue-50);
+}

--- a/client/my-sites/checkout/src/components/vat-form/style.css
+++ b/client/my-sites/checkout/src/components/vat-form/style.css
@@ -17,6 +17,6 @@
 	opacity: 0.5;
 }
 
-.is-section-checkout .components-checkbox-control__input[type=checkbox]:checked {
+.is-section-checkout .components-checkbox-control__input[type="checkbox"]:checked {
 	--wp-admin-theme-color: var(--studio-wordpress-blue-50);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/95817

## Proposed Changes

* Fix vat checkbox colors in checkout page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Match the color with the rest of the page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to checkout as a user in the UK
- Tick "Add VAT details" checkbox
- Tick "Is VAT for Northern Ireland?" checkbox
- Make sure the color matches the rest of the blue color in the page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
