### PR TITLE
Notifications: Fix the undo dismiss button

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -600,8 +600,6 @@ $with-sidebar-min-page-width: 1114px;
 		padding: 0 10px;
 		cursor: pointer;
 		user-select: none;
-		display: flex;
-		align-items: center;
 	}
 
 	.error-view {

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -579,6 +579,8 @@ $with-sidebar-min-page-width: 1114px;
 		p {
 			padding-top: 1em;
 			padding-bottom: 1em;
+			display: flex;
+			align-items: center;
 		}
 
 		.wpnc__undo-link {
@@ -594,10 +596,12 @@ $with-sidebar-min-page-width: 1114px;
 
 	.wpnc__close-link {
 		color: var(--color-text-inverted);
-		position: absolute;
-		right: 10px;
+		margin-left: auto;
+		padding: 0 10px;
 		cursor: pointer;
 		user-select: none;
+		display: flex;
+		align-items: center;
 	}
 
 	.error-view {

--- a/apps/notifications/src/panel/templates/undo-list-item.jsx
+++ b/apps/notifications/src/panel/templates/undo-list-item.jsx
@@ -132,8 +132,9 @@ export class UndoListItem extends Component {
 	};
 
 	actImmediately = ( event ) => {
-		if ( event && event.preventDefault ) {
+		if ( event ) {
 			event.preventDefault();
+			event.stopPropagation();
 		}
 		clearTimeout( this.state.undoTimer );
 		this.instance && this.setState( { isVisible: false } );
@@ -174,14 +175,6 @@ export class UndoListItem extends Component {
 		this.instance = ref;
 	};
 
-	hideNotification = ( event ) => {
-		if ( event ) {
-			event.preventDefault();
-		}
-		this.instance && this.setState( { isVisible: false } );
-		clearTimeout( this.state.undoTimer );
-	};
-
 	render() {
 		const actionMessages = {
 			spam: this.props.translate( 'Comment marked as spam' ),
@@ -199,7 +192,7 @@ export class UndoListItem extends Component {
 						{ undo_text }
 					</button>
 					<span className="wpnc__undo-message">{ message }</span>
-					<button className="wpnc__close-link" onClick={ this.hideNotification }>
+					<button className="wpnc__close-link" onClick={ this.actImmediately }>
 						<Gridicon icon="cross" size={ 24 } />
 					</button>
 				</p>

--- a/apps/notifications/src/panel/templates/undo-list-item.jsx
+++ b/apps/notifications/src/panel/templates/undo-list-item.jsx
@@ -174,6 +174,14 @@ export class UndoListItem extends Component {
 		this.instance = ref;
 	};
 
+	hideNotification = ( event ) => {
+		if ( event ) {
+			event.preventDefault();
+		}
+		this.instance && this.setState( { isVisible: false } );
+		clearTimeout( this.state.undoTimer );
+	};
+
 	render() {
 		const actionMessages = {
 			spam: this.props.translate( 'Comment marked as spam' ),
@@ -191,7 +199,7 @@ export class UndoListItem extends Component {
 						{ undo_text }
 					</button>
 					<span className="wpnc__undo-message">{ message }</span>
-					<button className="wpnc__close-link" onClick={ this.actImmediately }>
+					<button className="wpnc__close-link" onClick={ this.hideNotification }>
 						<Gridicon icon="cross" size={ 24 } />
 					</button>
 				</p>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/97784

## Proposed Changes

* Position the dismiss button correctly. Currently it sometimes gets pushed down the page and disappears.
* Close the undo notification, not the panel, when dismiss is clicked.

<img width="410" alt="Screen Shot 2024-12-30 at 12 11 25 PM" src="https://github.com/user-attachments/assets/e803ba1d-362b-44ee-b9d1-947891072d89" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* I noticed this issue when working on the gridicons.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the notifications panel from the admin bar via the bell icon.
* Click on a comment notification (you can add a test one if needed).
* Click to Trash the notification.
* A red undo notification will appear in the list. 
* Check that the Dismiss X is visible on the right.
* Click the Dismiss X.
* The undo notification should close, but not the panel.
* Test on your sandbox: `install-plugin.sh notifications fix/notifications-undo-dismiss`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
