### PR TITLE
Fix Social E2E tests for Atomic sites

### DIFF
--- a/packages/calypso-e2e/src/lib/utils/social-connections-manager.ts
+++ b/packages/calypso-e2e/src/lib/utils/social-connections-manager.ts
@@ -79,7 +79,7 @@ export class SocialConnectionsManager {
 			// Fetch original response.
 			const response = await route.fetch();
 
-			const result = await response.json();
+			let result = await response.json();
 
 			const url = route.request().url();
 
@@ -91,7 +91,32 @@ export class SocialConnectionsManager {
 				result.body.push( ...this.testConnections );
 			} else if ( this.patterns.JP_CONNECTION_TESTS.test( url ) ) {
 				// For JP connection tests, add test connections to the result.
-				result.push( ...this.testConnections );
+				if ( Array.isArray( result ) ) {
+					result.push( ...this.testConnections );
+				} else {
+					/**
+					 * It's possible that there are other connections added white these tests are running.
+					 * So we need to merge them.
+					 *
+					 * Since useAdminUiV1 flag is not activated on Atomic sites,
+					 * the result is still in weird format, thus we need to convert to
+					 *	{
+					 *		"tumblr": {
+					 *			"25481710": {
+					 *				"display_name": "Untitled",
+					 *				...
+					 *			}
+					 *		}
+					 *	}
+					 */
+					result = this.testConnections.reduce( ( acc, cnxn ) => {
+						acc[ cnxn.service_name ] = acc[ cnxn.service_name ] || {};
+
+						acc[ cnxn.service_name ][ cnxn.connection_id ] = cnxn;
+
+						return acc;
+					}, result );
+				}
 			}
 
 			await route.fulfill( {

--- a/packages/calypso-e2e/src/lib/utils/social-connections-manager.ts
+++ b/packages/calypso-e2e/src/lib/utils/social-connections-manager.ts
@@ -95,7 +95,7 @@ export class SocialConnectionsManager {
 					result.push( ...this.testConnections );
 				} else {
 					/**
-					 * It's possible that there are other connections added white these tests are running.
+					 * It's possible that there are other connections added while these tests are running.
 					 * So we need to merge them.
 					 *
 					 * Since useAdminUiV1 flag is not activated on Atomic sites,

--- a/test/e2e/specs/jetpack/social__editor-features.ts
+++ b/test/e2e/specs/jetpack/social__editor-features.ts
@@ -1,4 +1,5 @@
 /**
+ * @group calypso-pr
  * @group jetpack-wpcom-integration
  */
 


### PR DESCRIPTION
We had some E2E failures p1735137419811579-slack-C034JEXD1RD following #97774. The reason is explained in the comment in the code.

## Proposed Changes

* Fix Social E2E tests for Atomic sites by handling the case for invalid data format

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Just verify that CI is happy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?