### PR TITLE
Stats: Refactor date filtering shared components

### DIFF
--- a/client/components/date-control/index.tsx
+++ b/client/components/date-control/index.tsx
@@ -18,8 +18,6 @@ const DateControl = ( {
 	dateRange,
 	overlay,
 	shortcutList,
-	// Temporary prop to enable new date filtering UI.
-	isNewDateFilteringEnabled = false,
 }: DateControlProps ) => {
 	const moment = useLocalizedMoment();
 	const siteToday = useMomentSiteZone();
@@ -86,7 +84,6 @@ const DateControl = ( {
 				focusedMonth={ moment( dateRange.chartEnd ).toDate() }
 				shortcutList={ shortcutList }
 				onShortcutClick={ onShortcutClick }
-				isNewDateFilteringEnabled={ isNewDateFilteringEnabled }
 				trackExternalDateChanges
 			/>
 		</div>

--- a/client/components/date-control/types.d.ts
+++ b/client/components/date-control/types.d.ts
@@ -12,8 +12,6 @@ interface DateControlProps {
 	onShortcutClick: ( shortcut: DateRangePickerShortcut ) => void;
 	tooltip?: string;
 	overlay?: JSX.Element;
-	// Temporary prop to enable new date filtering UI.
-	isNewDateFilteringEnabled?: boolean;
 }
 
 interface DateControlPickerProps {

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -54,8 +54,6 @@ export class DateRange extends Component {
 		overlay: PropTypes.node,
 		customTitle: PropTypes.string,
 		onShortcutClick: PropTypes.func,
-		// Temporary prop to enable new date filtering UI.
-		isNewDateFilteringEnabled: PropTypes.bool,
 		trackExternalDateChanges: PropTypes.bool,
 		shortcutList: PropTypes.array,
 	};
@@ -75,7 +73,6 @@ export class DateRange extends Component {
 		useArrowNavigation: false,
 		overlay: null,
 		customTitle: '',
-		isNewDateFilteringEnabled: false,
 		trackExternalDateChanges: false,
 	};
 
@@ -497,7 +494,6 @@ export class DateRange extends Component {
 								startDate={ this.state.startDate }
 								endDate={ this.state.endDate }
 								onShortcutClick={ this.props.onShortcutClick } // for tracking shortcut clicks
-								isNewDateFilteringEnabled={ this.props.isNewDateFilteringEnabled }
 							/>
 						</div>
 					) }

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -43,14 +43,11 @@ const DateRangePickerShortcuts = ( {
 	const normalizedStartDate = startDate ? normalizeDate( startDate ) : null;
 	const normalizedEndDate = endDate ? normalizeDate( endDate ) : null;
 
-	const { supportedShortcutList: defaultShortcutList, selectedShortcut } = useShortcuts(
-		{
-			chartStart: normalizedStartDate?.format( DATE_FORMAT ) ?? '',
-			chartEnd: normalizedEndDate?.format( DATE_FORMAT ) ?? '',
-			daysInRange: ( normalizedEndDate?.diff( normalizedStartDate, 'days' ) ?? 0 ) + 1,
-		},
-		true
-	);
+	const { supportedShortcutList: defaultShortcutList, selectedShortcut } = useShortcuts( {
+		chartStart: normalizedStartDate?.format( DATE_FORMAT ) ?? '',
+		chartEnd: normalizedEndDate?.format( DATE_FORMAT ) ?? '',
+		daysInRange: ( normalizedEndDate?.diff( normalizedStartDate, 'days' ) ?? 0 ) + 1,
+	} );
 
 	shortcutList = shortcutList || defaultShortcutList;
 

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -26,8 +26,6 @@ const DateRangePickerShortcuts = ( {
 	startDate,
 	endDate,
 	shortcutList,
-	// Temporary prop to enable new date filtering UI.
-	isNewDateFilteringEnabled = false,
 }: {
 	currentShortcut?: string;
 	onClick: ( newFromDate: moment.Moment, newToDate: moment.Moment ) => void;
@@ -36,7 +34,6 @@ const DateRangePickerShortcuts = ( {
 	startDate?: MomentOrNull;
 	endDate?: MomentOrNull;
 	shortcutList?: DateRangePickerShortcut[];
-	isNewDateFilteringEnabled?: boolean;
 } ) => {
 	const normalizeDate = ( date: MomentOrNull ) => {
 		return date ? date.startOf( 'day' ) : date;
@@ -52,7 +49,7 @@ const DateRangePickerShortcuts = ( {
 			chartEnd: normalizedEndDate?.format( DATE_FORMAT ) ?? '',
 			daysInRange: ( normalizedEndDate?.diff( normalizedStartDate, 'days' ) ?? 0 ) + 1,
 		},
-		isNewDateFilteringEnabled
+		true
 	);
 
 	shortcutList = shortcutList || defaultShortcutList;

--- a/client/components/date-range/use-shortcuts.ts
+++ b/client/components/date-range/use-shortcuts.ts
@@ -40,8 +40,7 @@ export const getShortcuts = createSelector(
 			chartStart: string;
 			chartEnd: string;
 		},
-		translateFromProps,
-		isNewDateFilteringEnabled = true
+		translateFromProps
 	) => {
 		const translate = translateFromProps ?? i18nCalypsoTranslate;
 		const siteId = getSelectedSiteId( state );
@@ -51,6 +50,20 @@ export const getShortcuts = createSelector(
 		const yesterdayStr = siteYesterday.format( DATE_FORMAT );
 
 		const supportedShortcutList = [
+			{
+				id: 'today',
+				label: translate( 'Today' ),
+				startDate: siteTodayStr,
+				endDate: siteTodayStr,
+				period: DATERANGE_PERIOD.DAY,
+			},
+			{
+				id: 'yesterday',
+				label: translate( 'Yesterday' ),
+				startDate: yesterdayStr,
+				endDate: yesterdayStr,
+				period: DATERANGE_PERIOD.DAY,
+			},
 			{
 				id: 'last_7_days',
 				label: translate( 'Last 7 Days' ),
@@ -88,25 +101,6 @@ export const getShortcuts = createSelector(
 			},
 		];
 
-		if ( isNewDateFilteringEnabled ) {
-			supportedShortcutList.unshift(
-				{
-					id: 'today',
-					label: translate( 'Today' ),
-					startDate: siteTodayStr,
-					endDate: siteTodayStr,
-					period: DATERANGE_PERIOD.DAY,
-				},
-				{
-					id: 'yesterday',
-					label: translate( 'Yesterday' ),
-					startDate: yesterdayStr,
-					endDate: yesterdayStr,
-					period: DATERANGE_PERIOD.DAY,
-				}
-			);
-		}
-
 		return {
 			selectedShortcut: findShortcutForRange( supportedShortcutList, dateRange ),
 			supportedShortcutList,
@@ -117,31 +111,22 @@ export const getShortcuts = createSelector(
 		dateRange: {
 			chartStart: string;
 			chartEnd: string;
-		},
-		translateFromProps,
-		isNewDateFilteringEnabled
+		}
 	) => {
 		const siteId = getSelectedSiteId( state );
 		const siteToday = getMomentSiteZone( state, siteId );
 
-		return [
-			siteId,
-			siteToday.format( DATE_FORMAT ),
-			dateRange?.chartStart,
-			dateRange?.chartEnd,
-			isNewDateFilteringEnabled,
-		];
+		return [ siteId, siteToday.format( DATE_FORMAT ), dateRange?.chartStart, dateRange?.chartEnd ];
 	}
 );
 
-export function useShortcuts(
-	dateRange: { chartStart: string; chartEnd: string; daysInRange: number },
-	isNewDateFilteringEnabled = false
-) {
+export function useShortcuts( dateRange: {
+	chartStart: string;
+	chartEnd: string;
+	daysInRange: number;
+} ) {
 	const translate = useTranslate();
-	const shortcuts = useSelector( ( state ) =>
-		getShortcuts( state, dateRange, translate, isNewDateFilteringEnabled )
-	);
+	const shortcuts = useSelector( ( state ) => getShortcuts( state, dateRange, translate ) );
 
 	return shortcuts;
 }

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -26,8 +26,6 @@ interface StatsDateControlProps {
 		event_from: string,
 		stat_type: string
 	) => void;
-	// Temporary prop to enable new date filtering UI.
-	isNewDateFilteringEnabled: boolean;
 }
 
 // Define the event name keys for tracking events
@@ -81,7 +79,6 @@ const StatsDateControl = ( {
 	shortcutList,
 	overlay,
 	onGatedHandler,
-	isNewDateFilteringEnabled = false,
 }: StatsDateControlProps ) => {
 	// ToDo: Consider removing period from shortcuts.
 	// We could use the bestPeriodForDays() helper and keep the shortcuts
@@ -190,10 +187,9 @@ const StatsDateControl = ( {
 				const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 				recordTracksEvent( eventNames[ event_from ][ 'trigger_button' ] );
 			} }
-			tooltip={ isNewDateFilteringEnabled ? translate( 'Filter all data by date' ) : '' }
+			tooltip={ translate( 'Filter all data by date' ) }
 			overlay={ overlay }
 			shortcutList={ shortcutList }
-			isNewDateFilteringEnabled={ isNewDateFilteringEnabled }
 		/>
 	);
 };

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -833,7 +833,7 @@ export default connect(
 			config.isEnabled( 'stats/paid-wpcom-v3' ) &&
 			shouldGateStats( state, siteId, STATS_FEATURE_PAGE_TRAFFIC );
 
-		const { supportedShortcutList } = getShortcuts( state, {}, undefined, true );
+		const { supportedShortcutList } = getShortcuts( state, {}, undefined );
 
 		return {
 			canUserViewStats,

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -501,7 +501,6 @@ class StatsSite extends Component {
 							activeTab={ getActiveTab( this.props.chartTab ) }
 							activeLegend={ this.state.activeLegend }
 							onChangeLegend={ this.onChangeLegend }
-							isNewDateFilteringEnabled // @TODO:remove this prop once we release new date filtering
 							isWithNewDateControl
 							showArrows={ ! wpcomShowUpsell }
 							slug={ slug }
@@ -516,7 +515,6 @@ class StatsSite extends Component {
 								showQueryDate
 								isShort
 								dateRange={ customChartRange }
-								isNewDateFilteringEnabled // @TODO:remove this prop once we release new date filtering
 							/>
 						</StatsPeriodNavigation>
 					</StatsPeriodHeader>

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -173,24 +173,10 @@ class StatsDatePicker extends Component {
 
 	render() {
 		/* eslint-disable wpcalypso/jsx-classname-namespace*/
-		const {
-			summary,
-			translate,
-			query,
-			showQueryDate,
-			isActivity,
-			isShort,
-			dateRange,
-			reduxState,
-			isNewDateFilteringEnabled,
-		} = this.props;
+		const { summary, translate, query, showQueryDate, isActivity, isShort, dateRange, reduxState } =
+			this.props;
 		const isSummarizeQuery = get( query, 'summarize' );
-		const { selectedShortcut } = getShortcuts(
-			reduxState,
-			dateRange,
-			translate,
-			isNewDateFilteringEnabled
-		);
+		const { selectedShortcut } = getShortcuts( reduxState, dateRange, translate, true );
 
 		let sectionTitle = isActivity
 			? translate( '{{prefix}}Activity for {{/prefix}}{{period/}}', {

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -176,7 +176,7 @@ class StatsDatePicker extends Component {
 		const { summary, translate, query, showQueryDate, isActivity, isShort, dateRange, reduxState } =
 			this.props;
 		const isSummarizeQuery = get( query, 'summarize' );
-		const { selectedShortcut } = getShortcuts( reduxState, dateRange, translate, true );
+		const { selectedShortcut } = getShortcuts( reduxState, dateRange, translate );
 
 		let sectionTitle = isActivity
 			? translate( '{{prefix}}Activity for {{/prefix}}{{period/}}', {

--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -27,8 +27,7 @@
 	.stats-period-navigation {
 		@include section-header-with-siblings;
 
-	 // this new selector removes padding only for the date filtering design
-		&.stats-period-navigation__is-with-new-date-filtering {
+		&.stats-period-navigation__is-with-new-date-control {
 			padding: 0;
 			align-items: center;
 

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -7,19 +7,12 @@ import PropTypes from 'prop-types';
 import qs from 'qs';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import Legend from 'calypso/components/chart/legend';
 import { getShortcuts } from 'calypso/components/date-range/use-shortcuts';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import StatsDateControl from 'calypso/components/stats-date-control';
-import IntervalDropdown from 'calypso/components/stats-interval-dropdown';
 import {
 	STATS_FEATURE_DATE_CONTROL,
 	STATS_FEATURE_INTERVAL_DROPDOWN,
-	STATS_FEATURE_INTERVAL_DROPDOWN_DAY,
-	STATS_FEATURE_INTERVAL_DROPDOWN_MONTH,
-	STATS_FEATURE_INTERVAL_DROPDOWN_WEEK,
-	STATS_FEATURE_INTERVAL_DROPDOWN_YEAR,
-	STATS_PERIOD,
 } from 'calypso/my-sites/stats/constants';
 import { recordGoogleEvent as recordGoogleEventAction } from 'calypso/state/analytics/actions';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -45,7 +38,6 @@ class StatsPeriodNavigation extends PureComponent {
 		startDate: PropTypes.bool,
 		endDate: PropTypes.bool,
 		isWithNewDateControl: PropTypes.bool,
-		isNewDateFilteringEnabled: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -57,7 +49,6 @@ class StatsPeriodNavigation extends PureComponent {
 		startDate: false,
 		endDate: false,
 		isWithNewDateControl: false,
-		isNewDateFilteringEnabled: false,
 	};
 
 	handleArrowEvent = ( arrow, href ) => {
@@ -234,18 +225,15 @@ class StatsPeriodNavigation extends PureComponent {
 			queryParams,
 			slug,
 			isWithNewDateControl,
-			isNewDateFilteringEnabled,
 			dateRange,
 			shortcutList,
 			gateDateControl,
-			intervals,
 			siteId,
 			momentSiteZone,
 		} = this.props;
 
 		const isToday = moment( date ).isSame( momentSiteZone, period );
 
-		// TODO: Refactor the isNewDateFilteringEnabled dedicated variables.
 		const isChartRangeEndSameOrAfterToday = moment( dateRange?.chartEnd ).isSameOrAfter(
 			momentSiteZone,
 			'day'
@@ -256,7 +244,6 @@ class StatsPeriodNavigation extends PureComponent {
 			<div
 				className={ clsx( 'stats-period-navigation', {
 					'stats-period-navigation__is-with-new-date-control': isWithNewDateControl,
-					'stats-period-navigation__is-with-new-date-filtering': isNewDateFilteringEnabled,
 				} ) }
 			>
 				<div className="stats-period-navigation__children">{ children }</div>
@@ -272,7 +259,7 @@ class StatsPeriodNavigation extends PureComponent {
 				) }
 
 				{ /* New filtering view: Shows date control in a simplified layout */ }
-				{ isWithNewDateControl && isNewDateFilteringEnabled && (
+				{ isWithNewDateControl && (
 					<div className="stats-period-navigation__date-range-control">
 						{ showArrowsForDateRange && (
 							<NavigationArrows
@@ -298,55 +285,6 @@ class StatsPeriodNavigation extends PureComponent {
 										/>
 									)
 								}
-								isNewDateFilteringEnabled
-							/>
-						</div>
-					</div>
-				) }
-
-				{ /* Standard new date control view: Shows date control with additional controls (Legend, IntervalDropdown) */ }
-				{ isWithNewDateControl && ! isNewDateFilteringEnabled && (
-					<div className="stats-period-navigation__date-control">
-						<StatsDateControl
-							slug={ slug }
-							queryParams={ queryParams }
-							dateRange={ dateRange }
-							shortcutList={ shortcutList }
-							onGatedHandler={ this.onGatedHandler }
-							overlay={
-								gateDateControl && (
-									<StatsCardUpsell
-										className="stats-module__upsell"
-										statType={ STATS_FEATURE_DATE_CONTROL }
-										siteId={ siteId }
-									/>
-								)
-							}
-						/>
-						<div className="stats-period-navigation__period-control">
-							{ this.props.activeTab && (
-								<Legend
-									activeCharts={ this.props.activeLegend }
-									activeTab={ this.props.activeTab }
-									availableCharts={ this.props.availableLegend }
-									clickHandler={ this.onLegendClick }
-									tabs={ this.props.charts }
-								/>
-							) }
-							{ showArrows && (
-								<NavigationArrows
-									disableNextArrow={ disableNextArrow || isToday }
-									disablePreviousArrow={ disablePreviousArrow }
-									onClickNext={ this.handleArrowNext }
-									onClickPrevious={ this.handleArrowPrevious }
-								/>
-							) }
-							<IntervalDropdown
-								slug={ slug }
-								period={ period }
-								queryParams={ queryParams }
-								intervals={ intervals }
-								onGatedHandler={ this.onGatedHandler }
 							/>
 						</div>
 					</div>
@@ -363,7 +301,7 @@ const addIsGatedFor = ( state, siteId ) => ( shortcut ) => ( {
 } );
 
 const connectComponent = connect(
-	( state, { period, isNewDateFilteringEnabled, translate } ) => {
+	( state, { period, translate } ) => {
 		const siteId = getSelectedSiteId( state );
 		const gateDateControl = shouldGateStats( state, siteId, STATS_FEATURE_DATE_CONTROL );
 		const gatePeriodInterval = shouldGateStats(
@@ -375,45 +313,13 @@ const connectComponent = connect(
 			treatAtomicAsJetpackSite: false,
 		} );
 
-		const { supportedShortcutList } = getShortcuts(
-			state,
-			{},
-			translate,
-			isNewDateFilteringEnabled
-		);
+		const { supportedShortcutList } = getShortcuts( state, {}, translate, true );
 		const shortcutList = supportedShortcutList.map( addIsGatedFor( state, siteId ) );
-		const intervals = {
-			[ STATS_PERIOD.DAY ]: {
-				id: STATS_PERIOD.DAY,
-				label: translate( 'Days' ),
-				isGated: shouldGateStats( state, siteId, STATS_FEATURE_INTERVAL_DROPDOWN_DAY ),
-				statType: STATS_FEATURE_INTERVAL_DROPDOWN_DAY,
-			},
-			[ STATS_PERIOD.WEEK ]: {
-				id: STATS_PERIOD.WEEK,
-				label: translate( 'Weeks' ),
-				isGated: shouldGateStats( state, siteId, STATS_FEATURE_INTERVAL_DROPDOWN_WEEK ),
-				statType: STATS_FEATURE_INTERVAL_DROPDOWN_WEEK,
-			},
-			[ STATS_PERIOD.MONTH ]: {
-				id: STATS_PERIOD.MONTH,
-				label: translate( 'Months' ),
-				isGated: shouldGateStats( state, siteId, STATS_FEATURE_INTERVAL_DROPDOWN_MONTH ),
-				statType: STATS_FEATURE_INTERVAL_DROPDOWN_MONTH,
-			},
-			[ STATS_PERIOD.YEAR ]: {
-				id: STATS_PERIOD.YEAR,
-				label: translate( 'Years' ),
-				isGated: shouldGateStats( state, siteId, STATS_FEATURE_INTERVAL_DROPDOWN_YEAR ),
-				statType: STATS_FEATURE_INTERVAL_DROPDOWN_YEAR,
-			},
-		};
 
 		return {
 			shortcutList,
 			gateDateControl,
 			gatePeriodInterval,
-			intervals,
 			siteId,
 			isSiteJetpackNotAtomic,
 			momentSiteZone: getMomentSiteZone( state, siteId ),

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -313,7 +313,7 @@ const connectComponent = connect(
 			treatAtomicAsJetpackSite: false,
 		} );
 
-		const { supportedShortcutList } = getShortcuts( state, {}, translate, true );
+		const { supportedShortcutList } = getShortcuts( state, {}, translate );
 		const shortcutList = supportedShortcutList.map( addIsGatedFor( state, siteId ) );
 
 		return {

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -9,6 +9,22 @@
 	margin: 1.5em 0;
 	padding: 0 20px;
 
+	&.stats-period-navigation__is-with-new-date-control {
+		padding: 0;
+		align-items: flex-start;
+		row-gap: 8px;
+	
+		.stats-navigation-arrows {
+			justify-content: flex-end;
+		}
+	
+		.stats-period-navigation__date-range-control {
+			display:flex;
+			flex-direction: row;
+			gap: 20px;
+		}
+	}
+
 	.stats-period-navigation__children {
 		flex-grow: 1;
 	}
@@ -51,24 +67,4 @@
 	.chart__legend {
 		margin-bottom: initial;
 	}
-}
-
-// Styling specific to the new Date Filtering traffic page project
-.stats-period-navigation.stats-period-navigation__is-with-new-date-filtering {
-
-	.stats-navigation-arrows {
-		justify-content: flex-end;
-	}
-
-	.stats-period-navigation__date-range-control {
-		display:flex;
-		flex-direction: row;
-		gap: 20px;
-	  }
-}
-
-.stats-period-navigation.stats-period-navigation__is-with-new-date-control {
-	padding: 0;
-	align-items: flex-start;
-	row-gap: 8px;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/324.

## Proposed Changes

* Refactor date filtering relevant shared components to remove the `isNewDateFilteringEnabled` prop.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Use a separate PR to refactor the date filtering changes from the master one: https://github.com/Automattic/wp-calypso/pull/97789 for a more straightforward review.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Ensure everything is not changed and works well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
