### PR TITLE
Stats: Fix applying the saved date range shortcut

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -188,7 +188,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	} = useSelector( ( state ) => getEnvStatsFeatureSupportChecks( state, siteId ) );
 
 	const hasSiteLoadedFeatures = useSelector(
-		( state ) => isWPAdmin && hasLoadedSiteFeatures( state, siteId )
+		( state ) => isWPAdmin || hasLoadedSiteFeatures( state, siteId )
 	);
 
 	const shouldForceDefaultDateRange = useSelector( ( state ) =>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -334,6 +334,25 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		setActiveLegend( period !== 'hour' ? newActiveTab.legendOptions || [] : [] );
 	}, [ chartTab, period, activeTabState, context.query ] );
 
+	useEffect( () => {
+		// Use the stored period if it's different from the current period.
+		const storedPeriod = localStorage.getItem( 'jetpack_stats_stored_period' );
+		if (
+			hasSiteLoadedFeatures &&
+			! shouldForceDefaultPeriod &&
+			// Avoid the infinite redirect loop between single day period and hourly views.
+			period !== 'hour' &&
+			storedPeriod &&
+			storedPeriod !== period
+		) {
+			// TODO: Determine if we need to save the period as it might be a conflict with the drilling down.
+			page.redirect(
+				appendQueryStringForRedirection( `/stats/${ storedPeriod }/${ slug }`, context.query )
+			);
+			return;
+		}
+	}, [ hasSiteLoadedFeatures, shouldForceDefaultPeriod, slug ] ); // eslint-disable-line react-hooks/exhaustive-deps
+
 	// Set up a custom range for the chart.
 	// Dependant on new date range picker controls.
 	let customChartRange = null;
@@ -378,22 +397,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	// If it's single day period, redirect to hourly stats.
 	if ( ! shouldForceDefaultPeriod && period === 'day' && daysInRange === 1 ) {
 		page.redirect( appendQueryStringForRedirection( `/stats/hour/${ slug }`, context.query ) );
-		return;
-	}
-
-	// Use the stored period if it's different from the current period.
-	const storedPeriod = localStorage.getItem( 'jetpack_stats_stored_period' );
-	if (
-		hasSiteLoadedFeatures &&
-		! shouldForceDefaultPeriod &&
-		// Avoid the infinite redirect loop between single day period and hourly views.
-		period !== 'hour' &&
-		storedPeriod &&
-		storedPeriod !== period
-	) {
-		page.redirect(
-			appendQueryStringForRedirection( `/stats/${ storedPeriod }/${ slug }`, context.query )
-		);
 		return;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/97838/files#r1899360056

## Proposed Changes

* Fix the `hasSiteLoadedFeatures` check for Odyssey Stats, which does not request the `features` endpoint.
* Move the saved chart period redirection to run only at the initialization.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix the condition to apply the saved date range shortcut and chart period.
* Fix the timing of redirecting for the saved chart period to avoid breaking the drilling down of clicking on chart bars.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin the change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Launch the date range picker.
* Click on any of the date range shortcuts.
* Reload the page without any query string on the URL.
* Ensure the last time chosen date range shortcut is applied constantly.
* Choose the `Months` period to see monthly chart bars.
* Click on any chart bars to drill down to the daily chart of a certain month.
* Ensure the chart goes to the daily chart instead of being redirected to the last time chosen chart period, `Months`, again.

#### Before the change
https://github.com/user-attachments/assets/2251c778-5f0d-405b-b21e-1e4c8c5e0dbf

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
