### PR TITLE
Goals First: Record selected goals for every step in the calypso_signup_step_start event

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -1,9 +1,12 @@
 //* This hook is used to track the step route in the declarative flow.
 
+import { OnboardSelect } from '@automattic/data-stores';
 import { isAnyHostingFlow } from '@automattic/onboarding';
+import { useSelect } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import { STEPPER_TRACKS_EVENT_SIGNUP_STEP_START } from 'calypso/landing/stepper/constants';
 import { getStepOldSlug } from 'calypso/landing/stepper/declarative-flow/helpers/get-step-old-slug';
+import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
 import { getAssemblerSource } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-design';
 import recordStepComplete, {
 	type RecordStepCompleteProps,
@@ -12,6 +15,7 @@ import recordStepStart from 'calypso/landing/stepper/declarative-flow/internals/
 import { useIntent } from 'calypso/landing/stepper/hooks/use-intent';
 import { useSelectedDesign } from 'calypso/landing/stepper/hooks/use-selected-design';
 import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import kebabCase from 'calypso/landing/stepper/utils/kebabCase';
 import useSnakeCasedKeys from 'calypso/landing/stepper/utils/use-snake-cased-keys';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
@@ -57,6 +61,12 @@ export const useStepRouteTracking = ( { flow, stepSlug, skipStepRender }: Props 
 	const signupStepStartProps = useSnakeCasedKeys( {
 		input: flow.useTracksEventProps?.()?.[ STEPPER_TRACKS_EVENT_SIGNUP_STEP_START ],
 	} );
+	const isGoalsAtFrontExperiment = useGoalsFirstExperiment()[ 1 ];
+
+	const goals = useSelect(
+		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getGoals(),
+		[]
+	);
 
 	/**
 	 * Cleanup effect to record step-complete event when `StepRoute` unmounts.
@@ -94,6 +104,8 @@ export const useStepRouteTracking = ( { flow, stepSlug, skipStepRender }: Props 
 		recordStepStart( flowName, kebabCase( stepSlug ), {
 			intent,
 			is_in_hosting_flow: isAnyHostingFlow( flowName ),
+			is_goals_first: isGoalsAtFrontExperiment.toString(),
+			...( goals.length && { goals: goals.join( ',' ) } ),
 			...( design && { assembler_source: getAssemblerSource( design ) } ),
 			...( flowVariantSlug && { flow_variant: flowVariantSlug } ),
 			...( skipStepRender && { skip_step_render: skipStepRender } ),

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -1,12 +1,9 @@
 //* This hook is used to track the step route in the declarative flow.
 
-import { OnboardSelect } from '@automattic/data-stores';
 import { isAnyHostingFlow } from '@automattic/onboarding';
-import { useSelect } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import { STEPPER_TRACKS_EVENT_SIGNUP_STEP_START } from 'calypso/landing/stepper/constants';
 import { getStepOldSlug } from 'calypso/landing/stepper/declarative-flow/helpers/get-step-old-slug';
-import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
 import { getAssemblerSource } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-design';
 import recordStepComplete, {
 	type RecordStepCompleteProps,
@@ -15,7 +12,6 @@ import recordStepStart from 'calypso/landing/stepper/declarative-flow/internals/
 import { useIntent } from 'calypso/landing/stepper/hooks/use-intent';
 import { useSelectedDesign } from 'calypso/landing/stepper/hooks/use-selected-design';
 import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import kebabCase from 'calypso/landing/stepper/utils/kebabCase';
 import useSnakeCasedKeys from 'calypso/landing/stepper/utils/use-snake-cased-keys';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
@@ -61,12 +57,6 @@ export const useStepRouteTracking = ( { flow, stepSlug, skipStepRender }: Props 
 	const signupStepStartProps = useSnakeCasedKeys( {
 		input: flow.useTracksEventProps?.()?.[ STEPPER_TRACKS_EVENT_SIGNUP_STEP_START ],
 	} );
-	const isGoalsAtFrontExperiment = useGoalsFirstExperiment()[ 1 ];
-
-	const goals = useSelect(
-		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getGoals(),
-		[]
-	);
 
 	/**
 	 * Cleanup effect to record step-complete event when `StepRoute` unmounts.
@@ -104,8 +94,6 @@ export const useStepRouteTracking = ( { flow, stepSlug, skipStepRender }: Props 
 		recordStepStart( flowName, kebabCase( stepSlug ), {
 			intent,
 			is_in_hosting_flow: isAnyHostingFlow( flowName ),
-			...( isGoalsAtFrontExperiment && { is_goals_first: isGoalsAtFrontExperiment.toString() } ),
-			...( goals.length && { goals: goals.join( ',' ) } ),
 			...( design && { assembler_source: getAssemblerSource( design ) } ),
 			...( flowVariantSlug && { flow_variant: flowVariantSlug } ),
 			...( skipStepRender && { skip_step_render: skipStepRender } ),
@@ -129,8 +117,6 @@ export const useStepRouteTracking = ( { flow, stepSlug, skipStepRender }: Props 
 			recordStepStart( flowName, kebabCase( stepOldSlug ), {
 				intent,
 				is_in_hosting_flow: isAnyHostingFlow( flowName ),
-				...( isGoalsAtFrontExperiment && { is_goals_first: isGoalsAtFrontExperiment.toString() } ),
-				...( goals.length && { goals: goals.join( ',' ) } ),
 				...( design && { assembler_source: getAssemblerSource( design ) } ),
 				...( flowVariantSlug && { flow_variant: flowVariantSlug } ),
 				...( skipStepRender && { skip_step_render: skipStepRender } ),

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -104,7 +104,7 @@ export const useStepRouteTracking = ( { flow, stepSlug, skipStepRender }: Props 
 		recordStepStart( flowName, kebabCase( stepSlug ), {
 			intent,
 			is_in_hosting_flow: isAnyHostingFlow( flowName ),
-			is_goals_first: isGoalsAtFrontExperiment.toString(),
+			...( isGoalsAtFrontExperiment && { is_goals_first: isGoalsAtFrontExperiment.toString() } ),
 			...( goals.length && { goals: goals.join( ',' ) } ),
 			...( design && { assembler_source: getAssemblerSource( design ) } ),
 			...( flowVariantSlug && { flow_variant: flowVariantSlug } ),
@@ -129,6 +129,8 @@ export const useStepRouteTracking = ( { flow, stepSlug, skipStepRender }: Props 
 			recordStepStart( flowName, kebabCase( stepOldSlug ), {
 				intent,
 				is_in_hosting_flow: isAnyHostingFlow( flowName ),
+				...( isGoalsAtFrontExperiment && { is_goals_first: isGoalsAtFrontExperiment.toString() } ),
+				...( goals.length && { goals: goals.join( ',' ) } ),
 				...( design && { assembler_source: getAssemblerSource( design ) } ),
 				...( flowVariantSlug && { flow_variant: flowVariantSlug } ),
 				...( skipStepRender && { skip_step_render: skipStepRender } ),

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -18,6 +18,7 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import {
 	STEPPER_TRACKS_EVENT_SIGNUP_START,
+	STEPPER_TRACKS_EVENT_SIGNUP_STEP_START,
 	STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
 } from '../constants';
 import { useFlowLocale } from '../hooks/use-flow-locale';
@@ -51,6 +52,10 @@ const onboarding: Flow = {
 	useTracksEventProps() {
 		const isGoalsAtFrontExperiment = useGoalsFirstExperiment()[ 1 ];
 		const userIsLoggedIn = useSelector( isUserLoggedIn );
+		const goals = useSelect(
+			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getGoals(),
+			[]
+		);
 
 		return useMemo(
 			() => ( {
@@ -59,8 +64,14 @@ const onboarding: Flow = {
 					...( isGoalsAtFrontExperiment && { step: 'goals' } ),
 					is_logged_out: ( ! userIsLoggedIn ).toString(),
 				},
+				[ STEPPER_TRACKS_EVENT_SIGNUP_STEP_START ]: {
+					...( isGoalsAtFrontExperiment && {
+						is_goals_first: isGoalsAtFrontExperiment.toString(),
+					} ),
+					...( goals.length && { goals: goals.join( ',' ) } ),
+				},
 			} ),
-			[ isGoalsAtFrontExperiment, userIsLoggedIn ]
+			[ isGoalsAtFrontExperiment, userIsLoggedIn, goals ]
 		);
 	},
 	useSteps() {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes  https://github.com/Automattic/wp-calypso/issues/98058

## Proposed Changes

* add properties `goals` and `is_goals_first` to the `calypso_signup_step_start` event.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To simply the data work since they rely on `calypso_signup_step_start` to track user progression in the signup funnel. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `setup/onboarding`
* Go through the flow and verify for each step selected goals and `is_goals_first` is recorded in the `calypso_signup_step_start` event.


![image](https://github.com/user-attachments/assets/478dab29-0ea7-4a94-9e3f-54fdce22a034)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
