### PR TITLE
Checkout: clarify line item sub label for storage add-ons

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -670,12 +670,16 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 	if ( isTieredVolumeSpaceAddon( product ) ) {
 		const productQuantity = product?.quantity ?? 1;
 		const currentQuantity = product?.current_quantity ?? 1;
-		const spaceQuantity = productQuantity > 1 ? productQuantity : currentQuantity;
+		const spaceQuantity = productQuantity > 1 ? productQuantity - currentQuantity : currentQuantity;
 
 		return (
 			<>
 				{ translate( '%(quantity)s GB extra space, %(price)s per year', {
 					args: { quantity: spaceQuantity, price },
+				} ) }
+				<br></br>
+				{ translate( 'Total extra space after purchase: %(totalSpace)s GB', {
+					args: { totalSpace: product.is_renewal ? currentQuantity : productQuantity },
 				} ) }
 			</>
 		);

--- a/packages/wpcom-checkout/test/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/test/checkout-line-items.tsx
@@ -70,4 +70,53 @@ describe( 'LineItemSublabelAndPrice', () => {
 			);
 		} );
 	} );
+
+	describe( 'Tiered Volume Space AddOn', () => {
+		const spaceAddOnProduct = {
+			...getEmptyResponseCartProduct(),
+			product_slug: 'wordpress_com_1gb_space_addon_yearly',
+		};
+
+		test( 'should display correct space quantities for new purchase with current quantity as 0', async () => {
+			const product = {
+				...spaceAddOnProduct,
+				quantity: 50,
+				current_quantity: 0,
+				item_original_subtotal_integer: 1000,
+				is_renewal: false,
+			};
+			const { container } = render( <LineItemSublabelAndPrice product={ product } /> );
+			expect( container.innerHTML ).toEqual(
+				'50 GB extra space, $10 per year<br>Total extra space after purchase: 50 GB'
+			);
+		} );
+
+		test( 'should display correct space quantities for new purchase with current quantity > 0', async () => {
+			const product = {
+				...spaceAddOnProduct,
+				quantity: 100,
+				current_quantity: 50,
+				item_original_subtotal_integer: 1000,
+				is_renewal: false,
+			};
+			const { container } = render( <LineItemSublabelAndPrice product={ product } /> );
+			expect( container.innerHTML ).toEqual(
+				'50 GB extra space, $10 per year<br>Total extra space after purchase: 100 GB'
+			);
+		} );
+
+		test( 'should display correct space quantities for renewal purchase', async () => {
+			const product = {
+				...spaceAddOnProduct,
+				quantity: null,
+				current_quantity: 50,
+				item_original_subtotal_integer: 1000,
+				is_renewal: true,
+			};
+			const { container } = render( <LineItemSublabelAndPrice product={ product } /> );
+			expect( container.innerHTML ).toEqual(
+				'50 GB extra space, $10 per year<br>Total extra space after purchase: 50 GB'
+			);
+		} );
+	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #97229

## Proposed Changes

* Modifies the line item sublabel for storage add-ons to better explain the purchase.

**For a site with no extra space purchased**

| Production | This PR |
|--------|--------|
|<img width="625" alt="Image" src="https://github.com/user-attachments/assets/2ec3cad3-85e1-4a29-80a8-251938255690" /> | <img width="633" alt="Image" src="https://github.com/user-attachments/assets/3b7e4e58-b1c6-4cd7-8b07-7f7a5a280359" /> | 



**For a site with 50GB extra space purchased**
| Production | This PR |
|--------|--------|
|<img width="619" alt="Image" src="https://github.com/user-attachments/assets/b69a11dc-008c-48ad-a4aa-5cb1be142bd3" />|<img width="633" alt="Image" src="https://github.com/user-attachments/assets/1b633a94-2265-49ed-88f3-524dcb81d435" />|

**Renewing a 50GB extra space purchase**
| Production | This PR |
|--------|--------|
|<img width="639" alt="image" src="https://github.com/user-attachments/assets/73656ada-ba82-44a4-a12a-9bcb6fbb6f20" />|<img width="680" alt="image" src="https://github.com/user-attachments/assets/0f7f903b-748d-4800-88ae-aa516c75f27a" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When upgrading from the 50GB storage add-on to the 100GB add-on, the checkout page currently does not explain that the user is purchasing an extra 50GB of storage instead of an extra 100 GB.  However, the subtotal and pro-rated price reflects the user purchasing an additional 50GB instead of replacing their current storage. (See https://github.com/Automattic/wp-calypso/issues/97229#issuecomment-2563172774) This change aligns the line item text to better explain the product being purchased.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/add-ons/<site slug>` for a site without any purchased storage add-ons.
* Click on "Buy add-on" for the 50GB storage add-on.
* On the checkout page, confirm that the line item text matches the screenshot above with the correct price and quantities.
* Purchase the add-on. Go to `/purchases/<site slug>` and renew the storage add-on purchase.
* On the checkout page, confirm that the line item text matches the screenshot above with the correct price and quantities.
* Go to `/add-ons/<site slug>` for the same site.
* Click on "Buy add-on" for the 100GB storage add-on.
* On the checkout page, confirm that the line item text matches the screenshot above with the correct price and quantities.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
