### PR TITLE
Help Center: Add site domain to HC doc /plans link

### DIFF
--- a/packages/data-stores/src/help-center/types.ts
+++ b/packages/data-stores/src/help-center/types.ts
@@ -24,6 +24,7 @@ export interface HelpCenterSite {
 	ID: number | string;
 	name: string;
 	URL: string;
+	domain: string;
 	plan: Plan;
 	is_wpcom_atomic: boolean;
 	jetpack: boolean;

--- a/packages/help-center/src/hooks/use-content-filter.ts
+++ b/packages/help-center/src/hooks/use-content-filter.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from '@wordpress/element';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 
 const isThisASupportArticleLink = ( href: string ) =>
 	/wordpress\.com(\/\w\w)?(?=\/support\/)|support\.wordpress\.com/.test( href );
@@ -8,6 +9,7 @@ export const useContentFilter = ( node: HTMLDivElement | null ) => {
 	const navigate = useNavigate();
 	const [ searchParams ] = useSearchParams();
 	const link = searchParams.get( 'link' ) || '';
+	const { site } = useHelpCenterContext();
 
 	const filters = useMemo(
 		() => [
@@ -39,6 +41,18 @@ export const useContentFilter = ( node: HTMLDivElement | null ) => {
 
 						navigate( `/post?link=${ element.href }` );
 					};
+				},
+			},
+
+			{
+				pattern: 'a[href*="wordpress.com/plans/"], a[href^="/"]',
+				action: ( element: HTMLAnchorElement ) => {
+					const href = element.getAttribute( 'href' ) as string;
+					const currentSiteDomain = site?.domain;
+
+					if ( currentSiteDomain ) {
+						element.setAttribute( 'href', new URL( `${ href + currentSiteDomain }` ).href );
+					}
 				},
 			},
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/wp-calypso/issues/96391

## Proposed Changes

* Add site domain to `/plans` link in Help Center

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Easier navigation to the plans page for the site in the context for users from the Help Center
* Previously, it loaded the `/sites` before navigating to `/plan` for a site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Open the help center, access the `Upgrade Your Plan` support document, and Click on the `Upgrades → Plans` link.
* Verify you're redirected to the `/plans` for the current site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
