### PR TITLE
/start/onboarding always redirects to /setup/onboarding

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -5,7 +5,6 @@ import { createElement } from 'react';
 import store from 'store';
 import { notFound } from 'calypso/controller';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import { sectionify } from 'calypso/lib/route';
@@ -251,7 +250,6 @@ export default {
 		const isOnboardingFlow = flowName === 'onboarding';
 
 		if ( isOnboardingFlow && ! hasRedirected ) {
-			await loadExperimentAssignment( 'calypso_signup_onboarding_aa_test' );
 			setHasRedirectedForExperiment();
 
 			setReferrerPolicy();

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -254,10 +254,6 @@ export default {
 			await loadExperimentAssignment( 'calypso_signup_onboarding_aa_test' );
 			setHasRedirectedForExperiment();
 
-			const stepperOnboardingExperimentAssignment = await loadExperimentAssignment(
-				'calypso_signup_onboarding_stepper_flow_confidence_check_3'
-			);
-
 			setReferrerPolicy();
 			let url =
 				getStepUrl(
@@ -266,7 +262,7 @@ export default {
 					getStepSectionName( context.params ),
 					localeFromParams ?? localeFromStore,
 					null,
-					stepperOnboardingExperimentAssignment.variationName === 'stepper' ? '/setup' : '/start'
+					'/setup'
 				) +
 				'?redirected_1220=true' +
 				( context.querystring ? '&' + context.querystring : '' ) +

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -31,8 +31,6 @@ import {
 	clearSignupDestinationCookie,
 	getSignupCompleteFlowName,
 	wasSignupCheckoutPageUnloaded,
-	setHasRedirectedForExperiment,
-	getHasRedirectedForExperiment,
 } from './storageUtils';
 import {
 	getStepUrl,
@@ -240,18 +238,9 @@ export default {
 
 		store.set( 'signup-locale', localeFromParams );
 
-		const hasRedirected =
-			context.querystring?.includes( 'redirected_1220=true' ) ||
-			// Check the URL as well because sometimes the context.querystring lags behind the URL.
-			new URLSearchParams( window.location.search ).has( 'redirected_1220' ) ||
-			// Check session storage in case the query parma was omitted.
-			getHasRedirectedForExperiment();
-
 		const isOnboardingFlow = flowName === 'onboarding';
 
-		if ( isOnboardingFlow && ! hasRedirected ) {
-			setHasRedirectedForExperiment();
-
+		if ( isOnboardingFlow ) {
 			setReferrerPolicy();
 			let url =
 				getStepUrl(
@@ -262,7 +251,6 @@ export default {
 					null,
 					'/setup'
 				) +
-				'?redirected_1220=true' +
 				( context.querystring ? '&' + context.querystring : '' ) +
 				( context.hashstring ? '#' + context.hashstring : '' );
 

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
+import { isOnboardingFlow } from '@automattic/onboarding';
 import { isEmpty } from 'lodash';
 import { createElement } from 'react';
 import store from 'store';
@@ -238,9 +239,7 @@ export default {
 
 		store.set( 'signup-locale', localeFromParams );
 
-		const isOnboardingFlow = flowName === 'onboarding';
-
-		if ( isOnboardingFlow ) {
+		if ( isOnboardingFlow( flowName ) ) {
 			setReferrerPolicy();
 			let url =
 				getStepUrl(
@@ -251,7 +250,7 @@ export default {
 					null,
 					'/setup'
 				) +
-				( context.querystring ? '&' + context.querystring : '' ) +
+				( context.querystring ? '?' + context.querystring : '' ) +
 				( context.hashstring ? '#' + context.hashstring : '' );
 
 			if ( document.referrer ) {

--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -61,21 +61,6 @@ export const setSignupCheckoutPageUnloaded = ( value ) =>
 export const getSignupCompleteFlowName = () =>
 	ignoreFatalsForStorage( () => sessionStorage?.getItem( 'wpcom_signup_complete_flow_name' ) );
 
-export const getHasRedirectedForExperiment = () =>
-	ignoreFatalsForStorage( () =>
-		sessionStorage?.getItem(
-			'wpcom_redirected_calypso_signup_onboarding_stepper_flow_confidence_check_2'
-		)
-	);
-
-export const setHasRedirectedForExperiment = () =>
-	ignoreFatalsForStorage( () =>
-		sessionStorage?.setItem(
-			'wpcom_redirected_calypso_signup_onboarding_stepper_flow_confidence_check_2',
-			'1'
-		)
-	);
-
 export const setSignupCompleteFlowName = ( value ) =>
 	ignoreFatalsForStorage( () =>
 		sessionStorage?.setItem( 'wpcom_signup_complete_flow_name', value )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/96659

This is a pre-requisite for https://github.com/Automattic/wp-calypso/pull/97699

## Proposed Changes

Now the stepper confidence check is complete p8AJCL-Zq-p2 we can take all onboarding flow traffic for `/start` and redirect it to `/setup`.

* Remove the `calypso_signup_onboarding_stepper_flow_confidence_check_3` logic and assume all users would have been in the `stepper` variant.
* Remove code that used session storage and `?redirect_1220` to prevent double redirection
* Remove experiment assignment for `calypso_signup_onboarding_aa_test`, which is also now completed

As far as I can tell `?redirect_1220` was there to stop redirects happening when the legacy signup framework redirected back to the signup framework again. Now we're always redirect to the stepper this is no longer needed. It also caused issues where navigating to `/start` would only redirect me to the stepper on the first time (because of the session storage). But with this PR we always want `/start` to redirect to stepper. So it was getting in the way of that.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The control for the Goals-First test should be Stepper, not Classic/Start. So before releasing the goals-first test we need all (onboarding flow) users to be using the stepper.    Goals-first test: pbxNRc-4GM-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/start`, you should be taken to the stepper framework.
* Navigate to `/start` again, you should once again be taken to the stepper framework

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?