### PR TITLE
Temporarily disabling migration survey

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -63,7 +63,7 @@ const StepRoute = ( { step, flow, showWooLogo, renderStep, navigate }: StepRoute
 				<>
 					<SignupHeader pageTitle={ flow.title } showWooLogo={ showWooLogo } />
 					{ stepContent }
-					<SurveyManager />
+					<SurveyManager disabled />
 					<StepperPerformanceTrackerStop flow={ flow.name } step={ step.slug } />
 				</>
 			) }

--- a/client/landing/stepper/declarative-flow/internals/components/survery-manager/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/survery-manager/index.tsx
@@ -17,14 +17,11 @@ const MIGRATION_SURVEY_FLOWS = [
 	MIGRATION_SIGNUP_FLOW,
 ];
 
-const SurveyManager = () => {
-	// Temporarily disabled, context: https://a8c.slack.com/archives/C085HCWCEDN/p1735579884005299?thread_ts=1735306693.890579&cid=C085HCWCEDN
-	return null;
-
+const SurveyManager = ( { disabled }: { disabled: boolean } ) => {
 	const { params } = useFlowNavigation();
 	const isEnLocale = useIsEnglishLocale();
 
-	if ( ! params.flow ) {
+	if ( ! params.flow || disabled ) {
 		return null;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/components/survery-manager/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/survery-manager/index.tsx
@@ -18,6 +18,9 @@ const MIGRATION_SURVEY_FLOWS = [
 ];
 
 const SurveyManager = () => {
+	// Temporarily disabled, context: https://a8c.slack.com/archives/C085HCWCEDN/p1735579884005299?thread_ts=1735306693.890579&cid=C085HCWCEDN
+	return null;
+
 	const { params } = useFlowNavigation();
 	const isEnLocale = useIsEnglishLocale();
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1735579884005299/1735306693.890579-slack-C085HCWCEDN

## Proposed Changes

* We have enough data for now and don't need this Migration Survey to be at front of any flow

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The main driver was the new /setup/onboarding flow we're developing
* Turns out we want to further limit this Survey in the future, but keep it disabled for now

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the new http://calypso.localhost:3000/setup/onboarding flow
* Click at `Import or migrate an existing site` and make sure we don't see the survey anymore:

![image](https://github.com/user-attachments/assets/3c28e829-509f-453c-890d-b3f2c1d71ac8)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?