### PR TITLE
Goals first: Reset only the persisted state when entering the onboarding flow

### DIFF
--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -13,8 +13,6 @@ import {
 	clearSignupCompleteFlowName,
 	clearSignupDestinationCookie,
 } from 'calypso/signup/storageUtils';
-import { useDispatch as useReduxDispatch } from 'calypso/state';
-import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import {
 	STEPPER_TRACKS_EVENT_SIGNUP_START,
 	STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
@@ -350,24 +348,20 @@ const onboarding: Flow = {
 		};
 	},
 	useSideEffect( currentStepSlug ) {
-		const reduxDispatch = useReduxDispatch();
-		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
-
 		/**
-		 * Clears every state we're persisting during the flow
-		 * when entering it. This is to ensure that the user
-		 * starts on a clean slate.
+		 * Clears all pieces of state we're persisting
+		 * during the flow when entering it.
+		 * This is to ensure that the user starts
+		 * on a clean slate regarding flow continuity.
 		 */
 		useEffect( () => {
 			if ( ! currentStepSlug ) {
-				resetOnboardStore();
-				reduxDispatch( setSelectedSiteId( null ) );
 				clearStepPersistedState( this.name );
 				clearSignupDestinationCookie();
 				clearSignupCompleteFlowName();
 				clearSignupCompleteSlug();
 			}
-		}, [ currentStepSlug, reduxDispatch, resetOnboardStore ] );
+		}, [ currentStepSlug ] );
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -247,7 +247,7 @@ const siteSetupFlow: Flow = {
 			navigate( 'processing' );
 
 			// Clean-up the store so that if onboard for new site will be launched it will be launched with no preselected values
-			resetOnboardStoreWithSkipFlags( [ 'skipPendingAction', 'skipIntent' ] );
+			resetOnboardStoreWithSkipFlags( [ 'skipPendingAction', 'skipIntent', 'skipSelectedDesign' ] );
 		};
 
 		const { getPostFlowUrl, initializeLaunchpadState } = useLaunchpadDecider( {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/98012.

## Why are these changes being made?

In #98012, the onboard store was cleared whenever the user navigated to `/setup/onboarding`, which meant that their selected goals, which were being persisted, were gone.

This PR changes that behavior and avoids clearing the onboard store because the store itself doesn't interfere in site creation or domain selection, so there's no point in removing it, and it affects flow continuity since the user loses everything if they enter `/setup/onboarding` again (i.e., they lose their progress.)

**We're already clearing up that store whenever the user exits the flow**, so they won't see the same preselections if they create a second site.

## Testing Instructions

1. Enter `/setup/onboarding` and pick any goal. Refresh the page (the browser should be at `/setup/onboarding/goals`) and check that the goal's been persisted;
2. Enter `/setup/onboarding` again and verify that your goal is still checked;
3. Create the site with a free domain and a free plan, exit the flow through Launchpad ("Launch site" or "Skip")
4. Enter `/setup/onboarding` again and verify NO goals are selected.

Verify that all permutations described in https://github.com/Automattic/wp-calypso/pull/98012#pullrequestreview-2534266646 are still working, meaning you can create multiple sites through `/setup/onboarding`.

A good measure would be to test the non-goals-first onboarding flow too (i.e., disable the feature flag), to verify nothing is broken.