### PR TITLE
Stats: Convert site.jsx to a Function Component

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -342,6 +342,9 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		}
 	}, [ chartTab, period, activeTabState ] );
 
+	// TODO: Fix isOdysseyStats to include the environment running on WP-Admin of Simple sites.
+	const isRunningOnWPAdmin = useMemo( () => document.getElementById( 'wpadminbar' ), [] );
+
 	// Sort out end date for chart.
 	const chartEnd = getValidDateOrNullFromInput( context.query?.chartEnd, 'endDate' );
 
@@ -461,9 +464,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		'stats__flexible-grid-item--full--large',
 		'stats__flexible-grid-item--full--medium'
 	);
-
-	// TODO: Fix isOdysseyStats to include the environment running on WP-Admin of Simple sites.
-	const isRunningOnWPAdmin = document.getElementById( 'wpadminbar' );
 
 	return (
 		<div className="stats">

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import { eye } from '@automattic/components/src/icons';
 import { Icon, people, starEmpty, commentContent } from '@wordpress/icons';
 import clsx from 'clsx';
-import { translate } from 'i18n-calypso';
+import { localize, translate } from 'i18n-calypso';
 import { find } from 'lodash';
 import moment from 'moment';
 import { useState, useMemo, useEffect, useCallback } from 'react';
@@ -810,4 +810,4 @@ const StatsSite = ( props ) => {
 	);
 };
 
-export default StatsSite;
+export default localize( StatsSite );

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -3,11 +3,11 @@ import page from '@automattic/calypso-router';
 import { eye } from '@automattic/components/src/icons';
 import { Icon, people, starEmpty, commentContent } from '@wordpress/icons';
 import clsx from 'clsx';
-import { localize, translate } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { find } from 'lodash';
 import moment from 'moment';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useState, useMemo, useEffect, useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import titlecase from 'to-title-case';
 import illustration404 from 'calypso/assets/images/illustrations/illustration-404.svg';
 import JetpackBackupCredsBanner from 'calypso/blocks/jetpack-backup-creds-banner';
@@ -19,7 +19,7 @@ import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import QuerySiteKeyrings from 'calypso/components/data/query-site-keyrings';
-import { getShortcuts } from 'calypso/components/date-range/use-shortcuts';
+import { useShortcuts } from 'calypso/components/date-range/use-shortcuts';
 import EmptyContent from 'calypso/components/empty-content';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
@@ -46,7 +46,7 @@ import hasLoadedSiteFeatures from 'calypso/state/selectors/has-loaded-site-featu
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
-import { getJetpackStatsAdminVersion, isJetpackSite } from 'calypso/state/sites/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { getModuleToggles } from 'calypso/state/stats/module-toggles/selectors';
 import { getUpsellModalView } from 'calypso/state/stats/paid-stats-upsell/selectors';
