### PR TITLE
Notifications: Fix gear icon tooltip

### DIFF
--- a/apps/notifications/src/panel/templates/gridicons.jsx
+++ b/apps/notifications/src/panel/templates/gridicons.jsx
@@ -260,7 +260,7 @@ export default class extends Component {
 			case 'gridicons-cog':
 				return (
 					<svg { ...sharedProps } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-						<title>Cog</title>
+						<title>Open notification settings</title>
 						<g>
 							<path
 								d="M20,12c0-0.568-0.061-1.122-0.174-1.656l1.834-1.612l-2-3.464l-2.322,0.786c-0.819-0.736-1.787-1.308-2.859-1.657L14,2h-4


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92770

## Proposed Changes

* Update gear icon tooltip copy from "Cog" to "Open notification settings" (the existing aria-label):

Before | After
---- | -----
<img width="434" alt="Screen Shot 2024-12-25 at 10 02 40 AM" src="https://github.com/user-attachments/assets/fb46d602-76a4-4095-b6be-ef7fa0efcc4d" /> | <img width="432" alt="Screen Shot 2024-12-25 at 9 42 26 AM" src="https://github.com/user-attachments/assets/900a2ff4-567d-48cc-8797-c97d59a6a456" />

Note that:
- This will need a separate deploy to get to Atomic and Jetpack sites.
- The tooltip text in this file isn't translated.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To provide a more helpful tooltip.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* From your WordPress.com dashboard, open the BELL notifications sidebar
* Hover over the Gear icon

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
