### PR TITLE
Add site restore reminder banner

### DIFF
--- a/client/sites/components/sites-dashboard-banners-manager.tsx
+++ b/client/sites/components/sites-dashboard-banners-manager.tsx
@@ -7,6 +7,7 @@ import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { isCardDismissed } from 'calypso/blocks/dismissible-card/selectors';
 import Banner from 'calypso/components/banner';
+import { useRestoreSitesBanner } from './sites-dashboard-banners/use-restore-sites-reminder-banner';
 import type { Status } from '@automattic/sites/src/use-sites-list-grouping';
 
 const HELP_CENTER_STORE = HelpCenter.register();
@@ -59,6 +60,17 @@ const SitesDashboardBannersManager = ( {
 				/>
 			</div>
 		);
+	}
+
+	// TODO: refactor banners to use this pattern
+	// Define banner creators in priority order
+	const bannerCreators = [ useRestoreSitesBanner ];
+	// Return the first banner that should show
+	for ( const createBanner of bannerCreators ) {
+		const banner = createBanner();
+		if ( banner.shouldShow() ) {
+			return <div className="sites-banner-container">{ banner.render() }</div>;
+		}
 	}
 
 	if ( showA8CForAgenciesBanner ) {

--- a/client/sites/components/sites-dashboard-banners/styles.scss
+++ b/client/sites/components/sites-dashboard-banners/styles.scss
@@ -1,0 +1,37 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@wordpress/base-styles/breakpoints";
+
+.sites-banner-container {
+	.notice-banner {
+		width: 100%;
+		box-shadow: none;
+		padding: 16px;
+
+		.notice-banner__icon-wrapper {
+			margin-right: 8px;
+			position: unset;
+		}
+
+		.notice-banner__action-bar {
+			margin-top: 12px;
+		}
+
+		@media screen and (max-width: $break-medium) {
+			.notice-banner__close-button {
+				position: unset;
+				top: unset;
+				right: unset;
+			}
+		}
+	}
+
+	.notice-banner.is-info {
+		border: none;
+		background-color: $studio-wordpress-blue-5;
+		color: $studio-wordpress-blue-80;
+
+		.notice-banner__icon {
+			fill: $studio-wordpress-blue-80;
+		}
+	}
+}

--- a/client/sites/components/sites-dashboard-banners/use-restore-sites-reminder-banner.tsx
+++ b/client/sites/components/sites-dashboard-banners/use-restore-sites-reminder-banner.tsx
@@ -1,0 +1,41 @@
+import { NoticeBanner } from '@automattic/components';
+import { translate } from 'i18n-calypso';
+import { useState } from 'react';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+import './styles.scss';
+
+export function useRestoreSitesBanner() {
+	const id = 'restore-sites-reminder';
+	// Show banner when ?restored=true param exists, even if previously dismissed
+	const [ isDismissed, setIsDismissed ] = useState( false );
+
+	const dismissNotice = () => {
+		recordTracksEvent( 'calypso_sites_dashboard_restore_banner_dismiss' );
+		setIsDismissed( true );
+	};
+
+	return {
+		id,
+		shouldShow() {
+			const urlParams = new URLSearchParams( window.location.search );
+			const restored = urlParams.get( 'restored' );
+			return ! isDismissed && restored === 'true';
+		},
+		render() {
+			return (
+				<NoticeBanner
+					title={ translate( 'Choose which sites you’d like to restore' ) }
+					onClose={ dismissNotice }
+					level="info"
+				>
+					<div>
+						{ translate(
+							'You’ll need to invite any users that previously had access to your sites.'
+						) }
+					</div>
+				</NoticeBanner>
+			);
+		},
+	};
+}

--- a/client/sites/components/test/sites-dashboard-banners-manager.test.tsx
+++ b/client/sites/components/test/sites-dashboard-banners-manager.test.tsx
@@ -89,4 +89,32 @@ describe( 'SitesDashboardBannersManager', () => {
 			queryByText( "Building sites for customers? Here's how to earn more." )
 		).not.toBeInTheDocument();
 	} );
+
+	it( 'renders restore sites banner when ?restored=true param exists', () => {
+		// Setup URLSearchParams mock
+		const urlSearchParamsGetSpy = jest.spyOn( URLSearchParams.prototype, 'get' );
+		urlSearchParamsGetSpy.mockImplementation( ( param ) =>
+			param === 'restored' ? 'true' : null
+		);
+
+		const { getByText } = render(
+			<Provider store={ store }>
+				<SitesDashboardBannersManager sitesStatuses={ [] } sitesCount={ 0 } />
+			</Provider>
+		);
+
+		expect( getByText( 'Choose which sites you’d like to restore' ) ).toBeInTheDocument();
+
+		// Cleanup
+		urlSearchParamsGetSpy.mockRestore();
+	} );
+
+	it( 'does not render restore sites banner when ?restored=true param does not exist', () => {
+		const { queryByText } = render(
+			<Provider store={ store }>
+				<SitesDashboardBannersManager sitesStatuses={ [] } sitesCount={ 0 } />
+			</Provider>
+		);
+		expect( queryByText( 'Choose which sites you’d like to restore' ) ).not.toBeInTheDocument();
+	} );
 } );


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9502

## Proposed Changes

* Add site restore banner reminder
* Add tests
* Propose a pattern to organize the sites-dashboard banners to decouple banner logic to avoid everything being in one huge file situation as we add more banners in the future

https://github.com/user-attachments/assets/ecba2609-b7c9-4edc-9a19-9f4a14665caa

| Mobile | Desktop |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/5524797e-de58-4a50-b0cb-d9d5bc6a8aad"> | <img src="https://github.com/user-attachments/assets/ea43eed5-5cdb-4a43-814e-db241010d4cb"> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Add site restore banner reminder for users that restored their account to remember to restore their sites manually.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites?restored=true
* Check the banner and also the banner's responsiveness
* Dismiss the banner and make sure it shows again on refresh (so that we will remember to remind the user to restore their sites every time they've just restored their account)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
