### PR TITLE
Untangling Calypso Media Page: Implement Tracks events

### DIFF
--- a/client/my-sites/media-library/data-source.jsx
+++ b/client/my-sites/media-library/data-source.jsx
@@ -8,6 +8,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import GooglePhotosIcon from './google-photos-icon';
@@ -32,12 +33,18 @@ export class MediaLibraryDataSource extends Component {
 	storeButtonRef = ( ref ) => ( this.buttonRef = ref );
 
 	togglePopover = () => {
-		this.setState( { popover: ! this.state.popover } );
+		const nextValue = ! this.state.popover;
+		this.setState( { popover: nextValue } );
+		recordTracksEvent( 'calypso_media_data_source_toggle', { expanded: nextValue } );
 	};
 
 	changeSource = ( newSource ) => () => {
 		if ( newSource !== this.props.source ) {
 			this.props.onSourceChange( newSource );
+			recordTracksEvent( 'calypso_media_data_source_change', {
+				old_source: this.props.source,
+				new_source: newSource,
+			} );
 		}
 	};
 

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -6,6 +6,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import StickyPanel from 'calypso/components/sticky-panel';
 import { withAddExternalMedia } from 'calypso/data/media/with-add-external-media';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { changeMediaSource } from 'calypso/state/media/actions';
 import { fetchNextMediaPage } from 'calypso/state/media/thunks';
 import isFetchingNextPage from 'calypso/state/selectors/is-fetching-next-page';
@@ -93,6 +94,8 @@ class MediaLibraryExternalHeader extends Component {
 		onSourceChange( '', () => {
 			this.props.addExternalMedia( selectedItems, site, postId, source );
 		} );
+
+		recordTracksEvent( 'calypso_media_external_media_copy', { source } );
 	};
 
 	onChangeSelection = () => {

--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -7,6 +7,7 @@ import ButtonGroup from 'calypso/components/button-group';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import StickyPanel from 'calypso/components/sticky-panel';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { userCan } from 'calypso/lib/site/utils';
 import MediaModalSecondaryActions from 'calypso/post-editor/media-modal/secondary-actions';
 import { getSectionName } from 'calypso/state/ui/selectors';
@@ -53,12 +54,31 @@ class MediaLibraryHeader extends Component {
 			addingViaUrl: state,
 			isMoreOptionsVisible: false,
 		} );
+
+		recordTracksEvent( 'calypso_media_add_via_url_toggle', { expanded: state } );
 	};
 
 	toggleMoreOptions = ( state ) => {
 		this.setState( {
 			isMoreOptionsVisible: state,
 		} );
+
+		recordTracksEvent( 'calypso_media_more_options_toggle', { expanded: state } );
+	};
+
+	onViewDetails = () => {
+		this.props.onViewDetails();
+		recordTracksEvent( 'calypso_media_editor_open' );
+	};
+
+	onDeleteItem = () => {
+		this.props.onDeleteItem();
+		recordTracksEvent( 'calypso_media_item_delete' );
+	};
+
+	onMediaScaleChange = ( value ) => {
+		this.props.onMediaScaleChange( value );
+		recordTracksEvent( 'calypso_media_scale_change', { value } );
 	};
 
 	renderUploadButtons = () => {
@@ -127,12 +147,12 @@ class MediaLibraryHeader extends Component {
 				{ this.renderUploadButtons() }
 				<MediaModalSecondaryActions
 					selectedItems={ this.props.selectedItems }
-					onViewDetails={ this.props.onViewDetails }
-					onDelete={ this.props.onDeleteItem }
+					onViewDetails={ this.onViewDetails }
+					onDelete={ this.onDeleteItem }
 					site={ this.props.site }
 				/>
 				<MediaLibraryScale
-					onChange={ this.props.onMediaScaleChange }
+					onChange={ this.onMediaScaleChange }
 					mediaScale={ this.props.mediaScale }
 				/>
 			</Card>

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -15,6 +15,7 @@ import { withEditMedia } from 'calypso/data/media/use-edit-media-mutation';
 import { withDeleteMedia } from 'calypso/data/media/with-delete-media';
 import accept from 'calypso/lib/accept';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getMimeType } from 'calypso/lib/media/utils';
 import searchUrl from 'calypso/lib/search-url';
 import MediaLibrary from 'calypso/my-sites/media-library';
@@ -104,6 +105,8 @@ class Media extends Component {
 			currentDetail: null,
 			selectedItems: [],
 		} );
