### PR TITLE
Stats: add locations module scaffolding using country views as a base

### DIFF
--- a/client/my-sites/stats/features/modules/stats-locations/index.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './stats-locations';

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -1,0 +1,212 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
+import { SimplifiedSegmentedControl, StatsCard } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { mapMarker } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import React, { useState } from 'react';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import { useShouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
+import { QueryStatsParams } from 'calypso/my-sites/stats/hooks/utils';
+import StatsListCard from 'calypso/my-sites/stats/stats-list/stats-list-card';
+import StatsModulePlaceholder from 'calypso/my-sites/stats/stats-module/placeholder';
+import statsStrings from 'calypso/my-sites/stats/stats-strings';
+import { useSelector } from 'calypso/state';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsNormalizedData,
+} from 'calypso/state/stats/lists/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
+import { SUPPORT_URL, JETPACK_SUPPORT_URL_TRAFFIC } from '../../../const';
+import Geochart from '../../../geochart';
+import StatsCardSkeleton from '../shared/stats-card-skeleton';
+import StatsInfoArea from '../shared/stats-info-area';
+import type { StatsStateProps } from '../types';
+
+import './style.scss';
+
+const OPTION_KEYS = {
+	COUNTRIES: 'countries',
+	REGIONS: 'regions',
+	CITIES: 'cities',
+};
+
+type SelectOptionType = {
+	label: string;
+	value: string;
+};
+
+interface StatsModuleLocationsProps {
+	query: QueryStatsParams;
+	summaryUrl?: string;
+}
+
+const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summaryUrl } ) => {
+	const { locations: moduleStrings } = statsStrings();
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const statType = 'statsCountryViews';
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	const supportUrl = isOdysseyStats ? JETPACK_SUPPORT_URL_TRAFFIC : SUPPORT_URL;
+
+	// Use StatsModule to display paywall upsell.
+	const shouldGateStatsModule = useShouldGateStats( statType );
+
+	const isRequestingData = useSelector( ( state: StatsStateProps ) =>
+		isRequestingSiteStatsForQuery( state, siteId, statType, query )
+	);
+	const data = useSelector( ( state ) =>
+		getSiteStatsNormalizedData( state, siteId, statType, query )
+	) as [ id: number, label: string ];
+
+	const [ selectedOption, setSelectedOption ] = useState( OPTION_KEYS.COUNTRIES );
+	const optionLabels = {
+		[ OPTION_KEYS.COUNTRIES ]: {
+			selectLabel: translate( 'Countries' ),
+			headerLabel: translate( 'Top countries' ),
+			analyticsId: 'countries',
+		},
+		[ OPTION_KEYS.REGIONS ]: {
+			selectLabel: translate( 'Regions' ),
+			headerLabel: translate( 'Top regions' ),
+			analyticsId: 'regions',
+		},
+		[ OPTION_KEYS.CITIES ]: {
+			selectLabel: translate( 'Cities' ),
+			headerLabel: translate( 'Top cities' ),
+			analyticsId: 'cities',
+		},
+	};
+
+	const changeViewButton = ( selection: SelectOptionType ) => {
+		const filter = selection.value;
+
+		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
+		recordTracksEvent( `${ event_from }_locations_module_menu_clicked`, {
+			button: optionLabels[ filter ]?.analyticsId ?? filter,
+		} );
+
+		setSelectedOption( filter );
+	};
+
+	const toggleControlComponent = (
+		<SimplifiedSegmentedControl
+			className="stats-module-locations__tabs"
+			options={ Object.entries( optionLabels ).map( ( entry ) => ( {
+				value: entry[ 0 ], // optionLabels key
+				label: entry[ 1 ].selectLabel, // optionLabels object value
+			} ) ) }
+			initialSelected={ selectedOption }
+			// @ts-expect-error TODO: missing TS type
+			onSelect={ changeViewButton }
+		/>
+	);
+
+	const emptyMessage = (
+		<EmptyModuleCard
+			icon={ mapMarker }
+			description={ translate(
+				'Stats on visitors and their {{link}}viewing location{{/link}} will appear here to learn from where you are getting visits.',
+				{
+					comment: '{{link}} links to support documentation.',
+					components: {
+						link: (
+							<a
+								target="_blank"
+								rel="noreferrer"
+								href={ localizeUrl( `${ supportUrl }#countries` ) }
+							/>
+						),
+					},
+					context: 'Stats: Info box label when the Countries module is empty',
+				}
+			) }
+		/>
+	);
+
+	return (
+		<>
+			{ ! shouldGateStatsModule && siteId && statType && (
+				<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
+			) }
+			{ isRequestingData && (
+				<StatsCardSkeleton
+					isLoading={ isRequestingData }
+					title={ moduleStrings.title }
+					type={ 3 }
+					withHero
+				/>
+			) }
+			{ ( ( ! isRequestingData && !! data?.length ) || shouldGateStatsModule ) && (
+				// show data or an overlay
+				<>
+					{ /* @ts-expect-error TODO: Refactor StatsListCard with TypeScript. */ }
+					<StatsListCard
+						title={ moduleStrings.title }
+						titleNodes={
+							<StatsInfoArea>
+								{ translate( 'Stats on visitors and their {{link}}viewing location{{/link}}.', {
+									comment: '{{link}} links to support documentation.',
+									components: {
+										link: (
+											<a
+												target="_blank"
+												rel="noreferrer"
+												href={ localizeUrl( `${ supportUrl }#countries` ) }
+											/>
+										),
+									},
+									context: 'Stats: Link in a popover for Countries module when the module has data',
+								} ) }
+							</StatsInfoArea>
+						}
+						moduleType="countryviews"
+						data={ data }
+						emptyMessage={ emptyMessage }
+						metricLabel={ translate( 'Visitors' ) }
+						loader={ isRequestingData && <StatsModulePlaceholder isLoading={ isRequestingData } /> }
+						splitHeader
+						useShortNumber
+						heroElement={ <Geochart query={ query } skipQuery /> }
+						mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
+						toggleControl={ toggleControlComponent }
+						showMore={
+							summaryUrl
+								? {
+										url: summaryUrl,
+										label:
+											data.length >= 10
+												? translate( 'View all', {
+														context: 'Stats: Button link to show more detailed stats information',
+												  } )
+												: translate( 'View details', {
+														context: 'Stats: Button label to see the detailed content of a panel',
+												  } ),
+								  }
+								: undefined
+						}
+					/>
+				</>
+			) }
+			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (
+				// show empty state
+				<StatsCard
+					title={ translate( 'Locations' ) }
+					isEmpty
+					emptyMessage={ emptyMessage }
+					footerAction={
+						summaryUrl
+							? {
+									url: summaryUrl,
+									label: translate( 'View more' ),
+							  }
+							: undefined
+					}
+				/>
+			) }
+		</>
+	);
+};
+
+export default StatsLocations;

