### PR TITLE
Server settings: prevent loading SFTP settings for sites that don't support them

### DIFF
--- a/client/sites/tools/sftp-ssh/sftp-form.tsx
+++ b/client/sites/tools/sftp-ssh/sftp-form.tsx
@@ -177,12 +177,14 @@ export const SftpForm = ( {
 	useEffect( () => {
 		if ( ! disabled ) {
 			setIsLoading( true );
-			dispatch( requestAtomicSftpUsers( siteId ) );
+			if ( siteHasSftpFeature ) {
+				dispatch( requestAtomicSftpUsers( siteId ) );
+			}
 			if ( siteHasSshFeature ) {
 				dispatch( requestAtomicSshAccess( siteId ) );
 			}
 		}
-	}, [ disabled, siteId, siteHasSshFeature, dispatch ] );
+	}, [ disabled, siteId, siteHasSshFeature, siteHasSftpFeature, dispatch ] );
 
 	// For security reasons we remove the password from the state when the component is unmounted
 	// Since users should reset it every time they want to see it


### PR DESCRIPTION
Related to issue Automattic/dotcom-forge#9900



## Proposed Changes

For sites that do not support SFTP, don't dispatch `requestAtomicSftpUsers` action.

The action attempts to trigger the [sftp handlers registered in the data layer](https://github.com/Automattic/wp-calypso/blob/ad951ea36a26dcf3154c21abf9cdf906c3f07689/client/state/data-layer/wpcom/sites/hosting/sftp-user.js#L13-L13).


This prevents the `/hosting/ssh-users` endpoint being called with simple site IDs.

## Why are these changes being made?

If you switch to an Atomic site, the handlers are registered. Switching to a simple site fire the handlers, even though they don't support SFTP.


## Testing Instructions

Navigate to server settings on an Atomic site, e.g., http://calypso.localhost:3000/hosting-config/[ATOMIC_SITE]

Also monitor the network XHR requests. 

Make sure there is a correct 200 response from `/hosting/ssh-users` e.g.,

```json
{
    "body": {
        "users": [
            "YOUR_USER.wordpress.com",
            "SOME_OTHER"
        ]
    },
    "status": 200,
    "headers": []
}
```

Then switch to a simple site. Wait a bit.

The "Sorry, we had a problem retrieving your sftp user details. Please refresh the page and try again." error should not appear.

There should be no 200 to `/hosting/ssh-users` with the following response.

```
{
    "body": {
        "code": "rest_cannot_view",
        "message": "Sorry, you are not allowed to view that resource.",
        "data": {
            "status": 403
        }
    },
    "status": 403,
    "headers": []
}
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
