### PR TITLE
DIFM: Update landing page styling to use WordPress blue

### DIFF
--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -128,6 +128,7 @@ const FAQSection = styled.div`
 const FoldableFAQ = styled( FoldableFAQComponent )`
 	border: 1px solid #e9e9ea;
 	padding: 0;
+	border-radius: 4px;
 	margin-bottom: 24px;
 	.foldable-faq__question {
 		padding: 24px 16px 24px 24px;
@@ -144,12 +145,7 @@ const FoldableFAQ = styled( FoldableFAQComponent )`
 		}
 	}
 	&.is-expanded {
-		border: 2px solid var( --studio-blue-50 );
-		background: linear-gradient(
-			180deg,
-			rgba( 6, 117, 196, 0.2 ) -44.3%,
-			rgba( 255, 255, 255, 0 ) 100%
-		);
+		border: 2px solid var( --studio-wordpress-blue-50 );
 		.foldable-faq__answer {
 			margin: 0 16px 24px 0;
 			ul {
@@ -158,8 +154,7 @@ const FoldableFAQ = styled( FoldableFAQComponent )`
 		}
 	}
 	&:not( .is-expanded ) .foldable-faq__question:focus {
-		box-shadow: 0 0 0 var( --wp-admin-border-width-focus )
-			var( --wp-components-color-accent, var( --wp-admin-theme-color, #3858e9 ) );
+		box-shadow: 0 0 0 var( --studio-wordpress-blue-50, var( --wp-admin-theme-color, #3858e9 ) );
 		outline: 3px solid transparent;
 	}
 	.foldable-faq__answer {
@@ -187,10 +182,12 @@ const CTASectionWrapper = styled.div`
 		}
 	}
 	.components-button.is-secondary {
-		box-shadow: inset 0 0 0 1px var( --studio-blue-50, var( --wp-admin-theme-color, #3858e9 ) );
+		border-radius: 4px;
+		box-shadow: inset 0 0 0 1px
+			var( --studio-wordpress-blue-50, var( --wp-admin-theme-color, #3858e9 ) );
 		outline: 1px solid transparent;
 		white-space: nowrap;
-		color: var( --studio-blue-50, var( --wp-admin-theme-color, #3858e9 ) );
+		color: var( --studio-wordpress-blue-50, var( --wp-admin-theme-color, #3858e9 ) );
 		background: transparent;
 		border: none;
 		&:focus {


### PR DESCRIPTION
Fixes #98081

## Proposed Changes

* Update DIFM landing page styling to use WordPress blue variables
* Add border radius to FAQ component and the secondary button
* Simplify expanded FAQ state styling

| Before | After |
|--------|--------|
| <img width="850" alt="Screenshot 2025-01-09 at 12 01 34" src="https://github.com/user-attachments/assets/2b372c09-0fe5-4c0d-becc-381b3740bf71" /> | <img width="850" alt="Screenshot 2025-01-09 at 11 59 39" src="https://github.com/user-attachments/assets/a7721b94-4158-4f5f-a8fe-dc3d8bb7487d" /> |


## Why are these changes being made?

Updates visual styling to match WordPress.com design system.

## Testing Instructions

1. Visit `/setup/onboarding/difmStartingPoint` landing page
2. Verify FAQ sections have rounded corners
3. Verify expanded FAQ state uses WordPress blue color
4. Verify CTA buttons have rounded corners and correct blue color
5. Test focus states on FAQ questions

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
