### PR TITLE
Pattern Library: Visual tweaks for resize handle

### DIFF
--- a/client/my-sites/patterns/components/pattern-preview/style.scss
+++ b/client/my-sites/patterns/components/pattern-preview/style.scss
@@ -185,14 +185,21 @@
 		top: 3.4rem;
 
 		&::after {
-			background-color: #a7aaad;
+			background-color: var(--studio-gray-20);
 			border-radius: 3px;
 			box-shadow: none;
-			height: 50px;
+			height: 70px;
+			max-height: 90%;
 			right: 50%;
 			top: 50%;
 			transform: translate(50%, -50%);
+			transition: background-color 0.2s linear;
 			width: 6px;
+		}
+
+		&:hover::after,
+		&:active::after {
+			background-color: var(--studio-gray-40);
 		}
 
 		&::before {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6582

## Proposed Changes

Way back when, we received some feedback on the Pattern Library CfT post (pdtkmj-2wZ-p2#comment-4733) that the resize handle next to pattern previews wasn't easy to understand. This PR makes some changes based on @matt-west's suggestions in https://github.com/Automattic/dotcom-forge/issues/6582 that should hopefully make it easier to understand.

| Before | After |
| - | - |
| ![wordpress com_patterns(Medium laptop)](https://github.com/user-attachments/assets/d0871f8e-4d86-4a72-9c61-1c08898ab4ee) | ![calypso localhost_3000_patterns_about(Medium laptop)](https://github.com/user-attachments/assets/09816784-736f-4dc8-a0d2-e2cf40faea37) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/patterns/about`
2. Ensure that the resize handle next to the pattern previews look good and works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?