### PR TITLE
Update: heading tags on plugins/themes pages

### DIFF
--- a/client/components/navigation-header/index.tsx
+++ b/client/components/navigation-header/index.tsx
@@ -1,12 +1,9 @@
 import styled from '@emotion/styled';
 import clsx from 'clsx';
 import React, { ReactNode } from 'react';
-import { useSelector } from 'react-redux';
 import Breadcrumb, { Item as TBreadcrumbItem } from 'calypso/components/breadcrumb';
 import FormattedHeader from 'calypso/components/formatted-header';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { getSectionName } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
@@ -35,6 +32,7 @@ interface Props {
 	screenReader?: string | ReactNode;
 	screenOptionsTab?: string;
 	style?: object;
+	loggedIn?: boolean;
 }
 
 const NavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) => {
@@ -51,17 +49,10 @@ const NavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) 
 		alwaysShowTitle = false,
 		screenReader,
 		screenOptionsTab,
+		loggedIn = true,
 	} = props;
 
-	const sectionName = useSelector( getSectionName );
-	const isLoggedIn = useSelector( isUserLoggedIn );
-	const hideInSections = [ 'plugins', 'themes' ];
-
-	// For logged-out users, we handle title visibility differently.
-	const showTitle =
-		alwaysShowTitle ||
-		( isLoggedIn && navigationItems.length < 2 ) ||
-		! hideInSections.includes( sectionName || '' );
+	const showTitle = alwaysShowTitle || ( navigationItems.length < 2 && loggedIn );
 
 	return (
 		<header

--- a/client/components/navigation-header/index.tsx
+++ b/client/components/navigation-header/index.tsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import Breadcrumb, { Item as TBreadcrumbItem } from 'calypso/components/breadcrumb';
 import FormattedHeader from 'calypso/components/formatted-header';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSectionName } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -53,11 +54,14 @@ const NavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) 
 	} = props;
 
 	const sectionName = useSelector( getSectionName );
-	// SEO: Hide title on plugins and themes pages as they have their own titles in markup.
+	const isLoggedIn = useSelector( isUserLoggedIn );
 	const hideInSections = [ 'plugins', 'themes' ];
+
+	// For logged-out users, we handle title visibility differently.
 	const showTitle =
 		alwaysShowTitle ||
-		( navigationItems.length < 2 && ! hideInSections.includes( sectionName || '' ) );
+		( isLoggedIn && navigationItems.length < 2 ) ||
+		! hideInSections.includes( sectionName || '' );
 
 	return (
 		<header

--- a/client/components/navigation-header/index.tsx
+++ b/client/components/navigation-header/index.tsx
@@ -1,9 +1,11 @@
 import styled from '@emotion/styled';
 import clsx from 'clsx';
 import React, { ReactNode } from 'react';
+import { useSelector } from 'react-redux';
 import Breadcrumb, { Item as TBreadcrumbItem } from 'calypso/components/breadcrumb';
 import FormattedHeader from 'calypso/components/formatted-header';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
+import { getSectionName } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
@@ -49,7 +51,13 @@ const NavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) 
 		screenReader,
 		screenOptionsTab,
 	} = props;
-	const showTitle = alwaysShowTitle || navigationItems.length < 2;
+
+	const sectionName = useSelector( getSectionName );
+	// SEO: Hide title on plugins and themes pages as they have their own titles in markup.
+	const hideInSections = [ 'plugins', 'themes' ];
+	const showTitle =
+		alwaysShowTitle ||
+		( navigationItems.length < 2 && ! hideInSections.includes( sectionName || '' ) );
 
 	return (
 		<header

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -119,6 +119,7 @@ const PluginsBrowserList = ( {
 					resultCount={ resultCount }
 					browseAllLink={ browseAllLink }
 					listName={ listName }
+					isRootPage={ listType !== 'browse' }
 				/>
 			) }
 			{ listName === 'paid' && (

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -13,6 +13,7 @@ import { useLocalizedPlugins, useServerEffect } from 'calypso/my-sites/plugins/u
 import { recordTracksEvent, recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { appendBreadcrumb, resetBreadcrumbs } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -83,6 +84,7 @@ const ManageButton = ( {
 const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category, search } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	const selectedSite = useSelector( getSelectedSite );
 
@@ -173,6 +175,7 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 			title={ translate( 'Plugins {{wbr}}{{/wbr}}marketplace', {
 				components: { wbr: <wbr /> },
 			} ) }
+			loggedIn={ isLoggedIn }
 		>
 			<ManageButton
 				shouldShowManageButton={ shouldShowManageButton }

--- a/client/my-sites/plugins/plugins-results-header/index.tsx
+++ b/client/my-sites/plugins/plugins-results-header/index.tsx
@@ -14,6 +14,7 @@ export default function PluginsResultsHeader( {
 	browseAllLink,
 	resultCount,
 	listName,
+	isRootPage = true,
 }: {
 	title: TranslateResult;
 	subtitle: TranslateResult;
@@ -21,15 +22,17 @@ export default function PluginsResultsHeader( {
 	resultCount?: string;
 	className?: string;
 	listName?: string;
+	isRootPage?: boolean;
 } ) {
 	const { __ } = useI18n();
 	const selectedSite = useSelector( getSelectedSite );
+	const TitleTag = isRootPage ? 'h2' : 'h1';
 
 	return (
 		<div className={ clsx( 'plugins-results-header', className ) }>
 			{ ( title || subtitle ) && (
 				<div className="plugins-results-header__titles">
-					{ title && <h2 className="plugins-results-header__title">{ title }</h2> }
+					{ title && <TitleTag className="plugins-results-header__title">{ title }</TitleTag> }
 					{ subtitle && <div className="plugins-results-header__subtitle">{ subtitle }</div> }
 				</div>
 			) }

--- a/client/my-sites/plugins/plugins-results-header/index.tsx
+++ b/client/my-sites/plugins/plugins-results-header/index.tsx
@@ -29,7 +29,7 @@ export default function PluginsResultsHeader( {
 		<div className={ clsx( 'plugins-results-header', className ) }>
 			{ ( title || subtitle ) && (
 				<div className="plugins-results-header__titles">
-					{ title && <div className="plugins-results-header__title">{ title }</div> }
+					{ title && <h2 className="plugins-results-header__title">{ title }</h2> }
 					{ subtitle && <div className="plugins-results-header__subtitle">{ subtitle }</div> }
 				</div>
 			) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/Avalancha#76

## Proposed Changes

* Remove redundant hidden h1 on themes and plugins pages from navigation-header component
* Render sub-headings as h2 tags on the root plugins page
* Render category name as h1 on browse/category pages

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* For SEO, avoiding duplicate H1 tags, using semantic HTML elements, and ensuring pages have just one H1 element.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out branch and build Calypso locally
* Go to /plugins and /es/plugins, and inner category pages like /es/plugins/browse/seo and check in "view source" in the browser.
* Ensure that SSR still works, and the markup matches the below screenshots.
![CleanShot 2025-01-06 at 18 20 24@2x](https://github.com/user-attachments/assets/1ada879c-8b74-495e-bf51-b1745d81291c)
![CleanShot 2025-01-06 at 18 18 44@2x](https://github.com/user-attachments/assets/d2d84046-b432-4a6b-8076-f89def585add)
- There should be no visual changes (just markup)
- Also test logged-in versions of the routes.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
