### PR TITLE
Update social-logos to the latest version

### DIFF
--- a/client/components/social-logo/social-logos.d.ts
+++ b/client/components/social-logo/social-logos.d.ts
@@ -1,4 +1,0 @@
-declare module 'social-logos/svg-sprite/social-logos.svg' {
-	const def: string;
-	export = def;
-}

--- a/client/package.json
+++ b/client/package.json
@@ -200,7 +200,7 @@
 		"redux-dynamic-middlewares": "^2.2.0",
 		"redux-thunk": "^3.1.0",
 		"regenerator-runtime": "^0.13.9",
-		"social-logos": "^2.5.9",
+		"social-logos": "^3.1.15",
 		"source-map-support": "^0.5.19",
 		"store": "^2.0.12",
 		"striptags": "^3.1.1",

--- a/client/package.json
+++ b/client/package.json
@@ -200,7 +200,7 @@
 		"redux-dynamic-middlewares": "^2.2.0",
 		"redux-thunk": "^3.1.0",
 		"regenerator-runtime": "^0.13.9",
-		"social-logos": "^3.1.15",
+		"social-logos": "^3.1.16",
 		"source-map-support": "^0.5.19",
 		"store": "^2.0.12",
 		"striptags": "^3.1.1",

--- a/packages/wpcom-template-parts/package.json
+++ b/packages/wpcom-template-parts/package.json
@@ -34,7 +34,7 @@
 		"@automattic/i18n-utils": "workspace:^",
 		"@wordpress/url": "^4.8.0",
 		"i18n-calypso": "workspace:^",
-		"social-logos": "^3.1.15"
+		"social-logos": "^3.1.16"
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",

--- a/packages/wpcom-template-parts/package.json
+++ b/packages/wpcom-template-parts/package.json
@@ -34,11 +34,10 @@
 		"@automattic/i18n-utils": "workspace:^",
 		"@wordpress/url": "^4.8.0",
 		"i18n-calypso": "workspace:^",
-		"social-logos": "^2.5.2"
+		"social-logos": "^3.1.15"
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"@types/social-logos": "^2.3.1",
 		"typescript": "^5.3.3"
 	},
 	"peerDependencies": {

--- a/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
@@ -9,7 +9,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useLayoutEffect, useState } from 'react';
-import SocialLogo from 'social-logos';
+import { SocialLogo } from 'social-logos';
 import { AutomatticBrand, getAutomatticBrandingNoun } from '../utils';
 import type { FooterProps, PureFooterProps, LanguageOptions } from '../types';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2274,7 +2274,7 @@ __metadata:
     "@automattic/i18n-utils": "workspace:^"
     "@wordpress/url": "npm:^4.8.0"
     i18n-calypso: "workspace:^"
-    social-logos: "npm:^3.1.15"
+    social-logos: "npm:^3.1.16"
     typescript: "npm:^5.3.3"
   peerDependencies:
     "@wordpress/data": ^10.8.0
@@ -13120,7 +13120,7 @@ __metadata:
     redux-mock-store: "npm:^1.5.5"
     redux-thunk: "npm:^3.1.0"
     regenerator-runtime: "npm:^0.13.9"
-    social-logos: "npm:^3.1.15"
+    social-logos: "npm:^3.1.16"
     source-map-support: "npm:^0.5.19"
     store: "npm:^2.0.12"
     stream-browserify: "npm:^3.0.0"
@@ -30858,9 +30858,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"social-logos@npm:^3.1.15":
-  version: 3.1.15
-  resolution: "social-logos@npm:3.1.15"
+"social-logos@npm:^3.1.16":
+  version: 3.1.16
+  resolution: "social-logos@npm:3.1.16"
   dependencies:
     prop-types: "npm:^15.8.1"
     react: "npm:18.3.1"
