### PR TITLE
Update layout container height to full page height in /me pages

### DIFF
--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -20,6 +20,10 @@ body.is-section-me {
 		.layout_primary > div {
 			padding-bottom: 0;
 		}
+
+		.layout__primary > .main {
+			height: calc(100vh - var(--masterbar-height) - var(--content-padding-bottom) - var(--content-padding-top));
+		}
 	}
 
 	.layout__secondary .global-sidebar {

--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -1,3 +1,6 @@
+@import "~@wordpress/base-styles/breakpoints";
+@import "~@wordpress/base-styles/mixins";
+
 body.is-group-me.is-section-help,
 body.is-section-me {
 	background: var(--studio-gray-0);
@@ -22,7 +25,13 @@ body.is-section-me {
 		}
 
 		.layout__primary > .main {
-			height: calc(100vh - var(--masterbar-height) - var(--content-padding-bottom) - var(--content-padding-top));
+			height: calc(100vh - var(--masterbar-height) - var(--content-padding-top));
+		}
+
+		@include break-small {
+			.layout__primary > .main {
+				height: calc(100vh - var(--masterbar-height) - var(--content-padding-bottom) - var(--content-padding-top));
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #96621

## Proposed Changes

* Sets height of the container to full height and content overflows.

| Before | After |
| --- | --- |
| <img width="705" alt="image" src="https://github.com/user-attachments/assets/740ac7bc-1e20-4850-b777-7b8c52e936f7" /> | <img width="705" alt="image" src="https://github.com/user-attachments/assets/e948e9a1-4b05-45b5-933b-783052a1e217" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To make the /me pages consistent with /sites pages

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/me/notifications/comments`
* Verify that container now occupies full height
* Verify scrolling in other /me pages

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
