### PR TITLE
Bulk Plugin Management: Remove autoupdate label for all screen sizes

### DIFF
--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -225,6 +225,7 @@ export default function PluginRowFormatter( {
 				<div className="plugin-row-formatter__toggle">
 					<PluginAutoupdateToggle
 						plugin={ pluginOnSite }
+						hideLabel
 						site={ selectedSite }
 						wporg={ !! item.wporg }
 						isMarketplaceProduct={ isFromMarketplace }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10216

## Proposed Changes

* It hides the label for Autoupdates as it is displayed for small screens

|Before | After|
|-------|------|
|![CleanShot 2025-01-09 at 17 08 25@2x](https://github.com/user-attachments/assets/16522e7b-1c7f-4f73-99f7-90618da5645a)|![CleanShot 2025-01-09 at 17 08 42@2x](https://github.com/user-attachments/assets/57ee97c8-b33f-464e-8f2a-ee14d111834c)|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* That label is not required. It is there for a list visualization, but it does not apply to the current table visualization

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch and navigate to `/plugins/manage`
* Select a plugin that is installed on some sites
* Reduce the screen and check the `Autoupdate` label is not displayed
* Check there are no visual regressions accessing the Jetpack Cloud link below and navigating to `/plugins/manage/akismet` for example

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
