### PR TITLE
Revert "Refactor sites per plugin view to use DataViews (#97870)"

### DIFF
--- a/client/my-sites/plugins/constants.js
+++ b/client/my-sites/plugins/constants.js
@@ -44,9 +44,6 @@ export const AUTOMOMANAGED_PLUGINS = [
 	'polldaddy',
 	'classic-editor',
 	'wordpress-seo',
-	'amp',
-	'mailpoet',
-	'sensei-lms',
 ]; // These plugins auto update but can be activated / deactivated.
 
 export const ECOMMERCE_BUNDLED_PLUGINS = [

--- a/client/my-sites/plugins/plugin-action/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-action/plugin-action.jsx
@@ -72,7 +72,6 @@ class PluginAction extends Component {
 					id={ this.props.htmlFor }
 					label={ this.renderLabel() }
 					aria-label={ this.props.label }
-					__nextHasNoMarginBottom
 				/>
 				{ this.props.toggleExtraContent }
 			</>

--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -28,6 +28,7 @@
 	.components-toggle-control {
 		.components-base-control__field {
 			display: inline-block;
+			margin-bottom: 5px;
 
 			.components-form-toggle {
 				margin-right: 0;

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
@@ -1,20 +1,12 @@
-import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useState, useCallback } from 'react';
-import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
-import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
-import { DataViews } from 'calypso/components/dataviews';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import PluginCommonAction from 'calypso/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-actions';
-import PluginRowFormatter from 'calypso/my-sites/plugins/plugin-management-v2/plugin-row-formatter';
 import { getSitesWithSecondarySites } from 'calypso/my-sites/plugins/plugin-management-v2/utils/get-sites-with-secondary-sites';
-import { useDispatch, useSelector } from 'calypso/state';
-import { updatePlugin } from 'calypso/state/plugins/installed/actions';
-import { PluginSite } from 'calypso/state/plugins/installed/types';
+import { useSelector } from 'calypso/state';
 import PluginManageConnection from '../plugin-manage-connection';
 import PluginManageSubcription from '../plugin-manage-subscription';
 import RemovePlugin from '../remove-plugin';
+import SitesList from '../sites-list';
 import type { PluginComponentProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 
@@ -28,141 +20,34 @@ interface Props {
 	isWpCom?: boolean;
 }
 
-export default function SitesWithInstalledPluginsList( { sites, plugin, isWpCom }: Props ) {
+export default function SitesWithInstalledPluginsList( {
+	sites,
+	plugin,
+	selectedSite,
+	isWpCom,
+	...rest
+}: Props ) {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
-
-	const compareBooleans =
-		( fieldName: keyof PluginSite ) => ( a: SiteDetails, b: SiteDetails, direction: string ) => {
-			const aValue = plugin.sites[ a.ID ][ fieldName ];
-			const bValue = plugin.sites[ b.ID ][ fieldName ];
-			if ( aValue === bValue ) {
-				return 0;
-			}
-			if ( direction === 'asc' ) {
-				return aValue ? 1 : -1;
-			}
-			return aValue ? -1 : 1;
-		};
-
-	const renderActions = useCallback(
-		( site: SiteDetails ) => {
-			const settingsLink = plugin?.action_links?.Settings ?? null;
-			return (
-				<>
-					<RemovePlugin site={ site } plugin={ plugin } />
-					<PluginManageConnection site={ site } plugin={ plugin } />
-					{ isWpCom && (
-						<>
-							<PluginManageSubcription site={ site } plugin={ plugin } />
-							{ settingsLink && (
-								<PopoverMenuItem
-									className="plugin-management-v2__actions"
-									icon="cog"
-									href={ settingsLink }
-								>
-									{ translate( 'Settings' ) }
-								</PopoverMenuItem>
-							) }
-						</>
-					) }
-				</>
-			);
+	const columns = [
+		{
+			key: 'site-name',
+			header: translate( 'Site' ),
 		},
-		[ plugin, isWpCom, translate ]
-	);
-
-	const dataViewsFields = useMemo(
-		() => [
-			{
-				id: 'domain',
-				label: translate( 'Site' ),
-				getValue: ( { item }: { item: SiteDetails } ) => item.domain,
-				render: ( { item }: { item: SiteDetails } ) => {
-					return (
-						<PluginRowFormatter
-							item={ plugin }
-							columnKey="site-name"
-							selectedSite={ item }
-							siteCount={ sites.length }
-						/>
-					);
-				},
-				enableHiding: false,
-				enableSorting: true,
-				enableGlobalSearch: true,
-			},
-			{
-				id: 'activate',
-				label: translate( 'Active' ),
-				getValue: ( { item }: { item: SiteDetails } ) => plugin.sites[ item.ID ].active,
-				render: ( { item }: { item: SiteDetails } ) => {
-					return (
-						<PluginRowFormatter
-							item={ plugin }
-							columnKey="activate"
-							selectedSite={ item }
-							siteCount={ sites.length }
-						/>
-					);
-				},
-				enableHiding: false,
-				enableSorting: true,
-				sort: compareBooleans( 'active' ),
-			},
-			{
-				id: 'autoupdate',
-				label: translate( 'Autoupdate' ),
-				getValue: ( { item }: { item: SiteDetails } ) => plugin.sites[ item.ID ].autoupdate,
-				render: ( { item }: { item: SiteDetails } ) => {
-					return (
-						<PluginRowFormatter
-							item={ plugin }
-							columnKey="autoupdate"
-							selectedSite={ item }
-							siteCount={ sites.length }
-						/>
-					);
-				},
-				enableHiding: false,
-				enableSorting: true,
-				sort: compareBooleans( 'autoupdate' ),
-			},
-			{
-				id: 'update',
-				label: translate( 'Update' ),
-				render: ( { item }: { item: SiteDetails } ) => {
-					return (
-						<PluginRowFormatter
-							item={ plugin }
-							columnKey="update"
-							selectedSite={ item }
-							siteCount={ sites.length }
-							updatePlugin={ () => dispatch( updatePlugin( item.ID, plugin ) ) }
-						/>
-					);
-				},
-				enableHiding: false,
-				enableSorting: false,
-			},
-			{
-				id: 'actions',
-				label: translate( 'Actions' ),
-				render: ( { item }: { item: SiteDetails } ) => (
-					<PluginCommonAction item={ item } renderActions={ renderActions } />
-				),
-				enableHiding: false,
-				enableSorting: false,
-			},
-		],
-		[ translate, plugin, sites.length, dispatch, renderActions ]
-	);
-
-	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( () => ( {
-		...initialDataViewsState,
-		fields: [ 'domain', 'activate', 'autoupdate', 'update', 'actions' ],
-		items: sites,
-	} ) );
+		{
+			key: 'activate',
+			header: translate( 'Active' ),
+			smallColumn: true,
+		},
+		{
+			key: 'autoupdate',
+			header: translate( 'Autoupdate' ),
+			smallColumn: true,
+			colSpan: 4,
+		},
+		{
+			key: 'update',
+		},
+	];
 
 	const sitesWithSecondarySites = useSelector( ( state ) =>
 		getSitesWithSecondarySites( state, sites )
@@ -173,18 +58,33 @@ export default function SitesWithInstalledPluginsList( { sites, plugin, isWpCom 
 	}
 
 	const siteCount = sitesWithSecondarySites.length;
-	const dataViewsSites = sitesWithSecondarySites
-		.map( ( site ) => site.site )
-		.filter( ( site ) => site && ! site.is_deleted );
 
-	const { data, paginationInfo } = filterSortAndPaginate(
-		dataViewsSites.filter( ( site ): site is SiteDetails => site !== null && site !== undefined ),
-		dataViewsState,
-		dataViewsFields
-	);
+	const renderActions = ( site: SiteDetails ) => {
+		const settingsLink = plugin?.action_links?.Settings ?? null;
+		return (
+			<>
+				<RemovePlugin site={ site } plugin={ plugin } />
+				<PluginManageConnection site={ site } plugin={ plugin } />
+				{ isWpCom && (
+					<>
+						<PluginManageSubcription site={ site } plugin={ plugin } />
+						{ settingsLink && (
+							<PopoverMenuItem
+								className="plugin-management-v2__actions"
+								icon="cog"
+								href={ settingsLink }
+							>
+								{ translate( 'Settings' ) }
+							</PopoverMenuItem>
+						) }
+					</>
+				) }
+			</>
+		);
+	};
 
 	return (
-		<div className="plugin-details-v2__sites-list">
+		<>
 			<div className="plugin-details-v2__title">
 				{ translate(
 					'Installed on %(count)d site',
@@ -196,15 +96,16 @@ export default function SitesWithInstalledPluginsList( { sites, plugin, isWpCom 
 				) }
 			</div>
 			{ isWpCom && plugin.isMarketplaceProduct && <QueryUserPurchases /> }
-			<DataViews
-				fields={ dataViewsFields }
-				data={ data }
-				view={ dataViewsState }
-				onChangeView={ setDataViewsState }
-				paginationInfo={ paginationInfo }
-				defaultLayouts={ { table: {} } }
-				getItemId={ ( item ) => item.domain }
+			<SitesList
+				{ ...rest }
+				plugin={ plugin }
+				selectedSite={ selectedSite }
+				items={ sitesWithSecondarySites
+					.map( ( site ) => site.site )
+					.filter( ( site ) => site && ! site.is_deleted ) }
+				columns={ columns }
+				renderActions={ renderActions }
 			/>
-		</div>
+		</>
 	);
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/style.scss
@@ -1,5 +1,5 @@
-@import '@wordpress/base-styles/breakpoints';
-@import '@wordpress/base-styles/mixins';
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 .plugin-details-v2 {
 	padding: 0 16px;
@@ -15,7 +15,7 @@
 
 	.plugin-details-v2__body-container {
 		padding-block-start: 0;
-		background: var( --color-surface );
+		background: var(--color-surface);
 		margin: 32px -180px -32px;
 		padding: 0 180px;
 
@@ -24,7 +24,7 @@
 		}
 	}
 
-	@include breakpoint-deprecated( '>660px' ) {
+	@include breakpoint-deprecated( ">660px" ) {
 		padding: 0;
 	}
 
@@ -46,7 +46,7 @@
 		display: flex;
 		margin: 10px 0;
 
-		@include breakpoint-deprecated( '>660px' ) {
+		@include breakpoint-deprecated( ">660px" ) {
 			margin: 0;
 		}
 	}
@@ -54,7 +54,7 @@
 	.plugin-details__page {
 		padding: 0;
 
-		@include breakpoint-deprecated( '>660px' ) {
+		@include breakpoint-deprecated( ">660px" ) {
 			padding: 30px 0 0;
 		}
 	}
@@ -83,13 +83,13 @@
 				&:first-child .section-nav-tab__link {
 					padding: 8px 8px 12px;
 
-					@include breakpoint-deprecated( '>660px' ) {
+					@include breakpoint-deprecated( ">660px" ) {
 						padding-left: 0;
 					}
 				}
 
 				&.is-selected .section-nav-tab__link {
-					color: var( --color-text-inverted );
+					color: var(--color-text-inverted);
 
 					.section-nav-tab__text {
 						padding-bottom: 0;
@@ -97,7 +97,7 @@
 						border-bottom: none;
 					}
 
-					@include breakpoint-deprecated( '>660px' ) {
+					@include breakpoint-deprecated( ">660px" ) {
 						color: initial;
 					}
 				}
@@ -108,15 +108,15 @@
 
 .plugin-details-v2__header {
 	border-bottom: none !important;
-	background-color: var( --color-surface-backdrop ) !important;
+	background-color: var(--color-surface-backdrop) !important;
 
-	@include breakpoint-deprecated( '>660px' ) {
-		inset-inline-start: calc( var( --sidebar-width-min ) + 1px ) !important;
+	@include breakpoint-deprecated( ">660px" ) {
+		inset-inline-start: calc(var(--sidebar-width-min) + 1px) !important;
 		padding-inline-start: 24px !important;
 	}
 
 	@include break-large {
-		inset-inline-start: calc( var( --sidebar-width-min ) + 45px ) !important;
+		inset-inline-start: calc(var(--sidebar-width-min) + 45px) !important;
 		padding-inline-start: 39px !important;
 	}
 
@@ -132,31 +132,6 @@
 
 .plugin-details-v2__title {
 	font-size: 0.875rem;
-	color: var( --color-text );
+	color: var(--color-text);
 	margin: 16px 0;
-}
-
-.plugin-details-v2__sites-list {
-	.dataviews-view-table tr {
-		th:last-child {
-			text-align: right;
-			padding-right: 0;
-		}
-
-		td:last-child {
-			padding-right: 16px;
-		}
-
-		td:first-child .dataviews-view-table__cell-content-wrapper > span {
-			flex-grow: 1;
-
-			.plugin-row-formatter__overlay {
-				display: none;
-			}
-		}
-
-		td:last-child .dataviews-view-table__cell-content-wrapper {
-			justify-content: flex-end;
-		}
-	}
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
@@ -85,6 +85,15 @@ a.button.plugin-row-formatter__plugin-name-card {
 		}
 	}
 
+	.components-form-toggle {
+		position: absolute;
+		inset-inline-start: 200px;
+
+		@include break-xlarge {
+			position: relative;
+			inset-inline-start: unset;
+		}
+	}
 }
 
 .plugin-row-formatter__install-plugin {

--- a/client/my-sites/plugins/plugins-dashboard/style.scss
+++ b/client/my-sites/plugins/plugins-dashboard/style.scss
@@ -39,6 +39,7 @@
 	}
 
 	.plugin-manage-sites-pane {
+
 		.hosting-dashboard-layout__body-wrapper {
 			padding-inline: 24px;
 		}
@@ -56,7 +57,7 @@
 		}
 
 		.plugin-details-v2__title {
-			color: var( --studio-gray-100 );
+			color: var(--studio-gray-100);
 			font-size: 1.25rem;
 			padding: 16px 0;
 		}
@@ -220,17 +221,12 @@
 		max-width: none;
 	}
 
-	&.sites-dashboard__layout .hosting-dashboard-layout-with-columns__container {
+	&.sites-dashboard__layout .hosting-dashboard-layout-with-columns__container { 
 		.hosting-dashboard-layout-column .hosting-dashboard-layout-column__container {
 			display: flex;
 			flex-direction: column;
 			flex-wrap: nowrap;
-			height: calc(
-				100vh - var( --masterbar-height ) - var( --content-padding-top, 32px ) - var(
-						--content-padding-bottom,
-						32px
-					)
-			);
+			height: calc(100vh - var(--masterbar-height) - var(--content-padding-top, 32px ) - var(--content-padding-bottom, 32px));
 		}
 	}
 
@@ -347,7 +343,7 @@
 body.is-section-plugins .hosting-dashboard-layout,
 .is-section-jetpack-cloud-plugin-management .hosting-dashboard-layout {
 	.hosting-dashboard-layout-with-columns__container {
-		background-color: var( --studio-gray-0 );
+    background-color: var(--studio-gray-0);
 	}
 	.dataviews-wrapper {
 		margin: auto;


### PR DESCRIPTION
This reverts commit 03d14a51391bd6537250d58f44e1918fe0bfa838.

This is to have the previous version of the table

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
