### PR TITLE
Stats: add location views query hook

### DIFF
--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -164,7 +164,6 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 						metricLabel={ translate( 'Visitors' ) }
 						loader={ isRequestingData && <StatsModulePlaceholder isLoading={ isRequestingData } /> }
 						splitHeader
-						useShortNumber
 						heroElement={ <Geochart query={ query } skipQuery /> }
 						mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
 						toggleControl={ toggleControlComponent }

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -6,23 +6,21 @@ import { mapMarker } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import useLocationViewsQuery, {
+	StatsLocationViewsData,
+} from 'calypso/my-sites/stats/hooks/use-location-views-query';
 import { useShouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
 import { QueryStatsParams } from 'calypso/my-sites/stats/hooks/utils';
 import StatsListCard from 'calypso/my-sites/stats/stats-list/stats-list-card';
 import StatsModulePlaceholder from 'calypso/my-sites/stats/stats-module/placeholder';
 import statsStrings from 'calypso/my-sites/stats/stats-strings';
 import { useSelector } from 'calypso/state';
-import {
-	isRequestingSiteStatsForQuery,
-	getSiteStatsNormalizedData,
-} from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
 import { SUPPORT_URL, JETPACK_SUPPORT_URL_TRAFFIC } from '../../../const';
 import Geochart from '../../../geochart';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
 import StatsInfoArea from '../shared/stats-info-area';
-import type { StatsStateProps } from '../types';
 
 import './style.scss';
 
@@ -50,15 +48,14 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const supportUrl = isOdysseyStats ? JETPACK_SUPPORT_URL_TRAFFIC : SUPPORT_URL;
 
+	const {
+		data = [],
+		isLoading: isRequestingData,
+		isError,
+	} = useLocationViewsQuery< StatsLocationViewsData >( siteId, 'country', query );
+
 	// Use StatsModule to display paywall upsell.
 	const shouldGateStatsModule = useShouldGateStats( statType );
-
-	const isRequestingData = useSelector( ( state: StatsStateProps ) =>
-		isRequestingSiteStatsForQuery( state, siteId, statType, query )
-	);
-	const data = useSelector( ( state ) =>
-		getSiteStatsNormalizedData( state, siteId, statType, query )
-	) as [ id: number, label: string ];
 
 	const [ selectedOption, setSelectedOption ] = useState( OPTION_KEYS.COUNTRIES );
 	const optionLabels = {
@@ -138,7 +135,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 					withHero
 				/>
 			) }
-			{ ( ( ! isRequestingData && !! data?.length ) || shouldGateStatsModule ) && (
+			{ ( ( ! isRequestingData && ! isError && ! data ) || shouldGateStatsModule ) && (
 				// show data or an overlay
 				<>
 					{ /* @ts-expect-error TODO: Refactor StatsListCard with TypeScript. */ }
@@ -176,7 +173,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 								? {
 										url: summaryUrl,
 										label:
-											data.length >= 10
+											Array.isArray( data ) && data.length >= 10
 												? translate( 'View all', {
 														context: 'Stats: Button link to show more detailed stats information',
 												  } )
@@ -189,22 +186,25 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 					/>
 				</>
 			) }
-			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (
-				// show empty state
-				<StatsCard
-					title={ translate( 'Locations' ) }
-					isEmpty
-					emptyMessage={ emptyMessage }
-					footerAction={
-						summaryUrl
-							? {
-									url: summaryUrl,
-									label: translate( 'View more' ),
-							  }
-							: undefined
-					}
-				/>
-			) }
+			{ ! isRequestingData &&
+				Array.isArray( data ) &&
+				! data?.length &&
+				! shouldGateStatsModule && (
+					// show empty state
+					<StatsCard
+						title={ translate( 'Locations' ) }
+						isEmpty
+						emptyMessage={ emptyMessage }
+						footerAction={
+							summaryUrl
+								? {
+										url: summaryUrl,
+										label: translate( 'View more' ),
+								  }
+								: undefined
+						}
+					/>
+				) }
 		</>
 	);
 };

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -135,7 +135,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 					withHero
 				/>
 			) }
