### PR TITLE
Staging sites: Ensure specific error message is included in the frontend on staging site sync failure

### DIFF
--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -83,7 +83,7 @@ const ActionButtons = styled.div( {
 type CardContentProps = {
 	stagingSite: StagingSite;
 	siteId: number;
-	error?: string | null;
+	error?: { code: string; message: string } | null;
 	onDeleteClick: () => void;
 	onPushClick: () => void;
 	onPullClick: () => void;

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
@@ -431,7 +431,7 @@ const SyncCardContainer = ( {
 							icon="mention"
 							showDismiss={ false }
 							text={ translate(
-								"We couldn't synchronize the %(siteType)s environment. %(errorMessage)s",
+								"We couldn't synchronize the %(siteType)s environment.%(errorMessage)s",
 								{
 									args: {
 										siteType: siteToSync ?? '',

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
@@ -487,6 +487,7 @@ export const SiteSyncCard = ( {
 		[] as CheckboxOptionItem[]
 	);
 	const [ selectedOption, setSelectedOption ] = useState< string | null >( null );
+	const [ syncError, setSyncError ] = useState< { code: string; message: string } | null >( null );
 	const siteSlug = useSelector(
 		type === 'staging' ? ( state ) => getSiteSlug( state, productionSiteId ) : getSelectedSiteSlug
 	);
@@ -520,7 +521,6 @@ export const SiteSyncCard = ( {
 		}
 	}, [ dispatch, onPush, resetSyncStatus, selectedItems, transformSelectedItems, type ] );
 
-	const syncError = error || checkStatusError;
 	const onPullInternal = useCallback( () => {
 		resetSyncStatus();
 		dispatch( removeNotice( stagingSiteSyncSuccess ) );
@@ -545,6 +545,10 @@ export const SiteSyncCard = ( {
 	} else {
 		siteToSync = selectedOption === actionForType ? 'production' : 'staging';
 	}
+
+	useEffect( () => {
+		setSyncError( error ?? checkStatusError ?? null );
+	}, [ error, checkStatusError ] );
 
 	useEffect( () => {
 		if ( selectedOption && status === SiteSyncStatus.COMPLETED && ! syncError ) {

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
@@ -28,17 +28,19 @@ const STAGING_SYNC_JETPACK_ERROR_CODES = [
 ];
 const STAGING_SYNC_FAILED_ERROR_CODES = [ 'staging_site_sync_failed' ];
 
-function useIsJetpackConnectionSyncError( error: string | null | undefined ) {
+function useIsJetpackConnectionSyncError(
+	error: { code: string; message: string } | null | undefined
+) {
 	if ( ! error ) {
 		return false;
 	}
-	return STAGING_SYNC_JETPACK_ERROR_CODES.includes( error );
+	return STAGING_SYNC_JETPACK_ERROR_CODES.includes( error.code );
 }
-function useIsFailedSyncError( error: string | null | undefined ) {
+function useIsFailedSyncError( error: { code: string; message: string } | null | undefined ) {
 	if ( ! error ) {
 		return false;
 	}
-	return STAGING_SYNC_FAILED_ERROR_CODES.includes( error );
+	return STAGING_SYNC_FAILED_ERROR_CODES.includes( error.code );
 }
 
 const StagingSyncCardBody = styled.div( {
@@ -148,7 +150,7 @@ interface SyncCardProps {
 		production: string | null;
 		staging: string | null;
 	};
-	error?: string | null;
+	error?: { code: string; message: string } | null;
 }
 
 const StagingToProductionSync = ( {
@@ -360,7 +362,7 @@ const SyncCardContainer = ( {
 	isSyncInProgress: boolean;
 	siteToSync: 'production' | 'staging' | null;
 	siteUrls: SyncCardProps[ 'siteUrls' ];
-	error?: string | null;
+	error?: { code: string; message: string } | null;
 	onRetry?: () => void;
 } ) => {
 	const translate = useTranslate();
@@ -428,9 +430,15 @@ const SyncCardContainer = ( {
 							status="is-error"
 							icon="mention"
 							showDismiss={ false }
-							text={ translate( 'We couldn’t synchronize the %s environment.', {
-								args: [ siteToSync ?? '' ],
-							} ) }
+							text={ translate(
+								"We couldn't synchronize the %(siteType)s environment. %(errorMessage)s",
+								{
+									args: {
+										siteType: siteToSync ?? '',
+										errorMessage: error.message ? ' ' + error.message : '',
+									},
+								}
+							) }
 						>
 							<NoticeAction onClick={ () => onRetry?.() }>
 								{ translate( 'Try Again' ) }

--- a/client/sites/tools/staging-site/components/staging-site-card/index.js
+++ b/client/sites/tools/staging-site/components/staging-site-card/index.js
@@ -410,7 +410,7 @@ export const StagingSiteCard = ( {
 					code: error.code,
 				} )
 			);
-			setSyncError( error.code );
+			setSyncError( { code: error.code, message: error.message } );
 		},
 	} );
 

--- a/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
@@ -41,7 +41,7 @@ type CardProps = {
 function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps ) {
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
-	const [ syncError, setSyncError ] = useState< string | null >( null );
+	const [ syncError, setSyncError ] = useState< { code: string; message: string } | null >( null );
 	const stagingSiteUrl = useSelector( ( state ) => getSiteUrl( state, siteId ) );
 
 	const {
@@ -78,7 +78,7 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 					code: error.code,
 				} )
 			);
-			setSyncError( error.code );
+			setSyncError( error );
 		},
 	} );
 
@@ -94,7 +94,7 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 					code: error.code,
 				} )
 			);
-			setSyncError( error.code );
+			setSyncError( error );
 		},
 	} );
 

--- a/client/sites/tools/staging-site/hooks/use-site-sync-status.tsx
+++ b/client/sites/tools/staging-site/hooks/use-site-sync-status.tsx
@@ -22,7 +22,7 @@ export type SyncStatus = {
 	progress: number;
 	resetSyncStatus: () => void;
 	isSyncInProgress: boolean;
-	error: string;
+	error: { code: string; message: string } | null;
 	siteSource: 'production' | 'staging' | null;
 	siteTarget: 'production' | 'staging' | null;
 	restoreId: string;
@@ -97,7 +97,12 @@ export const useCheckSyncStatus = ( siteId: number ) => {
 			progress: syncProgress,
 			resetSyncStatus,
 			isSyncInProgress,
-			error: syncStatusError,
+			error: syncStatusError
+				? {
+						code: syncStatusError,
+						message: '',
+				  }
+				: null,
 			sourceSite: syncingSourceSite,
 			targetSite: syncingTargetSite,
 			lastRestoreId: syncLastRestoreId,


### PR DESCRIPTION
> [!NOTE]
> At the end I decided for a straightforward approach: https://github.com/Automattic/wp-calypso/pull/98216.


---

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/10008.

## Proposed Changes

* 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
