### PR TITLE
Fix Social E2E tests for WoA sites

### DIFF
--- a/packages/calypso-e2e/src/lib/utils/social-connections-manager.ts
+++ b/packages/calypso-e2e/src/lib/utils/social-connections-manager.ts
@@ -20,13 +20,13 @@ export class SocialConnectionsManager {
 	 */
 	get patterns() {
 		return {
-			CONNECTION_TESTS: new RegExp(
-				// The request that deals with connection test results
+			CONNECTION_TESTS_ON_SIMPLE: new RegExp(
+				// The request that deals with connection test results on Simple sites
 				`wpcom/v2/sites/${ this.siteId }/publicize/connection-test-results`
 			),
-			JP_CONNECTION_TESTS: new RegExp(
-				// The request that deals with connection test results via Jetpack
-				`jetpack/v4/publicize/connections\\?test_connections=1`
+			CONNECTION_TESTS_ON_ATOMIC: new RegExp(
+				// The request that deals with connection test results on Atomic sites
+				'wpcom/v2/publicize/connection-test-results'
 			),
 			GET_POST: new RegExp(
 				// The request that gets the post data in the editor
@@ -61,14 +61,18 @@ export class SocialConnectionsManager {
 	 * Whether the URL is the one we want to intercept
 	 */
 	isTargetUrl( url: URL ) {
-		const { GET_POST, POST_AUTOSAVES, CONNECTION_TESTS, JP_CONNECTION_TESTS } = this.patterns;
+		const { GET_POST, POST_AUTOSAVES, CONNECTION_TESTS_ON_SIMPLE, CONNECTION_TESTS_ON_ATOMIC } =
+			this.patterns;
 
 		// We don't want to intercept autosave requests.
 		if ( GET_POST.test( url.pathname ) && ! POST_AUTOSAVES.test( url.pathname ) ) {
 			return true;
 		}
 
-		return CONNECTION_TESTS.test( url.pathname ) || JP_CONNECTION_TESTS.test( url.toString() );
+		return (
+			CONNECTION_TESTS_ON_SIMPLE.test( url.pathname ) ||
+			CONNECTION_TESTS_ON_ATOMIC.test( url.toString() )
+		);
 	}
 
 	/**
@@ -79,44 +83,21 @@ export class SocialConnectionsManager {
 			// Fetch original response.
 			const response = await route.fetch();
 
-			let result = await response.json();
+			const result = await response.json();
 
 			const url = route.request().url();
 
 			if ( this.patterns.GET_POST.test( url ) ) {
 				// For posts, add a test connection to post attributes.
 				result.body.jetpack_publicize_connections.push( ...this.testConnections );
-			} else if ( this.patterns.CONNECTION_TESTS.test( url ) ) {
+			} else if ( this.patterns.CONNECTION_TESTS_ON_SIMPLE.test( url ) ) {
 				// For connection tests, add test connections to the body.
+				// Because the response is an object {"body":[],"status":200,"headers":{}}
 				result.body.push( ...this.testConnections );
-			} else if ( this.patterns.JP_CONNECTION_TESTS.test( url ) ) {
-				// For JP connection tests, add test connections to the result.
-				if ( Array.isArray( result ) ) {
-					result.push( ...this.testConnections );
-				} else {
-					/**
-					 * It's possible that there are other connections added while these tests are running.
-					 * So we need to merge them.
-					 *
-					 * Since useAdminUiV1 flag is not activated on Atomic sites,
-					 * the result is still in weird format, thus we need to convert to
-					 *	{
-					 *		"tumblr": {
-					 *			"25481710": {
-					 *				"display_name": "Untitled",
-					 *				...
-					 *			}
-					 *		}
-					 *	}
-					 */
-					result = this.testConnections.reduce( ( acc, cnxn ) => {
-						acc[ cnxn.service_name ] = acc[ cnxn.service_name ] || {};
-
-						acc[ cnxn.service_name ][ cnxn.connection_id ] = cnxn;
-
-						return acc;
-					}, result );
-				}
+			} else if ( this.patterns.CONNECTION_TESTS_ON_ATOMIC.test( url ) ) {
+				// For Atomic connection tests, add test connections directly to the result.
+				// because the response is already an array.
+				result.push( ...this.testConnections );
 			}
 
 			await route.fulfill( {
@@ -139,8 +120,8 @@ export class SocialConnectionsManager {
 	async waitForConnectionTests() {
 		await this.page.waitForResponse( ( response ) => {
 			return (
-				this.patterns.CONNECTION_TESTS.test( response.url() ) ||
-				this.patterns.JP_CONNECTION_TESTS.test( response.url() )
+				this.patterns.CONNECTION_TESTS_ON_SIMPLE.test( response.url() ) ||
+				this.patterns.CONNECTION_TESTS_ON_ATOMIC.test( response.url() )
 			);
 		} );
 	}


### PR DESCRIPTION
Following https://github.com/Automattic/jetpack/pull/40732, the Social connection test paths were updated for WoA sites and as a result, the E2E tests were failing for Atomic sites after the last Atomic release of Jetpack.

Now that Atomic sites use that WPCOM endpoint for Social connection tests, we just need to update the same in E2E tests

## Proposed Changes

* Update the connection test API path for E2E tests for Atomic sites 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Just verify that CI is happy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
