### PR TITLE
January Bump promo: Fix overflow breaking edge case

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/january-bump/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/january-bump/style.scss
@@ -1,7 +1,13 @@
+.swipeable__container{
+	.task.task__january-bump {
+			overflow: visible;
+	}
+}
+
 .task {
 	&.task__january-bump {
 		position: relative;
-
+		overflow: hidden;
 		&::before,
 		&::after {
 			content: "";


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fixes an overflow breaking issue related to a previous PR which breaks the home UI in an edge case.
    *  Related PR: https://github.com/Automattic/wp-calypso/pull/97692

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The home screen breaks when there are no cards visible and the task list below is completed.
![image](https://github.com/user-attachments/assets/7cc044f8-1316-4ad2-807d-404855a13ba2)

* It should look like below
![image](https://github.com/user-attachments/assets/1e4f785c-79b5-4932-802d-b7e69009556b)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a brand new site and on the home screen make sure the January Bump Sale is visible without any issues.
* Now complete the task list below the main cards panel and also hide all other cards in the swipeable card panel as well
* Make sure the UI is not broken

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
