### PR TITLE
i18n: Update use-my-domain/domain-input comp to use fixMe

### DIFF
--- a/client/components/domains/use-my-domain/domain-input.jsx
+++ b/client/components/domains/use-my-domain/domain-input.jsx
@@ -1,7 +1,7 @@
 import { Card, Button, FormInputValidation, Gridicon } from '@automattic/components';
-import { englishLocales, useLocale } from '@automattic/i18n-utils';
-import { __, hasTranslation } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
+import { fixMe } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useEffect, useRef } from 'react';
 import { connect } from 'react-redux';
@@ -25,7 +25,6 @@ function UseMyDomainInput( {
 	validationError,
 } ) {
 	const domainNameInput = useRef( null );
-	const locale = useLocale();
 
 	useEffect( () => {
 		shouldSetFocus && domainNameInput.current.focus();
@@ -47,11 +46,11 @@ function UseMyDomainInput( {
 		}
 	};
 
-	const hasDomainPlaceholderLabel =
-		englishLocales.includes( locale ) || hasTranslation( 'yourgroovydomain.com' );
-	const domainPlaceholderLabel = hasDomainPlaceholderLabel
-		? __( 'yourgroovydomain.com' )
-		: __( 'mydomain.com' );
+	const domainPlaceholderLabel = fixMe( {
+		text: 'yourgroovydomain.com',
+		translation: __( 'yourgroovydomain.com' ),
+		fallback: __( 'mydomain.com' ),
+	} );
 
 	return (
 		<Card className={ baseClassName }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/i18n-issues/issues/654

## Proposed Changes

- Part of addressing https://github.com/Automattic/i18n-issues/issues/654
- Follow-up to https://github.com/Automattic/wp-calypso/pull/97690
- Updates use-my-domain/domain-input component to replace `hasTranslation + locale` check with new `fixMe` method

### Media

<img width="455" alt="Screenshot 2025-01-07 at 3 44 25 PM" src="https://github.com/user-attachments/assets/425943a6-470c-4b97-b477-480befb46b26" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/654

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/start/domains/use-your-domain` with en locale
- Confirm media above
- Try with a different locale that has a translation for `yourgroovydomain.com` and confirm the same 
- Try with a different locale that does not have a translation for `yourgroovydomain.com` and confirm the translation for `mydomain.com` shows instead for placeholder text


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
