### PR TITLE
Revert "Goals first: Reset onboard store when entering the flow"

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -183,10 +183,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 	//User has already reached checkout and then hit the browser back button.
 	//In this case, site has already been created, and plan added to cart. We need to avoid to create another site.
 	const isManageSiteFlow = Boolean(
-		wasSignupCheckoutPageUnloaded() &&
-			signupDestinationCookieExists &&
-			isReEnteringFlow &&
-			getSignupCompleteSlug()
+		wasSignupCheckoutPageUnloaded() && signupDestinationCookieExists && isReEnteringFlow
 	);
 	const { addTempSiteToSourceOption } = useAddTempSiteToSourceOptionMutation();
 	const urlQueryParams = useQuery();

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -1,18 +1,15 @@
 import { OnboardSelect, Onboard, UserSelect } from '@automattic/data-stores';
-import { ONBOARDING_FLOW, clearStepPersistedState } from '@automattic/onboarding';
+import { ONBOARDING_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { pathToUrl } from 'calypso/lib/url';
 import {
-	clearSignupCompleteSlug,
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 	setSignupCompleteSlug,
 } from 'calypso/signup/storageUtils';
-import { useDispatch as useReduxDispatch } from 'calypso/state';
-import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import {
 	STEPPER_TRACKS_EVENT_SIGNUP_START,
 	STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
@@ -346,19 +343,6 @@ const onboarding: Flow = {
 		return {
 			state: isLoading ? AssertConditionState.CHECKING : AssertConditionState.SUCCESS,
 		};
-	},
-	useSideEffect( currentStepSlug ) {
-		const reduxDispatch = useReduxDispatch();
-		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
-
-		useEffect( () => {
-			if ( ! currentStepSlug ) {
-				resetOnboardStore();
-				reduxDispatch( setSelectedSiteId( null ) );
-				clearStepPersistedState( this.name );
-				clearSignupCompleteSlug();
-			}
-		}, [ currentStepSlug, reduxDispatch, resetOnboardStore ] );
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -96,7 +96,6 @@ const siteSetupFlow: Flow = {
 	},
 	useStepNavigation( currentStep, navigate ) {
 		const isGoalsHoldout = useIsGoalsHoldout( currentStep );
-		const isGoalsAtFrontExperiment = useGoalsAtFrontExperimentQueryParam();
 
 		const intent = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
@@ -247,10 +246,8 @@ const siteSetupFlow: Flow = {
 
 			navigate( 'processing' );
 
-			if ( ! isGoalsAtFrontExperiment ) {
-				// Clean-up the store so that if onboard for new site will be launched it will be launched with no preselected values
-				resetOnboardStoreWithSkipFlags( [ 'skipPendingAction', 'skipIntent' ] );
-			}
+			// Clean-up the store so that if onboard for new site will be launched it will be launched with no preselected values
+			resetOnboardStoreWithSkipFlags( [ 'skipPendingAction', 'skipIntent', 'skipSelectedDesign' ] );
 		};
 
 		const { getPostFlowUrl, initializeLaunchpadState } = useLaunchpadDecider( {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -34,7 +34,6 @@ import {
 	planItem,
 	hasPlan,
 	hasDomainRegistration,
-	hasPersonalPlan,
 	getDomainsInCart,
 } from 'calypso/lib/cart-values/cart-items';
 import {
@@ -184,19 +183,6 @@ export class RenderDomainsStep extends Component {
 		) {
 			// This call is expensive, so we only do it if the mini-cart hasDomainRegistration.
 			this.props.shoppingCartManager.addProductsToCart( [ this.props.multiDomainDefaultPlan ] );
-		}
-	}
-
-	componentDidUpdate( prevProps ) {
-		if ( prevProps?.cart?.products?.length !== this.props?.cart?.products?.length ) {
-			if (
-				shouldUseMultipleDomainsInCart( this.props.flowName ) &&
-				hasDomainRegistration( this.props.cart ) &&
-				! hasPersonalPlan( this.props.cart )
-			) {
-				// This call is expensive, so we only do it if the mini-cart hasDomainRegistration.
-				this.props.shoppingCartManager.addProductsToCart( [ this.props.multiDomainDefaultPlan ] );
-			}
 		}
 	}
 

--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -39,8 +39,6 @@ export const setSignupCompleteSlug = ( value ) =>
 	ignoreFatalsForStorage( () =>
 		sessionStorage?.setItem( 'wpcom_signup_complete_site_slug', value )
 	);
-export const clearSignupCompleteSlug = () =>
-	ignoreFatalsForStorage( () => sessionStorage?.removeItem( 'wpcom_signup_complete_site_slug' ) );
 export const getSignupCompleteSiteID = () =>
 	ignoreFatalsForStorage( () => sessionStorage?.getItem( 'wpcom_signup_complete_site_id' ) );
 export const setSignupCompleteSiteID = ( value ) =>

--- a/packages/onboarding/src/index.ts
+++ b/packages/onboarding/src/index.ts
@@ -26,7 +26,7 @@ export { default as SelectItemsAlt } from './select-items-alt';
 export { default as StepContainer } from './step-container';
 export { default as StepNavigationLink } from './step-navigation-link';
 export { default as MShotsImage } from './mshots-image';
-export { useStepPersistedState, clearStepPersistedState } from './hooks/use-persisted-state';
+export { useStepPersistedState } from './hooks/use-persisted-state';
 export * from './navigator';
 export { default as Notice } from './notice';
 export { default as SelectCardCheckbox } from './select-card-checkbox';


### PR DESCRIPTION
Reverts Automattic/wp-calypso#97936

Caught a regression before deploying staging to production.


p1736231522878019/1736196927.663189-slack-C085HCWCEDN