### PR TITLE
Domains Management Revamp: Add email plans comparison subpage

### DIFF
--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/compare-email-providers.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/compare-email-providers.tsx
@@ -1,0 +1,45 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { translate } from 'i18n-calypso';
+import React from 'react';
+import ExternalLink from 'calypso/components/external-link';
+import NavigationHeader from 'calypso/components/navigation-header';
+import { CustomHeaderComponentType } from './custom-header-component-type';
+
+export const addDnsRecordTitle = translate( 'Add a new DNS record' );
+export const editDnsRecordTitle = translate( 'Edit DNS record' );
+export const addDnsRecordsSubtitle = translate(
+	'DNS records change how your domain works. {{a}}Learn more{{/a}}.',
+	{
+		components: {
+			a: (
+				<ExternalLink href={ localizeUrl( 'https://wordpress.com/support/domains/custom-dns/' ) } />
+			),
+		},
+	}
+);
+
+const CompareEmailProvidersHeader: CustomHeaderComponentType = ( {
+	selectedDomainName,
+	selectedSiteSlug,
+} ) => {
+	return (
+		<NavigationHeader
+			className="navigation-header__breadcrumb"
+			navigationItems={ [
+				{
+					label: selectedDomainName,
+					href: `/domains/manage/all/overview/${ selectedDomainName }/${ selectedSiteSlug }`,
+				},
+				{
+					label: translate( 'Email' ),
+					href: `/domains/manage/all/email/${ selectedDomainName }/${ selectedSiteSlug }`,
+				},
+				{
+					label: translate( 'Compare plans' ),
+				},
+			] }
+		/>
+	);
+};
+
+export default CompareEmailProvidersHeader;

--- a/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
@@ -149,6 +149,20 @@
 			border-radius: 4px;
 		}
 	}
