### PR TITLE
Add spacing to unglue buttons when no domain exist.

### DIFF
--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -434,9 +434,14 @@
 		}
 
 		.empty-content__title,
-		.empty-content__line,
-		.empty-content__action {
+		.empty-content__line {
 			margin-top: 32px;
+		}
+
+		.empty-content__action {
+			margin-right: 8px;
+			margin-left: 8px;
+			margin-bottom: 16px;
 		}
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/98124

## Proposed Changes

This PR fixes an issue with button spacing for the [email-no-domains.tsx](https://github.com/Automattic/wp-calypso/blob/07c6d2bb84f836988815a3d6b7dc966d8c6b81b1/client/my-sites/email/email-management/home/email-no-domain.tsx#L58) view. I've copied the spacing used on `wordpress.com/domains/manage/{site_url}` ([code](https://github.com/Automattic/wp-calypso/blob/07c6d2bb84f836988815a3d6b7dc966d8c6b81b1/client/my-sites/domains/domain-management/list/empty-domains-list-card-skeleton.tsx#L59)) while making minimal changes to the HTML structure.

> [!CAUTION] 
> This problem is only visible in production due to CSS file concatenation and minimization. If you test this on a local instance of calypso, the styles will work properly.

## Screenshots
| Before (320,600,1200) | After (320,600,1200) |
|--------|--------|
| ![wordpress com_email_stevedufresnep2 wordpress com (2)](https://github.com/user-attachments/assets/c6f6fc80-b089-4012-842b-8022dfa9800d) | ![calypso localhost_3000_email_stevedufresnep2 wordpress com (2)](https://github.com/user-attachments/assets/45f3e756-1e6f-4bcd-8fbe-3151ce852415) |
| ![wordpress com_email_stevedufresnep2 wordpress com (1)](https://github.com/user-attachments/assets/0dd70c95-1bb6-46e4-9d92-7e911202eef9) | ![calypso localhost_3000_email_stevedufresnep2 wordpress com (1)](https://github.com/user-attachments/assets/c51a201f-32c7-429e-8e71-c8e6db846ed1) |
| ![wordpress com_email_stevedufresnep2 wordpress com](https://github.com/user-attachments/assets/6afce943-82b3-46a4-b2f6-e59b0faecf74) | ![calypso localhost_3000_email_stevedufresnep2 wordpress com](https://github.com/user-attachments/assets/2406520c-1c6f-4302-860b-70645247c585) |

## Why are these changes being made?
The buttons should not be touching.

## Testing Instructions
* On a free plan without a domain, navigate to `//(wordpress.com|calypso.localhost:3000)/email/{your_site_domain}`
* The buttons, "Upgrade to a plan" and "Just search for a domain" should have spacing between them.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
