### PR TITLE
Plan Downgrade: Allow plan downgrades to monthly when purchased with credits

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/get-upsell-type.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/get-upsell-type.ts
@@ -39,7 +39,7 @@ export type UpsellType =
  * @returns {UpsellType} The upsell nudge type
  */
 export function getUpsellType( reason: string, opts: UpsellOptions ): UpsellType {
-	const { productSlug, canRefund, canDowngrade, canOfferFreeMonth } = opts;
+	const { productSlug, canDowngrade, canOfferFreeMonth } = opts;
 	const liveChatSupported = config.isEnabled( 'livechat_solution' );
 
 	if ( ! productSlug ) {
@@ -58,10 +58,9 @@ export function getUpsellType( reason: string, opts: UpsellOptions ): UpsellType
 			}
 
 			if (
-				canRefund &&
-				( isWpComAnnualPlan( productSlug ) ||
-					isWpComBiennialPlan( productSlug ) ||
-					isWpComTriennialPlan( productSlug ) )
+				isWpComAnnualPlan( productSlug ) ||
+				isWpComBiennialPlan( productSlug ) ||
+				isWpComTriennialPlan( productSlug )
 			) {
 				return 'downgrade-monthly';
 			}

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -254,15 +254,16 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 								'You will lose your free domain registration since that feature is only included in annual/biannual plans.'
 							) }
 						{ refundAmount && <br /> }
-						{ refundAmount &&
-							translate(
-								'You can downgrade immediately and get a partial refund of %(refundAmount)s.',
-								{
-									args: {
-										refundAmount: formatCurrency( parseFloat( refundAmount ), currencyCode ),
-									},
-								}
-							) }
+						{ Number( refundAmount )
+							? translate(
+									'You can downgrade immediately and get a partial refund of %(refundAmount)s.',
+									{
+										args: {
+											refundAmount: formatCurrency( parseFloat( refundAmount ), currencyCode ),
+										},
+									}
+							  )
+							: null }
 					</>
 				</Upsell>
 			);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#3548


## Proposed Changes

* Allows the frontend to show plan downgrades to monthly plans even when the plan was purchased with credits 
* Related change: 169556-ghe-Automattic/wpcom

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Users weren't allowed to downgrade when a plan was purchased with credits. This is because a "downgrade" involved cancelling a plan and initiating a refund. And credits do not generally involve a refund. So this user flow was blocked. This change fixes this behaviour.

## Testing Instructions

* Checkout PR
* Sandbox the API
* Add credits to a site you have
* Purchase any multi year plan
* Cancel the plan with reason pricing budget
* Make sure the monthly downgrade view and button  is visible.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?


