### PR TITLE
Remove custom tooltip on theme upgrade badge

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
@@ -1,7 +1,6 @@
 import { getPlan } from '@automattic/calypso-products';
 import { PremiumBadge } from '@automattic/components';
 import { Plans } from '@automattic/data-stores';
-import { createInterpolateElement } from '@wordpress/element';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import useIsUpdatedBadgeDesign from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-is-updated-badge-design';
@@ -9,9 +8,7 @@ import { useSelector } from 'calypso/state';
 import { useThemeTierForTheme } from 'calypso/state/themes/hooks/use-theme-tier-for-theme';
 import { getMarketplaceThemeSubscriptionPrices } from 'calypso/state/themes/selectors';
 import { THEME_TIERS } from '../constants';
-import ThemeTierBadgeCheckoutLink from './theme-tier-badge-checkout-link';
 import { useThemeTierBadgeContext } from './theme-tier-badge-context';
-import ThemeTierTooltipTracker from './theme-tier-tooltip-tracker';
 
 export default function ThemeTierPlanUpgradeBadge( { showPartnerPrice } ) {
 	const translate = useTranslate();
@@ -20,7 +17,6 @@ export default function ThemeTierPlanUpgradeBadge( { showPartnerPrice } ) {
 
 	const tierMinimumUpsellPlan = THEME_TIERS[ themeTier?.slug ]?.minimumUpsellPlan;
 	const mappedPlan = getPlan( tierMinimumUpsellPlan );
-	const planPathSlug = mappedPlan?.getPathSlug();
 	const subscriptionPrices = useSelector( ( state ) =>
 		getMarketplaceThemeSubscriptionPrices( state, themeId )
 	);
@@ -63,24 +59,6 @@ export default function ThemeTierPlanUpgradeBadge( { showPartnerPrice } ) {
 		} );
 	};
 
-	const tooltipContent = (
-		<>
-			<ThemeTierTooltipTracker />
-			<div data-testid="upsell-message">
-				{ createInterpolateElement(
-					// Translators: %(planName)s is the name of the plan that includes this theme. Examples: "Personal" or "Premium".
-					translate( 'This theme is included in the <Link>%(planName)s plan</Link>.', {
-						args: { planName },
-						textOnly: true,
-					} ),
-					{
-						Link: <ThemeTierBadgeCheckoutLink plan={ planPathSlug } />,
-					}
-				) }
-			</div>
-		</>
-	);
-
 	return (
 		<PremiumBadge
 			className={ clsx( 'theme-tier-badge__content', {
@@ -89,7 +67,6 @@ export default function ThemeTierPlanUpgradeBadge( { showPartnerPrice } ) {
 			focusOnShow={ false }
 			labelText={ getLabel() }
 			tooltipClassName="theme-tier-badge-tooltip"
-			tooltipContent={ tooltipContent }
 			tooltipPosition="top"
 			shouldHideTooltip={ isUpdatedBadgeDesign }
 			isClickable={ ! isUpdatedBadgeDesign }

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
@@ -68,8 +68,8 @@ export default function ThemeTierPlanUpgradeBadge( { showPartnerPrice } ) {
 			labelText={ getLabel() }
 			tooltipClassName="theme-tier-badge-tooltip"
 			tooltipPosition="top"
-			shouldHideTooltip={ isUpdatedBadgeDesign }
-			isClickable={ ! isUpdatedBadgeDesign }
+			shouldHideTooltip
+			isClickable={ false }
 		/>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #95471

## Proposed Changes

This PR removes the custom tooltip from the theme upgrade badge, which is the first step described in the list of improvements in #95471. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

From #95471:

> It's not possible to click on "Personal" anyhow to see what this means—let's just remove the tooltip and instead rely on the single theme's existing call to action of "Upgrade to activate." It's a much more meaningful place to call action to and removing this is one less distraction.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the theme showcase from within an existing site
2. Find a theme with an "Upgrade" badge
3. Hover over the badge and see that the tooltip is no longer displayed

| Before | After |
| ---- | ----- |
| ![image](https://github.com/user-attachments/assets/61428a1e-51db-4e43-9b60-e84104d161e1) | ![image](https://github.com/user-attachments/assets/5ea1fadf-fe02-489d-82cb-5c0c63b5e292) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
