### PR TITLE
Localize the login link in the user step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -52,12 +52,14 @@ const UserStepComponent: Step = function UserStep( {
 		}
 	}, [ dispatch, isLoggedIn, navigation, wpAccountCreateResponse ] );
 
+	const locale = useFlowLocale();
+
 	const loginLink = login( {
 		signupUrl,
 		redirectTo,
+		locale,
 	} );
 
-	const locale = useFlowLocale();
 	const shouldRenderLocaleSuggestions = ! isLoggedIn; // For logged-in users, we respect the user language settings
 
 	const handleCreateAccountSuccess = ( data: AccountCreateReturn ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/97970

## Proposed Changes

* Get the locale from the flow and localize the login URL with it

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/wp-calypso/issues/97970

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit a signup flow using the locale param, eg. https://wordpress.com/setup/onboarding/de
* Click through the flow until the user step
* Click the login link in the top-right corner
* Check that the `locale` route parameter is passed to the URL and the login page is localized, not shown in English

| Trunk | This branch |
|--------|--------|
| ![CleanShot 2025-01-07 at 14 44 06@2x](https://github.com/user-attachments/assets/15ff5f78-288f-422a-9c13-67f27cd9714b) | ![CleanShot 2025-01-07 at 14 44 22@2x](https://github.com/user-attachments/assets/67d81062-e036-46e0-b95d-1de707ce402b) | 
