### PR TITLE
Use original backend for DataViews

### DIFF
--- a/client/my-sites/domains/domain-management/dataviews/components/auto-renew-dialog.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/components/auto-renew-dialog.tsx
@@ -1,16 +1,16 @@
 import { SelectDropdown } from '@automattic/components';
+import { PartialDomainData } from '@automattic/data-stores';
 import transformIcon from '@automattic/domains-table/src/bulk-actions-toolbar/transform.svg';
 import { RenderModalProps } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import { DomainData } from '../types';
 import { useDomainsDataViewsContext } from '../use-context';
 
 export const AutoRenewDiolog = ( {
 	items,
 	closeModal,
 	onActionPerformed,
-}: RenderModalProps< DomainData > ) => {
+}: RenderModalProps< PartialDomainData > ) => {
 	const { handleAutoRenew } = useDomainsDataViewsContext();
 	const translate = useTranslate();
 	const [ controlKey, setControlKey ] = useState( 1 );

--- a/client/my-sites/domains/domain-management/dataviews/components/bulk-update-notice.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/components/bulk-update-notice.tsx
@@ -36,7 +36,7 @@ export const BulkUpdateNotice = () => {
 					<Notice
 						key={ job.id }
 						status="is-error"
-						text={ translate( 'Some domain updates were not successful ' ) }
+						text={ translate( 'Some domain updates were not successful.' ) }
 						onDismissClick={ () => handleDismissNotice( job.id ) }
 					>
 						<StatusPopover
@@ -61,7 +61,7 @@ export const BulkUpdateNotice = () => {
 					status="is-success"
 					onDismissClick={ () => handleDismissNotice( job.id ) }
 				>
-					{ translate( 'Bulk domain updates finished successfully ' ) }
+					{ translate( 'Bulk domain updates finished successfully.' ) }
 				</Notice>
 			);
 		} );

--- a/client/my-sites/domains/domain-management/dataviews/dataviews-fields/domain-field.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/dataviews-fields/domain-field.tsx
@@ -1,3 +1,4 @@
+import { PartialDomainData } from '@automattic/data-stores';
 import { PrimaryDomainLabel } from '@automattic/domains-table';
 import { domainInfoContext } from '@automattic/domains-table/src/utils/constants';
 import { getDomainTypeText } from '@automattic/domains-table/src/utils/get-domain-type-text';
@@ -5,24 +6,36 @@ import { domainManagementLink as getDomainManagementLink } from '@automattic/dom
 import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { navigate } from 'calypso/lib/navigate';
-import { DomainData } from '../types';
+import { useDomainsDataViewsContext } from '../use-context';
 
 interface Props {
-	domain: DomainData;
+	domain: PartialDomainData;
 	isAllSitesView: boolean;
 	selectedFeature?: string;
-	openDomainPane?: ( domain: DomainData ) => void;
+	openDomainPane?: ( domain: PartialDomainData ) => void;
 }
 
