### PR TITLE
Increase delay of odie feedback animation

### DIFF
--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -439,7 +439,7 @@
 	}
 
 	.odie-question-collapse {
-		animation: odie-question-collapse-animation 0.3s ease-in-out 1s forwards;
+		animation: odie-question-collapse-animation 0.3s ease-in-out 2.5s forwards;
 		overflow: hidden;
 	}
 

--- a/packages/odie-client/src/components/message/style_redesign.scss
+++ b/packages/odie-client/src/components/message/style_redesign.scss
@@ -582,7 +582,7 @@
 	}
 
 	.odie-question-collapse {
-		animation: odie-question-collapse-animation 0.3s ease-in-out 1s forwards;
+		animation: odie-question-collapse-animation 0.3s ease-in-out 2.5s forwards;
 		overflow: hidden;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

| Before  | After |
| ------------- | ------------- |
| ![nGZ6cP.gif](https://github.com/user-attachments/assets/747ddc97-780c-40b9-815d-09ffe57bb82c)  | ![rBDY9x.gif](https://github.com/user-attachments/assets/bffcc9bb-c777-478c-ad9b-bef2505726bb)  |

Related to #
https://github.com/Automattic/wp-calypso/issues/97927

## Proposed Changes

* Increase delay of feedback animation

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The previous animation setting was hiding the thank you message too fast

## Testing Instructions
- Use PR link
- Write a question to odie
- Click the like button
- The thank you message should go away after 2.5 seconds instead of 1 second
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?