### PR TITLE
Storage Add-Ons: show notice when storage upgrade is available

### DIFF
--- a/client/my-sites/add-ons/main.tsx
+++ b/client/my-sites/add-ons/main.tsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { AddOns } from '@automattic/data-stores';
+import { AddOns, Purchases } from '@automattic/data-stores';
 import { css, Global } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -8,6 +8,7 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
+import Notice from 'calypso/components/notice';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
@@ -56,6 +57,40 @@ const ContainerMain = styled.div`
 	}
 `;
 
+export const StorageAddonsNotice = () => {
+	const translate = useTranslate();
+	const selectedSite = useSelector( getSelectedSite ) ?? null;
+	const availableStorageAddOns = AddOns.useAvailableStorageAddOns( { siteId: selectedSite?.ID } );
+	const storageAddOnPurchases = Purchases.useSitePurchasesByProductSlug( {
+		siteId: selectedSite?.ID,
+		productSlug: availableStorageAddOns?.[ 0 ]?.productSlug,
+	} );
+
+	// No storage add-ons available for purchase, so no need to show the notice
+	if ( ! availableStorageAddOns.length ) {
+		return null;
+	}
+
+	// No storage add-ons purchased, so no need to show the notice
+	if ( ! storageAddOnPurchases || ! Object.values( storageAddOnPurchases ).length ) {
+		return null;
+	}
+
+	return (
+		<Notice showDismiss={ false }>
+			{ translate(
+				'Purchasing a storage add-on will replace your current %(currentExtraStorage)sGB extra storage (not add to it).',
+				{
+					args: {
+						currentExtraStorage:
+							Object.values( storageAddOnPurchases )[ 0 ].purchaseRenewalQuantity || '0',
+					},
+				}
+			) }
+		</Notice>
+	);
+};
+
 const ContentWithHeader = ( props: { children: ReactElement } ) => {
 	const translate = useTranslate();
 
@@ -69,6 +104,7 @@ const ContentWithHeader = ( props: { children: ReactElement } ) => {
 						'Expand the functionality of your WordPress.com site by enabling any of the following features.'
 					) }
 				/>
+				<StorageAddonsNotice />
 				<div className="add-ons__main-content">{ props.children }</div>
 			</Main>
 		</ContainerMain>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #97229

## Proposed Changes

* Adds a notice on the add-ons page explaining that upgrading to a higher storage add-on will replace the current storage and not add to it.

<img width="1155" alt="image" src="https://github.com/user-attachments/assets/93178ab2-faa6-4047-8556-619a124f39c8" />

**Note**: I'll be adding the `String Freeze` label once the PR has been reviewed and the notice copy finalized.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The notice will help users understand that the cost of a higher storage tier includes the cost of the currently purchased storage. So upgrading will replace and not add to their current extra storage.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/add-ons/<site slug>` for a site without any purchased storage add-ons.
* Confirm that you do not see any notice.
* Purchase the 50GB add-on.
* Go to `/add-ons/<site slug>` for the same site.
* Confirm that you do see the notice.
* Purchase the 100GB add-on.
* Confirm that you do not see any notice.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
