### PR TITLE
Sites Dashboard: Update border styles to use neutral color for consistency

### DIFF
--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -41,7 +41,7 @@ $brand-display: "SF Pro Display", sans-serif;
 
 	&__header {
 		align-items: center;
-		border-block-end: 1px solid var(--color-border-secondary);
+		border-block-end: 1px solid var(--color-neutral-5);
 		display: flex;
 		flex-wrap: wrap;
 		row-gap: 1rem;

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -2,7 +2,7 @@
 
 $brand-display: "SF Pro Display", sans-serif;
 
-.plugins-update-manager-multisite {
+@mixin content-padding {
 	padding-inline: 48px;
 
 	@media (max-width: $break-medium) {
@@ -11,12 +11,14 @@ $brand-display: "SF Pro Display", sans-serif;
 
 	@media (max-width: $break-small) {
 		padding-inline: 16px;	
-	}
+	}	
+}
 
+.plugins-update-manager-multisite {
 	&__header {
-		@media screen and (max-width: $break-large) {
-			padding-top: 24px;
-		}
+		padding-top: 24px;
+		padding-bottom: 24px;
+		@include content-padding;
 	}
 
 	&__header-main {
@@ -69,6 +71,13 @@ $brand-display: "SF Pro Display", sans-serif;
 			}
 		}
 	}
+
+	.plugins-update-manager-multisite-filters {
+		padding-top: 24px;
+		padding-bottom: 24px;
+		@include content-padding;
+	}
+
 	.plugins-update-manager-multisite-filter {
 		margin-top: 1.25rem;
 		margin-bottom: 1.25rem;
@@ -80,6 +89,7 @@ $brand-display: "SF Pro Display", sans-serif;
 
 	.plugins-update-manager-multisite-card {
 		margin-bottom: 1rem;
+		@include content-padding;
 		border-bottom: solid 1px var(--studio-gray-0);
 
 		&:first-child {

--- a/client/components/dataviews/style.scss
+++ b/client/components/dataviews/style.scss
@@ -154,13 +154,6 @@
 	display: none !important;
 }
 
-// // TODO: remove when the site connectivity notice
-// // is updated to be part of a field.
-// .is-section-a8c-for-agencies-sites .dataviews-view-table tr,
-// .is-section-a8c-for-agencies-sites .dataviews-view-list li {
-// 	border-top: none;
-// }
-
 // TODO: remove when updating dataviews to have this built-in.
 //
 // https://github.com/WordPress/gutenberg/issues/64927

--- a/client/components/dataviews/style.scss
+++ b/client/components/dataviews/style.scss
@@ -25,14 +25,12 @@
 		}
 
 		th {
-			border-bottom: 1px solid var( --color-neutral-5 );
 			font-size: rem( 13px );
 			font-weight: 400;
 			vertical-align: middle;
 		}
 
 		td {
-			border-bottom: 1px solid var( --color-neutral-5 );
 			vertical-align: middle;
 
 			&:has( .sites-dataviews__site ) {
@@ -156,12 +154,12 @@
 	display: none !important;
 }
 
-// TODO: remove when the site connectivity notice
-// is updated to be part of a field.
-.is-section-a8c-for-agencies-sites .dataviews-view-table tr,
-.is-section-a8c-for-agencies-sites .dataviews-view-list li {
-	border-top: none;
-}
+// // TODO: remove when the site connectivity notice
+// // is updated to be part of a field.
+// .is-section-a8c-for-agencies-sites .dataviews-view-table tr,
+// .is-section-a8c-for-agencies-sites .dataviews-view-list li {
+// 	border-top: none;
+// }
 
 // TODO: remove when updating dataviews to have this built-in.
 //

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -285,7 +285,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					header.navigation-header {
 						padding-top: 24px;
 						padding-inline: 16px;
-						border-block-end: 1px solid var( --color-border-secondary );
+						border-block-end: 1px solid var( --color-neutral-5 );
 					}
 				}
 			}

--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -7,7 +7,7 @@ body.is-section-plugins .plugin-management-wrapper.is-bulk-plugin-management {
 	flex-wrap: nowrap;
 
 	.navigation-header {
-		border-block-end: 1px solid var( --color-border-secondary );
+		border-block-end: 1px solid var( --color-neutral-5 );
 		padding-inline: 48px;
 
 		@media ( max-width: 430px ) {

--- a/client/my-sites/plugins/plugins-navigation-header/style.scss
+++ b/client/my-sites/plugins/plugins-navigation-header/style.scss
@@ -9,7 +9,7 @@
 	}
 
 	@include break-medium {
-		border-block-end: 1px solid var(--color-border-secondary);
+		border-block-end: 1px solid var(--color-neutral-5);
 	}
 
 	@media (max-width: $break-medium) {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -139,7 +139,6 @@ body.is-section-plugins {
 		.plugins-update-manager-multisite__header,
 		.plugins-update-manager-multisite-filter {
 			margin: 0;
-			padding: 24px 0;
 		}
 
 		.plugins-update-manager-multisite__header {

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -38,7 +38,7 @@
 		}
 		.themes__header-navigation-container {
 			@media (min-width: $break-small) {
-				border-block-end: 1px solid var(--color-border-secondary);
+				border-block-end: 1px solid var(--color-neutral-5);
 			}
 		}
 		.navigation-header {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10178

## Proposed Changes

- Update the title section's border styles to use neutral colors for consistency. This PR focuses on fixing the border colors, though we should ideally adopt `client/layout/hosting-dashboard/header.tsx` and `client/layout/hosting-dashboard/top.tsx` and fix the padding inconsistency.
    - <img width="405" alt="Screenshot 2025-01-09 at 10 21 55" src="https://github.com/user-attachments/assets/cb3eef3e-bb37-4f35-b434-e7b4d50440e9" />
    - <img width="387" alt="Screenshot 2025-01-09 at 10 22 06" src="https://github.com/user-attachments/assets/5deb1843-8d94-49d0-9464-a9f6ab797798" />
    - <img width="306" alt="Screenshot 2025-01-09 at 10 22 25" src="https://github.com/user-attachments/assets/5bb26b51-9242-4811-b8d2-dedafd093e71" />
    - <img width="312" alt="Screenshot 2025-01-09 at 10 22 29" src="https://github.com/user-attachments/assets/34d21e56-c91a-472b-9b81-09321206bbc2" />
    - <img width="397" alt="Screenshot 2025-01-09 at 10 22 36" src="https://github.com/user-attachments/assets/517b3a00-f1a5-4ea1-b9b0-7f85c600ef4d" />
    - <img width="589" alt="Screenshot 2025-01-09 at 10 22 45" src="https://github.com/user-attachments/assets/db1539b5-438d-4f38-90ba-4c40faf33753" />
- Update DataViews border styles to use Core's color on A4A @Automattic/a4a-genesis 
    - <img width="638" alt="Screenshot 2025-01-09 at 10 28 28" src="https://github.com/user-attachments/assets/bab3045c-1c14-4499-bcfd-2aefb30e02b6" />
- Fix the Plugins Scheduled Updates page so it becomes full-width @Automattic/caribou 

| before | after |
|--------|--------|
| <img width="1198" alt="Screenshot 2025-01-09 at 10 30 21" src="https://github.com/user-attachments/assets/de32d1d6-93b0-4f08-8799-6cf285628c70" /> | <img width="1198" alt="Screenshot 2025-01-09 at 10 30 34" src="https://github.com/user-attachments/assets/d9e294c2-38b2-4bbc-84d7-5b1a2444fc38" /> | 

## Why are these changes being made?

<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- To make it consistent across platforms: https://github.com/Automattic/wp-calypso/pull/97773#issuecomment-2564883593

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Calypso Live

- Go to /site.
- Click all the top level menu items and see the border color is updated.
- Go to /plugins/scheduled-updates.
- Ensure nothing breaks across different device views.

A4A Live

- Go to /site.
- Observe the border color for the DataViews’ row is updated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ]  Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ]  [[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md)](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ]  Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ]  Have you checked for TypeScript, React or other console errors?
- [ ]  Have you used memoizing on expensive computations? More info in [[Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md)](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [[Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors)](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [[Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ]  Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ]  For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ]  For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?