### PR TITLE
Stats: Stop disabling module toggles

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -109,11 +109,6 @@ class StatsNavigation extends Component {
 			}
 		);
 
-		// toggle the visibility of video module itself
-		if ( ! nextProps.hasVideoPress ) {
-			nextProps.pageModuleToggles.videos = false;
-		}
-
 		if (
 			prevState.pageModules !== nextProps.pageModuleToggles ||
 			prevState.availableModuleToggles !== nextProps.availableModuleToggles

--- a/client/blocks/stats-navigation/page-module-toggler.tsx
+++ b/client/blocks/stats-navigation/page-module-toggler.tsx
@@ -80,7 +80,11 @@ export default function PageModuleToggler( {
 								<span>{ toggleItem.label }</span>
 								<FormToggle
 									className="page-modules-settings-toggle-control"
-									checked={ pageModules[ toggleItem.key ] !== false }
+									checked={
+										pageModules[ toggleItem.key ] !== null
+											? pageModules[ toggleItem.key ]
+											: toggleItem.defaultValue
+									}
 									onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) => {
 										onToggleModule( toggleItem.key, event.target.checked );
 									} }

--- a/client/blocks/stats-navigation/page-module-toggler.tsx
+++ b/client/blocks/stats-navigation/page-module-toggler.tsx
@@ -80,10 +80,7 @@ export default function PageModuleToggler( {
 								<span>{ toggleItem.label }</span>
 								<FormToggle
 									className="page-modules-settings-toggle-control"
-									checked={
-										toggleItem.disabled === false && pageModules[ toggleItem.key ] !== false
-									}
-									disabled={ toggleItem.disabled }
+									checked={ pageModules[ toggleItem.key ] !== false }
 									onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) => {
 										onToggleModule( toggleItem.key, event.target.checked );
 									} }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jpop-issues/issues/9408

## Proposed Changes

* Stop disabling toggles until we figure out why `videopress` feature is missing.
* I did have a brief look, and found that we might also want to check to Jetpack module status as well

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* temporary fix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a site without VideoPress plugin
* Ensure the toggle is default to off
* Ensure you can enable the video module

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
