### PR TITLE
Show domain in site context - layout, tab, main pages

### DIFF
--- a/client/hosting/overview/index.tsx
+++ b/client/hosting/overview/index.tsx
@@ -10,12 +10,34 @@ import {
 } from 'calypso/controller';
 import { handleHostingPanelRedirect } from 'calypso/hosting/server-settings/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
+import domainManagementController from 'calypso/my-sites/domains/domain-management/controller';
+import {
+	DOMAIN_OVERVIEW,
+	EMAIL_MANAGEMENT,
+} from 'calypso/my-sites/domains/domain-management/domain-overview-pane/constants';
+import emailController from 'calypso/my-sites/email/controller';
 import {
 	DOTCOM_HOSTING_CONFIG,
 	DOTCOM_OVERVIEW,
 } from 'calypso/sites/components/site-preview-pane/constants';
 import { siteDashboard } from 'calypso/sites/controller';
 import { hostingOverview, hostingConfiguration, hostingActivate } from './controller';
+
+function registerSiteDomainPage( { path, controllers }: { path: string; controllers: any[] } ) {
+	page(
+		path,
+		domainManagementController.domainManagementSiteContext,
+		siteSelection,
+		redirectIfCurrentUserCannot( 'manage_options' ),
+		redirectIfP2,
+		redirectIfJetpackNonAtomic,
+		navigation,
+		...controllers,
+		siteDashboard( undefined ),
+		makeLayout,
+		clientRender
+	);
+}
 
 export default function () {
 	page( '/overview', siteSelection, sites, makeLayout, clientRender );
@@ -78,4 +100,21 @@ export default function () {
 			clientRender
 		);
 	}
+
+	// Domain pages under site overview's context.
+	registerSiteDomainPage( {
+		path: '/overview/site-domain/domain/:domain/:site',
+		controllers: [
+			domainManagementController.domainManagementV2,
+			domainManagementController.domainManagementPaneView( DOMAIN_OVERVIEW ),
+		],
+	} );
+
+	registerSiteDomainPage( {
+		path: '/overview/site-domain/email/:domain/:site',
+		controllers: [
+			emailController.emailManagement,
+			domainManagementController.domainManagementPaneView( EMAIL_MANAGEMENT ),
+		],
+	} );
 }

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -394,6 +394,7 @@ export default {
 					selectedFeature={ feature }
 					siteSlug={ siteSlug }
 					site={ site }
+					inSiteContext={ pageContext.inSiteContext }
 				/>
 			);
 
@@ -410,6 +411,11 @@ export default {
 			};
 			next();
 		};
+	},
+
+	domainManagementSiteContext( pageContext, next ) {
+		pageContext.inSiteContext = true;
+		next();
 	},
 
 	domainManagementSubpageView( pageContext, next ) {

--- a/client/my-sites/domains/domain-management/domain-overview-pane/constants.ts
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/constants.ts
@@ -7,6 +7,6 @@ export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 };
 
 export const FEATURE_TO_ROUTE_MAP_IN_SITE_CONTEXT: { [ feature: string ]: string } = {
-	[ DOMAIN_OVERVIEW ]: 'domains/manage/all/overview/site-domain/:domain/:site',
-	[ EMAIL_MANAGEMENT ]: 'domains/manage/all/email/site-domain/:domain/:site',
+	[ DOMAIN_OVERVIEW ]: 'overview/site-domain/domain/:domain/:site',
+	[ EMAIL_MANAGEMENT ]: 'overview/site-domain/email/:domain/:site',
 };

--- a/client/my-sites/domains/domain-management/domain-overview-pane/constants.ts
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/constants.ts
@@ -5,3 +5,8 @@ export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	[ DOMAIN_OVERVIEW ]: 'domains/manage/all/overview/:domain/:site',
 	[ EMAIL_MANAGEMENT ]: 'domains/manage/all/email/:domain/:site',
 };
+
+export const FEATURE_TO_ROUTE_MAP_IN_SITE_CONTEXT: { [ feature: string ]: string } = {
+	[ DOMAIN_OVERVIEW ]: 'domains/manage/all/overview/site-domain/:domain/:site',
+	[ EMAIL_MANAGEMENT ]: 'domains/manage/all/email/site-domain/:domain/:site',
+};

