### PR TITLE
Design Picker: Remove Trending for your goals section

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -967,7 +967,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				showActiveThemeBadge={ intent !== 'build' }
 				isMultiFilterEnabled={ isGoalCentricFeature }
 				isBigSkyEligible={ isBigSkyEligible }
-				recommendedDesignSlugs={ allDesigns?.recommendation || [] }
 			/>
 		</>
 	);

--- a/packages/data-stores/src/starter-designs-queries/types.ts
+++ b/packages/data-stores/src/starter-designs-queries/types.ts
@@ -3,5 +3,4 @@ import type { Category, Design } from '@automattic/design-picker/src/types';
 export interface StarterDesigns {
 	filters: { subject: Record< string, Category > };
 	designs: Design[];
-	recommendation: string[];
 }

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -26,7 +26,6 @@ interface Options extends QueryOptions< StarterDesignsResponse > {
 interface StarterDesignsResponse {
 	filters: { subject: Record< string, Category > };
 	static: { designs: StarterDesign[] };
-	recommendation: string[];
 }
 
 export type ThemeTier = {
@@ -66,7 +65,6 @@ export function useStarterDesignsQuery(
 					subject: response.filters?.subject || {},
 				},
 				designs: response.static?.designs?.map( apiStarterDesignsToDesign ),
-				recommendation: response.recommendation,
 			};
 
 			return select ? select( allDesigns ) : allDesigns;

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useRef, useState } from 'react';
@@ -323,6 +324,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	isBigSkyEligible = false,
 } ) => {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 	const { selectedCategoriesWithoutDesignTier } = useDesignPickerFilters();
 
 	const categories = categorization?.categories || [];
@@ -406,7 +408,11 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 			{ isMultiFilterEnabled && selectedCategoriesWithoutDesignTier.length > 1 && (
 				<DesignCardGroup
 					{ ...designCardProps }
-					title={ translate( 'Best matching themes' ) }
+					title={
+						hasEnTranslation( 'Best theme matches' )
+							? translate( 'Best theme matches' )
+							: translate( 'Best matching themes' )
+					}
 					category="best"
 					designs={ best }
 				/>

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -303,7 +303,6 @@ interface DesignPickerProps {
 	showActiveThemeBadge?: boolean;
 	isMultiFilterEnabled?: boolean;
 	isBigSkyEligible?: boolean;
-	recommendedDesignSlugs?: string[];
 }
 
 const DesignPicker: React.FC< DesignPickerProps > = ( {
@@ -322,7 +321,6 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	showActiveThemeBadge = false,
 	isMultiFilterEnabled = false,
 	isBigSkyEligible = false,
-	recommendedDesignSlugs = [],
 } ) => {
 	const translate = useTranslate();
 	const { selectedCategoriesWithoutDesignTier } = useDesignPickerFilters();
@@ -341,32 +339,12 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 		[ categorization?.categories ]
 	);
 
-	const recommendedDesigns = useMemo( () => {
-		const recommendedDesignSlugsSet = new Set( recommendedDesignSlugs );
+	const { all, best, ...designsByGroup } = useFilteredDesignsByGroup( designs );
 
-		// The number should be a multiple of 3 but no more than 5
-		return designs
-			.filter( ( design ) => recommendedDesignSlugsSet.has( design.recipe?.stylesheet || '' ) )
-			.slice( 0, 3 );
-	}, [ designs, recommendedDesignSlugs ] );
-
-	// Show recommended themes only when the selected categories are never changed.
-	const showRecommendedAtTop =
-		isMultiFilterEnabled &&
-		! categorization?.isSelectionsChanged &&
-		recommendedDesigns.length === 3;
-	const showRecommendedAtBottom =
-		isMultiFilterEnabled && categorization?.isSelectionsChanged && recommendedDesigns.length === 3;
-	const showRecommendedDesigns = showRecommendedAtTop || showRecommendedAtBottom;
-
-	const { all, best, ...designsByGroup } = useFilteredDesignsByGroup( designs, {
-		excludeDesigns: showRecommendedDesigns ? recommendedDesigns : [],
-	} );
-
-	// Show no results only when the recommended themes is hidden and no design matches the selected categories and tiers.
-	const showNoResults =
-		! showRecommendedDesigns &&
-		Object.values( designsByGroup ).every( ( categoryDesigns ) => categoryDesigns.length === 0 );
+	// Show no results only when no design matches the selected categories and tiers.
+	const showNoResults = Object.values( designsByGroup ).every(
+		( categoryDesigns ) => categoryDesigns.length === 0
+	);
 
 	const getCategoryName = ( value: string ) =>
 		categories.find( ( { slug } ) => slug === value )?.name || '';
@@ -433,18 +411,11 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 					designs={ best }
 				/>
 			) }
-			{ showRecommendedAtTop && (
-				<DesignCardGroup
-					{ ...designCardProps }
-					title={ translate( 'Trending for your goals' ) }
-					category="recommended"
-					designs={ recommendedDesigns }
-				/>
-			) }
 
 			{ isMultiFilterEnabled && selectedCategoriesWithoutDesignTier.length === 0 && (
 				<DesignCardGroup { ...designCardProps } designs={ all } />
 			) }
+
 			{ /* We want to show the last one on top first. */ }
 			{ Object.entries( designsByGroup )
 				.reverse()
@@ -466,15 +437,6 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						showNoResults={ index === array.length - 1 && showNoResults }
 					/>
 				) ) }
