### PR TITLE
Add context on what 'Launch site' means

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -290,6 +290,11 @@ const Sidebar = ( {
 					launchpadContext="onboarding"
 					makeLastTaskPrimaryAction
 				/>
+				<p className="launchpad__sidebar-description">
+					{ translate(
+						"Your site is private and only visible to you. When you're ready, launch your site to make it public."
+					) }
+				</p>
 				{ showPlansModal && site?.ID && (
 					<RecurringPaymentsPlanAddEditModal
 						closeDialog={ () => setShowPlansModal( false ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -237,6 +237,15 @@ describe( 'Sidebar', () => {
 		expect( progressBar ).toBeVisible();
 	} );
 
+	it( 'displays site launch description', () => {
+		renderSidebar( props );
+
+		const launchingDescription = screen.getByText(
+			"Your site is private and only visible to you. When you're ready, launch your site to make it public."
+		);
+		expect( launchingDescription ).toBeVisible();
+	} );
+
 	describe( 'when no custom domain has been purchased', () => {
 		it( 'shows a copy url to clipboard button', () => {
 			renderSidebar( {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/76947

## Proposed Changes
![image](https://github.com/user-attachments/assets/03f5cc4c-908b-4f9f-bace-3c68fb5be50d)

Adds `Your site is private and only visible to you. When you're ready, launch your site to make it public.` description on launchpad.

This copy is already used on different areas and translation is ready to use.

![image](https://github.com/user-attachments/assets/560cfa61-16d7-4c35-9ef6-10db06ff4f44)

## Why are these changes being made?
Launching a site can sound too big of a change for a lot of customers. By adding context on what that change represents, we can make customers more confident, which should lead to an increase in launched sites.

## Testing Instructions

- Create a free site and follow the steps until you achieve the launchpad step.
- You should be able to see new copy under the `Launch your site` button.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
