### PR TITLE
Login: style button for Akismet-branded login in 'continue as user' scenario

### DIFF
--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -54,7 +54,8 @@ form {
 	font-size: 0.75rem;
 }
 
-.layout.is-white-login .login.is-akismet .login__form {
+.layout.is-white-login .login.is-akismet .login__form,
+.layout.is-white-login .login.is-akismet .continue-as-user {
 	.button.is-primary {
 		background-color: var(--color-akismet);
 


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/97435.

## Proposed Changes

* Small tweak to Akismet login styles to ensure the 'Continue' button is the correct color when the login step offers to continue as an existing user.

<img width="602" alt="Screenshot 2025-01-09 at 11 41 19" src="https://github.com/user-attachments/assets/17fbfe14-e470-434e-aade-c56d121f49b6" />




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the Akismet-branded login added originally in https://github.com/Automattic/wp-calypso/pull/97435.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Login to WordPress.com, then visit https://wordpress.com/log-in?redirect_to=https%3A%2F%2Fr-login.wordpress.com%2Fremote-login.php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet.com%252Faccount%252F.

The 'Continue' button should be green.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
