### PR TITLE
Help Center: Refactor AttachmentButton component to simplify rendering logic for the icon

### DIFF
--- a/packages/odie-client/src/components/send-message-input/attachment-button.tsx
+++ b/packages/odie-client/src/components/send-message-input/attachment-button.tsx
@@ -88,9 +88,7 @@ export const AttachmentButton: React.FC< {
 	return (
 		<FormFileUpload accept="image/*" onChange={ onFileUpload } disabled={ isAttachingFile }>
 			{ isAttachingFile && <Spinner style={ { margin: 0 } } /> }
-			{ ! isAttachingFile && attachmentButtonRef && (
-				<Icon ref={ attachmentButtonRef } icon={ image } />
-			) }
+			{ ! isAttachingFile && <Icon ref={ attachmentButtonRef } icon={ image } /> }
 		</FormFileUpload>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/97701

## Proposed Changes

* Refactor AttachmentButton component to simplify rendering logic for the icon

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Testing changes to fix issues with the attachment inconsistently displaying.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use lthe ive link.
* Open the Help Center, start a conversation with HE support
* Verify the attachment button appears next to the input field and is working correctly.
