### PR TITLE
A4A: Implement the initial product category menu using a standardized side-scrolling behavior.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-carousel/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-carousel/index.tsx
@@ -10,8 +10,6 @@ type Props = {
 	children: React.ReactNode;
 };
 
-const OFFSET_X_STEP = 500;
-
 export default function A4ACarousel( { children, className }: Props ) {
 	const [ offsetX, setOffsetX ] = useState( 0 );
 
@@ -23,13 +21,15 @@ export default function A4ACarousel( { children, className }: Props ) {
 
 	const maxOffset = Math.max( 0, contentWidth - containerWidth );
 
+	const offsetStep = containerWidth;
+
 	const moveLeft = useCallback( () => {
-		setOffsetX( Math.min( offsetX + OFFSET_X_STEP, 0 ) );
-	}, [ offsetX ] );
+		setOffsetX( Math.min( offsetX + offsetStep, 0 ) );
+	}, [ offsetStep, offsetX ] );
 
 	const moveRight = useCallback( () => {
-		setOffsetX( Math.max( offsetX - OFFSET_X_STEP, -maxOffset ) );
-	}, [ offsetX, maxOffset ] );
+		setOffsetX( Math.max( offsetX - offsetStep, -maxOffset ) );
+	}, [ offsetX, offsetStep, maxOffset ] );
 
 	return (
 		<div className={ clsx( `a4a-carousel-wrapper`, className ) }>
@@ -40,14 +40,14 @@ export default function A4ACarousel( { children, className }: Props ) {
 						onClick={ moveLeft }
 						disabled={ offsetX === 0 }
 					>
-						<Icon icon={ chevronLeft } />
+						<Icon icon={ chevronLeft } size={ 20 } />
 					</Button>
 					<Button
 						className="a4a-carousel__navigation-button"
 						onClick={ moveRight }
 						disabled={ offsetX === -maxOffset }
 					>
-						<Icon icon={ chevronRight } />
+						<Icon icon={ chevronRight } size={ 20 } />
 					</Button>
 				</div>
 				<div

--- a/client/a8c-for-agencies/components/a4a-carousel/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-carousel/index.tsx
@@ -1,0 +1,63 @@
+import { Button } from '@wordpress/components';
+import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
+import clsx from 'clsx';
+import { useCallback, useRef, useState } from 'react';
+
+import './style.scss';
+
+type Props = {
+	className?: string;
+	children: React.ReactNode;
+};
+
+const OFFSET_X_STEP = 500;
+
+export default function A4ACarousel( { children, className }: Props ) {
+	const [ offsetX, setOffsetX ] = useState( 0 );
+
+	const contentRef = useRef< HTMLDivElement >( null );
+	const containerRef = useRef< HTMLDivElement >( null );
+
+	const containerWidth = containerRef.current?.clientWidth ?? 0;
+	const contentWidth = contentRef.current?.clientWidth ?? 0;
+
+	const maxOffset = Math.max( 0, contentWidth - containerWidth );
+
+	const moveLeft = useCallback( () => {
+		setOffsetX( Math.min( offsetX + OFFSET_X_STEP, 0 ) );
+	}, [ offsetX ] );
+
+	const moveRight = useCallback( () => {
+		setOffsetX( Math.max( offsetX - OFFSET_X_STEP, -maxOffset ) );
+	}, [ offsetX, maxOffset ] );
+
+	return (
+		<div className={ clsx( `a4a-carousel-wrapper`, className ) }>
+			<div className="a4a-carousel" ref={ containerRef }>
+				<div className="a4a-carousel__navigation">
+					<Button
+						className="a4a-carousel__navigation-button"
+						onClick={ moveLeft }
+						disabled={ offsetX === 0 }
+					>
+						<Icon icon={ chevronLeft } />
+					</Button>
+					<Button
+						className="a4a-carousel__navigation-button"
+						onClick={ moveRight }
+						disabled={ offsetX === -maxOffset }
+					>
+						<Icon icon={ chevronRight } />
+					</Button>
+				</div>
+				<div
+					className="a4a-carousel__content"
+					style={ { transform: `translateX(${ offsetX }px)` } }
+					ref={ contentRef }
+				>
+					{ children }
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/components/a4a-carousel/style.scss
+++ b/client/a8c-for-agencies/components/a4a-carousel/style.scss
@@ -1,23 +1,41 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 .a4a-carousel {
 	display: flex;
 	flex-direction: column;
-	gap: 32px;
+	gap: 24px;
+
+	@include break-medium {
+		gap: 32px;
+	}
 }
 
 .a4a-carousel__navigation {
 	text-align: end;
 	display: flex;
 	flex-direction: row;
-	gap: 8px;
 	justify-content: flex-end;
+	gap: 16px;
+	padding-block-end: 16px;
+
+	@include break-medium {
+		gap: 8px;
+		padding-block-end: 0;
+	}
 }
 
 .a4a-carousel__navigation-button {
 	background-color: var(--color-surface);
 	border-radius: 50%!important;
-	width: 40px;
-	height: 40px;
+	min-width: 24px;
+	max-height: 24px;
+	padding: 0;
+	opacity: 0.9;
+
+	&:disabled {
+		opacity: 0.5;
+	}
 }
 
 .a4a-carousel__content {

--- a/client/a8c-for-agencies/components/a4a-carousel/style.scss
+++ b/client/a8c-for-agencies/components/a4a-carousel/style.scss
@@ -1,0 +1,30 @@
+
+.a4a-carousel {
+	display: flex;
+	flex-direction: column;
+	gap: 32px;
+}
+
+.a4a-carousel__navigation {
+	text-align: end;
+	display: flex;
+	flex-direction: row;
+	gap: 8px;
+	justify-content: flex-end;
+}
+
+.a4a-carousel__navigation-button {
+	background-color: var(--color-surface);
+	border-radius: 50%!important;
+	width: 40px;
+	height: 40px;
+}
+
+.a4a-carousel__content {
+	display: grid;
+	grid-auto-flow: column;
+	gap: 16px;
+	width: max-content;
+	transform: translateX( 0 );
+	transition: transform 0.3s cubic-bezier(0.50, 0.0, 0.50, 1);
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/hooks/use-compact-on-scroll.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/hooks/use-compact-on-scroll.ts
@@ -1,0 +1,27 @@
+import { useCallback, useState } from 'react';
+
+export default function useCompactOnScroll() {
+	const [ isCompact, setIsCompact ] = useState( false );
+	const [ lastScrollPosition, setLastScrollPosition ] = useState( 0 );
+
+	const onScroll = useCallback(
+		( event: React.UIEvent< HTMLDivElement > ) => {
+			const scrollPosition = event.currentTarget.scrollTop;
+			const isScrollingDown = scrollPosition > lastScrollPosition;
+
+			if ( isScrollingDown && ! isCompact && scrollPosition > 100 ) {
+				setIsCompact( true );
+			} else if ( ! isScrollingDown && isCompact && scrollPosition < 10 ) {
+				setIsCompact( false );
+			}
+
+			setLastScrollPosition( scrollPosition );
+		},
+		[ isCompact, lastScrollPosition ]
+	);
+
+	return {
+		onScroll,
+		isCompact,
+	};
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/hooks/use-compact-on-scroll.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/hooks/use-compact-on-scroll.ts
@@ -9,9 +9,9 @@ export default function useCompactOnScroll() {
 			const scrollPosition = event.currentTarget.scrollTop;
 			const isScrollingDown = scrollPosition > lastScrollPosition;
 
-			if ( isScrollingDown && ! isCompact && scrollPosition > 100 ) {
+			if ( isScrollingDown && ! isCompact && scrollPosition > 200 ) {
 				setIsCompact( true );
-			} else if ( ! isScrollingDown && isCompact && scrollPosition < 10 ) {
+			} else if ( ! isScrollingDown && isCompact && scrollPosition === 0 ) {
 				setIsCompact( false );
 			}
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/index.tsx
@@ -24,6 +24,7 @@ import withMarketplaceType from '../hoc/with-marketplace-type';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import ProductListing from '../products-overview/product-listing';
 import ShoppingCart from '../shopping-cart';
+import ProductCategoryMenu from './product-category-menu';
 
 import './style.scss';
 
@@ -100,6 +101,8 @@ export function ProductsOverviewV2( {
 						/>
 					</Actions>
 				</LayoutHeader>
+
+				<ProductCategoryMenu />
 			</LayoutTop>
 
 			<LayoutBody className="products-overview-v2__body">

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/index.tsx
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
 import { SiteDetails } from '@automattic/data-stores';
 import { useBreakpoint } from '@automattic/viewport-react';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
@@ -24,6 +25,7 @@ import withMarketplaceType from '../hoc/with-marketplace-type';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import ProductListing from '../products-overview/product-listing';
 import ShoppingCart from '../shopping-cart';
+import useCompactOnScroll from './hooks/use-compact-on-scroll';
 import ProductCategoryMenu from './product-category-menu';
 
 import './style.scss';
@@ -65,10 +67,13 @@ export function ProductsOverviewV2( {
 		}
 	}, [ siteId, sites ] );
 
+	const { onScroll, isCompact } = useCompactOnScroll();
+
 	return (
 		<Layout
-			className="products-overview-v2"
+			className={ clsx( 'products-overview-v2', { 'is-compact': isCompact } ) }
 			title={ isNarrowView ? '' : translate( 'Products Marketplace' ) }
+			onScroll={ onScroll }
 			wide
 		>
 			<LayoutTop>

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-category-menu/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-category-menu/index.tsx
@@ -6,6 +6,8 @@ import './style.scss';
 
 export default function ProductCategoryMenu() {
 	const translate = useTranslate();
+
+	// We will replace this with the actual categories on a separate PR
 	const categories = [
 		{ label: 'Jetpack', value: 'jetpack' },
 		{ label: 'Woo', value: 'woocommerce' },

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-category-menu/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-category-menu/index.tsx
@@ -1,0 +1,36 @@
+import { useBreakpoint } from '@automattic/viewport-react';
+import { useTranslate } from 'i18n-calypso';
+import A4ACarousel from 'calypso/a8c-for-agencies/components/a4a-carousel';
+
+import './style.scss';
+
+export default function ProductCategoryMenu() {
+	const translate = useTranslate();
+	const categories = [
+		{ label: 'Jetpack', value: 'jetpack' },
+		{ label: 'Woo', value: 'woocommerce' },
+		{ label: 'Security', value: 'security' },
+		{ label: 'Management', value: 'management' },
+		{ label: 'Conversion', value: 'conversion' },
+		{ label: 'Marketing', value: 'marketing' },
+		{ label: 'Social', value: 'social' },
+		{ label: 'Payments', value: 'payments' },
+	];
+
+	const isMobile = useBreakpoint( '<660px' );
+
+	return (
+		<div className="product-category-menu">
+			<h1 className="product-category-menu-title">
+				{ isMobile ? translate( 'Shop by category' ) : translate( 'Shop products by category' ) }
+			</h1>
+			<A4ACarousel className="product-category-menu-items">
+				{ categories.map( ( category ) => (
+					<div className="product-category-menu-item" key={ category.value }>
+						{ category.label }
+					</div>
+				) ) }
+			</A4ACarousel>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-category-menu/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-category-menu/style.scss
@@ -1,0 +1,22 @@
+.product-category-menu {
+	margin-block-start: 32px;
+}
+
+.product-category-menu-title {
+	@include a4a-font-heading-xl;
+	color: var(--color-text-inverted);
+}
+
+.product-category-menu-items {
+	margin-block-start: -24px;
+}
+
+.product-category-menu-item {
+	width: 200px;
+	height: 100px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background-color: var(--color-primary-0);
+	border-radius: 4px; // eslint-disable-line wpcalypso-border-radius-theme
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/style.scss
@@ -14,6 +14,7 @@ $background-color: #05374A;
 		position: sticky;
 		top: 0;
 		z-index: 100;
+		overflow: hidden;
     }
 
 	.hosting-dashboard-layout__header-breadcrumb {

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 $background-color: #05374A;
 
 .products-overview-v2.main.hosting-dashboard-layout {
@@ -15,6 +18,12 @@ $background-color: #05374A;
 		top: 0;
 		z-index: 100;
 		overflow: hidden;
+		height: 306px;
+		transition: height .25s ease-out;
+
+		@include break-medium {
+			height: 252px;
+		}
     }
 
 	.hosting-dashboard-layout__header-breadcrumb {
@@ -38,5 +47,24 @@ $background-color: #05374A;
 
 	.components-button:is(.is-primary, .is-secondary) {
 		min-height: 40px;
+	}
+
+	.product-category-menu {
+		opacity: 1;
+		transition: opacity .25s ease-out;
+	}
+}
+
+.products-overview-v2.main.hosting-dashboard-layout.is-compact {
+	.hosting-dashboard-layout__top-wrapper {
+		height: 104px;
+
+		@include break-medium {
+			height: 66px;
+		}
+	}
+
+	.product-category-menu {
+		opacity: 0;
 	}
 }


### PR DESCRIPTION
This PR introduces a working carousel menu on the new Products page. Just so you know, the menu items are placeholders and will be replaced with actual items in a separate PR.

We want this PR to focus exclusively on the Carousel element and the scroll-down behavior.

https://github.com/user-attachments/assets/5c0b484a-6744-4ee2-ab80-5832798e25e2


Depends on https://github.com/Automattic/wp-calypso/pull/98086
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1636

## Proposed Changes

* Standardize side-scrolling behavior in A4A using a Carousel component. This new component will be reused later for other side-scrolling use cases in the A4A context.
* Implement the product category menu on the new products page using the carousel component. For now, we will use placeholder items, which we will replace later with actual menu items in a separate PR.

## Why are these changes being made?

* This is part of the Marketplace UX improvement project.


## Testing Instructions
* Use the A4A live link and go to the /marketplace/products?flags=a4a-product-page-redesign.
* Test out the Product category menu carousel and scroll down behavior.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
