### PR TITLE
Domain management: Create add new mailbox subpage

### DIFF
--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/add-mailbox-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/add-mailbox-header.tsx
@@ -1,0 +1,41 @@
+import { useTranslate } from 'i18n-calypso';
+import NavigationHeader from 'calypso/components/navigation-header';
+import {
+	domainManagementAllEmailRoot,
+	domainManagementOverviewRoot,
+} from 'calypso/my-sites/domains/paths';
+import { CustomHeaderComponentType } from './custom-header-component-type';
+
+const AddMailboxHeader: CustomHeaderComponentType = ( {
+	selectedDomainName,
+	selectedSiteSlug,
+} ) => {
+	const translate = useTranslate();
+	return (
+		<>
+			<NavigationHeader
+				className="navigation-header__breadcrumb"
+				navigationItems={ [
+					{
+						label: selectedDomainName,
+						href: `${ domainManagementOverviewRoot() }/${ selectedDomainName }/${ selectedSiteSlug }`,
+					},
+					{
+						label: 'Emails',
+						href: `${ domainManagementAllEmailRoot() }/${ selectedDomainName }/${ selectedSiteSlug }`,
+					},
+					{
+						label: translate( 'Add new mailbox' ),
+					},
+				] }
+			/>
+			<NavigationHeader
+				className="navigation-header__title"
+				title={ translate( 'Add new Mailboxes' ) }
+				subtitle={ translate( 'Integrated email solution with powerful features.' ) }
+			/>
+		</>
+	);
+};
+
+export default AddMailboxHeader;

--- a/client/my-sites/domains/domain-management/subpage-wrapper/index.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/index.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { domainManagementAllOverview } from 'calypso/my-sites/domains/paths';
 import { getSubpageParams } from './subpages';
