### PR TITLE
Revert "Site Migration: Use the new experiment identifier"

### DIFF
--- a/client/sites/hooks/use-sites-dashboard-import-site-url.ts
+++ b/client/sites/hooks/use-sites-dashboard-import-site-url.ts
@@ -7,7 +7,7 @@ export const useSitesDashboardImportSiteUrl = (
 	additionalParameters: Record< string, Primitive >
 ) => {
 	const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
-		'calypso_signup_onboarding_site_migration_flow_202501_v1'
+		'calypso_optimized_migration_flow_v2'
 	);
 
 	if ( isLoadingExperiment ) {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#97892
Reverting because the A/B is targeting only the site-migration flow.

The updated flag was managing the access to the `/migration` flow