### PR TITLE
Adjust help center unread icon

### DIFF
--- a/apps/help-center/help-icon.svg
+++ b/apps/help-center/help-icon.svg
@@ -4,5 +4,5 @@
 
 <svg id="help-center-icon-with-notification" class="ab-icon"  width="24" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 	<path d="M12 2C6.477 2 2 6.477 2 12C2 17.523 6.477 22 12 22C17.523 22 22 17.523 22 12C22 6.477 17.523 2 12 2ZM13 18H11V16H13V18ZM13 13.859V15H11V13C11 12.448 11.448 12 12 12C13.103 12 14 11.103 14 10C14 8.897 13.103 8 12 8C10.897 8 10 8.897 10 10H8C8 7.791 9.791 6 12 6C14.209 6 16 7.791 16 10C16 11.862 14.722 13.413 13 13.859Z" fill="currentColor"/>
-	<circle cx="20" cy="5" r="4" fill="#e65054" stroke="#101517" stroke-width="2"/>
+	<circle cx="20" cy="3.5" r="4.3" fill="#e65054" stroke="#1d2327" stroke-width="2"/>
 </svg>

--- a/client/layout/masterbar/masterbar-help-center/help-center-icon.tsx
+++ b/client/layout/masterbar/masterbar-help-center/help-center-icon.tsx
@@ -17,7 +17,7 @@ export const HelpCenterIcon: React.FC< HelpCenterIconProps > = ( { hasUnread } )
 					d="M12 2C6.477 2 2 6.477 2 12C2 17.523 6.477 22 12 22C17.523 22 22 17.523 22 12C22 6.477 17.523 2 12 2ZM13 18H11V16H13V18ZM13 13.859V15H11V13C11 12.448 11.448 12 12 12C13.103 12 14 11.103 14 10C14 8.897 13.103 8 12 8C10.897 8 10 8.897 10 10H8C8 7.791 9.791 6 12 6C14.209 6 16 7.791 16 10C16 11.862 14.722 13.413 13 13.859Z"
 					fill="var( --color-masterbar-icon )"
 				/>
-				<circle cx="20" cy="5" r="4" fill="#e65054" stroke="#101517" strokeWidth="2" />
+				<circle cx="20" cy="3.5" r="4.3" fill="#e65054" stroke="#1d2327" strokeWidth="2" />
 			</svg>
 		);
 	}

--- a/packages/help-center/src/components/help-icon.tsx
+++ b/packages/help-center/src/components/help-icon.tsx
@@ -38,7 +38,7 @@ const HelpIcon = forwardRef< SVGSVGElement >( ( _, ref ) => {
 					xmlns="http://www.w3.org/2000/svg"
 				>
 					<path d="M12 4.75a7.25 7.25 0 100 14.5 7.25 7.25 0 000-14.5zM3.25 12a8.75 8.75 0 1117.5 0 8.75 8.75 0 01-17.5 0zM12 8.75a1.5 1.5 0 01.167 2.99c-.465.052-.917.44-.917 1.01V14h1.5v-.845A3 3 0 109 10.25h1.5a1.5 1.5 0 011.5-1.5zM11.25 15v1.5h1.5V15h-1.5z" />
-					<circle cx="20" cy="5" r="4" fill="#e65054" stroke="#101517" strokeWidth="1" />
+					<circle cx="20" cy="3.5" r="4.3" fill="#e65054" stroke="#1d2327" strokeWidth="1" />
 				</svg>
 			) : (
 				<svg


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

| Before  | After |
| ------------- | ------------- |
| ![FQUTDv.gif](https://github.com/user-attachments/assets/33a96406-ffa4-46c1-8914-b42027a79f64) | ![0enPwq.gif](https://github.com/user-attachments/assets/ed17d42c-64d7-4b95-a4d3-ebd038346c7b) 
| ![FOeUKP.gif](https://github.com/user-attachments/assets/6afba6ee-3736-4518-a717-0e474101464d) | ![I7Vsmt.gif](https://github.com/user-attachments/assets/72cb044a-c876-49df-9fd5-d5d579c3b70e) />



Related to #
https://github.com/Automattic/wp-calypso/issues/97930

## Proposed Changes

* Adjust help center unread icon to match unread notification size

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The help center unread icon should match better the unread notification circle
* This PR adjusts the size, position and stroke color of the circle of the help center icon

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test in wp-calypso and wp-admin how the unread indicator of the help center icon looks

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?