### PR TITLE
Restore isolated `@automattic/components` Storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
 		"clean:packages": "yarn workspaces foreach --all --parallel --verbose --exclude 'wp-calypso' run clean",
 		"clean:public": "rm -rf public",
 		"clean:translations": "rm -rf build/strings calypso-strings.pot chunks-map.*.json || true",
-		"components:storybook:start": "echo 'Storybook in Calypso moved into the root directory. Run `yarn storybook:start` instead.'",
+		"components:storybook:start": "echo 'Deprecated, run `yarn workspace @automattic/components run storybook` instead'",
 		"composite-checkout:storybook:start": "echo 'Deprecated, run `yarn workspace @automattic/composite-checkout run storybook` instead'",
 		"distclean": "yarn run clean && rm -rf **/node_modules **/.cache .yarn/install-state.gz || true",
 		"docker": "docker run -it --name wp-calypso --rm -p 80:3000 wp-calypso",

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -41,6 +41,4 @@ in the root of the repository to get the required `devDependencies`.
 
 ### Using [Storybook](https://storybook.js.org/)
 
-To see stories within this package, run `yarn workspace @automattic/components run start-storybook`.
-
-To see all stories within this repository, run `yarn storybook:start` at the root of the repository.
+To see stories within this package, run `yarn workspace @automattic/components run storybook`.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -69,6 +69,7 @@
 		"@automattic/calypso-storybook": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@storybook/addon-actions": "^7.6.19",
+		"@storybook/cli": "^7.6.19",
 		"@storybook/react": "^7.6.19",
 		"@testing-library/dom": "^10.1.0",
 		"@testing-library/jest-dom": "^6.4.5",
@@ -84,6 +85,7 @@
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
-		"prepack": "yarn run clean && yarn run build"
+		"prepack": "yarn run clean && yarn run build",
+		"storybook": "sb dev"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -653,6 +653,7 @@ __metadata:
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
     "@storybook/addon-actions": "npm:^7.6.19"
+    "@storybook/cli": "npm:^7.6.19"
     "@storybook/react": "npm:^7.6.19"
     "@testing-library/dom": "npm:^10.1.0"
     "@testing-library/jest-dom": "npm:^6.4.5"


### PR DESCRIPTION
## Proposed Changes

Restores ability to launch the `@automattic/components` Storybook in isolation.

## Why are these changes being made?

The documentation was outdated.

#76007 moved the component stories into the root Storybook, and soon after #76794 restored the ability to launch the component stories in isolation. However, the README instructions are now outdated, likely due to the Storybook 7 upgrade.

## Testing Instructions

`yarn workspace @automattic/components run storybook` to launch the isolated Storybook.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