@@ -30868,7 +30868,7 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 7f4b23f3b28567e4744ccd7aea9a51c392f9540553a4813c0e52760709e6156ba8f1615ac4a62213d4217c5b9c11eb7e9345cf2cb5b1ccd058cf6f92377465e2
+  checksum: 6fdd785b981b0581992897513d0785d8501f6f8f0d1555cabea274fb5b02d1544cdb74203897a0edbf5074220c50afc642262a40d492b54fe9da3b417612fda7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2272,10 +2272,9 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
-    "@types/social-logos": "npm:^2.3.1"
     "@wordpress/url": "npm:^4.8.0"
     i18n-calypso: "workspace:^"
-    social-logos: "npm:^2.5.2"
+    social-logos: "npm:^3.1.15"
     typescript: "npm:^5.3.3"
   peerDependencies:
     "@wordpress/data": ^10.8.0
@@ -8795,15 +8794,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/social-logos@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "@types/social-logos@npm:2.3.1"
-  dependencies:
-    "@types/react": "npm:*"
-  checksum: 1cbeae892b0e6bd770f2aa74dc5d72320e20ecb4125899f1cda5c17cb2d5863c02adc157fc7a1acb8e961814bdb973134bf56c61c3f1c8ffa4f2bbb67c517210
-  languageName: node
-  linkType: hard
-
 "@types/sockjs@npm:^0.3.33":
   version: 0.3.36
   resolution: "@types/sockjs@npm:0.3.36"
@@ -13130,7 +13120,7 @@ __metadata:
     redux-mock-store: "npm:^1.5.5"
     redux-thunk: "npm:^3.1.0"
     regenerator-runtime: "npm:^0.13.9"
-    social-logos: "npm:^2.5.9"
+    social-logos: "npm:^3.1.15"
     source-map-support: "npm:^0.5.19"
     store: "npm:^2.0.12"
     stream-browserify: "npm:^3.0.0"
@@ -28053,7 +28043,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18.2.0, react-dom@npm:^18.3.0, react-dom@npm:^18.3.1":
+"react-dom@npm:18.3.1, react-dom@npm:^18.2.0, react-dom@npm:^18.3.0, react-dom@npm:^18.3.1":
   version: 18.3.1
   resolution: "react-dom@npm:18.3.1"
   dependencies:
@@ -28424,7 +28414,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^18.0, react@npm:^18.2.0, react@npm:^18.3.0, react@npm:^18.3.1":
+"react@npm:18.3.1, react@npm:^18.0, react@npm:^18.2.0, react@npm:^18.3.0, react@npm:^18.3.1":
   version: 18.3.1
   resolution: "react@npm:18.3.1"
   dependencies:
@@ -30868,14 +30858,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"social-logos@npm:^2.5.2, social-logos@npm:^2.5.9":
-  version: 2.5.9
-  resolution: "social-logos@npm:2.5.9"
+"social-logos@npm:^3.1.15":
+  version: 3.1.15
+  resolution: "social-logos@npm:3.1.15"
   dependencies:
-    prop-types: "npm:^15.5.7"
+    prop-types: "npm:^15.8.1"
+    react: "npm:18.3.1"
+    react-dom: "npm:18.3.1"
   peerDependencies:
-    react: 15 - 18
-  checksum: 1f730f147b31ad9902b47bb03f32647ec5e3d131049e735758509be43870c8b2e17e9a93dfb20230e656314673f57fc10fcc62b220a13e65c83af6841b38f02f
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: 7f4b23f3b28567e4744ccd7aea9a51c392f9540553a4813c0e52760709e6156ba8f1615ac4a62213d4217c5b9c11eb7e9345cf2cb5b1ccd058cf6f92377465e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`social-logos` now has built-in TypeScript support and thus we don't need to have any declaration files for augmentation. Also, the default import from the package has been [deprecated](https://github.com/Automattic/jetpack/pull/40801) in favour of named import.

## Proposed Changes

* Update `social-logos` to the latest version
* Replace the deprecated default import with named import

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* `social-logos` dependency is outdated

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Goto a UI where social-logos are used, e.g. `/marketing/connections/:site`
* Verify that the social icons for the services are fine.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

<img width="521" alt="Screenshot 2025-01-02 at 9 54 54 AM" src="https://github.com/user-attachments/assets/9de53ecb-957b-426f-a67f-387b53e62e7e" />
