### PR TITLE
Goals first: Reset onboard store when entering the flow (v2)

### DIFF
--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -1,15 +1,18 @@
 import { OnboardSelect, Onboard, UserSelect } from '@automattic/data-stores';
-import { ONBOARDING_FLOW } from '@automattic/onboarding';
+import { ONBOARDING_FLOW, clearStepPersistedState } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { pathToUrl } from 'calypso/lib/url';
 import {
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 	setSignupCompleteSlug,
+	clearSignupCompleteSlug,
 } from 'calypso/signup/storageUtils';
+import { useDispatch as useReduxDispatch } from 'calypso/state';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import {
 	STEPPER_TRACKS_EVENT_SIGNUP_START,
 	STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
@@ -343,6 +346,19 @@ const onboarding: Flow = {
 		return {
 			state: isLoading ? AssertConditionState.CHECKING : AssertConditionState.SUCCESS,
 		};
+	},
+	useSideEffect( currentStepSlug ) {
+		const reduxDispatch = useReduxDispatch();
+		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
+
+		useEffect( () => {
+			if ( ! currentStepSlug ) {
+				resetOnboardStore();
+				reduxDispatch( setSelectedSiteId( null ) );
+				clearStepPersistedState( this.name );
+				clearSignupCompleteSlug();
+			}
+		}, [ currentStepSlug, reduxDispatch, resetOnboardStore ] );
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -10,6 +10,7 @@ import {
 	setSignupCompleteFlowName,
 	setSignupCompleteSlug,
 	clearSignupCompleteSlug,
+	clearSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
 import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
@@ -356,6 +357,7 @@ const onboarding: Flow = {
 				resetOnboardStore();
 				reduxDispatch( setSelectedSiteId( null ) );
 				clearStepPersistedState( this.name );
+				clearSignupCompleteFlowName();
 				clearSignupCompleteSlug();
 			}
 		}, [ currentStepSlug, reduxDispatch, resetOnboardStore ] );

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -11,6 +11,7 @@ import {
 	setSignupCompleteSlug,
 	clearSignupCompleteSlug,
 	clearSignupCompleteFlowName,
+	clearSignupDestinationCookie,
 } from 'calypso/signup/storageUtils';
 import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
@@ -352,11 +353,17 @@ const onboarding: Flow = {
 		const reduxDispatch = useReduxDispatch();
 		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
 
+		/**
+		 * Clears every state we're persisting during the flow
+		 * when entering it. This is to ensure that the user
+		 * starts on a clean slate.
+		 */
 		useEffect( () => {
 			if ( ! currentStepSlug ) {
 				resetOnboardStore();
 				reduxDispatch( setSelectedSiteId( null ) );
 				clearStepPersistedState( this.name );
+				clearSignupDestinationCookie();
 				clearSignupCompleteFlowName();
 				clearSignupCompleteSlug();
 			}

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -247,7 +247,7 @@ const siteSetupFlow: Flow = {
 			navigate( 'processing' );
 
 			// Clean-up the store so that if onboard for new site will be launched it will be launched with no preselected values
-			resetOnboardStoreWithSkipFlags( [ 'skipPendingAction', 'skipIntent', 'skipSelectedDesign' ] );
+			resetOnboardStoreWithSkipFlags( [ 'skipPendingAction', 'skipIntent' ] );
 		};
 
 		const { getPostFlowUrl, initializeLaunchpadState } = useLaunchpadDecider( {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -35,6 +35,7 @@ import {
 	hasPlan,
 	hasDomainRegistration,
 	getDomainsInCart,
+	hasPersonalPlan,
 } from 'calypso/lib/cart-values/cart-items';
 import {
 	getDomainProductSlug,
@@ -183,6 +184,19 @@ export class RenderDomainsStep extends Component {
 		) {
 			// This call is expensive, so we only do it if the mini-cart hasDomainRegistration.
 			this.props.shoppingCartManager.addProductsToCart( [ this.props.multiDomainDefaultPlan ] );
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( prevProps?.cart?.products?.length !== this.props?.cart?.products?.length ) {
+			if (
+				shouldUseMultipleDomainsInCart( this.props.flowName ) &&
+				hasDomainRegistration( this.props.cart ) &&
+				! hasPersonalPlan( this.props.cart )
+			) {
+				// This call is expensive, so we only do it if the mini-cart hasDomainRegistration.
+				this.props.shoppingCartManager.addProductsToCart( [ this.props.multiDomainDefaultPlan ] );
+			}
 		}
 	}
 

--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -39,6 +39,8 @@ export const setSignupCompleteSlug = ( value ) =>
 	ignoreFatalsForStorage( () =>
 		sessionStorage?.setItem( 'wpcom_signup_complete_site_slug', value )
 	);
+export const clearSignupCompleteSlug = () =>
+	ignoreFatalsForStorage( () => sessionStorage?.removeItem( 'wpcom_signup_complete_site_slug' ) );
 export const getSignupCompleteSiteID = () =>
 	ignoreFatalsForStorage( () => sessionStorage?.getItem( 'wpcom_signup_complete_site_id' ) );
 export const setSignupCompleteSiteID = ( value ) =>

--- a/packages/onboarding/src/hooks/use-persisted-state.ts
+++ b/packages/onboarding/src/hooks/use-persisted-state.ts
@@ -23,6 +23,25 @@ function getPersistedState( key: string, storage: Storage, TTL: number ) {
 	}
 }
 
+function getPersistedStateKey( flow?: string, step?: string, lang?: string, cacheKey?: string ) {
+	return [ VERSION, KEY, flow, step, lang, cacheKey ].filter( Boolean ).join( '-' );
+}
+
+/**
+ * Clears all persisted state created by useStepPersistedState
+ * @param flow The desired flow to clear
+ * @param storage The storage to clear (defaults to localStorage)
+ */
+export function clearStepPersistedState( flow?: string, storage: Storage = localStorage ): void {
+	const keys = Object.keys( storage );
+	const persistedKeys = keys.filter( ( key ) => key.startsWith( getPersistedStateKey( flow ) ) );
+
+	persistedKeys.forEach( ( key ) => {
+		storage.removeItem( key );
+		storage.removeItem( key + 'time' );
+	} );
+}
+
 type Options = {
 	/**
 	 * The used storage, defaults to sessionStorage.
@@ -36,7 +55,6 @@ type Options = {
 
 /**
  * A hook similar to useState, but persists the state. Uses `flow`, `step` and `lang`, and the passed key in the tree as keys.
- *
  * @param cacheKey the cache key. It will be concatenated with the flow, step and lang.
  * @param defaultValue the initial value of the state.
  * @param options the options for the hook.

--- a/packages/onboarding/src/index.ts
+++ b/packages/onboarding/src/index.ts
@@ -26,7 +26,7 @@ export { default as SelectItemsAlt } from './select-items-alt';
 export { default as StepContainer } from './step-container';
 export { default as StepNavigationLink } from './step-navigation-link';
 export { default as MShotsImage } from './mshots-image';
-export { useStepPersistedState } from './hooks/use-persisted-state';
+export { useStepPersistedState, clearStepPersistedState } from './hooks/use-persisted-state';
 export * from './navigator';
 export { default as Notice } from './notice';
 export { default as SelectCardCheckbox } from './select-card-checkbox';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Supersedes #97936. Closes https://github.com/Automattic/wp-calypso/issues/97887.

## Proposed Changes

We kept the domain selection information in case the user wants to create a new site with their previously selected domain (that they haven't bought.) This is okay for paid domains (p1736205514246109/1736196927.663189-slack-C085HCWCEDN), but we were keeping it for free domains, which causes the issue https://github.com/Automattic/wp-calypso/issues/97887

* Reset the store/persisted step data when a user enters the flow
* Continue to reset the `ONBOARD_STORE` at the end of the flow

> [!NOTE]  
> Known issues to be addressed in separate PRs to keep each PR change contained
> If a paid domain is selected, the domain price may be wrong when reentering the flow: PR TBD


https://github.com/user-attachments/assets/a4ea6980-feb6-4ad6-8efb-309370dff4fd



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Right now, it's impossible to create two sites through /setup/onboarding.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Two entry points to test
`/start` and `/setup/onboarding` (/start should redirect to /setup/onboarding)

Scenarios to test
* Create two sites: Enter /setup/onboarding and create a site. Enter the flow again and create a second site. You should end up with two sites. Both sites can be launched from the launchpad.
* Paid plan (cancel): Create a site but select a paid plan, at checkout empty the cart, launch the site
* Paid plan: Create a site that requires a paid plan, checkout, launch the site
* Paid domain (cancel): Create a site and select a domain, go through the flow and empty cart when checkout, launch the site

Note: always test the flow end to end until the user can launch the site.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?