### PR TITLE
[Odie] Give Wapuu a Chance

### DIFF
--- a/packages/odie-client/src/components/message/dislike-feedback-message.tsx
+++ b/packages/odie-client/src/components/message/dislike-feedback-message.tsx
@@ -1,18 +1,12 @@
 import { __ } from '@wordpress/i18n';
 import Markdown from 'react-markdown';
 import { WapuuAvatar } from '../../assets/wapuu-avatar';
-import WapuuAvatarSquared from '../../assets/wapuu-squared-avatar.svg';
 import { useOdieAssistantContext } from '../../context';
 import { GetSupport } from './get-support';
 
 export const DislikeFeedbackMessage = () => {
-	const {
-		shouldUseHelpCenterExperience,
-		extraContactOptions,
-		botName,
-		isUserEligibleForPaidSupport,
-		trackEvent,
-	} = useOdieAssistantContext();
+	const { botName, isUserEligibleForPaidSupport, trackEvent, experimentName } =
+		useOdieAssistantContext();
 
 	const handleContactSupportClick = () => {
 		trackEvent( 'chat_dislike_feedback', {
@@ -48,52 +42,24 @@ export const DislikeFeedbackMessage = () => {
 		);
 	};
 
-	const renderRedesignedComponent = () => {
-		return (
-			<>
-				<div className="message-header bot">
-					<WapuuAvatar />
-					<strong className="message-header-name"></strong>
-				</div>
-				<div className="odie-chatbox-dislike-feedback-message">
-					{ isUserEligibleForPaidSupport
-						? renderEligibleUserMessage()
-						: renderNotEligibleUserMessage() }
-				</div>
+	if ( experimentName === 'give_a_chance' ) {
+		return null;
+	}
 
-				<GetSupport onClickAdditionalEvent={ handleContactSupportClick } />
-			</>
-		);
-	};
-
-	// This can be removed after removing the feature flag
-	const renderCurrentComponentDesign = () => {
-		return (
-			<>
-				<div className="message-header bot">
-					<img
-						src={ WapuuAvatarSquared }
-						alt={ __( 'AI profile picture', __i18n_text_domain__ ) }
-						className="odie-chatbox-message-avatar"
-					/>
-					<strong className="message-header-name">{ botName }</strong>
-				</div>
-				<div className="odie-chatbox-dislike-feedback-message">
-					<Markdown>
-						{ __(
-							'I’m sorry my last response didn’t meet your expectations! Here’s some other ways to get more in-depth help:',
-							__i18n_text_domain__
-						) }
-					</Markdown>
-					{ extraContactOptions }
-				</div>
-			</>
-		);
-	};
-
-	return shouldUseHelpCenterExperience
-		? renderRedesignedComponent()
-		: renderCurrentComponentDesign();
+	return (
+		<>
+			<div className="message-header bot">
+				<WapuuAvatar />
+				<strong className="message-header-name"></strong>
+			</div>
+			<div className="odie-chatbox-dislike-feedback-message">
+				{ isUserEligibleForPaidSupport
+					? renderEligibleUserMessage()
+					: renderNotEligibleUserMessage() }
+			</div>
+			<GetSupport onClickAdditionalEvent={ handleContactSupportClick } />
+		</>
+	);
 };
 
 export default DislikeFeedbackMessage;

--- a/packages/odie-client/src/components/message/dislike-feedback-message.tsx
+++ b/packages/odie-client/src/components/message/dislike-feedback-message.tsx
@@ -42,7 +42,8 @@ export const DislikeFeedbackMessage = () => {
 		);
 	};
 
-	if ( experimentName === 'give_a_chance' ) {
+	// Stops conflating the escalating to human support with the dislike feedback message
+	if ( experimentName === 'give_wapuu_a_chance' ) {
 		return null;
 	}
 

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -55,7 +55,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 	};
 
 	const statusArray =
-		experimentName === 'give_a_chance'
+		experimentName === 'give_wapuu_a_chance'
 			? [ 'sending', 'transfer' ]
 			: [ 'sending', 'dislike', 'transfer' ];
 
@@ -87,7 +87,9 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 							/>
 						) ) }
 						<JumpToRecent containerReference={ messagesContainerRef } />
