### PR TITLE
A4A: Add feature flag for Products overview v2 page.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -18,6 +18,7 @@ import { getValidHostingSection } from './lib/hosting';
 import { getValidBrand } from './lib/product-brand';
 import DownloadProducts from './primary/download-products';
 import ProductsOverview from './products-overview';
+import ProductsOverviewV2 from './products-overview-v2';
 
 export const marketplaceContext: Callback = () => {
 	page.redirect( A4A_MARKETPLACE_HOSTING_LINK );
@@ -29,16 +30,21 @@ export const marketplaceProductsContext: Callback = ( context, next ) => {
 
 	context.secondary = <MarketplaceSidebar path={ context.path } />;
 	const purchaseType = purchase_type === 'referral' ? 'referral' : undefined;
+
 	context.primary = (
 		<>
 			<PageViewTracker title="Marketplace > Products" path={ context.path } />
-			<ProductsOverview
-				siteId={ site_id }
-				suggestedProduct={ product_slug }
-				defaultMarketplaceType={ purchaseType }
-				productBrand={ getValidBrand( productBrand ) }
-				searchQuery={ search_query }
-			/>
+			{ isEnabled( 'a4a-product-page-redesign' ) ? (
+				<ProductsOverviewV2 />
+			) : (
+				<ProductsOverview
+					siteId={ site_id }
+					suggestedProduct={ product_slug }
+					defaultMarketplaceType={ purchaseType }
+					productBrand={ getValidBrand( productBrand ) }
+					searchQuery={ search_query }
+				/>
+			) }
 		</>
 	);
 	next();

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -35,7 +35,13 @@ export const marketplaceProductsContext: Callback = ( context, next ) => {
 		<>
 			<PageViewTracker title="Marketplace > Products" path={ context.path } />
 			{ isEnabled( 'a4a-product-page-redesign' ) ? (
-				<ProductsOverviewV2 />
+				<ProductsOverviewV2
+					siteId={ site_id }
+					suggestedProduct={ product_slug }
+					defaultMarketplaceType={ purchaseType }
+					productBrand={ getValidBrand( productBrand ) }
+					searchQuery={ search_query }
+				/>
 			) : (
 				<ProductsOverview
 					siteId={ site_id }

--- a/client/a8c-for-agencies/sections/marketplace/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import {
 	A4A_MARKETPLACE_ASSIGN_LICENSE_LINK,
@@ -20,8 +21,11 @@ import {
 
 export default function () {
 	page( A4A_MARKETPLACE_LINK, requireAccessContext, marketplaceContext, makeLayout, clientRender );
+
 	page(
-		`${ A4A_MARKETPLACE_PRODUCTS_LINK }/:brand?`,
+		isEnabled( 'a4a-product-page-redesign' )
+			? A4A_MARKETPLACE_PRODUCTS_LINK
+			: `${ A4A_MARKETPLACE_PRODUCTS_LINK }/:brand?`,
 		requireAccessContext,
 		marketplaceProductsContext,
 		makeLayout,

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/index.tsx
@@ -1,3 +1,122 @@
-export default function ProductsOverviewV2() {
-	return <div>Products Overview V2</div>;
+import page from '@automattic/calypso-router';
+import { SiteDetails } from '@automattic/data-stores';
+import { useBreakpoint } from '@automattic/viewport-react';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
+import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import {
+	A4A_MARKETPLACE_CHECKOUT_LINK,
+	A4A_MARKETPLACE_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import LayoutBody from 'calypso/layout/hosting-dashboard/body';
+import LayoutHeader, {
+	LayoutHeaderActions as Actions,
+	LayoutHeaderBreadcrumb as Breadcrumb,
+} from 'calypso/layout/hosting-dashboard/header';
+import { useSelector } from 'calypso/state';
+import getSites from 'calypso/state/selectors/get-sites';
+import ReferralToggle from '../common/referral-toggle';
+import { ShoppingCartContext } from '../context';
+import withMarketplaceType from '../hoc/with-marketplace-type';
+import useShoppingCart from '../hooks/use-shopping-cart';
+import ProductListing from '../products-overview/product-listing';
+import ShoppingCart from '../shopping-cart';
+
+import './style.scss';
+
+type Props = {
+	siteId?: string;
+	suggestedProduct?: string;
+	productBrand: string;
+	searchQuery?: string;
+};
+
+export function ProductsOverviewV2( {
+	siteId,
+	suggestedProduct,
+	productBrand,
+	searchQuery,
+}: Props ) {
+	const [ selectedSite, setSelectedSite ] = useState< SiteDetails | null | undefined >( null );
+
+	const translate = useTranslate();
+
+	const isNarrowView = useBreakpoint( '<660px' );
+
+	const sites = useSelector( getSites );
+
+	const {
+		selectedCartItems,
+		setSelectedCartItems,
+		onRemoveCartItem,
+		showCart,
+		setShowCart,
+		toggleCart,
+	} = useShoppingCart();
+
+	useEffect( () => {
+		if ( siteId && sites.length > 0 ) {
+			const site = siteId ? sites.find( ( site ) => site?.ID === parseInt( siteId ) ) : null;
+			setSelectedSite( site );
+		}
+	}, [ siteId, sites ] );
+
+	return (
+		<Layout
+			className="products-overview-v2"
+			title={ isNarrowView ? '' : translate( 'Products Marketplace' ) }
+			wide
+		>
+			<LayoutTop>
+				<A4AAgencyApprovalNotice />
+				<LayoutHeader>
+					<Breadcrumb
+						items={ [
+							{
+								label: translate( 'Marketplace' ),
+								href: A4A_MARKETPLACE_LINK,
+							},
+							{
+								label: translate( 'Products' ),
+							},
+						] }
+					/>
+
+					<Actions>
+						<MobileSidebarNavigation />
+						<ReferralToggle />
+						<ShoppingCart
+							showCart={ showCart }
+							setShowCart={ setShowCart }
+							toggleCart={ toggleCart }
+							items={ selectedCartItems }
+							onRemoveItem={ onRemoveCartItem }
+							onCheckout={ () => {
+								page( A4A_MARKETPLACE_CHECKOUT_LINK );
+							} }
+						/>
+					</Actions>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody className="products-overview-v2__body">
+				<ShoppingCartContext.Provider value={ { setSelectedCartItems, selectedCartItems } }>
+					{
+						// we will remove this once we have the new product listing component
+						<ProductListing
+							selectedSite={ selectedSite }
+							suggestedProduct={ suggestedProduct }
+							productBrand={ productBrand }
+							searchQuery={ searchQuery }
+						/>
+					}
+				</ShoppingCartContext.Provider>
+			</LayoutBody>
+		</Layout>
+	);
 }
+
+export default withMarketplaceType( ProductsOverviewV2 );

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/index.tsx
@@ -1,0 +1,3 @@
+export default function ProductsOverviewV2() {
+	return <div>Products Overview V2</div>;
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/style.scss
@@ -1,0 +1,41 @@
+$background-color: #05374A;
+
+.products-overview-v2.main.hosting-dashboard-layout {
+	.hosting-dashboard-layout__container {
+		height: auto;
+		overflow: auto;
+		display: block;
+	}
+
+	.hosting-dashboard-layout__top-wrapper {
+		max-height: auto;
+		background: url( calypso/assets/images/a8c-for-agencies/marketplace-hosting-page-v3-bg.svg ) no-repeat top right $background-color;
+        border-block-end: none;
+		position: sticky;
+		top: 0;
+		z-index: 100;
+    }
+
+	.hosting-dashboard-layout__header-breadcrumb {
+		color: var(--color-neutral-40);
+		fill: var(--color-neutral-40);
+
+		a {
+			color: var(--color-primary-5);
+		}
+	}
+
+	.hosting-dashboard-layout__header-actions {
+		background-color: var(--color-surface);
+		border-radius: 8px; /* stylelint-disable-line */
+		padding: 8px 16px;
+
+		.shopping-cart {
+			margin: 0;
+		}
+	}
+
+	.components-button:is(.is-primary, .is-secondary) {
+		min-height: 40px;
+	}
+}

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -40,6 +40,7 @@
 		"a4a/site-migration": true,
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
+		"a4a-product-page-redesign": true,
 		"a4a-hosting-page-redesign-v3": true,
 		"a4a-dev-sites": true,
 		"a4a-migrations-page-v2": true,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -33,6 +33,7 @@
 		"a4a/site-migration": true,
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
+		"a4a-product-page-redesign": false,
 		"a4a-hosting-page-redesign-v3": true,
 		"a4a-dev-sites": true,
 		"a4a-migrations-page-v2": true,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -33,6 +33,7 @@
 		"oauth": true,
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
+		"a4a-product-page-redesign": false,
 		"a4a-hosting-page-redesign-v3": true,
 		"a4a-dev-sites": true,
 		"a4a-migrations-page-v2": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -35,6 +35,7 @@
 		"a4a/site-migration": false,
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
+		"a4a-product-page-redesign": false,
 		"a4a-hosting-page-redesign-v3": true,
 		"a4a-dev-sites": true,
 		"a4a-migrations-page-v2": true,


### PR DESCRIPTION
This PR adds a new feature flag for the redesigned products overview page. We also created a skeleton for the new page, making it easier to test the feature flag.

<img width="1728" alt="Screenshot 2025-01-08 at 10 11 50 PM" src="https://github.com/user-attachments/assets/6d180acc-aae4-4b21-a4b2-dba1b1e3ce1d" />


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1628
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1629

## Proposed Changes

* Add `a4a-product-page-redesign` feature flag for the A4A development environment. Be aware that this is not enabled by default in Horizon to prevent interference with other pull requests when testing.
* Implement the `ProductsOverviewV2` page component adopting the Hosting page design pattern. Load this component when the feature flag is enabled.

## Why are these changes being made?

* This is part of the Marketplace UX improvement project.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace/products?flags=a4a-product-page-redesign`.
* Confirm you see the new products overview page with a header style similar to the hosting page.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
