### PR TITLE
Fix Woo create account button UI

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1335,7 +1335,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 	.jetpack-connect__action-disclaimer {
 		padding: 0;
-		margin-top: 32px;
+		margin: 32px 0 0 0;
 
 		.button {
 			font-weight: 500;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1542,7 +1542,7 @@ $breakpoint-mobile: 660px;
 
 			.signup-form__passwordless-form-wrapper .logged-out-form__footer {
 				padding: 0;
-				margin-top: 24px;
+				margin: 24px 0 0 0;
 			}
 		}
 


### PR DESCRIPTION
## Proposed Changes

* Fix sign up button UI

## Why are these changes being made?

* Suspected https://github.com/Automattic/wp-calypso/pull/97777 caused a small regression in login UI since the negative margin styles are inherited
<img width="300" alt="image" src="https://github.com/user-attachments/assets/3932336f-2b3e-4dd2-9d06-6710b3075ff1" /><img width="300" alt="image" src="https://github.com/user-attachments/assets/fdd9e55e-2e97-459e-b5b5-d319695efe1b" />


## Testing Instructions

* Run this branch on local environment
* Go to [this link](http://calypso.localhost:3000/start/wpcc/oauth2-user?oauth2_client_id=50916&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D83659f9e8e7483d18f15468eff7fcc0c62c88c879841296d16389e8334eaeb10%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1&woo-passwordless=yes)
* Observe the `Continue` button width aligns with the rest of the form element's width

<img width="500" alt="image" src="https://github.com/user-attachments/assets/461e2c9c-4e0d-4174-8b0e-5d45a0ff1565" />


* Go to [this link](http://calypso.localhost:3000/jetpack/connect/authorize?client_id=240298919&redirect_uri=https%3A%2F%2Ffortunately-surprised-echidna.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fhandler%3Djetpack-connection-webhooks%26action%3Dauthorize%26_wpnonce%3D1a4f7d1826%26redirect%3Dhttps%253A%252F%252Ffortunately-surprised-echidna.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin&state=1&scope=na&user_email=user%40email.com&user_login=ilyasfoo&jp_version=14.2-a.9&secret=na&blogname=Fortunately%20Surprised%20Echidna&site_url=https%3A%2F%2Ffortunately-surprised-echidna.jurassic.ninja&home_url=https%3A%2F%2Ffortunately-surprised-echidna.jurassic.ninja&site_icon=&site_lang=en_US&site_created=2024-12-31%2004%3A30%3A47&allow_site_connection=1&calypso_env=production&source=&_as=wp-cli&locale=en&from=woocommerce-core-profiler&plugin_name=&color_scheme=default&_ui=189375772&_ut=wpcom%3Auser_id&_wp_nonce=c98dc459cb&redirect_after_auth=https%3A%2F%2Ffortunately-surprised-echidna.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-admin&site=https%3A%2F%2Ffortunately-surprised-echidna.jurassic.ninja)
* Observe same fix with the `Continue` button


<img width="500" alt="image" src="https://github.com/user-attachments/assets/08d47eae-131e-44ef-a915-3e4e791ef3ef" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
