### PR TITLE
Stats: add Regions/Cities tab

### DIFF
--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -30,6 +30,14 @@ const OPTION_KEYS = {
 	CITIES: 'cities',
 };
 
+type StatQueryType = 'country' | 'region' | 'city';
+
+const STAT_QUERY_TYPES: Record< string, StatQueryType > = {
+	[ OPTION_KEYS.COUNTRIES ]: 'country',
+	[ OPTION_KEYS.REGIONS ]: 'region',
+	[ OPTION_KEYS.CITIES ]: 'city',
+};
+
 type SelectOptionType = {
 	label: string;
 	value: string;
@@ -47,12 +55,6 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 	const statType = 'statsCountryViews';
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const supportUrl = isOdysseyStats ? JETPACK_SUPPORT_URL_TRAFFIC : SUPPORT_URL;
-
-	const {
-		data = [],
-		isLoading: isRequestingData,
-		isError,
-	} = useLocationViewsQuery< StatsLocationViewsData >( siteId, 'country', query );
 
 	// Use StatsModule to display paywall upsell.
 	const shouldGateStatsModule = useShouldGateStats( statType );
@@ -75,6 +77,14 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 			analyticsId: 'cities',
 		},
 	};
+
+	const statQueryType = STAT_QUERY_TYPES[ selectedOption ];
+
+	const {
+		data = [],
+		isLoading: isRequestingData,
+		isError,
+	} = useLocationViewsQuery< StatsLocationViewsData >( siteId, statQueryType, query );
 
 	const changeViewButton = ( selection: SelectOptionType ) => {
 		const filter = selection.value;

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -437,7 +437,7 @@ export const normalizers = {
 
 			// ’ in country names causes google's geo viz to break
 			return {
-				label: country.country_full.replace( /’/, "'" ),
+				label: viewData.location || country.country_full.replace( /’/, "'" ),
 				countryCode: viewData.country_code,
 				value: viewData.views,
 				region: country.map_region,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/jetpack-roadmap#2093.

## Proposed Changes

* Make use of the functionality merged on #97951 to update the `Regions`/`Cities` tab.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* (p1HpG7-rpL-p2)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to the Calypso Live preview environment.
- Access the Stats page of a website that has meaningful data, like `/stats/day/jetpack.com?flags=stats/locations`
  - It's important to keep the feature flag to enable the visualization.
- Scroll down to the map and click on the `Regions` and `Cities` tabs below it.

### Regions

| Before | After |
| :-: | :-: |
| <img width="957" alt="image" src="https://github.com/user-attachments/assets/102e47f1-d4df-4830-8fe5-be676c900c03" /> | <img width="958" alt="image" src="https://github.com/user-attachments/assets/110887c9-c216-44d3-a5f9-421644c44fae" /> |

### Cities

| Before | After |
| :-: | :-: |
| <img width="957" alt="image" src="https://github.com/user-attachments/assets/a86d283f-7a7f-4fb0-9147-ee61022a6d49" /> | <img width="956" alt="image" src="https://github.com/user-attachments/assets/08fe6862-43a3-4ae4-beda-d5df3bde7d4d" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
