### PR TITLE
Fixup domain row alignment

### DIFF
--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -31,7 +31,6 @@
 
 	&.domain-product-single-price {
 		justify-content: start;
-		margin-top: 6px;
 	}
 	.is-section-domains & {
 		@include breakpoint-deprecated( ">800px" ) {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -10,6 +10,7 @@
 	}
 
 	.domain-suggestion__content-domain {
+		align-items: center;
 		justify-content: space-between;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

<img width="1641" alt="Screenshot 2025-01-02 at 16 51 44" src="https://github.com/user-attachments/assets/d4bee4a5-ad71-4b4f-a5e5-8e2851e633c1" />


Fixes https://github.com/Automattic/wp-calypso/issues/95251

## Proposed Changes

* Remove margin-top and add align-items: center

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix misaligned domain row

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/setup/onboarding`
* Test alignment on domain row on multiple devices