--- a/client/my-sites/stats/features/modules/stats-locations/style.scss
+++ b/client/my-sites/stats/features/modules/stats-locations/style.scss
@@ -1,0 +1,79 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "../../../modernized-mixins";
+
+$break-large-stats-countries: 1280px;
+
+// Countries
+.stats__module-list--traffic {
+	@include segmented-controls;
+	.list-countryviews {
+		.stats-card--hero {
+			padding-bottom: 0;
+
+			.stats-geochart {
+				margin-bottom: 32px;
+
+				&.has-no-data {
+					margin-bottom: 0;
+				}
+			}
+		}
+	}
+
+	@media (min-width: $break-large-stats-countries) {
+
+		.stats__module-wrapper--countryviews .stats-module,
+		.list-countryviews .stats-card__content {
+			display: flex;
+			flex-direction: row;
+			flex-wrap: wrap;
+		}
+
+		.list-countryviews {
+			.stats-card--hero {
+				.stats-geochart {
+					margin-bottom: 0;
+				}
+
+				.stats-geochart.stats-module__placeholder {
+					min-width: 550px;
+				}
+			}
+
+			.stats-card--header-and-body {
+				flex: 1;
+			}
+
+			.stats-card--footer {
+				flex-basis: 100%;
+			}
+
+			.stats-module-locations__tabs {
+				width: 100%;
+
+				.segmented-control__item {
+					flex: 1 1 0;
+				}
+			}
+		}
+	}
+
+	.stats__module-wrapper--countryviews {
+		.module-content-text {
+			grid-column: map-start / list-end;
+			margin-bottom: 24px;
+		}
+
+		.stats-geochart {
+			grid-area: map;
+		}
+
+		.stats__list-wrapper {
+			grid-area: list;
+		}
+
+		.module-content-list:last-child {
+			padding-bottom: 0;
+		}
+	}
+}

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -58,6 +58,7 @@ import StatsModuleDevices, {
 	StatsModuleUpgradeDevicesOverlay,
 } from './features/modules/stats-devices';
 import StatsModuleDownloads from './features/modules/stats-downloads';
+import StatsModuleLocations from './features/modules/stats-locations';
 import StatsModuleReferrers from './features/modules/stats-referrers';
 import StatsModuleSearch from './features/modules/stats-search';
 import StatsModuleTopPosts from './features/modules/stats-top-posts';
