### PR TITLE
Stepper: Fix the previous step of the user step may be wrong (2nd try)

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -8,7 +8,7 @@ import { StepperPerformanceTrackerStop } from 'calypso/landing/stepper/utils/per
 import SignupHeader from 'calypso/signup/signup-header';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { STEPS } from '../../steps';
+import { PRIVATE_STEPS } from '../../steps';
 import SurveyManager from '../survery-manager';
 import { useStepRouteTracking } from './hooks/use-step-route-tracking';
 import type { Flow, Navigate, StepperStep } from '../../types';
@@ -56,7 +56,7 @@ const StepRoute = ( { step, flow, showWooLogo, renderStep, navigate }: StepRoute
 			nextStep: step.slug,
 		};
 
-		navigate( STEPS.USER.slug, extraData, true );
+		navigate( PRIVATE_STEPS.USER.slug, extraData, true );
 		return null;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
@@ -4,7 +4,7 @@ import { useCallback } from 'react';
 import { generatePath, useMatch, useNavigate } from 'react-router';
 import { useSearchParams } from 'react-router-dom';
 import { ONBOARD_STORE, STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
-import { Navigate, StepperStep } from '../../types';
+import type { Navigate, StepperStep } from '../../types';
 
 const useOnboardingIntent = () => {
 	const intent = useSelect(

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -23,6 +23,7 @@ import { useFlowAnalytics } from './hooks/use-flow-analytics';
 import { useFlowNavigation } from './hooks/use-flow-navigation';
 import { useSignUpStartTracking } from './hooks/use-sign-up-start-tracking';
 import { useStepNavigationWithTracking } from './hooks/use-step-navigation-with-tracking';
+import { STEPS } from './steps';
 import { AssertConditionState, type Flow, type StepperStep, type StepProps } from './types';
 import type { StepperInternalSelect } from '@automattic/data-stores';
 import './global.scss';
@@ -160,34 +161,32 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 			return null;
 		}
 
-		const firstAuthWalledStep = flowSteps.find( ( step ) => step.requiresLoggedInUser );
-
-		if ( step.slug === 'user' && firstAuthWalledStep ) {
+		// The `nextStep` is available only when logged-out users go to the step that requires auth
+		// and are redirected to the user step.
+		const nextStepSlug = stepData?.nextStep ?? '';
+		if ( step.slug === STEPS.USER.slug && nextStepSlug ) {
+			const previousStepSlug = stepData?.previousStep;
 			const postAuthStepPath = generatePath( '/setup/:flow/:step/:lang?', {
 				flow: flow.name,
-				step: firstAuthWalledStep.slug,
+				step: nextStepSlug,
 				lang: lang === 'en' || isLoggedIn ? null : lang,
 			} );
+
 			const signupUrl = generatePath( '/setup/:flow/:step/:lang?', {
 				flow: flow.name,
 				step: 'user',
 				lang: lang === 'en' || isLoggedIn ? null : lang,
 			} );
 
-			const lastPreAuthWalledStepIndex =
-				flowSteps.findIndex( ( step ) => step.slug === 'user' ) - 1;
-			const lastPreAuthWalledStep =
-				lastPreAuthWalledStepIndex < 0 ? null : flowSteps[ lastPreAuthWalledStepIndex ];
-
 			return (
 				<StepComponent
 					navigation={ {
 						submit() {
-							navigate( firstAuthWalledStep.slug, undefined, true );
+							navigate( nextStepSlug, undefined, true );
 						},
-						...( lastPreAuthWalledStep && {
+						...( previousStepSlug && {
 							goBack() {
-								navigate( lastPreAuthWalledStep.slug, undefined, true );
+								navigate( previousStepSlug, undefined, true );
 							},
 						} ),
 					} }

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -163,12 +163,12 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 
 		// The `nextStep` is available only when logged-out users go to the step that requires auth
 		// and are redirected to the user step.
-		const nextStepSlug = stepData?.nextStep ?? '';
-		if ( step.slug === PRIVATE_STEPS.USER.slug && nextStepSlug ) {
-			const previousStepSlug = stepData?.previousStep;
+		const postAuthStepSlug = stepData?.nextStep ?? '';
+		if ( step.slug === PRIVATE_STEPS.USER.slug && postAuthStepSlug ) {
+			const previousAuthStepSlug = stepData?.previousStep;
 			const postAuthStepPath = generatePath( '/setup/:flow/:step/:lang?', {
 				flow: flow.name,
-				step: nextStepSlug,
+				step: postAuthStepSlug,
 				lang: lang === 'en' || isLoggedIn ? null : lang,
 			} );
 
@@ -182,11 +182,11 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 				<StepComponent
 					navigation={ {
 						submit() {
-							navigate( nextStepSlug, undefined, true );
+							navigate( postAuthStepSlug, undefined, true );
 						},
-						...( previousStepSlug && {
+						...( previousAuthStepSlug && {
 							goBack() {
-								navigate( previousStepSlug, undefined, true );
+								navigate( previousAuthStepSlug, undefined, true );
 							},
 						} ),
 					} }

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -23,7 +23,7 @@ import { useFlowAnalytics } from './hooks/use-flow-analytics';
 import { useFlowNavigation } from './hooks/use-flow-navigation';
 import { useSignUpStartTracking } from './hooks/use-sign-up-start-tracking';
 import { useStepNavigationWithTracking } from './hooks/use-step-navigation-with-tracking';
-import { STEPS } from './steps';
+import { PRIVATE_STEPS } from './steps';
 import { AssertConditionState, type Flow, type StepperStep, type StepProps } from './types';
 import type { StepperInternalSelect } from '@automattic/data-stores';
 import './global.scss';
@@ -164,7 +164,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		// The `nextStep` is available only when logged-out users go to the step that requires auth
 		// and are redirected to the user step.
 		const nextStepSlug = stepData?.nextStep ?? '';
-		if ( step.slug === STEPS.USER.slug && nextStepSlug ) {
+		if ( step.slug === PRIVATE_STEPS.USER.slug && nextStepSlug ) {
 			const previousStepSlug = stepData?.previousStep;
 			const postAuthStepPath = generatePath( '/setup/:flow/:step/:lang?', {
 				flow: flow.name,
@@ -196,6 +196,13 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 					redirectTo={ postAuthStepPath }
 					signupUrl={ signupUrl }
 				/>
+			);
+		}
+
+		if ( step.slug === PRIVATE_STEPS.USER.slug ) {
+			// eslint-disable-next-line no-console
+			console.warn(
+				'Please define the next step after auth explicitly as we cannot find the user step automatically.'
 			);
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -319,4 +319,10 @@ export const STEPS = {
 		slug: 'migration-upgrade-plan',
 		asyncComponent: () => import( './steps-repository/migration-upgrade-plan' ),
 	},
+
+	USER: {
+		slug: 'user',
+		asyncComponent: () =>
+			import( /* webpackChunkName: "stepper-user-step" */ './steps-repository/__user' ),
+	},
 } satisfies Record< string, StepperStep >;

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -319,7 +319,12 @@ export const STEPS = {
 		slug: 'migration-upgrade-plan',
 		asyncComponent: () => import( './steps-repository/migration-upgrade-plan' ),
 	},
+} satisfies Record< string, StepperStep >;
 
+/**
+ * Define steps that are only used by the Stepper framework. Any flow should avoid include these steps as much as possible.
+ */
+export const PRIVATE_STEPS = {
 	USER: {
 		slug: 'user',
 		asyncComponent: () =>

--- a/client/landing/stepper/utils/enhanceFlowWithAuth.ts
+++ b/client/landing/stepper/utils/enhanceFlowWithAuth.ts
@@ -1,12 +1,5 @@
+import { STEPS } from '../declarative-flow/internals/steps';
 import type { Flow, StepperStep } from '../declarative-flow/internals/types';
-
-const USER_STEP: StepperStep = {
-	slug: 'user',
-	asyncComponent: () =>
-		import(
-			/* webpackChunkName: "stepper-user-step" */ '../declarative-flow/internals/steps-repository/__user'
-		),
-};
 
 function useInjectUserStepIfNeeded( flow: Flow ): StepperStep[] {
 	const steps = flow.useSteps();
@@ -17,7 +10,7 @@ function useInjectUserStepIfNeeded( flow: Flow ): StepperStep[] {
 	}
 
 	const newSteps = [ ...steps ];
-	newSteps.splice( firstAuthWalledStep, 0, USER_STEP );
+	newSteps.splice( firstAuthWalledStep, 0, STEPS.USER );
 	return newSteps;
 }
 

--- a/client/landing/stepper/utils/enhanceFlowWithAuth.ts
+++ b/client/landing/stepper/utils/enhanceFlowWithAuth.ts
@@ -1,4 +1,4 @@
-import { STEPS } from '../declarative-flow/internals/steps';
+import { PRIVATE_STEPS } from '../declarative-flow/internals/steps';
 import type { Flow, StepperStep } from '../declarative-flow/internals/types';
 
 function useInjectUserStepIfNeeded( flow: Flow ): StepperStep[] {
@@ -9,9 +9,11 @@ function useInjectUserStepIfNeeded( flow: Flow ): StepperStep[] {
 		return steps;
 	}
 
-	const newSteps = [ ...steps ];
-	newSteps.splice( firstAuthWalledStep, 0, STEPS.USER );
-	return newSteps;
+	// For logged-out users, we will redirect steps that require auth to the user step,
+	// and then redirect back to the original steps after auth.
+	// Therefore, we must avoid placing the user step as the first step,
+	// as it would prevent us from knowing which step to redirect back to.
+	return [ ...steps, PRIVATE_STEPS.USER ];
 }
 
 export function enhanceFlowWithAuth( flow: Flow ): Flow {

--- a/packages/data-stores/src/stepper-internal/reducer.ts
+++ b/packages/data-stores/src/stepper-internal/reducer.ts
@@ -7,6 +7,7 @@ type StepData = Record< string, unknown > & {
 	path: string;
 	intent: SiteIntent;
 	previousStep: string;
+	nextStep?: string;
 };
 
 export const stepData: Reducer< StepData | null, StepperInternalAction > = (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/97802, https://github.com/Automattic/wp-calypso/pull/97775

## Proposed Changes

**UPDATED**

* Avoid placing the user step as the first step, as it would prevent us from knowing which step to redirect back to
* Display the warning if we cannot find the next step after auth

---

* The flow relied on the `firstAuthWalledStep` and `lastPreAuthWalledStep` to get the previous step before auth and the next step after auth. However, it made the flow become liner because both of them are the result of the linear search in the steps array. So, the previous step and the next step might be wrong.
  * For example, if there were 2 steps (A1, A2) go to auth and 2 steps (B1, B2) after the auth, then the back button might always go back to the A1 step, and user might always be redirected to B1 step after the auth.
  ```
  A1 -> auth -> B1
  A2 -> auth -> B2
  ``` 
* This PR proposed
  * Save the current previous step before navigating to the user step so we can know what's the correct previous step
  * Save the current step that requires the auth as a next step so we can know what's the correct next step after the auth

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The previous step & next step of the user step may be wrong.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Default Onboarding Flow**

* Go to /setup/onboarding?flags=-onboarding/goals-first without logged-in
* Ensure you're back to the Domains screen after logging in

--

**Goals First Onboarding Flow**

* Go to /setup/onboarding without logged-in
* Select any goals
* Select any design
* On the user step,
  * Click the back button
  * Ensure you're back to the Design Picker screen
  * Continue to the user step again
  * Log in
  * Ensure you can see the Domains screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
