### PR TITLE
Fix domain list not scrolling in revamped domain management view

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -233,6 +233,8 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 			}
 
 			.domains-overview__list.multi-sites-dashboard-layout-column,
+			.domains-overview__list.main .hosting-dashboard-layout-column__container,
+			.domains-overview__list.main .hosting-dashboard-layout-column__container > .main,
 			.domains-overview__list .multi-sites-dashboard-layout-column__container,
 			.domains-overview__details .multi-sites-dashboard-layout-column__container,
 			.multi-sites-dashboard-layout-column.domains-overview__list.main
@@ -243,7 +245,8 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 
 			.multi-sites-dashboard-layout-column.domains-overview__list.main
 				.multi-sites-dashboard-layout-column__container
-				.main {
+				.main,
+			.domains-overview__list.main .hosting-dashboard-layout-column__container > .main {
 				display: flex;
 				flex-direction: column;
 				padding-bottom: 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/97819

## Proposed Changes

* Fixing broken scrolling. Probably a side effect of a recent project that changed the classnames of the components.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix broken issue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to wordpress.com/domains/manage
- Browse around, check inner functionalities, make sure you see no issues in how the table looks and works
- Now enable the feature flag by entering window.sessionStorage.setItem('flags', 'calypso/all-domain-management') in the - browser console. Reload the page
- Now click on different domains. They should open in the new layout now.
- Make sure you can scroll the domain list in left sidebar. The hovering also works and the clicking works as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
