### PR TITLE
POC Theme: Display palettes and typography sections

### DIFF
--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -17,6 +17,8 @@ import {
 } from '../../gutenberg-bridge';
 import { useRegisterCoreBlocks } from '../../hooks';
 import GlobalStylesVariationPreview from './preview';
+import GlobalStylesVariationPreviewColors from './preview-colors';
+import GlobalStylesVariationPreviewTypography from './preview-typography';
 import type { GlobalStylesObject } from '../../types';
 import './style.scss';
 
@@ -24,6 +26,9 @@ interface GlobalStylesVariationProps {
 	globalStylesVariation: GlobalStylesObject;
 	isActive: boolean;
 	showOnlyHoverView?: boolean;
+	VariationComponent:
+		| typeof GlobalStylesVariationPreview
+		| typeof GlobalStylesVariationPreviewColors;
 	onSelect: () => void;
 }
 
@@ -41,6 +46,7 @@ const isDefaultGlobalStyleVariationSlug = ( globalStylesVariation: GlobalStylesO
 	globalStylesVariation.slug === DEFAULT_GLOBAL_STYLES_VARIATION_SLUG;
 
 const GlobalStylesVariation = ( {
+	VariationComponent = GlobalStylesVariationPreview,
 	globalStylesVariation,
 	isActive,
 	showOnlyHoverView,
@@ -85,7 +91,7 @@ const GlobalStylesVariation = ( {
 		>
 			<div className="global-styles-variation__item-preview">
 				<GlobalStylesContext.Provider value={ context }>
-					<GlobalStylesVariationPreview
+					<VariationComponent
 						title={ globalStylesVariation.title }
 						inlineCss={ context.inline_css }
 						isFocused={ isFocused || showOnlyHoverView }
@@ -126,28 +132,53 @@ const GlobalStylesVariations = ( {
 			) ?? ( {} as GlobalStylesObject ),
 		[ globalStylesVariations ]
 	);
-	const globalStylesVariationsWithoutDefault = useMemo(
+
+	const { styleVariations, colorVariations, fontVariations } = useMemo(
 		() =>
-			globalStylesVariations.filter(
-				( globalStylesVariation ) =>
-					! isDefaultGlobalStyleVariationSlug( globalStylesVariation ) &&
-					! isColorVariation( globalStylesVariation ) &&
-					! isFontVariation( globalStylesVariation )
+			globalStylesVariations.reduce(
+				( acc, variation ) => {
+					if ( isDefaultGlobalStyleVariationSlug( variation ) ) {
+						return acc;
+					}
+
+					if ( isColorVariation( variation ) ) {
+						return {
+							...acc,
+							colorVariations: [ ...acc.colorVariations, variation ],
+						};
+					}
+
+					if ( isFontVariation( variation ) ) {
+						return {
+							...acc,
+							fontVariations: [ ...acc.fontVariations, variation ],
+						};
+					}
+
+					return {
+						...acc,
+						styleVariations: [ ...acc.styleVariations, variation ],
+					};
+				},
+				{
+					styleVariations: [],
+					colorVariations: [],
+					fontVariations: [],
+				}
 			),
 		[ globalStylesVariations ]
 	);
 
 	const nonDefaultStylesDescription = description ?? variationDescription;
-	const nonDefaultStyles = globalStylesVariationsWithoutDefault.map(
-		( globalStylesVariation, index ) => (
-			<GlobalStylesVariation
-				key={ index }
-				globalStylesVariation={ globalStylesVariation }
-				isActive={ globalStylesVariation.slug === selectedGlobalStylesVariation?.slug }
-				onSelect={ () => onSelect( globalStylesVariation ) }
-			/>
-		)
-	);
+	const nonDefaultStyles = styleVariations.map( ( globalStylesVariation, index ) => (
+		<GlobalStylesVariation
+			key={ index }
+			VariationComponent={ GlobalStylesVariationPreview }
+			globalStylesVariation={ globalStylesVariation }
+			isActive={ globalStylesVariation.slug === selectedGlobalStylesVariation?.slug }
+			onSelect={ () => onSelect( globalStylesVariation ) }
+		/>
+	) );
 
 	const headerText = splitDefaultVariation ? translate( 'Default Style' ) : translate( 'Styles' );
 
@@ -183,6 +214,7 @@ const GlobalStylesVariations = ( {
 					<div className="global-styles-variations">
 						<GlobalStylesVariation
 							key="base"
+							VariationComponent={ GlobalStylesVariationPreview }
 							globalStylesVariation={ baseGlobalStyles }
 							isActive={
 								! selectedGlobalStylesVariation ||
@@ -218,6 +250,46 @@ const GlobalStylesVariations = ( {
 							<p>{ nonDefaultStylesDescription }</p>
 						</div>
 						<div className="global-styles-variations">{ nonDefaultStyles }</div>
+						{ colorVariations.length > 0 && (
+							<>
+								<div className="global-styles-variations__header">
+									<p>{ translate( 'Palettes' ) }</p>
+								</div>
+								<div className="global-styles-variations">
+									{ colorVariations.map( ( globalStylesVariation, index ) => (
+										<GlobalStylesVariation
+											key={ index }
+											VariationComponent={ GlobalStylesVariationPreviewColors }
+											globalStylesVariation={ globalStylesVariation }
+											isActive={
+												globalStylesVariation.slug === selectedGlobalStylesVariation?.slug
+											}
+											onSelect={ () => onSelect( globalStylesVariation ) }
+										/>
+									) ) }
+								</div>
+							</>
+						) }
+						{ fontVariations.length > 0 && (
+							<>
+								<div className="global-styles-variations__header">
+									<p>{ translate( 'Typography' ) }</p>
+								</div>
+								<div className="global-styles-variations">
+									{ fontVariations.map( ( globalStylesVariation, index ) => (
+										<GlobalStylesVariation
+											key={ index }
+											VariationComponent={ GlobalStylesVariationPreviewTypography }
+											globalStylesVariation={ globalStylesVariation }
+											isActive={
+												globalStylesVariation.slug === selectedGlobalStylesVariation?.slug
+											}
+											onSelect={ () => onSelect( globalStylesVariation ) }
+										/>
+									) ) }
+								</div>
+							</>
+						) }
 					</div>
 				) }
 			</div>

--- a/packages/global-styles/src/components/global-styles-variations/preview-colors.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/preview-colors.tsx
@@ -1,0 +1,86 @@
+import { __unstableMotion as motion, __experimentalHStack as HStack } from '@wordpress/components';
+import { useResizeObserver } from '@wordpress/compose';
+import { useGlobalSetting, useGlobalStyle } from '../../gutenberg-bridge';
+import GlobalStylesVariationContainer from '../global-styles-variation-container';
+
+const firstFrame = {
+	start: {
+		scale: 1,
+		opacity: 1,
+	},
+	hover: {
+		scale: 0,
+		opacity: 0.9,
+	},
+};
+
+const normalizedWidth = 248;
+const normalizedHeight = 50;
+
+interface Props {
+	inlineCss?: string;
+	onFocusOut?: () => void;
+}
+
+const GlobalStylesVariationPreviewColors = ( { inlineCss, onFocusOut }: Props ) => {
+	const [ backgroundColor = 'white' ] = useGlobalStyle( 'color.background' );
+	const [ gradientValue ] = useGlobalStyle( 'color.gradient' );
+	const [ coreColors ] = useGlobalSetting( 'color.palette.core' );
+	const [ themeColors ] = useGlobalSetting( 'color.palette.theme' );
+	const [ customColors ] = useGlobalSetting( 'color.palette.custom' );
+	const [ containerResizeListener, { width } ] = useResizeObserver();
+	const ratio = width ? width / normalizedWidth : 1;
+	const paletteColors = ( themeColors ?? [] )
+		.concat( customColors ?? [] )
+		.concat( coreColors ?? [] );
+
+	return (
+		<GlobalStylesVariationContainer
+			width={ width }
+			height={ normalizedHeight * ratio }
+			inlineCss={ inlineCss }
+			containerResizeListener={ containerResizeListener }
+			onFocusOut={ onFocusOut }
+		>
+			<motion.div
+				style={ {
+					height: normalizedHeight * ratio,
+					width: '100%',
+					background: gradientValue ?? backgroundColor,
+					cursor: 'pointer',
+				} }
+				initial="start"
+			>
+				<motion.div
+					variants={ firstFrame }
+					style={ {
+						height: '100%',
+						overflow: 'hidden',
+					} }
+				>
+					<HStack
+						spacing={ 0 }
+						justify="center"
+						style={ {
+							height: '100%',
+							overflow: 'hidden',
+						} }
+					>
+						{ paletteColors.slice( 0, 4 ).map( ( { slug, color }, index ) => (
+							<div
+								key={ `${ slug }-${ index }` }
+								style={ {
+									flexGrow: 1,
+									height: '100%',
+									background: color,
+								} }
+							/>
+						) ) }
+					</HStack>
+				</motion.div>
+			</motion.div>
+		</GlobalStylesVariationContainer>
+	);
+};
+
+export default GlobalStylesVariationPreviewColors;

--- a/packages/global-styles/src/components/global-styles-variations/preview-typography.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/preview-typography.tsx
@@ -1,0 +1,119 @@
+import { __unstableMotion as motion, __experimentalHStack as HStack } from '@wordpress/components';
+import { useResizeObserver } from '@wordpress/compose';
+import { useContext } from 'react';
+import { GlobalStylesContext, useGlobalStyle } from '../../gutenberg-bridge';
+import GlobalStylesVariationContainer from '../global-styles-variation-container';
+import { getFamilyPreviewStyle } from './utils';
+
+function getFontFamilyFromSetting( fontFamilies, setting ) {
+	if ( ! Array.isArray( fontFamilies ) || ! setting ) {
+		return null;
+	}
+
+	const fontFamilyVariable = setting.replace( 'var(', '' ).replace( ')', '' );
+	const fontFamilySlug = fontFamilyVariable?.split( '--' ).slice( -1 )[ 0 ];
+
+	return fontFamilies.find( ( fontFamily ) => fontFamily.slug === fontFamilySlug );
+}
+
+function getFontFamilies( themeJson ) {
+	const themeFontFamilies = themeJson?.settings?.typography?.fontFamilies?.theme;
+	const customFontFamilies = themeJson?.settings?.typography?.fontFamilies?.custom;
+
+	let fontFamilies = [];
+	if ( themeFontFamilies && customFontFamilies ) {
+		fontFamilies = [ ...themeFontFamilies, ...customFontFamilies ];
+	} else if ( themeFontFamilies ) {
+		fontFamilies = themeFontFamilies;
+	} else if ( customFontFamilies ) {
+		fontFamilies = customFontFamilies;
+	}
+	const bodyFontFamilySetting = themeJson?.styles?.typography?.fontFamily;
+	const bodyFontFamily = getFontFamilyFromSetting( fontFamilies, bodyFontFamilySetting );
+
+	const headingFontFamilySetting = themeJson?.styles?.elements?.heading?.typography?.fontFamily;
+
+	let headingFontFamily;
+	if ( ! headingFontFamilySetting ) {
+		headingFontFamily = bodyFontFamily;
+	} else {
+		headingFontFamily = getFontFamilyFromSetting(
+			fontFamilies,
+			themeJson?.styles?.elements?.heading?.typography?.fontFamily
+		);
+	}
+
+	return [ bodyFontFamily, headingFontFamily ];
+}
+
+const normalizedWidth = 158;
+const normalizedHeight = 101;
+
+interface Props {
+	fontSize?: number;
+	inlineCss?: string;
+	onFocusOut?: () => void;
+}
+
+const GlobalStylesVariationPreviewTypography = ( {
+	fontSize = 36,
+	inlineCss,
+	onFocusOut,
+}: Props ) => {
+	const { merged } = useContext( GlobalStylesContext );
+	const [ containerResizeListener, { width } ] = useResizeObserver();
+	const ratio = width ? width / normalizedWidth : 1;
+
+	const [ textColor = 'black' ] = useGlobalStyle( 'color.text' );
+
+	const [ bodyFontFamilies, headingFontFamilies ] = getFontFamilies( merged );
+	const bodyPreviewStyle = bodyFontFamilies ? getFamilyPreviewStyle( bodyFontFamilies ) : {};
+	const headingPreviewStyle = headingFontFamilies
+		? getFamilyPreviewStyle( headingFontFamilies )
+		: {};
+
+	if ( textColor ) {
+		bodyPreviewStyle.color = textColor;
+		headingPreviewStyle.color = textColor;
+	}
+
+	if ( fontSize ) {
+		bodyPreviewStyle.fontSize = fontSize;
+		headingPreviewStyle.fontSize = fontSize;
+	}
+
+	return (
+		<GlobalStylesVariationContainer
+			width={ width }
+			height={ normalizedHeight * ratio }
+			inlineCss={ inlineCss }
+			containerResizeListener={ containerResizeListener }
+			onFocusOut={ onFocusOut }
+		>
+			<motion.div
+				style={ {
+					height: normalizedHeight * ratio,
+					width: '100%',
+					cursor: 'pointer',
+				} }
+			>
+				<HStack
+					spacing={ 10 * ratio }
+					justify="center"
+					align="center"
+					style={ {
+						height: '100%',
+						overflow: 'hidden',
+					} }
+				>
+					<motion.div>
+						<span style={ headingPreviewStyle }>A</span>
+						<span style={ bodyPreviewStyle }>a</span>
+					</motion.div>
+				</HStack>
+			</motion.div>
+		</GlobalStylesVariationContainer>
+	);
+};
+
+export default GlobalStylesVariationPreviewTypography;

--- a/packages/global-styles/src/components/global-styles-variations/utils.ts
+++ b/packages/global-styles/src/components/global-styles-variations/utils.ts
@@ -1,0 +1,147 @@
+function findNearest( input, numbers ) {
+	// If the numbers array is empty, return null
+	if ( numbers.length === 0 ) {
+		return null;
+	}
+	// Sort the array based on the absolute difference with the input
+	numbers.sort( ( a, b ) => Math.abs( input - a ) - Math.abs( input - b ) );
+	// Return the first element (which will be the nearest) from the sorted array
+	return numbers[ 0 ];
+}
+
+function extractFontWeights( fontFaces ) {
+	const result = [];
+
+	fontFaces.forEach( ( face ) => {
+		const weights = String( face.fontWeight ).split( ' ' );
+
+		if ( weights.length === 2 ) {
+			const start = parseInt( weights[ 0 ] );
+			const end = parseInt( weights[ 1 ] );
+
+			for ( let i = start; i <= end; i += 100 ) {
+				result.push( i );
+			}
+		} else if ( weights.length === 1 ) {
+			result.push( parseInt( weights[ 0 ] ) );
+		}
+	} );
+
+	return result;
+}
+
+/*
+ * Format the font family to use in the CSS font-family property of a CSS rule.
+ *
+ * The input can be a string with the font family name or a string with multiple font family names separated by commas.
+ * It follows the recommendations from the CSS Fonts Module Level 4.
+ * https://www.w3.org/TR/css-fonts-4/#font-family-prop
+ *
+ * @param {string} input - The font family.
+ * @return {string} The formatted font family.
+ *
+ * Example:
+ * formatFontFamily( "Open Sans, Font+Name, sans-serif" ) => '"Open Sans", "Font+Name", sans-serif'
+ * formatFontFamily( "'Open Sans', generic(kai), sans-serif" ) => '"Open Sans", sans-serif'
+ * formatFontFamily( "DotGothic16, Slabo 27px, serif" ) => '"DotGothic16","Slabo 27px",serif'
+ * formatFontFamily( "Mine's, Moe's Typography" ) => `"mine's","Moe's Typography"`
+ */
+export function formatFontFamily( input ) {
+	// Matches strings that are not exclusively alphabetic characters or hyphens, and do not exactly follow the pattern generic(alphabetic characters or hyphens).
+	const regex = /^(?!generic\([ a-zA-Z-]+\)$)(?!^[a-zA-Z-]+$).+/;
+	const output = input.trim();
+
+	const formatItem = ( item ) => {
+		item = item.trim();
+		if ( item.match( regex ) ) {
+			// removes leading and trailing quotes.
+			item = item.replace( /^["']|["']$/g, '' );
+			return `"${ item }"`;
+		}
+		return item;
+	};
+
+	if ( output.includes( ',' ) ) {
+		return output
+			.split( ',' )
+			.map( formatItem )
+			.filter( ( item ) => item !== '' )
+			.join( ', ' );
+	}
+
+	return formatItem( output );
+}
+
+/*
+ * Format the font face name to use in the font-family property of a font face.
+ *
+ * The input can be a string with the font face name or a string with multiple font face names separated by commas.
+ * It removes the leading and trailing quotes from the font face name.
+ *
+ * @param {string} input - The font face name.
+ * @return {string} The formatted font face name.
+ *
+ * Example:
+ * formatFontFaceName("Open Sans") => "Open Sans"
+ * formatFontFaceName("'Open Sans', sans-serif") => "Open Sans"
+ * formatFontFaceName(", 'Open Sans', 'Helvetica Neue', sans-serif") => "Open Sans"
+ */
+export function formatFontFaceName( input ) {
+	if ( ! input ) {
+		return '';
+	}
+
+	let output = input.trim();
+	if ( output.includes( ',' ) ) {
+		output = output
+			.split( ',' )
+			// finds the first item that is not an empty string.
+			.find( ( item ) => item.trim() !== '' )
+			.trim();
+	}
+	// removes leading and trailing quotes.
+	output = output.replace( /^["']|["']$/g, '' );
+
+	// Firefox needs the font name to be wrapped in double quotes meanwhile other browsers don't.
+	if ( window.navigator.userAgent.toLowerCase().includes( 'firefox' ) ) {
+		output = `"${ output }"`;
+	}
+	return output;
+}
+
+export function getFamilyPreviewStyle( family ) {
+	const style = { fontFamily: formatFontFamily( family.fontFamily ) };
+
+	if ( ! Array.isArray( family.fontFace ) ) {
+		style.fontWeight = '400';
+		style.fontStyle = 'normal';
+		return style;
+	}
+
+	if ( family.fontFace ) {
+		//get all the font faces with normal style
+		const normalFaces = family.fontFace.filter(
+			( face ) => face?.fontStyle && face.fontStyle.toLowerCase() === 'normal'
+		);
+		if ( normalFaces.length > 0 ) {
+			style.fontStyle = 'normal';
+			const normalWeights = extractFontWeights( normalFaces );
+			const nearestWeight = findNearest( 400, normalWeights );
+			style.fontWeight = String( nearestWeight ) || '400';
+		} else {
+			style.fontStyle = ( family.fontFace.length && family.fontFace[ 0 ].fontStyle ) || 'normal';
+			style.fontWeight =
+				( family.fontFace.length && String( family.fontFace[ 0 ].fontWeight ) ) || '400';
+		}
+	}
+
+	return style;
+}
+
+export function getFacePreviewStyle( face ) {
+	return {
+		fontFamily: formatFontFamily( face.fontFamily ),
+		fontStyle: face.fontStyle || 'normal',
+		fontWeight: face.fontWeight || '400',
+	};
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/97134

## Proposed Changes

* Display palette and typography sections on the Theme page

![image](https://github.com/user-attachments/assets/66199244-ef3f-4c93-a8f0-4da21f5a39be)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /theme/twentytwentyfive

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