-			{ ( ( ! isRequestingData && ! isError && ! data ) || shouldGateStatsModule ) && (
+			{ ( ( ! isRequestingData && ! isError && data ) || shouldGateStatsModule ) && (
 				// show data or an overlay
 				<>
 					{ /* @ts-expect-error TODO: Refactor StatsListCard with TypeScript. */ }

--- a/client/my-sites/stats/hooks/use-location-views-query.ts
+++ b/client/my-sites/stats/hooks/use-location-views-query.ts
@@ -29,7 +29,16 @@ const useLocationViewsQuery = < T = StatsLocationViewsData >(
 		queryKey: [ 'stats', 'location-views', siteId, geoMode, query ],
 		queryFn: () =>
 			queryStatsLocationViews( siteId, geoMode, processQueryParams( query ) ) as Promise< T >,
-		select: ( data ) => normalizers.statsCountryViews( data as StatsLocationViewsData ),
+		select: ( data ) => {
+			const normalizedStats = normalizers.statsCountryViews(
+				data as StatsLocationViewsData,
+				query
+			);
+
+			return Array.isArray( normalizedStats ) && normalizedStats?.length && query?.max
+				? normalizedStats.slice( 0, query.max )
+				: normalizedStats;
+		},
 		staleTime: 1000 * 60 * 5, // Cache for 5 minutes
 	} );
 };

--- a/client/my-sites/stats/hooks/use-location-views-query.ts
+++ b/client/my-sites/stats/hooks/use-location-views-query.ts
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { normalizers } from 'calypso/state/stats/lists/utils';
+import getDefaultQueryParams from './default-query-params';
+import { processQueryParams, QueryStatsParams } from './utils';
+
+export interface StatsLocationViewsData {
+	date: string;
+	days?: Array< { date: string; views: Record< string, number > } >;
+	summary?: Record< string, number >;
+	countryInfo?: Record< string, unknown >;
+}
+
+function queryStatsLocationViews(
+	siteId: number,
+	geoMode: 'country' | 'region' | 'city',
+	query: QueryStatsParams
+): Promise< StatsLocationViewsData > {
+	return wpcom.req.get( `/sites/${ siteId }/stats/location-views/${ geoMode }`, query );
+}
+
+const useLocationViewsQuery = < T = StatsLocationViewsData >(
+	siteId: number,
+	geoMode: 'country' | 'region' | 'city',
+	query: QueryStatsParams
+) => {
+	return useQuery( {
+		...getDefaultQueryParams(),
+		queryKey: [ 'stats', 'location-views', siteId, geoMode, query ],
+		queryFn: () =>
+			queryStatsLocationViews( siteId, geoMode, processQueryParams( query ) ) as Promise< T >,
+		select: ( data ) => normalizers.statsCountryViews( data as StatsLocationViewsData ),
+		staleTime: 1000 * 60 * 5, // Cache for 5 minutes
+	} );
+};
+
+export default useLocationViewsQuery;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves to https://github.com/Automattic/jetpack-roadmap/issues/2095

## Proposed Changes

* Add `useLocationViewsQuery` hook in `client/my-sites/stats/hooks/use-location-views-query.ts`.
* Abstract logic for fetching location-based (country, region, city) view stats into the new hook.
* Update relevant components to use the new hook, guarded by the `stats/location` feature flag to prevent any unintended impact on production users.

![CleanShot 2025-01-05 at 15 48 30@2x](https://github.com/user-attachments/assets/e568753c-dda9-4751-993b-23b7decb4168)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

p1HpG7-rpL-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> This can only be tested on WPCOM using Calypso Blue, which is suitable for the initial development process. We can begin testing it on Odyssey once the `location-views` API is implemented in the Jetpack API: https://github.com/Automattic/jetpack/pull/40852

1. **Setup**:
   - Spin up a Calypso Live branch with the latest changes.

2. **Enable the Feature**:
   - Navigate to the Stats traffic page.
   - Append `?flags=stats/locations` to the URL to enable the `stats/location` feature flag.

3. **Verify UI Changes**:
   - You should see the new **Locations** section on the page.
   - The section should render the **country visits list** as shown in the provided screenshot.

4. **Validate API Calls**:
   - Open your browser's Network tab.
   - Confirm that the page is making requests to the `stats/location-views/%` endpoint and that the responses are as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?