-						{ chat.status === 'dislike' && experimentName !== 'give_a_chance' && <DislikeThumb /> }
+						{ chat.status === 'dislike' && experimentName !== 'give_wapuu_a_chance' && (
+							<DislikeThumb />
+						) }
 						{ statusArray.includes( chat.status ) && (
 							<div className="odie-chatbox__action-message">
 								{ chat.status === 'sending' && <ThinkingPlaceholder /> }

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -38,7 +38,7 @@ interface ChatMessagesProps {
 }
 
 export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
-	const { chat, shouldUseHelpCenterExperience, botNameSlug } = useOdieAssistantContext();
+	const { chat, botNameSlug, experimentName } = useOdieAssistantContext();
 	const [ chatMessagesLoaded, setChatLoaded ] = useState( false );
 	const messagesContainerRef = useRef< HTMLDivElement >( null );
 	useZendeskMessageListener();
@@ -47,24 +47,28 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 		( chat?.status === 'loaded' || chat?.status === 'closed' ) && setChatLoaded( true );
 	}, [ chat ] );
 
-	const shouldLoadChat: boolean =
-		! shouldUseHelpCenterExperience || ( shouldUseHelpCenterExperience && chatMessagesLoaded );
+	const shouldLoadChat: boolean = chatMessagesLoaded;
 
 	// Used to apply the correct styling on messages
 	const isNextMessageFromSameSender = ( currentMessage: string, nextMessage: string ) => {
 		return currentMessage === nextMessage;
 	};
 
+	const statusArray =
+		experimentName === 'give_a_chance'
+			? [ 'sending', 'transfer' ]
+			: [ 'sending', 'dislike', 'transfer' ];
+
 	return (
 		<>
 			<div className="chatbox-messages" ref={ messagesContainerRef }>
-				{ shouldUseHelpCenterExperience && <ChatDate chat={ chat } /> }
+				<ChatDate chat={ chat } />
 				{ ! shouldLoadChat ? (
 					<LoadingChatSpinner />
 				) : (
 					<>
 						<ChatMessage
-							message={ getOdieInitialMessage( botNameSlug, shouldUseHelpCenterExperience ) }
+							message={ getOdieInitialMessage( botNameSlug, true ) }
 							key={ 0 }
 							currentUser={ currentUser }
 							isNextMessageFromSameSender={ false }
@@ -83,8 +87,8 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 							/>
 						) ) }
 						<JumpToRecent containerReference={ messagesContainerRef } />
