### PR TITLE
Update/site setup no reset data in goals first

### DIFF
--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -1,6 +1,6 @@
 import { OnboardSelect, Onboard, UserSelect } from '@automattic/data-stores';
 import { resetOnboardStore } from '@automattic/data-stores/src/onboard/actions';
-import { ONBOARDING_FLOW } from '@automattic/onboarding';
+import { ONBOARDING_FLOW, useStepPersistedState } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { useState, useMemo, useEffect } from 'react';
@@ -348,13 +348,15 @@ const onboarding: Flow = {
 	},
 	useSideEffect( currentStepSlug ) {
 		const dispatch = useDispatch();
+		const [ , , clearAllStepPersistedState ] = useStepPersistedState( 'onboarding' );
 
 		useEffect( () => {
-			if ( currentStepSlug === undefined ) {
+			if ( ! currentStepSlug ) {
 				resetOnboardStore();
 				dispatch( setSelectedSiteId( null ) );
+				clearAllStepPersistedState();
 			}
-		}, [ currentStepSlug, dispatch ] );
+		}, [ currentStepSlug, dispatch, clearAllStepPersistedState ] );
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -1,8 +1,9 @@
 import { OnboardSelect, Onboard, UserSelect } from '@automattic/data-stores';
+import { resetOnboardStore } from '@automattic/data-stores/src/onboard/actions';
 import { ONBOARDING_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { pathToUrl } from 'calypso/lib/url';
 import {
@@ -10,6 +11,7 @@ import {
 	setSignupCompleteFlowName,
 	setSignupCompleteSlug,
 } from 'calypso/signup/storageUtils';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import {
 	STEPPER_TRACKS_EVENT_SIGNUP_START,
 	STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
@@ -343,6 +345,16 @@ const onboarding: Flow = {
 		return {
 			state: isLoading ? AssertConditionState.CHECKING : AssertConditionState.SUCCESS,
 		};
+	},
+	useSideEffect( currentStepSlug ) {
+		const dispatch = useDispatch();
+
+		useEffect( () => {
+			if ( currentStepSlug === undefined ) {
+				resetOnboardStore();
+				dispatch( setSelectedSiteId( null ) );
+			}
+		}, [ currentStepSlug, dispatch ] );
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -95,6 +95,7 @@ const siteSetupFlow: Flow = {
 		return steps;
 	},
 	useStepNavigation( currentStep, navigate ) {
+		const isGoalsAtFrontExperiment = useGoalsAtFrontExperimentQueryParam();
 		const isGoalsHoldout = useIsGoalsHoldout( currentStep );
 
 		const intent = useSelect(
@@ -246,8 +247,14 @@ const siteSetupFlow: Flow = {
 
 			navigate( 'processing' );
 
-			// Clean-up the store so that if onboard for new site will be launched it will be launched with no preselected values
-			resetOnboardStoreWithSkipFlags( [ 'skipPendingAction', 'skipIntent', 'skipSelectedDesign' ] );
+			if ( ! isGoalsAtFrontExperiment ) {
+				// Clean-up the store so that if onboard for new site will be launched it will be launched with no preselected values
+				resetOnboardStoreWithSkipFlags( [
+					'skipPendingAction',
+					'skipIntent',
+					'skipSelectedDesign',
+				] );
+			}
 		};
 
 		const { getPostFlowUrl, initializeLaunchpadState } = useLaunchpadDecider( {

--- a/packages/onboarding/src/hooks/use-persisted-state.ts
+++ b/packages/onboarding/src/hooks/use-persisted-state.ts
@@ -23,6 +23,20 @@ function getPersistedState( key: string, storage: Storage, TTL: number ) {
 	}
 }
 
+/**
+ * Clears all persisted state created by useStepPersistedState
+ * @param storage The storage to clear (defaults to localStorage)
+ */
+function clearStepPersistedState( storage: Storage = localStorage ): void {
+	const keys = Object.keys( storage );
+	const persistedKeys = keys.filter( ( key ) => key.startsWith( `${ VERSION }-${ KEY }` ) );
+
+	persistedKeys.forEach( ( key ) => {
+		storage.removeItem( key );
+		storage.removeItem( key + 'time' );
+	} );
+}
+
 type Options = {
 	/**
 	 * The used storage, defaults to sessionStorage.
@@ -36,7 +50,6 @@ type Options = {
 
 /**
  * A hook similar to useState, but persists the state. Uses `flow`, `step` and `lang`, and the passed key in the tree as keys.
- *
  * @param cacheKey the cache key. It will be concatenated with the flow, step and lang.
  * @param defaultValue the initial value of the state.
  * @param options the options for the hook.
@@ -46,7 +59,7 @@ export function useStepPersistedState< T >(
 	cacheKey: string,
 	defaultValue?: T,
 	options: Options = { storage: localStorage, TTL: TWENTY_MINUTES }
-): [ T, ( newState: T ) => void ] {
+) {
 	const match = useMatch( '/:flow/:step?/:lang?' );
 	const { flow = 'flow', step = 'step', lang = 'lang' } = match?.params || {};
 	const key = [ VERSION, KEY, flow, step, lang, cacheKey ].join( '-' );
@@ -63,5 +76,9 @@ export function useStepPersistedState< T >(
 		[ _setState, key, options.storage ]
 	);
 
-	return [ state, setState ];
+	const clearAllStepPersistedState = useCallback( () => {
+		clearStepPersistedState( options.storage );
+	}, [ options.storage ] );
+
+	return [ state, setState, clearAllStepPersistedState ] as const;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
