### PR TITLE
Stepper: Fix navigating to a gated step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -78,7 +78,7 @@ const StepRoute = ( { step, flow, showWooLogo, renderStep, navigate }: StepRoute
 				<>
 					<SignupHeader pageTitle={ flow.title } showWooLogo={ showWooLogo } />
 					{ stepContent }
-					<SurveyManager disabled />
+					<SurveyManager disabled flow={ flow } />
 					<StepperPerformanceTrackerStop flow={ flow.name } step={ step.slug } />
 				</>
 			) }

--- a/client/landing/stepper/declarative-flow/internals/components/survery-manager/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/survery-manager/index.tsx
@@ -8,6 +8,7 @@ import {
 import { Suspense } from 'react';
 import { useFlowNavigation } from '../../hooks/use-flow-navigation';
 import AsyncMigrationSurvey from '../../steps-repository/components/migration-survey/async';
+import { Flow } from '../../types';
 import { DeferredRender } from '../deferred-render';
 
 const MIGRATION_SURVEY_FLOWS = [
@@ -17,8 +18,8 @@ const MIGRATION_SURVEY_FLOWS = [
 	MIGRATION_SIGNUP_FLOW,
 ];
 
-const SurveyManager = ( { disabled }: { disabled: boolean } ) => {
-	const { params } = useFlowNavigation();
+const SurveyManager = ( { disabled, flow }: { disabled: boolean; flow: Flow } ) => {
+	const { params } = useFlowNavigation( flow );
 	const isEnLocale = useIsEnglishLocale();
 
 	if ( ! params.flow || disabled ) {

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
@@ -4,7 +4,10 @@ import { useCallback } from 'react';
 import { generatePath, useMatch, useNavigate } from 'react-router';
 import { useSearchParams } from 'react-router-dom';
 import { ONBOARD_STORE, STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
-import type { Navigate, StepperStep } from '../../types';
+import { useSelector } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { PRIVATE_STEPS } from '../../steps';
+import type { Flow, Navigate, StepperStep } from '../../types';
 
 const useOnboardingIntent = () => {
 	const intent = useSelect(
@@ -33,16 +36,37 @@ interface FlowNavigation {
 /**
  *  Hook to manage the navigation between steps in the flow
  */
-export const useFlowNavigation = (): FlowNavigation => {
+export const useFlowNavigation = ( flow: Flow ): FlowNavigation => {
 	const intent = useOnboardingIntent();
 	const { setStepData } = useDispatch( STEPPER_INTERNAL_STORE );
 	const navigate = useNavigate();
 	const match = useMatch( '/:flow/:step?/:lang?' );
-	const { flow = null, step: currentStepSlug = null, lang = null } = match?.params || {};
+	const { step: currentStepSlug = null, lang = null } = match?.params || {};
 	const [ currentSearchParams ] = useSearchParams();
+	const steps = flow.useSteps();
+	const isLoggedIn = useSelector( isUserLoggedIn );
+	const stepsSlugs = steps.map( ( step ) => step.slug );
 
 	const customNavigate = useCallback< Navigate< StepperStep[] > >(
 		( nextStep: string, extraData = {}, replace = false ) => {
+			// If the user is not logged in, and the next step requires a logged in user, redirect to the login step.
+			if (
+				! isLoggedIn &&
+				steps.find( ( step ) => step.slug === nextStep )?.requiresLoggedInUser
+			) {
+				setStepData( {
+					intent: intent,
+					previousStep: currentStepSlug,
+					nextStep,
+				} );
+				const signInPath = generatePath( `/:flow/:step/:lang?`, {
+					flow: flow.name,
+					lang,
+					step: PRIVATE_STEPS.USER.slug,
+				} );
+
+				return navigate( signInPath, { replace: true } );
+			}
 			const hasQueryParams = nextStep.includes( '?' );
 
 			// Get the latest search params from the current location
@@ -56,20 +80,21 @@ export const useFlowNavigation = (): FlowNavigation => {
 			} );
 
 			const newPath = generatePath( `/:flow/:step/:lang?`, {
-				flow,
+				flow: flow.name,
 				lang,
 				step: nextStep,
 			} );
 
 			navigate( addQueryParams( newPath, queryParams ), { replace } );
 		},
-		[ flow, intent, lang, navigate, setStepData, currentStepSlug ]
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- steps array is recreated on every render, use stepsSlugs instead.
+		[ isLoggedIn, stepsSlugs, flow, intent, lang, navigate, setStepData, currentStepSlug ]
 	);
 
 	return {
 		navigate: customNavigate,
 		params: {
-			flow,
+			flow: flow.name,
 			step: currentStepSlug,
 		},
 		search: currentSearchParams,

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
@@ -50,6 +50,7 @@ export const useFlowNavigation = ( flow: Flow ): FlowNavigation => {
 	const customNavigate = useCallback< Navigate< StepperStep[] > >(
 		( nextStep: string, extraData = {}, replace = false ) => {
 			// If the user is not logged in, and the next step requires a logged in user, redirect to the login step.
+			// This only supports in-stepper auth. No need to bother with classic auth since it's deprecated.
 			if (
 				! isLoggedIn &&
 				flow.__experimentalUseBuiltinAuth &&

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
@@ -1,8 +1,11 @@
 import { OnboardSelect } from '@automattic/data-stores';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from 'react';
-import { generatePath, useMatch, useNavigate } from 'react-router';
+import { generatePath, createPath, useMatch, useNavigate } from 'react-router';
 import { useSearchParams } from 'react-router-dom';
+import { useFlowLocale } from 'calypso/landing/stepper/hooks/use-flow-locale';
+import { getLoginUrlForFlow } from 'calypso/landing/stepper/hooks/use-login-url-for-flow';
+import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
 import { ONBOARD_STORE, STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -46,28 +49,58 @@ export const useFlowNavigation = ( flow: Flow ): FlowNavigation => {
 	const steps = flow.useSteps();
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const stepsSlugs = steps.map( ( step ) => step.slug );
+	const locale = useFlowLocale();
+	const { siteId, siteSlug } = useSiteData();
 
 	const customNavigate = useCallback< Navigate< StepperStep[] > >(
 		( nextStep: string, extraData = {}, replace = false ) => {
 			// If the user is not logged in, and the next step requires a logged in user, redirect to the login step.
-			// This only supports in-stepper auth. No need to bother with classic auth since it's deprecated.
 			if (
 				! isLoggedIn &&
-				flow.__experimentalUseBuiltinAuth &&
 				steps.find( ( step ) => step.slug === nextStep )?.requiresLoggedInUser
 			) {
-				setStepData( {
-					intent: intent,
-					previousStep: currentStepSlug,
-					nextStep,
-				} );
-				const signInPath = generatePath( `/:flow/:step/:lang?`, {
-					flow: flow.name,
-					lang,
-					step: PRIVATE_STEPS.USER.slug,
+				// In-stepper auth.
+				if ( flow.__experimentalUseBuiltinAuth ) {
+					const signInPath = generatePath( `/:flow/:step/:lang?`, {
+						flow: flow.name,
+						lang,
+						step: PRIVATE_STEPS.USER.slug,
+					} );
+
+					setStepData( {
+						intent: intent,
+						previousStep: currentStepSlug,
+						nextStep,
+					} );
+
+					return navigate( signInPath );
+				}
+
+				const nextStepPath = createPath( {
+					// We have to include /setup, this this URL should be absolute and we can't use `useHref`.
+					pathname: generatePath( `/setup/:flow/:step/:lang?`, {
+						flow: flow.name,
+						lang,
+						step: nextStep,
+					} ),
+					search: currentSearchParams.toString(),
+					hash: window.location.hash,
 				} );
 
-				return navigate( signInPath, { replace: true } );
+				debugger;
+
+				// Classic /login auth.
+				const loginUrl = getLoginUrlForFlow( {
+					flow,
+					locale,
+					path: nextStepPath,
+					siteId,
+					siteSlug,
+				} );
+
+				debugger;
+
+				return window.location.assign( loginUrl );
 			}
 
 			const hasQueryParams = nextStep.includes( '?' );
@@ -91,7 +124,19 @@ export const useFlowNavigation = ( flow: Flow ): FlowNavigation => {
 			navigate( addQueryParams( newPath, queryParams ), { replace } );
 		},
 		// eslint-disable-next-line react-hooks/exhaustive-deps -- steps array is recreated on every render, use stepsSlugs instead.
-		[ isLoggedIn, stepsSlugs, flow, intent, lang, navigate, setStepData, currentStepSlug ]
+		[
+			stepsSlugs,
+			isLoggedIn,
+			locale,
+			siteId,
+			siteSlug,
+			flow,
+			intent,
+			lang,
+			navigate,
+			setStepData,
+			currentStepSlug,
+		]
 	);
 
 	return {

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
@@ -67,17 +67,17 @@ export const useFlowNavigation = ( flow: Flow ): FlowNavigation => {
 						step: PRIVATE_STEPS.USER.slug,
 					} );
 
+					// Inform the user step where to go after the user is authenticated.
 					setStepData( {
-						intent: intent,
 						previousStep: currentStepSlug,
 						nextStep,
 					} );
 
 					return navigate( signInPath );
 				}
-
+				// Classic /login auth.
 				const nextStepPath = createPath( {
-					// We have to include /setup, this this URL should be absolute and we can't use `useHref`.
+					// We have to include /setup, as this URL should be absolute and we can't use `useHref`.
 					pathname: generatePath( `/setup/:flow/:step/:lang?`, {
 						flow: flow.name,
 						lang,
@@ -87,9 +87,6 @@ export const useFlowNavigation = ( flow: Flow ): FlowNavigation => {
 					hash: window.location.hash,
 				} );
 
-				debugger;
-
-				// Classic /login auth.
 				const loginUrl = getLoginUrlForFlow( {
 					flow,
 					locale,
@@ -97,8 +94,6 @@ export const useFlowNavigation = ( flow: Flow ): FlowNavigation => {
 					siteId,
 					siteSlug,
 				} );
-
-				debugger;
 
 				return window.location.assign( loginUrl );
 			}

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
@@ -52,8 +52,8 @@ export const useFlowNavigation = ( flow: Flow ): FlowNavigation => {
 			// If the user is not logged in, and the next step requires a logged in user, redirect to the login step.
 			if (
 				! isLoggedIn &&
-				steps.find( ( step ) => step.slug === nextStep )?.requiresLoggedInUser &&
-				flow.__experimentalUseBuiltinAuth
+				flow.__experimentalUseBuiltinAuth &&
+				steps.find( ( step ) => step.slug === nextStep )?.requiresLoggedInUser
 			) {
 				setStepData( {
 					intent: intent,

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
@@ -52,7 +52,8 @@ export const useFlowNavigation = ( flow: Flow ): FlowNavigation => {
 			// If the user is not logged in, and the next step requires a logged in user, redirect to the login step.
 			if (
 				! isLoggedIn &&
-				steps.find( ( step ) => step.slug === nextStep )?.requiresLoggedInUser
+				steps.find( ( step ) => step.slug === nextStep )?.requiresLoggedInUser &&
+				flow.__experimentalUseBuiltinAuth
 			) {
 				setStepData( {
 					intent: intent,
@@ -67,6 +68,7 @@ export const useFlowNavigation = ( flow: Flow ): FlowNavigation => {
 
 				return navigate( signInPath, { replace: true } );
 			}
+
 			const hasQueryParams = nextStep.includes( '?' );
 
 			// Get the latest search params from the current location

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/test/index.tsx
@@ -8,7 +8,19 @@ import React from 'react';
 import { MemoryRouter, useLocation } from 'react-router';
 import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
 import { STEPPER_INTERNAL_STORE } from '../../../../../stores';
+import { Flow } from '../../../types';
 import { useFlowNavigation } from '../index';
+
+const mockFlow: Flow = {
+	name: 'some-flow',
+	isSignupFlow: false,
+	useSteps() {
+		return [ { slug: 'some-step', component: () => <div>Step 1</div> } ];
+	},
+	useStepNavigation() {
+		return {};
+	},
+};
 
 const LocationDisplay = () => {
 	const location = useLocation();
@@ -35,7 +47,7 @@ const Wrapper =
 
 const render = ( { initialEntry = '/setup/some-flow/some-step' } = {} ) => {
 	window.history.replaceState( null, '', initialEntry );
-	return renderHookWithProvider( () => useFlowNavigation(), {
+	return renderHookWithProvider( () => useFlowNavigation( mockFlow ), {
 		wrapper: Wrapper( initialEntry ),
 	} );
 };

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -68,7 +68,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	const flowSteps = flow.useSteps();
 	const stepPaths = flowSteps.map( ( step ) => step.slug );
 	const firstStepSlug = useFirstStep( stepPaths );
-	const { navigate, params } = useFlowNavigation();
+	const { navigate, params } = useFlowNavigation( flow );
 	const currentStepRoute = params.step || '';
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const { lang = null } = useParams();

--- a/client/landing/stepper/hooks/use-login-url-for-flow.ts
+++ b/client/landing/stepper/hooks/use-login-url-for-flow.ts
@@ -1,6 +1,6 @@
 import { addQueryArgs } from '@wordpress/url';
 import { useHref, useLocation } from 'react-router';
-import { useLoginUrl } from '../utils/path';
+import { getLoginUrl } from '../utils/path';
 import { useFlowLocale } from './use-flow-locale';
 import { useSiteData } from './use-site-data';
 import type { Flow } from 'calypso/landing/stepper/declarative-flow/internals/types';
@@ -16,14 +16,47 @@ export function useLoginUrlForFlow( { flow }: UseLoginUrlForFlowProps ): string 
 	const path = useHref( location.pathname );
 	const { extraQueryParams, customLoginPath } = flow.useLoginParams?.() ?? {};
 
+	return getLoginUrlForFlow( {
+		flow,
+		path,
+		locale,
+		siteId,
+		siteSlug,
+		search: location.search,
+		extraQueryParams,
+		customLoginPath,
+	} );
+}
+
+type GetLoginUrlForFlowProps = {
+	flow: Flow;
+	path: string;
+	locale: string;
+	siteId: string | number;
+	siteSlug: string;
+	search?: string;
+	extraQueryParams?: Record< string, string | number >;
+	customLoginPath?: string;
+};
+
+export function getLoginUrlForFlow( {
+	flow,
+	path,
+	locale,
+	siteId,
+	siteSlug,
+	search = window.location.search,
+	extraQueryParams = {},
+	customLoginPath,
+}: GetLoginUrlForFlowProps ): string {
 	const redirectTo = addQueryArgs( path, {
 		...( locale && locale !== 'en' ? { locale } : {} ),
 		...( siteId ? { siteId } : {} ),
 		...( siteSlug ? { siteSlug } : {} ),
-		...Object.fromEntries( new URLSearchParams( location.search ).entries() ),
+		...Object.fromEntries( new URLSearchParams( search ).entries() ),
 	} );
 
-	return useLoginUrl( {
+	return getLoginUrl( {
 		variationName: flow.variantSlug ?? flow.name,
 		pageTitle: flow.title,
 		locale,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/98059

## Proposed Changes

Stepper currently allows flows to navigate to a gated step while logged out, then it detects your auth status and if you're not logged in, [it will redirect you to login](https://github.com/Automattic/wp-calypso/blob/4298e744063b1495754be18a3e7d9c73fe01c87d/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx#L46-L60). This is a roundabout way to redirect to auth when we have all the information we need before going to the gated step. 

This change redirects the user to login before redirecting them to a gated step, without navigating to the gated step at all. 

## Why are these changes being made?
For a saner tracks narrative.

## Testing Instructions

This needs a bit of thorough testing.

### In-Stepper auth

1. While incognito,
2. Open DevTools > Network, tick "Preserve log", and filter by `calypso_signup_step_start`.
3. Go to /setup/onboarding.
4. Skip goals. You should see one more entry of `calypso_signup_step_start`. 
5. Pick a design. You should NOT see one more entry of `calypso_signup_step_start`.
6. Click Continue. You should see **one** more entry of `calypso_signup_step_start`.
7. You should land at the user step. You should see **one** more entry of `calypso_signup_step_start`.
8. Sign up using anything, you should end up at /setup/onboarding/domains.
9. Click Browser Back, you should end up at the design step.
10. Pick a design and click Continue.
11. You should land at the user step
12. Click Back from the flow's page top left.
13. You should end up at Pick a theme.

--- 

1. While incognito,
2. Open DevTools > Network, tick "Preserve log", and filter by `calypso_signup_step_start`.
3. Go to /setup/onboarding
4. Skip goals. You should see one more entry of `calypso_signup_step_start`. 
5. Pick a design. You should NOT see one more entry of `calypso_signup_step_start`.
6. Click Continue. You should see **one** more entry of `calypso_signup_step_start`.
7. You should land at the user step. Click "Log in".
8. Log in using any method.
14. You should end up at /setup/onboarding/domains.

### Legacy auth

This tests auth that uses legacy non-Stepper auth

1. While incognito,
2. Open DevTools > Network, tick "Preserve log", and filter by `calypso_signup_step_start`.
3. Go to /setup/newsletter.
4. You should see one `calypso_signup_step_start`.
5. Click "Launch my newsletter". 
6. You should land at the user URL (/start/...) and see one more `calypso_signup_step_start`.
7. Sign up.
8. You should land `newsletterSetup` page and see one more `calypso_signup_step_start`.
