### PR TITLE
Bump timeout in woo signup email test

### DIFF
--- a/test/e2e/specs/onboarding/signup__woo-email.ts
+++ b/test/e2e/specs/onboarding/signup__woo-email.ts
@@ -59,7 +59,7 @@ describe(
 			} );
 
 			it( 'Activate account', async function () {
-				await page.goto( activationLink );
+				await page.goto( activationLink, { timeout: 20000 } );
 			} );
 		} );
 


### PR DESCRIPTION
Bumping timeout in the `Signup: WordPress.com WPCC > WooCommerce via Email` test seems to help with flakiness.

p1736288516678589-slack-C02DQP0FP

It seems to take longer than 10 seconds to accept the link that gets emailed to the user.