### PR TITLE
A4A > Migrations: Remove feature flag logic

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -43,7 +43,6 @@ const useMainMenuItems = ( path: string ) => {
 
 	const menuItems = useMemo( () => {
 		const isAutomatedReferralsEnabled = config.isEnabled( 'a4a-automated-referrals' );
-		const isTrackingSiteMigrationsEnabled = config.isEnabled( 'a4a-tracking-site-migrations' );
 
 		let referralItems = [] as any[];
 
@@ -74,30 +73,18 @@ const useMainMenuItems = ( path: string ) => {
 				  ];
 		}
 
-		let migrationMenuItem = {};
-
-		if ( isSectionNameEnabled( 'a8c-for-agencies-migrations' ) ) {
-			migrationMenuItem = isTrackingSiteMigrationsEnabled
-				? {
-						icon: moveTo,
-						path: A4A_MIGRATIONS_LINK,
-						link: A4A_MIGRATIONS_OVERVIEW_LINK,
-						title: translate( 'Migrations' ),
-						trackEventProps: {
-							menu_item: 'Automattic for Agencies / Migrations',
-						},
-						withChevron: true,
-				  }
-				: {
-						icon: moveTo,
-						path: '/',
-						link: A4A_MIGRATIONS_LINK,
-						title: translate( 'Migrations' ),
-						trackEventProps: {
-							menu_item: 'Automattic for Agencies / Migrations',
-						},
-				  };
-		}
+		const migrationMenuItem = isSectionNameEnabled( 'a8c-for-agencies-migrations' )
+			? {
+					icon: moveTo,
+					path: A4A_MIGRATIONS_LINK,
+					link: A4A_MIGRATIONS_OVERVIEW_LINK,
+					title: translate( 'Migrations' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Migrations',
+					},
+					withChevron: true,
+			  }
+			: {};
 
 		return [
 			{

--- a/client/a8c-for-agencies/sections/migrations/controller.tsx
+++ b/client/a8c-for-agencies/sections/migrations/controller.tsx
@@ -24,7 +24,7 @@ export const migrationsOverviewContext: Callback = ( context, next ) => {
 	context.primary = (
 		<>
 			<PageViewTracker title="Migrations > Overview" path={ context.path } />
-			<MigrationsOverviewV2 isSiteMigrationsEnabled />
+			<MigrationsOverviewV2 />
 		</>
 	);
 	context.secondary = <MigrationsSidebar path={ context.path } />;

--- a/client/a8c-for-agencies/sections/migrations/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import {
 	A4A_MIGRATIONS_LINK,
@@ -13,50 +12,40 @@ import { makeLayout, render as clientRender } from 'calypso/controller';
 import * as controller from './controller';
 
 export default function () {
-	if ( isEnabled( 'a4a-tracking-site-migrations' ) ) {
-		page(
-			A4A_MIGRATIONS_OVERVIEW_LINK,
-			requireAccessContext,
-			controller.migrationsOverviewContext,
-			makeLayout,
-			clientRender
-		);
-		page(
-			A4A_MIGRATIONS_MIGRATE_TO_PRESSABLE_LINK,
-			requireAccessContext,
-			controller.migrateToPressableContext,
-			makeLayout,
-			clientRender
-		);
-		page(
-			A4A_MIGRATIONS_MIGRATE_TO_WPCOM_LINK,
-			requireAccessContext,
-			controller.migrateToWpcomContext,
-			makeLayout,
-			clientRender
-		);
-		page(
-			A4A_MIGRATIONS_COMMISSIONS_LINK,
-			requireAccessContext,
-			controller.migrationsCommissionsContext,
-			makeLayout,
-			clientRender
-		);
-		page(
-			A4A_MIGRATIONS_PAYMENT_SETTINGS,
-			requireAccessContext,
-			controller.migrationsPaymentSettingsContext,
-			makeLayout,
-			clientRender
-		);
-		page( A4A_MIGRATIONS_LINK, () => page.redirect( A4A_MIGRATIONS_OVERVIEW_LINK ) );
-	} else {
-		page(
-			A4A_MIGRATIONS_LINK,
-			requireAccessContext,
-			controller.migrationsContext,
-			makeLayout,
-			clientRender
-		);
-	}
+	page(
+		A4A_MIGRATIONS_OVERVIEW_LINK,
+		requireAccessContext,
+		controller.migrationsOverviewContext,
+		makeLayout,
+		clientRender
+	);
+	page(
+		A4A_MIGRATIONS_MIGRATE_TO_PRESSABLE_LINK,
+		requireAccessContext,
+		controller.migrateToPressableContext,
+		makeLayout,
+		clientRender
+	);
+	page(
+		A4A_MIGRATIONS_MIGRATE_TO_WPCOM_LINK,
+		requireAccessContext,
+		controller.migrateToWpcomContext,
+		makeLayout,
+		clientRender
+	);
+	page(
+		A4A_MIGRATIONS_COMMISSIONS_LINK,
+		requireAccessContext,
+		controller.migrationsCommissionsContext,
+		makeLayout,
+		clientRender
+	);
+	page(
+		A4A_MIGRATIONS_PAYMENT_SETTINGS,
+		requireAccessContext,
+		controller.migrationsPaymentSettingsContext,
+		makeLayout,
+		clientRender
+	);
+	page( A4A_MIGRATIONS_LINK, () => page.redirect( A4A_MIGRATIONS_OVERVIEW_LINK ) );
 }

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/index.tsx
@@ -1,7 +1,4 @@
-import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
-import { CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
@@ -10,8 +7,6 @@ import LayoutHeader, {
 	LayoutHeaderTitle as Title,
 	LayoutHeaderActions as Actions,
 } from 'calypso/layout/hosting-dashboard/header';
-import { useDispatch } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import MigrateSiteButton from './migrate-site-button';
 import MigrationsBanner from './sections/migrations-banner';
 import MigrationsClientRelationship from './sections/migrations-client-relationship';
@@ -24,19 +19,10 @@ import MigrationsTestimonials from './sections/migrations-testimonials';
 
 import './style.scss';
 
-export default function MigrationsOverviewV2( {
-	isSiteMigrationsEnabled = false,
-}: {
-	isSiteMigrationsEnabled?: boolean;
-} ) {
+export default function MigrationsOverviewV2() {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
 
 	const title = translate( 'Migrations' );
-
-	const onMigrateSitesClick = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_migrations_migrate_sites_button_click' ) );
-	}, [ dispatch ] );
 
 	return (
 		<Layout className="migrations-overview-v2" title={ title } wide>
@@ -45,18 +31,7 @@ export default function MigrationsOverviewV2( {
 					<Title>{ title }</Title>
 					<Actions>
 						<MobileSidebarNavigation />
-
-						{ isSiteMigrationsEnabled ? (
-							<MigrateSiteButton />
-						) : (
-							<Button
-								variant="primary"
-								onClick={ onMigrateSitesClick }
-								href={ CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT }
-							>
-								{ translate( 'Migrate your sites' ) }
-							</Button>
-						) }
+						<MigrateSiteButton />
 					</Actions>
 				</LayoutHeader>
 			</LayoutTop>

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-faqs/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-faqs/index.tsx
@@ -1,11 +1,7 @@
-import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import PageSection from 'calypso/a8c-for-agencies/components/page-section';
-import {
-	A4A_MIGRATIONS_PAYMENT_SETTINGS,
-	A4A_REFERRALS_PAYMENT_SETTINGS,
-} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { A4A_MIGRATIONS_PAYMENT_SETTINGS } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import FoldableFAQ from 'calypso/components/foldable-faq';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -153,11 +149,7 @@ export default function MigrationsFAQs() {
 						),
 						PaymentSettingLink: (
 							<a
-								href={
-									config.isEnabled( 'a4a-tracking-site-migrations' )
-										? A4A_MIGRATIONS_PAYMENT_SETTINGS
-										: A4A_REFERRALS_PAYMENT_SETTINGS
-								}
+								href={ A4A_MIGRATIONS_PAYMENT_SETTINGS }
 								onClick={ () =>
 									dispatch(
 										recordTracksEvent( 'calypso_a4a_migrations_payment_setting_link_click' )

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -45,7 +45,6 @@
 		"a4a-migrations-page-v2": true,
 		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
-		"a4a-tracking-site-migrations": true,
 		"a4a-updated-add-new-site": true
 	},
 	"enable_all_sections": false,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -38,7 +38,6 @@
 		"a4a-migrations-page-v2": true,
 		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
-		"a4a-tracking-site-migrations": true,
 		"a4a-updated-add-new-site": true
 	},
 	"enable_all_sections": false,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -37,8 +37,7 @@
 		"a4a-dev-sites": true,
 		"a4a-migrations-page-v2": true,
 		"a8c-for-agencies-agency-tier": true,
-		"a4a-pressable-referrals": true,
-		"a4a-tracking-site-migrations": true
+		"a4a-pressable-referrals": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -40,7 +40,6 @@
 		"a4a-migrations-page-v2": true,
 		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
-		"a4a-tracking-site-migrations": true,
 		"a4a-updated-add-new-site": true
 	},
 	"enable_all_sections": false,


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1438

## Proposed Changes

* This PR removes the feature flag logic for the tracking site migrations project.

## Testing Instructions

* Open the A4A live link
* Click the `Migrations >` side nav > Verify the page looks as below:

<img width="1726" alt="Screenshot 2025-01-06 at 4 57 57 PM" src="https://github.com/user-attachments/assets/798b7835-b853-41d7-aa62-7f47ed2723cc" />

- Click the `here` link on the text `You will also need to add your payment details to our payment partner, Tipalti, which you can do here` and verify you are redirected to `/migrations/payment-settings` in the `Frequently asked questions`
section (last item)

<img width="1387" alt="Screenshot 2025-01-06 at 4 59 14 PM" src="https://github.com/user-attachments/assets/50d7b2cf-94e0-48a8-9126-eb6a6445f2b7" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
