### PR TITLE
Subscribers: Update metrics for importing with categories

### DIFF
--- a/packages/subscriber/src/components/add-form/categories-section.tsx
+++ b/packages/subscriber/src/components/add-form/categories-section.tsx
@@ -42,7 +42,7 @@ export const CategoriesSection: React.FC< Props > = ( {
 		recordTracksEvent( 'calypso_subscriber_add_form_categories_change', {
 			site_id: siteId,
 			categories_count: validTokens.length,
-			action: 'added',
+			action: validTokens.length > selectedCategories.length ? 'added' : 'removed',
 		} );
 
 		setSelectedCategories( validTokens );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/248

## Proposed Changes

* Change action prop to "removed" when removing a category (for Tracks event).

<img width="1062" alt="Screen Shot 2025-01-06 at 4 20 52 PM" src="https://github.com/user-attachments/assets/81129099-341e-4766-b443-7290c799dc7d" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve Tracks event.
* I'm also adding the "[Status] Needs Privacy Updates" label because I realized these two Tracks events (`calypso_subscriber_add_form_categories_change` and `calypso_subscriber_add_form_categories_toggle` are new, and I didn't add that label on the previous PR. They're tracked on the Jetpack Cloud Subscribers page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start with a site that has categories enabled (/settings/newsletter > Newsletter categories) and at least one category.
* Head to [https://wordpress.com/subscribers/{SITE-URL}](https://wordpress.com/subscribers/%7BSITE-URL%7D)
* Click "Add subscribers" button in top right corner
* Click "Add subscribers manually"
* Toggle on Categories.
* Add and remove categories from the field and check that the Tracks event `calypso_subscriber_add_form_categories_change` is triggered with the correct action prop (added or removed).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
