### PR TITLE
Reader: Check for missing pageHandle in lastPage stream reducer

### DIFF
--- a/client/state/reader/streams/reducer.js
+++ b/client/state/reader/streams/reducer.js
@@ -239,11 +239,11 @@ export const lastPage = ( state = false, action ) => {
 export const pageHandle = ( state = null, action ) => {
 	if (
 		action.type === READER_STREAMS_PAGE_RECEIVE &&
-		action.payload.pageHandle &&
 		! action.payload.isPoll &&
 		! action.payload.gap
 	) {
-		return action.payload.pageHandle;
+		// Explicitly set pageHandle to null if server returns null.
+		return action.payload.pageHandle ?? null;
 	}
 	return state;
 };

--- a/client/state/reader/streams/reducer.js
+++ b/client/state/reader/streams/reducer.js
@@ -227,7 +227,7 @@ export const isRequesting = ( state = false, action ) => {
  */
 export const lastPage = ( state = false, action ) => {
 	if ( action.type === READER_STREAMS_PAGE_RECEIVE ) {
-		return action.payload.streamItems.length === 0;
+		return action.payload.streamItems.length === 0 || ! action.payload.pageHandle;
 	}
 	return state;
 };

--- a/client/state/reader/streams/test/reducer.js
+++ b/client/state/reader/streams/test/reducer.js
@@ -305,8 +305,21 @@ describe( 'streams.lastPage', () => {
 		expect( lastPage( undefined, action ) ).toBe( true );
 	} );
 
-	it( 'should maintain false if the last request had more items', () => {
-		const action = receivePage( { streamKey: 'following', streamItems: [ time2PostKey ] } );
+	it( 'should maintain false if the last request had more items and a pageHandle', () => {
+		const action = receivePage( {
+			streamKey: 'following',
+			streamItems: [ time2PostKey ],
+			pageHandle: 'next-page-token',
+		} );
 		expect( lastPage( false, action ) ).toBe( false );
+	} );
+
+	it( 'should return true if there are items but no pageHandle', () => {
+		const action = receivePage( {
+			streamKey: 'following',
+			streamItems: [ time2PostKey ],
+			pageHandle: null,
+		} );
+		expect( lastPage( false, action ) ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/295

## Proposed Changes

* Adds a check for missing pageHandle in lastPage stream reducer
* This prevents an infinite loop if an API call lacks a `next_page` field in the response results.
* Updates the unit tests

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Developing /read/users/:userId, we discovered an infinite loop of API requests on the last page of post results. The same bug also exists for the existing /read/blogs/:blogId route.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In production, go to https://wordpress.com/read/users/218803706 and https://wordpress.com/read/blogs/209207761
* Scroll to the bottom of the steam to view the infinite API call loop. You can view the infinite requests in the Network tab of your browser's web development tools.
* View this branch using [Calypso Live](https://github.com/Automattic/wp-calypso/pull/98046#issuecomment-2576267597) and go to /read/users/218803706 and /read/blogs/209207761
* Scroll to the bottom of the stream and view that infinite API call loop has stoped.
* To check for regressions, smoke test /read/users/:userId and /read/blogs/:blogId on a user/blog with multiple pages of posts and no posts.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
