### PR TITLE
Refactor a8c-for-agencies sites dashboard banner

### DIFF
--- a/client/sites/components/sites-dashboard-banners-manager.tsx
+++ b/client/sites/components/sites-dashboard-banners-manager.tsx
@@ -32,6 +32,10 @@ const SitesDashboardBannersManager = ( {
 		setShowHelpCenter( true );
 	}, [ setShowHelpCenter ] );
 
+	// TODO: refactor banners to use this pattern
+	// Define banners in priority order
+	const banners = [ useRestoreSitesBanner(), useA8CForAgenciesSitesBanner( { sitesCount } ) ];
+
 	if (
 		migrationPendingSitesCount &&
 		migrationPendingSitesCount > 0 &&
@@ -60,16 +64,8 @@ const SitesDashboardBannersManager = ( {
 		);
 	}
 
-	// TODO: refactor banners to use this pattern
-	// Define banner creators in priority order
-	const bannerCreators = [
-		useRestoreSitesBanner,
-		useA8CForAgenciesSitesBanner.bind( null, { sitesCount } ),
-	];
-
 	// Return the first banner that should show
-	for ( const createBanner of bannerCreators ) {
-		const banner = createBanner();
+	for ( const banner of banners ) {
 		if ( banner.shouldShow() ) {
 			return <div className="sites-banner-container">{ banner.render() }</div>;
 		}

--- a/client/sites/components/sites-dashboard-banners-manager.tsx
+++ b/client/sites/components/sites-dashboard-banners-manager.tsx
@@ -1,12 +1,11 @@
-import { Gridicon } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { isCardDismissed } from 'calypso/blocks/dismissible-card/selectors';
 import Banner from 'calypso/components/banner';
+import { useA8CForAgenciesSitesBanner } from './sites-dashboard-banners/use-a8c-for-agencies-sites-banner';
 import { useRestoreSitesBanner } from './sites-dashboard-banners/use-restore-sites-reminder-banner';
 import type { Status } from '@automattic/sites/src/use-sites-list-grouping';
 
@@ -23,7 +22,6 @@ const SitesDashboardBannersManager = ( {
 }: SitesDashboardBannersManagerProps ) => {
 	const { setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
 
-	const showA8CForAgenciesBanner = sitesCount >= 5;
 	const migrationPendingSitesCount = sitesStatuses.find(
 		( status ) => status.name === 'migration-pending'
 	)?.count;
@@ -64,38 +62,17 @@ const SitesDashboardBannersManager = ( {
 
 	// TODO: refactor banners to use this pattern
 	// Define banner creators in priority order
-	const bannerCreators = [ useRestoreSitesBanner ];
+	const bannerCreators = [
+		useRestoreSitesBanner,
+		useA8CForAgenciesSitesBanner.bind( null, { sitesCount } ),
+	];
+
 	// Return the first banner that should show
 	for ( const createBanner of bannerCreators ) {
 		const banner = createBanner();
 		if ( banner.shouldShow() ) {
 			return <div className="sites-banner-container">{ banner.render() }</div>;
 		}
-	}
-
-	if ( showA8CForAgenciesBanner ) {
-		return (
-			<div className="sites-banner-container">
-				<Banner
-					callToAction={ translate( 'Learn more {{icon/}}', {
-						components: {
-							icon: <Gridicon icon="external" />,
-						},
-					} ) }
-					className="sites-banner"
-					description={ translate(
-						"Earn up to 50% revenue share and get volume discounts on WordPress.com hosting when you migrate sites to our platform and promote Automattic's products to clients."
-					) }
-					dismissPreferenceName="dismissible-card-a8c-for-agencies-sites"
-					event="learn-more"
-					horizontal
-					href={ localizeUrl( 'https://wordpress.com/for-agencies?ref=wpcom-sites-dashboard' ) }
-					target="_blank"
-					title={ translate( "Building sites for customers? Here's how to earn more." ) }
-					tracksClickName="calypso_sites_dashboard_a4a_banner_click"
-				/>
-			</div>
-		);
 	}
 
 	return null;

--- a/client/sites/components/sites-dashboard-banners/use-a8c-for-agencies-sites-banner.tsx
+++ b/client/sites/components/sites-dashboard-banners/use-a8c-for-agencies-sites-banner.tsx
@@ -1,0 +1,38 @@
+import { Gridicon } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { translate } from 'i18n-calypso';
+import Banner from 'calypso/components/banner';
+
+export function useA8CForAgenciesSitesBanner( { sitesCount }: { sitesCount: number } ) {
+	const id = 'dismissible-card-a8c-for-agencies-sites';
+
+	return {
+		id,
+		shouldShow() {
+			const showA8CForAgenciesBanner = sitesCount >= 5;
+			return showA8CForAgenciesBanner;
+		},
+		render() {
+			return (
+				<Banner
+					callToAction={ translate( 'Learn more {{icon/}}', {
+						components: {
+							icon: <Gridicon icon="external" />,
+						},
+					} ) }
+					className="sites-banner"
+					description={ translate(
+						"Earn up to 50% revenue share and get volume discounts on WordPress.com hosting when you migrate sites to our platform and promote Automattic's products to clients."
+					) }
+					dismissPreferenceName="dismissible-card-a8c-for-agencies-sites"
+					event="learn-more"
+					horizontal
+					href={ localizeUrl( 'https://wordpress.com/for-agencies?ref=wpcom-sites-dashboard' ) }
+					target="_blank"
+					title={ translate( "Building sites for customers? Here's how to earn more." ) }
+					tracksClickName="calypso_sites_dashboard_a4a_banner_click"
+				/>
+			);
+		},
+	};
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/97845

## Proposed Changes

Refactor `dismissible-card-a8c-for-agencies-sites` to keep logic contained in the banner file.

Production behavior should not change since this is a refactor.
![banner@2x](https://github.com/user-attachments/assets/880bd6c2-4910-4c9f-a5a5-70d9a8a992e2)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the banner refactor that started in https://github.com/Automattic/wp-calypso/pull/97845

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Prerequisites
* you have to have at least five sites to see this banner.
* Make sure that your account preference's `dismissible-card-dismissible-card-a8c-for-agencies-sites` is false to see the banner, you can check at https://developer.wordpress.com/docs/api/console/

![preferences@2x](https://github.com/user-attachments/assets/ec318dfe-4f77-4320-a324-7b6ea0c5fe51)

If it is true, you can set it to false like this:

![preferences@2x](https://github.com/user-attachments/assets/c870276e-085a-472e-a8ff-3b41cdd3c591)


* Go to /sites
* Banner should show
* Dismiss the banner
* Refresh, banner should not show
* Test with an account that has less than 5 sites and banner should not show

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
