### PR TITLE
Stats: add Geochart regions/cities

### DIFF
--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -174,7 +174,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 						metricLabel={ translate( 'Visitors' ) }
 						loader={ isRequestingData && <StatsModulePlaceholder isLoading={ isRequestingData } /> }
 						splitHeader
-						heroElement={ <Geochart query={ query } skipQuery /> }
+						heroElement={ <Geochart data={ data } skipQuery /> }
 						mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
 						toggleControl={ toggleControlComponent }
 						showMore={

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -30,9 +30,9 @@ const OPTION_KEYS = {
 	CITIES: 'cities',
 };
 
-type StatQueryType = 'country' | 'region' | 'city';
+type GeoMode = 'country' | 'region' | 'city';
 
-const STAT_QUERY_TYPES: Record< string, StatQueryType > = {
+const GEO_MODES: Record< string, GeoMode > = {
 	[ OPTION_KEYS.COUNTRIES ]: 'country',
 	[ OPTION_KEYS.REGIONS ]: 'region',
 	[ OPTION_KEYS.CITIES ]: 'city',
@@ -78,13 +78,13 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 		},
 	};
 
-	const statQueryType = STAT_QUERY_TYPES[ selectedOption ];
+	const geoMode = GEO_MODES[ selectedOption ];
 
 	const {
 		data = [],
 		isLoading: isRequestingData,
 		isError,
-	} = useLocationViewsQuery< StatsLocationViewsData >( siteId, statQueryType, query );
+	} = useLocationViewsQuery< StatsLocationViewsData >( siteId, geoMode, query );
 
 	const changeViewButton = ( selection: SelectOptionType ) => {
 		const filter = selection.value;

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -174,7 +174,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 						metricLabel={ translate( 'Visitors' ) }
 						loader={ isRequestingData && <StatsModulePlaceholder isLoading={ isRequestingData } /> }
 						splitHeader
-						heroElement={ <Geochart data={ data } skipQuery /> }
+						heroElement={ <Geochart data={ data } geoMode={ geoMode } skipQuery /> }
 						mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
 						toggleControl={ toggleControlComponent }
 						showMore={

--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -196,7 +196,18 @@ class StatsGeochart extends Component {
 export default connect( ( state, ownProps ) => {
 	const siteId = getSelectedSiteId( state );
 	const statType = ownProps.statType ?? 'statsCountryViews';
+	const currentUserCountryCode = getCurrentUserCountryCode( state );
 	const { postId, query, kind } = ownProps;
+
+	// Skip data fetching if it was explicitly passed as a prop
+	if ( ownProps.data ) {
+		return {
+			currentUserCountryCode,
+			data: ownProps.data,
+			siteId,
+			statType,
+		};
+	}
 
 	const data =
 		kind === 'email'
@@ -212,7 +223,7 @@ export default connect( ( state, ownProps ) => {
 			: getSiteStatsNormalizedData( state, siteId, statType, query );
 
 	return {
-		currentUserCountryCode: getCurrentUserCountryCode( state ),
+		currentUserCountryCode,
 		data,
 		siteId,
 		statType,

--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -25,6 +25,7 @@ class StatsGeochart extends Component {
 		statType: PropTypes.string,
 		query: PropTypes.object,
 		data: PropTypes.array,
+		geoMode: PropTypes.string,
 		kind: PropTypes.string,
 		postId: PropTypes.number,
 		skipQuery: PropTypes.bool,
@@ -103,18 +104,23 @@ class StatsGeochart extends Component {
 	};
 
 	drawData = () => {
-		const { currentUserCountryCode, data, translate, numberLabel } = this.props;
+		const { currentUserCountryCode, data, geoMode, translate, numberLabel } = this.props;
 		if ( ! data || ! data.length ) {
 			return;
 		}
 
-		const mapData = map( data, ( country ) => {
+		const mapData = map( data, ( location ) => {
+			let code = location.countryCode;
+			if ( geoMode !== 'country' ) {
+				code = `${ location.countryCode } ${ location.label }`;
+			}
+
 			return [
 				{
-					v: country.countryCode,
-					f: country.label,
+					v: code,
+					f: location.label,
 				},
-				country.value,
+				location.value,
 			];
 		} );
 
@@ -140,6 +146,10 @@ class StatsGeochart extends Component {
 			colorAxis: { colors: [ chartColorLight, chartColorDark ] },
 			domain: currentUserCountryCode,
 		};
+
+		if ( geoMode !== 'country' ) {
+			options.displayMode = 'markers';
+		}
 
 		const regions = [ ...new Set( map( data, 'region' ) ) ];
 

--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -34,6 +34,7 @@ class StatsGeochart extends Component {
 	};
 
 	static defaultProps = {
+		geoMode: 'country',
 		kind: 'site',
 		numberLabel: '',
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/jetpack-roadmap#2093.

## Proposed Changes

* Render `Regions`/`Cities` as circle markers, instead of coloring their entire country.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* (p1HpG7-rpL-p2)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to the Calypso Live preview environment.
- Access the Stats page of a website that has meaningful data, like `/stats/day/jetpack.com?flags=stats/locations`
  - It's important to keep the feature flag to enable the visualization.
- Scroll down to the map and click on the `Regions` and `Cities` tabs close to it.

### Regions

| Before | After |
| :-: | :-: |
| <img width="960" alt="image" src="https://github.com/user-attachments/assets/a8517d73-2910-4372-861c-5aaf3e9d9f2c" /> | <img width="960" alt="image" src="https://github.com/user-attachments/assets/0195b830-8c04-4034-be0a-9d871eff6876" /> |

### Cities

| Before | After |
| :-: | :-: |
| <img width="962" alt="image" src="https://github.com/user-attachments/assets/75c4f2f8-f586-4e0f-9028-653fd7169b43" /> | <img width="961" alt="image" src="https://github.com/user-attachments/assets/2610c2c5-2341-4864-a073-ee32da1a072e" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://developers.google.com/chart/interactive/docs/gallery/geochart#marker-geocharts