-
-			{ showRecommendedAtBottom && (
-				<DesignCardGroup
-					{ ...designCardProps }
-					title={ translate( 'Trending for your goals' ) }
-					category="recommended"
-					designs={ recommendedDesigns }
-				/>
-			) }
 		</div>
 	);
 };
@@ -497,7 +459,6 @@ export interface UnifiedDesignPickerProps {
 	showActiveThemeBadge?: boolean;
 	isMultiFilterEnabled?: boolean;
 	isBigSkyEligible?: boolean;
-	recommendedDesignSlugs?: string[];
 }
 
 const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
@@ -518,7 +479,6 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	showActiveThemeBadge = false,
 	isMultiFilterEnabled = false,
 	isBigSkyEligible = false,
-	recommendedDesignSlugs = [],
 } ) => {
 	const hasCategories = !! ( categorization?.categories || [] ).length;
 
@@ -546,7 +506,6 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					showActiveThemeBadge={ showActiveThemeBadge }
 					isMultiFilterEnabled={ isMultiFilterEnabled }
 					isBigSkyEligible={ isBigSkyEligible }
-					recommendedDesignSlugs={ recommendedDesignSlugs }
 				/>
 				<InView onChange={ ( inView ) => inView && onViewAllDesigns() } />
 			</div>

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -339,7 +339,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 		[ categorization?.categories ]
 	);
 
-	const { all, best, ...designsByGroup } = useFilteredDesignsByGroup( designs );
+	const { designs, best, ...designsByGroup } = useFilteredDesignsByGroup( designs );
 
 	// Show no results only when no design matches the selected categories and tiers.
 	const showNoResults = Object.values( designsByGroup ).every(
@@ -413,7 +413,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 			) }
 
 			{ isMultiFilterEnabled && selectedCategoriesWithoutDesignTier.length === 0 && (
-				<DesignCardGroup { ...designCardProps } designs={ all } />
+				<DesignCardGroup { ...designCardProps } designs={ designs } />
 			) }
 
 			{ /* We want to show the last one on top first. */ }

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -339,7 +339,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 		[ categorization?.categories ]
 	);
 
-	const { designs, best, ...designsByGroup } = useFilteredDesignsByGroup( designs );
+	const { all, best, ...designsByGroup } = useFilteredDesignsByGroup( designs );
 
 	// Show no results only when no design matches the selected categories and tiers.
 	const showNoResults = Object.values( designsByGroup ).every(
@@ -413,7 +413,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 			) }
 
 			{ isMultiFilterEnabled && selectedCategoriesWithoutDesignTier.length === 0 && (
-				<DesignCardGroup { ...designCardProps } designs={ designs } />
+				<DesignCardGroup { ...designCardProps } designs={ all } />
 			) }
 
 			{ /* We want to show the last one on top first. */ }

