### PR TITLE
Subscribers: Add sharing network icons and links

### DIFF
--- a/packages/launchpad/src/action-components/share-site-modal/index.tsx
+++ b/packages/launchpad/src/action-components/share-site-modal/index.tsx
@@ -1,9 +1,14 @@
 import { Popover } from '@automattic/components';
 import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { useQueryClient } from '@tanstack/react-query';
-import { Button, Modal } from '@wordpress/components';
+import {
+	Button,
+	Modal,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { Icon, link, share } from '@wordpress/icons';
+import { link, share, check } from '@wordpress/icons';
 import { useState, useRef } from 'react';
 import { SocialLogo } from 'social-logos';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -56,7 +61,9 @@ const getShareLinks = ( siteUrl: string, text: string ): ShareLink[] => {
 			label: __( 'LinkedIn', 'launchpad' ),
 		},
 		{
-			href: `${ encodeURIComponent( encodedSiteUrl ) }&text=${ encodedText }`,
+			href: `https://t.me/share/url?url=${ encodeURIComponent(
+				encodedSiteUrl
+			) }&text=${ encodedText }`,
 			className: 'share-site-modal__modal-share-link',
 			title: __( 'Share on Telegram', 'launchpad' ),
 			icon: 'telegram',
@@ -86,7 +93,6 @@ const getShareLinks = ( siteUrl: string, text: string ): ShareLink[] => {
 	];
 };
 
-// @TODO add click events for social network to ensure tracking, then open in new window.
 const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 	const queryClient = useQueryClient();
 	const getSiteSlug = ( site: SiteDetails | null ) => {
@@ -119,16 +125,18 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 	const clipboardTextEl = useRef( null );
-
-	const copyHandler = async () => {
-		navigator.clipboard.writeText( shareData.url );
+	const trackShareClick = async () => {
 		if ( shareData.title ) {
 			await updateLaunchpadSettings( shareData.title, {
 				checklist_statuses: { share_site: true },
 			} );
 		}
 		queryClient.invalidateQueries( { queryKey: [ 'launchpad' ] } );
+	};
+	const copyHandler = async () => {
+		navigator.clipboard.writeText( shareData.url );
 		setClipboardCopied( true );
+		trackShareClick();
 		setTimeout( () => setClipboardCopied( false ), 3000 );
 	};
 
@@ -136,7 +144,14 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 		if ( ! canUseWebShare ) {
 			return;
 		}
+		trackShareClick();
 		await navigator.share( shareData );
+	};
+
+	const socialLinkClickHandler = ( event: React.MouseEvent< HTMLAnchorElement > ) => {
+		event.preventDefault();
+		trackShareClick();
+		window.open( event.currentTarget.href, '_blank' );
 	};
 
 	return (
@@ -144,21 +159,28 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 			<Modal
 				onRequestClose={ () => setModalIsOpen( false ) }
 				className="share-site-modal__modal"
-				title=""
+				title={ __( 'Share your site', 'launchpad' ) }
 			>
-				<div className="share-site-modal__modal-content">
-					<div className="share-site-modal__modal-text">
-						<h1 className="share-site-modal__modal-heading">
-							{ __( 'Share your site', 'launchpad' ) }
-						</h1>
-					</div>
-					<div className="share-site-modal__modal-actions">
-						<div className="share-site-modal__modal-site">
+				<VStack className="share-site-modal__modal-content" spacing={ 4 }>
+					<VStack className="share-site-modal__modal-actions" spacing={ 4 }>
+						<HStack className="share-site-modal__modal-site">
 							<div className="share-site-modal__modal-domain">
 								<p className="share-site-modal__modal-domain-text" ref={ clipboardTextEl }>
 									{ shareData.title }
 								</p>
+							</div>
 
+							<HStack className="share-site-modal__modal-actions-buttons">
+								<Button
+									onClick={ copyHandler }
+									className="share-site-modal__modal-copy-link"
+									disabled={ ! shareData.title || clipboardCopied }
+									icon={ clipboardCopied ? check : link }
+								>
+									<span className="share-site-modal__modal-view-site-text">
+										{ __( 'Copy', 'launchpad' ) }
+									</span>
+								</Button>
 								<Popover
 									className="share-site-modal__popover"
 									isVisible={ clipboardCopied }
@@ -167,55 +189,44 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 								>
 									{ __( 'Copied to clipboard!', 'launchpad' ) }
 								</Popover>
-							</div>
-
-							<div>
-								<Button
-									onClick={ copyHandler }
-									className="share-site-modal__modal-copy-link"
-									disabled={ ! shareData.title }
-								>
-									<Icon icon={ link } size={ 22 } />
-									<span className="share-site-modal__modal-view-site-text">
-										{ __( 'Copy', 'launchpad' ) }
-									</span>
-								</Button>
 								{ canUseWebShare && (
 									<Button
 										className="share-site-modal__modal-copy-link"
 										onClick={ webShareClickHandler }
+										icon={ share }
 									>
-										<Icon icon={ share } size={ 22 } />
 										<span className="share-site-modal__modal-view-site-text">
 											{ __( 'Share', 'launchpad' ) }
 										</span>
 									</Button>
 								) }
-							</div>
-						</div>
-						<div className="share-site-modal__modal-social">
+							</HStack>
+						</HStack>
+						<HStack className="share-site-modal__modal-social" as="ul" justify="start">
 							{ getShareLinks( shareData.url, shareData.text ).map(
 								( { href, className, title, icon, label }, index ) => (
-									<a
-										key={ index }
-										href={ href }
-										className={ className }
-										title={ title }
-										rel="noopener noreferrer"
-										target="_blank"
-									>
-										<SocialLogo
-											className="share-site-modal__modal-icon"
-											size={ 24 }
-											icon={ icon }
-										/>
-										<span>{ label }</span>
-									</a>
+									<li key={ index }>
+										<a
+											href={ href }
+											className={ className }
+											title={ title }
+											rel="noopener noreferrer"
+											target="_blank"
+											onClick={ socialLinkClickHandler }
+										>
+											<SocialLogo
+												className="share-site-modal__modal-icon"
+												size={ 24 }
+												icon={ icon }
+											/>
+											<span>{ label }</span>
+										</a>
+									</li>
 								)
 							) }
-						</div>
-					</div>
-				</div>
+						</HStack>
+					</VStack>
+				</VStack>
 			</Modal>
 		</>
 	);

--- a/packages/launchpad/src/action-components/share-site-modal/index.tsx
+++ b/packages/launchpad/src/action-components/share-site-modal/index.tsx
@@ -4,12 +4,14 @@ import { useQueryClient } from '@tanstack/react-query';
 import {
 	Button,
 	Modal,
+	__experimentalInputControl as InputControl,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	IconType,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { link, share, check } from '@wordpress/icons';
-import { useState, useRef } from 'react';
+import { copy, share, check } from '@wordpress/icons';
+import { useState, useRef, useMemo, useCallback } from 'react';
 import { SocialLogo } from 'social-logos';
 import type { SiteDetails } from '@automattic/data-stores';
 
@@ -20,13 +22,25 @@ interface ShareSiteModalProps {
 	site: SiteDetails | null;
 }
 
-interface ShareLink {
-	href: string;
+interface BaseShareLink {
 	className: string;
-	title: string;
-	icon: 'mail' | 'tumblr' | 'bluesky' | 'linkedin' | 'telegram' | 'reddit' | 'whatsapp' | 'x';
 	label: string;
 }
+
+interface SocialShareLink extends BaseShareLink {
+	type?: 'link';
+	href: string;
+	title: string;
+	icon: 'mail' | 'tumblr' | 'bluesky' | 'linkedin' | 'telegram' | 'reddit' | 'whatsapp' | 'x';
+}
+
+interface WordPressShareLink extends BaseShareLink {
+	type: 'button';
+	icon: IconType;
+	onClick: () => void;
+}
+
+type ShareLink = SocialShareLink | WordPressShareLink;
 
 const getShareLinks = ( siteUrl: string, text: string ): ShareLink[] => {
 	const encodedSiteUrl = encodeURIComponent( siteUrl );
@@ -91,24 +105,24 @@ const getShareLinks = ( siteUrl: string, text: string ): ShareLink[] => {
 	];
 };
 
-const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
-	const queryClient = useQueryClient();
-	const getSiteSlug = ( site: SiteDetails | null ) => {
-		if ( ! site ) {
-			return '';
-		}
-
-		if ( site.slug ) {
-			return site.slug;
-		}
-
-		if ( site.URL ) {
-			return new URL( site.URL ).host;
-		}
+const getSiteSlug = ( site: SiteDetails | null ) => {
+	if ( ! site ) {
 		return '';
-	};
+	}
+
+	if ( site.slug ) {
+		return site.slug;
+	}
+
+	if ( site.URL ) {
+		return new URL( site.URL ).host;
+	}
+	return '';
+};
+
+const getShareData = ( site: SiteDetails | null ) => {
 	const siteSlug = getSiteSlug( site );
-	const shareData = {
+	return {
 		title: siteSlug,
 		text: sprintf(
 			/* translators: siteSlug is the short form of the site URL with the https:// */
@@ -119,32 +133,37 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 		),
 		url: site?.URL || '',
 	};
-	const canUseWebShare = window.navigator?.canShare && window.navigator.canShare( shareData );
+};
+const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
+	const queryClient = useQueryClient();
+	const shareData = getShareData( site );
 
-	const [ clipboardCopied, setClipboardCopied ] = useState( false );
-	const clipboardTextEl = useRef( null );
-	const trackShareClick = async () => {
+	const trackShareClick = useCallback( async () => {
 		if ( shareData.title ) {
 			await updateLaunchpadSettings( shareData.title, {
 				checklist_statuses: { share_site: true },
 			} );
 		}
 		queryClient.invalidateQueries( { queryKey: [ 'launchpad' ] } );
-	};
-	const copyHandler = async () => {
+	}, [ shareData, queryClient ] );
+
+	const [ clipboardCopied, setClipboardCopied ] = useState( false );
+	const clipboardTextEl = useRef( null );
+	const copyHandler = () => {
 		navigator.clipboard.writeText( shareData.url );
 		setClipboardCopied( true );
 		trackShareClick();
 		setTimeout( () => setClipboardCopied( false ), 3000 );
 	};
 
-	const webShareClickHandler = async () => {
+	const canUseWebShare = window.navigator?.canShare && window.navigator.canShare( shareData );
+	const webShareClickHandler = useCallback( async () => {
 		if ( ! canUseWebShare ) {
 			return;
 		}
 		trackShareClick();
 		await navigator.share( shareData );
-	};
+	}, [ canUseWebShare, shareData, trackShareClick ] );
 
 	const socialLinkClickHandler = ( event: React.MouseEvent< HTMLAnchorElement > ) => {
 		event.preventDefault();
@@ -152,81 +171,84 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 		window.open( event.currentTarget.href, '_blank' );
 	};
 
-	return (
-		<>
-			<Modal
-				onRequestClose={ () => setModalIsOpen( false ) }
-				className="share-site-modal__modal"
-				title={ __( 'Share your site', 'launchpad' ) }
-			>
-				<VStack className="share-site-modal__modal-content" spacing={ 4 }>
-					<VStack className="share-site-modal__modal-actions" spacing={ 4 }>
-						<HStack className="share-site-modal__modal-site">
-							<div className="share-site-modal__modal-domain">
-								<p className="share-site-modal__modal-domain-text" ref={ clipboardTextEl }>
-									{ shareData.title }
-								</p>
-							</div>
+	const shareLinks = useMemo( () => {
+		const _shareLinks: ShareLink[] = [
+			{
+				type: 'button',
+				className: 'share-site-modal__modal-share-link',
+				label: __( 'Share via device', 'launchpad' ),
+				icon: share,
+				onClick: webShareClickHandler,
+			},
+			...getShareLinks( shareData.url, shareData.text ),
+		];
+		return _shareLinks;
+	}, [ shareData, webShareClickHandler ] );
 
-							<HStack className="share-site-modal__modal-actions-buttons">
-								<Button
-									onClick={ copyHandler }
-									className="share-site-modal__modal-copy-link"
-									disabled={ ! shareData.title || clipboardCopied }
-									icon={ clipboardCopied ? check : link }
-								>
-									<span className="share-site-modal__modal-view-site-text">
-										{ __( 'Copy', 'launchpad' ) }
-									</span>
-								</Button>
-								<Popover
-									className="share-site-modal__popover"
-									isVisible={ clipboardCopied }
-									context={ clipboardTextEl.current }
-									position="top"
-								>
-									{ __( 'Copied to clipboard!', 'launchpad' ) }
-								</Popover>
-								{ canUseWebShare && (
+	return (
+		<Modal
+			onRequestClose={ () => setModalIsOpen( false ) }
+			className="share-site-modal__modal"
+			title={ __( 'Share your site', 'launchpad' ) }
+		>
+			<VStack className="share-site-modal__modal-content" spacing={ 4 }>
+				<VStack className="share-site-modal__modal-actions" spacing={ 4 }>
+					<Popover
+						className="share-site-modal__popover"
+						isVisible={ clipboardCopied }
+						context={ clipboardTextEl.current }
+						position="top"
+					>
+						{ __( 'Copied to clipboard!', 'launchpad' ) }
+					</Popover>
+					<InputControl
+						className="share-site-modal__modal-input-container"
+						__next40pxDefaultSize
+						value={ shareData.title }
+						label={ __( 'Site URL', 'launchpad' ) }
+						ref={ clipboardTextEl }
+						readOnly
+						hideLabelFromVision
+						suffix={
+							<Button
+								onClick={ copyHandler }
+								className="share-site-modal__modal-copy-link"
+								disabled={ ! shareData.title || clipboardCopied }
+								icon={ clipboardCopied ? check : copy }
+								label={ __( 'Copy Site URL', 'launchpad' ) }
+							/>
+						}
+					/>
+					<HStack className="share-site-modal__modal-social" as="ul" justify="start">
+						{ shareLinks.map( ( link, index ) => (
+							<li key={ index }>
+								{ link.type === 'button' ? (
+									<Button className={ link.className } onClick={ link.onClick } icon={ link.icon }>
+										{ link.label }
+									</Button>
+								) : (
 									<Button
-										className="share-site-modal__modal-copy-link"
-										onClick={ webShareClickHandler }
-										icon={ share }
+										href={ link.href }
+										className={ link.className }
+										label={ link.title }
+										rel="noopener noreferrer"
+										target="_blank"
+										onClick={ socialLinkClickHandler }
 									>
-										<span className="share-site-modal__modal-view-site-text">
-											{ __( 'Share', 'launchpad' ) }
-										</span>
+										<SocialLogo
+											className="share-site-modal__modal-icon"
+											size={ 24 }
+											icon={ link.icon }
+										/>
+										<span>{ link.label }</span>
 									</Button>
 								) }
-							</HStack>
-						</HStack>
-						<HStack className="share-site-modal__modal-social" as="ul" justify="start">
-							{ getShareLinks( shareData.url, shareData.text ).map(
-								( { href, className, title, icon, label }, index ) => (
-									<li key={ index }>
-										<a
-											href={ href }
-											className={ className }
-											title={ title }
-											rel="noopener noreferrer"
-											target="_blank"
-											onClick={ socialLinkClickHandler }
-										>
-											<SocialLogo
-												className="share-site-modal__modal-icon"
-												size={ 24 }
-												icon={ icon }
-											/>
-											<span>{ label }</span>
-										</a>
-									</li>
-								)
-							) }
-						</HStack>
-					</VStack>
+							</li>
+						) ) }
+					</HStack>
 				</VStack>
-			</Modal>
-		</>
+			</VStack>
+		</Modal>
 	);
 };
 

--- a/packages/launchpad/src/action-components/share-site-modal/index.tsx
+++ b/packages/launchpad/src/action-components/share-site-modal/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Popover } from '@automattic/components';
 import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { useQueryClient } from '@tanstack/react-query';
@@ -13,13 +14,14 @@ import { __, sprintf } from '@wordpress/i18n';
 import { copy, share, check } from '@wordpress/icons';
 import { useState, useRef, useMemo, useCallback } from 'react';
 import { SocialLogo } from 'social-logos';
+import type { Task } from '../../types';
 import type { SiteDetails } from '@automattic/data-stores';
-
 import './style.scss';
 
 interface ShareSiteModalProps {
 	setModalIsOpen: ( isOpen: boolean ) => void;
 	site: SiteDetails | null;
+	task: Task | null;
 }
 
 interface BaseShareLink {
@@ -134,25 +136,33 @@ const getShareData = ( site: SiteDetails | null ) => {
 		url: site?.URL || '',
 	};
 };
-const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
+const ShareSiteModal = ( { setModalIsOpen, site, task }: ShareSiteModalProps ) => {
 	const queryClient = useQueryClient();
 	const shareData = getShareData( site );
 
-	const trackShareClick = useCallback( async () => {
-		if ( shareData.title ) {
-			await updateLaunchpadSettings( shareData.title, {
-				checklist_statuses: { share_site: true },
+	const trackShareClick = useCallback(
+		async ( eventType: string ) => {
+			recordTracksEvent( 'calypso_subscribers_share_site', {
+				type: eventType,
+				context: task?.id ? `launchpad-task-${ task.id }` : null,
+				site_url: shareData.url,
 			} );
-		}
-		queryClient.invalidateQueries( { queryKey: [ 'launchpad' ] } );
-	}, [ shareData, queryClient ] );
+			if ( shareData.title ) {
+				await updateLaunchpadSettings( shareData.title, {
+					checklist_statuses: { share_site: true },
+				} );
+			}
+			queryClient.invalidateQueries( { queryKey: [ 'launchpad' ] } );
+		},
+		[ shareData, queryClient, task?.id ]
+	);
 
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 	const clipboardTextEl = useRef( null );
 	const copyHandler = () => {
 		navigator.clipboard.writeText( shareData.url );
 		setClipboardCopied( true );
-		trackShareClick();
+		trackShareClick( 'copy' );
 		setTimeout( () => setClipboardCopied( false ), 3000 );
 	};
 
@@ -161,13 +171,14 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 		if ( ! canUseWebShare ) {
 			return;
 		}
-		trackShareClick();
+		trackShareClick( 'web-share' );
 		await navigator.share( shareData );
 	}, [ canUseWebShare, shareData, trackShareClick ] );
 
 	const socialLinkClickHandler = ( event: React.MouseEvent< HTMLAnchorElement > ) => {
 		event.preventDefault();
-		trackShareClick();
+		const eventType = event.currentTarget.dataset.eventType as string;
+		trackShareClick( eventType );
 		window.open( event.currentTarget.href, '_blank' );
 	};
 
@@ -234,6 +245,7 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 										rel="noopener noreferrer"
 										target="_blank"
 										onClick={ socialLinkClickHandler }
+										data-event-type={ link.icon }
 									>
 										<SocialLogo
 											className="share-site-modal__modal-icon"

--- a/packages/launchpad/src/action-components/share-site-modal/index.tsx
+++ b/packages/launchpad/src/action-components/share-site-modal/index.tsx
@@ -49,14 +49,12 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 
 	const copyHandler = async () => {
 		navigator.clipboard.writeText( `https://${ siteSlug }` );
-		/*
 		if ( siteSlug ) {
 			await updateLaunchpadSettings( siteSlug, {
 				checklist_statuses: { share_site: true },
 			} );
 		}
 		queryClient.invalidateQueries( { queryKey: [ 'launchpad' ] } );
-	*/
 		setClipboardCopied( true );
 		setTimeout( () => setClipboardCopied( false ), 3000 );
 	};
@@ -73,12 +71,6 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 						<h1 className="share-site-modal__modal-heading">
 							{ __( 'Share your site', 'launchpad' ) }
 						</h1>
-						<p className="share-site-modal__modal-body">
-							{ __(
-								'Copy your site link below or select a network to share your site.',
-								'launchpad'
-							) }
-						</p>
 					</div>
 					<div className="share-site-modal__modal-actions">
 						<div className="share-site-modal__modal-site">

--- a/packages/launchpad/src/action-components/share-site-modal/index.tsx
+++ b/packages/launchpad/src/action-components/share-site-modal/index.tsx
@@ -5,6 +5,7 @@ import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, link } from '@wordpress/icons';
 import { useState, useRef } from 'react';
+import SocialLogo from 'calypso/components/social-logo';
 import type { SiteDetails } from '@automattic/data-stores';
 
 import './style.scss';
@@ -14,6 +15,17 @@ interface ShareSiteModalProps {
 	site: SiteDetails | null;
 }
 
+// @TODO: build and use this list to generate links. Get site title.
+const shareLinkNetworks = [
+	{
+		icon: 'tumblr',
+		url: `http://www.reddit.com/submit?url=%%SITE_URL%%&title=%%SITE_TITLE%%`,
+		label: __( 'Tumblr', 'launchpad' ),
+	},
+];
+
+// @TODO: consider making the slug text use https://developer.mozilla.org/en-US/docs/Web/API/Web_Share_API
+// @TODO add click events for social network to ensure tracking, then open in new window.
 const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 	const queryClient = useQueryClient();
 	const getSiteSlug = ( site: SiteDetails | null ): string | null => {
@@ -37,12 +49,14 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 
 	const copyHandler = async () => {
 		navigator.clipboard.writeText( `https://${ siteSlug }` );
+		/*
 		if ( siteSlug ) {
 			await updateLaunchpadSettings( siteSlug, {
 				checklist_statuses: { share_site: true },
 			} );
 		}
 		queryClient.invalidateQueries( { queryKey: [ 'launchpad' ] } );
+	*/
 		setClipboardCopied( true );
 		setTimeout( () => setClipboardCopied( false ), 3000 );
 	};
@@ -61,7 +75,7 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 						</h1>
 						<p className="share-site-modal__modal-body">
 							{ __(
-								'Now you can head over to your site and share it with the world.',
+								'Copy your site link below or select a network to share your site.',
 								'launchpad'
 							) }
 						</p>
@@ -85,7 +99,7 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 
 							<Button
 								onClick={ copyHandler }
-								className="share-site-modal__modal-view-site"
+								className="share-site-modal__modal-copy-link"
 								disabled={ ! siteSlug }
 							>
 								<Icon icon={ link } size={ 22 } />
@@ -93,6 +107,102 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 									{ __( 'Copy', 'launchpad' ) }
 								</span>
 							</Button>
+						</div>
+						<div className="share-site-modal__modal-social">
+							<a
+								href="https://wordpress.com"
+								className="share-site-modal__modal-share-link"
+								title={ __( 'Share via email', 'launchpad' ) }
+							>
+								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="mail" />
+								<span>{ __( 'Email', 'launchpad' ) }</span>
+							</a>
+							<a
+								href="https://wordpress.com"
+								className="share-site-modal__modal-share-link"
+								title={ __( 'Share on WordPress', 'launchpad' ) }
+							>
+								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="wordpress" />
+								<span>{ __( 'WordPress', 'launchpad' ) }</span>
+							</a>
+							<a
+								href="https://wordpress.com"
+								className="share-site-modal__modal-share-link"
+								title={ __( 'Share on Tumblr', 'launchpad' ) }
+							>
+								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="tumblr" />
+								<span>{ __( 'Tumblr', 'launchpad' ) }</span>
+							</a>
+							<a
+								href="https://wordpress.com"
+								className="share-site-modal__modal-share-link"
+								title={ __( 'Share on Bluesky', 'launchpad' ) }
+							>
+								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="bluesky" />
+								<span>{ __( 'Bluesky', 'launchpad' ) }</span>
+							</a>
+							<a
+								href="https://wordpress.com"
+								className="share-site-modal__modal-share-link"
+								title={ __( 'Share on Instagram', 'launchpad' ) }
+							>
+								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="instagram" />
+								<span>{ __( 'Instagram', 'launchpad' ) }</span>
+							</a>
+							<a
+								href="https://wordpress.com"
+								className="share-site-modal__modal-share-link"
+								title={ __( 'Share on LinkedIn', 'launchpad' ) }
+							>
+								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="linkedin" />
+								<span>{ __( 'LinkedIn', 'launchpad' ) }</span>
+							</a>
+							<a
+								href="https://wordpress.com"
+								className="share-site-modal__modal-share-link"
+								title={ __( 'Share on Medium', 'launchpad' ) }
+							>
+								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="medium" />
+								<span>{ __( 'Medium', 'launchpad' ) }</span>
+							</a>
+							<a
+								href="https://wordpress.com"
+								className="share-site-modal__modal-share-link"
+								title={ __( 'Share on Telegram', 'launchpad' ) }
+							>
+								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="telegram" />
+								<span>{ __( 'Telegram', 'launchpad' ) }</span>
+							</a>
+							<a
+								href={ `http://www.reddit.com/submit?url=${ encodeURI(
+									'https://' + siteSlug
+								) }&title=` }
+								className="share-site-modal__modal-share-link"
+								title={ __( 'Share on Reddit', 'launchpad' ) }
+							>
+								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="whatsapp" />
+								<span>{ __( 'Reddit', 'launchpad' ) }</span>
+							</a>
+							<a
+								href={ `https://api.whatsapp.com/send?text=${ encodeURI(
+									'https://' + siteSlug
+								) } ` }
+								className="share-site-modal__modal-share-link"
+								title={ __( 'Share on WhatsApp', 'launchpad' ) }
+							>
+								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="whatsapp" />
+								<span>{ __( 'WhatsApp', 'launchpad' ) }</span>
+							</a>
+							<a
+								href={ `https://x.com/intent/post?url=${ encodeURI(
+									'https://' + siteSlug
+								) }&text=` }
+								className="share-site-modal__modal-share-link"
+								title={ __( 'Share on X', 'launchpad' ) }
+							>
+								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="x" />
+								<span>{ __( 'X', 'launchpad' ) }</span>
+							</a>
 						</div>
 					</div>
 				</div>

--- a/packages/launchpad/src/action-components/share-site-modal/index.tsx
+++ b/packages/launchpad/src/action-components/share-site-modal/index.tsx
@@ -2,10 +2,10 @@ import { Popover } from '@automattic/components';
 import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button, Modal } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { Icon, link } from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+import { Icon, link, share } from '@wordpress/icons';
 import { useState, useRef } from 'react';
-import SocialLogo from 'calypso/components/social-logo';
+import { SocialLogo } from 'social-logos';
 import type { SiteDetails } from '@automattic/data-stores';
 
 import './style.scss';
@@ -15,22 +15,90 @@ interface ShareSiteModalProps {
 	site: SiteDetails | null;
 }
 
-// @TODO: build and use this list to generate links. Get site title.
-const shareLinkNetworks = [
-	{
-		icon: 'tumblr',
-		url: `http://www.reddit.com/submit?url=%%SITE_URL%%&title=%%SITE_TITLE%%`,
-		label: __( 'Tumblr', 'launchpad' ),
-	},
-];
+interface ShareLink {
+	href: string;
+	className: string;
+	title: string;
+	icon: string;
+	label: string;
+}
 
-// @TODO: consider making the slug text use https://developer.mozilla.org/en-US/docs/Web/API/Web_Share_API
+const getShareLinks = ( siteUrl: string, text: string ): ShareLink[] => {
+	const encodedSiteUrl = encodeURIComponent( siteUrl );
+	const encodedText = encodeURIComponent( text );
+	return [
+		{
+			href: `mailto:?subject=${ encodedText }&body=${ encodedSiteUrl }`,
+			className: 'share-site-modal__modal-share-link',
+			title: __( 'Share via email', 'launchpad' ),
+			icon: 'mail',
+			label: __( 'Email', 'launchpad' ),
+		},
+		{
+			href: `https://wordpress.com/post?url=${ encodedSiteUrl }&is_post_share=true`,
+			className: 'share-site-modal__modal-share-link',
+			title: __( 'Share on WordPress', 'launchpad' ),
+			icon: 'wordpress',
+			label: __( 'WordPress', 'launchpad' ),
+		},
+		{
+			href: `http://www.tumblr.com/share/link?url=${ encodedSiteUrl }`,
+			className: 'share-site-modal__modal-share-link',
+			title: __( 'Share on Tumblr', 'launchpad' ),
+			icon: 'tumblr',
+			label: __( 'Tumblr', 'launchpad' ),
+		},
+		{
+			href: `https://bsky.app/intent/compose?text=${ encodedSiteUrl }`,
+			className: 'share-site-modal__modal-share-link',
+			title: __( 'Share on Bluesky', 'launchpad' ),
+			icon: 'bluesky',
+			label: __( 'Bluesky', 'launchpad' ),
+		},
+		{
+			href: `https://www.linkedin.com/shareArticle?mini=true&url=${ encodedSiteUrl }&title=${ encodedText }`,
+			className: 'share-site-modal__modal-share-link',
+			title: __( 'Share on LinkedIn', 'launchpad' ),
+			icon: 'linkedin',
+			label: __( 'LinkedIn', 'launchpad' ),
+		},
+		{
+			href: `${ encodeURIComponent( encodedSiteUrl ) }&text=${ encodedText }`,
+			className: 'share-site-modal__modal-share-link',
+			title: __( 'Share on Telegram', 'launchpad' ),
+			icon: 'telegram',
+			label: __( 'Telegram', 'launchpad' ),
+		},
+		{
+			href: `http://www.reddit.com/submit?url=${ encodedSiteUrl }&title=${ encodedText }`,
+			className: 'share-site-modal__modal-share-link',
+			title: __( 'Share on Reddit', 'launchpad' ),
+			icon: 'reddit',
+			label: __( 'Reddit', 'launchpad' ),
+		},
+		{
+			href: `https://api.whatsapp.com/send?text=${ encodedSiteUrl }`,
+			className: 'share-site-modal__modal-share-link',
+			title: __( 'Share on WhatsApp', 'launchpad' ),
+			icon: 'whatsapp',
+			label: __( 'WhatsApp', 'launchpad' ),
+		},
+		{
+			href: `https://x.com/intent/post?url=${ encodedSiteUrl }&text=${ encodedText }`,
+			className: 'share-site-modal__modal-share-link',
+			title: __( 'Share on X', 'launchpad' ),
+			icon: 'x',
+			label: __( 'X', 'launchpad' ),
+		},
+	];
+};
+
 // @TODO add click events for social network to ensure tracking, then open in new window.
 const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 	const queryClient = useQueryClient();
-	const getSiteSlug = ( site: SiteDetails | null ): string | null => {
+	const getSiteSlug = ( site: SiteDetails | null ) => {
 		if ( ! site ) {
-			return null;
+			return '';
 		}
 
 		if ( site.slug ) {
@@ -40,23 +108,42 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 		if ( site.URL ) {
 			return new URL( site.URL ).host;
 		}
-		return null;
+		return '';
 	};
 	const siteSlug = getSiteSlug( site );
+	const shareData = {
+		title: siteSlug,
+		text: sprintf(
+			/* translators: siteSlug is the short form of the site URL with the https:// */
+			__( 'Please visit my site: %(siteSlug)s', 'launchpad' ),
+			{
+				siteSlug,
+			}
+		),
+		url: site?.URL || '',
+	};
+	const canUseWebShare = window.navigator?.canShare && window.navigator.canShare( shareData );
 
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 	const clipboardTextEl = useRef( null );
 
 	const copyHandler = async () => {
-		navigator.clipboard.writeText( `https://${ siteSlug }` );
-		if ( siteSlug ) {
-			await updateLaunchpadSettings( siteSlug, {
+		navigator.clipboard.writeText( shareData.url );
+		if ( shareData.title ) {
+			await updateLaunchpadSettings( shareData.title, {
 				checklist_statuses: { share_site: true },
 			} );
 		}
 		queryClient.invalidateQueries( { queryKey: [ 'launchpad' ] } );
 		setClipboardCopied( true );
 		setTimeout( () => setClipboardCopied( false ), 3000 );
+	};
+
+	const webShareClickHandler = async () => {
+		if ( ! canUseWebShare ) {
+			return;
+		}
+		await navigator.share( shareData );
 	};
 
 	return (
@@ -76,7 +163,7 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 						<div className="share-site-modal__modal-site">
 							<div className="share-site-modal__modal-domain">
 								<p className="share-site-modal__modal-domain-text" ref={ clipboardTextEl }>
-									{ siteSlug }
+									{ shareData.title }
 								</p>
 
 								<Popover
@@ -89,112 +176,48 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 								</Popover>
 							</div>
 
-							<Button
-								onClick={ copyHandler }
-								className="share-site-modal__modal-copy-link"
-								disabled={ ! siteSlug }
-							>
-								<Icon icon={ link } size={ 22 } />
-								<span className="share-site-modal__modal-view-site-text">
-									{ __( 'Copy', 'launchpad' ) }
-								</span>
-							</Button>
+							<div>
+								<Button
+									onClick={ copyHandler }
+									className="share-site-modal__modal-copy-link"
+									disabled={ ! shareData.title }
+								>
+									<Icon icon={ link } size={ 22 } />
+									<span className="share-site-modal__modal-view-site-text">
+										{ __( 'Copy', 'launchpad' ) }
+									</span>
+								</Button>
+								{ canUseWebShare && (
+									<Button
+										className="share-site-modal__modal-copy-link"
+										onClick={ webShareClickHandler }
+									>
+										<Icon icon={ share } size={ 22 } />
+										<span className="share-site-modal__modal-view-site-text">
+											{ __( 'Share', 'launchpad' ) }
+										</span>
+									</Button>
+								) }
+							</div>
 						</div>
 						<div className="share-site-modal__modal-social">
-							<a
-								href="https://wordpress.com"
-								className="share-site-modal__modal-share-link"
-								title={ __( 'Share via email', 'launchpad' ) }
-							>
-								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="mail" />
-								<span>{ __( 'Email', 'launchpad' ) }</span>
-							</a>
-							<a
-								href="https://wordpress.com"
-								className="share-site-modal__modal-share-link"
-								title={ __( 'Share on WordPress', 'launchpad' ) }
-							>
-								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="wordpress" />
-								<span>{ __( 'WordPress', 'launchpad' ) }</span>
-							</a>
-							<a
-								href="https://wordpress.com"
-								className="share-site-modal__modal-share-link"
-								title={ __( 'Share on Tumblr', 'launchpad' ) }
-							>
-								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="tumblr" />
-								<span>{ __( 'Tumblr', 'launchpad' ) }</span>
-							</a>
-							<a
-								href="https://wordpress.com"
-								className="share-site-modal__modal-share-link"
-								title={ __( 'Share on Bluesky', 'launchpad' ) }
-							>
-								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="bluesky" />
-								<span>{ __( 'Bluesky', 'launchpad' ) }</span>
-							</a>
-							<a
-								href="https://wordpress.com"
-								className="share-site-modal__modal-share-link"
-								title={ __( 'Share on Instagram', 'launchpad' ) }
-							>
-								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="instagram" />
-								<span>{ __( 'Instagram', 'launchpad' ) }</span>
-							</a>
-							<a
-								href="https://wordpress.com"
-								className="share-site-modal__modal-share-link"
-								title={ __( 'Share on LinkedIn', 'launchpad' ) }
-							>
-								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="linkedin" />
-								<span>{ __( 'LinkedIn', 'launchpad' ) }</span>
-							</a>
-							<a
-								href="https://wordpress.com"
-								className="share-site-modal__modal-share-link"
-								title={ __( 'Share on Medium', 'launchpad' ) }
-							>
-								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="medium" />
-								<span>{ __( 'Medium', 'launchpad' ) }</span>
-							</a>
-							<a
-								href="https://wordpress.com"
-								className="share-site-modal__modal-share-link"
-								title={ __( 'Share on Telegram', 'launchpad' ) }
-							>
-								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="telegram" />
-								<span>{ __( 'Telegram', 'launchpad' ) }</span>
-							</a>
-							<a
-								href={ `http://www.reddit.com/submit?url=${ encodeURI(
-									'https://' + siteSlug
-								) }&title=` }
-								className="share-site-modal__modal-share-link"
-								title={ __( 'Share on Reddit', 'launchpad' ) }
-							>
-								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="whatsapp" />
-								<span>{ __( 'Reddit', 'launchpad' ) }</span>
-							</a>
-							<a
-								href={ `https://api.whatsapp.com/send?text=${ encodeURI(
-									'https://' + siteSlug
-								) } ` }
-								className="share-site-modal__modal-share-link"
-								title={ __( 'Share on WhatsApp', 'launchpad' ) }
-							>
-								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="whatsapp" />
-								<span>{ __( 'WhatsApp', 'launchpad' ) }</span>
-							</a>
-							<a
-								href={ `https://x.com/intent/post?url=${ encodeURI(
-									'https://' + siteSlug
-								) }&text=` }
-								className="share-site-modal__modal-share-link"
-								title={ __( 'Share on X', 'launchpad' ) }
-							>
-								<SocialLogo className="share-site-modal__modal-icon" size={ 24 } icon="x" />
-								<span>{ __( 'X', 'launchpad' ) }</span>
-							</a>
+							{ getShareLinks( shareData.url, shareData.text ).map( ( link, index ) => (
+								<a
+									key={ index }
+									href={ link.href }
+									className={ link.className }
+									title={ link.title }
+									rel="noopener noreferrer"
+									target="_blank"
+								>
+									<SocialLogo
+										className="share-site-modal__modal-icon"
+										size={ 24 }
+										icon={ link.icon }
+									/>
+									<span>{ link.label }</span>
+								</a>
+							) ) }
 						</div>
 					</div>
 				</div>

--- a/packages/launchpad/src/action-components/share-site-modal/index.tsx
+++ b/packages/launchpad/src/action-components/share-site-modal/index.tsx
@@ -61,9 +61,7 @@ const getShareLinks = ( siteUrl: string, text: string ): ShareLink[] => {
 			label: __( 'LinkedIn', 'launchpad' ),
 		},
 		{
-			href: `https://t.me/share/url?url=${ encodeURIComponent(
-				encodedSiteUrl
-			) }&text=${ encodedText }`,
+			href: `https://t.me/share/url?url=${ encodedSiteUrl }&text=${ encodedText }`,
 			className: 'share-site-modal__modal-share-link',
 			title: __( 'Share on Telegram', 'launchpad' ),
 			icon: 'telegram',

--- a/packages/launchpad/src/action-components/share-site-modal/index.tsx
+++ b/packages/launchpad/src/action-components/share-site-modal/index.tsx
@@ -19,7 +19,7 @@ interface ShareLink {
 	href: string;
 	className: string;
 	title: string;
-	icon: string;
+	icon: 'mail' | 'tumblr' | 'bluesky' | 'linkedin' | 'telegram' | 'reddit' | 'whatsapp' | 'x';
 	label: string;
 }
 
@@ -33,13 +33,6 @@ const getShareLinks = ( siteUrl: string, text: string ): ShareLink[] => {
 			title: __( 'Share via email', 'launchpad' ),
 			icon: 'mail',
 			label: __( 'Email', 'launchpad' ),
-		},
-		{
-			href: `https://wordpress.com/post?url=${ encodedSiteUrl }&is_post_share=true`,
-			className: 'share-site-modal__modal-share-link',
-			title: __( 'Share on WordPress', 'launchpad' ),
-			icon: 'wordpress',
-			label: __( 'WordPress', 'launchpad' ),
 		},
 		{
 			href: `http://www.tumblr.com/share/link?url=${ encodedSiteUrl }`,
@@ -201,23 +194,25 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 							</div>
 						</div>
 						<div className="share-site-modal__modal-social">
-							{ getShareLinks( shareData.url, shareData.text ).map( ( link, index ) => (
-								<a
-									key={ index }
-									href={ link.href }
-									className={ link.className }
-									title={ link.title }
-									rel="noopener noreferrer"
-									target="_blank"
-								>
-									<SocialLogo
-										className="share-site-modal__modal-icon"
-										size={ 24 }
-										icon={ link.icon }
-									/>
-									<span>{ link.label }</span>
-								</a>
-							) ) }
+							{ getShareLinks( shareData.url, shareData.text ).map(
+								( { href, className, title, icon, label }, index ) => (
+									<a
+										key={ index }
+										href={ href }
+										className={ className }
+										title={ title }
+										rel="noopener noreferrer"
+										target="_blank"
+									>
+										<SocialLogo
+											className="share-site-modal__modal-icon"
+											size={ 24 }
+											icon={ icon }
+										/>
+										<span>{ label }</span>
+									</a>
+								)
+							) }
 						</div>
 					</div>
 				</div>

--- a/packages/launchpad/src/action-components/share-site-modal/style.scss
+++ b/packages/launchpad/src/action-components/share-site-modal/style.scss
@@ -3,49 +3,10 @@
 .share-site-modal__modal {
 	max-width: 640px;
 
-	.share-site-modal__modal-heading {
-		font-size: 1.25rem;
-		font-weight: 600;
-	}
-
-	.share-site-modal__modal-domain-text {
-		padding: 0 8px;
-		margin: 0;
-		color: var(--studio-gray-80);
-		font-size: 1rem;
-		line-height: 24px;
-		// prevent text overflow
-		text-overflow: ellipsis;
-		white-space: nowrap;
-		overflow: hidden;
-	}
-
-	.share-site-modal__modal-actions-buttons {
-		justify-content: end;
-		width: auto;
-		min-width: 180px;
-	}
-
-	.share-site-modal__modal-site {
-		padding: 8px;
-		background: var(--studio-gray-0);
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		align-items: center;
-	}
-
-	.launchpad__clipboard-button {
-		opacity: 0;
-	}
-
-	.launchpad__clipboard-button:focus {
-		opacity: 1;
-	}
-
-	.share-site-modal__modal-site:hover {
-		.launchpad__clipboard-button {
-			opacity: 1;
+	.share-site-modal__modal-input-container {
+		input {
+			/* Required to tame the WordPress component's outrageously specific font size */
+			font-size: $font-body !important;
 		}
 	}
 
@@ -62,24 +23,14 @@
 		align-items: center;
 		font-weight: 500;
 		padding: 4px 8px;
-		margin: 0 4px 4px 0;
-		background-color: var(--studio-gray-0);
-		/* stylelint-disable-next-line */
-		font-size: 14px;
+		font-size: $font-body-small;
 		line-height: 20px;
 		letter-spacing: -0.154px;
 		color: #101517;
 		.share-site-modal__modal-icon {
-			background-color: #fff;
-			border: 1px solid var(--studio-gray-90);
 			border-radius: 100%;
 			padding: 4px;
 		}
-	}
-
-	.share-site-modal__modal-copy-link {
-		background-color: #fff;
-		margin: 0 0 0 4px;
 	}
 
 	.share-site-modal__modal-copy-link:disabled {

--- a/packages/launchpad/src/action-components/share-site-modal/style.scss
+++ b/packages/launchpad/src/action-components/share-site-modal/style.scss
@@ -43,7 +43,6 @@
 		align-items: center;
 	}
 
-	.share-site-modal__modal-body,
 	.share-site-modal__modal-domain-text {
 		margin: 0;
 		color: var(--studio-gray-80);

--- a/packages/launchpad/src/action-components/share-site-modal/style.scss
+++ b/packages/launchpad/src/action-components/share-site-modal/style.scss
@@ -139,7 +139,7 @@
 		letter-spacing: -0.154px;
 		color: #101517;
 		.share-site-modal__modal-icon {
-			background-color: $white;
+			background-color: #fff;
 			border: 1px solid var(--studio-gray-90);
 			border-radius: 100%;
 			padding: 4px;
@@ -147,7 +147,7 @@
 	}
 
 	.share-site-modal__modal-copy-link {
-		background-color: $white;
+		background-color: #fff;
 		margin: 0 0 0 4px;
 	}
 

--- a/packages/launchpad/src/action-components/share-site-modal/style.scss
+++ b/packages/launchpad/src/action-components/share-site-modal/style.scss
@@ -17,7 +17,13 @@
 		padding-bottom: 40px;
 		display: flex;
 		flex-direction: column;
-		gap: 32px;
+		gap: 16px;
+	}
+
+	.share-site-modal__modal-actions {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
 	}
 
 	.share-site-modal__modal-heading {
@@ -118,23 +124,42 @@
 		font-weight: bold;
 	}
 
-	.share-site-modal__modal-view-site {
+	.share-site-modal__modal-social {
 		display: flex;
-		gap: 4px;
+		flex-wrap: wrap;
+	}
 
+	.share-site-modal__modal-copy-link,
+	.share-site-modal__modal-share-link {
+		gap: 4px;
+		display: inline-flex;
+		align-items: center;
 		font-weight: 500;
+		padding: 4px 8px;
+		margin: 0 4px 4px 0;
+		background-color: var(--studio-gray-0);
 		/* stylelint-disable-next-line */
 		font-size: 14px;
 		line-height: 20px;
 		letter-spacing: -0.154px;
 		color: #101517;
+		.share-site-modal__modal-icon {
+			background-color: white;
+			border: 1px solid var(--studio-gray-90);
+			border-radius: 100%;
+			padding: 4px;
+		}
 	}
 
-	.share-site-modal__modal-view-site:visited {
+	.share-site-modal__modal-copy-link {
+		background-color: white;
+	}
+
+	.share-site-modal__modal-share-link:visited {
 		color: #101517;
 	}
 
-	.share-site-modal__modal-view-site:hover:not(:disabled) {
+	.share-site-modal__modal-share-link:hover:not(:disabled) {
 		text-decoration: underline;
 	}
 }

--- a/packages/launchpad/src/action-components/share-site-modal/style.scss
+++ b/packages/launchpad/src/action-components/share-site-modal/style.scss
@@ -44,15 +44,11 @@
 	}
 
 	.share-site-modal__modal-domain-text {
+		padding: 0 8px;
 		margin: 0;
 		color: var(--studio-gray-80);
 		font-size: 1rem;
 		line-height: 24px;
-	}
-
-	.share-site-modal__modal-domain-text {
-		padding: 0 8px;
-
 		// prevent text overflow
 		text-overflow: ellipsis;
 		white-space: nowrap;
@@ -143,7 +139,7 @@
 		letter-spacing: -0.154px;
 		color: #101517;
 		.share-site-modal__modal-icon {
-			background-color: white;
+			background-color: $white;
 			border: 1px solid var(--studio-gray-90);
 			border-radius: 100%;
 			padding: 4px;
@@ -151,7 +147,8 @@
 	}
 
 	.share-site-modal__modal-copy-link {
-		background-color: white;
+		background-color: $white;
+		margin: 0 0 0 4px;
 	}
 
 	.share-site-modal__modal-share-link:visited {

--- a/packages/launchpad/src/action-components/share-site-modal/style.scss
+++ b/packages/launchpad/src/action-components/share-site-modal/style.scss
@@ -4,7 +4,7 @@
 	max-width: 640px;
 
 	.share-site-modal__modal-heading {
-		font-size: 1.2rem;
+		font-size: 1.25rem;
 		font-weight: 600;
 	}
 

--- a/packages/launchpad/src/action-components/share-site-modal/style.scss
+++ b/packages/launchpad/src/action-components/share-site-modal/style.scss
@@ -3,44 +3,9 @@
 .share-site-modal__modal {
 	max-width: 640px;
 
-	.components-modal__header {
-		padding: 48px;
-	}
-
-	.components-modal__content {
-		margin: 0;
-		padding: 0;
-	}
-
-	.share-site-modal__modal-content {
-		padding: 48px;
-		padding-bottom: 40px;
-		display: flex;
-		flex-direction: column;
-		gap: 16px;
-	}
-
-	.share-site-modal__modal-actions {
-		display: flex;
-		flex-direction: column;
-		gap: 16px;
-	}
-
 	.share-site-modal__modal-heading {
-		color: var(--studio-gray-100);
-		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
-		font-size: 2rem;
-		line-height: 40px;
-		font-weight: 400;
-		letter-spacing: 0.2px;
-		margin: 0;
-		padding-bottom: 8px;
-	}
-
-	.share-site-modal__modal-domain {
-		display: flex;
-		justify-content: center;
-		align-items: center;
+		font-size: 1.2rem;
+		font-weight: 600;
 	}
 
 	.share-site-modal__modal-domain-text {
@@ -55,11 +20,10 @@
 		overflow: hidden;
 	}
 
-	.share-site-modal__modal-buttons {
-		display: flex;
-		flex-direction: row;
+	.share-site-modal__modal-actions-buttons {
 		justify-content: end;
-		gap: 16px;
+		width: auto;
+		min-width: 180px;
 	}
 
 	.share-site-modal__modal-site {
@@ -85,43 +49,10 @@
 		}
 	}
 
-	.share-site-modal__modal-customize {
-		color: var(--studio-blue-50);
-		font-size: 0.875rem;
-		display: inline-flex;
-		flex-direction: row;
-		justify-content: start;
-		gap: 6px;
-		padding: 0;
-		margin: 0;
-		margin-top: 16px;
-	}
-
-	.share-site-modal__modal-upsell {
-		border-top: 1px solid var(--studio-gray-5);
-		background: var(--studio-gray-0);
-		display: flex;
-		justify-content: center;
-		align-items: center;
-		padding: 32px 48px;
-		gap: 32px;
-
-		.components-button {
-			height: 42px;
-		}
-	}
-
-	.share-site-modal__modal-upsell-content p {
-		margin-bottom: 0;
-	}
-
-	.share-site-modal__modal-upsell-content-highlight {
-		font-weight: bold;
-	}
-
 	.share-site-modal__modal-social {
-		display: flex;
 		flex-wrap: wrap;
+		margin: 0;
+		list-style: none;
 	}
 
 	.share-site-modal__modal-copy-link,
@@ -149,6 +80,10 @@
 	.share-site-modal__modal-copy-link {
 		background-color: #fff;
 		margin: 0 0 0 4px;
+	}
+
+	.share-site-modal__modal-copy-link:disabled {
+		opacity: 0.5;
 	}
 
 	.share-site-modal__modal-share-link:visited {

--- a/packages/launchpad/src/launchpad.tsx
+++ b/packages/launchpad/src/launchpad.tsx
@@ -77,11 +77,15 @@ const Launchpad = ( {
 	if ( ! launchpadContext ) {
 		return null;
 	}
-
+	const shareSiteTask = checklist?.find( ( task: Task ) => task.id === 'share_site' ) ?? null;
 	return (
 		<>
 			{ shareSiteModalIsOpen && site && (
-				<ShareSiteModal setModalIsOpen={ setShareSiteModalIsOpen } site={ site } />
+				<ShareSiteModal
+					setModalIsOpen={ setShareSiteModalIsOpen }
+					site={ site }
+					task={ shareSiteTask }
+				/>
 			) }
 			<LaunchpadInternal
 				site={ site }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/97973


## Proposed Changes

This PR:

- adds social media and [Web Share API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Share_API)  buttons to the share site launchpad model.
- replaces HTML with common Gutenberg component patterns, e.g., button, flex containers
- ensures consistency with spacing and headings with the other modals, e.g., Import existing subscribers
- fixes the overflow in very looooong domain names

### Before


<img width="670" alt="Screenshot 2025-02-14 at 4 48 55 pm" src="https://github.com/user-attachments/assets/c3e20f29-5331-416d-a468-bb1388399059" />

### After

![2025-03-12 11 25 35](https://github.com/user-attachments/assets/09d3197a-90db-4ba9-90f6-be6bc3f66ebc)

<img width="700" alt="Screenshot 2025-03-12 at 11 17 02 am" src="https://github.com/user-attachments/assets/af949ed0-b90c-4ebf-a30b-d7c43092184e" />



## Why are these changes being made?

As noted in https://github.com/Automattic/wp-calypso/issues/97973, the current screen is confusing:

- It urges users to copy the link and _"...head over to your site and share it with the world"_. How is pasting my site link on my own site sharing it with the world?
- It offers no alternatives to share the link with the world.
- It's inconsistent with other modals. Let's just use the default padding and title attribute.

## Testing Instructions

Go to `/subscribers/[YOUR_SITE_SUBDOMAIN].wordpress.com` and click on "Share your site"

If you've already shared your site the options might be missing. 

If you need to reset the launch pad options, you can delete the `launchpad_checklist_tasks_statuses` blog option. E.g., 

```
echo switch_to_blog(get_blog_id_from_url('[YOUR_SITE_NAME].wordpress.com'));
echo delete_option('launchpad_checklist_tasks_statuses');
```

Click on every action button to ensure the links work.

Ensure that clicking on any share link triggers the launchpad status, e.g., Share your site will be checked off


<img width="635" alt="Screenshot 2025-03-10 at 2 11 58 pm" src="https://github.com/user-attachments/assets/417d09f8-c25b-4fe1-9a42-0bd05263a92a" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
