### PR TITLE
Help Center: Return focus to input field after message submission

### DIFF
--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -73,6 +73,7 @@ export const OdieSendMessageButton = () => {
 			} );
 		} finally {
 			setSubmitDisabled( false );
+			inputRef.current?.focus();
 		}
 	}, [ isChatBusy, shouldUseHelpCenterExperience, chat?.provider, trackEvent, sendMessage ] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdDR7T-1X1-p2#comment-2494

## Proposed Changes

* Return focus to input field after message is submitted.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It is easier for users to continue sending multiple messages in succession.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link.
* Open the help center, start a new conversation, and send a message.
* Verify the focus returns back to the input field after your message is submmited.
