### PR TITLE
Media Library: Fix media modal edit button not working

### DIFF
--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -66,8 +66,8 @@ class MediaLibraryHeader extends Component {
 		recordTracksEvent( 'calypso_media_more_options_toggle', { expanded: state } );
 	};
 
-	onViewDetails = () => {
-		this.props.onViewDetails();
+	onViewDetails = ( ...args ) => {
+		this.props.onViewDetails( ...args );
 		recordTracksEvent( 'calypso_media_editor_open' );
 	};
 


### PR DESCRIPTION
Related to #97898

## Proposed Changes

The media modal's edit button was not working due to missing argument forwarding in an analytics wrapper. When clicking edit, users would encounter a "can't access property meta" error because the analytics-wrapped action was being called without its required arguments.

The issue was caused by the `onViewDetails` wrapper method calling the prop directly without forwarding the arguments needed by the Redux action's analytics middleware. Fixed by ensuring all arguments are properly passed through using rest parameters.

Bug introduced in #97843

## Testing Instructions

To test:

1. Add an image block
2. Open media library
3. Select an image
4. Click the edit button
5. Verify the edit modal opens correctly without any console errors

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
