### PR TITLE
i18n: Update theme-tier translations to use fixMe

### DIFF
--- a/client/components/theme-tier/constants.js
+++ b/client/components/theme-tier/constants.js
@@ -5,15 +5,11 @@ import {
 	PLAN_PREMIUM,
 	getPlan,
 } from '@automattic/calypso-products';
-import { translate, fixMe } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 const getIncludedWithLabel = ( planSlug ) => {
-	return fixMe( {
-		text: 'Included with %(planName)s',
-		translation: translate( 'Included with %(planName)s', {
-			args: { planName: getPlan( planSlug )?.getTitle() },
-		} ),
-		fallback: getPlan( planSlug )?.getTitle(),
+	return translate( 'Included with %(planName)s', {
+		args: { planName: getPlan( planSlug )?.getTitle() },
 	} );
 };
 

--- a/client/components/theme-tier/constants.js
+++ b/client/components/theme-tier/constants.js
@@ -5,21 +5,16 @@ import {
 	PLAN_PREMIUM,
 	getPlan,
 } from '@automattic/calypso-products';
-import { englishLocales } from '@automattic/i18n-utils';
-import i18n, { translate } from 'i18n-calypso';
+import { translate, fixMe } from 'i18n-calypso';
 
 const getIncludedWithLabel = ( planSlug ) => {
-	const localeSlug = i18n.getLocaleSlug();
-
-	const shouldShowNewString =
-		( localeSlug && englishLocales.includes( i18n.getLocaleSlug() ) ) ||
-		i18n.hasTranslation( 'Included with %(planName)s' );
-
-	return shouldShowNewString
-		? translate( 'Included with %(planName)s', {
-				args: { planName: getPlan( planSlug )?.getTitle() },
-		  } )
-		: getPlan( planSlug )?.getTitle();
+	return fixMe( {
+		text: 'Included with %(planName)s',
+		translation: translate( 'Included with %(planName)s', {
+			args: { planName: getPlan( planSlug )?.getTitle() },
+		} ),
+		fallback: getPlan( planSlug )?.getTitle(),
+	} );
 };
 
 export const THEME_TIER_PREMIUM = 'premium';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/i18n-issues/issues/654

## Proposed Changes

- Part of addressing https://github.com/Automattic/i18n-issues/issues/654
- Follow-up to https://github.com/Automattic/wp-calypso/pull/97690
- ~Updates theme-tier constants to replace `hasTranslation` + `locale` check with new `fixMe` method~ EDIT: Removes fallback instead since translations are completed 

### Media

<img width="954" alt="Screenshot 2025-01-07 at 15 02 27" src="https://github.com/user-attachments/assets/8f14e4ba-e790-4881-bf54-28c70caee807" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/654

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- This is the dropdown in the Theme Showcase (`/themes/:site`) - per media above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
