### PR TITLE
Remove duplicate views: Redirect from Calypso Pages to WP Admin Pages

### DIFF
--- a/client/my-sites/pages/index.js
+++ b/client/my-sites/pages/index.js
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import { makeLayout, render as clientRender, redirectIfDuplicatedView } from 'calypso/controller';
 import { getSiteFragment } from 'calypso/lib/route';
 import { navigation, siteSelection } from 'calypso/my-sites/controller';
 import { pages } from './controller';
@@ -8,6 +8,7 @@ export default function () {
 	page(
 		'/pages/:author(my)?/:status(published|drafts|scheduled|trashed)?/:domain?',
 		siteSelection,
+		redirectIfDuplicatedView( 'edit.php?post_type=page' ),
 		navigation,
 		pages,
 		makeLayout,


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/95620

## Proposed Changes

Redirects from `/pages/:site` to `/wp-admin/edit.php?post_type=page` if the user participates in the "Remove duplicate views" experiment

## Why are these changes being made?

Because even if the Pages menu already links to WP Admin, some users might access the Calypso URL directly, so we want to ensure that these users land in WP Admin.

## Testing Instructions

- Assign yourself to the `treatment` variant of the experiment: 22129-explat-experiment
- Use the Calypso live link below
- Go to `/pages/:site` for a site with the default admin interface
- Make sure it redirects to WP Admin

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?