### PR TITLE
Improve consistency of the login form

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -898,7 +898,10 @@ export class LoginForm extends Component {
 		);
 
 		const showLastUsedAuthenticationMethod =
-			lastUsedAuthenticationMethod && lastUsedAuthenticationMethod !== 'password' && isSocialFirst;
+			lastUsedAuthenticationMethod &&
+			lastUsedAuthenticationMethod !== 'password' &&
+			lastUsedAuthenticationMethod !== 'magic-login' &&
+			isSocialFirst;
 
 		if ( showSocialLoginFormOnly ) {
 			return config.isEnabled( 'signup/social' ) ? (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #97899

## Proposed Changes

We've changed it so that the "Email Address or Username" input is visible when the previously-used login method was magic-login. The social button on the right will also always read "Email me a login link".

We're not moving the "Password" input at this point since there's a lot of infrastructure for other login flows that depends on the password being entered in a second step.

All other social logins will remain the same and appear under "Previously used".

### Before
![CleanShot 2025-01-08 at 09 23 27](https://github.com/user-attachments/assets/dd475ed5-e7f2-4000-a7b2-7f6fdd59d41e)

### After
<img width="968" alt="CleanShot 2025-01-08 at 09 23 45@2x" src="https://github.com/user-attachments/assets/f6945e08-1e3c-4d30-a16c-4ddce1d10020" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Previously, if the user had used the magic-link before, we showed them a "Previously used: Email me a magic link" button and changed the button on the right from "Email me a login link" to "Continue with email".

This has led to confusion with some users being unsure of how to login with a password.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### (Optional) See the current behavior on WordPress.com:

1. Log out of WordPress.com if you're currently logged in.
2. Go to https://wordpress.com/log-in/ and click "Email me a login link".
3. Enter your email or username and click "Send link".
4. Click the magic link in your email to login.
5. Log back out.
6. The login page should show "Previously used: Email me a login link" instead of the email/username input.

### (Required) Test the new behavior:

You can use calypso.live or calypso.localhost.

1. Add the cookie `last_used_authentication_method = magic-login`
2. Refresh the page
3. The login page should still show the email/username input (and not 'Previously used').
4. Now change the cookie to `last_used_authentication_method = google`.
5. Refresh the page.
6. The login page should show "Previously used: Continue with Google".

<img width="1002" alt="CleanShot 2025-01-09 at 09 22 08@2x" src="https://github.com/user-attachments/assets/72db92d2-8709-4564-bd17-c0d12a46eed3" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