--- a/packages/design-picker/src/hooks/use-filtered-designs.ts
+++ b/packages/design-picker/src/hooks/use-filtered-designs.ts
@@ -74,7 +74,9 @@ export const useFilteredDesignsByGroup = ( designs: Design[] ): { [ key: string 
 			);
 		}
 
-		return { designs };
+		return {
+			designs,
+		};
 	}, [ designs, selectedCategoriesWithoutDesignTier, selectedDesignTiers ] );
 
 	return filteredDesigns;

--- a/packages/design-picker/src/hooks/use-filtered-designs.ts
+++ b/packages/design-picker/src/hooks/use-filtered-designs.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { isBlankCanvasDesign, getDesignSlug } from '../utils';
+import { isBlankCanvasDesign } from '../utils';
 import { useDesignPickerFilters } from './use-design-picker-filters';
 import type { Design } from '../types';
 
@@ -62,29 +62,13 @@ export const getFilteredDesignsByCategory = (
 	return filteredDesignsByCategory;
 };
 
-interface UseFilteredDesignsByGroupOptions {
-	excludeDesigns?: Design[];
-}
-
-export const useFilteredDesignsByGroup = (
-	designs: Design[],
-	{ excludeDesigns }: UseFilteredDesignsByGroupOptions = {}
-): { [ key: string ]: Design[] } => {
+export const useFilteredDesignsByGroup = ( designs: Design[] ): { [ key: string ]: Design[] } => {
 	const { selectedCategoriesWithoutDesignTier, selectedDesignTiers } = useDesignPickerFilters();
 
 	const filteredDesigns = useMemo( () => {
-		const excludeDesignSlugs = excludeDesigns
-			? excludeDesigns.map( ( design ) => getDesignSlug( design ) )
-			: [];
-		const excludeDesignSlugsSet = new Set( excludeDesignSlugs );
-		const all =
-			excludeDesignSlugs.length > 0
-				? designs.filter( ( design ) => ! excludeDesignSlugsSet.has( getDesignSlug( design ) ) )
-				: designs;
-
 		if ( selectedCategoriesWithoutDesignTier.length > 0 || selectedDesignTiers.length > 0 ) {
 			return getFilteredDesignsByCategory(
-				all,
+				designs,
 				selectedCategoriesWithoutDesignTier,
 				selectedDesignTiers
 			);
@@ -93,7 +77,7 @@ export const useFilteredDesignsByGroup = (
 		return {
 			all,
 		};
-	}, [ designs, excludeDesigns, selectedCategoriesWithoutDesignTier, selectedDesignTiers ] );
+	}, [ designs, selectedCategoriesWithoutDesignTier, selectedDesignTiers ] );
 
 	return filteredDesigns;
 };

--- a/packages/design-picker/src/hooks/use-filtered-designs.ts
+++ b/packages/design-picker/src/hooks/use-filtered-designs.ts
@@ -74,9 +74,7 @@ export const useFilteredDesignsByGroup = ( designs: Design[] ): { [ key: string 
 			);
 		}
 
-		return {
-			all,
-		};
+		return { designs };
 	}, [ designs, selectedCategoriesWithoutDesignTier, selectedDesignTiers ] );
 
 	return filteredDesigns;

--- a/packages/design-picker/src/hooks/use-filtered-designs.ts
+++ b/packages/design-picker/src/hooks/use-filtered-designs.ts
@@ -75,7 +75,7 @@ export const useFilteredDesignsByGroup = ( designs: Design[] ): { [ key: string 
 		}
 
 		return {
-			designs,
+			all: designs,
 		};
 	}, [ designs, selectedCategoriesWithoutDesignTier, selectedDesignTiers ] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/97718

## Proposed Changes

This PR removes the "Trending for your goals" section since it didn't quite fit with the Design Picker due to it being related to goals instead of category filters.

![Screenshot 2025-01-08 at 6 08 49 PM](https://github.com/user-attachments/assets/6edfe858-7cd4-4bac-92d2-582baf052d03)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://github.com/Automattic/wp-calypso/issues/97718#issuecomment-2573704889

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Design Picker.
* Smoke-test to ensure it works as intended.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
