### PR TITLE
A4A > Checkout: Show Pressable limit warning

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -252,6 +252,7 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 									<ProductInfo
 										key={ `product-info-${ items.product_id }-${ items.quantity }` }
 										product={ items }
+										isAutomatedReferrals={ isAutomatedReferrals }
 									/>
 								) )
 							) }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
@@ -109,6 +109,16 @@ export default function ProductInfo( { product }: { product: ShoppingCartItem } 
 					<span className="product-info__count">{ countInfo }</span>
 				</div>
 				<p className="product-info__description">{ productDescription }</p>
+				{
+					// Show pressable limit warning only if the product is a Pressable plan
+					product.family_slug === 'pressable-hosting' && (
+						<div className="product-info__pressable-limit-warning">
+							{ translate(
+								"*If you exceed your plan's storage or traffic limits, you will be charged $0.50 per GB and $8 per 10K visits per month."
+							) }
+						</div>
+					)
+				}
 				{ product.licenseId && siteUrls && <p className="product-info__site-url">{ siteUrls }</p> }
 			</div>
 		</div>

--- a/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
@@ -7,7 +7,13 @@ import getProductIcon from 'calypso/my-sites/plans/jetpack-plans/product-store/u
 import getPressablePlan from '../pressable-overview/lib/get-pressable-plan';
 import type { ShoppingCartItem } from '../types';
 
-export default function ProductInfo( { product }: { product: ShoppingCartItem } ) {
+export default function ProductInfo( {
+	product,
+	isAutomatedReferrals,
+}: {
+	product: ShoppingCartItem;
+	isAutomatedReferrals?: boolean;
+} ) {
 	const translate = useTranslate();
 
 	const { title, product: productInfo } = useLicenseLightboxData( product );
@@ -110,8 +116,8 @@ export default function ProductInfo( { product }: { product: ShoppingCartItem } 
 				</div>
 				<p className="product-info__description">{ productDescription }</p>
 				{
-					// Show pressable limit warning only if the product is a Pressable plan
-					product.family_slug === 'pressable-hosting' && (
+					// Show pressable limit warning if the product is a Pressable plan and it's not a referral
+					product.family_slug === 'pressable-hosting' && ! isAutomatedReferrals && (
 						<div className="product-info__pressable-limit-warning">
 							{ translate(
 								"*If you exceed your plan's storage or traffic limits, you will be charged $0.50 per GB and $8 per 10K visits per month."

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -370,3 +370,8 @@
 		text-decoration: underline;
 	}
 }
+
+.product-info__pressable-limit-warning {
+	margin-block-start: 8px;
+	@include a4a-font-body-sm;
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1603

## Proposed Changes

This PR adds a Pressable limit warning on the checkout page. 

## Why are these changes being made?

* To let the users know about the Pressable limit. 

## Testing Instructions

* Open the A4A live link
* Go to the Marketplace > Add a Pressable plan and any other product > Go to the checkout by clicking on the cart
* Verify that a limit warning is displayed as shown below only for the Pressable plan:

Agency view: 

<img width="1728" alt="Screenshot 2025-01-07 at 1 58 15 PM" src="https://github.com/user-attachments/assets/af4c843a-fbe6-486d-a9ae-ad64e89c5185" />

Client view:

<img width="1728" alt="Screenshot 2025-01-09 at 2 53 40 PM" src="https://github.com/user-attachments/assets/f3d0b8b7-d765-448f-addc-378089f2a8d1" />

Agency view with Refer mode:

<img width="1728" alt="Screenshot 2025-01-09 at 2 54 07 PM" src="https://github.com/user-attachments/assets/9426dabb-5fda-4a6d-91a4-741a2cf82ccb" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
