### PR TITLE
Update social E2E smoke test

### DIFF
--- a/test/e2e/specs/jetpack/social__editor-smoke.ts
+++ b/test/e2e/specs/jetpack/social__editor-smoke.ts
@@ -1,4 +1,5 @@
 /**
+ * @group calypso-pr
  * @group jetpack-wpcom-integration
  */
 

--- a/test/e2e/specs/jetpack/social__editor-smoke.ts
+++ b/test/e2e/specs/jetpack/social__editor-smoke.ts
@@ -40,10 +40,6 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor Smoke test' ), function (
 
 		const toggle = editorParent.getByLabel( 'Share when publishing' );
 
-		expect( await toggle.isChecked() ).toBe( false );
-
-		const link = editorParent.getByRole( 'link', { name: 'Connect an account' } );
-
-		expect( await link.isVisible() ).toBe( true );
+		await toggle.waitFor();
 	} );
 } );


### PR DESCRIPTION
Following #97761 and #97774, we now have proper tests for Social features on WPCOM.

The smoke test assumed that there are no social connections and thus it asserted that "Connect an account" link exists. Now that it's possible that a site may have social accounts added via those feature tests, we can remove that assertion in the smoke test and make it a generic one.

This is to fix the test failures resulted in the above case - TC calypso_WPComTests_jetpack_simple_deployment_e2e_desktop/13961906

## Proposed Changes

* Update Social smoke test to remove a feature test

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* CI should be happy.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
