### PR TITLE
Stats: Refactor date filtering on the Traffic page along with dedicated components

### DIFF
--- a/client/components/date-control/index.tsx
+++ b/client/components/date-control/index.tsx
@@ -18,8 +18,6 @@ const DateControl = ( {
 	dateRange,
 	overlay,
 	shortcutList,
-	// Temporary prop to enable new date filtering UI.
-	isNewDateFilteringEnabled = false,
 }: DateControlProps ) => {
 	const moment = useLocalizedMoment();
 	const siteToday = useMomentSiteZone();
@@ -86,7 +84,6 @@ const DateControl = ( {
 				focusedMonth={ moment( dateRange.chartEnd ).toDate() }
 				shortcutList={ shortcutList }
 				onShortcutClick={ onShortcutClick }
-				isNewDateFilteringEnabled={ isNewDateFilteringEnabled }
 				trackExternalDateChanges
 			/>
 		</div>

--- a/client/components/date-control/types.d.ts
+++ b/client/components/date-control/types.d.ts
@@ -12,8 +12,6 @@ interface DateControlProps {
 	onShortcutClick: ( shortcut: DateRangePickerShortcut ) => void;
 	tooltip?: string;
 	overlay?: JSX.Element;
-	// Temporary prop to enable new date filtering UI.
-	isNewDateFilteringEnabled?: boolean;
 }
 
 interface DateControlPickerProps {

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -54,8 +54,6 @@ export class DateRange extends Component {
 		overlay: PropTypes.node,
 		customTitle: PropTypes.string,
 		onShortcutClick: PropTypes.func,
-		// Temporary prop to enable new date filtering UI.
-		isNewDateFilteringEnabled: PropTypes.bool,
 		trackExternalDateChanges: PropTypes.bool,
 		shortcutList: PropTypes.array,
 	};
@@ -75,7 +73,6 @@ export class DateRange extends Component {
 		useArrowNavigation: false,
 		overlay: null,
 		customTitle: '',
-		isNewDateFilteringEnabled: false,
 		trackExternalDateChanges: false,
 	};
 
@@ -497,7 +494,6 @@ export class DateRange extends Component {
 								startDate={ this.state.startDate }
 								endDate={ this.state.endDate }
 								onShortcutClick={ this.props.onShortcutClick } // for tracking shortcut clicks
-								isNewDateFilteringEnabled={ this.props.isNewDateFilteringEnabled }
 							/>
 						</div>
 					) }

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -26,8 +26,6 @@ const DateRangePickerShortcuts = ( {
 	startDate,
 	endDate,
 	shortcutList,
-	// Temporary prop to enable new date filtering UI.
-	isNewDateFilteringEnabled = false,
 }: {
 	currentShortcut?: string;
 	onClick: ( newFromDate: moment.Moment, newToDate: moment.Moment ) => void;
@@ -36,7 +34,6 @@ const DateRangePickerShortcuts = ( {
 	startDate?: MomentOrNull;
 	endDate?: MomentOrNull;
 	shortcutList?: DateRangePickerShortcut[];
-	isNewDateFilteringEnabled?: boolean;
 } ) => {
 	const normalizeDate = ( date: MomentOrNull ) => {
 		return date ? date.startOf( 'day' ) : date;
@@ -46,14 +43,11 @@ const DateRangePickerShortcuts = ( {
 	const normalizedStartDate = startDate ? normalizeDate( startDate ) : null;
 	const normalizedEndDate = endDate ? normalizeDate( endDate ) : null;
 
-	const { supportedShortcutList: defaultShortcutList, selectedShortcut } = useShortcuts(
-		{
-			chartStart: normalizedStartDate?.format( DATE_FORMAT ) ?? '',
-			chartEnd: normalizedEndDate?.format( DATE_FORMAT ) ?? '',
-			daysInRange: ( normalizedEndDate?.diff( normalizedStartDate, 'days' ) ?? 0 ) + 1,
-		},
-		isNewDateFilteringEnabled
-	);
+	const { supportedShortcutList: defaultShortcutList, selectedShortcut } = useShortcuts( {
+		chartStart: normalizedStartDate?.format( DATE_FORMAT ) ?? '',
+		chartEnd: normalizedEndDate?.format( DATE_FORMAT ) ?? '',
+		daysInRange: ( normalizedEndDate?.diff( normalizedStartDate, 'days' ) ?? 0 ) + 1,
+	} );
 
 	shortcutList = shortcutList || defaultShortcutList;
 

--- a/client/components/date-range/use-shortcuts.ts
+++ b/client/components/date-range/use-shortcuts.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { createSelector } from '@automattic/state-utils';
 import { translate as i18nCalypsoTranslate, useTranslate } from 'i18n-calypso';
 import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
@@ -42,7 +41,7 @@ export const getShortcuts = createSelector(
 			chartEnd: string;
 		},
 		translateFromProps,
-		isNewDateFilteringEnabled = config.isEnabled( 'stats/new-date-filtering' )
+		isNewDateFilteringEnabled = true
 	) => {
 		const translate = translateFromProps ?? i18nCalypsoTranslate;
 		const siteId = getSelectedSiteId( state );

--- a/client/components/date-range/use-shortcuts.ts
+++ b/client/components/date-range/use-shortcuts.ts
@@ -40,8 +40,7 @@ export const getShortcuts = createSelector(
 			chartStart: string;
 			chartEnd: string;
 		},
-		translateFromProps,
-		isNewDateFilteringEnabled = true
+		translateFromProps
 	) => {
 		const translate = translateFromProps ?? i18nCalypsoTranslate;
 		const siteId = getSelectedSiteId( state );
@@ -51,6 +50,20 @@ export const getShortcuts = createSelector(
 		const yesterdayStr = siteYesterday.format( DATE_FORMAT );
 
 		const supportedShortcutList = [
+			{
+				id: 'today',
+				label: translate( 'Today' ),
+				startDate: siteTodayStr,
+				endDate: siteTodayStr,
+				period: DATERANGE_PERIOD.DAY,
+			},
+			{
+				id: 'yesterday',
+				label: translate( 'Yesterday' ),
+				startDate: yesterdayStr,
+				endDate: yesterdayStr,
+				period: DATERANGE_PERIOD.DAY,
+			},
 			{
 				id: 'last_7_days',
 				label: translate( 'Last 7 Days' ),
@@ -88,25 +101,6 @@ export const getShortcuts = createSelector(
 			},
 		];
 
-		if ( isNewDateFilteringEnabled ) {
-			supportedShortcutList.unshift(
-				{
-					id: 'today',
-					label: translate( 'Today' ),
-					startDate: siteTodayStr,
-					endDate: siteTodayStr,
-					period: DATERANGE_PERIOD.DAY,
-				},
-				{
-					id: 'yesterday',
-					label: translate( 'Yesterday' ),
-					startDate: yesterdayStr,
-					endDate: yesterdayStr,
-					period: DATERANGE_PERIOD.DAY,
-				}
-			);
-		}
-
 		return {
 			selectedShortcut: findShortcutForRange( supportedShortcutList, dateRange ),
 			supportedShortcutList,
@@ -117,31 +111,22 @@ export const getShortcuts = createSelector(
 		dateRange: {
 			chartStart: string;
 			chartEnd: string;
-		},
-		translateFromProps,
-		isNewDateFilteringEnabled
+		}
 	) => {
 		const siteId = getSelectedSiteId( state );
 		const siteToday = getMomentSiteZone( state, siteId );
 
-		return [
-			siteId,
-			siteToday.format( DATE_FORMAT ),
-			dateRange?.chartStart,
-			dateRange?.chartEnd,
-			isNewDateFilteringEnabled,
-		];
+		return [ siteId, siteToday.format( DATE_FORMAT ), dateRange?.chartStart, dateRange?.chartEnd ];
 	}
 );
 
-export function useShortcuts(
-	dateRange: { chartStart: string; chartEnd: string; daysInRange: number },
-	isNewDateFilteringEnabled = false
-) {
+export function useShortcuts( dateRange: {
+	chartStart: string;
+	chartEnd: string;
+	daysInRange: number;
+} ) {
 	const translate = useTranslate();
-	const shortcuts = useSelector( ( state ) =>
-		getShortcuts( state, dateRange, translate, isNewDateFilteringEnabled )
-	);
+	const shortcuts = useSelector( ( state ) => getShortcuts( state, dateRange, translate ) );
 
 	return shortcuts;
 }

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -26,8 +26,6 @@ interface StatsDateControlProps {
 		event_from: string,
 		stat_type: string
 	) => void;
-	// Temporary prop to enable new date filtering UI.
-	isNewDateFilteringEnabled: boolean;
 }
 
 // Define the event name keys for tracking events
@@ -81,7 +79,6 @@ const StatsDateControl = ( {
 	shortcutList,
 	overlay,
 	onGatedHandler,
-	isNewDateFilteringEnabled = false,
 }: StatsDateControlProps ) => {
 	// ToDo: Consider removing period from shortcuts.
 	// We could use the bestPeriodForDays() helper and keep the shortcuts
@@ -190,10 +187,9 @@ const StatsDateControl = ( {
 				const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 				recordTracksEvent( eventNames[ event_from ][ 'trigger_button' ] );
 			} }
-			tooltip={ isNewDateFilteringEnabled ? translate( 'Filter all data by date' ) : '' }
+			tooltip={ translate( 'Filter all data by date' ) }
 			overlay={ overlay }
 			shortcutList={ shortcutList }
-			isNewDateFilteringEnabled={ isNewDateFilteringEnabled }
 		/>
 	);
 };

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { PAST_SEVEN_DAYS, PAST_THIRTY_DAYS } from '@automattic/components';
 import { eye } from '@automattic/components/src/icons';
 import { Icon, people, starEmpty, commentContent } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -49,8 +48,6 @@ import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getJetpackStatsAdminVersion, isJetpackSite } from 'calypso/state/sites/selectors';
 import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
-import { requestModuleSettings } from 'calypso/state/stats/module-settings/actions';
-import { getModuleSettings } from 'calypso/state/stats/module-settings/selectors';
 import { getModuleToggles } from 'calypso/state/stats/module-toggles/selectors';
 import { getUpsellModalView } from 'calypso/state/stats/paid-stats-upsell/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -61,14 +58,12 @@ import StatsModuleDevices, {
 	StatsModuleUpgradeDevicesOverlay,
 } from './features/modules/stats-devices';
 import StatsModuleDownloads from './features/modules/stats-downloads';
-import StatsModuleEmails from './features/modules/stats-emails';
 import StatsModuleReferrers from './features/modules/stats-referrers';
 import StatsModuleSearch from './features/modules/stats-search';
 import StatsModuleTopPosts from './features/modules/stats-top-posts';
 import StatsModuleUTM, { StatsModuleUTMOverlay } from './features/modules/stats-utm';
 import StatsModuleVideos from './features/modules/stats-videos';
 import StatsFeedbackPresentor from './feedback';
-import HighlightsSection from './highlights-section';
 import { shouldGateStats } from './hooks/use-should-gate-stats';
 import MiniCarousel from './mini-carousel';
 import { StatsGlobalValuesContext } from './pages/providers/global-provider';
@@ -90,11 +85,6 @@ import { getPathWithUpdatedQueryString } from './utils';
 const HIDDABLE_MODULES = AVAILABLE_PAGE_MODULES.traffic.map( ( module ) => {
 	return module.key;
 } );
-
-const memoizedQuery = memoizeLast( ( period, endOf ) => ( {
-	period,
-	date: endOf,
-} ) );
 
 const chartRangeToQuery = memoizeLast( ( chartRange ) => ( {
 	period: 'day',
@@ -275,17 +265,12 @@ class StatsSite extends Component {
 
 	// Return a default amount of days to subtracts from the present day depending on the period selected.
 	// Used in case no starting date is present in the URL.
-	getDefaultDaysForPeriod( period, defaultSevenDaysForPeriodDay = false ) {
+	getDefaultDaysForPeriod( period ) {
 		switch ( period ) {
 			case 'hour':
 				return 1;
 			case 'day':
-				// TODO: Temporary fix for the new date filtering feature.
-				if ( defaultSevenDaysForPeriodDay ) {
-					return 7;
-				}
-
-				return 30;
+				return 7;
 			case 'week':
 				return 12 * 7; // ~last 3 months
 			case 'month':
@@ -327,9 +312,7 @@ class StatsSite extends Component {
 			isSitePrivate,
 			isOdysseyStats,
 			context,
-			moduleSettings,
 			supportsPlanUsage,
-			supportsEmailStats,
 			supportsUTMStatsFeature,
 			supportsDevicesStatsFeature,
 			isOldJetpack,
@@ -340,21 +323,12 @@ class StatsSite extends Component {
 			momentSiteZone,
 			wpcomShowUpsell,
 		} = this.props;
-		const isNewDateFilteringEnabled = config.isEnabled( 'stats/new-date-filtering' );
-		let defaultPeriod = PAST_SEVEN_DAYS;
-
 		const shouldShowUpsells = isOdysseyStats && ! isAtomic;
 		const supportsUTMStats = supportsUTMStatsFeature || isInternal;
 		const supportsDevicesStats = supportsDevicesStatsFeature || isInternal;
 
-		// Set the current period based on the module settings.
-		// @TODO: Introduce the loading state to avoid flickering due to slow module settings request.
-		if ( moduleSettings?.highlights?.period_in_days === 30 ) {
-			defaultPeriod = PAST_THIRTY_DAYS;
-		}
-
 		const queryDate = date.format( DATE_FORMAT );
-		const { period, endOf } = this.props.period;
+		const { period } = this.props.period;
 		const moduleStrings = statsStrings();
 
 		// Set up a custom range for the chart.
@@ -373,7 +347,7 @@ class StatsSite extends Component {
 		}
 
 		// Find the quantity of bars for the chart.
-		let daysInRange = this.getDefaultDaysForPeriod( period, isNewDateFilteringEnabled );
+		let daysInRange = this.getDefaultDaysForPeriod( period );
 		const chartStart = this.getValidDateOrNullFromInput( context.query?.chartStart, 'startDate' );
 		const isSameOrBefore = moment( chartStart ).isSameOrBefore( moment( chartEnd ) );
 
@@ -449,9 +423,7 @@ class StatsSite extends Component {
 				.format( DATE_FORMAT );
 		}
 
-		const query = isNewDateFilteringEnabled
-			? chartRangeToQuery( customChartRange )
-			: memoizedQuery( period, endOf.format( DATE_FORMAT ) );
+		const query = chartRangeToQuery( customChartRange );
 
 		// For period option links
 		const traffic = {
@@ -516,118 +488,59 @@ class StatsSite extends Component {
 					isOdysseyStats={ isOdysseyStats }
 					statsPurchaseSuccess={ context.query.statsPurchaseSuccess }
 				/>
-				{ ! isNewDateFilteringEnabled && (
-					// @TODO: remove highlight section completely once flag is released
-					<HighlightsSection siteId={ siteId } currentPeriod={ defaultPeriod } />
-				) }
-				{ isNewDateFilteringEnabled && (
-					// moves date range block into new location
-					<StickyPanel headerId={ isRunningOnWPAdmin ? 'wpadminbar' : 'header' }>
-						<StatsPeriodHeader>
-							<StatsPeriodNavigation
-								date={ date }
+				<StickyPanel headerId={ isRunningOnWPAdmin ? 'wpadminbar' : 'header' }>
+					<StatsPeriodHeader>
+						<StatsPeriodNavigation
+							date={ date }
+							period={ period }
+							url={ `/stats/${ period }/${ slug }` }
+							queryParams={ context.query }
+							pathTemplate={ pathTemplate }
+							charts={ CHARTS }
+							availableLegend={ this.getAvailableLegend() }
+							activeTab={ getActiveTab( this.props.chartTab ) }
+							activeLegend={ this.state.activeLegend }
+							onChangeLegend={ this.onChangeLegend }
+							isNewDateFilteringEnabled // @TODO:remove this prop once we release new date filtering
+							isWithNewDateControl
+							showArrows={ ! wpcomShowUpsell }
+							slug={ slug }
+							dateRange={ customChartRange }
+						>
+							{ ' ' }
+							<DatePicker
 								period={ period }
-								url={ `/stats/${ period }/${ slug }` }
-								queryParams={ context.query }
-								pathTemplate={ pathTemplate }
-								charts={ CHARTS }
-								availableLegend={ this.getAvailableLegend() }
-								activeTab={ getActiveTab( this.props.chartTab ) }
-								activeLegend={ this.state.activeLegend }
-								onChangeLegend={ this.onChangeLegend }
-								isNewDateFilteringEnabled // @TODO:remove this prop once we release new date filtering
-								isWithNewDateControl
-								showArrows={ ! wpcomShowUpsell }
-								slug={ slug }
+								date={ date }
+								query={ query }
+								statsType="statsTopPosts"
+								showQueryDate
+								isShort
 								dateRange={ customChartRange }
-							>
-								{ ' ' }
-								<DatePicker
-									period={ period }
-									date={ date }
-									query={ query }
-									statsType="statsTopPosts"
-									showQueryDate
-									isShort
-									dateRange={ customChartRange }
-									isNewDateFilteringEnabled // @TODO:remove this prop once we release new date filtering
-								/>
-							</StatsPeriodNavigation>
-						</StatsPeriodHeader>
-					</StickyPanel>
-				) }
+								isNewDateFilteringEnabled // @TODO:remove this prop once we release new date filtering
+							/>
+						</StatsPeriodNavigation>
+					</StatsPeriodHeader>
+				</StickyPanel>
 				<div id="my-stats-content" className={ wrapperClass }>
-					<>
-						{ ! isNewDateFilteringEnabled && (
-							<StatsPeriodHeader>
-								<StatsPeriodNavigation
-									date={ date }
-									period={ period }
-									url={ `/stats/${ period }/${ slug }` }
-									queryParams={ context.query }
-									pathTemplate={ pathTemplate }
-									charts={ CHARTS }
-									availableLegend={ this.getAvailableLegend() }
-									activeTab={ getActiveTab( this.props.chartTab ) }
-									activeLegend={ this.state.activeLegend }
-									onChangeLegend={ this.onChangeLegend }
-									isWithNewDateControl
-									showArrows
-									slug={ slug }
-									dateRange={ customChartRange }
-								>
-									{ ' ' }
-									<DatePicker
-										period={ period }
-										date={ date }
-										query={ query }
-										statsType="statsTopPosts"
-										showQueryDate
-										isShort
-										isNewDateFilteringEnabled={ false }
-									/>
-								</StatsPeriodNavigation>
-							</StatsPeriodHeader>
-						) }
-
-						{ isNewDateFilteringEnabled && ( //adds a new chart instance for the newdatefiltering project
-							<ChartTabs
-								slug={ slug }
-								period={ this.props.period }
-								queryParams={ context.query }
-								activeTab={ getActiveTab( this.props.chartTab ) }
-								activeLegend={ this.state.activeLegend }
-								availableLegend={ this.getAvailableLegend() }
-								onChangeLegend={ this.onChangeLegend }
-								barClick={ this.barClick.bind( this, shouldForceDefaultDateRange ) }
-								className="is-date-filtering-enabled"
-								switchTab={ this.switchChart }
-								charts={ CHARTS }
-								queryDate={ queryDate }
-								chartTab={ this.props.chartTab }
-								customQuantity={ customChartQuantity }
-								customRange={ customChartRange }
-								showChartHeader // in the new date filtering enabled experience there is a new chart header to show
-								isNewDateFilteringEnabled
-							/>
-						) }
-						{ ! isNewDateFilteringEnabled && ( // legacy/old chart @TODO: remove once NewDateFiltering flag is flipped
-							<ChartTabs
-								activeTab={ getActiveTab( this.props.chartTab ) }
-								activeLegend={ this.state.activeLegend }
-								availableLegend={ this.getAvailableLegend() }
-								onChangeLegend={ this.onChangeLegend }
-								barClick={ this.barClick.bind( this, shouldForceDefaultDateRange ) }
-								switchTab={ this.switchChart }
-								charts={ CHARTS }
-								queryDate={ queryDate }
-								period={ this.props.period }
-								chartTab={ this.props.chartTab }
-								customQuantity={ customChartQuantity }
-								customRange={ customChartRange }
-							/>
-						) }
-					</>
+					<ChartTabs
+						slug={ slug }
+						period={ this.props.period }
+						queryParams={ context.query }
+						activeTab={ getActiveTab( this.props.chartTab ) }
+						activeLegend={ this.state.activeLegend }
+						availableLegend={ this.getAvailableLegend() }
+						onChangeLegend={ this.onChangeLegend }
+						barClick={ this.barClick.bind( this, shouldForceDefaultDateRange ) }
+						className="is-date-filtering-enabled"
+						switchTab={ this.switchChart }
+						charts={ CHARTS }
+						queryDate={ queryDate }
+						chartTab={ this.props.chartTab }
+						customQuantity={ customChartQuantity }
+						customRange={ customChartRange }
+						showChartHeader // in the new date filtering enabled experience there is a new chart header to show
+						isNewDateFilteringEnabled
+					/>
 
 					{ ! wpcomShowUpsell && (
 						<>
@@ -697,17 +610,6 @@ class StatsSite extends Component {
 										period={ this.props.period }
 										query={ query }
 										summaryUrl={ this.getStatHref( 'authors', query ) }
-										className={ halfWidthModuleClasses }
-									/>
-								) }
-
-								{ /* Either stacks with "Authors" or takes full width, depending on UTM and Authors visibility */ }
-								{ ! isNewDateFilteringEnabled && supportsEmailStats && (
-									<StatsModuleEmails
-										period={ this.props.period }
-										moduleStrings={ moduleStrings.emails }
-										query={ query }
-										summaryUrl={ this.getStatHref( 'emails', query ) }
 										className={ halfWidthModuleClasses }
 									/>
 								) }
@@ -811,11 +713,6 @@ class StatsSite extends Component {
 		);
 	}
 
-	componentDidMount() {
-		// TODO: Migrate to a query component pattern (i.e. <QueryStatsModuleSettings siteId={siteId} />).
-		this.props.requestModuleSettings( this.props.siteId );
-	}
-
 	renderInsufficientPermissionsPage() {
 		return (
 			<EmptyContent
@@ -917,7 +814,6 @@ export default connect(
 
 		const {
 			supportsPlanUsage,
-			supportsEmailStats,
 			supportsUTMStats,
 			supportsDevicesStats,
 			isOldJetpack,
@@ -953,11 +849,9 @@ export default connect(
 			showEnableStatsModule,
 			path: getCurrentRouteParameterized( state, siteId ),
 			isOdysseyStats,
-			moduleSettings: getModuleSettings( state, siteId, 'traffic' ),
 			moduleToggles: getModuleToggles( state, siteId, 'traffic' ),
 			upsellModalView,
 			statsAdminVersion,
-			supportsEmailStats,
 			supportsPlanUsage,
 			supportsUTMStatsFeature: supportsUTMStats,
 			supportsDevicesStatsFeature: supportsDevicesStats,
@@ -975,6 +869,5 @@ export default connect(
 		recordGoogleEvent,
 		enableJetpackStatsModule,
 		recordTracksEvent,
-		requestModuleSettings,
 	}
 )( localize( StatsSite ) );

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -538,8 +538,6 @@ class StatsSite extends Component {
 						chartTab={ this.props.chartTab }
 						customQuantity={ customChartQuantity }
 						customRange={ customChartRange }
-						showChartHeader // in the new date filtering enabled experience there is a new chart header to show
-						isNewDateFilteringEnabled
 					/>
 
 					{ ! wpcomShowUpsell && (

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -501,7 +501,6 @@ class StatsSite extends Component {
 							activeTab={ getActiveTab( this.props.chartTab ) }
 							activeLegend={ this.state.activeLegend }
 							onChangeLegend={ this.onChangeLegend }
-							isNewDateFilteringEnabled // @TODO:remove this prop once we release new date filtering
 							isWithNewDateControl
 							showArrows={ ! wpcomShowUpsell }
 							slug={ slug }
@@ -516,7 +515,6 @@ class StatsSite extends Component {
 								showQueryDate
 								isShort
 								dateRange={ customChartRange }
-								isNewDateFilteringEnabled // @TODO:remove this prop once we release new date filtering
 							/>
 						</StatsPeriodNavigation>
 					</StatsPeriodHeader>
@@ -835,7 +833,7 @@ export default connect(
 			config.isEnabled( 'stats/paid-wpcom-v3' ) &&
 			shouldGateStats( state, siteId, STATS_FEATURE_PAGE_TRAFFIC );
 
-		const { supportedShortcutList } = getShortcuts( state, {}, undefined, true );
+		const { supportedShortcutList } = getShortcuts( state, {}, undefined );
 
 		return {
 			canUserViewStats,

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -173,24 +173,10 @@ class StatsDatePicker extends Component {
 
 	render() {
 		/* eslint-disable wpcalypso/jsx-classname-namespace*/
-		const {
-			summary,
-			translate,
-			query,
-			showQueryDate,
-			isActivity,
-			isShort,
-			dateRange,
-			reduxState,
-			isNewDateFilteringEnabled,
-		} = this.props;
+		const { summary, translate, query, showQueryDate, isActivity, isShort, dateRange, reduxState } =
+			this.props;
 		const isSummarizeQuery = get( query, 'summarize' );
-		const { selectedShortcut } = getShortcuts(
-			reduxState,
-			dateRange,
-			translate,
-			isNewDateFilteringEnabled
-		);
+		const { selectedShortcut } = getShortcuts( reduxState, dateRange, translate );
 
 		let sectionTitle = isActivity
 			? translate( '{{prefix}}Activity for {{/prefix}}{{period/}}', {

--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -27,8 +27,7 @@
 	.stats-period-navigation {
 		@include section-header-with-siblings;
 
-	 // this new selector removes padding only for the date filtering design
-		&.stats-period-navigation__is-with-new-date-filtering {
+		&.stats-period-navigation__is-with-new-date-control {
 			padding: 0;
 			align-items: center;
 

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -9,6 +9,22 @@
 	margin: 1.5em 0;
 	padding: 0 20px;
 
+	&.stats-period-navigation__is-with-new-date-control {
+		padding: 0;
+		align-items: flex-start;
+		row-gap: 8px;
+	
+		.stats-navigation-arrows {
+			justify-content: flex-end;
+		}
+	
+		.stats-period-navigation__date-range-control {
+			display:flex;
+			flex-direction: row;
+			gap: 20px;
+		}
+	}
+
 	.stats-period-navigation__children {
 		flex-grow: 1;
 	}
@@ -51,24 +67,4 @@
 	.chart__legend {
 		margin-bottom: initial;
 	}
-}
-
-// Styling specific to the new Date Filtering traffic page project
-.stats-period-navigation.stats-period-navigation__is-with-new-date-filtering {
-
-	.stats-navigation-arrows {
-		justify-content: flex-end;
-	}
-
-	.stats-period-navigation__date-range-control {
-		display:flex;
-		flex-direction: row;
-		gap: 20px;
-	  }
-}
-
-.stats-period-navigation.stats-period-navigation__is-with-new-date-control {
-	padding: 0;
-	align-items: flex-start;
-	row-gap: 8px;
 }

--- a/config/client.json
+++ b/config/client.json
@@ -24,7 +24,6 @@
 	"signup_url",
 	"stats/empty-module-traffic",
 	"stats/empty-module-v2",
-	"stats/new-date-filtering",
 	"wpcom_concierge_schedule_id",
 	"wpcom_signup_id",
 	"wpcom_signup_key",

--- a/config/development.json
+++ b/config/development.json
@@ -220,7 +220,6 @@
 		"ssr/prefetch-timebox": false,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
-		"stats/new-date-filtering": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stepper-woocommerce-poc": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -144,7 +144,6 @@
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
-		"stats/new-date-filtering": true,
 		"stats/paid-wpcom-v2": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/config/production.json
+++ b/config/production.json
@@ -191,7 +191,6 @@
 		"ssr/sample-log-cache-misses": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
-		"stats/new-date-filtering": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stepper-woocommerce-poc": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -187,7 +187,6 @@
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
-		"stats/new-date-filtering": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stepper-woocommerce-poc": true,

--- a/config/test.json
+++ b/config/test.json
@@ -137,7 +137,6 @@
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
-		"stats/new-date-filtering": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -184,7 +184,6 @@
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
-		"stats/new-date-filtering": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stepper-woocommerce-poc": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/324.

## Proposed Changes

* Remove the feature flag usage on the Traffic page and its dedicated `StatTabs` component.
* Remove the feature flag `stats/new-date-filtering`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Refactor as the follow-up for the date filtering project.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Ensure everything is not changed and works well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
