### PR TITLE
Onboarding: clear signup destination on flow load

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/use-is-managed-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/use-is-managed-site-flow.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import {
 	getSignupCompleteFlowName,
@@ -12,22 +12,24 @@ import {
 export const useIsManagedSiteFlowProps = () => {
 	const postSignUpSiteSlugParam = getSignupCompleteSlug();
 	const postSignUpSiteIdParam = getSignupCompleteSiteID();
+	const isManageSiteFlow = useMemo( () => {
+		return (
+			wasSignupCheckoutPageUnloaded() &&
+			retrieveSignupDestination() &&
+			getSignupCompleteFlowName() === 'onboarding'
+		);
+	}, [] );
 
 	const selectedSite = useSite( postSignUpSiteSlugParam || postSignUpSiteIdParam );
 
 	useEffect( () => {
-		const signupDestinationCookieExists = retrieveSignupDestination();
-		const isReEnteringFlow = getSignupCompleteFlowName() === 'onboarding';
-		const isManageSiteFlow =
-			wasSignupCheckoutPageUnloaded() && signupDestinationCookieExists && isReEnteringFlow;
-
 		if ( ! isManageSiteFlow ) {
 			clearSignupDestinationCookie();
 			return;
 		}
-	}, [] );
+	}, [ isManageSiteFlow ] );
 
-	if ( selectedSite ) {
+	if ( selectedSite && isManageSiteFlow ) {
 		return {
 			selectedSite,
 			showExampleSuggestions: false,

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -2,13 +2,14 @@ import { OnboardSelect, Onboard, UserSelect } from '@automattic/data-stores';
 import { ONBOARDING_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { pathToUrl } from 'calypso/lib/url';
 import {
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 	setSignupCompleteSlug,
+	clearSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
 import {
 	STEPPER_TRACKS_EVENT_SIGNUP_START,
@@ -55,6 +56,15 @@ const onboarding: Flow = {
 			[ isGoalsAtFrontExperiment ]
 		);
 	},
+
+	useSideEffect( currentStepSlug ) {
+		useEffect( () => {
+			if ( ! currentStepSlug ) {
+				clearSignupCompleteFlowName();
+			}
+		}, [ currentStepSlug ] );
+	},
+
 	useSteps() {
 		// We have already checked the value has loaded in useAssertConditions
 		const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
