### PR TITLE
i18n: Remove fallback translations from landing/subscriptions hook

### DIFF
--- a/client/landing/subscriptions/hooks/use-subheader-text.tsx
+++ b/client/landing/subscriptions/hooks/use-subheader-text.tsx
@@ -1,47 +1,27 @@
 import { SubscriptionManager } from '@automattic/data-stores';
-import { useLocale } from '@automattic/i18n-utils';
-import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 
 const useSubheaderText = () => {
 	const emailAddress = SubscriptionManager.useSubscriberEmailAddress();
 	const translate = useTranslate();
-	const locale = useLocale();
-	const { hasTranslation } = useI18n();
+
 	return useMemo( () => {
 		if ( emailAddress ) {
-			return locale.startsWith( 'en' ) ||
-				hasTranslation(
-					'Manage WordPress.com sites and newsletters you’ve subscribed to with {{span}}%(emailAddress)s{{/span}}.'
-				)
-				? translate(
-						'Manage WordPress.com sites and newsletters you’ve subscribed to with {{span}}%(emailAddress)s{{/span}}.',
-						{
-							args: {
-								emailAddress: emailAddress,
-							},
-							components: {
-								span: <span className="email-address" />,
-							},
-						}
-				  )
-				: translate(
-						"Manage the WordPress.com newsletter and blogs you've subscribed to with {{span}}%(emailAddress)s{{/span}}.",
-						{
-							args: {
-								emailAddress: emailAddress,
-							},
-							components: {
-								span: <span className="email-address" />,
-							},
-						}
-				  );
+			return translate(
+				'Manage WordPress.com sites and newsletters you’ve subscribed to with {{span}}%(emailAddress)s{{/span}}.',
+				{
+					args: {
+						emailAddress: emailAddress,
+					},
+					components: {
+						span: <span className="email-address" />,
+					},
+				}
+			);
 		}
-		return locale.startsWith( 'en' ) ||
-			hasTranslation( 'Manage your WordPress.com site and newsletter subscriptions.' )
-			? translate( 'Manage your WordPress.com site and newsletter subscriptions.' )
-			: translate( 'Manage your WordPress.com blog and newsletter subscriptions.' );
+
+		return translate( 'Manage your WordPress.com site and newsletter subscriptions.' );
 	}, [ emailAddress, translate ] );
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/i18n-issues/issues/654

## Proposed Changes

- Part of addressing https://github.com/Automattic/i18n-issues/issues/654
- Follow-up to https://github.com/Automattic/wp-calypso/pull/97690
- Initially meant to update the `hasTranslation` + `locale` checks with the new `fixMe` method, but upon checking the strings, they are all translated. So this instead removes the fallback strings 

### Media
| without subkey/email | with subkey/email |
|--------|--------|
| <img alt="Screenshot 2025-01-08 at 11 32 23 AM" src="https://github.com/user-attachments/assets/fadadd83-f306-40ea-b55f-c832484b380b" /> | <img alt="Screenshot 2025-01-08 at 11 54 01 AM" src="https://github.com/user-attachments/assets/74313402-9b35-4ce4-b11f-e0e47edb5ba5" /> | 




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- Part of addressing https://github.com/Automattic/i18n-issues/issues/654
- Cleanup code

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/subscriptions/settings` and ensure the first media above
- Ensure you have a valid `subkey` value in your cookie which is pointing to `calypso.localhost` and confirm the second media above (or hardcode the condition in code - as I did 😁 ) - per instructions from https://github.com/Automattic/wp-calypso/pull/75067

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
