### PR TITLE
Stats: Record track events for date range navigation

### DIFF
--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import clsx from 'clsx';
 import { localize, withRtl } from 'i18n-calypso';
@@ -140,6 +141,13 @@ class StatsPeriodNavigation extends PureComponent {
 
 	handleArrowNavigation = ( previousOrNext = false ) => {
 		const { moment, period, slug, dateRange } = this.props;
+
+		const isWPAdmin = config.isEnabled( 'is_odyssey' );
+		const event_from = isWPAdmin ? 'jetpack_odyssey' : 'calypso';
+		recordTracksEvent( `${ event_from }_stats_date_range_navigation`, {
+			range_in_days: dateRange.daysInRange,
+			direction: previousOrNext ? 'previous' : 'next',
+		} );
 
 		const navigationStart = moment( dateRange.chartStart );
 		const navigationEnd = moment( dateRange.chartEnd );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1HpG7-vox-p2#measure-success

## Proposed Changes

* Record the track events when users operate navigation between date ranges to measure usage for improvement.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* p1HpG7-vox-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Launch the date range picker.
* Apply a date range under 30 days.
* Click on the date range navigation arrows.

<img width="1308" alt="截圖 2025-01-02 晚上9 55 12" src="https://github.com/user-attachments/assets/fd251e72-10b3-4bc6-8476-4fccc377b9f0" />

* Open the browser developer console > Network tab.
* Ensure the track event `calypso_stats_date_range_navigation` is sent with parameter `range_in_days` and `direction`.

<img width="667" alt="截圖 2025-01-02 晚上9 53 38" src="https://github.com/user-attachments/assets/35768c7f-23ca-4ada-91de-72e6852daa18" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?