### PR TITLE
Goals First: Keep paid domains in the cart when free plan is selected.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -194,7 +194,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 		! isNewHostedSiteCreationFlow( flow ) &&
 		! isSiteAssemblerFlow( flow ) &&
 		! isMigrationSignupFlow( flow );
-	const shouldGoToCheckout = Boolean( planCartItem || mergedDomainCartItems.length );
+	const shouldGoToCheckout = Boolean( planCartItem );
 
 	async function createSite() {
 		if ( isManageSiteFlow ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -48,8 +48,7 @@ export default function PlansStepAdaptor( props: StepProps ) {
 	const coupon = useQuery().get( 'coupon' ) ?? undefined;
 	const { data: defaultDesign } = useStarterDesignBySlug( 'twentytwentyfour' );
 	const [ , isGoalFirstExperiment ] = useGoalsFirstExperiment();
-	const { setDomainCartItem, setDomainCartItems, setSiteUrl, setSelectedDesign, setPendingAction } =
-		useWPDispatch( ONBOARD_STORE );
+	const { setSiteUrl, setSelectedDesign, setPendingAction } = useWPDispatch( ONBOARD_STORE );
 	const { setDesignOnSite } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
 
@@ -137,15 +136,8 @@ export default function PlansStepAdaptor( props: StepProps ) {
 				setStepState( ( mostRecentState = { ...stepState, ...step } ) );
 			} }
 			submitSignupStep={ ( stepInfo ) => {
-				/* The plans step removes paid domains when the user picks a free plan
-				   after picking a paid domain */
-				if ( stepInfo.stepName === 'domains' ) {
-					if ( stepInfo.isPurchasingItem === false ) {
-						setDomainCartItem( undefined );
-						setDomainCartItems( undefined );
-					} else if ( stepInfo.siteUrl ) {
-						setSiteUrl( stepInfo.siteUrl );
-					}
+				if ( stepInfo.stepName === 'domains' && stepInfo.siteUrl ) {
+					setSiteUrl( stepInfo.siteUrl );
 				} else {
 					setStepState( ( mostRecentState = { ...stepState, ...stepInfo } ) );
 				}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/97854

## Proposed Changes
This PR removes the logic that emptied paid domain cart when user choses a free plan but had previously selected a paid domain.

* Keep paid domains in cart when free plan is selected
* Bypass going to checkout if free plan is selected and paid domains are in the cart.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding`
* Go through the flow and select a paid domain
* At the plan step select `start with a free plan` and click `continue with free`
* Verify your site is created and that the paid domain is in the cart on the home page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
