### PR TITLE
Enable me/account-restore flag up to staging

### DIFF
--- a/client/me/account-close/closed.jsx
+++ b/client/me/account-close/closed.jsx
@@ -80,6 +80,7 @@ function AccountDeletedPage() {
 						{ translate( 'Return to WordPress.com' ) }
 					</Button>
 					{ config.isEnabled( 'me/account-restore' ) &&
+						restoreToken &&
 						( isRestoring ? (
 							<div className="account-deleted__restoring">
 								<Spinner />

--- a/config/development.json
+++ b/config/development.json
@@ -146,6 +146,7 @@
 		"marketplace-test": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
+		"me/account-restore": true,
 		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -93,6 +93,7 @@
 		"marketplace-reviews-notification": false,
 		"marketplace-test": false,
 		"me/account/color-scheme-picker": true,
+		"me/account-restore": true,
 		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -118,6 +118,7 @@
 		"marketplace-test": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
+		"me/account-restore": true,
 		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -114,6 +114,7 @@
 		"marketplace-test": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
+		"me/account-restore": true,
 		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7817

## Proposed Changes

* Enable `me/account-restore` flag for testing

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /me/account/close and delete the account
* On the account deleted page, you can see the restore account button

![restore@2x](https://github.com/user-attachments/assets/c7f03047-da5f-4b69-b5b3-c4196c04323f)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
