### PR TITLE
Verbum Block Editor: Allow mutliple instance of VBE on the same page

### DIFF
--- a/packages/verbum-block-editor/src/editor/index.tsx
+++ b/packages/verbum-block-editor/src/editor/index.tsx
@@ -106,7 +106,8 @@ export const Editor: FC< EditorProps > = ( { initialContent = '', onChange, isRT
 				<BlockEditorProvider
 					settings={ editorSettings( isRTL ) }
 					value={ editorContent }
-					useSubRegistry={ false }
+					// This allows multiple editors to be used on the same page (namely inside QueryLoop).
+					useSubRegistry
 					onInput={ handleContentUpdate }
 					onChange={ handleContentUpdate }
 				>


### PR DESCRIPTION
To support rendering multiple forms on the same page.

Related to: https://github.com/Automattic/wp-calypso/issues/98136