### PR TITLE
Refactor sites dashboard banners manager

### DIFF
--- a/client/sites/components/sites-dashboard-banners-manager.tsx
+++ b/client/sites/components/sites-dashboard-banners-manager.tsx
@@ -1,15 +1,7 @@
-import { HelpCenter } from '@automattic/data-stores';
-import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
-import { translate } from 'i18n-calypso';
-import { useCallback } from 'react';
-import { useSelector } from 'react-redux';
-import { isCardDismissed } from 'calypso/blocks/dismissible-card/selectors';
-import Banner from 'calypso/components/banner';
 import { useA8CForAgenciesSitesBanner } from './sites-dashboard-banners/use-a8c-for-agencies-sites-banner';
+import { useMigrationPendingSitesBanner } from './sites-dashboard-banners/use-migration-pending-sites-banner';
 import { useRestoreSitesBanner } from './sites-dashboard-banners/use-restore-sites-reminder-banner';
 import type { Status } from '@automattic/sites/src/use-sites-list-grouping';
-
-const HELP_CENTER_STORE = HelpCenter.register();
 
 type SitesDashboardBannersManagerProps = {
 	sitesStatuses: Status[];
@@ -20,49 +12,12 @@ const SitesDashboardBannersManager = ( {
 	sitesStatuses,
 	sitesCount,
 }: SitesDashboardBannersManagerProps ) => {
-	const { setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
-
-	const migrationPendingSitesCount = sitesStatuses.find(
-		( status ) => status.name === 'migration-pending'
-	)?.count;
-
-	const isMigrationBannerDismissed = useSelector( isCardDismissed( 'migration-pending-sites' ) );
-
-	const openHelpCenter = useCallback( () => {
-		setShowHelpCenter( true );
-	}, [ setShowHelpCenter ] );
-
-	// TODO: refactor banners to use this pattern
 	// Define banners in priority order
-	const banners = [ useRestoreSitesBanner(), useA8CForAgenciesSitesBanner( { sitesCount } ) ];
-
-	if (
-		migrationPendingSitesCount &&
-		migrationPendingSitesCount > 0 &&
-		// If the banner is dismissed, we don't want to return earlier to show the other banner.
-		! isMigrationBannerDismissed
-	) {
-		return (
-			<div className="sites-banner-container">
-				<Banner
-					icon="info-outline"
-					callToAction={ translate( 'Get help' ) }
-					primaryButton={ false }
-					className="sites-banner"
-					description={ translate(
-						"Let's solve it together. Reach out to our support team to get your migration started."
-					) }
-					dismissPreferenceName="migration-pending-sites"
-					event="get-help"
-					horizontal
-					onClick={ openHelpCenter }
-					target="_blank"
-					title={ translate( 'Stuck on your migration?' ) }
-					tracksClickName="calypso_sites_dashboard_migration_banner_click"
-				/>
-			</div>
-		);
-	}
+	const banners = [
+		useRestoreSitesBanner(),
+		useMigrationPendingSitesBanner( { sitesStatuses } ),
+		useA8CForAgenciesSitesBanner( { sitesCount } ),
+	];
 
 	// Return the first banner that should show
 	for ( const banner of banners ) {

--- a/client/sites/components/sites-dashboard-banners/use-a8c-for-agencies-sites-banner.tsx
+++ b/client/sites/components/sites-dashboard-banners/use-a8c-for-agencies-sites-banner.tsx
@@ -1,16 +1,22 @@
 import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { isCardDismissed } from 'calypso/blocks/dismissible-card/selectors';
 import Banner from 'calypso/components/banner';
 
 export function useA8CForAgenciesSitesBanner( { sitesCount }: { sitesCount: number } ) {
 	const id = 'dismissible-card-a8c-for-agencies-sites';
+	const isA8CForAgenciesBannerDismissed = useSelector( isCardDismissed( id ) );
 
 	return {
 		id,
 		shouldShow() {
-			const showA8CForAgenciesBanner = sitesCount >= 5;
-			return showA8CForAgenciesBanner;
+			if ( isA8CForAgenciesBannerDismissed ) {
+				return false;
+			}
+			// Show banner when user has 5 or more sites
+			return sitesCount >= 5;
 		},
 		render() {
 			return (
@@ -24,7 +30,7 @@ export function useA8CForAgenciesSitesBanner( { sitesCount }: { sitesCount: numb
 					description={ translate(
 						"Earn up to 50% revenue share and get volume discounts on WordPress.com hosting when you migrate sites to our platform and promote Automattic's products to clients."
 					) }
-					dismissPreferenceName="dismissible-card-a8c-for-agencies-sites"
+					dismissPreferenceName={ id }
 					event="learn-more"
 					horizontal
 					href={ localizeUrl( 'https://wordpress.com/for-agencies?ref=wpcom-sites-dashboard' ) }

--- a/client/sites/components/sites-dashboard-banners/use-migration-pending-sites-banner.tsx
+++ b/client/sites/components/sites-dashboard-banners/use-migration-pending-sites-banner.tsx
@@ -1,0 +1,56 @@
+import { HelpCenter } from '@automattic/data-stores';
+import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
+import { translate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { isCardDismissed } from 'calypso/blocks/dismissible-card/selectors';
+import Banner from 'calypso/components/banner';
+import type { Status } from '@automattic/sites/src/use-sites-list-grouping';
+
+export function useMigrationPendingSitesBanner( { sitesStatuses }: { sitesStatuses: Status[] } ) {
+	const id = 'migration-pending-sites';
+
+	const migrationPendingSitesCount = sitesStatuses.find(
+		( status ) => status.name === 'migration-pending'
+	)?.count;
+	const isMigrationBannerDismissed = useSelector( isCardDismissed( id ) );
+
+	const HELP_CENTER_STORE = HelpCenter.register();
+
+	const { setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
+
+	const openHelpCenter = useCallback( () => {
+		setShowHelpCenter( true );
+	}, [ setShowHelpCenter ] );
+
+	return {
+		id,
+		shouldShow() {
+			if ( isMigrationBannerDismissed ) {
+				return false;
+			}
+			// Show banner when user has migration pending sites
+			return migrationPendingSitesCount && migrationPendingSitesCount > 0;
+		},
+		render() {
+			return (
+				<Banner
+					icon="info-outline"
+					callToAction={ translate( 'Get help' ) }
+					primaryButton={ false }
+					className="sites-banner"
+					description={ translate(
+						"Let's solve it together. Reach out to our support team to get your migration started."
+					) }
+					dismissPreferenceName={ id }
+					event="get-help"
+					horizontal
+					onClick={ openHelpCenter }
+					target="_blank"
+					title={ translate( 'Stuck on your migration?' ) }
+					tracksClickName="calypso_sites_dashboard_migration_banner_click"
+				/>
+			);
+		},
+	};
+}

--- a/client/sites/components/sites-dashboard-banners/use-restore-sites-reminder-banner.tsx
+++ b/client/sites/components/sites-dashboard-banners/use-restore-sites-reminder-banner.tsx
@@ -18,9 +18,13 @@ export function useRestoreSitesBanner() {
 	return {
 		id,
 		shouldShow() {
+			if ( isDismissed ) {
+				return false;
+			}
+			// Show banner when ?restored=true param exists
 			const urlParams = new URLSearchParams( window.location.search );
 			const restored = urlParams.get( 'restored' );
-			return ! isDismissed && restored === 'true';
+			return restored === 'true';
 		},
 		render() {
 			return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/97868

## Proposed Changes

* Finish refactoring for `sites-dashboard-banners-manager`
* Moved the migration banner to a separate file
* Check for whether the banner has been dismissed first in `shouldShow`. Then check the conditions related to rendering the banner. We always need to check if the banner has been dismissed first, if it has been dismissed, `shouldShow` should return false so that the next banner in the `banners` array can be checked instead of returning early.

Sites restored banner `/sites?restored=true`
![restored@2x](https://github.com/user-attachments/assets/a6214456-b828-4489-a967-1c962f407d9d)

Migration and a8c banner priority demo

https://github.com/user-attachments/assets/d7da5419-537e-4731-a065-845476b7f717



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Keep the banner logic separate from each other 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* For testing the migration banner, you can go to /setup/onboarding and click on "Import or migrate an existing site" and follow the process there
* For testing the site restore banner, go to /sites?restored=true
* For testing the a8c agencies banner, have at least 5 sites in that account

For testing banner priority, prepare an account with 5 sites, a site pending migration and go to /sites?restored=true.
1. You will see the restore banner first, dismiss it
2. You will see the migration banner, dismiss it
3. You will see the a8c agencies banner, dismiss it
4. Refresh the page, you will see the restore banner (as this is rendered everytime restored=true is present), dismiss it and nothing will show

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