@@ -135,49 +135,101 @@ Object.defineProperty( CHART_COMMENTS, 'label', {
 
 const getActiveTab = ( chartTab ) => find( CHARTS, { attr: chartTab } ) || CHARTS[ 0 ];
 
-class StatsSite extends Component {
-	static defaultProps = {
-		chartTab: 'views',
-	};
-
-	// getDerivedStateFromProps will set the state both on init and tab switch
-	state = {
-		activeTab: null,
-		activeLegend: null,
-		customChartQuantity: null,
-	};
-
-	static getDerivedStateFromProps( props, state ) {
-		// when switching from one tab to another or when initializing the component,
-		// reset the active legend charts to the defaults for that tab. The legends
-		// can be then toggled on and off by the user in `onLegendClick`.
-		const activeTab = getActiveTab( props.chartTab );
-		if ( activeTab !== state.activeTab ) {
-			return {
-				activeTab,
-				// TODO: remove this when we support hourly visitors.
-				activeLegend: props.period !== 'hour' ? activeTab.legendOptions || [] : [],
-			};
-		}
-		return null;
+// Return a default amount of days to subtracts from the present day depending on the period selected.
+// Used in case no starting date is present in the URL.
+const getDefaultDaysForPeriod = ( period ) => {
+	switch ( period ) {
+		case 'hour':
+			return 1;
+		case 'day':
+			return 7;
+		case 'week':
+			return 12 * 7; // ~last 3 months
+		case 'month':
+			return 6 * 30; // ~last 6 months
+		case 'year':
+			return 5 * 365; // ~last 5 years
+		default:
+			return 30;
 	}
+};
 
-	getAvailableLegend() {
-		const { period } = this.props.period;
-		const activeTab = getActiveTab( this.props.chartTab );
+function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...props } ) {
+	const dispatch = useDispatch();
+
+	const [ activeTabState, setActiveTabState ] = useState( null );
+	const [ activeLegend, setActiveLegend ] = useState( null );
+	const { period } = props.period;
+
+	const queryDate = date.format( DATE_FORMAT );
+	const moduleStrings = statsStrings();
+
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	const isWPAdmin = config.isEnabled( 'is_odyssey' );
+
+	const slug = useSelector( getSelectedSiteSlug );
+	const upsellModalView = useSelector(
+		( state ) => config.isEnabled( 'stats/paid-wpcom-v2' ) && getUpsellModalView( state, siteId )
+	);
+
+	const {
+		supportsPlanUsage,
+		supportsUTMStats: supportsUTMStatsFeature,
+		supportsDevicesStats: supportsDevicesStatsFeature,
+		isOldJetpack,
+		supportUserFeedback,
+	} = useSelector( ( state ) => getEnvStatsFeatureSupportChecks( state, siteId ) );
+
+	const hasSiteLoadedFeatures = useSelector(
+		( state ) => isWPAdmin && hasLoadedSiteFeatures( state, siteId )
+	);
+
+	const shouldForceDefaultDateRange = useSelector( ( state ) =>
+		shouldGateStats( state, siteId, STATS_FEATURE_DATE_CONTROL_LAST_30_DAYS )
+	);
+
+	const shouldForceDefaultPeriod = useSelector( ( state ) =>
+		shouldGateStats( state, siteId, STATS_FEATURE_INTERVAL_DROPDOWN_WEEK )
+	);
+
+	const wpcomShowUpsell = useSelector(
+		( state ) =>
+			config.isEnabled( 'stats/paid-wpcom-v3' ) &&
+			shouldGateStats( state, siteId, STATS_FEATURE_PAGE_TRAFFIC )
+	);
+
+	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
+	const isSitePrivate = useSelector( ( state ) => isPrivateSite( state, siteId ) );
+
+	const moduleToggles = useSelector( ( state ) => getModuleToggles( state, siteId, 'traffic' ) );
+	const momentSiteZone = useSelector( ( state ) => getMomentSiteZone( state, siteId ) );
+
+	const { supportedShortcutList } = useShortcuts();
+
+	const shouldShowUpsells = isOdysseyStats && ! isAtomic;
+	const supportsUTMStats = supportsUTMStatsFeature || isInternal;
+	const supportsDevicesStats = supportsDevicesStatsFeature || isInternal;
+
+	// Set up a custom range for the chart.
+	// Dependant on new date range picker controls.
+	let customChartRange = null;
+
+	const getAvailableLegend = () => {
+		const activeTab = getActiveTab( chartTab );
 		// TODO: remove this when we support hourly visitors.
 		return period !== 'hour' ? activeTab.legendOptions || [] : [];
-	}
+	};
 
-	navigationFromChartBar = ( periodStartDate, period ) => {
+	const navigationFromChartBar = ( periodStartDate, currentPeriod ) => {
 		let chartStart = periodStartDate;
 		let chartEnd = moment( chartStart )
-			.endOf( period === 'week' ? 'isoWeek' : period )
+			.endOf( currentPeriod === 'week' ? 'isoWeek' : currentPeriod )
 			.format( DATE_FORMAT );
 
 		// Limit navigation within the currently selected range.
-		const currentChartStart = this.props.context.query?.chartStart;
-		const currentChartEnd = this.props.context.query?.chartEnd;
+		const currentChartStart = context.query?.chartStart;
+		const currentChartEnd = context.query?.chartEnd;
 		if ( currentChartStart && moment( chartStart ).isBefore( currentChartStart ) ) {
 			chartStart = currentChartStart;
 		}
@@ -187,22 +239,22 @@ class StatsSite extends Component {
 
 		// Determine the target period for the navigation.
 		let targetPeriod = 'day';
-		if ( period === 'day' ) {
+		if ( currentPeriod === 'day' ) {
 			targetPeriod = 'hour';
-		} else if ( period === 'year' ) {
+		} else if ( currentPeriod === 'year' ) {
 			targetPeriod = 'month';
 		}
 
-		const path = `/stats/${ targetPeriod }/${ this.props.slug }`;
+		const path = `/stats/${ targetPeriod }/${ slug }`;
 		const url = getPathWithUpdatedQueryString( { chartStart, chartEnd }, path );
 
 		return url;
 	};
 
-	barClick = ( shouldForceDefaultDateRange, bar ) => {
-		this.props.recordGoogleEvent( 'Stats', 'Clicked Chart Bar' );
+	const barClick = ( bar ) => {
+		dispatch( recordGoogleEvent( 'Stats', 'Clicked Chart Bar' ) );
 
-		const { period: barPeriod } = this.props.period;
+		const { period: barPeriod } = props.period;
 		// Stop navigation if the bar period is hour.
 		// Stop navigation if date control is locked to prevent navigation to hourly stats.
 		// TODO: Determine if we should allow navigation to hourly stats when STATS_FEATURE_DATE_CONTROL_LAST_30_DAYS is locked.
@@ -211,36 +263,36 @@ class StatsSite extends Component {
 		}
 
 		// Navigate from the chart bar with period and period start date.
-		page( this.navigationFromChartBar( bar.data.period, barPeriod ) );
+		page( navigationFromChartBar( bar.data.period, barPeriod ) );
 	};
 
-	onChangeLegend = ( activeLegend ) => this.setState( { activeLegend } );
+	const onChangeLegend = useCallback(
+		( newLegend ) => setActiveLegend( newLegend ),
+		[ setActiveLegend ]
+	);
 
-	switchChart = ( tab ) => {
-		if ( ! tab.loading && tab.attr !== this.props.chartTab ) {
-			this.props.recordGoogleEvent( 'Stats', 'Clicked ' + titlecase( tab.attr ) + ' Tab' );
-			// switch the tab by navigating to route with updated query string
-			page.show( getPathWithUpdatedQueryString( { tab: tab.attr } ) );
-		}
-	};
+	const switchChart = useCallback(
+		( tab ) => {
+			if ( ! tab.loading && tab.attr !== chartTab ) {
+				dispatch( recordGoogleEvent( 'Stats', 'Clicked ' + titlecase( tab.attr ) + ' Tab' ) );
+				// switch the tab by navigating to route with updated query string
+				page.show( getPathWithUpdatedQueryString( { tab: tab.attr } ) );
+			}
+		},
+		[ chartTab, dispatch ]
+	);
 
-	isModuleHidden( moduleName ) {
+	const isModuleHidden = ( moduleName ) => {
 		// Determine which modules are hidden.
 		// @TODO: Rearrange the layout of modules to be more flexible with hidden blocks.
-		if (
-			HIDDABLE_MODULES.includes( moduleName ) &&
-			this.props.moduleToggles[ moduleName ] === false
-		) {
+		if ( HIDDABLE_MODULES.includes( moduleName ) && moduleToggles[ moduleName ] === false ) {
 			return true;
 		}
-	}
+	};
 
-	getValidDateOrNullFromInput( inputDate, inputKey ) {
+	const getValidDateOrNullFromInput = ( inputDate, inputKey ) => {
 		// Use the stored chartStart and chartEnd if they are valid when the inputDate is absent.
 		if ( inputDate === undefined ) {
-			const { hasSiteLoadedFeatures, shouldForceDefaultDateRange, supportedShortcutList } =
-				this.props;
-
 			const appliedShortcutId = localStorage.getItem(
 				'jetpack_stats_stored_date_range_shortcut_id'
 			);
@@ -261,613 +313,501 @@ class StatsSite extends Component {
 		const isValid = moment( inputDate ).isValid();
 
 		return isValid ? inputDate : null;
-	}
-
-	// Return a default amount of days to subtracts from the present day depending on the period selected.
-	// Used in case no starting date is present in the URL.
-	getDefaultDaysForPeriod( period ) {
-		switch ( period ) {
-			case 'hour':
-				return 1;
-			case 'day':
-				return 7;
-			case 'week':
-				return 12 * 7; // ~last 3 months
-			case 'month':
-				return 6 * 30; // ~last 6 months
-			case 'year':
-				return 5 * 365; // ~last 5 years
-			default:
-				return 30;
-		}
-	}
+	};
 
 	// Note: This is only used in the empty version of the module.
 	// There's a similar function inside stats-module/index.jsx that is used when we have content.
-	getStatHref( path, query ) {
-		const { period, slug } = this.props;
-		const paramsValid = period && path && slug;
+	const getStatHref = ( path, query ) => {
+		const paramsValid = props.period && path && slug;
 		if ( ! paramsValid ) {
 			return undefined;
 		}
 
-		let url = `/stats/${ period.period }/${ path }/${ slug }`;
+		let url = `/stats/${ props.period.period }/${ path }/${ slug }`;
 
 		if ( query?.start_date ) {
 			url += `?startDate=${ query.start_date }&endDate=${ query.date }`;
 		} else {
-			url += `?startDate=${ period.endOf.format( DATE_FORMAT ) }`;
+			url += `?startDate=${ props.period.endOf.format( DATE_FORMAT ) }`;
 		}
 
 		return url;
-	}
-
-	renderStats( isInternal ) {
-		const {
-			date,
-			siteId,
-			slug,
-			isAtomic,
-			isJetpack,
-			isSitePrivate,
-			isOdysseyStats,
-			context,
-			supportsPlanUsage,
-			supportsUTMStatsFeature,
-			supportsDevicesStatsFeature,
-			isOldJetpack,
-			hasSiteLoadedFeatures,
-			shouldForceDefaultDateRange,
-			shouldForceDefaultPeriod,
-			supportUserFeedback,
-			momentSiteZone,
-			wpcomShowUpsell,
-		} = this.props;
-		const shouldShowUpsells = isOdysseyStats && ! isAtomic;
-		const supportsUTMStats = supportsUTMStatsFeature || isInternal;
-		const supportsDevicesStats = supportsDevicesStatsFeature || isInternal;
-
-		const queryDate = date.format( DATE_FORMAT );
-		const { period } = this.props.period;
-		const moduleStrings = statsStrings();
-
-		// Set up a custom range for the chart.
-		// Dependant on new date range picker controls.
-		let customChartRange = null;
-
-		// Sort out end date for chart.
-		const chartEnd = this.getValidDateOrNullFromInput( context.query?.chartEnd, 'endDate' );
-
-		if ( chartEnd ) {
-			customChartRange = { chartEnd };
-		} else {
-			customChartRange = {
-				chartEnd: momentSiteZone.format( DATE_FORMAT ),
-			};
-		}
-
-		// Find the quantity of bars for the chart.
-		let daysInRange = this.getDefaultDaysForPeriod( period );
-		const chartStart = this.getValidDateOrNullFromInput( context.query?.chartStart, 'startDate' );
-		const isSameOrBefore = moment( chartStart ).isSameOrBefore( moment( chartEnd ) );
-
-		if ( chartStart && isSameOrBefore ) {
-			// Add one to calculation to include the start date.
-			daysInRange = moment( chartEnd ).diff( moment( chartStart ), 'days' ) + 1;
-			customChartRange.chartStart = chartStart;
-		} else {
-			// if start date is missing let the frequency of data take over to avoid showing one bar
-			// (e.g. months defaulting to 30 days and showing one point)
-			customChartRange.chartStart = momentSiteZone
-				.clone()
-				.subtract( daysInRange - 1, 'days' )
-				.format( DATE_FORMAT );
-		}
-
-		customChartRange.daysInRange = daysInRange;
-
-		// Redirect to the daily views if the period dropdown is locked.
-		if ( shouldForceDefaultPeriod && period !== 'day' ) {
-			page.redirect( appendQueryStringForRedirection( `/stats/day/${ slug }`, context.query ) );
-			return;
-		}
-
-		// TODO: all the date logic should be done in controllers, otherwise it affects the performance.
-		// If it's single day period, redirect to hourly stats.
-		if ( ! shouldForceDefaultPeriod && period === 'day' && daysInRange === 1 ) {
-			page.redirect( appendQueryStringForRedirection( `/stats/hour/${ slug }`, context.query ) );
-			return;
-		}
-
-		// Use the stored period if it's different from the current period.
-		const storedPeriod = localStorage.getItem( 'jetpack_stats_stored_period' );
-		if (
-			hasSiteLoadedFeatures &&
-			! shouldForceDefaultPeriod &&
-			// Avoid the infinite redirect loop between single day period and hourly views.
-			period !== 'hour' &&
-			storedPeriod &&
-			storedPeriod !== period
-		) {
-			page.redirect(
-				appendQueryStringForRedirection( `/stats/${ storedPeriod }/${ slug }`, context.query )
-			);
-			return;
-		}
-
-		// Calculate diff between requested start and end in `priod` units.
-		// Move end point (most recent) to the end of period to account for partial periods
-		// (e.g. requesting period between June 2020 and Feb 2021 would require 2 `yearly` units but would return 1 unit without the shift to the end of period)
-		// TODO: We need to align the start day of week from the backend.
-		let momentPeriod = period;
-		if ( momentPeriod === 'week' ) {
-			momentPeriod = 'isoWeek';
-		} else if ( momentPeriod === 'hour' ) {
-			momentPeriod = 'day';
-		}
-		const adjustedChartStartDate = moment( customChartRange.chartStart ).startOf( momentPeriod );
-		const adjustedChartEndDate = moment( customChartRange.chartEnd ).endOf( momentPeriod );
-
-		let customChartQuantity = Math.ceil(
-			adjustedChartEndDate.diff( adjustedChartStartDate, period, true )
-		);
-
-		// Force the default date range to be 7 days if the 30-day option is locked.
-		if ( shouldForceDefaultDateRange && period !== 'hour' ) {
-			// For ChartTabs
-			customChartQuantity = 7;
-
-			// For StatsDateControl
-			customChartRange.daysInRange = 7;
-			customChartRange.chartEnd = momentSiteZone.format( DATE_FORMAT );
-			customChartRange.chartStart = moment( customChartRange.chartEnd )
-				.subtract( customChartRange.daysInRange - 1, 'days' )
-				.format( DATE_FORMAT );
-		}
-
-		const query = chartRangeToQuery( customChartRange );
-
-		// For period option links
-		const traffic = {
-			label: translate( 'Traffic' ),
-			path: '/stats',
-		};
-		const slugPath = slug ? `/${ slug }` : '';
-		const pathTemplate = `${ traffic.path }/{{ interval }}${ slugPath }?tab=${
-			this.state.activeTab ? this.state.activeTab.attr : 'views'
-		}`;
-
-		const wrapperClass = clsx( 'stats-content', {
-			'is-period-year': period === 'year',
-		} );
-
-		const moduleListClasses = clsx(
-			'is-events',
-			'stats__module-list',
-			'stats__module-list--traffic',
-			'stats__module--unified',
-			'stats__flexible-grid-container'
-		);
-
-		const halfWidthModuleClasses = clsx(
-			'stats__flexible-grid-item--half',
-			'stats__flexible-grid-item--full--large',
-			'stats__flexible-grid-item--full--medium'
-		);
-
-		// TODO: Fix isOdysseyStats to include the environment running on WP-Admin of Simple sites.
-		const isRunningOnWPAdmin = document.getElementById( 'wpadminbar' );
-
-		return (
-			<div className="stats">
-				{ ! isOdysseyStats && (
-					<div className="stats-banner-wrapper">
-						<JetpackBackupCredsBanner event="stats-backup-credentials" />
-					</div>
-				) }
-				<NavigationHeader
-					className="stats__section-header modernized-header"
-					title={ translate( 'Jetpack Stats' ) }
-					subtitle={ translate(
-						"Gain insights into the activity and behavior of your site's visitors. {{learnMoreLink}}Learn more{{/learnMoreLink}}",
-						{
-							components: {
-								learnMoreLink: <InlineSupportLink supportContext="stats" showIcon={ false } />,
-							},
-						}
-					) }
-					screenReader={ navItems.traffic?.label }
-					navigationItems={ [] }
-				></NavigationHeader>
-				<StatsNavigation
-					selectedItem="traffic"
-					interval={ period }
-					siteId={ siteId }
-					slug={ slug }
-				/>
-				<StatsNotices
-					siteId={ siteId }
-					isOdysseyStats={ isOdysseyStats }
-					statsPurchaseSuccess={ context.query.statsPurchaseSuccess }
-				/>
-				<StickyPanel headerId={ isRunningOnWPAdmin ? 'wpadminbar' : 'header' }>
-					<StatsPeriodHeader>
-						<StatsPeriodNavigation
-							date={ date }
-							period={ period }
-							url={ `/stats/${ period }/${ slug }` }
-							queryParams={ context.query }
-							pathTemplate={ pathTemplate }
-							charts={ CHARTS }
-							availableLegend={ this.getAvailableLegend() }
-							activeTab={ getActiveTab( this.props.chartTab ) }
-							activeLegend={ this.state.activeLegend }
-							onChangeLegend={ this.onChangeLegend }
-							isWithNewDateControl
-							showArrows={ ! wpcomShowUpsell }
-							slug={ slug }
-							dateRange={ customChartRange }
-						>
-							{ ' ' }
-							<DatePicker
-								period={ period }
-								date={ date }
-								query={ query }
-								statsType="statsTopPosts"
-								showQueryDate
-								isShort
-								dateRange={ customChartRange }
-							/>
-						</StatsPeriodNavigation>
-					</StatsPeriodHeader>
-				</StickyPanel>
-				<div id="my-stats-content" className={ wrapperClass }>
-					<ChartTabs
-						slug={ slug }
-						period={ this.props.period }
-						queryParams={ context.query }
-						activeTab={ getActiveTab( this.props.chartTab ) }
-						activeLegend={ this.state.activeLegend }
-						availableLegend={ this.getAvailableLegend() }
-						onChangeLegend={ this.onChangeLegend }
-						barClick={ this.barClick.bind( this, shouldForceDefaultDateRange ) }
-						className="is-date-filtering-enabled"
-						switchTab={ this.switchChart }
-						charts={ CHARTS }
-						queryDate={ queryDate }
-						chartTab={ this.props.chartTab }
-						customQuantity={ customChartQuantity }
-						customRange={ customChartRange }
-					/>
-
-					{ ! wpcomShowUpsell && (
-						<>
-							{ ! isOdysseyStats && <MiniCarousel slug={ slug } isSitePrivate={ isSitePrivate } /> }
-
-							<div className={ moduleListClasses }>
-								<StatsModuleTopPosts
-									moduleStrings={ moduleStrings.posts }
-									period={ this.props.period }
-									query={ query }
-									summaryUrl={ this.getStatHref( 'posts', query ) }
-									className={ halfWidthModuleClasses }
-								/>
-								<StatsModuleReferrers
-									moduleStrings={ moduleStrings.referrers }
-									period={ this.props.period }
-									query={ query }
-									summaryUrl={ this.getStatHref( 'referrers', query ) }
-									className={ halfWidthModuleClasses }
-								/>
-
-								<StatsModuleCountries
-									moduleStrings={ moduleStrings.countries }
-									period={ this.props.period }
-									query={ query }
-									summaryUrl={ this.getStatHref( 'countryviews', query ) }
-									className={ clsx( 'stats__flexible-grid-item--full' ) }
-								/>
-
-								{ /* If UTM if supported display the module or update Jetpack plugin card */ }
-								{ supportsUTMStats && ! isOldJetpack && (
-									<StatsModuleUTM
-										siteId={ siteId }
-										period={ this.props.period }
-										query={ query }
-										summaryUrl={ this.getStatHref( 'utm', query ) }
-										summary={ false }
-										className={ halfWidthModuleClasses }
-									/>
-								) }
-
-								{ supportsUTMStats && isOldJetpack && (
-									<StatsModuleUTMOverlay
-										siteId={ siteId }
-										className={ halfWidthModuleClasses }
-										overlay={
-											<StatsCardUpdateJetpackVersion
-												className="stats-module__upsell stats-module__upgrade"
-												siteId={ siteId }
-												statType="utm"
-											/>
-										}
-									/>
-								) }
-
-								<StatsModuleClicks
-									moduleStrings={ moduleStrings.clicks }
-									period={ this.props.period }
-									query={ query }
-									summaryUrl={ this.getStatHref( 'clicks', query ) }
-									className={ halfWidthModuleClasses }
-								/>
-
-								{ ! this.isModuleHidden( 'authors' ) && (
-									<StatsModuleAuthors
-										moduleStrings={ moduleStrings.authors }
-										period={ this.props.period }
-										query={ query }
-										summaryUrl={ this.getStatHref( 'authors', query ) }
-										className={ halfWidthModuleClasses }
-									/>
-								) }
-
-								<StatsModuleSearch
-									moduleStrings={ moduleStrings.search }
-									period={ this.props.period }
-									query={ query }
-									summaryUrl={ this.getStatHref( 'searchterms', query ) }
-									className={ halfWidthModuleClasses }
-								/>
-
-								{ ! this.isModuleHidden( 'videos' ) && (
-									<StatsModuleVideos
-										moduleStrings={ moduleStrings.videoplays }
-										period={ this.props.period }
-										query={ query }
-										summaryUrl={ this.getStatHref( 'videoplays', query ) }
-										className={ halfWidthModuleClasses }
-									/>
-								) }
-
-								{
-									// File downloads are not yet supported in Jetpack environment
-									! isJetpack && (
-										<StatsModuleDownloads
-											moduleStrings={ moduleStrings.filedownloads }
-											period={ this.props.period }
-											query={ query }
-											summaryUrl={ this.getStatHref( 'filedownloads', query ) }
-											className={ halfWidthModuleClasses }
-										/>
-									)
-								}
-
-								{ supportsDevicesStats && ! isOldJetpack && (
-									<StatsModuleDevices
-										siteId={ siteId }
-										period={ this.props.period }
-										query={ query }
-										className={ halfWidthModuleClasses }
-									/>
-								) }
-
-								{ supportsDevicesStats && isOldJetpack && (
-									<StatsModuleUpgradeDevicesOverlay
-										className={ halfWidthModuleClasses }
-										siteId={ siteId }
-										overlay={
-											<StatsCardUpdateJetpackVersion
-												className="stats-module__upsell stats-module__upgrade"
-												siteId={ siteId }
-												statType="devices"
-											/>
-										}
-									/>
-								) }
-							</div>
-						</>
-					) }
-
-					{ wpcomShowUpsell && <StatsUpsell siteId={ siteId } /> }
-				</div>
-				{ supportsPlanUsage && (
-					<StatsPlanUsage siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
-				) }
-				{ ! shouldShowUpsells ? null : (
-					<AsyncLoad require="calypso/my-sites/stats/jetpack-upsell-section" />
-				) }
-				{ ! config.isEnabled( 'stats/paid-wpcom-v3' ) && (
-					<PromoCards isOdysseyStats={ isOdysseyStats } pageSlug="traffic" slug={ slug } />
-				) }
-				{ supportUserFeedback && <StatsFeedbackPresentor siteId={ siteId } /> }
-				<JetpackColophon />
-				<AsyncLoad require="calypso/lib/analytics/track-resurrections" placeholder={ null } />
-				{ this.props.upsellModalView && <StatsUpsellModal siteId={ siteId } /> }
-			</div>
-		);
-	}
-
-	enableStatsModule = () => {
-		const { siteId, path } = this.props;
-		this.props.enableJetpackStatsModule( siteId, path );
 	};
 
-	renderEnableStatsModule() {
-		return (
-			<EmptyContent
-				illustration={ illustration404 }
-				title={ translate( 'Looking for stats?' ) }
-				line={
-					<p>
-						{ translate(
-							'Enable Jetpack Stats to see detailed information about your traffic, likes, comments, and subscribers.'
-						) }
-					</p>
-				}
-				action={ translate( 'Enable Jetpack Stats' ) }
-				actionCallback={ this.enableStatsModule }
-			/>
-		);
-	}
-
-	renderInsufficientPermissionsPage() {
-		return (
-			<EmptyContent
-				illustration={ illustration404 }
-				title={ translate( 'Looking for stats?' ) }
-				line={
-					<p>
-						<div>
-							{ translate( "We're sorry, but you do not have permission to access this page." ) }
-						</div>
-						<div>{ translate( "Please contact your site's administrator for access." ) }</div>
-					</p>
-				}
-			/>
-		);
-	}
-
-	renderBody( isInternal ) {
-		if ( ! this.props.canUserViewStats ) {
-			return this.renderInsufficientPermissionsPage();
-		} else if ( this.props.showEnableStatsModule ) {
-			return this.renderEnableStatsModule();
+	useMemo( () => {
+		const activeTab = getActiveTab( chartTab );
+		if ( activeTab !== activeTabState ) {
+			setActiveTabState( activeTab );
+			setActiveLegend( period !== 'hour' ? activeTab.legendOptions || [] : [] );
 		}
+	}, [ chartTab, period, activeTabState ] );
 
-		return this.renderStats( isInternal );
+	// Sort out end date for chart.
+	const chartEnd = getValidDateOrNullFromInput( context.query?.chartEnd, 'endDate' );
+
+	if ( chartEnd ) {
+		customChartRange = { chartEnd };
+	} else {
+		customChartRange = {
+			chartEnd: momentSiteZone.format( DATE_FORMAT ),
+		};
 	}
 
-	render() {
-		const { isJetpack, siteId, isOdysseyStats } = this.props;
-		const { period } = this.props.period;
+	// Find the quantity of bars for the chart.
+	let daysInRange = getDefaultDaysForPeriod( period );
+	const chartStart = getValidDateOrNullFromInput( context.query?.chartStart, 'startDate' );
+	const isSameOrBefore = moment( chartStart ).isSameOrBefore( moment( chartEnd ) );
 
-		// Track the last viewed tab.
-		// Necessary to properly configure the fixed navigation headers.
-		sessionStorage.setItem( 'jp-stats-last-tab', 'traffic' );
+	if ( chartStart && isSameOrBefore ) {
+		// Add one to calculation to include the start date.
+		daysInRange = moment( chartEnd ).diff( moment( chartStart ), 'days' ) + 1;
+		customChartRange.chartStart = chartStart;
+	} else {
+		// if start date is missing let the frequency of data take over to avoid showing one bar
+		// (e.g. months defaulting to 30 days and showing one point)
+		customChartRange.chartStart = momentSiteZone
+			.clone()
+			.subtract( daysInRange - 1, 'days' )
+			.format( DATE_FORMAT );
+	}
 
-		return (
-			<Main fullWidthLayout ariaLabel={ translate( 'Jetpack Stats' ) }>
-				{ config.isEnabled( 'stats/paid-wpcom-v2' ) && ! isOdysseyStats && (
-					<QuerySiteFeatures siteIds={ [ siteId ] } />
-				) }
-				{ /* Odyssey: Google Business Profile pages are currently unsupported. */ }
-				{ ! isOdysseyStats && (
-					<>
-						<QueryKeyringConnections />
-						<QuerySiteKeyrings siteId={ siteId } />
-					</>
-				) }
-				{ /* Odyssey: if Stats module is not enabled, the page will not be rendered. */ }
-				{ ! isOdysseyStats && isJetpack && <QueryJetpackModules siteId={ siteId } /> }
-				<DocumentHead title={ translate( 'Jetpack Stats' ) } />
-				<PageViewTracker
-					path={ `/stats/${ period }/:site` }
-					title={ `Stats > ${ titlecase( period ) }` }
-				/>
-				<StatsGlobalValuesContext.Consumer>
-					{ ( isInternal ) => this.renderBody( isInternal ) }
-				</StatsGlobalValuesContext.Consumer>
-			</Main>
+	customChartRange.daysInRange = daysInRange;
+
+	// Redirect to the daily views if the period dropdown is locked.
+	if ( shouldForceDefaultPeriod && period !== 'day' ) {
+		page.redirect( appendQueryStringForRedirection( `/stats/day/${ slug }`, context.query ) );
+		return;
+	}
+
+	// TODO: all the date logic should be done in controllers, otherwise it affects the performance.
+	// If it's single day period, redirect to hourly stats.
+	if ( ! shouldForceDefaultPeriod && period === 'day' && daysInRange === 1 ) {
+		page.redirect( appendQueryStringForRedirection( `/stats/hour/${ slug }`, context.query ) );
+		return;
+	}
+
+	// Use the stored period if it's different from the current period.
+	const storedPeriod = localStorage.getItem( 'jetpack_stats_stored_period' );
+	if (
+		hasSiteLoadedFeatures &&
+		! shouldForceDefaultPeriod &&
+		// Avoid the infinite redirect loop between single day period and hourly views.
+		period !== 'hour' &&
+		storedPeriod &&
+		storedPeriod !== period
+	) {
+		page.redirect(
+			appendQueryStringForRedirection( `/stats/${ storedPeriod }/${ slug }`, context.query )
 		);
+		return;
 	}
-}
 
-const enableJetpackStatsModule = ( siteId, path ) =>
-	withAnalytics(
-		recordTracksEvent( 'calypso_jetpack_module_toggle', {
-			module: 'stats',
-			path,
-			toggled: 'on',
-		} ),
-		activateModule( siteId, 'stats' )
+	// Calculate diff between requested start and end in `priod` units.
+	// Move end point (most recent) to the end of period to account for partial periods
+	// (e.g. requesting period between June 2020 and Feb 2021 would require 2 `yearly` units but would return 1 unit without the shift to the end of period)
+	// TODO: We need to align the start day of week from the backend.
+	let momentPeriod = period;
+	if ( momentPeriod === 'week' ) {
+		momentPeriod = 'isoWeek';
+	} else if ( momentPeriod === 'hour' ) {
+		momentPeriod = 'day';
+	}
+	const adjustedChartStartDate = moment( customChartRange.chartStart ).startOf( momentPeriod );
+	const adjustedChartEndDate = moment( customChartRange.chartEnd ).endOf( momentPeriod );
+
+	let customChartQuantity = Math.ceil(
+		adjustedChartEndDate.diff( adjustedChartStartDate, period, true )
 	);
 
-export default connect(
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
-		const canUserManageOptions = canCurrentUser( state, siteId, 'manage_options' );
-		const isJetpack = isJetpackSite( state, siteId );
-		const statsAdminVersion = getJetpackStatsAdminVersion( state, siteId );
-		const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-		const isWPAdmin = config.isEnabled( 'is_odyssey' );
+	// Force the default date range to be 7 days if the 30-day option is locked.
+	if ( shouldForceDefaultDateRange && period !== 'hour' ) {
+		// For ChartTabs
+		customChartQuantity = 7;
 
-		// Odyssey Stats: This UX is not possible in Odyssey as this page would not be able to render in the first place.
-		const showEnableStatsModule =
-			! isOdysseyStats &&
-			siteId &&
-			isJetpack &&
-			isJetpackModuleActive( state, siteId, 'stats' ) === false &&
-			canUserManageOptions;
-
-		// Odyssey Stats: Access control is done in PHP, so skip capability check here.
-		// TODO: Fix incorrect view_stats permission on Calypso.
-		//       If the user's role is missing from the site's stats dashboard access allowlist (fetched via getJetpackSettings.role),
-		//       then it should be reflected in the user's view_stats capability.
-		const canUserViewStats =
-			isOdysseyStats || canUserManageOptions || canCurrentUser( state, siteId, 'view_stats' );
-
-		const slug = getSelectedSiteSlug( state );
-		const upsellModalView =
-			config.isEnabled( 'stats/paid-wpcom-v2' ) && getUpsellModalView( state, siteId );
-
-		const {
-			supportsPlanUsage,
-			supportsUTMStats,
-			supportsDevicesStats,
-			isOldJetpack,
-			supportUserFeedback,
-		} = getEnvStatsFeatureSupportChecks( state, siteId );
-
-		// Odyssey Stats does not need loading features to determine gated features.
-		const hasSiteLoadedFeatures = isWPAdmin || hasLoadedSiteFeatures( state, siteId );
-		// Determine if the default date range should be forced to 7 days.
-		const shouldForceDefaultDateRange = shouldGateStats(
-			state,
-			siteId,
-			STATS_FEATURE_DATE_CONTROL_LAST_30_DAYS
-		);
-		const shouldForceDefaultPeriod = shouldGateStats(
-			state,
-			siteId,
-			STATS_FEATURE_INTERVAL_DROPDOWN_WEEK
-		);
-
-		const wpcomShowUpsell =
-			config.isEnabled( 'stats/paid-wpcom-v3' ) &&
-			shouldGateStats( state, siteId, STATS_FEATURE_PAGE_TRAFFIC );
-
-		const { supportedShortcutList } = getShortcuts( state, {}, undefined );
-
-		return {
-			canUserViewStats,
-			isAtomic: isAtomicSite( state, siteId ),
-			isJetpack,
-			isSitePrivate: isPrivateSite( state, siteId ),
-			siteId,
-			slug,
-			showEnableStatsModule,
-			path: getCurrentRouteParameterized( state, siteId ),
-			isOdysseyStats,
-			moduleToggles: getModuleToggles( state, siteId, 'traffic' ),
-			upsellModalView,
-			statsAdminVersion,
-			supportsPlanUsage,
-			supportsUTMStatsFeature: supportsUTMStats,
-			supportsDevicesStatsFeature: supportsDevicesStats,
-			supportUserFeedback,
-			isOldJetpack,
-			hasSiteLoadedFeatures,
-			shouldForceDefaultDateRange,
-			shouldForceDefaultPeriod,
-			momentSiteZone: getMomentSiteZone( state, siteId ),
-			wpcomShowUpsell,
-			supportedShortcutList,
-		};
-	},
-	{
-		recordGoogleEvent,
-		enableJetpackStatsModule,
-		recordTracksEvent,
+		// For StatsDateControl
+		customChartRange.daysInRange = 7;
+		customChartRange.chartEnd = momentSiteZone.format( DATE_FORMAT );
+		customChartRange.chartStart = moment( customChartRange.chartEnd )
+			.subtract( customChartRange.daysInRange - 1, 'days' )
+			.format( DATE_FORMAT );
 	}
-)( localize( StatsSite ) );
+
+	const query = chartRangeToQuery( customChartRange );
+
+	// For period option links
+	const traffic = {
+		label: translate( 'Traffic' ),
+		path: '/stats',
+	};
+	const slugPath = slug ? `/${ slug }` : '';
+	const pathTemplate = `${ traffic.path }/{{ interval }}${ slugPath }?tab=${
+		activeTabState ? activeTabState.attr : 'views'
+	}`;
+
+	const wrapperClass = clsx( 'stats-content', {
+		'is-period-year': period === 'year',
+	} );
+
+	const moduleListClasses = clsx(
+		'is-events',
+		'stats__module-list',
+		'stats__module-list--traffic',
+		'stats__module--unified',
+		'stats__flexible-grid-container'
+	);
+
+	const halfWidthModuleClasses = clsx(
+		'stats__flexible-grid-item--half',
+		'stats__flexible-grid-item--full--large',
+		'stats__flexible-grid-item--full--medium'
+	);
+
+	// TODO: Fix isOdysseyStats to include the environment running on WP-Admin of Simple sites.
+	const isRunningOnWPAdmin = document.getElementById( 'wpadminbar' );
+
+	return (
+		<div className="stats">
+			{ ! isOdysseyStats && (
+				<div className="stats-banner-wrapper">
+					<JetpackBackupCredsBanner event="stats-backup-credentials" />
+				</div>
+			) }
+			<NavigationHeader
+				className="stats__section-header modernized-header"
+				title={ translate( 'Jetpack Stats' ) }
+				subtitle={ translate(
+					"Gain insights into the activity and behavior of your site's visitors. {{learnMoreLink}}Learn more{{/learnMoreLink}}",
+					{
+						components: {
+							learnMoreLink: <InlineSupportLink supportContext="stats" showIcon={ false } />,
+						},
+					}
+				) }
+				screenReader={ navItems.traffic?.label }
+				navigationItems={ [] }
+			></NavigationHeader>
+			<StatsNavigation selectedItem="traffic" interval={ period } siteId={ siteId } slug={ slug } />
+			<StatsNotices
+				siteId={ siteId }
+				isOdysseyStats={ isOdysseyStats }
+				statsPurchaseSuccess={ context.query.statsPurchaseSuccess }
+			/>
+			<StickyPanel headerId={ isRunningOnWPAdmin ? 'wpadminbar' : 'header' }>
+				<StatsPeriodHeader>
+					<StatsPeriodNavigation
+						date={ date }
+						period={ period }
+						url={ `/stats/${ period }/${ slug }` }
+						queryParams={ context.query }
+						pathTemplate={ pathTemplate }
+						charts={ CHARTS }
+						availableLegend={ getAvailableLegend() }
+						activeTab={ getActiveTab( chartTab ) }
+						activeLegend={ activeLegend }
+						onChangeLegend={ onChangeLegend }
+						isWithNewDateControl
+						showArrows={ ! wpcomShowUpsell }
+						slug={ slug }
+						dateRange={ customChartRange }
+					>
+						{ ' ' }
+						<DatePicker
+							period={ period }
+							date={ date }
+							query={ query }
+							statsType="statsTopPosts"
+							showQueryDate
+							isShort
+							dateRange={ customChartRange }
+						/>
+					</StatsPeriodNavigation>
+				</StatsPeriodHeader>
+			</StickyPanel>
+			<div id="my-stats-content" className={ wrapperClass }>
+				<ChartTabs
+					slug={ slug }
+					period={ props.period }
+					queryParams={ context.query }
+					activeTab={ getActiveTab( chartTab ) }
+					activeLegend={ activeLegend }
+					availableLegend={ getAvailableLegend() }
+					onChangeLegend={ onChangeLegend }
+					// TODO: test default date range
+					barClick={ barClick }
+					className="is-date-filtering-enabled"
+					switchTab={ switchChart }
+					charts={ CHARTS }
+					queryDate={ queryDate }
+					chartTab={ chartTab }
+					customQuantity={ customChartQuantity }
+					customRange={ customChartRange }
+				/>
+
+				{ ! wpcomShowUpsell && (
+					<>
+						{ ! isOdysseyStats && <MiniCarousel slug={ slug } isSitePrivate={ isSitePrivate } /> }
+
+						<div className={ moduleListClasses }>
+							<StatsModuleTopPosts
+								moduleStrings={ moduleStrings.posts }
+								period={ props.period }
+								query={ query }
+								summaryUrl={ getStatHref( 'posts', query ) }
+								className={ halfWidthModuleClasses }
+							/>
+							<StatsModuleReferrers
+								moduleStrings={ moduleStrings.referrers }
+								period={ props.period }
+								query={ query }
+								summaryUrl={ getStatHref( 'referrers', query ) }
+								className={ halfWidthModuleClasses }
+							/>
+
+							<StatsModuleCountries
+								moduleStrings={ moduleStrings.countries }
+								period={ props.period }
+								query={ query }
+								summaryUrl={ getStatHref( 'countryviews', query ) }
+								className={ clsx( 'stats__flexible-grid-item--full' ) }
+							/>
+
+							{ /* If UTM if supported display the module or update Jetpack plugin card */ }
+							{ supportsUTMStats && ! isOldJetpack && (
+								<StatsModuleUTM
+									siteId={ siteId }
+									period={ props.period }
+									query={ query }
+									summaryUrl={ getStatHref( 'utm', query ) }
+									summary={ false }
+									className={ halfWidthModuleClasses }
+								/>
+							) }
+
+							{ supportsUTMStats && isOldJetpack && (
+								<StatsModuleUTMOverlay
+									siteId={ siteId }
+									className={ halfWidthModuleClasses }
+									overlay={
+										<StatsCardUpdateJetpackVersion
+											className="stats-module__upsell stats-module__upgrade"
+											siteId={ siteId }
+											statType="utm"
+										/>
+									}
+								/>
+							) }
+
+							<StatsModuleClicks
+								moduleStrings={ moduleStrings.clicks }
+								period={ props.period }
+								query={ query }
+								summaryUrl={ getStatHref( 'clicks', query ) }
+								className={ halfWidthModuleClasses }
+							/>
+
+							{ ! isModuleHidden( 'authors' ) && (
+								<StatsModuleAuthors
+									moduleStrings={ moduleStrings.authors }
+									period={ props.period }
+									query={ query }
+									summaryUrl={ getStatHref( 'authors', query ) }
+									className={ halfWidthModuleClasses }
+								/>
+							) }
+
+							<StatsModuleSearch
+								moduleStrings={ moduleStrings.search }
+								period={ props.period }
+								query={ query }
+								summaryUrl={ getStatHref( 'searchterms', query ) }
+								className={ halfWidthModuleClasses }
+							/>
+
+							{ ! isModuleHidden( 'videos' ) && (
+								<StatsModuleVideos
+									moduleStrings={ moduleStrings.videoplays }
+									period={ props.period }
+									query={ query }
+									summaryUrl={ getStatHref( 'videoplays', query ) }
+									className={ halfWidthModuleClasses }
+								/>
+							) }
+
+							{
+								// File downloads are not yet supported in Jetpack environment
+								! isJetpack && (
+									<StatsModuleDownloads
+										moduleStrings={ moduleStrings.filedownloads }
+										period={ props.period }
+										query={ query }
+										summaryUrl={ getStatHref( 'filedownloads', query ) }
+										className={ halfWidthModuleClasses }
+									/>
+								)
+							}
+
+							{ supportsDevicesStats && ! isOldJetpack && (
+								<StatsModuleDevices
+									siteId={ siteId }
+									period={ props.period }
+									query={ query }
+									className={ halfWidthModuleClasses }
+								/>
+							) }
+
+							{ supportsDevicesStats && isOldJetpack && (
+								<StatsModuleUpgradeDevicesOverlay
+									className={ halfWidthModuleClasses }
+									siteId={ siteId }
+									overlay={
+										<StatsCardUpdateJetpackVersion
+											className="stats-module__upsell stats-module__upgrade"
+											siteId={ siteId }
+											statType="devices"
+										/>
+									}
+								/>
+							) }
+						</div>
+					</>
+				) }
+
+				{ wpcomShowUpsell && <StatsUpsell siteId={ siteId } /> }
+			</div>
+			{ supportsPlanUsage && (
+				<StatsPlanUsage siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
+			) }
+			{ ! shouldShowUpsells ? null : (
+				<AsyncLoad require="calypso/my-sites/stats/jetpack-upsell-section" />
+			) }
+			{ ! config.isEnabled( 'stats/paid-wpcom-v3' ) && (
+				<PromoCards isOdysseyStats={ isOdysseyStats } pageSlug="traffic" slug={ slug } />
+			) }
+			{ supportUserFeedback && <StatsFeedbackPresentor siteId={ siteId } /> }
+			<JetpackColophon />
+			<AsyncLoad require="calypso/lib/analytics/track-resurrections" placeholder={ null } />
+			{ upsellModalView && <StatsUpsellModal siteId={ siteId } /> }
+		</div>
+	);
+}
+
+const EnableStatsModule = ( props ) => {
+	const dispatch = useDispatch();
+	const path = useSelector( ( state ) => getCurrentRouteParameterized( state, props.siteId ) );
+	const enableStatsModule = () => {
+		dispatch(
+			withAnalytics(
+				recordTracksEvent( 'calypso_jetpack_module_toggle', {
+					module: 'stats',
+					path,
+					toggled: 'on',
+				} ),
+				activateModule( props.siteId, 'stats' )
+			)
+		);
+	};
+
+	return (
+		<EmptyContent
+			illustration={ illustration404 }
+			title={ translate( 'Looking for stats?' ) }
+			line={
+				<p>
+					{ translate(
+						'Enable Jetpack Stats to see detailed information about your traffic, likes, comments, and subscribers.'
+					) }
+				</p>
+			}
+			action={ translate( 'Enable Jetpack Stats' ) }
+			actionCallback={ enableStatsModule }
+		/>
+	);
+};
+
+const InsufficientPermissionsPage = () => {
+	return (
+		<EmptyContent
+			illustration={ illustration404 }
+			title={ translate( 'Looking for stats?' ) }
+			line={
+				<p>
+					<div>
+						{ translate( "We're sorry, but you do not have permission to access this page." ) }
+					</div>
+					<div>{ translate( "Please contact your site's administrator for access." ) }</div>
+				</p>
+			}
+		/>
+	);
+};
+
+const StatsBodyAccessCheck = ( props ) => {
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, props.siteId ) );
+	const canUserManageOptions = useSelector( ( state ) =>
+		canCurrentUser( state, props.siteId, 'manage_options' )
+	);
+	const canUserViewStats = useSelector(
+		( state ) =>
+			isOdysseyStats || canUserManageOptions || canCurrentUser( state, props.siteId, 'view_stats' )
+	);
+	const showEnableStatsModule = useSelector(
+		( state ) =>
+			! isOdysseyStats &&
+			props.siteId &&
+			isJetpack &&
+			isJetpackModuleActive( state, props.siteId, 'stats' ) === false &&
+			canUserManageOptions
+	);
+
+	if ( ! canUserViewStats ) {
+		return <InsufficientPermissionsPage />;
+	} else if ( showEnableStatsModule ) {
+		return <EnableStatsModule siteId={ props.siteId } />;
+	}
+
+	return <StatsBody { ...props } />;
+};
+
+const StatsSite = ( props ) => {
+	const { period } = props.period;
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	const siteId = useSelector( getSelectedSiteId );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+
+	useEffect(
+		() =>
+			// Necessary to properly configure the fixed navigation headers.
+			sessionStorage.setItem( 'jp-stats-last-tab', 'traffic' ),
+		[]
+	); // Track the last viewed tab.
+
+	return (
+		<Main fullWidthLayout ariaLabel={ translate( 'Jetpack Stats' ) }>
+			{ config.isEnabled( 'stats/paid-wpcom-v2' ) && ! isOdysseyStats && (
+				<QuerySiteFeatures siteIds={ [ siteId ] } />
+			) }
+			{ /* Odyssey: Google Business Profile pages are currently unsupported. */ }
+			{ ! isOdysseyStats && (
+				<>
+					<QueryKeyringConnections />
+					<QuerySiteKeyrings siteId={ siteId } />
+				</>
+			) }
+			{ /* Odyssey: if Stats module is not enabled, the page will not be rendered. */ }
+			{ ! isOdysseyStats && isJetpack && <QueryJetpackModules siteId={ siteId } /> }
+			<DocumentHead title={ translate( 'Jetpack Stats' ) } />
+			<PageViewTracker
+				path={ `/stats/${ period }/:site` }
+				title={ `Stats > ${ titlecase( period ) }` }
+			/>
+			<StatsGlobalValuesContext.Consumer>
+				{ ( isInternal ) => (
+					<StatsBodyAccessCheck isInternal={ isInternal } siteId={ siteId } { ...props } />
+				) }
+			</StatsGlobalValuesContext.Consumer>
+		</Main>
+	);
+};
+
+export default StatsSite;

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -156,19 +156,25 @@ const getDefaultDaysForPeriod = ( period ) => {
 
 function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...props } ) {
 	const dispatch = useDispatch();
-
-	const [ activeTabState, setActiveTabState ] = useState( null );
-	const [ activeLegend, setActiveLegend ] = useState( null );
 	const { period } = props.period;
-
+	const [ activeTabState, setActiveTabState ] = useState( () => getActiveTab( chartTab ) );
+	const [ activeLegend, setActiveLegend ] = useState( () =>
+		period !== 'hour' ? getActiveTab( chartTab ).legendOptions || [] : []
+	);
 	const queryDate = date.format( DATE_FORMAT );
+
+	const { supportedShortcutList } = useShortcuts();
 	const moduleStrings = statsStrings();
 
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const isWPAdmin = config.isEnabled( 'is_odyssey' );
-
+	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
+	const isSitePrivate = useSelector( ( state ) => isPrivateSite( state, siteId ) );
 	const slug = useSelector( getSelectedSiteSlug );
+	const moduleToggles = useSelector( ( state ) => getModuleToggles( state, siteId, 'traffic' ) );
+	const momentSiteZone = useSelector( ( state ) => getMomentSiteZone( state, siteId ) );
+
 	const upsellModalView = useSelector(
 		( state ) => config.isEnabled( 'stats/paid-wpcom-v2' ) && getUpsellModalView( state, siteId )
 	);
@@ -198,14 +204,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 			config.isEnabled( 'stats/paid-wpcom-v3' ) &&
 			shouldGateStats( state, siteId, STATS_FEATURE_PAGE_TRAFFIC )
 	);
-
-	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
-	const isSitePrivate = useSelector( ( state ) => isPrivateSite( state, siteId ) );
-
-	const moduleToggles = useSelector( ( state ) => getModuleToggles( state, siteId, 'traffic' ) );
-	const momentSiteZone = useSelector( ( state ) => getMomentSiteZone( state, siteId ) );
-
-	const { supportedShortcutList } = useShortcuts();
 
 	const shouldShowUpsells = isOdysseyStats && ! isAtomic;
 	const supportsUTMStats = supportsUTMStatsFeature || isInternal;

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 import { localize, translate } from 'i18n-calypso';
 import { find } from 'lodash';
 import moment from 'moment';
-import { useState, useMemo, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import titlecase from 'to-title-case';
 import illustration404 from 'calypso/assets/images/illustrations/illustration-404.svg';
@@ -182,7 +182,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	} = useSelector( ( state ) => getEnvStatsFeatureSupportChecks( state, siteId ) );
 
 	const hasSiteLoadedFeatures = useSelector(
-		( state ) => isWPAdmin || hasLoadedSiteFeatures( state, siteId )
+		( state ) => isWPAdmin && hasLoadedSiteFeatures( state, siteId )
 	);
 
 	const shouldForceDefaultDateRange = useSelector( ( state ) =>
@@ -334,7 +334,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		return url;
 	};
 
-	useMemo( () => {
+	useEffect( () => {
 		const activeTab = getActiveTab( chartTab );
 		if ( activeTab !== activeTabState ) {
 			setActiveTabState( activeTab );

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -182,7 +182,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	} = useSelector( ( state ) => getEnvStatsFeatureSupportChecks( state, siteId ) );
 
 	const hasSiteLoadedFeatures = useSelector(
-		( state ) => isWPAdmin && hasLoadedSiteFeatures( state, siteId )
+		( state ) => isWPAdmin || hasLoadedSiteFeatures( state, siteId )
 	);
 
 	const shouldForceDefaultDateRange = useSelector( ( state ) =>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -317,13 +317,13 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 
 	// Note: This is only used in the empty version of the module.
 	// There's a similar function inside stats-module/index.jsx that is used when we have content.
-	const getStatHref = ( path, query ) => {
-		const paramsValid = props.period && path && slug;
+	const getStatHref = ( modulePath, query ) => {
+		const paramsValid = props.period && modulePath && slug;
 		if ( ! paramsValid ) {
 			return undefined;
 		}
 
-		let url = `/stats/${ props.period.period }/${ path }/${ slug }`;
+		let url = `/stats/${ props.period.period }/${ modulePath }/${ slug }`;
 
 		if ( query?.start_date ) {
 			url += `?startDate=${ query.start_date }&endDate=${ query.date }`;

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -329,12 +329,10 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	};
 
 	useEffect( () => {
-		const activeTab = getActiveTab( chartTab );
-		if ( activeTab !== activeTabState ) {
-			setActiveTabState( activeTab );
-			setActiveLegend( period !== 'hour' ? activeTab.legendOptions || [] : [] );
-		}
-	}, [ chartTab, period, activeTabState ] );
+		const newActiveTab = getActiveTab( chartTab );
+		setActiveTabState( newActiveTab );
+		setActiveLegend( period !== 'hour' ? newActiveTab.legendOptions || [] : [] );
+	}, [ chartTab, period, activeTabState, context.query ] );
 
 	// Set up a custom range for the chart.
 	// Dependant on new date range picker controls.

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -211,10 +211,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	const supportsUTMStats = supportsUTMStatsFeature || isInternal;
 	const supportsDevicesStats = supportsDevicesStatsFeature || isInternal;
 
-	// Set up a custom range for the chart.
-	// Dependant on new date range picker controls.
-	let customChartRange = null;
-
 	const getAvailableLegend = () => {
 		const activeTab = getActiveTab( chartTab );
 		// TODO: remove this when we support hourly visitors.
@@ -342,6 +338,9 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		}
 	}, [ chartTab, period, activeTabState ] );
 
+	// Set up a custom range for the chart.
+	// Dependant on new date range picker controls.
+	let customChartRange = null;
 	// Sort out end date for chart.
 	const chartEnd = getValidDateOrNullFromInput( context.query?.chartEnd, 'endDate' );
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -342,9 +342,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		}
 	}, [ chartTab, period, activeTabState ] );
 
-	// TODO: Fix isOdysseyStats to include the environment running on WP-Admin of Simple sites.
-	const isRunningOnWPAdmin = useMemo( () => document.getElementById( 'wpadminbar' ), [] );
-
 	// Sort out end date for chart.
 	const chartEnd = getValidDateOrNullFromInput( context.query?.chartEnd, 'endDate' );
 
@@ -464,6 +461,9 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		'stats__flexible-grid-item--full--large',
 		'stats__flexible-grid-item--full--medium'
 	);
+
+	// TODO: Fix isOdysseyStats to include the environment running on WP-Admin of Simple sites.
+	const isRunningOnWPAdmin = document.getElementById( 'wpadminbar' );
 
 	return (
 		<div className="stats">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Convert site.jsx to a Function Component

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It's been quite a burden not being able to use hooks

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure Traffic page still looks exactly like it was
* Ensure the chart works with the date range selection
  * Ensure bar clicking still works
  * Ensure tab clicking still works
  * Ensure legends still work
* Ensure the modules show data from the date ranges and change with the date range
* Ensure links to summary pages work
* Ensure module toggles still work okay
* 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
