### PR TITLE
Subscribers: Add subscribers-dataviews flag and component

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/index.ts
+++ b/client/my-sites/subscribers/components/subscriber-data-views/index.ts
@@ -1,0 +1,1 @@
+export { default as SubscriberDataViews } from './subscriber-data-views';

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -1,5 +1,1 @@
-@import '@wordpress/base-styles/variables';
-@import '@wordpress/base-styles/breakpoints';
-@import '@wordpress/base-styles/mixins';
 @import '@wordpress/dataviews/build-style/style.css';
-@import 'calypso/assets/stylesheets/shared/mixins/hide-content-accessibly';

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -1,1 +1,7 @@
 @import '@wordpress/dataviews/build-style/style.css';
+
+.subscribers--dataviews.main {
+    .navigation-header {
+        padding: 0 48px;
+    }
+}

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -1,7 +1,7 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/dataviews/build-style/style.css';
 
-.subscribers--dataviews.main {
+.subscribers.subscribers--dataviews.main {
     .navigation-header {
         padding: 0 48px;
 

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -1,7 +1,26 @@
+@import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/dataviews/build-style/style.css';
 
 .subscribers--dataviews.main {
     .navigation-header {
         padding: 0 48px;
+
+        @media ( max-width: $break-small ) {
+            padding: 0 24px;
+        }
     }
+}
+
+.subscriber-data-views {
+	.subscriber-profile.subscriber-profile--compact {
+		@media ( max-width: $break-xlarge ) {
+            max-width: 225px;
+        }
+
+		.subscriber-profile__user-details {
+			.subscriber-profile__name {
+				text-align: left;
+			}
+		}
+	}
 }

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -1,0 +1,5 @@
+@import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/dataviews/build-style/style.css';
+@import 'calypso/assets/stylesheets/shared/mixins/hide-content-accessibly';

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -1,4 +1,4 @@
-import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { DataViews } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import TimeSince from 'calypso/components/time-since';
@@ -36,6 +36,7 @@ const SubscriberDataViews = ( {
 		isOwnerSubscribed,
 		perPage,
 		setPerPage,
+		handleSearch,
 	} = useSubscribersPage();
 
 	const isSimple = useSelector( isSimpleSite );
@@ -114,27 +115,21 @@ const SubscriberDataViews = ( {
 			setPerPage( newView.perPage );
 			pageChangeCallback( 1 );
 		}
+
+		if ( typeof newView.search === 'string' && newView.search !== searchTerm ) {
+			handleSearch( newView.search );
+		}
 	};
 
 	const { data, paginationInfo } = useMemo( () => {
-		const result = filterSortAndPaginate< Subscriber >(
-			subscribers,
-			{
-				...currentView,
-				page: 1,
-				perPage: subscribers.length,
-			},
-			fields
-		);
-
 		return {
-			data: result.data,
+			data: subscribers,
 			paginationInfo: {
 				totalItems: grandTotal,
 				totalPages: pages ?? 0,
 			},
 		};
-	}, [ subscribers, currentView, fields, grandTotal, pages ] );
+	}, [ subscribers, grandTotal, pages ] );
 
 	return (
 		<section className="subscriber-data-views">

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -9,6 +9,7 @@ import { Subscriber } from 'calypso/my-sites/subscribers/types';
 import { useSelector } from 'calypso/state';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isSimpleSite } from 'calypso/state/sites/selectors';
+import { SubscribersSortBy } from '../../constants';
 import type { View, Field, Action } from '@wordpress/dataviews';
 import './style.scss';
 
@@ -37,6 +38,8 @@ const SubscriberDataViews = ( {
 		perPage,
 		setPerPage,
 		handleSearch,
+		sortTerm,
+		setSortTerm,
 	} = useSubscribersPage();
 
 	const isSimple = useSelector( isSimpleSite );
@@ -94,18 +97,6 @@ const SubscriberDataViews = ( {
 		[ translate, onClickView, onClickUnsubscribe ]
 	);
 
-	const currentView = useMemo< View >(
-		() => ( {
-			type: 'table',
-			layout: {},
-			search: searchTerm,
-			page,
-			perPage,
-			sort: { field: 'date_subscribed', direction: 'desc' },
-		} ),
-		[ searchTerm, page, perPage ]
-	);
-
 	const handleViewChange = ( newView: View ) => {
 		if ( typeof newView.page === 'number' && newView.page !== page ) {
 			pageChangeCallback( newView.page );
@@ -119,7 +110,30 @@ const SubscriberDataViews = ( {
 		if ( typeof newView.search === 'string' && newView.search !== searchTerm ) {
 			handleSearch( newView.search );
 		}
+
+		if ( newView.sort?.field ) {
+			const newSortTerm =
+				newView.sort.field === 'name' ? SubscribersSortBy.Name : SubscribersSortBy.DateSubscribed;
+			if ( newSortTerm !== sortTerm ) {
+				setSortTerm( newSortTerm );
+			}
+		}
 	};
+
+	const currentView = useMemo< View >(
+		() => ( {
+			type: 'table',
+			layout: {},
+			search: searchTerm,
+			page,
+			perPage,
+			sort: {
+				field: sortTerm === SubscribersSortBy.Name ? 'name' : 'date_subscribed',
+				direction: 'desc',
+			},
+		} ),
+		[ searchTerm, page, perPage, sortTerm ]
+	);
 
 	const { data, paginationInfo } = useMemo( () => {
 		return {

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -5,6 +5,7 @@ import TimeSince from 'calypso/components/time-since';
 import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
 import { SubscriberLaunchpad } from 'calypso/my-sites/subscribers/components/subscriber-launchpad';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
+import { useSubscriptionPlans } from 'calypso/my-sites/subscribers/hooks';
 import { Subscriber } from 'calypso/my-sites/subscribers/types';
 import { useSelector } from 'calypso/state';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -12,6 +13,17 @@ import { isSimpleSite } from 'calypso/state/sites/selectors';
 import { SubscribersSortBy } from '../../constants';
 import type { View, Field, Action } from '@wordpress/dataviews';
 import './style.scss';
+
+const SubscriptionTypeCell = ( { subscriber }: { subscriber: Subscriber } ) => {
+	const plans = useSubscriptionPlans( subscriber );
+	return (
+		<>
+			{ plans.map( ( plan, index ) => (
+				<div key={ index }>{ plan.plan }</div>
+			) ) }
+		</>
+	);
+};
 
 type SubscriberDataViewsProps = {
 	siteId: number | null;
@@ -65,6 +77,8 @@ const SubscriberDataViews = ( {
 			{
 				id: 'subscription_type',
 				label: translate( 'Subscription type' ),
+				getValue: ( { item }: { item: Subscriber } ) => ( item.plans?.length ? 'Paid' : 'Free' ),
+				render: ( { item }: { item: Subscriber } ) => <SubscriptionTypeCell subscriber={ item } />,
 				enableHiding: false,
 				enableSorting: true,
 			},

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -138,20 +138,23 @@ const SubscriberDataViews = ( {
 
 	return (
 		<section className="subscriber-data-views">
-			<DataViews< Subscriber >
-				data={ data }
-				fields={ fields }
-				view={ currentView }
-				onChangeView={ handleViewChange }
-				isLoading={ isLoading }
-				paginationInfo={ paginationInfo }
-				getItemId={ ( item: Subscriber ) => item.subscription_id.toString() }
-				defaultLayouts={ { table: {} } }
-				actions={ actions }
-				search
-				searchLabel={ translate( 'Search by name, username or email…' ) }
-			/>
-			{ shouldShowLaunchpad && <EmptyComponent /> }
+			{ shouldShowLaunchpad ? (
+				<EmptyComponent />
+			) : (
+				<DataViews< Subscriber >
+					data={ data }
+					fields={ fields }
+					view={ currentView }
+					onChangeView={ handleViewChange }
+					isLoading={ isLoading }
+					paginationInfo={ paginationInfo }
+					getItemId={ ( item: Subscriber ) => item.subscription_id.toString() }
+					defaultLayouts={ { table: {} } }
+					actions={ actions }
+					search
+					searchLabel={ translate( 'Search by name, username or email…' ) }
+				/>
+			) }
 		</section>
 	);
 };

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -1,3 +1,4 @@
+import { useBreakpoint } from '@automattic/viewport-react';
 import { DataViews } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
@@ -38,6 +39,7 @@ const SubscriberDataViews = ( {
 	onClickUnsubscribe,
 }: SubscriberDataViewsProps ) => {
 	const translate = useTranslate();
+	const isMobile = useBreakpoint( '<782px' );
 	const {
 		grandTotal,
 		page,
@@ -60,8 +62,8 @@ const SubscriberDataViews = ( {
 	const shouldShowLaunchpad =
 		! isLoading && ! searchTerm && ( ! grandTotal || ( grandTotal === 1 && isOwnerSubscribed ) );
 
-	const fields = useMemo< Field< Subscriber >[] >(
-		() => [
+	const fields = useMemo< Field< Subscriber >[] >( () => {
+		const baseFields = [
 			{
 				id: 'name',
 				label: translate( 'Name' ),
@@ -74,25 +76,33 @@ const SubscriberDataViews = ( {
 				enableHiding: false,
 				enableSorting: true,
 			},
-			{
-				id: 'subscription_type',
-				label: translate( 'Subscription type' ),
-				getValue: ( { item }: { item: Subscriber } ) => ( item.plans?.length ? 'Paid' : 'Free' ),
-				render: ( { item }: { item: Subscriber } ) => <SubscriptionTypeCell subscriber={ item } />,
-				enableHiding: false,
-				enableSorting: true,
-			},
-			{
-				id: 'date_subscribed',
-				label: translate( 'Since' ),
-				getValue: ( { item }: { item: Subscriber } ) => item.date_subscribed,
-				render: ( { item }: { item: Subscriber } ) => <TimeSince date={ item.date_subscribed } />,
-				enableHiding: false,
-				enableSorting: true,
-			},
-		],
-		[ translate, onClickView ]
-	);
+		];
+
+		if ( ! isMobile ) {
+			baseFields.push(
+				{
+					id: 'subscription_type',
+					label: translate( 'Subscription type' ),
+					getValue: ( { item }: { item: Subscriber } ) => ( item.plans?.length ? 'Paid' : 'Free' ),
+					render: ( { item }: { item: Subscriber } ) => (
+						<SubscriptionTypeCell subscriber={ item } />
+					),
+					enableHiding: false,
+					enableSorting: true,
+				},
+				{
+					id: 'date_subscribed',
+					label: translate( 'Since' ),
+					getValue: ( { item }: { item: Subscriber } ) => item.date_subscribed,
+					render: ( { item }: { item: Subscriber } ) => <TimeSince date={ item.date_subscribed } />,
+					enableHiding: false,
+					enableSorting: true,
+				}
+			);
+		}
+
+		return baseFields;
+	}, [ translate, onClickView, isMobile ] );
 
 	const actions = useMemo< Action< Subscriber >[] >(
 		() => [

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -5,6 +5,7 @@ import { useMemo } from 'react';
 import TimeSince from 'calypso/components/time-since';
 import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
 import { SubscriberLaunchpad } from 'calypso/my-sites/subscribers/components/subscriber-launchpad';
+import { SubscriberProfile } from 'calypso/my-sites/subscribers/components/subscriber-profile';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import { useSubscriptionPlans } from 'calypso/my-sites/subscribers/hooks';
 import { Subscriber } from 'calypso/my-sites/subscribers/types';
@@ -39,7 +40,7 @@ const SubscriberDataViews = ( {
 	onClickUnsubscribe,
 }: SubscriberDataViewsProps ) => {
 	const translate = useTranslate();
-	const isMobile = useBreakpoint( '<782px' );
+	const isMobile = useBreakpoint( '<1040px' );
 	const {
 		grandTotal,
 		page,
@@ -70,7 +71,12 @@ const SubscriberDataViews = ( {
 				getValue: ( { item }: { item: Subscriber } ) => item.display_name,
 				render: ( { item }: { item: Subscriber } ) => (
 					<button onClick={ () => onClickView( item ) }>
-						{ item.display_name || item.email_address }
+						<SubscriberProfile
+							avatar={ item.avatar }
+							displayName={ item.display_name }
+							email={ item.email_address }
+							url={ item.url }
+						/>
 					</button>
 				),
 				enableHiding: false,

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -61,14 +61,6 @@ const SubscriberDataViews = ( {
 			{
 				id: 'subscription_type',
 				label: translate( 'Subscription type' ),
-				getValue: ( { item }: { item: Subscriber } ) =>
-					item.user_id === 0
-						? translate( 'Email subscriber' )
-						: translate( 'WordPress.com follower' ),
-				render: ( { item }: { item: Subscriber } ) =>
-					item.user_id === 0
-						? translate( 'Email subscriber' )
-						: translate( 'WordPress.com follower' ),
 				enableHiding: false,
 				enableSorting: true,
 			},

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -1,0 +1,167 @@
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import TimeSince from 'calypso/components/time-since';
+import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
+import { SubscriberLaunchpad } from 'calypso/my-sites/subscribers/components/subscriber-launchpad';
+import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
+import { Subscriber } from 'calypso/my-sites/subscribers/types';
+import { useSelector } from 'calypso/state';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { isSimpleSite } from 'calypso/state/sites/selectors';
+import type { View, Field, Action } from '@wordpress/dataviews';
+import './style.scss';
+
+type SubscriberDataViewsProps = {
+	siteId: number | null;
+	onClickView: ( subscriber: Subscriber ) => void;
+	onClickUnsubscribe: ( subscriber: Subscriber ) => void;
+	onGiftSubscription: ( subscriber: Subscriber ) => void;
+};
+
+const SubscriberDataViews = ( {
+	siteId,
+	onClickView,
+	onClickUnsubscribe,
+}: SubscriberDataViewsProps ) => {
+	const translate = useTranslate();
+	const {
+		grandTotal,
+		page,
+		pageChangeCallback,
+		searchTerm,
+		isLoading,
+		subscribers,
+		pages,
+		isOwnerSubscribed,
+		perPage,
+		setPerPage,
+	} = useSubscribersPage();
+
+	const isSimple = useSelector( isSimpleSite );
+	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
+	const EmptyComponent = isSimple || isAtomic ? SubscriberLaunchpad : EmptyListView;
+	const shouldShowLaunchpad =
+		! isLoading && ! searchTerm && ( ! grandTotal || ( grandTotal === 1 && isOwnerSubscribed ) );
+
+	const fields = useMemo< Field< Subscriber >[] >(
+		() => [
+			{
+				id: 'name',
+				label: translate( 'Name' ),
+				getValue: ( { item }: { item: Subscriber } ) => item.display_name,
+				render: ( { item }: { item: Subscriber } ) => (
+					<button onClick={ () => onClickView( item ) }>
+						{ item.display_name || item.email_address }
+					</button>
+				),
+				enableHiding: false,
+				enableSorting: true,
+			},
+			{
+				id: 'subscription_type',
+				label: translate( 'Subscription type' ),
+				getValue: ( { item }: { item: Subscriber } ) =>
+					item.user_id === 0
+						? translate( 'Email subscriber' )
+						: translate( 'WordPress.com follower' ),
+				render: ( { item }: { item: Subscriber } ) =>
+					item.user_id === 0
+						? translate( 'Email subscriber' )
+						: translate( 'WordPress.com follower' ),
+				enableHiding: false,
+				enableSorting: true,
+			},
+			{
+				id: 'date_subscribed',
+				label: translate( 'Since' ),
+				getValue: ( { item }: { item: Subscriber } ) => item.date_subscribed,
+				render: ( { item }: { item: Subscriber } ) => <TimeSince date={ item.date_subscribed } />,
+				enableHiding: false,
+				enableSorting: true,
+			},
+		],
+		[ translate, onClickView ]
+	);
+
+	const actions = useMemo< Action< Subscriber >[] >(
+		() => [
+			{
+				id: 'view',
+				label: translate( 'View' ),
+				callback: ( items: Subscriber[] ) => onClickView( items[ 0 ] ),
+				isPrimary: true,
+			},
+			{
+				id: 'remove',
+				label: translate( 'Remove' ),
+				callback: ( items: Subscriber[] ) => onClickUnsubscribe( items[ 0 ] ),
+			},
+		],
+		[ translate, onClickView, onClickUnsubscribe ]
+	);
+
+	const currentView = useMemo< View >(
+		() => ( {
+			type: 'table',
+			layout: {},
+			search: searchTerm,
+			page,
+			perPage,
+			sort: { field: 'date_subscribed', direction: 'desc' },
+		} ),
+		[ searchTerm, page, perPage ]
+	);
+
+	const handleViewChange = ( newView: View ) => {
+		if ( typeof newView.page === 'number' && newView.page !== page ) {
+			pageChangeCallback( newView.page );
+		}
+
+		if ( typeof newView.perPage === 'number' && newView.perPage !== perPage ) {
+			setPerPage( newView.perPage );
+			pageChangeCallback( 1 );
+		}
+	};
+
+	const { data, paginationInfo } = useMemo( () => {
+		const result = filterSortAndPaginate< Subscriber >(
+			subscribers,
+			{
+				...currentView,
+				page: 1,
+				perPage: subscribers.length,
+			},
+			fields
+		);
+
+		return {
+			data: result.data,
+			paginationInfo: {
+				totalItems: grandTotal,
+				totalPages: pages ?? 0,
+			},
+		};
+	}, [ subscribers, currentView, fields, grandTotal, pages ] );
+
+	return (
+		<section className="subscriber-data-views">
+			<DataViews< Subscriber >
+				data={ data }
+				fields={ fields }
+				view={ currentView }
+				onChangeView={ handleViewChange }
+				isLoading={ isLoading }
+				paginationInfo={ paginationInfo }
+				getItemId={ ( item: Subscriber ) => item.subscription_id.toString() }
+				defaultLayouts={ { table: {} } }
+				actions={ actions }
+				search
+				searchLabel={ translate( 'Search by name, username or email…' ) }
+			/>
+			{ shouldShowLaunchpad && <EmptyComponent /> }
+		</section>
+	);
+};
+
+export default SubscriberDataViews;

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button, Gridicon } from '@automattic/components';
 import { HelpCenter, Subscriber as SubscriberDataStore } from '@automattic/data-stores';
@@ -14,6 +15,7 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import SubscriberValidationGate from 'calypso/components/subscribers-validation-gate';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import GiftSubscriptionModal from 'calypso/my-sites/subscribers/components/gift-modal/gift-modal';
+import { SubscriberDataViews } from 'calypso/my-sites/subscribers/components/subscriber-data-views';
 import { SubscriberListContainer } from 'calypso/my-sites/subscribers/components/subscriber-list-container';
 import {
 	SubscribersPageProvider,
@@ -187,12 +189,23 @@ const SubscribersPage = ( {
 					disableCta={ isUnverified || isStagingSite }
 				/>
 				<SubscriberValidationGate siteId={ siteId }>
-					<SubscriberListContainer
-						siteId={ siteId }
-						onClickView={ onClickView }
-						onGiftSubscription={ onGiftSubscription }
-						onClickUnsubscribe={ onClickUnsubscribe }
-					/>
+					{ isEnabled( 'subscribers-dataviews' ) ? (
+						// Your new dataviews component
+						<SubscriberDataViews
+							siteId={ siteId }
+							onClickView={ onClickView }
+							onGiftSubscription={ onGiftSubscription }
+							onClickUnsubscribe={ onClickUnsubscribe }
+						/>
+					) : (
+						// Existing subscriber list
+						<SubscriberListContainer
+							siteId={ siteId }
+							onClickView={ onClickView }
+							onGiftSubscription={ onGiftSubscription }
+							onClickUnsubscribe={ onClickUnsubscribe }
+						/>
+					) }
 
 					<UnsubscribeModal
 						subscriber={ currentSubscriber }

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -181,7 +181,12 @@ const SubscribersPage = ( {
 			sortTermChanged={ sortTermChanged }
 		>
 			<QueryMembershipsSettings siteId={ siteId ?? 0 } source="calypso" />
-			<Main wideLayout className="subscribers">
+			<Main
+				wideLayout
+				className={ `subscribers${
+					isEnabled( 'subscribers-dataviews' ) ? ' subscribers--dataviews' : ''
+				}` }
+			>
 				<DocumentHead title={ translate( 'Subscribers' ) } />
 
 				<SubscribersHeader


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/291

## Proposed Changes

* Add DataViews subscribers table behind flag `subscribers-dataviews`.

<img width="1047" alt="Screen Shot 2025-01-09 at 6 09 26 PM" src="https://github.com/user-attachments/assets/a86f4f21-0ec1-44c2-8eb7-d5bd19e2413c" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pe7F0s-2oe-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/subscribers/{ site id }?flags=subscribers-dataviews`
* Check that the pagination works.
* Check that you change the number of items per page using the gear icon.
* Check that you can search by name, username, or email.
* Check that you can sort by name or since (but only descending).

Note: I tested with paid subscribers and we're not currently returning plans data from the endpoint used here. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?