### PR TITLE
Site Migration: Show the correct landing page when users ask for help

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-support-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-support-instructions/index.tsx
@@ -1,16 +1,18 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { StepContainer } from '@automattic/onboarding';
 import { translate, useTranslate } from 'i18n-calypso';
+import { useMemo, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { useLocale } from 'calypso/landing/stepper/hooks/use-locale';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { UserData } from 'calypso/lib/user/user';
 import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import FlowCard from '../components/flow-card';
 import { redirect } from '../import/util';
+import { useSubmitMigrationTicket } from '../importer-migrate-message/hooks/use-submit-migration-ticket';
 import type { Step } from '../../types';
-
 import './style.scss';
 
 const StepContent = () => {
@@ -42,34 +44,55 @@ export const SiteMigrationSupportInstructions: Step = ( { stepName } ) => {
 	const user = useSelector( getCurrentUser ) as UserData;
 	const [ query ] = useSearchParams();
 	const variation = query.get( 'variation' ) || 'default';
+	const siteSlug = query.get( 'siteSlug' ) || '';
+	const fromUrl = query.get( 'from' ) || '';
+	const locale = useLocale();
 
-	const contentVariation = {
-		default: translate(
-			'We apologize for the problems you’re running into. Our Happiness Engineers will reach out to you shortly at {{strong}}%(email)s{{/strong}} to help you figure out your next steps together.',
-			{
-				args: {
-					email: user.email!,
-				},
-				components: {
-					strong: <strong />,
-				},
-			}
-		),
-		goals_shared: translate(
-			'Thanks for sharing your goals. Our Happiness Engineers will reach out to you shortly at {{strong}}%(email)s{{/strong}} to help you figure out your next steps together.',
-			{
-				args: {
-					email: user.email!,
-				},
-				components: {
-					strong: <strong />,
-				},
-			}
-		),
-	};
+	const contentVariation = useMemo(
+		() => ( {
+			default: translate(
+				'We apologize for the problems you’re running into. Our Happiness Engineers will reach out to you shortly at {{strong}}%(email)s{{/strong}} to help you figure out your next steps together.',
+				{
+					args: {
+						email: user.email!,
+					},
+					components: {
+						strong: <strong />,
+					},
+				}
+			),
+			goals_shared: translate(
+				'Thanks for sharing your goals. Our Happiness Engineers will reach out to you shortly at {{strong}}%(email)s{{/strong}} to help you figure out your next steps together.',
+				{
+					args: {
+						email: user.email!,
+					},
+					components: {
+						strong: <strong />,
+					},
+				}
+			),
+		} ),
+		[ user.email, translate ]
+	);
 
 	const content =
 		contentVariation[ variation as keyof typeof contentVariation ] ?? contentVariation.default;
+
+	const { sendTicket } = useSubmitMigrationTicket();
+
+	useEffect( () => {
+		recordTracksEvent( 'wpcom_support_free_migration_request_click', {
+			path: window.location.pathname,
+			automated_migration: true,
+		} );
+
+		sendTicket( {
+			locale,
+			blog_url: siteSlug,
+			from_url: fromUrl,
+		} );
+	}, [ sendTicket, locale, siteSlug, fromUrl ] );
 
 	return (
 		<StepContainer

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-support-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-support-instructions/index.tsx
@@ -1,10 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useLocale } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { translate, useTranslate } from 'i18n-calypso';
 import { useMemo, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { useLocale } from 'calypso/landing/stepper/hooks/use-locale';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { UserData } from 'calypso/lib/user/user';
 import { useSelector } from 'calypso/state';

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -55,6 +55,7 @@ const siteMigration: Flow = {
 			STEPS.SITE_MIGRATION_ALREADY_WPCOM,
 			STEPS.SITE_MIGRATION_OTHER_PLATFORM_DETECTED_IMPORT,
 			STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_AUTHORIZATION,
+			STEPS.SITE_MIGRATION_SUPPORT_INSTRUCTIONS,
 		];
 
 		const hostedVariantSteps = isHostedSiteMigrationFlow( this.variantSlug ?? FLOW_NAME )
@@ -516,7 +517,7 @@ const siteMigration: Flow = {
 					return navigate(
 						addQueryArgs(
 							{ siteId, from: fromQueryParam, siteSlug },
-							STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug
+							STEPS.SITE_MIGRATION_SUPPORT_INSTRUCTIONS.slug
 						)
 					);
 				}

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -530,7 +530,7 @@ describe( 'Site Migration Flow', () => {
 			expect( getFlowLocation() ).toEqual( {
 				path: addQueryArgs(
 					{ siteId: 123, from: 'oldsite.com', siteSlug: 'example.wordpress.com' },
-					`/${ STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug }`
+					`/${ STEPS.SITE_MIGRATION_SUPPORT_INSTRUCTIONS.slug }`
 				),
 				state: null,
 			} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #97664

## Proposed Changes
* Move the user to the SITE_MIGRATION_SUPPORT_INSTRUCTIONS step when they ask if the platform is not supported and ask for help. 
* Create a help ticket when the user clicks the support instructions step.


## Why are these changes being made?
* As described in the original ticket, nowadays, when the user asks for help,  we redirect the user to the regular SITE_MIGRATION_ASSISTED_MIGRATION, which says the migration will happen and also marks the migration as started. 

## Screenshots
![image](https://github.com/user-attachments/assets/474d17ac-936f-407d-bf1a-c0af14db7131)


## Testing Instructions
* Go to any of the migration flows (e.g /setup/hosted-site-migration)
* Follow all steps by choosing the DIFM  until the `Tell us about your WordPress site` 
* Set any non-WordPress site 
* On the `Looks like there's been a mix-up`  step, click `Looks like there's been a mix-up`
* Check if you can see the `migration-support-instructions` step 
* Check if a ticket was created (http call to `/help/migration-ticket/new`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
