### PR TITLE
Onboarding: Clear store and persisted state when starting the flow

### DIFF
--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -1,8 +1,9 @@
 import { OnboardSelect, Onboard, UserSelect } from '@automattic/data-stores';
 import { ONBOARDING_FLOW } from '@automattic/onboarding';
+import { clearStepPersistedState } from '@automattic/onboarding/src/utils/persisted-state';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { pathToUrl } from 'calypso/lib/url';
 import {
@@ -10,6 +11,8 @@ import {
 	setSignupCompleteFlowName,
 	setSignupCompleteSlug,
 } from 'calypso/signup/storageUtils';
+import { useDispatch as reduxUseDispatch } from 'calypso/state';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import {
 	STEPPER_TRACKS_EVENT_SIGNUP_START,
 	STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
@@ -56,6 +59,14 @@ const onboarding: Flow = {
 		);
 	},
 	useSteps() {
+		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
+		const dispatch = reduxUseDispatch();
+		useEffect( () => {
+			resetOnboardStore();
+			dispatch( setSelectedSiteId( null ) );
+			clearStepPersistedState();
+		}, [] );
+
 		// We have already checked the value has loaded in useAssertConditions
 		const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 
@@ -337,6 +348,7 @@ const onboarding: Flow = {
 
 		return { goBack, submit };
 	},
+
 	useAssertConditions() {
 		const [ isLoading ] = useGoalsFirstExperiment();
 

--- a/packages/onboarding/src/hooks/use-persisted-state.ts
+++ b/packages/onboarding/src/hooks/use-persisted-state.ts
@@ -2,8 +2,8 @@ import { useCallback, useState } from 'react';
 import { useMatch } from 'react-router';
 
 const TWENTY_MINUTES = 20 * 60 * 1000;
-const VERSION = 1;
-const KEY = '@automattic/persisted-state';
+export const VERSION = 1;
+export const KEY = '@automattic/persisted-state';
 
 function setPersistedState( key: string, state: unknown, storage: Storage ) {
 	storage.setItem( key, JSON.stringify( state ) );

--- a/packages/onboarding/src/utils/persisted-state.ts
+++ b/packages/onboarding/src/utils/persisted-state.ts
@@ -1,0 +1,15 @@
+import { VERSION, KEY } from '../hooks/use-persisted-state';
+
+/**
+ * Clears all persisted state created by useStepPersistedState
+ * @param storage The storage to clear (defaults to localStorage)
+ */
+export function clearStepPersistedState( storage: Storage = localStorage ): void {
+	const keys = Object.keys( storage );
+	const persistedKeys = keys.filter( ( key ) => key.startsWith( `${ VERSION }-${ KEY }` ) );
+
+	persistedKeys.forEach( ( key ) => {
+		storage.removeItem( key );
+		storage.removeItem( key + 'time' );
+	} );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/97887#top

## Proposed Changes

https://github.com/user-attachments/assets/4f060f3c-1370-41d4-a81a-3b52c886a383

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
