### PR TITLE
Reader: fix scroll depth tracking

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -197,6 +197,8 @@ export class FullPostView extends Component {
 		document.removeEventListener( 'keydown', this.handleKeydown, true );
 		document.removeEventListener( 'visibilitychange', this.handleVisibilityChange );
 
+		// Track scroll depth and remove related instruments
+		this.trackScrollDepth( this.props.post );
 		if ( this.scrollableContainer ) {
 			this.scrollableContainer.removeEventListener( 'scroll', this.setScrollDepth );
 		}

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -295,13 +295,16 @@ export class FullPostView extends Component {
 
 	setScrollDepth = () => {
 		if ( this.scrollableContainer ) {
-			const scrollTop = this.scrollableContainer.scrollTop;
-			const scrollHeight = this.scrollableContainer.scrollHeight;
-			const clientHeight = this.scrollableContainer.clientHeight;
-			const scrollDepth = ( scrollTop / ( scrollHeight - clientHeight ) ) * 100;
+			const scrollTop = this.scrollableContainer.scrollTop ?? 0;
+			const scrollHeight = this.scrollableContainer.scrollHeight ?? 0;
+			const clientHeight = this.scrollableContainer.clientHeight ?? 0;
+
+			const denominator = scrollHeight - clientHeight;
+			const scrollDepth = denominator <= 0 ? 0 : scrollTop / denominator;
+
 			this.setState( ( prevState ) => ( {
-				maxScrollDepth: Math.max( prevState.maxScrollDepth, scrollDepth ) || 0,
-				hasCompleted: prevState.hasCompleted || scrollDepth >= 90,
+				maxScrollDepth: Math.min( 1, Math.max( 0, prevState.maxScrollDepth || 0, scrollDepth ) ),
+				hasCompleted: prevState.hasCompleted || scrollDepth >= 0.9,
 			} ) );
 		}
 	};
@@ -313,10 +316,11 @@ export class FullPostView extends Component {
 		}
 
 		if ( this.scrollableContainer && post.ID ) {
-			const roundedDepth = Math.round( maxScrollDepth * 100 ) / 100;
+			const scrollDepthPercentage = Math.round( maxScrollDepth * 100 );
+
 			recordTrackForPost( 'calypso_reader_article_scroll_depth', post, {
 				context: 'full-post',
-				scroll_depth: roundedDepth,
+				scroll_depth: scrollDepthPercentage,
 			} );
 		}
 	};

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -280,6 +280,11 @@ export class FullPostView extends Component {
 	resetScroll = () => {
 		this.clearResetScrollTimeout();
 		this.resetScrollTimeout = setTimeout( () => {
+			this.scrollableContainer.scrollTo( {
+				top: 0,
+				left: 0,
+				behavior: 'instant',
+			} );
 			this.scrollTracker.resetMaxScrollDepth();
 		}, 0 ); // Defer until after the DOM update
 	};

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -77,6 +77,7 @@ import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { disableAppBanner, enableAppBanner } from 'calypso/state/ui/actions';
 import ReaderFullPostHeader from './header';
 import ReaderFullPostContentPlaceholder from './placeholders/content';
+import ScrollTracker from './scroll-tracker';
 import ReaderFullPostUnavailable from './unavailable';
 
 import './style.scss';
@@ -101,8 +102,6 @@ export class FullPostView extends Component {
 
 	state = {
 		isSuggestedFollowsModalOpen: false,
-		maxScrollDepth: 0, // Track the maximum scroll depth achieved
-		hasCompleted: false, // Track whether the user completed the post
 	};
 
 	openSuggestedFollowsModal = ( followClicked ) => {
@@ -113,6 +112,7 @@ export class FullPostView extends Component {
 	};
 
 	componentDidMount() {
+		this.scrollTracker = new ScrollTracker();
 		// Send page view
 		this.hasSentPageView = false;
 		this.hasLoaded = false;
@@ -141,8 +141,8 @@ export class FullPostView extends Component {
 			document.querySelector( '#primary > div > div.recent-feed > section' ) || // for Recent Feed in Dataview
 			document.querySelector( '#primary > div > div' ); // for Recent Feed in Stream
 		if ( scrollableContainer ) {
-			scrollableContainer.addEventListener( 'scroll', this.setScrollDepth );
-			this.scrollableContainer = scrollableContainer; // Save reference for cleanup
+			this.scrollableContainer = scrollableContainer;
+			this.scrollTracker.setContainer( scrollableContainer );
 			this.resetScroll();
 		}
 	}
@@ -199,9 +199,7 @@ export class FullPostView extends Component {
 
 		// Track scroll depth and remove related instruments
 		this.trackScrollDepth( this.props.post );
-		if ( this.scrollableContainer ) {
-			this.scrollableContainer.removeEventListener( 'scroll', this.setScrollDepth );
-		}
+		this.scrollTracker.cleanup();
 		this.clearResetScrollTimeout();
 	}
 
@@ -282,54 +280,31 @@ export class FullPostView extends Component {
 	resetScroll = () => {
 		this.clearResetScrollTimeout();
 		this.resetScrollTimeout = setTimeout( () => {
-			if ( this.scrollableContainer ) {
-				this.scrollableContainer.scrollTo( {
-					top: 0,
-					left: 0,
-					behavior: 'instant',
-				} );
-			}
-			this.setState( { maxScrollDepth: 0, hasCompleted: false } );
+			this.scrollTracker.resetMaxScrollDepth();
 		}, 0 ); // Defer until after the DOM update
 	};
 
-	setScrollDepth = () => {
-		if ( this.scrollableContainer ) {
-			const scrollTop = this.scrollableContainer.scrollTop ?? 0;
-			const scrollHeight = this.scrollableContainer.scrollHeight ?? 0;
-			const clientHeight = this.scrollableContainer.clientHeight ?? 0;
-
-			const denominator = scrollHeight - clientHeight;
-			const scrollDepth = denominator <= 0 ? 0 : scrollTop / denominator;
-
-			this.setState( ( prevState ) => ( {
-				maxScrollDepth: Math.min( 1, Math.max( 0, prevState.maxScrollDepth || 0, scrollDepth ) ),
-				hasCompleted: prevState.hasCompleted || scrollDepth >= 0.9,
-			} ) );
-		}
-	};
-
 	trackScrollDepth = ( post = null ) => {
-		const { maxScrollDepth } = this.state;
 		if ( ! post ) {
 			post = this.props.post;
 		}
 
 		if ( this.scrollableContainer && post.ID ) {
-			const scrollDepthPercentage = Math.round( maxScrollDepth * 100 );
-
+			const maxScrollDepth = this.scrollTracker.getMaxScrollDepthAsPercentage();
 			recordTrackForPost( 'calypso_reader_article_scroll_depth', post, {
 				context: 'full-post',
-				scroll_depth: scrollDepthPercentage,
+				scroll_depth: maxScrollDepth,
 			} );
 		}
 	};
 
 	trackExitBeforeCompletion = ( post = null ) => {
-		const { hasCompleted, maxScrollDepth } = this.state;
 		if ( ! post ) {
 			post = this.props.post;
 		}
+
+		const maxScrollDepth = this.scrollTracker.getMaxScrollDepthAsPercentage();
+		const hasCompleted = maxScrollDepth >= 90; // User has read 90% of the post
 
 		if ( this.scrollableContainer && post.ID && ! hasCompleted ) {
 			recordTrackForPost( 'calypso_reader_article_exit_before_completion', post, {

--- a/client/blocks/reader-full-post/scroll-tracker.ts
+++ b/client/blocks/reader-full-post/scroll-tracker.ts
@@ -26,10 +26,8 @@ export default class ScrollTracker {
 	 * @param container - The HTML element to track scrolling on, or null to stop tracking
 	 */
 	public setContainer( container: HTMLElement | null ): void {
-		if ( this.container ) {
-			this.container.removeEventListener( 'scroll', this.handleScroll );
-		}
-
+		this.cleanup();
+		this.resetMaxScrollDepth();
 		this.container = container;
 		if ( container ) {
 			container.addEventListener( 'scroll', this.handleScroll );

--- a/client/blocks/reader-full-post/scroll-tracker.ts
+++ b/client/blocks/reader-full-post/scroll-tracker.ts
@@ -1,0 +1,81 @@
+/**
+ * Tracks scroll depth for a container element.
+ */
+export default class ScrollTracker {
+	private container: HTMLElement | null = null;
+	private maxScrollDepth: number = 0;
+
+	private handleScroll = (): void => {
+		if ( ! this.container ) {
+			return;
+		}
+
+		const scrollTop = this.container.scrollTop ?? 0;
+		const scrollHeight = this.container.scrollHeight ?? 0;
+		const clientHeight = this.container.clientHeight ?? 0;
+
+		const denominator = scrollHeight - clientHeight;
+		const scrollDepth = denominator <= 0 ? 0 : scrollTop / denominator;
+
+		this.maxScrollDepth = calcAndClampMaxValue( scrollDepth, this.maxScrollDepth );
+	};
+
+	/**
+	 * Sets the container element to track scrolling on.
+	 * Removes scroll listener from previous container if it exists.
+	 * @param container - The HTML element to track scrolling on, or null to stop tracking
+	 */
+	public setContainer( container: HTMLElement | null ): void {
+		if ( this.container ) {
+			this.container.removeEventListener( 'scroll', this.handleScroll );
+		}
+
+		this.container = container;
+		if ( container ) {
+			container.addEventListener( 'scroll', this.handleScroll );
+		}
+	}
+
+	/**
+	 * Gets the maximum scroll depth reached as a decimal between 0 and 1.
+	 * @returns A number between 0 and 1 representing the maximum scroll depth
+	 */
+	public getMaxScrollDepth(): number {
+		return this.maxScrollDepth;
+	}
+
+	/**
+	 * Gets the maximum scroll depth reached as a percentage between 0 and 100.
+	 * @returns A rounded number between 0 and 100 representing the maximum scroll depth percentage
+	 */
+	public getMaxScrollDepthAsPercentage(): number {
+		return Math.round( this.maxScrollDepth * 100 );
+	}
+
+	/**
+	 * Resets the maximum scroll depth back to 0.
+	 */
+	public resetMaxScrollDepth = (): void => {
+		this.maxScrollDepth = 0;
+	};
+
+	/**
+	 * Removes scroll event listener from container.
+	 * Should be called when tracking is no longer needed.
+	 */
+	public cleanup(): void {
+		if ( this.container ) {
+			this.container.removeEventListener( 'scroll', this.handleScroll );
+		}
+	}
+}
+
+/**
+ * Calculates the maximum value between two numbers and clamps the result between 0 and 1.
+ * @param valueA - First number to compare
+ * @param valueB - Second number to compare
+ * @returns A number between 0 and 1 representing the maximum value between valueA and valueB
+ */
+function calcAndClampMaxValue( valueA: number, valueB: number ): number {
+	return Math.min( 1, Math.max( 0, valueA, valueB ) );
+}

--- a/client/blocks/reader-full-post/test/scroll-tracker.ts
+++ b/client/blocks/reader-full-post/test/scroll-tracker.ts
@@ -1,0 +1,130 @@
+/**
+ * @jest-environment jsdom
+ */
+import ScrollTracker from '../scroll-tracker';
+
+describe( 'ScrollTracker', () => {
+	let scrollTracker;
+	let container;
+
+	beforeEach( () => {
+		scrollTracker = new ScrollTracker();
+		container = document.createElement( 'div' );
+		// Setup scrollable container
+		Object.defineProperties( container, {
+			scrollTop: { value: 0, configurable: true },
+			scrollHeight: { value: 1000, configurable: true },
+			clientHeight: { value: 500, configurable: true },
+		} );
+	} );
+
+	afterEach( () => {
+		scrollTracker.cleanup();
+	} );
+
+	describe( 'getMaxScrollDepth()', () => {
+		it( 'should return 0 when no scrolling has occurred', () => {
+			expect( scrollTracker.getMaxScrollDepth() ).toBe( 0 );
+		} );
+
+		it( 'should return correct depth when scrolled', () => {
+			scrollTracker.setContainer( container );
+			Object.defineProperty( container, 'scrollTop', { value: 250 } );
+			container.dispatchEvent( new Event( 'scroll' ) );
+			expect( scrollTracker.getMaxScrollDepth() ).toBe( 0.5 );
+		} );
+
+		it( 'should return the highest depth reached', () => {
+			scrollTracker.setContainer( container );
+
+			Object.defineProperty( container, 'scrollTop', { value: 375 } );
+			container.dispatchEvent( new Event( 'scroll' ) );
+
+			Object.defineProperty( container, 'scrollTop', { value: 250 } );
+			container.dispatchEvent( new Event( 'scroll' ) );
+
+			expect( scrollTracker.getMaxScrollDepth() ).toBe( 0.75 );
+		} );
+
+		it( 'should reset when container changes', () => {
+			scrollTracker.setContainer( container );
+			Object.defineProperty( container, 'scrollTop', { value: 250 } );
+			container.dispatchEvent( new Event( 'scroll' ) );
+
+			const newContainer = document.createElement( 'div' );
+			Object.defineProperties( newContainer, {
+				scrollTop: { value: 0, configurable: true },
+				scrollHeight: { value: 1000, configurable: true },
+				clientHeight: { value: 500, configurable: true },
+			} );
+			scrollTracker.setContainer( newContainer );
+
+			expect( scrollTracker.getMaxScrollDepth() ).toBe( 0 );
+		} );
+	} );
+
+	describe( 'getMaxScrollDepthAsPercentage()', () => {
+		it( 'should return 0 when no scrolling has occurred', () => {
+			expect( scrollTracker.getMaxScrollDepthAsPercentage() ).toBe( 0 );
+		} );
+
+		it( 'should return the correct percentage when scrolled', () => {
+			scrollTracker.setContainer( container );
+			Object.defineProperty( container, 'scrollTop', { value: 250 } );
+			container.dispatchEvent( new Event( 'scroll' ) );
+			expect( scrollTracker.getMaxScrollDepthAsPercentage() ).toBe( 50 );
+		} );
+
+		it( 'should return the highest percentage reached', () => {
+			scrollTracker.setContainer( container );
+
+			Object.defineProperty( container, 'scrollTop', { value: 375 } );
+			container.dispatchEvent( new Event( 'scroll' ) );
+
+			Object.defineProperty( container, 'scrollTop', { value: 250 } );
+			container.dispatchEvent( new Event( 'scroll' ) );
+
+			expect( scrollTracker.getMaxScrollDepthAsPercentage() ).toBe( 75 );
+		} );
+	} );
+
+	describe( 'setContainer()', () => {
+		it( 'should track scroll events on the new container', () => {
+			scrollTracker.setContainer( container );
+			Object.defineProperty( container, 'scrollTop', { value: 250 } );
+			container.dispatchEvent( new Event( 'scroll' ) );
+			expect( scrollTracker.getMaxScrollDepthAsPercentage() ).toBe( 50 );
+		} );
+
+		it( 'should stop tracking previous container when setting new one', () => {
+			const oldContainer = document.createElement( 'div' );
+			Object.defineProperties( oldContainer, {
+				scrollTop: { value: 0, configurable: true },
+				scrollHeight: { value: 1000, configurable: true },
+				clientHeight: { value: 500, configurable: true },
+			} );
+
+			scrollTracker.setContainer( oldContainer );
+			Object.defineProperty( oldContainer, 'scrollTop', { value: 250 } );
+			oldContainer.dispatchEvent( new Event( 'scroll' ) );
+
+			scrollTracker.setContainer( container );
+			Object.defineProperty( oldContainer, 'scrollTop', { value: 375 } );
+			oldContainer.dispatchEvent( new Event( 'scroll' ) );
+
+			expect( scrollTracker.getMaxScrollDepthAsPercentage() ).toBe( 0 );
+		} );
+	} );
+
+	describe( 'cleanup()', () => {
+		it( 'should stop tracking scroll events', () => {
+			scrollTracker.setContainer( container );
+			scrollTracker.cleanup();
+
+			Object.defineProperty( container, 'scrollTop', { value: 250 } );
+			container.dispatchEvent( new Event( 'scroll' ) );
+
+			expect( scrollTracker.getMaxScrollDepthAsPercentage() ).toBe( 0 );
+		} );
+	} );
+} );

--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -18,6 +18,7 @@ body.is-reader-full-post {
 	);
 
 	height: $feed-content-height !important; // Using !important here to avoid having a lengthy selector.
+	overflow-y: hidden !important; // Keeps the scrolling container consistent between one and two column layouts.
 
 	@media ( min-width: $break-wide ) {
 		display: flex;
@@ -200,6 +201,7 @@ body.is-reader-full-post {
 		@extend %column-shared;
 		display: none;
 		overflow-y: auto;
+		height: 100%;
 
 		&.overlay {
 			display: block;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/loop#300

## Proposed Changes

* Fixes large values for scroll depth in future Tracks events, keeping them as a percentage between 0 and 100
* Tracks scroll depth on mobile and desktop viewports
* Tracks scroll depth on both stream and two-column views
* Separates the scroll tracking logic into its own class that's composed into the React component. This removes the need to component state, reducing re-renders drastically.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Some of the values in Tracks were above 100, indicating there was a bug in the calculation.
* The events weren't being sent to Tracks depending on how the component was rendered, specifically in a mobile viewport. Now the events are sent in every rendering of the full post component.
* Separating out the scroll tracking from the component rendering meant we don't need to re-render the component whenever a scroll value changed, improving performance.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/read` and navigate between full post views
- Make sure to test both the stream and two-column layout, as well as mobile and desktop
- When you navigate away from the post, you should see the track event `calypso_reader_article_scroll_depth` logged
- If the scroll depth doesn't go past 90% then a track event `calypso_reader_article_exit_before_completion` should also be logged.
- You should be able to see these events on tracks after 5 mins
- To see them live, I suggest adding console.log to the `recordTrackForPost` method.
- Make sure all track values represent a percentage (0-100); they should be whole numbers.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
