### PR TITLE
Stepper: Experiment - load the flow in parallel with the user

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -114,6 +114,10 @@ window.AppBoot = async () => {
 		return ( window.location.href = `/setup/${ DEFAULT_FLOW }${ window.location.search }` );
 	}
 
+	const flowLoader = determineFlow();
+	// Load the flow asynchronously while things happen in parallel.
+	const flowPromise = flowLoader();
+
 	// Start tracking performance, bearing in mind this is a full page load.
 	startStepperPerformanceTracking( { fullPageLoad: true } );
 
@@ -144,8 +148,7 @@ window.AppBoot = async () => {
 
 	setupErrorLogger( reduxStore );
 
-	const flowLoader = determineFlow();
-	const { default: rawFlow } = await flowLoader();
+	const { default: rawFlow } = await flowPromise;
 	const flow = rawFlow.__experimentalUseBuiltinAuth ? enhanceFlowWithAuth( rawFlow ) : rawFlow;
 
 	// When re-using steps from /start, we need to set the current flow name in the redux store, since some depend on it.


### PR DESCRIPTION
This parallelizes loading the Stepper flow while the rest of asynchronous tasks are running. This is in hopes of bringing the LCP time down. Without any throttling, this saves me ~200ms.

### Before
![image](https://github.com/user-attachments/assets/50bfd594-2555-48ac-bbe1-32c4c7d94f44)

### After

![image](https://github.com/user-attachments/assets/dabb4679-1f04-4745-9108-2eedbc9a916c)


### Testing steps
1. While incognito, go to /setup/onboarding.
2. You should be able to signup and create a site.
3. Repeat the process while logged in.
4. Your login status should be recognized. 

