### PR TITLE
fixed styles to address the misalignment of campaign spend

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -1048,11 +1048,11 @@ export default function CampaignItemDetails( props: Props ) {
 													<span className="campaign-item-details__label">
 														{ __( 'Weekly spend' ) }
 													</span>
-													<span className="campaign-item-details__text wp-brand-font">
+													<span className="campaign-item-details__text wp-brand-font align-baseline">
 														{ ! isLoading ? (
 															<>
 																{ weeklySpendFormatted }{ ' ' }
-																<span className="campaign-item-details__details">
+																<span className="campaign-item-details__details no-bottom-margin">
 																	/ { totalBudgetFormatted }
 																</span>
 															</>

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -1039,8 +1039,6 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 			margin-bottom: 24px;
 		}
 
-
-
 		.campaign-item-details__destination {
 			margin-bottom: 24px;
 		}

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -622,6 +622,10 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 
 		}
 
+		.campaign-item-details__text.align-baseline {
+			align-items: baseline;
+		}
+
 		.campaign-item-details__details {
 			color: var(--studio-gray-50);
 			font-size: 0.875rem;
@@ -1034,6 +1038,8 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 		.campaign-item-details__details:not(.no-bottom-margin) {
 			margin-bottom: 24px;
 		}
+
+
 
 		.campaign-item-details__destination {
 			margin-bottom: 24px;


### PR DESCRIPTION


Related to #

2967-gh-tumblr/a8c-dsp

## Proposed Changes
we spotted an issue with the alignment of the texts for evergreen campaign in the weekly spend

before version

![screenshot_2024-12-30_at_10 19 49___am_720](https://github.com/user-attachments/assets/fb22e598-44c4-4cd7-9800-05490566b81e)


after version
![screenshot_2024-12-30_at_6 52 29___pm_720](https://github.com/user-attachments/assets/96cecfa1-574a-4db8-afd8-f1900bc4173e)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

checkout the branch and check an evergreen campaign (also a normal one to make sure we are not breaking anything else)

as I didn't have a recent campaign with stats I just hardcoded some values in the 
client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
file.. 

i used something like that just before the return of the jsx element

```
  const total_budget_used = 35;
  const clicks_total = 25;
  const clickthrough_rate = 1.15;
  const weeklySpend = 11.55;
  const overallSpendingFormatted =  "$14.15"
```
  
  (don't forget to comment out all the original constants so you don't have issues running the app)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