+
+    .email-providers-in-depth-comparison__table {
+        border: solid 1px $studio-gray-5;
+        border-radius: 4px;
+        padding: 24px;
+
+        > table {
+            margin-top: 0;
+
+            td {
+                padding-top: 12px;
+            }
+        }
+    }
 }
 
 .is-bulk-all-domains-page .layout__content .main {

--- a/client/my-sites/domains/domain-management/subpage-wrapper/subpages.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/subpages.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import AddForwardingEmailHeader from './headers/add-fowarding-email-header';
+import CompareEmailProvidersHeader from './headers/compare-email-providers';
 import { CustomHeaderComponentType } from './headers/custom-header-component-type';
 import DnsRecordHeader, {
 	addDnsRecordTitle,
@@ -21,6 +22,7 @@ type SubpageWrapperParamsType = {
 
 // Subpage keys
 export const ADD_FORWARDING_EMAIL = 'add-forwarding-email';
+export const COMPARE_EMAIL_PROVIDERS = 'compare-email-providers';
 export const DNS_RECORDS = 'dns-records';
 export const ADD_DNS_RECORD = 'add-dns-record';
 export const EDIT_DNS_RECORD = 'edit-dns-record';
@@ -33,6 +35,9 @@ const SUBPAGE_TO_PARAMS_MAP: Record< string, SubpageWrapperParamsType > = {
 		showFormHeader: true,
 		showPageHeader: false,
 	},
+	[ COMPARE_EMAIL_PROVIDERS ]: {
+		CustomHeader: CompareEmailProvidersHeader,
+	},
 	[ DNS_RECORDS ]: {
 		CustomHeader: DNSRecordsHeader,
 		titleOverride: dnsRecordsTitle,
@@ -41,13 +46,11 @@ const SUBPAGE_TO_PARAMS_MAP: Record< string, SubpageWrapperParamsType > = {
 		showDetails: false,
 	},
 	[ EDIT_CONTACT_INFO ]: {
-		subPageKey: EDIT_CONTACT_INFO,
 		title: __( 'Contact information' ),
 		subtitle: __( "Manage your domain's contact details." ),
 	},
 	[ ADD_DNS_RECORD ]: {
 		CustomHeader: DnsRecordHeader,
-		subPageKey: ADD_DNS_RECORD,
 		titleOverride: addDnsRecordTitle,
 		subtitleOverride: addDnsRecordsSubtitle,
 		showBreadcrumb: false,
@@ -55,7 +58,6 @@ const SUBPAGE_TO_PARAMS_MAP: Record< string, SubpageWrapperParamsType > = {
 	},
 	[ EDIT_DNS_RECORD ]: {
 		CustomHeader: DnsRecordHeader,
-		subPageKey: EDIT_DNS_RECORD,
 		titleOverride: editDnsRecordTitle,
 		subtitleOverride: addDnsRecordsSubtitle,
 		showBreadcrumb: false,

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -18,6 +18,7 @@ import {
 } from './domain-management/domain-overview-pane/constants';
 import {
 	ADD_FORWARDING_EMAIL,
+	COMPARE_EMAIL_PROVIDERS,
 	DNS_RECORDS,
 	ADD_DNS_RECORD,
 	EDIT_DNS_RECORD,
@@ -407,6 +408,18 @@ export default function () {
 		navigation,
 		emailController.emailManagement,
 		domainManagementController.domainManagementPaneView( EMAIL_MANAGEMENT ),
+		domainManagementController.domainDashboardLayout,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		paths.domainManagementAllEmailRoot() + '/:domain/compare/:site',
+		siteSelection,
+		navigation,
+		domainManagementController.domainManagementSubpageParams( COMPARE_EMAIL_PROVIDERS ),
+		emailController.emailManagementInDepthComparison,
+		domainManagementController.domainManagementSubpageView,
 		domainManagementController.domainDashboardLayout,
 		makeLayout,
 		clientRender

--- a/client/my-sites/domains/style.scss
+++ b/client/my-sites/domains/style.scss
@@ -81,6 +81,9 @@ body.is-section-domains.is-domain-plan-package-flow {
 	}
 
 	.domains-overview__details.main {
-		height: 100%;
+		&,
+		.hosting-dashboard-layout-column__container {
+			height: 100%;
+		}
 	}
 }

--- a/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
@@ -121,12 +121,14 @@ const EmailProvidersInDepthComparison = ( {
 				onIntervalChange={ changeIntervalLength }
 			/>
 
-			<ComparisonComponent
-				emailProviders={ [ professionalEmailFeatures, googleWorkspaceFeatures ] }
-				intervalLength={ selectedIntervalLength }
-				onSelectEmailProvider={ selectEmailProvider }
-				selectedDomainName={ selectedDomainName }
-			/>
+			<div className="email-providers-in-depth-comparison__table">
+				<ComparisonComponent
+					emailProviders={ [ professionalEmailFeatures, googleWorkspaceFeatures ] }
+					intervalLength={ selectedIntervalLength }
+					onSelectEmailProvider={ selectEmailProvider }
+					selectedDomainName={ selectedDomainName }
+				/>
+			</div>
 
 			<EmailForwardingLink selectedDomainName={ selectedDomainName } />
 		</Main>

--- a/client/my-sites/email/paths.ts
+++ b/client/my-sites/email/paths.ts
@@ -184,12 +184,21 @@ export const getEmailInDepthComparisonPath = (
 	relativeTo?: string,
 	source?: string,
 	intervalLength?: string
-) =>
-	getPath( siteName, domainName, 'compare', relativeTo, {
+) => {
+	if ( isEnabled( 'calypso/all-domain-management' ) && isUnderDomainManagementAll( relativeTo ) ) {
+		return `${ domainsManagementPrefix }/${ domainName }/compare/${ siteName }${ buildQueryString( {
+			interval: intervalLength,
+			referrer: relativeTo,
+			source,
+		} ) }`;
+	}
+
+	return getPath( siteName, domainName, 'compare', relativeTo, {
 		interval: intervalLength,
 		referrer: relativeTo,
 		source,
 	} );
+};
 
 export const getProfessionalEmailCheckoutUpsellPath = (
 	siteName: string,

--- a/client/my-sites/email/test/paths.ts
+++ b/client/my-sites/email/test/paths.ts
@@ -25,6 +25,8 @@ import {
 const siteName = 'hello.wordpress.com';
 const domainName = 'hello.com';
 
+jest.mock( '@automattic/calypso-config', () => ( { isEnabled: () => true } ) );
+
 describe( 'path helper functions', () => {
 	it( 'getAddEmailForwardsPath', () => {
 		expect( getAddEmailForwardsPath( siteName, domainName ) ).toEqual(
@@ -170,6 +172,13 @@ describe( 'path helper functions', () => {
 		);
 		expect( getEmailInDepthComparisonPath( siteName, null ) ).toEqual( `/email/${ siteName }` );
 		expect( getEmailInDepthComparisonPath( null, null ) ).toEqual( '/email' );
+
+		const relativeTo = '/domains/manage/all/email';
+		expect( getEmailInDepthComparisonPath( siteName, domainName, relativeTo ) ).toEqual(
+			`/domains/manage/all/email/${ domainName }/compare/${ siteName }?referrer=${ encodeURIComponent(
+				relativeTo
+			) }`
+		);
 	} );
 
 	it( 'getMailboxesPath', () => {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/97815

## Proposed Changes

* Add Email Plans Comparison subpage.
* Fix vertical scrolling for subpages.
* Update tests.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of the Domain Management Revamp project: pfuQfP-13x-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR to your local
* Go to http://calypso.localhost:3000/domains/manage?flags=calypso/all-domain-management
* Click on a domain that doesn't have emails configured
* Click on the Email tab
* Click on "See how they compare" link
* The plans comparison page should be rendered with the new layout
* Select one of the email plans
* It should return to the Email overview page with the correct plan expanded
* Go back to the plans comparison page
* Switch to Monthly plans and select a different plan
* It should return to the Email overview page with the correct interval selected and the plan expanded
* Go to the old UI and perform the same tests (WP Admin -> Hosting -> Email)
* The page should work as before, without changes on visual or behavior

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?