### PR TITLE
Stats: add Summary 'Locations' path

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -252,6 +252,7 @@ export function summary( context, next ) {
 		'referrers',
 		'clicks',
 		'countryviews',
+		'locations',
 		'authors',
 		'videoplays',
 		'videodetails',

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -37,6 +37,7 @@ export default function () {
 		'referrers',
 		'clicks',
 		'countryviews',
+		'locations',
 		'authors',
 		'videoplays',
 		'videodetails',

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -568,11 +568,10 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 							{ config.isEnabled( 'stats/locations' ) ? (
 								<>
 									<StatsModuleLocations
-										path="countryviews"
 										moduleStrings={ moduleStrings.locations }
 										period={ props.period }
 										query={ query }
-										summaryUrl={ getStatHref( 'countryviews', query ) }
+										summaryUrl={ getStatHref( 'locations', query ) }
 										className={ clsx( 'stats__flexible-grid-item--full' ) }
 									/>
 								</>

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -168,6 +168,25 @@ class StatsSummary extends Component {
 				);
 				break;
 
+			case 'locations':
+				title = translate( 'Locations' );
+				path = 'locations';
+				statType = 'statsCountryViews';
+
+				summaryView = (
+					<Fragment key="countries-summary">
+						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
+						<StatsModuleLocations
+							moduleStrings={ StatsStrings.countries }
+							period={ this.props.period }
+							query={ moduleQuery }
+							summary
+							listItemClassName={ listItemClassName }
+						/>
+					</Fragment>
+				);
+				break;
+
 			case 'posts':
 				title = translate( 'Posts & pages' );
 				path = 'posts';

--- a/client/my-sites/stats/test/index.js
+++ b/client/my-sites/stats/test/index.js
@@ -45,6 +45,7 @@ const validModules = [
 	'referrers',
 	'clicks',
 	'countryviews',
+	'locations',
 	'authors',
 	'videoplays',
 	'videodetails',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/jetpack-roadmap#2097.

## Proposed Changes

* Changes the Stats summary URL from `/countryviews/` to `/locations/`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* (p1HpG7-rpL-p2)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Access the Calypso Live preview linked below.
- Access the Stats page of a website that has meaningful data, like `/stats/day/jetpack.com?flags=stats/locations`
- Scroll down to the map and click on the `View all` link after the locations list.
- It should redirect to a link similar to `/stats/day/locations/jetpack.com?startDate=2025-01-03&endDate=2025-01-09`
  - Ensure the path contains `/locations/` and NOT `/countryviews/`
- The breadcrumbs on the same page should also say `Locations` instead of `Countries`.

| Before | After |
| - | - |
| <img width="355" alt="image" src="https://github.com/user-attachments/assets/fa88a40d-792a-4c9e-9729-17d5032bc7a0" /> | <img width="353" alt="image" src="https://github.com/user-attachments/assets/a85e88de-3b84-41d5-b30b-45d8455dceee" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
