### PR TITLE
Increase spacing between items in design picker

### DIFF
--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -7,7 +7,7 @@
 	justify-content: space-between;
 	flex-direction: column;
 	gap: 10px;
-	margin-bottom: 24px;
+	margin-bottom: 40px;
 
 	@include break-medium {
 		flex-direction: row;
@@ -19,7 +19,7 @@
 	button.components-button.responsive-toolbar-group__swipe-item {
 		padding: 8px 16px;
 		margin-inline-start: -4px;
-		margin-inline-end: 4px;
+		margin-inline-end: 2px;
 		font-size: rem(13px);
 
 		&::before {

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -120,8 +120,8 @@
 
 			@include break-medium {
 				grid-template-columns: 1fr 1fr;
-				column-gap: 24px;
-				row-gap: 28px;
+				column-gap: 40px;
+				row-gap: 48px;
 			}
 		}
 
@@ -393,11 +393,11 @@
 
 	.design-picker__grid {
 		@supports ( display: grid ) {
-			row-gap: 24px;
+			row-gap: 48px;
 
 			@include break-medium {
 				grid-template-columns: 1fr 1fr 1fr;
-				column-gap: 24px;
+				column-gap: 40px;
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/10173

## Proposed Changes

Before:
<img width="821" alt="image" src="https://github.com/user-attachments/assets/c5670425-a77b-46aa-885b-84e0d219afac" />

After:
<img width="821" alt="image" src="https://github.com/user-attachments/assets/6e0aaf13-1a14-45f2-951a-8f695ec8f021" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*  UX feedback: pfYzsZ-17G-p2#comment-996

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* visit: `/setup/site-setup/designSetup?siteSlug=:site&siteId=:id&categories=blog`
* Validate the spacing between the themes in the designs grid.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?