### PR TITLE
Keep consistent punctuation (or lack thereof) in onboarding modals

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/paid-domain-suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/paid-domain-suggested-plan-section.tsx
@@ -1,4 +1,5 @@
 import { type PlanSlug, PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import PlanUpsellButton from './plan-upsell-button';
@@ -23,6 +24,12 @@ export default function PaidDomainSuggestedPlanSection( props: {
 	const translate = useTranslate();
 	const { paidDomainName, onPlanSelected, isBusy } = props;
 
+	const previousCopy = translate( 'Free for one year. Includes Premium themes.' );
+	const updatedCopy = translate( 'Free for one year, includes Premium themes' );
+	const hasTranslationForUpdatedCopy = useHasEnTranslation()(
+		'Free for one year, includes Premium themes'
+	);
+
 	return (
 		<>
 			{ paidDomainName && (
@@ -40,7 +47,7 @@ export default function PaidDomainSuggestedPlanSection( props: {
 				<DomainName>
 					<div>{ paidDomainName }</div>
 					<FreeDomainText>
-						{ translate( 'Free for one year, includes Premium themes' ) }
+						{ hasTranslationForUpdatedCopy ? updatedCopy : previousCopy }
 					</FreeDomainText>
 				</DomainName>
 			) }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/paid-domain-suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/paid-domain-suggested-plan-section.tsx
@@ -40,7 +40,7 @@ export default function PaidDomainSuggestedPlanSection( props: {
 				<DomainName>
 					<div>{ paidDomainName }</div>
 					<FreeDomainText>
-						{ translate( 'Free for one year. Includes Premium themes.' ) }
+						{ translate( 'Free for one year, includes Premium themes' ) }
 					</FreeDomainText>
 				</DomainName>
 			) }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/paid-domain-suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/paid-domain-suggested-plan-section.tsx
@@ -22,11 +22,12 @@ export default function PaidDomainSuggestedPlanSection( props: {
 	isBusy: boolean;
 } ) {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 	const { paidDomainName, onPlanSelected, isBusy } = props;
 
 	const previousCopy = translate( 'Free for one year. Includes Premium themes.' );
 	const updatedCopy = translate( 'Free for one year, includes Premium themes' );
-	const hasTranslationForUpdatedCopy = useHasEnTranslation()(
+	const hasTranslationForUpdatedCopy = hasEnTranslation(
 		'Free for one year, includes Premium themes'
 	);
 


### PR DESCRIPTION
Keep consistent punctuation (or lack thereof) in onboarding modals: no periods at end of feature snippets

Fixes this:
pdtkmj-3es-p2#comment-6090



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes


| BEFORE (English)  | AFTER (English) |
|--------|--------|
|![image](https://github.com/user-attachments/assets/032f80f3-39b7-492d-badb-43fd4907c050) | <img width="885" alt="image" src="https://github.com/user-attachments/assets/4633ce57-6e8b-4f4d-acce-ca29ad70d876" /> |


Check that a non-English locale uses the old translation (has the periods at the end of the sentance):
![image](https://github.com/user-attachments/assets/4c912e67-9de2-4e90-86c0-fae43b6a9af2)



## Why are these changes being made?

To have consistent punctuation in plan snippets (the microcopy for plan details)

*

## Testing Instructions

* Go to /setup/onboarding
* Go through flow, selecting a paid domain
* On the plans page click "start with a free plan"
* See the modal with:
  *  updated copy for English
  *  old copy for other languages
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
    - [ ] NO because code handles waiting for translations
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?