### PR TITLE
Add meta desciption to plugins pages

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -302,6 +302,18 @@ function PluginDetails( props ) {
 		} );
 	};
 
+	const getMetaDescription = () => {
+		if ( wporgPlugin?.short_description ) {
+			return wporgPlugin.short_description;
+		}
+		if ( wpComPluginData?.description ) {
+			return wpComPluginData.description;
+		}
+		return translate(
+			"Discover and install WordPress plugins to extend your site's functionality."
+		);
+	};
+
 	if ( ! isRequestingSites && ! userCanManagePlugins ) {
 		return <NoPermissionsError title={ getPageTitle() } />;
 	}
@@ -359,7 +371,10 @@ function PluginDetails( props ) {
 
 	return (
 		<MainComponent className="is-plugin-details" wideLayout isLoggedOut={ ! isLoggedIn }>
-			<DocumentHead title={ getPageTitle() } />
+			<DocumentHead
+				title={ getPageTitle() }
+				meta={ [ { name: 'description', content: getMetaDescription() } ] }
+			/>
 			<PageViewTracker
 				path={ analyticsPath }
 				title="Plugins > Plugin Details"

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -149,6 +149,25 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 		);
 	};
 
+	const getMetaDescription = () => {
+		if ( category ) {
+			return translate(
+				"Discover %(category)s plugins to extend your WordPress site's functionality.",
+				{
+					args: { category },
+				}
+			);
+		}
+		if ( search ) {
+			return translate( 'Search results for "%(search)s" in the WordPress plugin directory.', {
+				args: { search },
+			} );
+		}
+		return translate(
+			"Browse and discover WordPress plugins to extend your site's functionality."
+		);
+	};
+
 	if ( ! isRequestingSitesData && noPermissionsError ) {
 		return <NoPermissionsError title={ __( 'Plugins' ) } />;
 	}
@@ -176,6 +195,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 						? translate( '%(categoryName)s Plugins', { args: { categoryName } } )
 						: translate( 'Plugins' )
 				}
+				meta={ [ { name: 'description', content: getMetaDescription() } ] }
 			/>
 
 			<PluginsNavigationHeader

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -152,19 +152,15 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 	const getMetaDescription = () => {
 		if ( category ) {
 			return translate(
-				"Discover %(category)s plugins to extend your WordPress site's functionality.",
+				'Discover %(category)s plugins to extend your WordPress site’s functionality and unlock its full potential with tools built for success.',
 				{
 					args: { category },
 				}
 			);
 		}
-		if ( search ) {
-			return translate( 'Search results for "%(search)s" in the WordPress plugin directory.', {
-				args: { search },
-			} );
-		}
+
 		return translate(
-			"Browse and discover WordPress plugins to extend your site's functionality."
+			'Discover and install WordPress plugins to extend your site’s functionality. Boost SEO, e-commerce, and security with seamless WordPress.com integration.'
 		);
 	};
 


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/Avalancha#76

## Proposed Changes

* Adds meta description to the logged out (SSR) /plugins pages, including the main/category and details pages.
* This change is done for SEO purposes. For details pages we should have a unique short description per page, while for the category and home page, this PR proposes a way to generate these

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This was identified in the Spanish SEO audit.
* NOTE: If the current strings are fine, we need to add a "string freeze" prior to merging this.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check out this branch and build Calypso locally.
- Visit plugins pages such as /plugins, /es/plugins, https://wordpress.com/es/plugins/browse/affiliate/ and https://wordpress.com/es/plugins/easy-accordion-block and confirm by showing the source (non-JS generated) that you see an appropriate meta description per page.
- Test the logged-in routes, and confirm no related console errors.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