--- a/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
@@ -8,7 +8,12 @@ import { useMemo, useRef } from 'react';
 import ItemView from 'calypso/layout/hosting-dashboard/item-view';
 import * as paths from 'calypso/my-sites/domains/paths';
 import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
-import { FEATURE_TO_ROUTE_MAP, DOMAIN_OVERVIEW, EMAIL_MANAGEMENT } from './constants';
+import {
+	FEATURE_TO_ROUTE_MAP,
+	DOMAIN_OVERVIEW,
+	EMAIL_MANAGEMENT,
+	FEATURE_TO_ROUTE_MAP_IN_SITE_CONTEXT,
+} from './constants';
 import type {
 	ItemData,
 	FeaturePreviewInterface,
@@ -22,6 +27,7 @@ interface Props {
 	selectedFeature: string;
 	siteSlug: string;
 	site: SiteExcerptData;
+	inSiteContext?: boolean;
 }
 
 export function showDomainManagementPage( route: string ) {
@@ -56,6 +62,7 @@ const DomainOverviewPane = ( {
 	selectedFeature,
 	siteSlug,
 	site,
+	inSiteContext,
 }: Props ) => {
 	const itemData: ItemData = {
 		title: selectedDomain,
@@ -117,8 +124,12 @@ const DomainOverviewPane = ( {
 					selected,
 					onTabClick: () => {
 						if ( enabled && ! selected ) {
+							const featureMap = inSiteContext
+								? FEATURE_TO_ROUTE_MAP_IN_SITE_CONTEXT
+								: FEATURE_TO_ROUTE_MAP;
+
 							showDomainManagementPage(
-								FEATURE_TO_ROUTE_MAP[ defaultFeatureId ]
+								featureMap[ defaultFeatureId ]
 									.replace( ':domain', selectedDomain )
 									.replace( ':site', siteSlug )
 							);
@@ -140,7 +151,7 @@ const DomainOverviewPane = ( {
 			features={ features }
 			enforceTabsView
 			itemViewHeaderExtraProps={ {
-				headerButtons: PreviewPaneHeaderButtons,
+				headerButtons: inSiteContext ? undefined : PreviewPaneHeaderButtons,
 			} }
 		/>
 	);

--- a/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
@@ -151,7 +151,7 @@ const DomainOverviewPane = ( {
 			features={ features }
 			enforceTabsView
 			itemViewHeaderExtraProps={ {
-				headerButtons: inSiteContext ? undefined : PreviewPaneHeaderButtons,
+				headerButtons: PreviewPaneHeaderButtons,
 			} }
 		/>
 	);

--- a/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
@@ -146,7 +146,7 @@ const DomainOverviewPane = ( {
 		<ItemView
 			itemData={ itemData }
 			closeItemView={ () => {
-				page.show( paths.domainManagementRoot() );
+				inSiteContext ? page.show( '/sites' ) : page.show( paths.domainManagementRoot() );
 			} }
 			features={ features }
 			enforceTabsView

--- a/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
@@ -1,7 +1,13 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.domains-overview .hosting-dashboard-item-view {
+.wpcom-site .hosting-dashboard-layout.domains-overview 	.site-preview-pane.domains-overview__details {
+	.hosting-dashboard-item-view .hosting-dashboard-item-view__content {
+		font-size: 1rem;
+	}
+}
+
+.hosting-dashboard-layout.domains-overview .hosting-dashboard-item-view {
 	.hosting-dashboard-item-view__header .hosting-dashboard-item-view__header-content .hosting-dashboard-item-view__header-title-summary {
 		 .hosting-dashboard-item-view__header-summary-link {
 			color: var(--studio-gray-50, #646970);
@@ -46,7 +52,7 @@
 		}
 	}
 
-	.domains-overview__navigation-header.navigation-header {
+	div.hosting-dashboard-item-view__content header.domains-overview__navigation-header.navigation-header {
 		padding: 24px;
 		border: 0;
 

--- a/client/my-sites/domains/domain-management/settings/style.scss
+++ b/client/my-sites/domains/domain-management/settings/style.scss
@@ -2,7 +2,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-body.edit__body-white.theme-default.color-scheme {
+body:not(.is-global).edit__body-white.theme-default.color-scheme {
 	--color-surface-backdrop: var(--studio-white);
 }
 

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -15,7 +15,7 @@ import {
 	stagingSiteNotSupportedRedirect,
 	noSite,
 } from 'calypso/my-sites/controller';
-import * as siteController from 'calypso/sites/controller';
+import { siteDashboard } from 'calypso/sites/controller';
 import emailController from '../email/controller';
 import domainsController from './controller';
 import domainManagementController from './domain-management/controller';
@@ -87,7 +87,7 @@ function registerSiteDomainPage( { path, controllers } ) {
 		redirectIfJetpackNonAtomic,
 		navigation,
 		...controllers,
-		siteController.siteDashboard(),
+		siteDashboard(),
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -1,11 +1,5 @@
 import page from '@automattic/calypso-router';
-import {
-	makeLayout,
-	render as clientRender,
-	redirectIfCurrentUserCannot,
-	redirectIfP2,
-	redirectIfJetpackNonAtomic,
-} from 'calypso/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
 import { recordSiftScienceUser } from 'calypso/lib/siftscience';
 import {
 	navigation,
@@ -15,7 +9,6 @@ import {
 	stagingSiteNotSupportedRedirect,
 	noSite,
 } from 'calypso/my-sites/controller';
-import { siteDashboard } from 'calypso/sites/controller';
 import emailController from '../email/controller';
 import domainsController from './controller';
 import domainManagementController from './domain-management/controller';
@@ -73,22 +66,6 @@ function getCommonHandlers( {
 	}
 
 	return handlers;
-}
-
-function registerSiteDomainPage( { path, controllers } ) {
-	page(
-		path,
-		domainManagementController.domainManagementSiteContext,
-		siteSelection,
-		redirectIfCurrentUserCannot( 'manage_options' ),
-		redirectIfP2,
-		redirectIfJetpackNonAtomic,
-		navigation,
-		...controllers,
-		siteDashboard(),
-		makeLayout,
-		clientRender
-	);
 }
 
 export default function () {
@@ -494,20 +471,4 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
-
-	registerSiteDomainPage( {
-		path: paths.domainManagementOverviewRoot() + '/site-domain/:domain/:site',
-		controllers: [
-			domainManagementController.domainManagementV2,
-			domainManagementController.domainManagementPaneView( DOMAIN_OVERVIEW ),
-		],
-	} );
-
-	registerSiteDomainPage( {
-		path: paths.domainManagementAllEmailRoot() + '/site-domain/:domain/:site',
-		controllers: [
-			emailController.emailManagement,
-			domainManagementController.domainManagementPaneView( EMAIL_MANAGEMENT ),
-		],
-	} );
 }

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -1,5 +1,11 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	redirectIfCurrentUserCannot,
+	redirectIfP2,
+	redirectIfJetpackNonAtomic,
+} from 'calypso/controller';
 import { recordSiftScienceUser } from 'calypso/lib/siftscience';
 import {
 	navigation,
@@ -9,6 +15,7 @@ import {
 	stagingSiteNotSupportedRedirect,
 	noSite,
 } from 'calypso/my-sites/controller';
+import * as siteController from 'calypso/sites/controller';
 import emailController from '../email/controller';
 import domainsController from './controller';
 import domainManagementController from './domain-management/controller';
@@ -66,6 +73,24 @@ function getCommonHandlers( {
 	}
 
 	return handlers;
+}
+
+function registerSiteDomainPage( { path, controllers } ) {
+	page(
+		path,
+		domainManagementController.domainManagementSiteContext,
+		siteSelection,
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		redirectIfCurrentUserCannot( 'manage_options' ),
+		redirectIfP2,
+		redirectIfJetpackNonAtomic,
+		navigation,
+		...controllers,
+		siteController.siteDashboard(),
+		makeLayout,
+		clientRender
+	);
 }
 
 export default function () {
@@ -471,4 +496,20 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
+
+	registerSiteDomainPage( {
+		path: paths.domainManagementOverviewRoot() + '/site-domain/:domain/:site',
+		controllers: [
+			domainManagementController.domainManagementV2,
+			domainManagementController.domainManagementPaneView( DOMAIN_OVERVIEW ),
+		],
+	} );
+
+	registerSiteDomainPage( {
+		path: paths.domainManagementAllEmailRoot() + '/site-domain/:domain/:site',
+		controllers: [
+			emailController.emailManagement,
+			domainManagementController.domainManagementPaneView( EMAIL_MANAGEMENT ),
+		],
+	} );
 }

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -80,8 +80,6 @@ function registerSiteDomainPage( { path, controllers } ) {
 		path,
 		domainManagementController.domainManagementSiteContext,
 		siteSelection,
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
 		redirectIfCurrentUserCannot( 'manage_options' ),
 		redirectIfP2,
 		redirectIfJetpackNonAtomic,

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -61,7 +61,10 @@ export function isUnderDomainManagementAll( path ) {
 }
 
 export function isUnderDomainManagementOverview( path ) {
-	return path?.startsWith( domainManagementOverviewRoot() + '/' );
+	return (
+		path?.startsWith( domainManagementOverviewRoot() + '/' ) ||
+		path?.startsWith( '/overview/site-domain/' )
+	);
 }
 
 export function domainAddNew( siteName, searchTerm ) {

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -444,12 +444,13 @@
 /**
  * Context: All Domain Management
  */
+.wpcom-site .hosting-dashboard-item-view__content .context-all-domain-management, /* For Domain and Email related pages under site context. */
 .context-all-domain-management {
 	&.main {
 		margin-left: 0;
 		width: 100%;
 
-		.domains-email__navigation-header.navigation-header {
+		header.domains-email__navigation-header.navigation-header {
 			border: 0;
 			padding: 1.5rem;
 

--- a/client/sites/components/sites-dashboard.tsx
+++ b/client/sites/components/sites-dashboard.tsx
@@ -65,6 +65,7 @@ interface SitesDashboardProps {
 	initialSiteFeature?: string;
 	selectedSiteFeaturePreview?: React.ReactNode;
 	sectionName?: string;
+	isOnlyLayoutView?: boolean;
 }
 
 const siteSortingKeys = [
@@ -129,6 +130,7 @@ const SitesDashboard = ( {
 	},
 	initialSiteFeature = isEnabled( 'untangling/hosting-menu' ) ? OVERVIEW : DOTCOM_OVERVIEW,
 	selectedSiteFeaturePreview = undefined,
+	isOnlyLayoutView = undefined,
 }: SitesDashboardProps ) => {
 	const [ initialSortApplied, setInitialSortApplied ] = useState( false );
 	const isWide = useBreakpoint( WIDE_BREAKPOINT );
@@ -384,7 +386,8 @@ const SitesDashboard = ( {
 			className={ clsx(
 				'sites-dashboard',
 				'sites-dashboard__layout',
-				! selectedSite && 'preview-hidden'
+				! selectedSite && 'preview-hidden',
+				isOnlyLayoutView && 'domains-overview'
 			) }
 			wide
 			title={ selectedSite ? null : dashboardTitle }
@@ -426,14 +429,24 @@ const SitesDashboard = ( {
 					preferenceNames={ CALYPSO_ONBOARDING_TOURS_PREFERENCE_NAME }
 					eventNames={ CALYPSO_ONBOARDING_TOURS_EVENT_NAMES }
 				>
-					<LayoutColumn className="site-preview-pane" wide>
-						<DotcomPreviewPane
-							site={ selectedSite }
-							selectedSiteFeature={ initialSiteFeature }
-							selectedSiteFeaturePreview={ selectedSiteFeaturePreview }
-							closeSitePreviewPane={ closeSitePreviewPane }
-							changeSitePreviewPane={ changeSitePreviewPane }
-						/>
+					<LayoutColumn
+						className={ clsx(
+							'site-preview-pane',
+							isOnlyLayoutView && 'domains-overview__details'
+						) }
+						wide
+					>
+						{ isOnlyLayoutView ? (
+							selectedSiteFeaturePreview
+						) : (
+							<DotcomPreviewPane
+								site={ selectedSite }
+								selectedSiteFeature={ initialSiteFeature }
+								selectedSiteFeaturePreview={ selectedSiteFeaturePreview }
+								closeSitePreviewPane={ closeSitePreviewPane }
+								changeSitePreviewPane={ changeSitePreviewPane }
+							/>
+						) }
 					</LayoutColumn>
 					<GuidedTour defaultTourId="siteManagementTour" />
 				</GuidedTourContextProvider>

--- a/client/sites/components/style.scss
+++ b/client/sites/components/style.scss
@@ -774,3 +774,21 @@
 		justify-content: center;
 	}
 }
+
+/*
+ * For Domain and Email related pages under site context.
+ */
+.wpcom-site .hosting-dashboard-layout.domains-overview.main .hosting-dashboard-item-view {
+	.hosting-dashboard-item-view__content {
+		padding: 0;
+		padding-bottom: 48px;
+
+		@include break-medium {
+			padding: 24px;
+		}
+
+		@include break-large {
+			padding: 32px 48px 48px;
+		}
+	}
+}

--- a/client/sites/controller.tsx
+++ b/client/sites/controller.tsx
@@ -125,7 +125,7 @@ export function sitesDashboard( context: Context, next: () => void ) {
 	next();
 }
 
-export function siteDashboard( feature: string ) {
+export function siteDashboard( feature: string | undefined ) {
 	return ( context: Context, next: () => void ) => {
 		context.primary = (
 			<SitesDashboard

--- a/client/sites/controller.tsx
+++ b/client/sites/controller.tsx
@@ -132,6 +132,7 @@ export function siteDashboard( feature: string ) {
 				initialSiteFeature={ feature }
 				selectedSiteFeaturePreview={ context.primary }
 				queryParams={ getQueryParams( context ) }
+				isOnlyLayoutView={ context.inSiteContext }
 			/>
 		);
 		next();

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -100,7 +100,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 	const handleSelect = () => {
 		const isAllDomainManagementEnabled = config.isEnabled( 'calypso/all-domain-management' );
 
-		if ( isAllDomainManagementEnabled && isAllSitesView ) {
+		if ( isAllDomainManagementEnabled ) {
 			page.show( domainManagementLink );
 			return;
 		}

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -23,14 +23,15 @@ export function domainManagementLink(
 	const isAllDomainManagementEnabled = config.isEnabled( 'calypso/all-domain-management' );
 
 	if ( isAllDomainManagementEnabled ) {
-		const siteDomainPath = isAllSitesView ? '' : 'site-domain/';
 		switch ( feature ) {
 			case 'email-management':
 				return `${ domainManagementAllRoot() }/email/${ domain }/${ siteSlug }`;
 
 			case 'domain-overview':
 			default:
-				return `${ domainManagementAllRoot() }/overview/${ siteDomainPath + domain }/${ siteSlug }`;
+				return isAllSitesView
+					? `${ domainManagementAllRoot() }/overview/${ domain }/${ siteSlug }`
+					: `/overview/site-domain/domain/${ domain }/${ siteSlug }`;
 		}
 	}
 

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -22,14 +22,15 @@ export function domainManagementLink(
 
 	const isAllDomainManagementEnabled = config.isEnabled( 'calypso/all-domain-management' );
 
-	if ( isAllDomainManagementEnabled && isAllSitesView ) {
+	if ( isAllDomainManagementEnabled ) {
+		const siteDomainPath = isAllSitesView ? '' : 'site-domain/';
 		switch ( feature ) {
 			case 'email-management':
 				return `${ domainManagementAllRoot() }/email/${ domain }/${ siteSlug }`;
 
 			case 'domain-overview':
 			default:
-				return `${ domainManagementAllRoot() }/overview/${ domain }/${ siteSlug }`;
+				return `${ domainManagementAllRoot() }/overview/${ siteDomainPath + domain }/${ siteSlug }`;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to item-preview__admin-button

## Proposed Changes

- Create a layout for domain opened in site context
- Make tab switch work in site context
- Implement some style fixes for the main pages (style will be fully taken care of under the page-specific card for that page)
- Links to sub-page will be implemented in the Page specific issues

https://github.com/user-attachments/assets/afba453c-002a-4cfa-b494-e05d60ffd71d

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Domain management revamp - site context

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the feature flag by entering `window.sessionStorage.setItem('flags', 'calypso/all-domain-management')` in dev console
* Go to calypso.localhost:3000/sites
* Open a site that has a manageable domain
* Scroll to the bottom of the site's overview pane, click on the domain
* Make sure the domain opens in the new site-context layout (sites on left, domain details on right)
* Open the accordions and make sure the spacing looks right in general
* Try in mobile view as well
* Make sure the tab switching works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
