### PR TITLE
Fix colours on email create account screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -95,6 +95,7 @@
 
 	.signup-form-social-first-email {
 		.card {
+			background: transparent;
 			box-shadow: none;
 			padding-left: 0;
 			padding-right: 0;
@@ -152,11 +153,11 @@
 			text-underline-offset: 5px;
 
 			&:hover {
-				color: var(--studio-blue-50, #0675c4);
+				color: var(--studio-wordpress-blue, #3858e9);
 			}
 
 			&:focus {
-				outline: 1px dashed var(--studio-blue-50, #0675c4);
+				outline: 1px dashed var(--studio-wordpress-blue, #3858e9);
 				outline-offset: 3px;
 				box-shadow: none;
 				border-radius: 0;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -153,11 +153,11 @@
 			text-underline-offset: 5px;
 
 			&:hover {
-				color: var(--studio-wordpress-blue, #3858e9);
+				color: var(--color-accent, #3858e9);
 			}
 
 			&:focus {
-				outline: 1px dashed var(--studio-wordpress-blue, #3858e9);
+				outline: 1px dashed var(--color-accent, #3858e9);
 				outline-offset: 3px;
 				box-shadow: none;
 				border-radius: 0;


### PR DESCRIPTION
## Proposed Changes

This PR removes an unintended background colour and fixes the back button's hover colour. The background is subtle. You can't unsee it after you do.

**Before**
<img width="1725" alt="image" src="https://github.com/user-attachments/assets/fc71d5f0-48d8-4e8c-956b-5039bcbb769f" />

**After**
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/184dfb21-76a3-4433-bf7d-509b7f59693a" />

## Testing Instructions

* Open an incognito window or visit your local host while logged out
* Navigate to `/setup/onboarding/user?categories=blog&theme=psychedeli`
* Hover hover Back (You should see the Blue Berry Blue vs. the old one)
* Compare against `https://wordpress.com/setup/onboarding/user?categories=blog&theme=psychedeli`

(You might need to set a dark colour on a parent item to really notice the difference. It's subtle!)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
