### PR TITLE
Tracks: Remove event prop assembler_source

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -29,7 +29,6 @@ export function recordPreviewedDesign( {
 			colorVariation,
 			fontVariation,
 		} ),
-		...getDesignTypeProps( design ),
 		...getVirtualDesignProps( design ),
 	} );
 }
@@ -68,17 +67,10 @@ export function recordSelectedDesign( {
 				colorVariation,
 				fontVariation,
 			} ),
-			...getDesignTypeProps( design ),
 			...getVirtualDesignProps( design ),
 			...optionalProps,
 		} );
 	}
-}
-
-export function getDesignTypeProps( design?: Design ) {
-	return {
-		assembler_source: getAssemblerSource( design ),
-	};
 }
 
 export function getDesignEventProps( {
@@ -129,30 +121,4 @@ export function getVirtualDesignProps( design: Design ) {
 		is_virtual: design.is_virtual,
 		slug: design.is_virtual ? design.recipe?.slug : design.slug,
 	};
-}
-
-/**
- * Tracks prop
- *  name: assembler_source
- *  values:
- *		• virtual-theme
- *		• blank-canvas-theme
- * 		• standard
- * 		• premium
- * 		• default
- */
-export function getAssemblerSource( design?: Design ) {
-	const { design_type, is_virtual } = design ?? {};
-
-	if ( is_virtual ) {
-		return 'virtual-theme';
-	}
-
-	if ( design_type === 'assembler' ) {
-		// blank-canvas-theme
-		return 'design-your-own';
-	}
-
-	// Standard, premium, default...
-	return design?.design_type;
 }

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -4,13 +4,11 @@ import { isAnyHostingFlow } from '@automattic/onboarding';
 import { useEffect, useRef } from '@wordpress/element';
 import { STEPPER_TRACKS_EVENT_SIGNUP_STEP_START } from 'calypso/landing/stepper/constants';
 import { getStepOldSlug } from 'calypso/landing/stepper/declarative-flow/helpers/get-step-old-slug';
-import { getAssemblerSource } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-design';
 import recordStepComplete, {
 	type RecordStepCompleteProps,
 } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-step-complete';
 import recordStepStart from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-step-start';
 import { useIntent } from 'calypso/landing/stepper/hooks/use-intent';
-import { useSelectedDesign } from 'calypso/landing/stepper/hooks/use-selected-design';
 import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
 import kebabCase from 'calypso/landing/stepper/utils/kebabCase';
 import useSnakeCasedKeys from 'calypso/landing/stepper/utils/use-snake-cased-keys';
@@ -48,7 +46,6 @@ interface Props {
  */
 export const useStepRouteTracking = ( { flow, stepSlug, skipStepRender }: Props ) => {
 	const intent = useIntent();
-	const design = useSelectedDesign();
 	const hasRequestedSelectedSite = useHasRequestedSelectedSite();
 	const stepCompleteEventPropsRef = useRef< RecordStepCompleteProps | null >( null );
 	const pathname = window.location.pathname;
@@ -94,7 +91,6 @@ export const useStepRouteTracking = ( { flow, stepSlug, skipStepRender }: Props 
 		recordStepStart( flowName, kebabCase( stepSlug ), {
 			intent,
 			is_in_hosting_flow: isAnyHostingFlow( flowName ),
-			...( design && { assembler_source: getAssemblerSource( design ) } ),
 			...( flowVariantSlug && { flow_variant: flowVariantSlug } ),
 			...( skipStepRender && { skip_step_render: skipStepRender } ),
 			...reenteringStepAfterSignupCompleteProps,
@@ -117,7 +113,6 @@ export const useStepRouteTracking = ( { flow, stepSlug, skipStepRender }: Props 
 			recordStepStart( flowName, kebabCase( stepOldSlug ), {
 				intent,
 				is_in_hosting_flow: isAnyHostingFlow( flowName ),
-				...( design && { assembler_source: getAssemblerSource( design ) } ),
 				...( flowVariantSlug && { flow_variant: flowVariantSlug } ),
 				...( skipStepRender && { skip_step_render: skipStepRender } ),
 				...reenteringStepAfterSignupCompleteProps,

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/test/index.tsx
@@ -165,7 +165,6 @@ describe( 'StepRoute', () => {
 
 			expect( recordStepStart ).toHaveBeenCalledWith( 'some-flow', 'some-step-slug', {
 				intent: 'build',
-				assembler_source: 'premium',
 				is_in_hosting_flow: false,
 			} );
 		} );
@@ -181,7 +180,6 @@ describe( 'StepRoute', () => {
 				signup_complete_flow_name: 'some-flow',
 				signup_complete_step_name: 'some-step-slug',
 				intent: 'build',
-				assembler_source: 'premium',
 				is_in_hosting_flow: false,
 			} );
 		} );
@@ -213,7 +211,6 @@ describe( 'StepRoute', () => {
 
 			expect( recordStepStart ).toHaveBeenCalledWith( 'some-flow', 'some-step-slug', {
 				intent: 'build',
-				assembler_source: 'premium',
 				is_in_hosting_flow: false,
 				skip_step_render: true,
 				signup_complete_flow_name: 'some-other-flow',
@@ -247,7 +244,6 @@ describe( 'StepRoute', () => {
 
 			expect( recordStepStart ).toHaveBeenCalledWith( 'some-flow', 'some-step-slug', {
 				intent: 'build',
-				assembler_source: 'premium',
 				is_in_hosting_flow: false,
 				skip_step_render: true,
 				signup_complete_flow_name: 'some-other-flow',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -79,7 +79,6 @@ import { goToCheckout } from '../../../../utils/checkout';
 import { useGoalsFirstExperiment } from '../../../helpers/use-goals-first-experiment';
 import {
 	getDesignEventProps,
-	getDesignTypeProps,
 	recordPreviewedDesign,
 	recordSelectedDesign,
 	getVirtualDesignProps,
@@ -714,7 +713,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 		submit?.( {
 			...providedDependencies,
-			...getDesignTypeProps( _selectedDesign ),
 			eventProps: commonFilterProperties,
 		} );
 	}


### PR DESCRIPTION
## Proposed Changes

This PR removes the event prop `assembler_source` introduced via https://github.com/Automattic/dotcom-forge/issues/2509. This is no longer needed as we have sunset the Site Assembler.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Code clean-up.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Smoke test the Design Picker flow.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