@@ -15,7 +16,7 @@ const SubpageWrapper = ( { children, subpageKey, siteName, domainName }: Subpage
 
 	if ( CustomHeader ) {
 		return (
-			<div className="subpage-wrapper">
+			<div className={ clsx( 'subpage-wrapper', `subpage-wrapper--${ subpageKey }` ) }>
 				<CustomHeader
 					selectedDomainName={ domainName }
 					selectedSiteSlug={ siteName }
@@ -38,7 +39,7 @@ const SubpageWrapper = ( { children, subpageKey, siteName, domainName }: Subpage
 		];
 
 		return (
-			<div className="subpage-wrapper">
+			<div className={ clsx( 'subpage-wrapper', `subpage-wrapper--${ subpageKey }` ) }>
 				<NavigationHeader
 					className="subpage-wrapper__header"
 					navigationItems={ breadcrumbItems }

--- a/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
@@ -167,7 +167,7 @@
 	&.subpage-wrapper--add-mailbox {
 		.card-heading.new-mailbox-list__numbered-heading,
 		.section-header__label {
-			color: var(--studio-gray-100);
+			color: $studio-gray-100;
 			font-size: 1rem;
 			font-weight: 500;
 			margin-bottom: 1rem;
@@ -176,6 +176,21 @@
 		.card.new-mailbox {
 			border-radius: 4px;
 		}
+
+        .new-mailbox-list__separator {
+            margin-inline: -24px;
+            background: $studio-gray-5;
+        }
+
+        .vertical-nav {
+            .card.is-placeholder:first-child {
+                border-radius: 4px 4px 0 0;
+            }
+
+            .card.is-placeholder:last-child {
+                border-radius: 0 0 4px 4px;
+            }
+        }
 	}
 }
 

--- a/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
@@ -163,6 +163,20 @@
             }
         }
     }
+
+	&.subpage-wrapper--add-mailbox {
+		.card-heading.new-mailbox-list__numbered-heading,
+		.section-header__label {
+			color: var(--studio-gray-100);
+			font-size: 1rem;
+			font-weight: 500;
+			margin-bottom: 1rem;
+		}
+
+		.card.new-mailbox {
+			border-radius: 4px;
+		}
+	}
 }
 
 .is-bulk-all-domains-page .layout__content .main {

--- a/client/my-sites/domains/domain-management/subpage-wrapper/subpages.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/subpages.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import AddForwardingEmailHeader from './headers/add-fowarding-email-header';
+import MailboxHeader from './headers/add-mailbox-header';
 import CompareEmailProvidersHeader from './headers/compare-email-providers';
 import { CustomHeaderComponentType } from './headers/custom-header-component-type';
 import DnsRecordHeader, {
@@ -21,6 +22,7 @@ type SubpageWrapperParamsType = {
 };
 
 // Subpage keys
+export const ADD_MAILBOX = 'add-mailbox';
 export const ADD_FORWARDING_EMAIL = 'add-forwarding-email';
 export const COMPARE_EMAIL_PROVIDERS = 'compare-email-providers';
 export const DNS_RECORDS = 'dns-records';
@@ -62,6 +64,12 @@ const SUBPAGE_TO_PARAMS_MAP: Record< string, SubpageWrapperParamsType > = {
 		subtitleOverride: addDnsRecordsSubtitle,
 		showBreadcrumb: false,
 		context: 'edit',
+	},
+	[ ADD_MAILBOX ]: {
+		CustomHeader: MailboxHeader,
+		showFormHeader: false,
+		showPageHeader: false,
+		customFormHeader: __( 'New mailbox' ),
 	},
 };
 

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -17,6 +17,7 @@ import {
 	EMAIL_MANAGEMENT,
 } from './domain-management/domain-overview-pane/constants';
 import {
+	ADD_MAILBOX,
 	ADD_FORWARDING_EMAIL,
 	COMPARE_EMAIL_PROVIDERS,
 	DNS_RECORDS,
@@ -479,6 +480,18 @@ export default function () {
 		navigation,
 		domainManagementController.domainManagementSubpageParams( EDIT_DNS_RECORD ),
 		domainManagementController.domainManagementDnsEditRecord,
+		domainManagementController.domainManagementSubpageView,
+		domainManagementController.domainDashboardLayout,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		paths.domainManagementAllEmailRoot() + '/:site/titan/new/:domain',
+		siteSelection,
+		navigation,
+		domainManagementController.domainManagementSubpageParams( ADD_MAILBOX ),
+		emailController.emailManagementNewTitanAccount,
 		domainManagementController.domainManagementSubpageView,
 		domainManagementController.domainDashboardLayout,
 		makeLayout,

--- a/client/my-sites/email/add-mailboxes/index.tsx
+++ b/client/my-sites/email/add-mailboxes/index.tsx
@@ -18,6 +18,10 @@ import { GOOGLE_PROVIDER_NAME } from 'calypso/lib/gsuite/constants';
 import { getTitanProductName } from 'calypso/lib/titan';
 import { TITAN_PROVIDER_NAME } from 'calypso/lib/titan/constants';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import {
+	domainManagementAllEmailRoot,
+	isUnderDomainManagementAll,
+} from 'calypso/my-sites/domains/paths';
 import AddEmailAddressesCardPlaceholder from 'calypso/my-sites/email/add-mailboxes/add-users-placeholder';
 import EmailProviderPricingNotice from 'calypso/my-sites/email/add-mailboxes/email-provider-pricing-notice';
 import {
@@ -245,6 +249,7 @@ const MailboxesForm = ( {
 	translate,
 	showFormHeader,
 	customFormHeader,
+	currentRoute,
 }: AddMailboxesAdditionalProps & {
 	emailProduct: ProductListItem | null;
 	goToEmail: () => void;
@@ -318,10 +323,18 @@ const MailboxesForm = ( {
 		recordContinueEvent( { canContinue: true } );
 		setIsAddingToCart( true );
 
+		const selectedSiteSlug = selectedSite?.slug ?? '';
+		let checkoutPath = '/checkout/' + selectedSiteSlug;
+
+		if ( isUnderDomainManagementAll( currentRoute ) ) {
+			const redirectTo = `${ domainManagementAllEmailRoot() }/${ selectedDomainName }/${ selectedSiteSlug }`;
+			checkoutPath += '?redirect_to=' + encodeURIComponent( redirectTo );
+		}
+
 		cartManager
 			.addProductsToCart( [ getCartItems( mailboxOperations.mailboxes, mailProperties ) ] )
 			.then( () => {
-				page( '/checkout/' + selectedSite?.slug ?? '' );
+				page( checkoutPath );
 			} )
 			.finally( () => setIsAddingToCart( false ) )
 			.catch( () => {

--- a/client/my-sites/email/add-mailboxes/index.tsx
+++ b/client/my-sites/email/add-mailboxes/index.tsx
@@ -327,7 +327,8 @@ const MailboxesForm = ( {
 		let checkoutPath = '/checkout/' + selectedSiteSlug;
 
 		if ( isUnderDomainManagementAll( currentRoute ) ) {
-			const redirectTo = `${ domainManagementAllEmailRoot() }/${ selectedDomainName }/${ selectedSiteSlug }`;
+			const newEmail = mailboxOperations.mailboxes[ 0 ].getAsCartItem().email;
+			const redirectTo = `${ domainManagementAllEmailRoot() }/${ selectedDomainName }/${ selectedSiteSlug }?new-email=${ newEmail }`;
 			checkoutPath += '?redirect_to=' + encodeURIComponent( redirectTo );
 		}
 

--- a/client/my-sites/email/add-mailboxes/index.tsx
+++ b/client/my-sites/email/add-mailboxes/index.tsx
@@ -62,6 +62,9 @@ interface AddMailboxesProps {
 	provider?: EmailProvider;
 	selectedDomainName: string;
 	source?: string;
+	showPageHeader?: boolean;
+	showFormHeader?: boolean;
+	customFormHeader?: boolean;
 }
 
 interface AddMailboxesAdditionalProps {
@@ -75,6 +78,9 @@ interface AddMailboxesAdditionalProps {
 	selectedSiteId: number | undefined | null;
 	source: string;
 	translate: typeof translate;
+	showPageHeader?: boolean;
+	showFormHeader?: boolean;
+	customFormHeader?: boolean;
 }
 
 const isTitan = ( provider: EmailProvider ): boolean => provider === EmailProvider.Titan;
@@ -83,6 +89,9 @@ const useAdditionalProps = ( {
 	provider = EmailProvider.Titan,
 	selectedDomainName,
 	source = '',
+	showPageHeader = true,
+	showFormHeader = true,
+	customFormHeader,
 }: AddMailboxesProps ): AddMailboxesAdditionalProps => {
 	const selectedSite = useSelector( getSelectedSite );
 	const selectedSiteId = selectedSite?.ID;
@@ -117,6 +126,9 @@ const useAdditionalProps = ( {
 		selectedSiteId,
 		source,
 		translate,
+		showPageHeader,
+		showFormHeader,
+		customFormHeader,
 	};
 };
 
@@ -231,6 +243,8 @@ const MailboxesForm = ( {
 	selectedSite,
 	source,
 	translate,
+	showFormHeader,
+	customFormHeader,
 }: AddMailboxesAdditionalProps & {
 	emailProduct: ProductListItem | null;
 	goToEmail: () => void;
@@ -317,9 +331,14 @@ const MailboxesForm = ( {
 
 	return (
 		<>
-			<SectionHeader label={ translate( 'Add New Mailboxes' ) } />
+			{ showFormHeader && <SectionHeader label={ translate( 'Add New Mailboxes' ) } /> }
 
-			<Card>
+			<Card className="new-mailbox">
+				{ !! customFormHeader && (
+					<div className="section-header__label">
+						<span className="section-header__label-text">{ customFormHeader }</span>
+					</div>
+				) }
 				<NewMailBoxList
 					areButtonsBusy={ isAddingToCart || isValidating }
 					hiddenFieldNames={ hiddenFieldNames }
@@ -354,6 +373,7 @@ const AddMailboxes = ( props: AddMailboxesProps ): JSX.Element | null => {
 		selectedSite,
 		source,
 		translate,
+		showPageHeader,
 	} = additionalProps;
 
 	const emailProduct = useSelector( ( state ) =>
@@ -396,9 +416,14 @@ const AddMailboxes = ( props: AddMailboxesProps ): JSX.Element | null => {
 			<Main wideLayout>
 				<DocumentHead title={ translate( 'Add New Mailboxes' ) } />
 
-				<EmailHeader />
-
-				<HeaderCake onClick={ goToEmail }>{ productName + ': ' + selectedDomainName }</HeaderCake>
+				{ showPageHeader && (
+					<>
+						<EmailHeader />
+						<HeaderCake onClick={ goToEmail }>
+							{ productName + ': ' + selectedDomainName }
+						</HeaderCake>
+					</>
+				) }
 
 				<WithVerificationGate productFamily={ productName } provider={ provider }>
 					<MailboxNotices { ...additionalProps } emailProduct={ emailProduct } />

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -103,6 +103,9 @@ export default {
 					provider={ EmailProvider.Titan }
 					selectedDomainName={ pageContext.params.domain }
 					source={ pageContext.query.source }
+					showPageHeader={ pageContext?.params?.showPageHeader }
+					showFormHeader={ pageContext?.params?.showFormHeader }
+					customFormHeader={ pageContext?.params?.customFormHeader }
 				/>
 			</CalypsoShoppingCartProvider>
 		);

--- a/client/my-sites/email/paths.ts
+++ b/client/my-sites/email/paths.ts
@@ -126,7 +126,15 @@ export const getNewTitanAccountPath: EmailPathUtilityFunction = (
 	domainName,
 	relativeTo,
 	urlParameters
-) => getPath( siteName, domainName, 'titan/new', relativeTo, urlParameters );
+) => {
+	if ( isUnderDomainManagementAll( relativeTo ) ) {
+		return `${ domainsManagementPrefix }/${ domainName }/titan/new/${ siteName }${ buildQueryString(
+			urlParameters
+		) }`;
+	}
+
+	return getPath( siteName, domainName, 'titan/new', relativeTo, urlParameters );
+};
 
 // Retrieves the URL to set up Titan mailboxes
 export const getTitanSetUpMailboxPath: EmailPathUtilityFunction = (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/97822
Closes https://github.com/Automattic/wp-calypso/issues/97826

## Proposed Changes

* Create "Add new mailbox" subpage
* Adjust the current logic to load a new subpage based on context

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Domain Management Revamp project

## Testing Instructions

* Go to `/domains/manage?flags=all-domain-management`
* Select a domain with a created mailbox
* Click on the "Add mailbox" button
* Check if you stay inside the "all-domain-management" context
* Pass the purchase step
* Check if you end up on the mailbox list page

<img width="1025" alt="Screenshot 2024-12-30 at 19 02 12" src="https://github.com/user-attachments/assets/7f4b8897-ed88-4c42-ab0e-7c73370d9125" />

<img width="1025" alt="Screenshot 2024-12-30 at 19 02 28" src="https://github.com/user-attachments/assets/f871348e-9b5f-4515-bbe1-db74b7493af7" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
