### PR TITLE
Stats: check if subscribers module is active before showing the tab

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -18,7 +18,11 @@ import isGoogleMyBusinessLocationConnectedSelector from 'calypso/state/selectors
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isSiteStore from 'calypso/state/selectors/is-site-store';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import { getJetpackStatsAdminVersion, getSiteOption } from 'calypso/state/sites/selectors';
+import {
+	getJetpackStatsAdminVersion,
+	getSiteOption,
+	isSimpleSite,
+} from 'calypso/state/sites/selectors';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import {
 	updateModuleToggles,
@@ -61,6 +65,8 @@ class StatsNavigation extends Component {
 		isGoogleMyBusinessLocationConnected: PropTypes.bool.isRequired,
 		isStore: PropTypes.bool,
 		isWordAds: PropTypes.bool,
+		isSubscriptionsModuleActive: PropTypes.bool,
+		isSimple: PropTypes.bool,
 		hasVideoPress: PropTypes.bool,
 		selectedItem: PropTypes.oneOf( Object.keys( navItems ) ).isRequired,
 		siteId: PropTypes.number,
@@ -70,7 +76,6 @@ class StatsNavigation extends Component {
 		showLock: PropTypes.bool,
 		hideModuleSettings: PropTypes.bool,
 		delayTooltipPresentation: PropTypes.bool,
-		isSubscriptionsModuleActive: PropTypes.bool,
 	};
 
 	state = {
@@ -145,6 +150,7 @@ class StatsNavigation extends Component {
 			isStore,
 			isWordAds,
 			isSubscriptionsModuleActive,
+			isSimple,
 			siteId,
 		} = this.props;
 
@@ -167,7 +173,7 @@ class StatsNavigation extends Component {
 					return false;
 				}
 
-				return isSubscriptionsModuleActive;
+				return isSimple || isSubscriptionsModuleActive;
 
 			default:
 				return true;
@@ -310,6 +316,8 @@ export default connect(
 			isWordAds:
 				getSiteOption( state, siteId, 'wordads' ) &&
 				canCurrentUser( state, siteId, 'manage_options' ),
+			isSubscriptionsModuleActive: isJetpackModuleActive( state, siteId, 'subscriptions' ),
+			isSimple: isSimpleSite( state, siteId ),
 			hasVideoPress: siteHasFeature( state, siteId, 'videopress' ),
 			siteId,
 			pageModuleToggles: getModuleToggles( state, siteId, [ selectedItem ] ),
@@ -319,7 +327,6 @@ export default connect(
 			gatedTrafficPage:
 				config.isEnabled( 'stats/paid-wpcom-v3' ) &&
 				shouldGateStats( state, siteId, STATS_FEATURE_PAGE_TRAFFIC ),
-			isSubscriptionsModuleActive: isJetpackModuleActive( state, siteId, 'subscriptions' ),
 		};
 	},
 	{ requestModuleToggles, updateModuleToggles }

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -4,6 +4,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
@@ -14,6 +15,7 @@ import { useNoticeVisibilityQuery } from 'calypso/my-sites/stats/hooks/use-notic
 import { shouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isGoogleMyBusinessLocationConnectedSelector from 'calypso/state/selectors/is-google-my-business-location-connected';
+import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isSiteStore from 'calypso/state/selectors/is-site-store';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getJetpackStatsAdminVersion, getSiteOption } from 'calypso/state/sites/selectors';
@@ -68,6 +70,7 @@ class StatsNavigation extends Component {
 		showLock: PropTypes.bool,
 		hideModuleSettings: PropTypes.bool,
 		delayTooltipPresentation: PropTypes.bool,
+		isSubscriptionsModuleActive: PropTypes.bool,
 	};
 
 	state = {
@@ -137,7 +140,13 @@ class StatsNavigation extends Component {
 	};
 
 	isValidItem = ( item ) => {
-		const { isGoogleMyBusinessLocationConnected, isStore, isWordAds, siteId } = this.props;
+		const {
+			isGoogleMyBusinessLocationConnected,
+			isStore,
+			isWordAds,
+			isSubscriptionsModuleActive,
+			siteId,
+		} = this.props;
 
 		switch ( item ) {
 			case 'wordads':
@@ -157,6 +166,8 @@ class StatsNavigation extends Component {
 				if ( 'undefined' === typeof siteId ) {
 					return false;
 				}
+
+				return isSubscriptionsModuleActive;
 
 			default:
 				return true;
@@ -179,6 +190,7 @@ class StatsNavigation extends Component {
 			hideModuleSettings,
 			delayTooltipPresentation,
 			gatedTrafficPage,
+			siteId,
 		} = this.props;
 		const { pageModules, isPageSettingsTooltipDismissed, availableModuleToggles } = this.state;
 		const { label, showIntervals, path } = navItems[ selectedItem ];
@@ -205,6 +217,7 @@ class StatsNavigation extends Component {
 
 		return (
 			<div className={ wrapperClass }>
+				{ siteId && <QueryJetpackModules siteId={ siteId } /> }
 				<SectionNav selectedText={ label }>
 					<NavTabs selectedText={ label }>
 						{ Object.keys( navItems )
@@ -306,6 +319,7 @@ export default connect(
 			gatedTrafficPage:
 				config.isEnabled( 'stats/paid-wpcom-v3' ) &&
 				shouldGateStats( state, siteId, STATS_FEATURE_PAGE_TRAFFIC ),
+			isSubscriptionsModuleActive: isJetpackModuleActive( state, siteId, 'subscriptions' ),
 		};
 	},
 	{ requestModuleToggles, updateModuleToggles }

--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -4,6 +4,8 @@ import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
+import { isSimpleSite } from 'calypso/state/sites/selectors';
 import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { getPostStat } from 'calypso/state/stats/posts/selectors';
 import StatsDetailsNavigation from '../stats-details-navigation';
@@ -80,8 +82,16 @@ export default function PostDetailHighlightsSection( {
 		getEnvStatsFeatureSupportChecks( state, siteId )
 	);
 
+	const isSubscriptionsModuleActive =
+		useSelector( ( state ) => isJetpackModuleActive( state, siteId, 'subscriptions' ) ) ?? false;
+
+	const isSimple = useSelector( ( state ) => isSimpleSite( state, siteId ) );
+
+	const subscriptionsEnabled = isSimple || isSubscriptionsModuleActive;
+
 	// postId > 0: Show the tabs for posts except for the Home Page (postId = 0).
 	const isEmailTabsAvailable =
+		subscriptionsEnabled &&
 		postId > 0 &&
 		! post?.dont_email_post_to_subs &&
 		post?.date &&

--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -82,10 +82,10 @@ export default function PostDetailHighlightsSection( {
 		getEnvStatsFeatureSupportChecks( state, siteId )
 	);
 
+	const isSimple = useSelector( isSimpleSite );
+
 	const isSubscriptionsModuleActive =
 		useSelector( ( state ) => isJetpackModuleActive( state, siteId, 'subscriptions' ) ) ?? false;
-
-	const isSimple = useSelector( ( state ) => isSimpleSite( state, siteId ) );
 
 	const subscriptionsEnabled = isSimple || isSubscriptionsModuleActive;
 

--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -1,5 +1,6 @@
 import { Card, Count, PostStatsCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import { useSelector } from 'calypso/state';
@@ -101,6 +102,7 @@ export default function PostDetailHighlightsSection( {
 
 	return (
 		<>
+			{ siteId && <QueryJetpackModules siteId={ siteId } /> }
 			{ isEmailTabsAvailable && (
 				<div className="stats-navigation stats-navigation--modernized">
 					<StatsDetailsNavigation postId={ postId } givenSiteId={ siteId } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack/issues/960

Related to hiding email tabs when post wasn't sent as email https://github.com/Automattic/wp-calypso/pull/97739

## Proposed Changes

* Hide "Subscriptions" and "Email click/open" tabs when Subscriptions module isn't enabled.

### Before
<img width="417" alt="Screenshot 2024-12-27 at 15 19 31" src="https://github.com/user-attachments/assets/d29a443d-5888-4390-b9f8-8a0dfddfbf23" />
<img width="482" alt="Screenshot 2024-12-27 at 15 19 25" src="https://github.com/user-attachments/assets/0bc92c08-282f-4d5f-bd66-fb16fc3919b7" />


### After
<img width="440" alt="Screenshot 2024-12-27 at 15 27 18" src="https://github.com/user-attachments/assets/207ef635-63e5-47bc-948f-319268e468cb" />
<img width="504" alt="Screenshot 2024-12-27 at 15 29 37" src="https://github.com/user-attachments/assets/0c56b2a1-2ffe-4981-aca4-3b3f4e1caaca" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Showing features which customer hasn't enabled contributes to perception of "bloat" in Jetpack. Similar to [hiding the block](https://github.com/Automattic/jetpack/pull/39802).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test Jetpack site with module enabled/disabled, simple site (where module is always enabled), Atomic site

* Open Stats
* See Subscribers tab
* See Email open/click tabs under individual post stats
* Go Jetpack -> Settings -> Newsletter for a Jetpack/Atomic site (not available for a simple site)
* Disable the main feature toggle
    <img width="469" alt="image" src="https://github.com/user-attachments/assets/aeb70375-4618-441f-bf99-9a808c195192" />
* See that the tabs are gone

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