@@ -558,13 +559,26 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 								className={ halfWidthModuleClasses }
 							/>
 
-							<StatsModuleCountries
-								moduleStrings={ moduleStrings.countries }
-								period={ props.period }
-								query={ query }
-								summaryUrl={ getStatHref( 'countryviews', query ) }
-								className={ clsx( 'stats__flexible-grid-item--full' ) }
-							/>
+							{ config.isEnabled( 'stats/locations' ) ? (
+								<>
+									<StatsModuleLocations
+										path="countryviews"
+										moduleStrings={ moduleStrings.locations }
+										period={ props.period }
+										query={ query }
+										summaryUrl={ getStatHref( 'countryviews', query ) }
+										className={ clsx( 'stats__flexible-grid-item--full' ) }
+									/>
+								</>
+							) : (
+								<StatsModuleCountries
+									moduleStrings={ moduleStrings.countries }
+									period={ props.period }
+									query={ query }
+									summaryUrl={ getStatHref( 'countryviews', query ) }
+									className={ clsx( 'stats__flexible-grid-item--full' ) }
+								/>
+							) }
 
 							{ /* If UTM if supported display the module or update Jetpack plugin card */ }
 							{ supportsUTMStats && ! isOldJetpack && (

--- a/client/my-sites/stats/stats-strings.js
+++ b/client/my-sites/stats/stats-strings.js
@@ -92,6 +92,32 @@ export default function () {
 		),
 	};
 
+	statsStrings.locations = {
+		title: translate( 'Locations', { context: 'Stats: title of module', textOnly: true } ),
+		item: translate( 'Location', {
+			context: 'Stats: module row header for views by country, region or city.',
+		} ),
+		value: translate( 'Views', {
+			context: 'Stats: module row header for number of views from a country, region or city.',
+		} ),
+		empty: translate(
+			'Stats on visitors and {{link}}their viewing location{{/link}} will appear here.',
+			{
+				comment: '{{link}} links to support documentation.',
+				components: {
+					link: (
+						<a
+							target="_blank"
+							rel="noreferrer"
+							href={ localizeUrl( `${ SUPPORT_URL }#countries` ) }
+						/>
+					),
+				},
+				context: 'Stats: Info box label when the Locations module is empty',
+			}
+		),
+	};
+
 	statsStrings.utm = {
 		title: translate( 'UTM', { context: 'Stats: title of module', textOnly: true } ),
 		item: translate( 'UTM', { context: 'Stats: module row header for UTM module.' } ),

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -20,6 +20,7 @@ import getMediaItem from 'calypso/state/selectors/get-media-item';
 import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { getUpsellModalView } from 'calypso/state/stats/paid-stats-upsell/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import StatsModuleLocations from '../features/modules/stats-locations';
 import StatsModuleUTM from '../features/modules/stats-utm';
 import { StatsGlobalValuesContext } from '../pages/providers/global-provider';
 import DownloadCsv from '../stats-download-csv';
@@ -146,13 +147,23 @@ class StatsSummary extends Component {
 				summaryView = (
 					<Fragment key="countries-summary">
 						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
-						<StatsModuleCountries
-							moduleStrings={ StatsStrings.countries }
-							period={ this.props.period }
-							query={ moduleQuery }
-							summary
-							listItemClassName={ listItemClassName }
-						/>
+						{ isEnabled( 'stats/locations' ) ? (
+							<StatsModuleLocations
+								moduleStrings={ StatsStrings.countries }
+								period={ this.props.period }
+								query={ moduleQuery }
+								summary
+								listItemClassName={ listItemClassName }
+							/>
+						) : (
+							<StatsModuleCountries
+								moduleStrings={ StatsStrings.countries }
+								period={ this.props.period }
+								query={ moduleQuery }
+								summary
+								listItemClassName={ listItemClassName }
+							/>
+						) }
 					</Fragment>
 				);
 				break;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-roadmap/issues/2081

This is a proposal to add foundation code that we could use to start iterating on the new locations module that will enable users to filter stats by countries, regions and cities.

## Proposed Changes

* StatsLocations module component scaffolding using Country module as a base
* Render the new component under the `stats/locations` feature flag

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://github.com/Automattic/jetpack-roadmap/issues/2081

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Calypso Live Branch and pass `?flags=stats/locations` to the URL
* Navigate to stats page
* Ensure you see the new design for the Locations module. Tabs are just mocks for now.

![CleanShot 2024-12-31 at 01 46 48@2x](https://github.com/user-attachments/assets/2d7f9f53-def5-4f72-acc3-7604e0dbffe7)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
