### PR TITLE
My Home: Add Change Theme to Quick Links

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -40,7 +40,6 @@ import './style.scss';
 export const QuickLinks = ( {
 	canEditPages,
 	canCustomize,
-	canSwitchThemes,
 	canManageSite,
 	canModerateComments,
 	customizeUrl,
@@ -178,15 +177,6 @@ export const QuickLinks = ( {
 					/>
 				</>
 			) }
-			{ canSwitchThemes && (
-				<ActionBox
-					href={ `/themes/${ siteSlug }` }
-					hideLinkIndicator
-					onClick={ trackChangeThemeAction }
-					label={ translate( 'Change theme' ) }
-					materialIcon="view_quilt"
-				/>
-			) }
 			{ canManageSite && ! isWpcomStagingSite && (
 				<>
 					{ canAddEmail ? (
@@ -227,6 +217,18 @@ export const QuickLinks = ( {
 			) }
 			{ canManageSite && (
 				<>
+					<ActionBox
+						href={ usesWpAdminInterface ? `${ siteAdminUrl }themes.php` : `/themes/${ siteSlug }` }
+						hideLinkIndicator
+						onClick={ trackChangeThemeAction }
+						label={ translate( 'Change theme' ) }
+						iconComponent={
+							<span
+								className="quick-links__action-box-icon dashicons dashicons-admin-appearance"
+								aria-hidden
+							/>
+						}
+					/>
 					<ActionBox
 						href={
 							usesWpAdminInterface ? `${ siteAdminUrl }plugins.php` : `/plugins/${ siteSlug }`
@@ -479,7 +481,6 @@ const mapStateToProps = ( state ) => {
 		siteId,
 		canEditPages: canCurrentUser( state, siteId, 'edit_pages' ),
 		canCustomize: canCurrentUser( state, siteId, 'customize' ),
-		canSwitchThemes: canCurrentUser( state, siteId, 'switch_themes' ),
 		canManageSite: canCurrentUser( state, siteId, 'manage_options' ),
 		canModerateComments: canCurrentUser( state, siteId, 'moderate_comments' ),
 		customizeUrl: getCustomizerUrl( state, siteId ),

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -69,6 +69,11 @@
 
 		&.dashicons {
 			color: var(--color-neutral-80);
+
+			&.dashicons-admin-appearance {
+				color: var(--color-neutral-60);
+				line-height: 24px;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/94063

## Proposed Changes

This PR adds "Change theme" to the Quick Links section in My Home.

It turns out that the "Change theme" quick link was already implemented, but never rendered since the capability `switch_themes` seems to be filtered out from the endpoint. Thus, we check for manage_option instead to follow the Explore Plugins quick link. Another option would be to check for `edit_theme_options` which is available.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Contributes to the overall polish of WordPress.com.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /home/:domain
* Ensure that the "Change theme" quick link is now available
* In the Default admin interface, it should link to /themes/:domain
* In the Classic admin interface, it should link to themes.php

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
