### PR TITLE
Remove dot from learn more text to make it uniform

### DIFF
--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -62,7 +62,7 @@ function SubscribersTeam( props: Props ) {
 				navigationItems={ [] }
 				title={ translate( 'Users' ) }
 				subtitle={ translate(
-					'Invite team members to your site and manage their access settings. {{learnMore}}Learn more{{/learnMore}}.',
+					'Invite team members to your site and manage their access settings. {{learnMore}}Learn more{{/learnMore}}',
 					{
 						components: {
 							learnMore: (

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/card-content-wrapper.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/card-content-wrapper.tsx
@@ -17,7 +17,7 @@ export const CardContentWrapper: FunctionComponent< Props > = ( { children, subt
 				subtitle={
 					subtitle ||
 					translate(
-						'Preview and troubleshoot changes before updating your production site. {{a}}Learn more{{/a}}.',
+						'Preview and troubleshoot changes before updating your production site. {{a}}Learn more{{/a}}',
 						{
 							components: {
 								a: <InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #96627

## Proposed Changes

<img width="500" alt="image" src="https://github.com/user-attachments/assets/04afe9ad-2391-4d30-8504-f60cfab84c59" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/0f370762-3bae-4815-80ec-eaf7e154ace3" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To make labeling consistent across the Ui.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify Users page in wp-admin
* Verify in `/staging-site/:site`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
