### PR TITLE
[Odie] Fix Tracks Events for forum and chat

### DIFF
--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -7,7 +7,7 @@ import { useCreateZendeskConversation } from '../../hooks';
 import './get-support.scss';
 
 interface GetSupportProps {
-	onClickAdditionalEvent?: () => void;
+	onClickAdditionalEvent?: ( destination: string ) => void;
 	isUserEligibleForPaidSupport?: boolean;
 }
 
@@ -68,7 +68,7 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 			return {
 				text: __( 'Get instant support', __i18n_text_domain__ ),
 				action: async () => {
-					onClickAdditionalEvent?.();
+					onClickAdditionalEvent?.( 'chat' );
 					await newConversation();
 				},
 			};
@@ -77,7 +77,7 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 		return {
 			text: __( 'Ask in our forums', __i18n_text_domain__ ),
 			action: async () => {
-				onClickAdditionalEvent?.();
+				onClickAdditionalEvent?.( 'forum' );
 				navigate( '/contact-form?mode=FORUM' );
 			},
 		};

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -45,9 +45,10 @@ export const UserMessage = ( {
 	const displayMessage =
 		isUserEligibleForPaidSupport && hasCannedResponse ? message.content : forwardMessage;
 
-	const handleContactSupportClick = () => {
+	const handleContactSupportClick = ( destination: string ) => {
 		trackEvent( 'chat_get_support', {
 			location: 'chat',
+			destination,
 		} );
 	};
 


### PR DESCRIPTION
## Why are these changes being made?
We need to differentiate when the user's destination is either chat or forum

## Testing Instructions
Get a free WordPress account, chat with AI and ask for escalation. Click on the button and check that the event triggers a new property "destination: forum"

Do the same with a paid account, check the destination is "chat"

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?