-						{ chat.status === 'dislike' && shouldUseHelpCenterExperience && <DislikeThumb /> }
-						{ [ 'sending', 'dislike', 'transfer' ].includes( chat.status ) && (
+						{ chat.status === 'dislike' && experimentName !== 'give_a_chance' && <DislikeThumb /> }
+						{ statusArray.includes( chat.status ) && (
 							<div className="odie-chatbox__action-message">
 								{ chat.status === 'sending' && <ThinkingPlaceholder /> }
 								{ chat.status === 'dislike' && <DislikeFeedbackMessage /> }

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -9,7 +9,19 @@ import { DirectEscalationLink } from './direct-escalation-link';
 import { GetSupport } from './get-support';
 import { uriTransformer } from './uri-transformer';
 import WasThisHelpfulButtons from './was-this-helpful-buttons';
-import type { Message } from '../../types';
+import type { Chat, Message } from '../../types';
+
+const isWordPressRelatedQuestion = ( message: Message ) => {
+	return ! (
+		message.context?.question_tags?.category === 'Other (everything else)' &&
+		message.context?.question_tags?.inquiry_type === 'other' &&
+		message.context?.question_tags?.product === 'unknown'
+	);
+};
+
+const shouldRenderRatingButtons = ( chat: Chat, message: Message ) => {
+	return isWordPressRelatedQuestion( message ) && chat.provider !== 'zendesk';
+};
 
 export const UserMessage = ( {
 	message,
@@ -26,17 +38,17 @@ export const UserMessage = ( {
 		shouldUseHelpCenterExperience,
 		trackEvent,
 		chat,
+		userHasEverEscalatedToHumanSupport,
 	} = useOdieAssistantContext();
 
 	const hasCannedResponse = message.context?.flags?.canned_response;
 	const isRequestingHumanSupport = message.context?.flags?.forward_to_human_support;
 	const hasFeedback = !! message?.rating_value;
 	const isBot = message.role === 'bot';
-	const isConnectedToZendesk = chat?.provider === 'zendesk';
 	const isPositiveFeedback =
 		hasFeedback && message && message.rating_value && +message.rating_value === 1;
 	const showExtraContactOptions =
-		( hasFeedback && ! isPositiveFeedback ) || isRequestingHumanSupport;
+		hasFeedback && ! isPositiveFeedback && userHasEverEscalatedToHumanSupport;
 
 	const forwardMessage = isUserEligibleForPaidSupport
 		? ODIE_FORWARD_TO_ZENDESK_MESSAGE
@@ -76,11 +88,13 @@ export const UserMessage = ( {
 
 	const renderDisclaimers = () => (
 		<>
-			{ ! isConnectedToZendesk && (
+			{ shouldRenderRatingButtons( chat, message ) && (
 				<WasThisHelpfulButtons message={ message } isDisliked={ isDisliked } />
 			) }
 
-			{ ! showExtraContactOptions && <DirectEscalationLink messageId={ message.message_id } /> }
+			{ userHasEverEscalatedToHumanSupport && (
+				<DirectEscalationLink messageId={ message.message_id } />
+			) }
 
 			<div className="disclaimer">
 				{ createInterpolateElement(
@@ -123,11 +137,13 @@ export const UserMessage = ( {
 					{ showExtraContactOptions &&
 						( shouldUseHelpCenterExperience ? <GetSupport /> : extraContactOptions ) }
 
-					{ ! showExtraContactOptions && (
+					{ shouldRenderRatingButtons( chat, message ) && (
 						<WasThisHelpfulButtons message={ message } isDisliked={ isDisliked } />
 					) }
 
-					{ ! showExtraContactOptions && <DirectEscalationLink messageId={ message.message_id } /> }
+					{ userHasEverEscalatedToHumanSupport && (
+						<DirectEscalationLink messageId={ message.message_id } />
+					) }
 
 					<div className="disclaimer">
 						{ createInterpolateElement(

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -9,19 +9,7 @@ import { DirectEscalationLink } from './direct-escalation-link';
 import { GetSupport } from './get-support';
 import { uriTransformer } from './uri-transformer';
 import WasThisHelpfulButtons from './was-this-helpful-buttons';
-import type { Chat, Message } from '../../types';
-
-const isWordPressRelatedQuestion = ( message: Message ) => {
-	return ! (
-		message.context?.question_tags?.category === 'Other (everything else)' &&
-		message.context?.question_tags?.inquiry_type === 'other' &&
-		message.context?.question_tags?.product === 'unknown'
-	);
-};
-
-const shouldRenderRatingButtons = ( chat: Chat, message: Message ) => {
-	return isWordPressRelatedQuestion( message ) && chat.provider !== 'zendesk';
-};
+import type { Message } from '../../types';
 
 export const UserMessage = ( {
 	message,
@@ -34,6 +22,7 @@ export const UserMessage = ( {
 } ) => {
 	const {
 		extraContactOptions,
+		experimentName,
 		isUserEligibleForPaidSupport,
 		shouldUseHelpCenterExperience,
 		trackEvent,
@@ -42,13 +31,20 @@ export const UserMessage = ( {
 	} = useOdieAssistantContext();
 
 	const hasCannedResponse = message.context?.flags?.canned_response;
-	const isRequestingHumanSupport = message.context?.flags?.forward_to_human_support;
+	const isRequestingHumanSupport = message.context?.flags?.forward_to_human_support ?? false;
 	const hasFeedback = !! message?.rating_value;
 	const isBot = message.role === 'bot';
 	const isPositiveFeedback =
 		hasFeedback && message && message.rating_value && +message.rating_value === 1;
-	const showExtraContactOptions =
-		hasFeedback && ! isPositiveFeedback && userHasEverEscalatedToHumanSupport;
+	const isConnectedToZendesk = chat?.provider === 'zendesk';
+
+	let showExtraContactOptions: boolean;
+
+	if ( experimentName === 'give_a_chance' ) {
+		showExtraContactOptions = userHasEverEscalatedToHumanSupport && isRequestingHumanSupport;
+	} else {
+		showExtraContactOptions = ( hasFeedback && ! isPositiveFeedback ) || isRequestingHumanSupport;
+	}
 
 	const forwardMessage = isUserEligibleForPaidSupport
 		? ODIE_FORWARD_TO_ZENDESK_MESSAGE
@@ -88,7 +84,7 @@ export const UserMessage = ( {
 
 	const renderDisclaimers = () => (
 		<>
-			{ shouldRenderRatingButtons( chat, message ) && (
+			{ ! isConnectedToZendesk && (
 				<WasThisHelpfulButtons message={ message } isDisliked={ isDisliked } />
 			) }
 
@@ -137,7 +133,7 @@ export const UserMessage = ( {
 					{ showExtraContactOptions &&
 						( shouldUseHelpCenterExperience ? <GetSupport /> : extraContactOptions ) }
 
-					{ shouldRenderRatingButtons( chat, message ) && (
+					{ ! showExtraContactOptions && (
 						<WasThisHelpfulButtons message={ message } isDisliked={ isDisliked } />
 					) }
 

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -40,7 +40,7 @@ export const UserMessage = ( {
 
 	let showExtraContactOptions: boolean;
 
-	if ( experimentName === 'give_a_chance' ) {
+	if ( experimentName === 'give_wapuu_a_chance' ) {
 		showExtraContactOptions = userHasEverEscalatedToHumanSupport && isRequestingHumanSupport;
 	} else {
 		showExtraContactOptions = ( hasFeedback && ! isPositiveFeedback ) || isRequestingHumanSupport;

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -47,6 +47,7 @@ export const OdieAssistantContext = createContext< OdieAssistantContextInterface
 	setWaitAnswerToFirstMessageFromHumanSupport: noop,
 	shouldUseHelpCenterExperience: false,
 	trackEvent: noop,
+	userHasEverEscalatedToHumanSupport: false,
 	waitAnswerToFirstMessageFromHumanSupport: false,
 } );
 
@@ -167,6 +168,13 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 	const versionParams = urlSearchParams.get( 'version' );
 	const overriddenVersion = versionParams || version;
 
+	/**
+	 * Find if the users has ever escalated to human support at any point in the chat.
+	 */
+	const userHasEverEscalatedToHumanSupport = mainChatState.messages.some(
+		( message ) => message.context?.flags?.forward_to_human_support
+	);
+
 	return (
 		<OdieAssistantContext.Provider
 			value={ {
@@ -190,6 +198,7 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 				setWaitAnswerToFirstMessageFromHumanSupport,
 				shouldUseHelpCenterExperience: shouldUseHelpCenterExperience ?? false,
 				trackEvent,
+				userHasEverEscalatedToHumanSupport,
 				version: overriddenVersion,
 				waitAnswerToFirstMessageFromHumanSupport,
 			} }

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -41,6 +41,7 @@ export const OdieAssistantContext = createContext< OdieAssistantContextInterface
 	isMinimized: false,
 	isUserEligibleForPaidSupport: false,
 	odieBroadcastClientId: '',
+	setExperimentName: noop,
 	setChat: noop,
 	setChatStatus: noop,
 	setMessageLikedStatus: noop,
@@ -72,6 +73,7 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 	children,
 	shouldUseHelpCenterExperience,
 } ) => {
+	const [ experimentName, setExperimentName ] = useState< string | undefined >( undefined );
 	const { botNameSlug, isMinimized, isChatLoaded } = useSelect( ( select ) => {
 		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
 
@@ -182,6 +184,7 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 				botName,
 				botNameSlug,
 				chat: mainChatState,
+				experimentName,
 				setChat: setMainChatState,
 				clearChat,
 				currentUser,
@@ -194,6 +197,7 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 				selectedSiteId,
 				selectedSiteURL,
 				setChatStatus,
+				setExperimentName,
 				setMessageLikedStatus,
 				setWaitAnswerToFirstMessageFromHumanSupport,
 				shouldUseHelpCenterExperience: shouldUseHelpCenterExperience ?? false,

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -114,13 +114,12 @@ export const useSendOdieMessage = () => {
 				message_id: returnedChat.messages[ 0 ].message_id,
 				internal_message_id,
 				content: returnedChat.messages[ 0 ].content,
-				experimentName: returnedChat.messages[ 0 ].experimentName,
 				role: 'bot',
 				type: 'message',
 				context: returnedChat.messages[ 0 ].context,
 			};
 
-			setExperimentName( botMessage.experimentName );
+			setExperimentName( returnedChat.experiment_name );
 			addMessage( botMessage, { odieId: returnedChat.chat_id } );
 			broadcastOdieMessage( botMessage, odieBroadcastClientId );
 		},

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -41,6 +41,7 @@ export const useSendOdieMessage = () => {
 		setChat,
 		odieBroadcastClientId,
 		setChatStatus,
+		setExperimentName,
 		shouldUseHelpCenterExperience,
 	} = useOdieAssistantContext();
 
@@ -113,12 +114,13 @@ export const useSendOdieMessage = () => {
 				message_id: returnedChat.messages[ 0 ].message_id,
 				internal_message_id,
 				content: returnedChat.messages[ 0 ].content,
+				experimentName: returnedChat.messages[ 0 ].experimentName,
 				role: 'bot',
-				simulateTyping: returnedChat.messages[ 0 ].simulateTyping,
 				type: 'message',
 				context: returnedChat.messages[ 0 ].context,
 			};
 
+			setExperimentName( botMessage.experimentName );
 			addMessage( botMessage, { odieId: returnedChat.chat_id } );
 			broadcastOdieMessage( botMessage, odieBroadcastClientId );
 		},

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -23,6 +23,7 @@ export type OdieAssistantContextInterface = {
 	setChat: ( chat: Chat | SetStateAction< Chat > ) => void;
 	setChatStatus: ( status: ChatStatus ) => void;
 	trackEvent: ( event: string, properties?: Record< string, unknown > ) => void;
+	userHasEverEscalatedToHumanSupport: boolean;
 	version?: string | null;
 	setWaitAnswerToFirstMessageFromHumanSupport: (
 		waitAnswerToFirstMessageFromHumanSupport: boolean
@@ -96,7 +97,8 @@ type InquiryType =
 	| 'refund'
 	| 'billing'
 	| 'unrelated-to-wordpress'
-	| 'request-for-human-support';
+	| 'request-for-human-support'
+	| 'other';
 
 export type OdieUserTracking = {
 	path: string;
@@ -112,6 +114,7 @@ export type Context = {
 	user_tracking?: OdieUserTracking[];
 	sources?: Source[];
 	question_tags?: {
+		category?: string;
 		feature?: Feature;
 		inquiry_type?: InquiryType;
 		language?: string;

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -157,7 +157,6 @@ export type Message = {
 	rating_value?: number;
 	role: MessageRole;
 	type: MessageType;
-	directEscalationSupport?: boolean;
 	created_at?: string;
 };
 

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -11,6 +11,7 @@ export type OdieAssistantContextInterface = {
 	chat: Chat;
 	clearChat: () => void;
 	currentUser: CurrentUser;
+	experimentName?: string;
 	isMinimized?: boolean;
 	isUserEligibleForPaidSupport: boolean;
 	extraContactOptions?: ReactNode;
@@ -21,6 +22,7 @@ export type OdieAssistantContextInterface = {
 	waitAnswerToFirstMessageFromHumanSupport: boolean;
 	setMessageLikedStatus: ( message: Message, liked: boolean ) => void;
 	setChat: ( chat: Chat | SetStateAction< Chat > ) => void;
+	setExperimentName: ( experimentName: string | undefined ) => void;
 	setChatStatus: ( status: ChatStatus ) => void;
 	trackEvent: ( event: string, properties?: Record< string, unknown > ) => void;
 	userHasEverEscalatedToHumanSupport: boolean;
@@ -147,13 +149,13 @@ export type MessageType =
 export type Message = {
 	content: string;
 	context?: Context;
+	experimentName?: string;
 	internal_message_id?: string;
 	message_id?: number;
 	meta?: Record< string, string >;
 	liked?: boolean | null;
 	rating_value?: number;
 	role: MessageRole;
-	simulateTyping?: boolean;
 	type: MessageType;
 	directEscalationSupport?: boolean;
 	created_at?: string;

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -22,7 +22,7 @@ export type OdieAssistantContextInterface = {
 	waitAnswerToFirstMessageFromHumanSupport: boolean;
 	setMessageLikedStatus: ( message: Message, liked: boolean ) => void;
 	setChat: ( chat: Chat | SetStateAction< Chat > ) => void;
-	setExperimentName: ( experimentName: string | undefined ) => void;
+	setExperimentName: ( experimentName: string | undefined | null ) => void;
 	setChatStatus: ( status: ChatStatus ) => void;
 	trackEvent: ( event: string, properties?: Record< string, unknown > ) => void;
 	userHasEverEscalatedToHumanSupport: boolean;
@@ -162,7 +162,12 @@ export type Message = {
 
 export type ChatStatus = 'loading' | 'loaded' | 'sending' | 'dislike' | 'transfer' | 'closed';
 
-export type ReturnedChat = { chat_id: number; messages: Message[]; wpcom_user_id: number };
+export type ReturnedChat = {
+	chat_id: number;
+	messages: Message[];
+	wpcom_user_id: number;
+	experiment_name?: string | null;
+};
 
 export type OdieChat = {
 	messages: Message[];


### PR DESCRIPTION
## Proposed Changes

- Added new types to typings
- Added new implementation to show direct escalation buttons
- Added new implementation to show helpful buttons 
- Stop conflating negative feedback with escalation

## Why are these changes being made?

We've noticed that many support tickets could be easily resolved by our AI systems. However, users often request human assistance before even attempting to see if the AI can help. To improve this process, we are encouraging users to provide more context before escalating their issues to human support.

By doing so, users will experience faster issue resolution, as they will only need to escalate to a human agent if the AI has already attempted to provide a solution. Additionally, when escalation does occur, our support team will have more information about the issue upfront, allowing them to assist the user more effectively and efficiently.

## Testing Instructions

1. Use Calypso live branch
2. Sandbox your public-api.
3. Force version 16 in the backend (Odie assistant)
4. Include experiment name in the wpcom response
5. Play around with the AI.

Examples:
Ask the AI to escalate as the first message
Try to trick the AI into providing a problem that is not related to WordPress
Check that the buttons for rating the message are only shown when the response is related to a real problem around the site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?