+
+		recordTracksEvent( 'calypso_media_editor_close' );
 		this.maybeRedirectToAll();
 	};
 
@@ -120,16 +123,23 @@ class Media extends Component {
 
 	editImage = () => {
 		this.setState( { currentDetail: null, editedImageItem: this.getSelectedIndex() } );
+		recordTracksEvent( 'calypso_media_editor_edit_click', { type: 'image' } );
 	};
 
 	editVideo = () => {
 		this.setState( { currentDetail: null, editedVideoItem: this.getSelectedIndex() } );
+		recordTracksEvent( 'calypso_media_editor_edit_click', { type: 'video' } );
+	};
+
+	onImageEditorReset = () => {
+		recordTracksEvent( 'calypso_media_image_editor_reset' );
 	};
 
 	onImageEditorCancel = ( imageEditorProps ) => {
 		const { resetAllImageEditorState } = imageEditorProps;
-		this.setState( { currentDetail: this.state.editedImageItem, editedImageItem: null } );
 
+		this.setState( { currentDetail: this.state.editedImageItem, editedImageItem: null } );
+		recordTracksEvent( 'calypso_media_image_editor_cancel' );
 		resetAllImageEditorState();
 	};
 
@@ -153,7 +163,9 @@ class Media extends Component {
 
 		this.props.editMedia( site.ID, item );
 		resetAllImageEditorState();
+
 		this.setState( { currentDetail: null, editedImageItem: null, selectedItems: [] } );
+		recordTracksEvent( 'calypso_media_image_editor_done' );
 		this.maybeRedirectToAll();
 	};
 
@@ -186,10 +198,13 @@ class Media extends Component {
 
 	onVideoEditorCancel = () => {
 		this.setState( { currentDetail: this.state.editedVideoItem, editedVideoItem: null } );
+		recordTracksEvent( 'calypso_media_video_editor_cancel' );
 	};
 
 	onVideoEditorUpdatePoster = () => {
 		this.setState( { currentDetail: null, editedVideoItem: null, selectedItems: [] } );
+		recordTracksEvent( 'calypso_media_video_editor_update_poster_update' );
+
 		this.maybeRedirectToAll();
 	};
 
@@ -286,6 +301,7 @@ class Media extends Component {
 
 	deleteMediaByItemDetail = () => {
 		this.deleteMedia( () => this.closeDetailsModal() );
+		recordTracksEvent( 'calypso_media_editor_delete' );
 	};
 
 	confirmDeleteMedia = () => {
@@ -446,6 +462,7 @@ class Media extends Component {
 								siteId={ site && site.ID }
 								media={ this.getSelectedItem( this.state.editedImageItem ) }
 								onDone={ this.onImageEditorDone }
+								onReset={ this.onImageEditorReset }
 								onCancel={ this.onImageEditorCancel }
 							/>
 						) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/10179

## Proposed Changes

This PR implements Tracks events to help with data analysis. The events are as follows:

| Name | Description |
| --- | --- |
| calypso_media_data_source_toggle | The data source dropdown was clicked |
| calypso_media_data_source_change | The data source dropdown value changed |
| calypso_media_external_media_copy | An external media was copied |
| calypso_media_more_options_toggle | The more options button was clicked |
| calypso_media_add_via_url_toggle | The "Add via URL" component was toggled |
| calypso_media_editor_open | The action button "Edit" was clicked |  
| calypso_media_item_delete | The action button "Delete" was clicked |
| calypso_media_scale_change | The grid density scale changed |
| calypso_media_editor_close | The media editor "Close" button was closed |
| calypso_media_editor_delete | The media editor "Delete" button was clicked |
| calypso_media_editor_edit_click | The media editor "Edit" button was clicked |
| calypso_media_image_editor_reset | The image editor "Reset" button was clicked |
| calypso_media_image_editor_cancel | The image editor "Cancel" button was clicked |
| calypso_media_image_editor_done | The image editor "Done" button was clicked |
| calypso_media_video_editor_update_poster_update | The video editor poster was updated |
| calypso_media_video_editor_cancel | The video editor "Cancel" button was clicked |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Data analysis.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Head to /media
2. Ensure that the Tracks events trigger as described above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
