### PR TITLE
Add back button to migration if contains back_to url

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -231,8 +231,12 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 		const shouldHideBasedOnRef = [ 'entrepreneur-signup', 'calypso-importer' ].includes( ref );
 		const shouldHideBasedOnVariant = [ HOSTED_SITE_MIGRATION_FLOW ].includes( variantSlug || '' );
 		const shouldNotHideBasedOnRef = [ GUIDED_ONBOARDING_FLOW_REFERRER ].includes( ref );
-
-		return ( shouldHideBasedOnRef || shouldHideBasedOnVariant ) && ! shouldNotHideBasedOnRef;
+		const shouldNotHideIfBackToIsSet = Boolean( urlQueryParams.get( 'back_to' ) );
+		return (
+			( shouldHideBasedOnRef || shouldHideBasedOnVariant ) &&
+			! shouldNotHideBasedOnRef &&
+			! shouldNotHideIfBackToIsSet
+		);
 	};
 
 	return (
@@ -243,6 +247,7 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 				flowName="site-migration"
 				className="import__onboarding-page"
 				hideBack={ shouldHideBackButton() }
+				backUrl={ urlQueryParams.get( 'back_to' ) || undefined }
 				hideSkip
 				hideFormattedHeader
 				goBack={ navigation?.goBack }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/97706

## Proposed Changes

After the user clicks on "Import or migrate an existing site" and goes through signup, the first step won't have a back button. We're already passing `back_to` parameter to the goals step, so we're utilizing the parameter to render the back button

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/user-attachments/assets/4d142757-7a36-48da-b60c-e5b22df36337">  | <img src="https://github.com/user-attachments/assets/7c037e49-023a-490f-9c5a-cf98c1ed4331">|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Allow users to go back to the place specified in `back_to` query param, which should be the step they came from

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/onboarding
* Select "Import or migrate an existing site" on the goals screen
* Create an account if not logged in yet
* See the Migration screen, top left back button should go take us back to the first step which is `/setup/onboarding/goals`, should also match the user's locale as well

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
