### PR TITLE
January Bump promo: Ensure CTA opens the target LP on same domain

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/january-bump/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/january-bump/index.jsx
@@ -23,6 +23,7 @@ const JanuaryBump = () => {
 			actionUrl={ localizeUrl(
 				'https://wordpress.com/pricing/start-your-someday-project?ref=my-home-card'
 			) }
+			actionTarget="_self"
 			illustration={ januaryBumpIllustration }
 			taskId={ TASK_JANUARY_BUMP }
 		/>

--- a/client/my-sites/customer-home/cards/tasks/january-bump/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/january-bump/index.jsx
@@ -23,7 +23,6 @@ const JanuaryBump = () => {
 			actionUrl={ localizeUrl(
 				'https://wordpress.com/pricing/start-your-someday-project?ref=my-home-card'
 			) }
-			completeOnStart={ false }
 			illustration={ januaryBumpIllustration }
 			taskId={ TASK_JANUARY_BUMP }
 		/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #97874

## Proposed Changes

This ensures the January Bump LP is opened in new tab

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

My home cards with CTA URLs matching the current domain are perceived as rout changes. Adding a `target` ensures they open as separate pages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You'll need to run Calypso from `wordpress.com`
* Go to My Home
* Clicking on the January Bump CTA takes you to the Landing Page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
