### PR TITLE
i18n: Remove redundant `hasTranslation` checks (across the codebase)

### DIFF
--- a/client/components/domains/use-my-domain/domain-input.jsx
+++ b/client/components/domains/use-my-domain/domain-input.jsx
@@ -1,6 +1,5 @@
 import { Card, Button, FormInputValidation, Gridicon } from '@automattic/components';
-import { englishLocales, useLocale } from '@automattic/i18n-utils';
-import { __, hasTranslation } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
 import PropTypes from 'prop-types';
 import { useEffect, useRef } from 'react';
@@ -25,7 +24,6 @@ function UseMyDomainInput( {
 	validationError,
 } ) {
 	const domainNameInput = useRef( null );
-	const locale = useLocale();
 
 	useEffect( () => {
 		shouldSetFocus && domainNameInput.current.focus();
@@ -47,12 +45,6 @@ function UseMyDomainInput( {
 		}
 	};
 
-	const hasDomainPlaceholderLabel =
-		englishLocales.includes( locale ) || hasTranslation( 'yourgroovydomain.com' );
-	const domainPlaceholderLabel = hasDomainPlaceholderLabel
-		? __( 'yourgroovydomain.com' )
-		: __( 'mydomain.com' );
-
 	return (
 		<Card className={ baseClassName }>
 			{ ! isSignupStep && (
@@ -64,7 +56,7 @@ function UseMyDomainInput( {
 				<label>{ __( 'Enter the domain you would like to use:' ) }</label>
 				<FormFieldset className={ baseClassName + '__domain-input-fieldset' }>
 					<FormTextInput
-						placeholder={ domainPlaceholderLabel }
+						placeholder={ __( 'yourgroovydomain.com' ) }
 						value={ domainName }
 						onChange={ onChange }
 						onKeyDown={ keyDown }

--- a/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
@@ -1,5 +1,5 @@
 import { TERM_MONTHLY } from '@automattic/calypso-products';
-import i18n, { TranslateResult, getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import type { Duration } from 'calypso/my-sites/plans/jetpack-plans/types';
@@ -119,42 +119,18 @@ const PartialDiscountTimeFrame: React.FC< PartialDiscountTimeFrameProps & A11yPr
 
 	/* eslint-disable wpcalypso/i18n-mismatched-placeholders */
 	if ( billingTerm === TERM_MONTHLY ) {
-		if (
-			getLocaleSlug() === 'en' ||
-			getLocaleSlug() === 'en-gb' ||
-			i18n.hasTranslation( 'for the first month, then %(original_price)s /month, billed monthly' )
-		) {
-			text = translate(
-				'for the first month, then %(original_price)s /month, billed monthly',
-				'for the first %(months)d months, then %(original_price)s /month, billed monthly',
-				opts
-			);
-		} else {
-			text = translate(
-				'for the first month, billed monthly',
-				'for the first %(months)d months, billed monthly',
-				opts
-			);
-		}
+		text = translate(
+			'for the first month, then %(original_price)s /month, billed monthly',
+			'for the first %(months)d months, then %(original_price)s /month, billed monthly',
+			opts
+		);
 	} else {
 		// eslint-disable-next-line no-lonely-if
-		if (
-			getLocaleSlug() === 'en' ||
-			getLocaleSlug() === 'en-gb' ||
-			i18n.hasTranslation( 'for the first month, then %(original_price)s /month, billed yearly' )
-		) {
-			text = translate(
-				'for the first month, then %(original_price)s /month, billed yearly',
-				'for the first %(months)d months, then %(original_price)s /month, billed yearly',
-				opts
-			);
-		} else {
-			text = translate(
-				'for the first month, billed yearly',
-				'for the first %(months)d months, billed yearly',
-				opts
-			);
-		}
+		text = translate(
+			'for the first month, then %(original_price)s /month, billed yearly',
+			'for the first %(months)d months, then %(original_price)s /month, billed yearly',
+			opts
+		);
 	}
 
 	if ( forScreenReader ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
@@ -1,4 +1,3 @@
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { IntentScreen, GOOGLE_TRANSFER } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { Icon, unlock, plus, payment } from '@wordpress/icons';
@@ -12,8 +11,7 @@ interface Props {
 }
 
 const Intro: React.FC< Props > = ( { onSubmit, variantSlug } ) => {
-	const { __, hasTranslation } = useI18n();
-	const isEnglishLocale = useIsEnglishLocale();
+	const { __ } = useI18n();
 	const isGoogleDomainsTransferFlow = GOOGLE_TRANSFER === variantSlug;
 
 	return (
@@ -63,16 +61,9 @@ const Intro: React.FC< Props > = ( { onSubmit, variantSlug } ) => {
 							: __( 'We pay the first year for Google domains' ),
 						description: (
 							<p>
-								{ isEnglishLocale ||
-								hasTranslation(
+								{ __(
 									"Review your payment and contact details. If you're transferring a domain from Squarespace, we'll pay for an additional year of registration if your domain was registered before July 1, 2023."
-								)
-									? __(
-											"Review your payment and contact details. If you're transferring a domain from Squarespace, we'll pay for an additional year of registration if your domain was registered before July 1, 2023."
-									  )
-									: __(
-											"Review your payment and contact details. If you're transferring a domain from Google, we'll pay for an additional year of registration."
-									  ) }
+								) }
 							</p>
 						),
 						icon: <Icon icon={ payment } />,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
@@ -1,8 +1,6 @@
-import { englishLocales } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSiteDomains } from '../../../../hooks/use-site-domains';
@@ -17,8 +15,7 @@ const WarningsOrHoldsSection = styled.div`
 
 const ErrorStep: Step = function ErrorStep( { navigation } ) {
 	const { goBack, goNext } = navigation;
-	const translate = useTranslate();
-	const { __, hasTranslation } = useI18n();
+	const { __ } = useI18n();
 	const siteDomains = useSiteDomains();
 	const siteSetupError = useSiteSetupError();
 
@@ -29,21 +26,8 @@ const ErrorStep: Step = function ErrorStep( { navigation } ) {
 	}
 
 	const messageCopy = () => {
-		// New copy waiting on translation.
-		if (
-			englishLocales.includes( translate?.localeSlug || '' ) ||
-			hasTranslation(
-				'It looks like something went wrong while setting up your site. Please contact support so that we can help you out.'
-			)
-		) {
-			return __(
-				'It looks like something went wrong while setting up your site. Please contact support so that we can help you out.'
-			);
-		}
-
-		// Original copy
 		return __(
-			'It looks like something went wrong while setting up your store. Please contact support so that we can help you out.'
+			'It looks like something went wrong while setting up your site. Please contact support so that we can help you out.'
 		);
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/access-method-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/access-method-picker.tsx
@@ -1,7 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { FormLabel } from '@automattic/components';
-import { useLocale } from '@automattic/i18n-utils';
-import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
 import { Controller } from 'react-hook-form';
@@ -10,16 +8,10 @@ import { CredentialsFormFieldProps } from '../types';
 
 export const AccessMethodPicker: FC< CredentialsFormFieldProps > = ( { control } ) => {
 	const translate = useTranslate();
-	const locale = useLocale();
-
 	const applicationPasswordEnabled = isEnabled( 'automated-migration/application-password' );
-	const hasLabelTranslation =
-		locale.startsWith( 'en' ) || hasTranslation( 'WordPress site credentials' );
-
-	const credentialsLabel =
-		applicationPasswordEnabled && hasLabelTranslation
-			? translate( 'WordPress site credentials' )
-			: translate( 'WordPress credentials' );
+	const credentialsLabel = applicationPasswordEnabled
+		? translate( 'WordPress site credentials' )
+		: translate( 'WordPress credentials' );
 
 	return (
 		<div>

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -1,12 +1,11 @@
 import { Button } from '@automattic/components';
-import { localizeUrl, englishLocales } from '@automattic/i18n-utils';
+import { localizeUrl } from '@automattic/i18n-utils';
 import {
 	SETTING_PRIMARY_DOMAIN,
 	INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS,
 	GDPR_POLICIES,
 	DOMAIN_EXPIRATION_AUCTION,
 } from '@automattic/urls';
-import i18n, { getLocaleSlug } from 'i18n-calypso';
 import moment from 'moment';
 import { useMyDomainInputMode } from 'calypso/components/domains/connect-domain-step/constants';
 import { isExpiringSoon } from 'calypso/lib/domains/utils/is-expiring-soon';
@@ -508,49 +507,26 @@ export function resolveDomainStatus(
 				domain.transferStatus === transferStatus.COMPLETED &&
 				! domain.pointsToWpcom
 			) {
-				const hasTranslation =
-					englishLocales.includes( String( getLocaleSlug() ) ) ||
-					i18n.hasTranslation(
-						'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need to {{a}}point it to WordPress.com.{{/a}}'
-					);
-
-				const oldCopy = translate(
-					'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need to {{a}}point it to WordPress.com name servers.{{/a}}',
-					{
-						components: {
-							strong: <strong />,
-							a: (
-								<a
-									href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute, {
-										nameservers: true,
-									} ) }
-								/>
-							),
-						},
-					}
-				);
-
-				const newCopy = translate(
-					'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need to {{a}}point it to WordPress.com.{{/a}}',
-					{
-						components: {
-							strong: <strong />,
-							a: (
-								<a
-									href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute, {
-										nameservers: true,
-									} ) }
-								/>
-							),
-						},
-					}
-				);
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-success',
 					status: translate( 'Active' ),
 					icon: 'info',
-					noticeText: hasTranslation ? newCopy : oldCopy,
+					noticeText: translate(
+						'{{strong}}Transfer successful!{{/strong}} To make this domain work with your WordPress.com site you need to {{a}}point it to WordPress.com.{{/a}}',
+						{
+							components: {
+								strong: <strong />,
+								a: (
+									<a
+										href={ domainManagementEdit( siteSlug as string, domain.domain, currentRoute, {
+											nameservers: true,
+										} ) }
+									/>
+								),
+							},
+						}
+					),
 					listStatusWeight: 600,
 					isDismissable: true,
 				};

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -1,6 +1,4 @@
 import { FormLabel } from '@automattic/components';
-import { englishLocales } from '@automattic/i18n-utils';
-import { hasTranslation } from '@wordpress/i18n';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
@@ -132,21 +130,14 @@ class RequestLoginEmailForm extends Component {
 	}
 
 	getSubHeaderText() {
-		const { translate, locale, subHeaderText } = this.props;
+		const { translate, subHeaderText } = this.props;
 		const siteName = this.state.site?.name;
 
 		if ( subHeaderText ) {
 			return subHeaderText;
 		}
 
-		// If we have a siteName and new translation is available
-		if (
-			siteName &&
-			( englishLocales.includes( locale ) ||
-				hasTranslation(
-					'We’ll send you an email with a login link that will log you in right away to {site name}.'
-				) )
-		) {
+		if ( siteName ) {
 			return translate(
 				'We’ll send you an email with a login link that will log you in right away to %(siteName)s.',
 				{
@@ -157,19 +148,8 @@ class RequestLoginEmailForm extends Component {
 			);
 		}
 
-		// If no siteName but new translation is available
-		if (
-			englishLocales.includes( locale ) ||
-			hasTranslation( 'We’ll send you an email with a login link that will log you in right away.' )
-		) {
-			return translate(
-				'We’ll send you an email with a login link that will log you in right away.'
-			);
-		}
-
-		// Fallback is old text
 		return translate(
-			'Get a link sent to the email address associated with your account to log in instantly without your password.'
+			'We’ll send you an email with a login link that will log you in right away.'
 		);
 	}
 
@@ -187,7 +167,6 @@ class RequestLoginEmailForm extends Component {
 			hideSubHeaderText,
 			inputPlaceholder,
 			submitButtonLabel,
-			locale,
 			customFormLabel,
 			onSubmitEmail,
 			errorMessage,
@@ -223,16 +202,11 @@ class RequestLoginEmailForm extends Component {
 				? requestError
 				: translate( 'Unable to complete request' );
 
-		const buttonLabel =
-			englishLocales.includes( locale ) || hasTranslation( 'Send Link' )
-				? translate( 'Send link' )
-				: translate( 'Get Link' );
+		const buttonLabel = translate( 'Send link' );
 
-		const formLabel =
-			customFormLabel ||
-			( hasTranslation( 'Email address or username' )
-				? this.props.translate( 'Email address or username' )
-				: this.props.translate( 'Email Address or Username' ) );
+		const formLabel = customFormLabel
+			? this.props.translate( 'Email address or username' )
+			: this.props.translate( 'Email Address or Username' );
 
 		const onSubmit = onSubmitEmail
 			? ( e ) => onSubmitEmail( this.getUsernameOrEmailFromState(), e )

--- a/client/me/account/toggle-sites-as-landing-page.tsx
+++ b/client/me/account/toggle-sites-as-landing-page.tsx
@@ -1,4 +1,3 @@
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -33,22 +32,15 @@ function ToggleSitesAsLandingPage() {
 		);
 	}
 
-	const oldCopy = translate( 'Show me all my sites when logging in to WordPress.com' );
-	const updatedCopy = translate(
-		'Display all my sites instead of just my primary site when I visit WordPress.com.'
-	);
-
-	const hasTranslationForNewCopy = useHasEnTranslation()(
-		'Display all my sites instead of just my primary site when I visit WordPress.com.'
-	);
-
 	return (
 		<div>
 			<ToggleControl
 				checked={ !! useSitesAsLandingPage }
 				onChange={ handleToggle }
 				disabled={ isSaving }
-				label={ hasTranslationForNewCopy ? updatedCopy : oldCopy }
+				label={ translate(
+					'Display all my sites instead of just my primary site when I visit WordPress.com.'
+				) }
 			/>
 		</div>
 	);

--- a/client/me/developer/dev-survey-notice.tsx
+++ b/client/me/developer/dev-survey-notice.tsx
@@ -1,6 +1,5 @@
 import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
-import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import surveyImage from 'calypso/assets/images/illustrations/developer-survey.svg';
 
@@ -19,8 +18,6 @@ export const DeveloperSurveyNotice = ( {
 	localeSlug,
 }: DeveloperSurveyNoticeProps ) => {
 	const translate = useTranslate();
-	const { hasTranslation } = useI18n();
-
 	const href =
 		localeSlug === 'es'
 			? 'https://wordpressdotcom.survey.fm/developer-survey-es'
@@ -61,9 +58,7 @@ export const DeveloperSurveyNotice = ( {
 							variant="tertiary"
 							onClick={ () => onClose( ONE_DAY_IN_SECONDS, 'remind-later-button' ) }
 						>
-							{ hasTranslation( 'Maybe later' ) || localeSlug === 'en'
-								? translate( 'Maybe later' )
-								: translate( 'Remind later' ) }
+							{ translate( 'Maybe later' ) }
 						</Button>
 						<Button
 							variant="primary"

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -1,5 +1,5 @@
 import { Card, FormLabel } from '@automattic/components';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -56,7 +56,7 @@ class NotificationSubscriptions extends Component {
 	}
 
 	render() {
-		const { locale, teams } = this.props;
+		const { teams } = this.props;
 		const isAutomattician = isAutomatticTeamMember( teams );
 
 		return (
@@ -210,11 +210,7 @@ class NotificationSubscriptions extends Component {
 						</FormFieldset>
 
 						<FormFieldset>
-							<FormLegend>
-								{ locale === 'en' || i18n.hasTranslation( 'Pause emails' )
-									? this.props.translate( 'Pause emails' )
-									: this.props.translate( 'Block emails' ) }
-							</FormLegend>
+							<FormLegend>{ this.props.translate( 'Pause emails' ) }</FormLegend>
 							<FormLabel>
 								<FormCheckbox
 									checked={ this.props.getSetting( 'subscription_delivery_email_blocked' ) }
@@ -230,16 +226,11 @@ class NotificationSubscriptions extends Component {
 									) }
 								</span>
 							</FormLabel>
-							{ ( locale === 'en' ||
-								i18n.hasTranslation(
+							<FormSettingExplanation>
+								{ this.props.translate(
 									'Newsletters are sent via WordPress.com. If you pause emails, you will not receive newsletters from the sites you are subscribed to.'
-								) ) && (
-								<FormSettingExplanation>
-									{ this.props.translate(
-										'Newsletters are sent via WordPress.com. If you pause emails, you will not receive newsletters from the sites you are subscribed to.'
-									) }
-								</FormSettingExplanation>
-							) }
+								) }
+							</FormSettingExplanation>
 						</FormFieldset>
 
 						{ isAutomattician && (

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -1,7 +1,7 @@
 import { isDomainRegistration } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Card, CompactCard, FormLabel } from '@automattic/components';
-import i18n, { getLocaleSlug, localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { map, find } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
@@ -122,30 +122,16 @@ class ConfirmCancelDomain extends Component {
 			}
 
 			if ( error ) {
-				if (
-					getLocaleSlug() === 'en' ||
-					getLocaleSlug() === 'en-gb' ||
-					i18n.hasTranslation(
-						'Unable to cancel your purchase. Please try again later or {{a}}contact support{{/a}}.'
+				this.props.errorNotice(
+					translate(
+						'Unable to cancel your purchase. Please try again later or {{a}}contact support{{/a}}.',
+						{
+							components: {
+								a: <ActionPanelLink href="/help/contact" />,
+							},
+						}
 					)
-				) {
-					this.props.errorNotice(
-						translate(
-							'Unable to cancel your purchase. Please try again later or {{a}}contact support{{/a}}.',
-							{
-								components: {
-									a: <ActionPanelLink href="/help/contact" />,
-								},
-							}
-						)
-					);
-				} else {
-					this.props.errorNotice(
-						translate(
-							'Unable to cancel your purchase. Please try again later or contact support.'
-						)
-					);
-				}
+				);
 
 				return;
 			}

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { getAllFeaturesForPlan } from '@automattic/calypso-products/';
 import { JetpackLogo, FoldableCard } from '@automattic/components';
 import { GeneratorModal } from '@automattic/jetpack-ai-calypso';
-import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { connect, useSelector } from 'react-redux';
 import { useDebouncedCallback } from 'use-debounce';
@@ -242,13 +242,7 @@ export const QuickLinks = ( {
 						href="https://wp.me/logo-maker/?utm_campaign=my_home"
 						onClick={ trackDesignLogoAction }
 						target="_blank"
-						label={
-							getLocaleSlug() === 'en' ||
-							getLocaleSlug() === 'en-gb' ||
-							i18n.hasTranslation( 'Create a logo with Fiverr' )
-								? translate( 'Create a logo with Fiverr' )
-								: translate( 'Create a logo' )
-						}
+						label={ translate( 'Create a logo with Fiverr' ) }
 						external
 						iconSrc={ fiverrIcon }
 					/>

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
@@ -6,7 +6,7 @@ import {
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { useDomainSuggestions } from '@automattic/domain-picker/src';
-import { useHasEnTranslation, useLocale } from '@automattic/i18n-utils';
+import { useLocale } from '@automattic/i18n-utils';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useMemo } from '@wordpress/element';
 import { Icon, lock } from '@wordpress/icons';
@@ -147,7 +147,7 @@ export function RenderDomainUpsell( { isFreePlan, isMonthlyPlan, searchTerm, sit
 			? translate( 'That perfect domain is waiting' )
 			: translate( 'Own a domain. Build a site.' );
 
-	const updatedCopy = translate(
+	const cardSubtitleFreePlansCopy = translate(
 		'{{strong}}%(domainSuggestion)s{{/strong}} is a perfect site address. It’s available, easy to find, share, and follow. Get it now and claim a corner of the web.',
 		{
 			components: {
@@ -159,25 +159,6 @@ export function RenderDomainUpsell( { isFreePlan, isMonthlyPlan, searchTerm, sit
 			},
 		}
 	);
-
-	const oldCopy = translate(
-		"{{strong}}%(domainSuggestion)s{{/strong}} is a perfect site address. It's available and easy to find and follow. Get it now and claim a corner of the web.",
-		{
-			components: {
-				strong: <strong />,
-			},
-			args: {
-				domainSuggestion: domainSuggestionName,
-				domainPrice: domainProductCost,
-			},
-		}
-	);
-
-	const hasTranslationForNewCopy = useHasEnTranslation()(
-		"{{strong}}%(domainSuggestion)s{{/strong}} is the perfect site address. It's available and easy to find and follow. And .com, .net, and .org domains start at just %(domainPrice)s—Get it now and claim a corner of the web."
-	);
-
-	const cardSubtitleFreePlansCopy = hasTranslationForNewCopy ? updatedCopy : oldCopy;
 
 	const cardSubtitle =
 		! isFreePlan && ! isMonthlyPlan

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -1,7 +1,7 @@
 import { PLAN_100_YEARS, domainProductSlugs, isFreePlan } from '@automattic/calypso-products';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import clsx from 'clsx';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { domainAddNew, domainUseMyDomain } from 'calypso/my-sites/domains/paths';
@@ -20,9 +20,7 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 
 	const siteHasHundredYearPlan = selectedSite?.plan?.product_slug === PLAN_100_YEARS;
 
-	let title = i18n.hasTranslation( 'Get your free domain' )
-		? translate( 'Get your free domain' )
-		: translate( 'Get your domain' );
+	let title = translate( 'Get your free domain' );
 	let line = translate(
 		'Get a free one-year domain registration or transfer with any annual paid plan.'
 	);

--- a/client/my-sites/domains/domain-management/settings/cards/transferred-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/transferred-domain-details.tsx
@@ -1,9 +1,8 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 import { Button } from '@automattic/components';
-import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { INCOMING_DOMAIN_TRANSFER_STATUSES } from '@automattic/urls';
-import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { useMyDomainInputMode } from 'calypso/components/domains/connect-domain-step/constants';
 import { transferStatus } from 'calypso/lib/domains/constants';
@@ -18,7 +17,6 @@ const TransferredDomainDetails = ( {
 	selectedSite,
 }: DetailsCardProps ) => {
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
 
 	const getStartTransferHref = ( siteSlug: string, domainName: string ) => {
 		return domainUseMyDomain( siteSlug, {
@@ -142,19 +140,10 @@ const TransferredDomainDetails = ( {
 				  );
 		}
 
-		return hasTranslation(
+		return translate(
 			'Your transfer has been started and is waiting for authorization from your current ' +
 				"domain provider. Your current domain provider should allow you to speed this process up, either through their website or an email they've already sent you."
-		) || isEnglishLocale
-			? translate(
-					'Your transfer has been started and is waiting for authorization from your current ' +
-						"domain provider. Your current domain provider should allow you to speed this process up, either through their website or an email they've already sent you."
-			  )
-			: translate(
-					'Your transfer has been started and is waiting for authorization from your current ' +
-						'domain provider. This process can take up to 7 days. If you need to cancel or expedite the ' +
-						'transfer please contact them for assistance.'
-			  );
+		);
 	};
 
 	return (

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -1,10 +1,9 @@
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
-import { englishLocales } from '@automattic/i18n-utils';
 import { useEffect, useState } from '@wordpress/element';
 import { Icon, info } from '@wordpress/icons';
 import { removeQueryArgs } from '@wordpress/url';
-import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Accordion from 'calypso/components/domains/accordion';
@@ -481,20 +480,10 @@ const Settings = ( {
 			return null;
 		}
 
-		let translatedTitle;
-		if (
-			englishLocales.includes( getLocaleSlug() || '' ) ||
-			i18n.hasTranslation( 'Domain forwarding' )
-		) {
-			translatedTitle = translate( 'Domain forwarding', { textOnly: true } );
-		} else {
-			translatedTitle = translate( 'Domain Forwarding', { textOnly: true } );
-		}
-
 		return (
 			<Accordion
 				className="domain-forwarding-card__accordion"
-				title={ translatedTitle }
+				title={ translate( 'Domain forwarding', { textOnly: true } ) }
 				subtitle={ translate( 'Forward your domain to another' ) }
 				isDisabled={ domain.isMoveToNewSitePending }
 			>

--- a/client/my-sites/patterns/components/get-started/index.tsx
+++ b/client/my-sites/patterns/components/get-started/index.tsx
@@ -1,4 +1,4 @@
-import { useHasEnTranslation, useLocalizeUrl, useLocale } from '@automattic/i18n-utils';
+import { useLocalizeUrl, useLocale } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import imagePreviewPublish from 'calypso/my-sites/patterns/components/get-started/images/preview-publish.png';
@@ -16,7 +16,6 @@ export function PatternsGetStarted( { theme }: { theme?: 'dark' | 'blue' } ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const localizeUrl = useLocalizeUrl();
 	const locale = useLocale();
-	const hasTranslation = useHasEnTranslation();
 
 	return (
 		<PatternsSection
@@ -114,16 +113,10 @@ export function PatternsGetStarted( { theme }: { theme?: 'dark' | 'blue' } ) {
 					/>
 					<div className="patterns-get-started__item-name">{ translate( 'Free course' ) }</div>
 					<div className="patterns-get-started__item-description">
-						{ hasTranslation( 'Launch your site faster' ) &&
-							translate( 'Launch Your Site Faster', {
-								comment:
-									'This string is taken from the first line of the page content from https://wordpress.com/learn/courses/quick-launch/',
-							} ) }
-						{ ! hasTranslation( 'Launch your site faster' ) &&
-							translate( 'Design Your Homepage', {
-								comment:
-									'This string is a copy of the page title from wordpress.com/learn/webinars/compelling-homepages/',
-							} ) }
+						{ translate( 'Launch Your Site Faster', {
+							comment:
+								'This string is taken from the first line of the page content from https://wordpress.com/learn/courses/quick-launch/',
+						} ) }
 					</div>
 				</a>
 			</div>

--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -1,11 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
-import {
-	useLocale,
-	addLocaleToPathLocaleInFront,
-	useHasEnTranslation,
-} from '@automattic/i18n-utils';
+import { useLocale, addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { Icon, category as iconCategory } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -93,7 +89,6 @@ export const PatternLibrary = ( {
 }: PatternLibraryProps ) => {
 	const locale = useLocale();
 	const translate = useTranslate();
-	const hasTranslation = useHasEnTranslation();
 	const navRef = useRef< HTMLDivElement >( null );
 	const readymadeTemplateSectionRef = useRef< HTMLDivElement >( null );
 
@@ -248,18 +243,6 @@ export const PatternLibrary = ( {
 		} );
 	}
 
-	const pageLayoutsHeading = hasTranslation( 'Beautiful, curated page layouts' )
-		? translate( 'Beautiful, curated page layouts', {
-				comment:
-					'Heading text for a section in the Pattern Library with links to block pattern categories containing page layouts',
-				textOnly: true,
-		  } )
-		: translate( 'Beautifully curated page layouts', {
-				comment:
-					'Heading text for a section in the Pattern Library with links to block pattern categories containing page layouts',
-				textOnly: true,
-		  } );
-
 	return (
 		<>
 			{ isHomePage ? (
@@ -390,7 +373,11 @@ export const PatternLibrary = ( {
 				{ isHomePage && (
 					<>
 						<CategoryGallery
-							title={ pageLayoutsHeading }
+							title={ translate( 'Beautiful, curated page layouts', {
+								comment:
+									'Heading text for a section in the Pattern Library with links to block pattern categories containing page layouts',
+								textOnly: true,
+							} ) }
 							description={ translate(
 								'Our page layouts are exactly what you need to easily create professional-looking pages using preassembled patterns.'
 							) }

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -1,13 +1,11 @@
 import { PatternRenderer } from '@automattic/block-renderer';
 import { usePatternsRendererContext } from '@automattic/block-renderer/src/components/patterns-renderer-context';
 import { Button } from '@automattic/components';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { isMobile } from '@automattic/viewport';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { ResizableBox, Tooltip } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { Icon, check, copy, lock } from '@wordpress/icons';
-import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { useRtl, useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState } from 'react';
@@ -124,8 +122,6 @@ function PatternPreviewFragment( {
 	}
 
 	const translate = useTranslate();
-	const isEnglish = useIsEnglishLocale();
-	const { hasTranslation } = useI18n();
 
 	const titleTooltipText = isPermalinkCopied
 		? translate( 'Copied link to pattern', {
@@ -148,19 +144,11 @@ function PatternPreviewFragment( {
 		  } );
 
 	if ( isPatternCopied ) {
-		const patternCopiedText =
-			isEnglish || hasTranslation( 'Pattern copied' )
-				? translate( 'Pattern copied', {
-						comment: 'Button label for when a pattern was just copied',
-						textOnly: true,
-				  } )
-				: translate( 'Pattern copied!', {
-						comment: 'Button label for when a pattern was just copied',
-						textOnly: true,
-				  } );
-
 		copyButtonText = isPreviewLarge
-			? patternCopiedText
+			? translate( 'Pattern copied', {
+					comment: 'Button label for when a pattern was just copied',
+					textOnly: true,
+			  } )
 			: translate( 'Copied', {
 					comment: 'Button label for when a pattern was just copied',
 					textOnly: true,

--- a/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.tsx
+++ b/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.tsx
@@ -10,9 +10,7 @@ import { PlanPrice } from '@automattic/components';
 import Card from '@automattic/components/src/card';
 import { Plans } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { CustomSelectControl } from '@wordpress/components';
-import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode, useState } from 'react';
 import './style.scss';
@@ -145,7 +143,6 @@ export function EntrepreneurPlan( props: EntrepreneurPlanProps ) {
 	const translate = useTranslate();
 	const selectedSite = useSelector( getSelectedSite );
 	const plans = useEntrepreneurPlanPrices();
-	const isEnglish = useIsEnglishLocale();
 	const [ selectedInterval, setSelectedInterval ] = useState< PlanKeys >( 'PLAN_ECOMMERCE' );
 	const selectedPlan = plans[ selectedInterval ];
 
@@ -177,17 +174,13 @@ export function EntrepreneurPlan( props: EntrepreneurPlanProps ) {
 		setSelectedInterval( key );
 	};
 
-	const hasNewTitleTranslation = hasTranslation( "What's included in your free trial:" );
-	const titleTranslation =
-		isEnglish || hasNewTitleTranslation
-			? translate( "What's included in your free trial:" )
-			: translate( "What's included in your free trial" );
-
 	return (
 		<>
 			{ ! hideTrialIncluded && (
 				<>
-					<h2 className="entrepreneur-trial-plan__section-title">{ titleTranslation }</h2>
+					<h2 className="entrepreneur-trial-plan__section-title">
+						{ translate( "What's included in your free trial:" ) }
+					</h2>
 					<div className="entrepreneur-trial-plan__included-wrapper">
 						<EcommerceTrialIncluded displayAll />
 					</div>
@@ -212,22 +205,17 @@ export function EntrepreneurPlan( props: EntrepreneurPlanProps ) {
 							{ getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '' }
 						</h3>
 						<p className="card-text">
-							{ isEnglish ||
-							hasTranslation(
-								"Secure the full benefits of the %(planName)s plan. Purchase today and maximize your store's potential!"
-							)
-								? // translators: %(planName)s is a plan name. E.g. Commerce plan.
-								  translate(
-										"Secure the full benefits of the %(planName)s plan. Purchase today and maximize your store's potential!",
-										{
-											args: {
-												planName: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
-											},
-										}
-								  )
-								: translate(
-										"Secure the full benefits of the Entrepreneur plan. Purchase today and maximize your store's potential!"
-								  ) }
+							{
+								// translators: %(planName)s is a plan name. E.g. Commerce plan.
+								translate(
+									"Secure the full benefits of the %(planName)s plan. Purchase today and maximize your store's potential!",
+									{
+										args: {
+											planName: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+										},
+									}
+								)
+							}
 						</p>
 					</div>
 					<div className="price-block">

--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
@@ -8,8 +8,6 @@ import {
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { Plans } from '@automattic/data-stores';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
 import { getPlanCartItem } from 'calypso/lib/cart-values/cart-items';
@@ -46,8 +44,6 @@ export function WooExpressPlans( props: WooExpressPlansProps ) {
 		yearlyControlProps,
 	} = props;
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
-
 	const pricingMeta = Plans.usePricingMetaForGridPlans( {
 		planSlugs: [ PLAN_WOOEXPRESS_MEDIUM, PLAN_WOOEXPRESS_MEDIUM_MONTHLY ],
 		siteId,
@@ -74,28 +70,16 @@ export function WooExpressPlans( props: WooExpressPlansProps ) {
 				...yearlyControlProps,
 				content: (
 					<span>
-						{ isEnglishLocale ||
-						hasTranslation( 'Pay Annually {{span}}(Save %(percentageSavings)s%%){{/span}}' )
-							? translate( 'Pay Annually {{span}}(Save %(percentageSavings)s%%){{/span}}', {
-									args: { percentageSavings },
-									components: { span: <span className="wooexpress-plans__interval-savings" /> },
-							  } )
-							: translate( 'Pay Annually (Save %(percentageSavings)s%%)', {
-									args: { percentageSavings },
-							  } ) }
+						{ translate( 'Pay Annually {{span}}(Save %(percentageSavings)s%%){{/span}}', {
+							args: { percentageSavings },
+							components: { span: <span className="wooexpress-plans__interval-savings" /> },
+						} ) }
 					</span>
 				),
 				selected: interval === 'yearly',
 			},
 		];
-	}, [
-		interval,
-		translate,
-		monthlyControlProps,
-		percentageSavings,
-		yearlyControlProps,
-		isEnglishLocale,
-	] );
+	}, [ interval, translate, monthlyControlProps, percentageSavings, yearlyControlProps ] );
 
 	const onUpgradeClick = useCallback(
 		( cartItems?: MinimalRequestCartProduct[] | null ) => {

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -15,10 +15,8 @@ import {
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { WpcomPlansUI, Plans } from '@automattic/data-stores';
-import { englishLocales } from '@automattic/i18n-utils';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { useDispatch } from '@wordpress/data';
-import { hasTranslation } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { localize, useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -397,22 +395,13 @@ class PlansComponent extends Component {
 		const wooExpressSubHeaderText = translate(
 			"Discover what's available in your Woo Express plan."
 		);
-
-		const hasEntrepreneurTrialSubHeaderTextTranslation = hasTranslation(
-			"Discover what's available in your %(planName)s plan."
-		);
-
-		const isEnglishLocale = englishLocales.includes( this.props.locale );
-
 		const entrepreneurTrialSubHeaderText =
-			isEnglishLocale || hasEntrepreneurTrialSubHeaderTextTranslation
-				? // translators: %(planName)s is a plan name. E.g. Commerce plan.
-				  translate( "Discover what's available in your %(planName)s plan.", {
-						args: {
-							planName: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
-						},
-				  } )
-				: translate( "Discover what's available in your Entrepreneur plan." );
+			// translators: %(planName)s is a plan name. E.g. Commerce plan.
+			translate( "Discover what's available in your %(planName)s plan.", {
+				args: {
+					planName: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+				},
+			} );
 
 		const isWooExpressTrial = purchase?.isWooExpressTrial;
 

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -1,4 +1,3 @@
-import { useLocale } from '@automattic/i18n-utils';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -110,10 +109,8 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 	const sites = useSelector( getSelectedOrAllSitesJetpackCanManage );
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
-	const { __, hasTranslation } = useI18n();
+	const { __ } = useI18n();
 	const translate = useTranslate();
-	const locale = useLocale();
-
 	const categories = useCategories();
 	const fallbackCategoryName = category
 		? category.charAt( 0 ).toUpperCase() + category.slice( 1 )
@@ -209,17 +206,9 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 							isSticky={ isAboveElement }
 							searchTerm={ search }
 							isSearching={ isFetchingPluginsBySearchTerm }
-							title={
-								'en' === locale || hasTranslation( 'Flex your site’s features with plugins' )
-									? __( 'Flex your site’s features with plugins' )
-									: __( 'Plugins you need to get your projects done' )
-							}
+							title={ __( 'Flex your site’s features with plugins' ) }
 							subtitle={
 								! isLoggedIn &&
-								( 'en' === locale ||
-									hasTranslation(
-										'Add new functionality and integrations to your site with thousands of plugins.'
-									) ) &&
 								__(
 									'Add new functionality and integrations to your site with thousands of plugins.'
 								)

--- a/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-toggle.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-toggle.tsx
@@ -1,6 +1,4 @@
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
-import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 
@@ -18,8 +16,6 @@ const NewsletterCategoriesToggle = ( {
 	value = false,
 }: NewsletterCategoriesToggleProps ) => {
 	const translate = useTranslate();
-	const { hasTranslation } = useI18n();
-	const isEnglishLocale = useIsEnglishLocale();
 
 	return (
 		<div className="newsletter-categories-toggle">
@@ -30,20 +26,13 @@ const NewsletterCategoriesToggle = ( {
 				label={ translate( 'Enable newsletter categories' ) }
 			/>
 			<FormSettingExplanation>
-				{ isEnglishLocale ||
-				hasTranslation(
+				{ translate(
 					'Newsletter categories allow visitors to subscribe only to specific topics.'
-				)
-					? translate(
-							'Newsletter categories allow visitors to subscribe only to specific topics.'
-					  ) +
-					  ' ' +
-					  translate(
-							'When enabled, only posts published under the categories selected below will be emailed to your subscribers.'
-					  )
-					: translate(
-							'This will allow your visitors to specifically subscribe to the selected categories. When this is enabled, only posts published under the created newsletter categories will be sent out to your subscribers.'
-					  ) }
+				) +
+					' ' +
+					translate(
+						'When enabled, only posts published under the categories selected below will be emailed to your subscribers.'
+					) }
 			</FormSettingExplanation>
 		</div>
 	);

--- a/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
+++ b/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
@@ -1,6 +1,4 @@
-import { englishLocales, useLocale, localizeUrl } from '@automattic/i18n-utils';
 import { Card, CardBody, Icon, ExternalLink } from '@wordpress/components';
-import { hasTranslation } from '@wordpress/i18n';
 import { chartBar, people, trendingUp } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { SectionContainer } from 'calypso/components/section';
@@ -60,7 +58,6 @@ const GrowYourAudienceCard = ( {
 };
 
 const GrowYourAudience = () => {
-	const locale = useLocale();
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
@@ -74,52 +71,26 @@ const GrowYourAudience = () => {
 	);
 	const globalSiteEnabled = isAdminInterfaceWPAdmin && isClassicEarlyRelease;
 
-	const statsCardTranslated =
-		englishLocales.includes( locale ) ||
-		( hasTranslation( 'Explore your stats' ) &&
-			hasTranslation(
-				'Take a look at your stats and refine your content strategy for better engagement.'
-			) &&
-			hasTranslation( 'Check stats' ) );
-
 	const statsUrl =
 		! isWPCOMSite || globalSiteEnabled
 			? `${ siteAdminUrl }admin.php?page=stats#!/stats/subscribers/${ selectedSiteSlug }`
 			: `https://wordpress.com/stats/subscribers/${ selectedSiteSlug }`;
-
-	const subscribeBlockUrl = ! isWPCOMSite
-		? 'https://jetpack.com/support/jetpack-blocks/subscription-form-block/'
-		: 'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/';
 
 	return (
 		<SectionContainer className="grow-your-audience">
 			<h2 className="grow-your-audience__title">{ translate( 'Grow your audience' ) }</h2>
 
 			<div className="grow-your-audience__cards">
-				{ statsCardTranslated ? (
-					<GrowYourAudienceCard
-						icon={ chartBar }
-						text={ translate(
-							'Take a look at your stats and refine your content strategy for better engagement.'
-						) }
-						title={ translate( 'Explore your stats' ) }
-						tracksEventCta="stats"
-						ctaLabel={ translate( 'Check stats' ) }
-						url={ statsUrl }
-					/>
-				) : (
-					<GrowYourAudienceCard
-						icon={ chartBar }
-						text={ translate(
-							'Using a subscriber block is the first step to growing your audience.'
-						) }
-						title={ translate( 'Every visitor is a potential subscriber' ) }
-						tracksEventCta="subscribe-block"
-						ctaLabel={ translate( 'Learn more' ) }
-						externalUrl
-						url={ localizeUrl( subscribeBlockUrl ) }
-					/>
-				) }
+				<GrowYourAudienceCard
+					icon={ chartBar }
+					text={ translate(
+						'Take a look at your stats and refine your content strategy for better engagement.'
+					) }
+					title={ translate( 'Explore your stats' ) }
+					tracksEventCta="stats"
+					ctaLabel={ translate( 'Check stats' ) }
+					url={ statsUrl }
+				/>
 				{ isWPCOMSite && (
 					<>
 						<GrowYourAudienceCard

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -1,9 +1,8 @@
 import page from '@automattic/calypso-router';
 import { Button, Gridicon } from '@automattic/components';
 import { HelpCenter, Subscriber as SubscriberDataStore } from '@automattic/data-stores';
-import { useIsEnglishLocale, useLocalizeUrl } from '@automattic/i18n-utils';
+import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { useDispatch as useDataStoreDispatch, useSelect } from '@wordpress/data';
-import { useI18n } from '@wordpress/react-i18n';
 import { translate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -44,8 +43,6 @@ const SubscribersHeader = ( { selectedSiteId, disableCta }: SubscribersHeaderPro
 	const { setShowAddSubscribersModal } = useSubscribersPage();
 	const localizeUrl = useLocalizeUrl();
 	const { setShowHelpCenter, setShowSupportDoc } = useDataStoreDispatch( HELP_CENTER_STORE );
-	const { hasTranslation } = useI18n();
-	const isEnglishLocale = useIsEnglishLocale();
 	const selectedSite = useSelector( getSelectedSite );
 	const siteId = selectedSite?.ID || null;
 	const isWPCOMSite = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
@@ -77,25 +74,14 @@ const SubscribersHeader = ( { selectedSiteId, disableCta }: SubscribersHeaderPro
 		},
 	};
 
-	const subtitle =
-		isEnglishLocale ||
-		hasTranslation(
-			'Add subscribers to your site and send them a free or {{link}}paid newsletter{{/link}}.'
-		)
-			? translate(
-					'Add subscribers to your site and send them a free or {{link}}paid newsletter{{/link}}.',
-					subtitleOptions
-			  )
-			: translate(
-					'Add subscribers to your site and send them a free or paid {{link}}newsletter{{/link}}.',
-					subtitleOptions
-			  );
-
 	return (
 		<NavigationHeader
 			className="stats__section-header modernized-header"
 			title={ translate( 'Subscribers' ) }
-			subtitle={ subtitle }
+			subtitle={ translate(
+				'Add subscribers to your site and send them a free or {{link}}paid newsletter{{/link}}.',
+				subtitleOptions
+			) }
 			screenReader={ navItems.insights?.label }
 			navigationItems={ [] }
 		>

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -555,18 +555,16 @@ export function generateSteps( {
 			stepName: 'site-or-domain',
 			props: {
 				getHeaderText( domainCart ) {
-					return i18n.getLocaleSlug() === 'en' ||
-						i18n.hasTranslation( 'Choose how to use your domains' )
-						? i18n.translate( 'Choose how to use your domain', 'Choose how to use your domains', {
-								count: domainCart.length,
-						  } )
-						: i18n.translate( 'Choose how to use your domain' );
+					return i18n.translate(
+						'Choose how to use your domain',
+						'Choose how to use your domains',
+						{
+							count: domainCart.length,
+						}
+					);
 				},
 				get subHeaderText() {
-					return i18n.getLocaleSlug() === 'en' ||
-						i18n.hasTranslation( 'Don’t worry, you can easily change it later.' )
-						? i18n.translate( 'Don’t worry, you can easily change it later.' )
-						: i18n.translate( 'Don’t worry, you can easily add a site later' );
+					return i18n.translate( 'Don’t worry, you can easily change it later.' );
 				},
 			},
 			providesDependencies: [

--- a/client/signup/steps/design-picker/design-picker.tsx
+++ b/client/signup/steps/design-picker/design-picker.tsx
@@ -9,7 +9,7 @@ import {
 import { MShotsImage } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { sprintf, hasTranslation } from '@wordpress/i18n';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { noop } from 'lodash';
@@ -118,9 +118,7 @@ const DesignButton: FC< DesignButtonProps > = ( {
 						onCheckout?.();
 					} }
 				>
-					{ 'en' === locale || hasTranslation( 'Included in WordPress.com Premium' )
-						? __( 'Included in WordPress.com Premium' )
-						: __( 'Upgrade to Premium' ) }
+					{ __( 'Included in WordPress.com Premium' ) }
 				</Button>
 			);
 		} else if ( isPremiumDesign && ! shouldUpgrade && hasPurchasedTheme ) {

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import { SelectItems } from '@automattic/onboarding';
 import { globe, addCard, layout } from '@wordpress/icons';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { get, isEmpty } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -61,13 +61,9 @@ class SiteOrDomain extends Component {
 		const { translate, isReskinned, isLoggedIn, siteCount } = this.props;
 
 		const domainName = this.getDomainName();
-		let buyADomainTitle =
-			i18n.getLocaleSlug() === 'en' || i18n.hasTranslation( 'Just buy domains' )
-				? translate( 'Just buy a domain', 'Just buy domains', {
-						count: this.getDomainCart().length,
-				  } )
-				: translate( 'Just buy a domain' );
-
+		let buyADomainTitle = translate( 'Just buy a domain', 'Just buy domains', {
+			count: this.getDomainCart().length,
+		} );
 		if ( this.isLeanDomainSearch() && domainName ) {
 			// translators: %s is a domain name
 			buyADomainTitle = translate( 'Just buy %s', { args: [ domainName ] } );
@@ -75,11 +71,7 @@ class SiteOrDomain extends Component {
 
 		const choices = [];
 
-		const buyADomainDescription =
-			i18n.getLocaleSlug() === 'en' || i18n.hasTranslation( 'Add a site later.' )
-				? translate( 'Add a site later.' )
-				: translate( 'Show a "coming soon" notice on your domain. Add a site later.' );
-
+		const buyADomainDescription = translate( 'Add a site later.' );
 		if ( isReskinned ) {
 			choices.push( {
 				key: 'domain',
@@ -94,29 +86,15 @@ class SiteOrDomain extends Component {
 			choices.push( {
 				key: 'page',
 				title: translate( 'New site' ),
-				description:
-					i18n.getLocaleSlug() === 'en' ||
-					i18n.hasTranslation(
-						'Customize and launch your site.{{br/}}{{strong}}Free domain for the first year on annual plans.{{/strong}}'
-					)
-						? translate(
-								'Customize and launch your site.{{br/}}{{strong}}Free domain for the first year on annual plans.{{/strong}}',
-								{
-									components: {
-										strong: <strong />,
-										br: <br />,
-									},
-								}
-						  )
-						: translate(
-								'Customize and launch your site.{{br/}}{{strong}}Free domain for the first year*{{/strong}}',
-								{
-									components: {
-										strong: <strong />,
-										br: <br />,
-									},
-								}
-						  ),
+				description: translate(
+					'Customize and launch your site.{{br/}}{{strong}}Free domain for the first year on annual plans.{{/strong}}',
+					{
+						components: {
+							strong: <strong />,
+							br: <br />,
+						},
+					}
+				),
 				icon: null,
 				titleIcon: addCard,
 				value: 'page',
@@ -127,29 +105,15 @@ class SiteOrDomain extends Component {
 				choices.push( {
 					key: 'existing-site',
 					title: translate( 'Existing WordPress.com site' ),
-					description:
-						i18n.getLocaleSlug() === 'en' ||
-						i18n.hasTranslation(
-							'Use the domain with a site you already started.{{br/}}{{strong}}Free domain for the first year on annual plans.{{/strong}}'
-						)
-							? translate(
-									'Use the domain with a site you already started.{{br/}}{{strong}}Free domain for the first year on annual plans.{{/strong}}',
-									{
-										components: {
-											strong: <strong />,
-											br: <br />,
-										},
-									}
-							  )
-							: translate(
-									'Use with a site you already started.{{br/}}{{strong}}Free domain for the first year*{{/strong}}',
-									{
-										components: {
-											strong: <strong />,
-											br: <br />,
-										},
-									}
-							  ),
+					description: translate(
+						'Use the domain with a site you already started.{{br/}}{{strong}}Free domain for the first year on annual plans.{{/strong}}',
+						{
+							components: {
+								strong: <strong />,
+								br: <br />,
+							},
+						}
+					),
 					icon: null,
 					titleIcon: layout,
 					value: 'existing-site',

--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { englishLocales, useLocale } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { useInView } from 'react-intersection-observer';
@@ -84,8 +83,7 @@ const recordNagView = () => {
 };
 
 export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
-	const { __, hasTranslation } = useI18n();
-	const locale = useLocale();
+	const { __ } = useI18n();
 	const { ref } = useInView( {
 		onChange: ( inView ) => inView && recordNagView(),
 	} );
@@ -107,11 +105,8 @@ export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 	const link = validSiteIntent
 		? getLaunchpadUrl( site.slug, validSiteIntent )
 		: getDashboardUrl( site.slug );
-	const checklistTranslation =
-		hasTranslation( 'Checklist' ) || englishLocales.includes( locale )
-			? __( 'Checklist' )
-			: __( 'Launch checklist' );
-	const text = validSiteIntent ? __( 'Launch guide' ) : checklistTranslation;
+
+	const text = validSiteIntent ? __( 'Launch guide' ) : __( 'Checklist' );
 
 	return (
 		<SiteLaunchNagLink

--- a/client/sites/settings/administration/tools/delete-site/index.jsx
+++ b/client/sites/settings/administration/tools/delete-site/index.jsx
@@ -1,7 +1,7 @@
 import { isFreePlanProduct } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
-import i18n, { getLocaleSlug, localize, translate } from 'i18n-calypso';
+import { localize, translate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -57,24 +57,7 @@ class DeleteSite extends Component {
 		}
 
 		const warningText = () => {
-			if (
-				getLocaleSlug() === 'en' ||
-				getLocaleSlug() === 'en-gb' ||
-				i18n.hasTranslation(
-					'Before deleting your site, consider exporting its content as a backup'
-				)
-			) {
-				return translate( 'Before deleting your site, consider exporting its content as a backup' );
-			}
-
-			return translate( '{{strong}}%(siteDomain)s{{/strong}} will be unavailable in the future.', {
-				components: {
-					strong: <strong />,
-				},
-				args: {
-					siteDomain,
-				},
-			} );
+			return translate( 'Before deleting your site, consider exporting its content as a backup' );
 		};
 
 		return (
@@ -93,40 +76,21 @@ class DeleteSite extends Component {
 			this.state.confirmDomain.replace( /\s/g, '' ) !== siteDomain;
 		const isAtomicRemovalInProgress = isFreePlan && isAtomic;
 
-		let deletionText = translate(
-			'Please type in {{warn}}%(siteAddress)s{{/warn}} in the field below to confirm. ' +
-				'Your site will then be gone forever.',
-			{
-				components: {
-					warn: <span className="delete-site__target-domain" />,
-				},
-				args: {
-					siteAddress: this.props.siteId && this.props.siteDomain,
-				},
-			}
-		);
-
-		if (
-			getLocaleSlug() === 'en' ||
-			getLocaleSlug() === 'en-gb' ||
-			i18n.hasTranslation( 'Before deleting your site, consider exporting its content as a backup' )
-		) {
-			deletionText = translate(
-				'Type {{strong}}%(siteDomain)s{{/strong}} below to confirm you want to delete the site:',
-				{
-					components: {
-						strong: <strong />,
-					},
-					args: {
-						siteDomain: this.props.siteDomain,
-					},
-				}
-			);
-		}
-
 		return (
 			<>
-				<p>{ deletionText }</p>
+				<p>
+					{ translate(
+						'Type {{strong}}%(siteDomain)s{{/strong}} below to confirm you want to delete the site:',
+						{
+							components: {
+								strong: <strong />,
+							},
+							args: {
+								siteDomain: this.props.siteDomain,
+							},
+						}
+					) }
+				</p>
 				<>
 					<FormTextInput
 						autoCapitalize="off"

--- a/client/sites/tools/deployments/components/deployments-survey/index.tsx
+++ b/client/sites/tools/deployments/components/deployments-survey/index.tsx
@@ -1,37 +1,23 @@
 import { useLocale } from '@automattic/i18n-utils';
-import { useI18n } from '@wordpress/react-i18n';
 import { translate } from 'i18n-calypso';
 import ReactDOM from 'react-dom';
 import SurveyModal from 'calypso/components/survey-modal';
 
 export const GitHubDeploymentSurvey = () => {
 	const localeSlug = useLocale();
-	const { hasTranslation } = useI18n();
 
 	if ( localeSlug !== 'en' ) {
 		return null;
 	}
 
-	const title = hasTranslation( 'Share your thoughts on GitHub Deployments' )
-		? translate( 'Share your thoughts on GitHub Deployments' )
-		: translate( 'Hey Developer!' );
-
-	const description = hasTranslation(
-		'Got a moment? We’d love to hear about your experience using GitHub Deployments in our quick survey.'
-	)
-		? translate(
-				'Got a moment? We’d love to hear about your experience using GitHub Deployments in our quick survey.'
-		  )
-		: translate(
-				'Got a moment? How do you like using GitHub Deployments so far? Share your thoughts with us in our quick survey.'
-		  );
-
 	return ReactDOM.createPortal(
 		<SurveyModal
 			name="github-deployments"
 			url="https://automattic.survey.fm/github-deployments-survey?initiated-from=calypso"
-			title={ title }
-			description={ description }
+			title={ translate( 'Share your thoughts on GitHub Deployments' ) }
+			description={ translate(
+				'Got a moment? We’d love to hear about your experience using GitHub Deployments in our quick survey.'
+			) }
 			dismissText={ translate( 'Remind later' ) }
 			confirmText={ translate( 'Take survey' ) }
 			showOverlay={ false }

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
@@ -1,7 +1,6 @@
 import { FormLabel } from '@automattic/components';
-import { englishLocales } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
-import i18n, { translate, useTranslate } from 'i18n-calypso';
+import { translate, useTranslate } from 'i18n-calypso';
 import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import FormRadio from 'calypso/components/forms/form-radio';
@@ -233,22 +232,7 @@ const StagingToProductionSync = ( {
 		],
 		[ translate ]
 	);
-	const syncWarningTranslation =
-		englishLocales.includes( i18n.getLocaleSlug() || 'en' ) ||
-		i18n.hasTranslation(
-			'{{span}}This site has WooCommerce installed.{{/span}} We do not recommend syncing or pushing data from a staging site to live production news sites or sites that use eCommerce plugins, such as WooCommerce, without proper planning and testing. Keep in mind that data on the destination site could have newer transactions, such as customers and orders, and would be lost when overwritten by the staging site’s data.'
-		)
-			? translate(
-					'{{span}}This site has WooCommerce installed.{{/span}} We do not recommend syncing or pushing data from a staging site to live production news sites or sites that use eCommerce plugins, such as WooCommerce, without proper planning and testing. Keep in mind that data on the destination site could have newer transactions, such as customers and orders, and would be lost when overwritten by the staging site’s data.',
-					{
-						components: {
-							span: <ConfirmationModalRedSpan />,
-						},
-					}
-			  )
-			: translate(
-					'We do not recommend syncing or pushing data from a staging site to live production news sites or sites that use eCommerce plugins, such as WooCommerce, without proper planning and testing. Keep in mind that data on the destination site could have newer transactions, such as customers and orders, and would be lost when overwritten by the staging site’s data.'
-			  );
+
 	return (
 		<>
 			{ showSyncPanel && (
@@ -284,7 +268,16 @@ const StagingToProductionSync = ( {
 							{ isSiteWooStore && isSqlSyncOptionChecked && (
 								<SyncWarningContainer>
 									<SyncWarningTitle>{ translate( 'Warning:' ) }</SyncWarningTitle>
-									<SyncWarningContent>{ syncWarningTranslation }</SyncWarningContent>
+									<SyncWarningContent>
+										{ translate(
+											'{{span}}This site has WooCommerce installed.{{/span}} We do not recommend syncing or pushing data from a staging site to live production news sites or sites that use eCommerce plugins, such as WooCommerce, without proper planning and testing. Keep in mind that data on the destination site could have newer transactions, such as customers and orders, and would be lost when overwritten by the staging site’s data.',
+											{
+												components: {
+													span: <ConfirmationModalRedSpan />,
+												},
+											}
+										) }
+									</SyncWarningContent>
 								</SyncWarningContainer>
 							) }
 							<ConfirmationModalInputTitle>

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -1,6 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { MaterialIcon, ExternalLink, ExternalLinkWithTracking } from '@automattic/components';
-import { englishLocales, localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { DOMAIN_PRICING_AND_AVAILABLE_TLDS } from '@automattic/urls';
 import i18n from 'i18n-calypso';
 import { MemoExoticComponent } from 'react';
@@ -2438,36 +2438,15 @@ const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_FAST_SUPPORT_FROM_EXPERTS ]: {
 		getSlug: () => FEATURE_FAST_SUPPORT_FROM_EXPERTS,
-		getTitle: () => {
-			if (
-				englishLocales.includes( i18n.getLocaleSlug() || 'en' ) ||
-				i18n.hasTranslation( 'Fast support from our expert team' )
-			) {
-				return i18n.translate( 'Fast support from our expert team' );
-			}
-
-			return i18n.translate( 'Expert support' );
-		},
+		getTitle: () => i18n.translate( 'Fast support from our expert team' ),
 		getDescription: () =>
 			i18n.translate( 'Prompt support from our expert, friendly Happiness team' ),
 	},
 	[ FEATURE_PRIORITY_24_7_SUPPORT ]: {
 		getSlug: () => FEATURE_PRIORITY_24_7_SUPPORT,
-		getTitle: () => {
-			if (
-				englishLocales.includes( i18n.getLocaleSlug() || 'en' ) ||
-				i18n.hasTranslation( 'Priority 24/7 support from our expert team' )
-			) {
-				return i18n.translate( 'Priority 24/7 support from our expert team' );
-			}
-
-			return i18n.translate( '24/7 priority support' );
-		},
+		getTitle: () => i18n.translate( 'Priority 24/7 support from our expert team' ),
 		getDescription: () =>
-			englishLocales.includes( i18n.getLocaleSlug() || 'en' ) ||
-			i18n.hasTranslation( 'The fastest 24/7 support from our expert, friendly Happiness team' )
-				? i18n.translate( 'The fastest 24/7 support from our expert, friendly Happiness team' )
-				: i18n.translate( '24/7 priority support' ),
+			i18n.translate( 'The fastest 24/7 support from our expert, friendly Happiness team' ),
 	},
 	/* END: 2023 Pricing Grid Features */
 
@@ -2635,11 +2614,7 @@ const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_SENSEI_SELL_COURSES ]: {
 		getSlug: () => FEATURE_SENSEI_SELL_COURSES,
-		getTitle: () =>
-			englishLocales.includes( i18n.getLocaleSlug() || 'en' ) ||
-			i18n.hasTranslation( 'Sell courses' )
-				? i18n.translate( 'Sell courses' )
-				: i18n.translate( 'Sell courses and subscriptions' ),
+		getTitle: () => i18n.translate( 'Sell courses' ),
 	},
 	[ FEATURE_SENSEI_STORAGE ]: {
 		getSlug: () => FEATURE_SENSEI_STORAGE,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import i18n, { getLocaleSlug, translate } from 'i18n-calypso';
+import i18n, { translate } from 'i18n-calypso';
 import {
 	FEATURE_13GB_STORAGE,
 	FEATURE_200GB_STORAGE,
@@ -3506,10 +3506,7 @@ PLANS_LIST[ PLAN_WPCOM_STARTER ] = {
 	getStoreSlug: () => PLAN_WPCOM_STARTER,
 	getPathSlug: () => 'starter',
 	getDescription: () =>
-		i18n.hasTranslation( 'Start with a custom domain name, simple payments, and extra storage.' ) ||
-		[ 'en', 'en-gb' ].includes( getLocaleSlug() || '' )
-			? i18n.translate( 'Start with a custom domain name, simple payments, and extra storage.' )
-			: i18n.translate( 'Start your WordPress.com website. Limited functionality and storage.' ),
+		i18n.translate( 'Start with a custom domain name, simple payments, and extra storage.' ),
 	getSubTitle: () => i18n.translate( 'Essential features. Freedom to grow.' ),
 	getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
 	getPlanCompareFeatures: () => [

--- a/packages/domain-picker/src/components/domain-suggestion-item/suggestion-item.tsx
+++ b/packages/domain-picker/src/components/domain-suggestion-item/suggestion-item.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 import { recordTrainTracksInteract } from '@automattic/calypso-analytics';
-import { useLocale, useLocalizeUrl } from '@automattic/i18n-utils';
+import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { Spinner, Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { createInterpolateElement } from '@wordpress/element';
@@ -55,8 +55,7 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 	type = SUGGESTION_ITEM_TYPE_RADIO,
 	buttonRef,
 } ) => {
-	const { __, hasTranslation } = useI18n();
-	const locale = useLocale();
+	const { __ } = useI18n();
 	const localizeUrl = useLocalizeUrl();
 
 	const isMobile = ! useViewportMatch( 'small', '>=' );
@@ -73,28 +72,10 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 	const freeDomainLabelFree = __( 'Free', __i18n_text_domain__ );
 	const freeDomainLabel =
 		type === SUGGESTION_ITEM_TYPE_INDIVIDUAL ? freeDomainLabelDefault : freeDomainLabelFree;
-
-	const fallbackIncludedLabel = __( 'Included with annual plans', __i18n_text_domain__ );
-	const newIncludedLabel = __( 'Included in annual plans', __i18n_text_domain__ );
-	const includedLabel =
-		locale === 'en' || hasTranslation?.( 'Included in annual plans' )
-			? newIncludedLabel
-			: fallbackIncludedLabel;
-
-	// translators: text in between the <strong></strong> marks is styled as bold text
-	const fallbackIncludedLabelFormatted = __(
-		'<strong>First year included</strong> in paid plans',
-		__i18n_text_domain__
-	);
-	// translators: text in between the <strong></strong> marks is styled as bold text
-	const newIncludedLabelFormatted = __(
-		'<strong>First year included</strong> in annual plans',
-		__i18n_text_domain__
-	);
+	const includedLabel = __( 'Included in annual plans', __i18n_text_domain__ );
 	const includedLabelFormatted =
-		locale === 'en' || hasTranslation?.( '<strong>First year included</strong> in annual plans' )
-			? newIncludedLabelFormatted
-			: fallbackIncludedLabelFormatted;
+		// translators: text in between the <strong></strong> marks is styled as bold text
+		__( '<strong>First year included</strong> in annual plans', __i18n_text_domain__ );
 	const paidIncludedDomainLabel = isMobile
 		? includedLabel
 		: createInterpolateElement( includedLabelFormatted, {

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -11,7 +11,7 @@ import { useGetSupportInteractions } from '@automattic/odie-client/src/data';
 import { useLoadZendeskMessaging } from '@automattic/zendesk-client';
 import { Button } from '@wordpress/components';
 import { useEffect, useMemo, useState } from '@wordpress/element';
-import { hasTranslation, sprintf } from '@wordpress/i18n';
+import { sprintf } from '@wordpress/i18n';
 import { backup, comment, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
@@ -94,7 +94,7 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 
 		if ( isLanguageSupported ) {
 			const language = getLanguage( locale )?.name;
-			return language && hasTranslation( 'Email (%s)' )
+			return language
 				? sprintf(
 						// translators: %s is the language name
 						__( 'Email (%s)', __i18n_text_domain__ ),
@@ -103,11 +103,7 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 				: __( 'Email', __i18n_text_domain__ );
 		}
 
-		if ( hasTranslation( 'Email (English)' ) ) {
-			return __( 'Email (English)', __i18n_text_domain__ );
-		}
-
-		return __( 'Email', __i18n_text_domain__ );
+		return __( 'Email (English)', __i18n_text_domain__ );
 	}, [ __, locale, isEnglishLocale ] );
 
 	if ( isLoading ) {

--- a/packages/help-center/src/components/help-center-contact-support-option.tsx
+++ b/packages/help-center/src/components/help-center-contact-support-option.tsx
@@ -1,13 +1,11 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { FormInputValidation } from '@automattic/components';
 import { HelpCenterSelect, HelpCenterSite } from '@automattic/data-stores';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import {
 	useCanConnectToZendeskMessaging,
 	useOpenZendeskMessaging,
 } from '@automattic/zendesk-client';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { hasTranslation } from '@wordpress/i18n';
 import { Icon, comment } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo, useState } from 'react';
@@ -36,7 +34,6 @@ const HelpCenterContactSupportOption = ( {
 	trackEventName,
 }: HelpCenterContactSupportOptionProps ) => {
 	const { __ } = useI18n();
-	const isEnglishLocale = useIsEnglishLocale();
 	const { hasActiveChats, isEligibleForChat } = useChatStatus();
 	const { resetStore, setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
 	const currentSupportInteraction = useSelect(
@@ -59,12 +56,8 @@ const HelpCenterContactSupportOption = ( {
 	const [ hasSubmittingError, setHasSubmittingError ] = useState< boolean >( false );
 
 	const supportHeaderText = useMemo( () => {
-		if ( isEnglishLocale || ! hasTranslation( 'Contact WordPress.com Support (English)' ) ) {
-			return __( 'Contact WordPress.com Support', __i18n_text_domain__ );
-		}
-
-		return __( 'Contact WordPress.com Support (English)', __i18n_text_domain__ );
-	}, [ __, isEnglishLocale ] );
+		return __( 'Contact WordPress.com Support', __i18n_text_domain__ );
+	}, [ __ ] );
 
 	const handleOnClick = () => {
 		generateContactOnClickEvent( 'chat', trackEventName );

--- a/packages/help-center/src/components/help-center-contact-support-option.tsx
+++ b/packages/help-center/src/components/help-center-contact-support-option.tsx
@@ -8,7 +8,7 @@ import {
 import { useDispatch, useSelect } from '@wordpress/data';
 import { Icon, comment } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import useChatStatus from '../hooks/use-chat-status';
 import { HELP_CENTER_STORE } from '../stores';
 import ThirdPartyCookiesNotice from './help-center-third-party-cookies-notice';
@@ -54,10 +54,6 @@ const HelpCenterContactSupportOption = ( {
 	);
 
 	const [ hasSubmittingError, setHasSubmittingError ] = useState< boolean >( false );
-
-	const supportHeaderText = useMemo( () => {
-		return __( 'Contact WordPress.com Support', __i18n_text_domain__ );
-	}, [ __ ] );
 
 	const handleOnClick = () => {
 		generateContactOnClickEvent( 'chat', trackEventName );
@@ -117,7 +113,7 @@ const HelpCenterContactSupportOption = ( {
 							<Icon icon={ comment } />
 						</div>
 						<div>
-							<h2>{ supportHeaderText }</h2>
+							<h2>{ __( 'Contact WordPress.com Support', __i18n_text_domain__ ) }</h2>
 							<p>{ __( 'Our Happiness team will get back to you soon', __i18n_text_domain__ ) }</p>
 						</div>
 					</div>

--- a/packages/help-center/src/components/help-center-gpt.tsx
+++ b/packages/help-center/src/components/help-center-gpt.tsx
@@ -3,12 +3,11 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { LoadingPlaceholder } from '@automattic/components';
 import { HelpCenterSelect } from '@automattic/data-stores';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { Button, ExternalLink } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { createElement, createInterpolateElement } from '@wordpress/element';
-import { hasTranslation, sprintf } from '@wordpress/i18n';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useEffect, useMemo, useState } from 'react';
 import stripTags from 'striptags';
@@ -72,8 +71,6 @@ const handleContentClick = ( event: React.MouseEvent ) => {
 
 export function HelpCenterGPT( { onResponseReceived, redirectToArticle }: Props ) {
 	const { __ } = useI18n();
-	const isEnglishLocale = useIsEnglishLocale();
-
 	const [ feedbackGiven, setFeedbackGiven ] = useState< boolean >( false );
 
 	// Report loading state up.
@@ -152,12 +149,8 @@ export function HelpCenterGPT( { onResponseReceived, redirectToArticle }: Props 
 	};
 
 	const aiResponseHeader = useMemo( () => {
-		if ( isEnglishLocale || hasTranslation( 'AI Generated Response:' ) ) {
-			return __( 'AI Generated Response:', __i18n_text_domain__ );
-		}
-
-		return __( 'Quick response:', __i18n_text_domain__ );
-	}, [ __, isEnglishLocale ] );
+		return __( 'AI Generated Response:', __i18n_text_domain__ );
+	}, [ __ ] );
 
 	return (
 		<div className="help-center-gpt__container">

--- a/packages/plans-grid/src/plans-interval-toggle/index.tsx
+++ b/packages/plans-grid/src/plans-interval-toggle/index.tsx
@@ -1,4 +1,3 @@
-import { useLocale } from '@automattic/i18n-utils';
 import { Popover } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -59,27 +58,14 @@ const PlansIntervalToggle: React.FunctionComponent< PlansIntervalToggleProps > =
 	className = '',
 	children,
 } ) => {
-	const { __, _x, hasTranslation } = useI18n();
-	const locale = useLocale();
+	const { __, _x } = useI18n();
 	const [ spanRef, setSpanRef ] = useState< HTMLSpanElement >();
-
-	const fallbackMonthlyLabel = __( 'Pay monthly', __i18n_text_domain__ );
-	// Translators: intended as "pay monthly", as opposed to "pay annually"
-	const newMonthlyLabel = _x( 'Monthly', 'Adverb (as in "Pay monthly")', __i18n_text_domain__ );
 	const monthlyLabel =
-		locale === 'en' ||
-		hasTranslation( 'Monthly', 'Adverb (as in "Pay monthly")', __i18n_text_domain__ )
-			? newMonthlyLabel
-			: fallbackMonthlyLabel;
-
-	const fallbackAnnuallyLabel = __( 'Pay annually', __i18n_text_domain__ );
-	// Translators: intended as "pay annually", as opposed to "pay monthly"
-	const newAnnuallyLabel = _x( 'Annually', 'Adverb (as in "Pay annually")', __i18n_text_domain__ );
+		// Translators: intended as "pay monthly", as opposed to "pay annually"
+		_x( 'Monthly', 'Adverb (as in "Pay monthly")', __i18n_text_domain__ );
 	const annuallyLabel =
-		locale === 'en' ||
-		hasTranslation( 'Annually', 'Adverb (as in "Pay annually")', __i18n_text_domain__ )
-			? newAnnuallyLabel
-			: fallbackAnnuallyLabel;
+		// Translators: intended as "pay annually", as opposed to "pay monthly"
+		_x( 'Annually', 'Adverb (as in "Pay annually")', __i18n_text_domain__ );
 
 	return (
 		<div

--- a/packages/plans-grid/src/plans-table/plan-item.tsx
+++ b/packages/plans-grid/src/plans-table/plan-item.tsx
@@ -1,4 +1,3 @@
-import { useLocale } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
@@ -77,9 +76,7 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 	popularBadgeText,
 	CTAButtonLabel,
 } ) => {
-	const { __, hasTranslation } = useI18n();
-	const locale = useLocale();
-
+	const { __ } = useI18n();
 	const planProduct = useSelect(
 		( select ) => ( select( PLANS_STORE ) as PlansSelect ).getPlanProduct( slug, billingPeriod ),
 		[ slug, billingPeriod ]
@@ -102,17 +99,15 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 	const fullWidthCtaLabelSelected = __( 'Current Selection', __i18n_text_domain__ );
 	// translators: %s is a WordPress.com plan name (eg: Free, Personal)
 	const fullWidthCtaLabelUnselected = __( 'Select %s', __i18n_text_domain__ );
-
-	const fallbackPlanItemPriceLabelAnnually = __( 'billed annually', __i18n_text_domain__ );
 	// translators: %s is the cost per year (e.g "billed as 96$ annually")
 	const newPlanItemPriceLabelAnnually = __(
 		'per month, billed as %s annually',
 		__i18n_text_domain__
 	);
-	const planItemPriceLabelAnnually =
-		locale === 'en' || hasTranslation?.( 'per month, billed as %s annually' )
-			? sprintf( newPlanItemPriceLabelAnnually, planProduct?.annualPrice )
-			: fallbackPlanItemPriceLabelAnnually;
+	const planItemPriceLabelAnnually = sprintf(
+		newPlanItemPriceLabelAnnually,
+		planProduct?.annualPrice
+	);
 
 	const planItemPriceLabelMonthly = __( 'per month, billed monthly', __i18n_text_domain__ );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/i18n-issues/issues/654

## Proposed Changes

- Part of addressing https://github.com/Automattic/i18n-issues/issues/654 and follow-up to https://github.com/Automattic/wp-calypso/pull/97690
- Initially I meant to go through the codebase and replace the various `hasTranslation` + `locale` checks with the new `fixMe` method, but all of the current cases are effectively redundant checks (meaning, translations have been completed), so instead created a wholistic PR to remove the checks and fallback strings all across the codebase.
- The refactor only includes cases where the `hasTranslation` + `locale` check was done to choose between an original and new translation. Some other cases exist (I think 2-3) where a component will not render at all if a translation is not present. I left those as-is for now - might do in a follow-up.

This is a risky PR as it touches many files.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of addressing https://github.com/Automattic/i18n-issues/issues/654
* Removes a lot of redundant conditioning from the codebase
* Creates a new base from which we can more directly introduce/suggest usage of the new `fixme` method i.e. removes any precedent of `hasTranslation` + `locale` check.
* This is a wholistic and risky PR to just get this out of the way. The alternative would have been something like 40 or so individual PRs (never gonna happen).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Code-review as detailed as possible.
- For functional testing:
  - I don't think it's effective to attempt to test all these cases one by one. We can instead get the PR in a working/shippable state and let experience guide us / and allow the risk of regressions, which we can address in follow-ups. 🤷‍♂️ 
- For translations:
  - For each of the original/new combinations, confirm (I have confirmed most if not all of these):
    - Go to GlotPress and confirm the translations across locales between the original and the new string are equivalent.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
