### PR TITLE
Sites Dashboard: Add margin-top to banner

### DIFF
--- a/client/sites/components/dotcom-style.scss
+++ b/client/sites/components/dotcom-style.scss
@@ -34,7 +34,7 @@
 		box-sizing: border-box;
 		display: flex;
 		justify-content: center;
-		margin: 0 auto;
+		margin: 16px auto 0;
 		padding-inline: 48px;
 		width: 100%;
 	}

--- a/client/sites/components/dotcom-style.scss
+++ b/client/sites/components/dotcom-style.scss
@@ -34,12 +34,13 @@
 		box-sizing: border-box;
 		display: flex;
 		justify-content: center;
-		margin: 16px auto 0;
+		margin: 24px auto 8px;
 		padding-inline: 48px;
 		width: 100%;
 	}
 
 	.sites-banner {
+		margin: 0;
 		width: 100%;
 
 		.banner__action {


### PR DESCRIPTION
## Proposed Changes

This PR fixes an issue where the banner is rendered to close to the Sites Dashboard header border.

| Before | After |
| --- | --- |
| ![Screenshot 2025-01-02 at 10 55 35 AM](https://github.com/user-attachments/assets/99d9a1ce-3dc7-41cc-9d06-f09bb2a66aa0) | ![Screenshot 2025-01-02 at 10 55 26 AM](https://github.com/user-attachments/assets/6a2b017a-223b-4c09-a51a-24d2503c1e04) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Contributes to the overall polish of WordPress.com.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /sites
* Ensure that the banner margin is updated as shown above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
