### PR TITLE
Don't show "Your account is being deleted" as the default state

### DIFF
--- a/client/me/account-close/closed.jsx
+++ b/client/me/account-close/closed.jsx
@@ -7,7 +7,7 @@ import { BlankCanvas } from 'calypso/components/blank-canvas';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { restoreAccount } from 'calypso/state/account/actions';
 import { getIsRestoring, getRestoreToken } from 'calypso/state/account/selectors';
-import isAccountClosed from 'calypso/state/selectors/is-account-closed';
+import isAccountDeleting from 'calypso/state/selectors/is-account-deleting';
 
 import './closed.scss';
 
@@ -16,7 +16,7 @@ function AccountDeletedPage() {
 	const dispatch = useDispatch();
 
 	const isRestoring = useSelector( getIsRestoring );
-	const isUserAccountClosed = useSelector( isAccountClosed );
+	const isDeleting = useSelector( isAccountDeleting );
 
 	// restore token is either in the URL or in the reducer
 	const params = new URLSearchParams( window.location.search );
@@ -41,7 +41,7 @@ function AccountDeletedPage() {
 		dispatch( restoreAccount( restoreToken ) );
 	};
 
-	if ( ( ! isUserAccountClosed && ! config.isEnabled( 'me/account-restore' ) ) || ! restoreToken ) {
+	if ( isDeleting ) {
 		return (
 			<BlankCanvas className="account-deleted">
 				<BlankCanvas.Header />

--- a/client/state/account/reducer.js
+++ b/client/state/account/reducer.js
@@ -1,11 +1,24 @@
 import { withStorageKey } from '@automattic/state-utils';
 import {
+	ACCOUNT_CLOSE,
 	ACCOUNT_CLOSE_SUCCESS,
 	ACCOUNT_RESTORE,
 	ACCOUNT_RESTORE_FAILED,
 	ACCOUNT_RESTORE_SUCCESS,
 } from 'calypso/state/action-types';
 import { combineReducers } from 'calypso/state/utils';
+
+export const isDeleting = ( state = false, action ) => {
+	switch ( action.type ) {
+		case ACCOUNT_CLOSE:
+			return true;
+
+		case ACCOUNT_CLOSE_SUCCESS:
+			return false;
+	}
+
+	return state;
+};
 
 export const isClosed = ( state = false, action ) => {
 	switch ( action.type ) {
@@ -41,5 +54,5 @@ export const isRestoring = ( state = false, action ) => {
 	return state;
 };
 
-const combinedReducer = combineReducers( { isClosed, restoreToken, isRestoring } );
+const combinedReducer = combineReducers( { isDeleting, isClosed, restoreToken, isRestoring } );
 export default withStorageKey( 'account', combinedReducer );

--- a/client/state/selectors/is-account-deleting.js
+++ b/client/state/selectors/is-account-deleting.js
@@ -1,0 +1,7 @@
+import { get } from 'lodash';
+
+import 'calypso/state/account/init';
+
+export default function isAccountDeleting( state ) {
+	return get( state, [ 'account', 'isDeleting' ], false );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9460

## Proposed Changes

Update the default screen to be


![default screen@2x](https://github.com/user-attachments/assets/bb2c8aa0-900b-41d2-bc74-f3bcd5edf4f8)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The current default screen is confusing, as it's not really deleting an account.

![deleting@2x](https://github.com/user-attachments/assets/707c7809-e2e9-4432-9d37-6ea57742719e)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Directly go to /me/account/closed
* Should show the new default screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
