### PR TITLE
Login: ensure social login button is Akismet color where appropriate

### DIFF
--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -68,8 +68,8 @@ form {
 .wp-login__main .login.is-akismet .is-social-first .card.login__form > .social-buttons__button.button {
 	background-color: var(--color-akismet);
 
-		&:hover,
-    	&:focus {
-        	background-color: var(--color-akismet);
-    	}	
+	&:hover,
+	&:focus {
+    	background-color: var(--color-akismet);
+	}	
 }

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -55,7 +55,7 @@ form {
 }
 
 .layout.is-white-login .login.is-akismet .login__form {
-	.button {
+	.button.is-primary {
 		background-color: var(--color-akismet);
 
 		&:hover,
@@ -63,4 +63,13 @@ form {
         	background-color: var(--color-akismet);
     	}
     }
+}
+
+.wp-login__main .login.is-akismet .is-social-first .card.login__form > .social-buttons__button.button {
+	background-color: var(--color-akismet);
+
+		&:hover,
+    	&:focus {
+        	background-color: var(--color-akismet);
+    	}	
 }


### PR DESCRIPTION
After shipping https://github.com/Automattic/wp-calypso/pull/97435 which added an Akismet-branded login, I noticed that the button was the wrong color if a 'previously used' login option was provided, like this:

<img width="871" alt="Screenshot 2025-01-07 at 15 21 10" src="https://github.com/user-attachments/assets/3169edc2-f1c5-4f97-b776-9eb57b50586b" />

## Proposed Changes
* This PR ensures that all buttons in the login form receive the Akismet green color if it's an Akismet-branded login.

A previous attempt in https://github.com/Automattic/wp-calypso/pull/98004 was not specific enough.

## Why are these changes being made?
* Make button colors consistent on Akismet-branded login.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Go to http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fr-login.wordpress.com%2Fremote-login.php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet.com%252Faccount%252F. This is the same URL generated by the 'Sign in' link on akismet.com.

Check that there is an Akismet logo, heading and green button.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
