### PR TITLE
Stats: Bring back Subscribers tab for self-hosted sites

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -21,6 +21,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import {
 	getJetpackStatsAdminVersion,
 	getSiteOption,
+	isJetpackSite,
 	isSimpleSite,
 } from 'calypso/state/sites/selectors';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
@@ -67,6 +68,7 @@ class StatsNavigation extends Component {
 		isWordAds: PropTypes.bool,
 		isSubscriptionsModuleActive: PropTypes.bool,
 		isSimple: PropTypes.bool,
+		isSiteJetpackNotAtomic: PropTypes.bool,
 		hasVideoPress: PropTypes.bool,
 		selectedItem: PropTypes.oneOf( Object.keys( navItems ) ).isRequired,
 		siteId: PropTypes.number,
@@ -146,6 +148,7 @@ class StatsNavigation extends Component {
 			isWordAds,
 			isSubscriptionsModuleActive,
 			isSimple,
+			isSiteJetpackNotAtomic,
 			siteId,
 		} = this.props;
 
@@ -168,7 +171,10 @@ class StatsNavigation extends Component {
 					return false;
 				}
 
-				return isSimple || isSubscriptionsModuleActive;
+				// The value of isSubscriptionsModuleActive is null in Odyssey Stats so we default to showing the tab.
+				// Maintains existing behaviour inside wp-admin for self-hosted sites.
+				// For DotCom sites, it will only be shown on Simple sites or if subs are enabled.
+				return isSiteJetpackNotAtomic || isSimple || isSubscriptionsModuleActive;
 
 			default:
 				return true;
@@ -313,6 +319,7 @@ export default connect(
 				canCurrentUser( state, siteId, 'manage_options' ),
 			isSubscriptionsModuleActive: isJetpackModuleActive( state, siteId, 'subscriptions' ),
 			isSimple: isSimpleSite( state, siteId ),
+			isSiteJetpackNotAtomic: isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } ),
 			hasVideoPress: siteHasFeature( state, siteId, 'videopress' ),
 			siteId,
 			pageModuleToggles: getModuleToggles( state, siteId, [ selectedItem ] ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: https://github.com/Automattic/wp-calypso/pull/97811

## Proposed Changes

The newly introduced check for module activation returns null when checked from `/wp-admin` (ie: Odyssey running on self-hosted) so we enable the Subscribers tab by default for any self-hosted site (in both environments for consistency).

Without this, the Subscribers tab will never be visible via the `/wp-admin` dashboard on self-hosted sites.

If we want to disable the tab when the module is disabled, we'll need to revisit the logic and find something that works in the self-hosted environment as it appears the function is not available there.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Maintains existing behaviour for current self-hosted sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up Odyssey Stats test environment per: PCYsg-Pp7-p2
* Visit Traffic page.
* Confirm Subscribers tab is visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?