### PR TITLE
Style Variations: Filter out the colors and fonts

### DIFF
--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -12,6 +12,8 @@ import {
 	GlobalStylesContext,
 	mergeBaseAndUserConfigs,
 	withExperimentalBlockEditorProvider,
+	isColorVariation,
+	isFontVariation,
 } from '../../gutenberg-bridge';
 import { useRegisterCoreBlocks } from '../../hooks';
 import GlobalStylesVariationPreview from './preview';
@@ -127,7 +129,10 @@ const GlobalStylesVariations = ( {
 	const globalStylesVariationsWithoutDefault = useMemo(
 		() =>
 			globalStylesVariations.filter(
-				( globalStylesVariation ) => ! isDefaultGlobalStyleVariationSlug( globalStylesVariation )
+				( globalStylesVariation ) =>
+					! isDefaultGlobalStyleVariationSlug( globalStylesVariation ) &&
+					! isColorVariation( globalStylesVariation ) &&
+					! isFontVariation( globalStylesVariation )
 			),
 		[ globalStylesVariations ]
 	);

--- a/packages/global-styles/src/gutenberg-bridge/index.tsx
+++ b/packages/global-styles/src/gutenberg-bridge/index.tsx
@@ -20,6 +20,7 @@ const {
 	cleanEmptyObject,
 	ExperimentalBlockEditorProvider,
 	GlobalStylesContext: UntypedGSContext,
+	areGlobalStyleConfigsEqual,
 	useGlobalStylesOutput,
 	useGlobalSetting,
 	useGlobalStyle,
@@ -64,10 +65,64 @@ const useSafeGlobalStylesOutput = () => {
 	}
 };
 
+/**
+ * Returns a new object, with properties specified in `properties` array.,
+ * maintain the original object tree structure.
+ * The function is recursive, so it will perform a deep search for the given properties.
+ * E.g., the function will return `{ a: { b: { c: { test: 1 } } } }` if the properties are  `[ 'test' ]`.
+ *
+ * @param {Object}   object     The object to filter
+ * @param {string[]} properties The properties to filter by
+ * @returns {Object} The merged object.
+ */
+const filterObjectByProperties = ( object: { [ key: string ]: any }, properties: string[] ) => {
+	if ( ! object || ! properties?.length ) {
+		return {};
+	}
+
+	const newObject = {};
+	Object.keys( object ).forEach( ( key ) => {
+		if ( properties.includes( key ) ) {
+			newObject[ key ] = object[ key ];
+		} else if ( typeof object[ key ] === 'object' ) {
+			const newFilter = filterObjectByProperties( object[ key ], properties );
+			if ( Object.keys( newFilter ).length ) {
+				newObject[ key ] = newFilter;
+			}
+		}
+	} );
+	return newObject;
+};
+
+/**
+ * Compares a style variation to the same variation filtered by the specified properties.
+ * Returns true if the variation contains only the properties specified.
+ *
+ * @param {Object}   variation  The variation to compare.
+ * @param {string[]} properties The properties to compare.
+ * @returns {boolean} Whether the variation contains only the specified properties.
+ */
+const isVariationWithProperties = ( variation: GlobalStylesObject, properties: string[] ) => {
+	const variationWithProperties = filterObjectByProperties(
+		window.structuredClone( variation ),
+		properties
+	);
+
+	return areGlobalStyleConfigsEqual( variationWithProperties, variation );
+};
+
+const isColorVariation = ( variation: GlobalStylesObject ) =>
+	isVariationWithProperties( variation, [ 'color' ] );
+
+const isFontVariation = ( variation: GlobalStylesObject ) =>
+	isVariationWithProperties( variation, [ 'typography' ] );
+
 export {
 	cleanEmptyObject,
 	ExperimentalBlockEditorProvider,
 	GlobalStylesContext,
+	isColorVariation,
+	isFontVariation,
 	transformStyles,
 	useSafeGlobalStylesOutput,
 	useGlobalSetting,

--- a/packages/global-styles/src/gutenberg-bridge/index.tsx
+++ b/packages/global-styles/src/gutenberg-bridge/index.tsx
@@ -75,17 +75,20 @@ const useSafeGlobalStylesOutput = () => {
  * @param {string[]} properties The properties to filter by
  * @returns {Object} The merged object.
  */
-const filterObjectByProperties = ( object: { [ key: string ]: any }, properties: string[] ) => {
+const filterObjectByProperties = ( object: Record< string, any >, properties: string[] ) => {
 	if ( ! object || ! properties?.length ) {
 		return {};
 	}
 
-	const newObject = {};
+	const newObject: Record< string, any > = {};
 	Object.keys( object ).forEach( ( key ) => {
 		if ( properties.includes( key ) ) {
 			newObject[ key ] = object[ key ];
 		} else if ( typeof object[ key ] === 'object' ) {
-			const newFilter = filterObjectByProperties( object[ key ], properties );
+			const newFilter = filterObjectByProperties(
+				object[ key ] as Record< string, any >,
+				properties
+			);
 			if ( Object.keys( newFilter ).length ) {
 				newObject[ key ] = newFilter;
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/97134

## Proposed Changes

* Don't show palette variations and typography variations on the Theme page to align with the Core. In addition, 
  * The slug between style variations and color variations might be the same, and it made the selection weird
  * The preview of the font variations look too similar

| Before | After | Core |
| - | - | - |
| ![image](https://github.com/user-attachments/assets/1efadc31-7aaf-4e0b-8ffa-fe59504bb5e9) | ![image](https://github.com/user-attachments/assets/793d930e-333b-4e5e-a1a4-bcd7bd5688fa) | ![image](https://github.com/user-attachments/assets/8bab424a-cf6c-48bd-af10-315e1d5468d6) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/wp-calypso/issues/97134

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /theme/twentytwentyfive
* Ensure there are only 8 style variations

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
