### PR TITLE
Add hide manage site button for detached domains

### DIFF
--- a/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
@@ -72,20 +72,22 @@ const DomainOverviewPane = ( {
 
 	const PreviewPaneHeaderButtons = ( { focusRef, closeSitePreviewPane }: BtnProps ) => {
 		const adminButtonRef = useRef< HTMLButtonElement | null >( null );
-
+		const mergedRef = useMergeRefs( [ adminButtonRef, focusRef ] );
 		return (
 			<>
 				<Button onClick={ closeSitePreviewPane } className="button item-view__close-button">
 					{ __( 'Close' ) }
 				</Button>
-				<Button
-					primary
-					className="button item-preview__admin-button"
-					href={ adminUrl }
-					ref={ useMergeRefs( [ adminButtonRef, focusRef ] ) }
-				>
-					{ translate( 'Manage site' ) }
-				</Button>
+				{ ! site.options?.is_domain_only && (
+					<Button
+						primary
+						className="button item-preview__admin-button"
+						href={ adminUrl }
+						ref={ mergedRef }
+					>
+						{ translate( 'Manage site' ) }
+					</Button>
+				) }
 			</>
 		);
 	};

--- a/client/my-sites/domains/domain-management/domain-overview-pane/test/index.test.tsx
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/test/index.test.tsx
@@ -113,6 +113,21 @@ describe( 'DomainOverviewPane', () => {
 		expect( screen.getByText( 'Manage site' ) ).toBeInTheDocument();
 	} );
 
+	it( 'does not show Manage Site button when domain only and unattached', () => {
+		const siteProps = {
+			...defaultProps,
+			site: {
+				...defaultProps.site,
+				options: {
+					...defaultProps.site.options,
+					is_domain_only: true,
+				},
+			},
+		};
+		renderComponent( siteProps );
+		expect( screen.queryByText( 'Manage site' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'handles tab switching', () => {
 		renderComponent();
 		fireEvent.click( screen.getByText( 'Email' ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/97644

## Proposed Changes

* Don't show "Manage site" button when Domain is not attached

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Domain management revamp

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Enable the feature flag window.sessionStorage.setItem('flags', 'calypso/all-domain-management')
- Go to calypso.localhost:3000/domains/manage
- Make sure you have domains that are attached to sites and some domains that are not attached
- Select a detached domain, it should open in flyout. Make sure the "Manage site" button is not there
- Select an attached domain, make sure the "Manage site button is the"ere

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