-const DomainField = ( { domain, isAllSitesView, selectedFeature, openDomainPane }: Props ) => {
+const DomainField = ( {
+	domain: partialDomain,
+	isAllSitesView,
+	selectedFeature,
+	openDomainPane,
+}: Props ) => {
 	const { __ } = useI18n();
 
-	const domainManagementLink = ! domain.processed.isWPCOMDomain
-		? getDomainManagementLink( domain.processed, domain.original.site_slug, true, selectedFeature )
+	const { getFullDomain, getSiteSlug } = useDomainsDataViewsContext();
+
+	const domain = getFullDomain( partialDomain );
+	const siteSlug = getSiteSlug( partialDomain );
+
+	const domainManagementLink = ! partialDomain.wpcom_domain
+		? getDomainManagementLink( partialDomain, siteSlug, true, selectedFeature )
 		: '';
 
-	const domainTypeText = getDomainTypeText( domain.processed, __, domainInfoContext.DOMAIN_ROW );
-	const showPrimaryDomainLabel = ! isAllSitesView && domain.processed.isPrimary;
+	const domainTypeText = domain
+		? getDomainTypeText( domain, __, domainInfoContext.DOMAIN_ROW )
+		: '';
+	const showPrimaryDomainLabel = ! isAllSitesView && domain && domain.isPrimary;
 
 	const onDomainClick = ( event: React.MouseEvent ) => {
 		event.preventDefault();
@@ -43,7 +56,7 @@ const DomainField = ( { domain, isAllSitesView, selectedFeature, openDomainPane 
 		}
 
 		if ( openDomainPane ) {
-			openDomainPane( domain );
+			openDomainPane( partialDomain );
 		} else {
 			navigate( domainManagementLink, openInNewTab );
 		}
@@ -52,7 +65,7 @@ const DomainField = ( { domain, isAllSitesView, selectedFeature, openDomainPane 
 	return (
 		<Button className="domains-dataviews__domain-name-button" onClick={ onDomainClick }>
 			{ showPrimaryDomainLabel && <PrimaryDomainLabel /> }
-			<div className="domains-dataviews__domain-name">{ domain.processed.domain }</div>
+			<div className="domains-dataviews__domain-name">{ partialDomain.domain }</div>
 
 			{ domainTypeText && (
 				<div className="domains-table-row__domain-type-text">{ domainTypeText }</div>

--- a/client/my-sites/domains/domain-management/dataviews/dataviews-fields/domain-status-field.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/dataviews-fields/domain-status-field.tsx
@@ -1,24 +1,35 @@
-import { SiteDetails } from '@automattic/data-stores';
+import { PartialDomainData, SiteDetails } from '@automattic/data-stores';
 import { DomainsTableStatusCell } from '@automattic/domains-table/src/domains-table/domains-table-status-cell';
 import { resolveDomainStatus } from '@automattic/domains-table/src/utils/resolve-domain-status';
 import { useTranslate } from 'i18n-calypso';
-import { DomainData } from '../types';
 import { useDomainsDataViewsContext } from '../use-context';
 
 interface Props {
-	domain: DomainData;
+	domain: PartialDomainData;
 }
 
-const DomainStatusField = ( { domain }: Props ) => {
-	const { sites, domainResults, updatingDomain, domainStatusPurchaseActions } =
-		useDomainsDataViewsContext();
+const DomainStatusField = ( props: Props ) => {
+	const {
+		sites,
+		getSiteSlug,
+		getFullDomain,
+		domainResults,
+		updatingDomain,
+		domainStatusPurchaseActions,
+	} = useDomainsDataViewsContext();
 	const translate = useTranslate();
 
-	const site =
-		sites[ domain.processed.blogId ] && ( sites[ domain.processed.blogId ] as SiteDetails );
-	const pendingUpdates = domainResults.get( domain.processed.domain ) ?? [];
+	const domain = getFullDomain( props.domain );
+	if ( ! domain ) {
+		return <></>;
+	}
 
-	if ( domain.processed.domain === updatingDomain?.domain && updatingDomain?.message ) {
+	const siteSlug = getSiteSlug( props.domain );
+
+	const site = sites[ domain.blogId ] && ( sites[ domain.blogId ] as SiteDetails );
+	const pendingUpdates = domainResults.get( domain.domain ) ?? [];
+
+	if ( domain.domain === updatingDomain?.domain && updatingDomain?.message ) {
 		pendingUpdates.unshift( {
 			created_at: updatingDomain?.created_at,
 			message: updatingDomain?.message,
@@ -27,23 +38,17 @@ const DomainStatusField = ( { domain }: Props ) => {
 	}
 
 	const domainStatus = domain
-		? resolveDomainStatus( domain.processed, {
-				siteSlug: domain.original.site_slug,
+		? resolveDomainStatus( domain, {
+				siteSlug: siteSlug,
 				translate,
 				getMappingErrors: true,
 				currentRoute: window.location.pathname,
-				isPurchasedDomain: domainStatusPurchaseActions?.isPurchasedDomain?.( domain.processed ),
-				isCreditCardExpiring: domainStatusPurchaseActions?.isCreditCardExpiring?.(
-					domain.processed
-				),
+				isPurchasedDomain: domainStatusPurchaseActions?.isPurchasedDomain?.( domain ),
+				isCreditCardExpiring: domainStatusPurchaseActions?.isCreditCardExpiring?.( domain ),
 				onRenewNowClick: () =>
-					domainStatusPurchaseActions?.onRenewNowClick?.(
-						domain.original.site_slug ?? '',
-						domain.processed
-					),
-				monthsUtilCreditCardExpires: domainStatusPurchaseActions?.monthsUtilCreditCardExpires?.(
-					domain.processed
-				),
+					domainStatusPurchaseActions?.onRenewNowClick?.( siteSlug ?? '', domain ),
+				monthsUtilCreditCardExpires:
+					domainStatusPurchaseActions?.monthsUtilCreditCardExpires?.( domain ),
 				isVipSite: site?.is_vip,
 		  } )
 		: null;

--- a/client/my-sites/domains/domain-management/dataviews/dataviews-fields/ssl-status-field.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/dataviews-fields/ssl-status-field.tsx
@@ -1,22 +1,32 @@
+import { PartialDomainData } from '@automattic/data-stores';
 import DomainsTableSslCell from '@automattic/domains-table/src/domains-table/domains-table-ssl-cell';
 import { domainManagementLink as getDomainManagementLink } from '@automattic/domains-table/src/utils/paths';
-import { DomainData } from '../types';
+import { useDomainsDataViewsContext } from '../use-context';
 
 interface Props {
-	domain: DomainData;
+	domain: PartialDomainData;
 }
 
-const SslStatusField = ( { domain }: Props ) => {
-	const domainManagementLink = ! domain.processed.isWPCOMDomain
-		? getDomainManagementLink( domain.processed, domain.original.site_slug, true )
+const SslStatusField = ( props: Props ) => {
+	const { getFullDomain, getSiteSlug } = useDomainsDataViewsContext();
+	const domain = getFullDomain( props.domain );
+
+	if ( ! domain ) {
+		return <></>;
+	}
+
+	const siteSlug = getSiteSlug( props.domain );
+
+	const domainManagementLink = ! domain.isWPCOMDomain
+		? getDomainManagementLink( domain, siteSlug, true )
 		: '';
 
-	const hasWpcomManagedSslCert = domain.processed.type === 'wpcom';
+	const hasWpcomManagedSslCert = domain.type === 'wpcom';
 
 	return (
 		<DomainsTableSslCell
 			domainManagementLink={ domainManagementLink }
-			sslStatus={ domain.processed.sslStatus }
+			sslStatus={ domain.sslStatus }
 			hasWpcomManagedSslCert={ hasWpcomManagedSslCert }
 			as="div"
 		/>

--- a/client/my-sites/domains/domain-management/dataviews/domains-dataviews.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/domains-dataviews.tsx
@@ -1,9 +1,9 @@
+import { PartialDomainData } from '@automattic/data-stores';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import { BulkUpdateNotice } from './components/bulk-update-notice';
-import { DomainData } from './types';
 import { useActions } from './use-actions';
 import { useDomainsDataViewsContext } from './use-context';
 import { getDomainId } from './use-domains';
@@ -12,11 +12,11 @@ import { useFields } from './use-fields';
 import useView, { getFieldsByBreakpoint } from './use-view';
 
 type Props = {
-	domains: DomainData[];
+	domains: PartialDomainData[] | undefined;
 	isLoading: boolean;
 	sidebarMode?: boolean;
 	selectedDomainName?: string;
-	openDomainPane?: ( domain: DomainData ) => void;
+	openDomainPane?: ( domain: PartialDomainData ) => void;
 };
 
 export const DomainsDataViews = ( {
@@ -32,14 +32,13 @@ export const DomainsDataViews = ( {
 	const { view, setView } = useView( { sidebarMode, isDesktop } );
 	const fields = useFields( { openDomainPane } );
 	const actions = useActions( { sidebarMode } );
-
-	const { data: processedDomains, paginationInfo } = useMemo( () => {
-		return filterSortAndPaginate( domains, view, fields );
+	const { data: domainsToDisplay, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( domains || [], view, fields );
 	}, [ domains, view, fields ] );
 
 	const [ selectedIds, setSelectedIds ] = useState< string[] >( [] );
-	const selectedDomain = domains
-		.filter( ( d: DomainData ) => d.processed.domain === selectedDomainName )
+	const selectedDomain = domainsToDisplay
+		.filter( ( d: PartialDomainData ) => d.domain === selectedDomainName )
 		.pop();
 
 	useEffect( () => {
@@ -58,7 +57,7 @@ export const DomainsDataViews = ( {
 		<div className={ clsx( 'domains-dataviews', { 'domains-dataviews-list': sidebarMode } ) }>
 			{ ! sidebarMode && <BulkUpdateNotice /> }
 			<DataViews
-				data={ processedDomains }
+				data={ domainsToDisplay }
 				fields={ fields }
 				onChangeView={ ( newView ) => setView( () => newView ) }
 				view={ view }

--- a/client/my-sites/domains/domain-management/dataviews/types.ts
+++ b/client/my-sites/domains/domain-management/dataviews/types.ts
@@ -3,8 +3,9 @@ import {
 	JobStatus,
 	BulkUpdateVariables,
 	BulkDomainUpdateStatusQueryFnData,
+	PartialDomainData,
 } from '@automattic/data-stores';
-import { DomainData as QueryDomainData } from '@automattic/data-stores/src/queries/use-site-domains-query';
+import { SiteDomainsQueryFnData } from '@automattic/data-stores/src/queries/use-site-domains-query';
 import { DomainStatusPurchaseActions, ResponseDomain } from '@automattic/domains-table';
 import { DomainAction } from '@automattic/domains-table/src/domains-table/domains-table-row-actions';
 import { SiteExcerptData } from '@automattic/sites';
@@ -20,7 +21,7 @@ type DomainActionDescription = {
 /**
  * Utility type for domain action handlers.
  */
-type OnDomainAction = (
+export type OnDomainAction = (
 	action: DomainAction,
 	domain: ResponseDomain
 ) => DomainActionDescription | void;
@@ -40,10 +41,10 @@ interface DomainsDataViewsUpdatingDomain {
  */
 interface BaseDomainsDataViewsProps {
 	className?: string;
-	domains: DomainData[];
+	domains: PartialDomainData[] | undefined;
 	isLoading: boolean;
-	selectedItem: DomainData | null | undefined;
-	openDomainPane?: ( domain: DomainData ) => void;
+	selectedItem: PartialDomainData | null | undefined;
+	openDomainPane?: ( domain: PartialDomainData ) => void;
 	isAllSitesView: boolean;
 	domainStatusPurchaseActions?: DomainStatusPurchaseActions;
 	onDomainAction?: OnDomainAction;
@@ -54,6 +55,9 @@ interface BaseDomainsDataViewsProps {
 	sidebarMode?: boolean;
 	selectedDomainName?: string;
 	selectedFeature?: string;
+	fetchSiteDomains?: (
+		siteIdOrSlug: number | string | null | undefined
+	) => Promise< SiteDomainsQueryFnData >;
 	createBulkAction?: ( variables: BulkUpdateVariables ) => Promise< void >;
 	fetchBulkActionStatus?: () => Promise< BulkDomainUpdateStatusQueryFnData >;
 	deleteBulkActionStatus?: () => Promise< void >;
@@ -72,16 +76,21 @@ export type DomainsDataViewsProps =
  */
 export interface Context {
 	sites: Record< number, SiteExcerptData >;
+	getFullDomain: ( domain: PartialDomainData ) => ResponseDomain | undefined;
+	getSiteSlug: ( domain: PartialDomainData ) => string;
 	isLoadingSites?: boolean;
 	isLoadingDomains?: boolean;
+	fetchSiteDomains?: (
+		siteIdOrSlug: number | string | null | undefined
+	) => Promise< SiteDomainsQueryFnData >;
 	createBulkAction?: ( variables: BulkUpdateVariables ) => Promise< void >;
 	fetchBulkActionStatus?: () => Promise< BulkDomainUpdateStatusQueryFnData >;
 	deleteBulkActionStatus?: () => Promise< void >;
 	isAllSitesView: boolean;
 	domainStatusPurchaseActions?: DomainStatusPurchaseActions;
 	domainsRequiringAttention?: number;
-	handleAutoRenew: ( domains: DomainData[], enable: boolean ) => void;
-	handleUpdateContactInfo: ( domains: DomainData[] ) => void;
+	handleAutoRenew: ( domains: PartialDomainData[], enable: boolean ) => void;
+	handleUpdateContactInfo: ( domains: PartialDomainData[] ) => void;
 	onDomainsRequiringAttentionChange: ( domainsRequiringAttention: number ) => void;
 	completedJobs: JobStatus[];
 	domainResults: Map< string, DomainUpdateStatus[] >;
@@ -91,45 +100,4 @@ export interface Context {
 	userCanSetPrimaryDomains: BaseDomainsDataViewsProps[ 'userCanSetPrimaryDomains' ];
 	isDesktop: boolean;
 	selectedFeature?: string;
-}
-
-/**
- * Extended domain data with additional fields.
- */
-type DomainDataExtension = {
-	site_slug: string;
-	domain_status: {
-		status: string;
-		status_type: string;
-		status_weight: number;
-	};
-};
-
-/**
- * Domain data with extended definition.
- */
-export type QueryDomainExtendedData = QueryDomainData & DomainDataExtension;
-
-/**
- * Domain data with original and processed data.
- */
-export type DomainData = {
-	original: QueryDomainExtendedData;
-	processed: ResponseDomain;
-};
-
-/**
- * Arguments for the domains query.
- */
-export interface DomainsQueryArgs {
-	no_wpcom?: boolean;
-	resolve_status?: boolean;
-	extended_data?: boolean;
-}
-
-/**
- * Data returned by the domains query function.
- */
-export interface DomainsQueryFnData {
-	domains: QueryDomainExtendedData[];
 }

--- a/client/my-sites/domains/domain-management/dataviews/use-actions.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/use-actions.tsx
@@ -1,5 +1,5 @@
 import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
-import { SiteDetails } from '@automattic/data-stores';
+import { PartialDomainData, SiteDetails } from '@automattic/data-stores';
 import { canSetAsPrimary } from '@automattic/domains-table/src/utils/can-set-as-primary';
 import {
 	type as domainTypes,
@@ -24,13 +24,14 @@ import { useTranslate } from 'i18n-calypso';
 import { navigate } from 'calypso/lib/navigate';
 import { domainManagementEditContactInfo } from '../../paths';
 import { AutoRenewDiolog } from './components/auto-renew-dialog';
-import { DomainData } from './types';
 import { useDomainsDataViewsContext } from './use-context';
 
 export function useActions( { sidebarMode }: { sidebarMode?: boolean }, onClose?: () => void ) {
 	const translate = useTranslate();
 	const {
+		getFullDomain,
 		sites,
+		getSiteSlug,
 		isAllSitesView,
 		domainStatusPurchaseActions,
 		updatingDomain,
@@ -39,63 +40,67 @@ export function useActions( { sidebarMode }: { sidebarMode?: boolean }, onClose?
 		handleUpdateContactInfo,
 	} = useDomainsDataViewsContext();
 
-	const actions: Action< DomainData >[] = [
+	const actions: Action< PartialDomainData >[] = [
 		{
 			id: 'manage-domain',
 			isPrimary: true,
 			icon: drawerLeft,
-			label: ( domains: Array< DomainData > ) => {
-				const domain = domains.length > 0 && domains[ 0 ];
-				return domain && domain.processed.type === domainTypes.TRANSFER
+			label: ( domains: Array< PartialDomainData > ) => {
+				const domain = domains.length > 0 && domains[ 0 ] && getFullDomain( domains[ 0 ] );
+				return domain && domain.type === domainTypes.TRANSFER
 					? translate( 'View transfer' )
 					: translate( 'View settings' );
 			},
-			callback: ( domains: Array< DomainData > ) => {
-				const domain = domains[ 0 ];
-				const url = domainManagementLink(
-					domain.processed,
-					domain.original.site_slug,
-					isAllSitesView
-				);
+			callback: ( domains: Array< PartialDomainData > ) => {
+				const domain = domains.length > 0 && domains[ 0 ] && getFullDomain( domains[ 0 ] );
+				if ( ! domain ) {
+					return;
+				}
+				const url = domainManagementLink( domain, getSiteSlug( domains[ 0 ] ), isAllSitesView );
 				navigate( url );
 			},
-			isEligible( domain: DomainData ) {
-				return domain.processed.type !== domainTypes.WPCOM;
+			isEligible( partialDomain: PartialDomainData ) {
+				const domain = getFullDomain( partialDomain );
+				if ( ! domain ) {
+					return false;
+				}
+				return domain.type !== domainTypes.WPCOM;
 			},
 		},
 		{
 			id: 'manage-dns-settings',
-			callback: ( domains: Array< DomainData > ) => {
-				const domain = domains.length > 0 && domains[ 0 ];
+			callback: ( domains: Array< PartialDomainData > ) => {
+				const domain = domains.length > 0 && domains[ 0 ] && getFullDomain( domains[ 0 ] );
 				if ( domain ) {
-					onDomainAction?.( 'manage-dns-settings', domain.processed );
-					const url = domainManagementDNS( domain.original.site_slug, domain.processed.domain );
+					onDomainAction?.( 'manage-dns-settings', domain );
+					const url = domainManagementDNS( getSiteSlug( domains[ 0 ] ), domain.domain );
 					navigate( url );
 				}
 			},
 			label: translate( 'Manage DNS' ),
 			supportsBulk: false,
-			isEligible( domain: DomainData ) {
+			isEligible( partialDomain: PartialDomainData ) {
+				const domain = getFullDomain( partialDomain );
+				if ( ! domain ) {
+					return false;
+				}
 				return (
-					domain.processed.canManageDnsRecords &&
-					domain.processed.transferStatus !== transferStatus.PENDING_ASYNC &&
-					domain.processed.type !== domainTypes.SITE_REDIRECT
+					domain.canManageDnsRecords &&
+					domain.transferStatus !== transferStatus.PENDING_ASYNC &&
+					domain.type !== domainTypes.SITE_REDIRECT
 				);
 			},
 		},
 		{
 			id: 'manage-contact-info',
 			icon: <Icon icon={ info } />,
-			callback: ( domains: Array< DomainData > ) => {
+			callback: ( domains: Array< PartialDomainData > ) => {
 				if ( domains.length === 0 ) {
 					return;
 				}
 				if ( domains.length === 1 ) {
 					const domain = domains[ 0 ];
-					const url = domainManagementEditContactInfo(
-						domain.original.site_slug,
-						domain.processed.domain
-					);
+					const url = domainManagementEditContactInfo( getSiteSlug( domain ), domain.domain );
 					navigate( url );
 				} else {
 					handleUpdateContactInfo( domains );
@@ -103,29 +108,37 @@ export function useActions( { sidebarMode }: { sidebarMode?: boolean }, onClose?
 			},
 			label: translate( 'Manage contact information' ),
 			supportsBulk: ! sidebarMode,
-			isEligible( domain: DomainData ) {
+			isEligible( partialDomain: PartialDomainData ) {
+				const domain = getFullDomain( partialDomain );
+				if ( ! domain ) {
+					return false;
+				}
 				return (
-					domain.processed.currentUserIsOwner &&
-					domain.processed.type === domainTypes.REGISTERED &&
-					( isDomainUpdateable( domain.processed ) || isDomainInGracePeriod( domain.processed ) )
+					domain.currentUserIsOwner &&
+					domain.type === domainTypes.REGISTERED &&
+					( isDomainUpdateable( domain ) || isDomainInGracePeriod( domain ) )
 				);
 			},
 		},
 		{
 			id: 'set-primary-site-address',
-			callback: ( domains: Array< DomainData > ) => {
-				const domain = domains.length > 0 && domains[ 0 ];
+			callback: ( domains: Array< PartialDomainData > ) => {
+				const domain = domains.length > 0 && domains[ 0 ] && getFullDomain( domains[ 0 ] );
 				if ( domain ) {
-					onDomainAction?.( 'set-primary-address', domain.processed );
+					onDomainAction?.( 'set-primary-address', domain );
 					onClose?.();
 				}
 			},
 			label: translate( 'Make primary site address' ),
 			disabled: updatingDomain?.action === 'set-primary-address',
 			supportsBulk: false,
-			isEligible( domain: DomainData ) {
-				const site =
-					sites[ domain.processed.blogId ] && ( sites[ domain.processed.blogId ] as SiteDetails );
+			isEligible( partialDomain: PartialDomainData ) {
+				const domain = getFullDomain( partialDomain );
+				if ( ! domain ) {
+					return false;
+				}
+
+				const site = sites[ domain.blogId ] && ( sites[ domain.blogId ] as SiteDetails );
 				const canSetPrimaryDomainForSite =
 					site?.plan?.features.active.includes( FEATURE_SET_PRIMARY_CUSTOM_DOMAIN ) ?? false;
 				const isSiteOnFreePlan = site?.plan?.is_free ?? true;
@@ -133,26 +146,26 @@ export function useActions( { sidebarMode }: { sidebarMode?: boolean }, onClose?
 				return (
 					! isAllSitesView &&
 					canSetAsPrimary(
-						domain.processed,
-						shouldUpgradeToMakeDomainPrimary( domain.processed, {
-							isDomainOnly: domain.processed.currentUserCanCreateSiteFromDomainOnly,
+						domain,
+						shouldUpgradeToMakeDomainPrimary( domain, {
+							isDomainOnly: domain.currentUserCanCreateSiteFromDomainOnly,
 							canSetPrimaryDomainForSite,
 							userCanSetPrimaryDomains,
 							isSiteOnFreePlan,
 						} )
 					) &&
-					! isRecentlyRegistered( domain.processed.registrationDate )
+					! isRecentlyRegistered( domain.registrationDate )
 				);
 			},
 		},
 		{
 			id: 'transfer-domain',
-			callback: ( domains: Array< DomainData > ) => {
+			callback: ( domains: Array< PartialDomainData > ) => {
 				const domain = domains.length > 0 && domains[ 0 ];
 				if ( domain ) {
 					const url = domainUseMyDomain(
-						domain.original.site_slug,
-						domain.processed.domain,
+						getSiteSlug( domain ),
+						domain.domain,
 						useMyDomainInputMode.transferDomain
 					);
 					navigate( url );
@@ -160,65 +173,70 @@ export function useActions( { sidebarMode }: { sidebarMode?: boolean }, onClose?
 			},
 			label: translate( 'Transfer to WordPress.com' ),
 			supportsBulk: false,
-			isEligible( domain: DomainData ) {
-				return (
-					domain.processed.type === domainTypes.MAPPED &&
-					domain.processed.isEligibleForInboundTransfer
-				);
+			isEligible( partialDomain: PartialDomainData ) {
+				const domain = getFullDomain( partialDomain );
+				if ( ! domain ) {
+					return false;
+				}
+				return domain.type === domainTypes.MAPPED && domain.isEligibleForInboundTransfer;
 			},
 		},
 		{
 			id: 'connect-to-site',
-			callback: ( domains: Array< DomainData > ) => {
+			callback: ( domains: Array< PartialDomainData > ) => {
 				const domain = domains.length > 0 && domains[ 0 ];
 				if ( domain ) {
 					const url = domainManagementTransferToOtherSiteLink(
-						domain.original.site_slug,
-						domain.processed.domain
+						getSiteSlug( domains[ 0 ] ),
+						domain.domain
 					);
 					navigate( url );
 				}
 			},
 			label: translate( 'Attach to an existing site' ),
 			supportsBulk: false,
-			isEligible( domain: DomainData ) {
-				return domain.processed.currentUserCanCreateSiteFromDomainOnly;
+			isEligible( partialDomain: PartialDomainData ) {
+				const domain = getFullDomain( partialDomain );
+				if ( ! domain ) {
+					return false;
+				}
+				return domain.currentUserCanCreateSiteFromDomainOnly;
 			},
 		},
 		{
 			id: 'change-site-address',
-			callback: ( domains: Array< DomainData > ) => {
-				const domain = domains.length > 0 && domains[ 0 ];
+			callback: ( domains: Array< PartialDomainData > ) => {
+				const domain = domains.length > 0 && domains[ 0 ] && getFullDomain( domains[ 0 ] );
 				if ( domain ) {
-					onDomainAction?.( 'change-site-address', domain.processed );
+					onDomainAction?.( 'change-site-address', domain );
 					onClose?.();
 				}
 			},
 			label: translate( 'Change site address' ),
 			supportsBulk: false,
-			isEligible( domain: DomainData ) {
-				const site =
-					sites[ domain.processed.blogId ] && ( sites[ domain.processed.blogId ] as SiteDetails );
+			isEligible( domain: PartialDomainData ) {
+				const site = sites[ domain.blog_id ] && ( sites[ domain.blog_id ] as SiteDetails );
 				const isSimpleSite = ! site?.is_wpcom_atomic;
-				return ! isAllSitesView && isSimpleSite && isFreeUrlDomainName( domain.processed.domain );
+				return ! isAllSitesView && isSimpleSite && isFreeUrlDomainName( domain.domain );
 			},
 		},
 		{
 			id: 'renew-domain',
-			callback: ( domains: Array< DomainData > ) => {
-				const domain = domains.length > 0 && domains[ 0 ];
+			callback: ( domains: Array< PartialDomainData > ) => {
+				const domain = domains.length > 0 && domains[ 0 ] && getFullDomain( domains[ 0 ] );
 				if ( domain ) {
-					domainStatusPurchaseActions?.onRenewNowClick?.(
-						domain.processed.domain ?? '',
-						domain.processed
-					);
+					domainStatusPurchaseActions?.onRenewNowClick?.( domain.domain ?? '', domain );
 					onClose?.();
 				}
 			},
 			label: translate( 'Renew now' ),
 			supportsBulk: false,
-			isEligible( domain: DomainData ) {
-				return isDomainRenewable( domain.processed );
+			isEligible( partialDomain: PartialDomainData ) {
+				const domain = getFullDomain( partialDomain );
+				if ( ! domain ) {
+					return false;
+				}
+				return isDomainRenewable( domain );
 			},
 		},
 		{
@@ -226,8 +244,12 @@ export function useActions( { sidebarMode }: { sidebarMode?: boolean }, onClose?
 			icon: <Icon icon={ update } />,
 			label: translate( 'Manage auto-renew' ),
 			supportsBulk: ! sidebarMode,
-			isEligible( domain: DomainData ) {
-				return isDomainRenewable( domain.processed );
+			isEligible( partialDomain: PartialDomainData ) {
+				const domain = getFullDomain( partialDomain );
+				if ( ! domain ) {
+					return false;
+				}
+				return isDomainRenewable( domain );
 			},
 			RenderModal: ( props ) => <AutoRenewDiolog { ...props } />,
 		},

--- a/client/my-sites/domains/domain-management/dataviews/use-context.ts
+++ b/client/my-sites/domains/domain-management/dataviews/use-context.ts
@@ -1,13 +1,20 @@
 import page from '@automattic/calypso-router';
-import { useDomainsBulkActionsMutation } from '@automattic/data-stores';
+import {
+	PartialDomainData,
+	getSiteDomainsQueryObject,
+	useDomainsBulkActionsMutation,
+} from '@automattic/data-stores';
+import { ResponseDomain } from '@automattic/domains-table';
 import { useDomainBulkUpdateStatus } from '@automattic/domains-table/src/use-domain-bulk-update-status';
+import { createSiteDomainObject } from '@automattic/domains-table/src/utils/assembler';
 import { SiteExcerptData } from '@automattic/sites';
 import { DESKTOP_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
+import { useQueries } from '@tanstack/react-query';
 import { addQueryArgs } from '@wordpress/url';
 import { createContext, useCallback, useContext, useMemo, useState } from 'react';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
-import { Context, DomainData, DomainsDataViewsProps } from './types';
+import { Context, DomainsDataViewsProps } from './types';
 
 export const DomainsDataViewsContext = createContext< Context | undefined >( undefined );
 
@@ -16,6 +23,7 @@ export const useDomainsDataViewsContext = () => useContext( DomainsDataViewsCont
 export const useGenerateDomainsDataViewsState = ( props: DomainsDataViewsProps ) => {
 	const {
 		domains: allDomains,
+		fetchSiteDomains,
 		createBulkAction,
 		fetchBulkActionStatus,
 		deleteBulkActionStatus,
@@ -38,16 +46,16 @@ export const useGenerateDomainsDataViewsState = ( props: DomainsDataViewsProps )
 		}
 
 		const hasWpcomStagingDomain = allDomains.find(
-			( domain: DomainData ) => domain.processed.isWpcomStagingDomain
+			( domain: PartialDomainData ) => domain.is_wpcom_staging_domain
 		);
 
 		if ( ! hasWpcomStagingDomain ) {
 			return allDomains;
 		}
 
-		return allDomains.filter( ( domain: DomainData ) => {
-			if ( domain.processed.isWPCOMDomain ) {
-				return domain.processed.isWpcomStagingDomain;
+		return allDomains.filter( ( domain: PartialDomainData ) => {
+			if ( domain.wpcom_domain ) {
+				return domain.is_wpcom_staging_domain;
 			}
 
 			return true;
@@ -55,8 +63,32 @@ export const useGenerateDomainsDataViewsState = ( props: DomainsDataViewsProps )
 	}, [ allDomains, isAllSitesView ] );
 
 	const allSiteIds = [
-		...new Set( domains?.map( ( domain: DomainData ) => domain.processed.blogId ) ?? [] ),
+		...new Set( domains?.map( ( domain: PartialDomainData ) => domain.blog_id ) ?? [] ),
 	];
+
+	const allSiteDomains = useQueries( {
+		queries: allSiteIds.map( ( siteId ) =>
+			getSiteDomainsQueryObject( siteId, {
+				...( fetchSiteDomains && { queryFn: () => fetchSiteDomains( siteId ) } ),
+			} )
+		),
+	} );
+
+	const siteDomains = useMemo( () => {
+		const fetchedSiteDomains: Record< number, ResponseDomain[] > = {};
+		for ( const { data } of allSiteDomains ) {
+			const siteId = data?.domains?.[ 0 ]?.blog_id;
+			if ( typeof siteId === 'number' ) {
+				fetchedSiteDomains[ siteId ] = data?.domains.map( createSiteDomainObject ) ?? [];
+			}
+		}
+		return fetchedSiteDomains;
+	}, [ allSiteDomains ] );
+
+	const getFullDomain = ( domain: PartialDomainData ) => {
+		const domains = siteDomains[ domain.blog_id ] ?? [];
+		return domains.find( ( d ) => d.name === domain.domain );
+	};
 
 	const sitesFilterCallback = ( site: SiteExcerptData ) => {
 		return allSiteIds.includes( site.ID );
@@ -69,6 +101,7 @@ export const useGenerateDomainsDataViewsState = ( props: DomainsDataViewsProps )
 		[ 'is_a4a_dev_site', 'site_migration', 'is_vip' ],
 		[ 'theme_slug' ]
 	);
+
 	const sites = allSites.reduce(
 		( acc, site ) => {
 			const siteId = site.ID;
@@ -79,6 +112,20 @@ export const useGenerateDomainsDataViewsState = ( props: DomainsDataViewsProps )
 		},
 		{} as Record< number, SiteExcerptData >
 	);
+
+	const getSiteSlug = ( domain: PartialDomainData ) => {
+		const site = sites[ domain.blog_id ];
+		if ( ! site?.URL ) {
+			// Fall back to the site's ID if we're still loading detailed site data
+			return domain.blog_id.toString( 10 );
+		}
+
+		if ( site.options?.is_redirect && site.options?.unmapped_url ) {
+			return new URL( site.options.unmapped_url ).host;
+		}
+
+		return new URL( site.URL ).host.replace( /\//g, '::' );
+	};
 
 	const { setAutoRenew } = useDomainsBulkActionsMutation(
 		createBulkAction && { mutationFn: createBulkAction }
@@ -93,28 +140,31 @@ export const useGenerateDomainsDataViewsState = ( props: DomainsDataViewsProps )
 
 	const [ updatingDomain, setUpdatingDomain ] = useState< Context[ 'updatingDomain' ] >( null );
 
-	const handleAutoRenew = ( domains: DomainData[], enable: boolean ) => {
-		const domainNames = domains.map( ( domain: DomainData ) => domain.processed.domain );
+	const handleAutoRenew = ( domains: PartialDomainData[], enable: boolean ) => {
+		const domainNames = domains.map( ( domain: PartialDomainData ) => domain.domain );
 		const blogIds = [
-			...new Set< number >( domains.map( ( domain: DomainData ) => domain.processed.blogId ) ),
+			...new Set< number >( domains.map( ( domain: PartialDomainData ) => domain.blog_id ) ),
 		];
 		setAutoRenew( domainNames, blogIds, enable );
 		handleRestartDomainStatusPolling();
 	};
 
-	const handleUpdateContactInfo = ( domains: DomainData[] ) => {
+	const handleUpdateContactInfo = ( domains: PartialDomainData[] ) => {
 		const baseUrl = isAllSitesView
 			? '/domains/manage/all/edit-selected-contact-info'
 			: `/domains/manage/edit-selected-contact-info/${ props.siteSlug }`;
 		const formLink = addQueryArgs( baseUrl, {
-			selected: domains.map( ( domain: DomainData ) => domain.processed.domain ),
+			selected: domains.map( ( domain: PartialDomainData ) => domain.domain ),
 		} );
 		page( formLink );
 	};
 
 	const context: Context = {
 		sites,
+		getFullDomain,
+		getSiteSlug,
 		isLoadingSites,
+		fetchSiteDomains,
 		createBulkAction,
 		fetchBulkActionStatus,
 		deleteBulkActionStatus,

--- a/client/my-sites/domains/domain-management/dataviews/use-domains.ts
+++ b/client/my-sites/domains/domain-management/dataviews/use-domains.ts
@@ -1,43 +1,5 @@
-import { createSiteDomainObject } from '@automattic/domains-table/src/utils/assembler';
-import { useQuery } from '@tanstack/react-query';
-import { addQueryArgs } from '@wordpress/url';
-import { map } from 'lodash';
-import wpcom from 'calypso/lib/wp';
-import { DomainData, DomainsQueryArgs, DomainsQueryFnData } from './types';
+import { PartialDomainData } from '@automattic/data-stores';
 
-export const getDomainsQueryKey = ( queryArgs: DomainsQueryArgs = {} ) => [
-	'all-domains',
-	queryArgs,
-];
-
-async function fetchDomains( queryArgs: DomainsQueryArgs ): Promise< DomainsQueryFnData > {
-	return wpcom.req.get( {
-		path: addQueryArgs( '/all-domains', queryArgs ),
-		apiVersion: '1.1',
-	} );
-}
-
-export const useDomainsQuery = ( queryArgs: DomainsQueryArgs = {} ) => {
-	return useQuery( {
-		queryKey: getDomainsQueryKey( queryArgs ),
-		queryFn: () => fetchDomains( queryArgs ),
-	} );
-};
-
-export function useDomains() {
-	const queryArgs = { no_wpcom: true, resolve_status: true, extended_data: true };
-	const { data, ...queryResult } = useDomainsQuery( queryArgs );
-	return {
-		...queryResult,
-		domains: map( data?.domains ?? [], ( d ) => {
-			return {
-				original: d,
-				processed: createSiteDomainObject( d ),
-			} as DomainData;
-		} ),
-	};
-}
-
-export function getDomainId( domain: DomainData ): string {
-	return domain.processed.domain + domain.processed.blogId;
+export function getDomainId( domain: PartialDomainData ): string {
+	return domain.domain + domain.blog_id;
 }

--- a/client/my-sites/domains/domain-management/dataviews/use-fields.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/use-fields.tsx
@@ -1,39 +1,30 @@
 import { PartialDomainData } from '@automattic/data-stores';
 import { DomainsTableExpiresRenewsOnCell } from '@automattic/domains-table/src/domains-table/domains-table-expires-renews-cell';
 import { DomainsTableSiteCell } from '@automattic/domains-table/src/domains-table/domains-table-site-cell';
-import { SiteExcerptData } from '@automattic/sites';
 import { Field } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { DomainField } from './dataviews-fields/domain-field';
 import { DomainStatusField } from './dataviews-fields/domain-status-field';
 import { SslStatusField } from './dataviews-fields/ssl-status-field';
-import { DomainData } from './types';
 import { useDomainsDataViewsContext } from './use-context';
 
 interface Props {
-	openDomainPane?: ( domain: DomainData ) => void;
+	openDomainPane?: ( domain: PartialDomainData ) => void;
 }
 
 export function useFields( { openDomainPane }: Props ) {
 	const translate = useTranslate();
-	const { isAllSitesView, domainsRequiringAttention, sites, selectedFeature } =
-		useDomainsDataViewsContext();
+	const {
+		isAllSitesView,
+		domainsRequiringAttention,
+		sites,
+		selectedFeature,
+		getSiteSlug,
+		getFullDomain,
+	} = useDomainsDataViewsContext();
 
-	const siteSlug = ( domain: PartialDomainData, site?: SiteExcerptData ) => {
-		if ( ! site?.URL ) {
-			// Fall back to the site's ID if we're still loading detailed site data
-			return domain.blog_id.toString( 10 );
-		}
-
-		if ( site.options?.is_redirect && site.options?.unmapped_url ) {
-			return new URL( site.options.unmapped_url ).host;
-		}
-
-		return new URL( site.URL ).host.replace( /\//g, '::' );
-	};
-
-	const fields = useMemo< Field< DomainData >[] >(
+	const fields = useMemo< Field< PartialDomainData >[] >(
 		() => [
 			{
 				id: 'domain_name',
@@ -41,8 +32,8 @@ export function useFields( { openDomainPane }: Props ) {
 				enableHiding: false,
 				enableSorting: true,
 				enableGlobalSearch: true,
-				getValue: ( { item }: { item: DomainData } ) => item.processed.domain,
-				render: ( { item }: { item: DomainData } ) => (
+				getValue: ( { item }: { item: PartialDomainData } ) => item.domain,
+				render: ( { item }: { item: PartialDomainData } ) => (
 					<DomainField
 						domain={ item }
 						isAllSitesView={ isAllSitesView }
@@ -56,14 +47,21 @@ export function useFields( { openDomainPane }: Props ) {
 				label: translate( 'Owner' ),
 				enableHiding: false,
 				enableSorting: true,
-				getValue: ( { item }: { item: DomainData } ) =>
-					item.processed.owner.replace( / \((?!.*\().+\)$/, '' ),
-				render: ( { item }: { item: DomainData } ) => {
+				getValue: ( { item }: { item: PartialDomainData } ) => {
+					const domain = getFullDomain( item );
+					if ( ! domain ) {
+						return '';
+					}
 					// Removes the username that appears in parentheses after the owner's name.
 					// Uses $ and the negative lookahead assertion (?!.*\() to ensure we only match the very last parenthetical.
-					return item.processed.owner
-						? item.processed.owner.replace( / \((?!.*\().+\)$/, '' )
-						: '-';
+					return domain.owner.replace( / \((?!.*\().+\)$/, '' );
+				},
+				render: ( { item }: { item: PartialDomainData } ) => {
+					const domain = getFullDomain( item );
+					if ( ! domain || ! domain.owner ) {
+						return '-';
+					}
+					return domain.owner.replace( / \((?!.*\().+\)$/, '' );
 				},
 			},
 			{
@@ -71,17 +69,17 @@ export function useFields( { openDomainPane }: Props ) {
 				label: translate( 'Site' ),
 				enableHiding: false,
 				enableSorting: true,
-				getValue: ( { item }: { item: DomainData } ) => item.original.blog_name ?? '',
-				render: ( { item }: { item: DomainData } ) => {
-					const site = sites[ item.processed.blogId ];
-					const userCanAddSiteToDomain =
-						item.processed.currentUserCanCreateSiteFromDomainOnly ?? false;
+				getValue: ( { item }: { item: PartialDomainData } ) => sites[ item.blog_id ]?.name ?? '',
+				render: ( { item }: { item: PartialDomainData } ) => {
+					const domain = getFullDomain( item );
+					const site = sites[ item.blog_id ];
+					const userCanAddSiteToDomain = domain?.currentUserCanCreateSiteFromDomainOnly ?? false;
 
 					return (
 						<DomainsTableSiteCell
 							site={ site }
 							userCanAddSiteToDomain={ userCanAddSiteToDomain }
-							siteSlug={ siteSlug( item.original, site ) }
+							siteSlug={ getSiteSlug( item ) }
 						/>
 					);
 				},
@@ -91,18 +89,21 @@ export function useFields( { openDomainPane }: Props ) {
 				label: translate( 'SSL' ),
 				enableHiding: false,
 				enableSorting: true,
-				getValue: ( { item }: { item: DomainData } ) => item.processed.sslStatus,
-				render: ( { item }: { item: DomainData } ) => <SslStatusField domain={ item } />,
+				getValue: ( { item }: { item: PartialDomainData } ) => {
+					const domain = getFullDomain( item );
+					return domain?.sslStatus;
+				},
+				render: ( { item }: { item: PartialDomainData } ) => <SslStatusField domain={ item } />,
 			},
 			{
 				id: 'expiry',
 				label: translate( 'Expires/Renews on' ),
 				enableHiding: false,
 				enableSorting: true,
-				getValue: ( { item }: { item: DomainData } ) =>
-					item.processed.expiry ? Date.parse( item.processed.expiry ) : 0,
-				render: ( { item }: { item: DomainData } ) => (
-					<DomainsTableExpiresRenewsOnCell domain={ item.original } as="div" />
+				getValue: ( { item }: { item: PartialDomainData } ) =>
+					item.expiry ? Date.parse( item.expiry ) : 0,
+				render: ( { item }: { item: PartialDomainData } ) => (
+					<DomainsTableExpiresRenewsOnCell domain={ item } as="div" />
 				),
 			},
 			{
@@ -118,11 +119,20 @@ export function useFields( { openDomainPane }: Props ) {
 				) : (
 					translate( 'Status' )
 				),
-				getValue: ( { item }: { item: DomainData } ) => item.original.domain_status.status,
-				render: ( { item }: { item: DomainData } ) => <DomainStatusField domain={ item } />,
+				getValue: ( { item }: { item: PartialDomainData } ) => item.domain_status?.status,
+				render: ( { item }: { item: PartialDomainData } ) => <DomainStatusField domain={ item } />,
 			},
 		],
-		[ domainsRequiringAttention, isAllSitesView, openDomainPane, sites, translate ]
+		[
+			domainsRequiringAttention,
+			isAllSitesView,
+			openDomainPane,
+			sites,
+			translate,
+			getFullDomain,
+			getSiteSlug,
+			selectedFeature,
+		]
 	);
 
 	return fields;

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { PartialDomainData } from '@automattic/data-stores';
 import {
 	DomainStatusPurchaseActions,
 	DomainsTable,
@@ -15,7 +16,6 @@ import { useSelector } from 'calypso/state';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import DomainHeader, { NavigationItem } from '../components/domain-header';
 import DotcomDomainsDataViews from '../dataviews';
-import { useDomains } from '../dataviews/use-domains';
 import {
 	createBulkAction,
 	deleteBulkActionStatus,
@@ -630,6 +630,8 @@ type RendererProps = {
 	selectedDomainName?: string;
 	item: NavigationItem;
 	selectedFeature?: string;
+	domains: PartialDomainData[];
+	isLoading?: boolean;
 };
 
 function DomainsTableRenderer( {
@@ -637,51 +639,27 @@ function DomainsTableRenderer( {
 	purchaseActions,
 	sidebarMode,
 	selectedDomainName,
-	item,
 	selectedFeature,
+	domains,
+	isLoading,
 }: RendererProps ) {
-	const { domains = [], isFetched, isLoading } = useDomainsTable( fetchAllDomains );
-
-	const isDomainsEmpty = isFetched && domains.length === 0;
-	const buttons = ! isDomainsEmpty
-		? [
-				<OptionsDomainButton
-					key="breadcrumb_button_1"
-					allDomainsList
-					sidebarMode={ sidebarMode }
-				/>,
-		  ]
-		: [];
-
 	return (
-		<>
-			<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
-			{ ! isLoading && ! isDomainsEmpty && <GoogleDomainOwnerBanner /> }
-			{ ! isDomainsEmpty ? (
-				<DomainsTable
-					isLoadingDomains={ isLoading }
-					domains={ domains }
-					isAllSitesView
-					domainStatusPurchaseActions={ purchaseActions }
-					currentUserCanBulkUpdateContactInfo={ ! isInSupportSession }
-					fetchAllDomains={ fetchAllDomains }
-					fetchSite={ fetchSite }
-					fetchSiteDomains={ fetchSiteDomains }
-					createBulkAction={ createBulkAction }
-					fetchBulkActionStatus={ fetchBulkActionStatus }
-					deleteBulkActionStatus={ deleteBulkActionStatus }
-					sidebarMode={ sidebarMode }
-					selectedFeature={ selectedFeature }
-					selectedDomainName={ selectedDomainName }
-				/>
-			) : (
-				<div className="bulk-domains-empty-state">
-					<div className="bulk-domains-empty-state__main">
-						<EmptyState />
-					</div>
-				</div>
-			) }
-		</>
+		<DomainsTable
+			isLoadingDomains={ isLoading }
+			domains={ domains }
+			isAllSitesView
+			domainStatusPurchaseActions={ purchaseActions }
+			currentUserCanBulkUpdateContactInfo={ ! isInSupportSession }
+			fetchAllDomains={ fetchAllDomains }
+			fetchSite={ fetchSite }
+			fetchSiteDomains={ fetchSiteDomains }
+			createBulkAction={ createBulkAction }
+			fetchBulkActionStatus={ fetchBulkActionStatus }
+			deleteBulkActionStatus={ deleteBulkActionStatus }
+			sidebarMode={ sidebarMode }
+			selectedFeature={ selectedFeature }
+			selectedDomainName={ selectedDomainName }
+		/>
 	);
 }
 
@@ -691,47 +669,24 @@ function DomainsDataViewsRenderer( {
 	sidebarMode,
 	selectedDomainName,
 	selectedFeature,
-	item,
+	domains,
+	isLoading,
 }: RendererProps ) {
-	const { isLoading, isFetched, domains } = useDomains();
-
-	const isDomainsEmpty = isFetched && domains.length === 0;
-	const buttons = ! isDomainsEmpty
-		? [
-				<OptionsDomainButton
-					key="breadcrumb_button_1"
-					allDomainsList
-					sidebarMode={ sidebarMode }
-				/>,
-		  ]
-		: [];
-
 	return (
-		<>
-			<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
-			{ ! isLoading && ! isDomainsEmpty && <GoogleDomainOwnerBanner /> }
-			{ ! isDomainsEmpty ? (
-				<DotcomDomainsDataViews
-					domains={ domains ?? [] }
-					isLoading={ isLoading }
-					selectedItem={ undefined }
-					isAllSitesView
-					domainStatusPurchaseActions={ purchaseActions }
-					currentUserCanBulkUpdateContactInfo={ ! isInSupportSession }
-					createBulkAction={ createBulkAction }
-					fetchBulkActionStatus={ fetchBulkActionStatus }
-					selectedDomainName={ selectedDomainName }
-					sidebarMode={ sidebarMode }
-					selectedFeature={ selectedFeature }
-				/>
-			) : (
-				<div className="bulk-domains-empty-state">
-					<div className="bulk-domains-empty-state__main">
-						<EmptyState />
-					</div>
-				</div>
-			) }
-		</>
+		<DotcomDomainsDataViews
+			domains={ domains ?? [] }
+			isLoading={ !! isLoading }
+			selectedItem={ undefined }
+			isAllSitesView
+			domainStatusPurchaseActions={ purchaseActions }
+			currentUserCanBulkUpdateContactInfo={ ! isInSupportSession }
+			fetchSiteDomains={ fetchSiteDomains }
+			createBulkAction={ createBulkAction }
+			fetchBulkActionStatus={ fetchBulkActionStatus }
+			selectedDomainName={ selectedDomainName }
+			sidebarMode={ sidebarMode }
+			selectedFeature={ selectedFeature }
+		/>
 	);
 }
 
@@ -753,29 +708,54 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 	};
 
 	const purchaseActions = usePurchaseActions();
+	const { domains = [], isFetched, isLoading } = useDomainsTable( fetchAllDomains );
 
-	const showDataViews = isDomainsDataViewsEnabled;
-	const Element = showDataViews ? DomainsDataViewsRenderer : DomainsTableRenderer;
+	const isDomainsEmpty = isFetched && domains.length === 0;
+	const buttons = ! isDomainsEmpty
+		? [
+				<OptionsDomainButton
+					key="breadcrumb_button_1"
+					allDomainsList
+					sidebarMode={ props.sidebarMode }
+				/>,
+		  ]
+		: [];
+
+	const Element = isDomainsDataViewsEnabled ? DomainsDataViewsRenderer : DomainsTableRenderer;
 
 	return (
 		<>
 			<Global
-				styles={ showDataViews ? domainsDataViewsGlobalStyles : domainsDashboardGlobalStyles }
+				styles={
+					isDomainsDataViewsEnabled ? domainsDataViewsGlobalStyles : domainsDashboardGlobalStyles
+				}
 			/>
 			<PageViewTracker path={ props.analyticsPath } title={ props.analyticsTitle } />
-			<Main className={ showDataViews ? 'dataviews' : '' }>
+			<Main className={ isDomainsDataViewsEnabled ? 'dataviews' : '' }>
 				<DocumentHead title={ translate( 'Domains' ) } />
 				<BodySectionCssClass
 					bodyClass={ [ 'edit__body-white', 'is-bulk-domains-page', 'is-bulk-all-domains-page' ] }
 				/>
-				<Element
-					isInSupportSession={ isInSupportSession }
-					purchaseActions={ purchaseActions }
-					sidebarMode={ props.sidebarMode }
-					selectedDomainName={ props.selectedDomainName }
-					selectedFeature={ props.selectedFeature }
-					item={ item }
-				/>
+				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
+				{ ! isLoading && ! isDomainsEmpty && <GoogleDomainOwnerBanner /> }
+				{ ! isDomainsEmpty ? (
+					<Element
+						isInSupportSession={ isInSupportSession }
+						purchaseActions={ purchaseActions }
+						sidebarMode={ props.sidebarMode }
+						selectedDomainName={ props.selectedDomainName }
+						selectedFeature={ props.selectedFeature }
+						item={ item }
+						domains={ domains }
+						isLoading={ isLoading }
+					/>
+				) : (
+					<div className="bulk-domains-empty-state">
+						<div className="bulk-domains-empty-state__main">
+							<EmptyState />
+						</div>
+					</div>
+				) }
 			</Main>
 		</>
 	);

--- a/packages/data-stores/src/queries/use-all-domains-query.ts
+++ b/packages/data-stores/src/queries/use-all-domains-query.ts
@@ -22,6 +22,7 @@ export type PartialDomainData = Pick<
 	| 'tld_maintenance_end_time'
 	| 'type'
 	| 'wpcom_domain'
+	| 'domain_status'
 >;
 
 export interface AllDomainsQueryFnData {
@@ -30,6 +31,7 @@ export interface AllDomainsQueryFnData {
 
 export interface AllDomainsQueryArgs {
 	no_wpcom?: boolean;
+	resolve_status?: boolean;
 }
 
 export const getAllDomainsQueryKey = ( queryArgs: AllDomainsQueryArgs = {} ) => [

--- a/packages/data-stores/src/queries/use-site-domains-query.ts
+++ b/packages/data-stores/src/queries/use-site-domains-query.ts
@@ -129,6 +129,11 @@ export interface DomainData {
 	pending_registration_at_registry_url: string;
 	registered_via_trustee: boolean;
 	registered_via_trustee_url: string;
+	domain_status?: {
+		status: string;
+		status_type: string;
+		status_weight: number;
+	};
 }
 
 export interface SiteDomainsQueryFnData {

--- a/packages/domains-table/src/use-domains-table.ts
+++ b/packages/domains-table/src/use-domains-table.ts
@@ -7,7 +7,7 @@ import {
 export function useDomainsTable(
 	fetchAllDomains?: ( queryArgs?: AllDomainsQueryArgs ) => Promise< AllDomainsQueryFnData >
 ) {
-	const queryArgs = { no_wpcom: true };
+	const queryArgs = { no_wpcom: true, resolve_status: true };
 
 	const { data, ...queryResult } = useAllDomainsQuery(
 		queryArgs,


### PR DESCRIPTION
Built on top of: https://github.com/Automattic/wp-calypso/pull/97677

Our original idea was to light load domains first, then load full data for domains on the screen.

However, there is a chicken-and-egg problem:
- To sort and filter domains (and then “paginate” them) we need to have all the data.
- We want to load full data when domains are already paginated.

Eventually, in this implementation we have all drawbacks of the original solution with domains table: we preload all the data.

## Proposed Changes

* Use original backend to load data for DataViews

## Why are these changes being made?

* We would like to use DataViews without any changes on the backend, for now.

## Testing Instructions

- Turn on feature flags in your browser's console: `window.sessionStorage.setItem('flags', ['calypso/all-domain-management', 'calypso/domains-dataviews'])`.
- Go to http://calypso.localhost:3000/plugins/manage
- Check filtering, sorting, actions, bulk actions.
- Click on a domain and check if it opened a pane on the right.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
