### PR TITLE
Subscribers: Update placeholder text when adding subscribers with categories

### DIFF
--- a/packages/subscriber/src/components/add-form/categories-section.tsx
+++ b/packages/subscriber/src/components/add-form/categories-section.tsx
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
 import { Button, Popover, ToggleControl, FormTokenField } from '@wordpress/components';
 import { TokenItem } from '@wordpress/components/build-types/form-token-field/types';
 import { createInterpolateElement, useRef, useState } from '@wordpress/element';
@@ -23,7 +23,8 @@ export const CategoriesSection: React.FC< Props > = ( {
 	setSelectedCategories,
 	isWPCOMSite = false,
 } ) => {
-	const { __ } = useI18n();
+	const { __, hasTranslation } = useI18n();
+	const isEnglishLocale = useIsEnglishLocale();
 	const [ showCategories, setShowCategories ] = useState( false );
 	const [ showInfoPopover, setShowInfoPopover ] = useState( false );
 	const infoButtonRef = useRef< HTMLButtonElement >( null );
@@ -132,7 +133,11 @@ export const CategoriesSection: React.FC< Props > = ( {
 					suggestions={ newsletterCategories.map( ( cat ) => cat.name ) }
 					onChange={ handleCategoryChange }
 					label=""
-					placeholder={ __( 'Search…' ) }
+					placeholder={
+						isEnglishLocale || hasTranslation( 'Type to add categories' )
+							? __( 'Type to add categories' )
+							: __( 'Search…' )
+					}
 				/>
 			) }
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/248

## Proposed Changes

* Change placeholder copy to "Type to add categories"

Before | After
---- | ----
<img width="506" alt="Screen Shot 2025-01-02 at 2 59 20 PM" src="https://github.com/user-attachments/assets/80036cb8-4ef4-48ee-a877-59a6abe98118" /> | <img width="513" alt="Screen Shot 2025-01-02 at 2 58 52 PM" src="https://github.com/user-attachments/assets/e219c650-512d-475b-94d0-ec53ae60c469" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To match the design from pe7F0s-2mg-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start with a site that has categories enabled (/settings/newsletter > Newsletter categories) and at least one category. 
* Head to https://wordpress.com/subscribers/{SITE-URL}
* Click "Add subscribers" button in top right corner
* Click "Add subscribers manually"
* Toggle on Categories.
* Check that the placeholder is "Type to add categories"
* Switch your account to another language
* Check that the placeholder is translated from Search...

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?