### PR TITLE
Domain management: Fix redirection issue when the feature is OFF

### DIFF
--- a/client/my-sites/email/paths.ts
+++ b/client/my-sites/email/paths.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { stringify } from 'qs';
 import { isUnderDomainManagementAll, domainManagementRoot } from 'calypso/my-sites/domains/paths';
 
@@ -149,7 +150,7 @@ export const getEmailManagementPath: EmailPathUtilityFunction = (
 	relativeTo,
 	urlParameters
 ) => {
-	if ( isUnderDomainManagementAll( relativeTo ) ) {
+	if ( isEnabled( 'calypso/all-domain-management' ) && isUnderDomainManagementAll( relativeTo ) ) {
 		return `${ domainsManagementPrefix }/${ siteName }/${ domainName }${ buildQueryString(
 			urlParameters
 		) }`;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/97800

## Proposed Changes

* Add an additional `calypso/all-domain-management` feature  check  when building the `View email` path

<img width="1160" alt="Screenshot 2024-12-27 at 12 22 56" src="https://github.com/user-attachments/assets/c8fd6fcf-7c54-43e4-9b93-20f81e430a86" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Domain management revamp regresssion

## Testing Instructions

* Do not enable the domain revamp feature flag
* Create a domain
* Attach it to a site
* Add a couple of Mailboxes (Titan)
* Now go to wordpress.com/domains/manage and click on the domain
* In the domain management screen, click on the "View Emails" button
* It will take you to the new Domain management screen instead of the old one

See video: https://github.com/Automattic/wp-calypso/issues/97800

The old screen also starts with `/domains/manage/all` and that's why we need to add an additional feature flag check.
<img width="606" alt="Screenshot 2024-12-27 at 12 16 56" src="https://github.com/user-attachments/assets/d7c9f5a4-13fb-4463-8313-3d400db2edf6" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
