### PR TITLE
A4A: avoid multiple agency creations when reloading signup page

### DIFF
--- a/client/a8c-for-agencies/sections/signup/primary/agency-signup-finish/hooks/use-agency-creation.ts
+++ b/client/a8c-for-agencies/sections/signup/primary/agency-signup-finish/hooks/use-agency-creation.ts
@@ -1,0 +1,72 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import page from '@automattic/calypso-router';
+import { APIError } from '@automattic/data-stores';
+import { useCallback } from 'react';
+import { A4A_SIGNUP_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { useDispatch } from 'calypso/state';
+import { fetchAgencies } from 'calypso/state/a8c-for-agencies/agency/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { MUTATION_DEBOUNCE_MS } from '..';
+import useCreateAgencyMutation from '../../../agency-details-form/hooks/use-create-agency-mutation';
+import { AgencyDetailsPayload } from '../../../agency-details-form/types';
+import { clearSignupDataFromLocalStorage } from '../../../lib/signup-data-to-local-storage';
+
+const NOTIFICATION_ID = 'a4a-agency-signup-form';
+
+function useAgencyCreation() {
+	const dispatch = useDispatch();
+
+	const createAgency = useCreateAgencyMutation( {
+		onSuccess: () => {
+			dispatch( fetchAgencies() );
+			clearSignupDataFromLocalStorage();
+		},
+		onError: ( error: APIError ) => {
+			page( A4A_SIGNUP_LINK );
+			dispatch( errorNotice( error?.message, { id: NOTIFICATION_ID } ) );
+		},
+	} );
+
+	const submitAgencyData = useCallback(
+		( signupData: AgencyDetailsPayload ) => {
+			const lastMutationTimestamp = localStorage.getItem( 'createAgencylastMutationTimestamp' );
+			const currentTime = Date.now();
+
+			if ( lastMutationTimestamp ) {
+				const timeSinceLastMutation = currentTime - parseInt( lastMutationTimestamp, 10 );
+				if ( timeSinceLastMutation < MUTATION_DEBOUNCE_MS ) {
+					return false;
+				}
+			}
+
+			createAgency.mutate( signupData );
+			localStorage.setItem( 'createAgencylastMutationTimestamp', currentTime.toString() );
+
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_create_agency_finish_submit', {
+					first_name: signupData.firstName,
+					last_name: signupData.lastName,
+					name: signupData.agencyName,
+					business_url: signupData.agencyUrl,
+					managed_sites: signupData.managedSites,
+					services_offered: ( signupData.servicesOffered || [] ).join( ',' ),
+					products_offered: ( signupData.productsOffered || [] ).join( ',' ),
+					city: signupData.city,
+					line1: signupData.line1,
+					line2: signupData.line2,
+					country: signupData.country,
+					postal_code: signupData.postalCode,
+					state: signupData.state,
+					referer: signupData.referer,
+				} )
+			);
+
+			return true;
+		},
+		[ createAgency, dispatch ]
+	);
+
+	return { submitAgencyData };
+}
+
+export default useAgencyCreation;

--- a/client/a8c-for-agencies/sections/signup/primary/agency-signup-finish/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/primary/agency-signup-finish/index.tsx
@@ -1,5 +1,4 @@
 import page from '@automattic/calypso-router';
-import { APIError } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import A4ALogo, { LOGO_COLOR_SECONDARY_ALT } from 'calypso/a8c-for-agencies/components/a4a-logo';
@@ -7,76 +6,64 @@ import {
 	A4A_OVERVIEW_LINK,
 	A4A_SIGNUP_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { useInterval } from 'calypso/lib/interval';
 import { useDispatch, useSelector } from 'calypso/state';
 import { fetchAgencies } from 'calypso/state/a8c-for-agencies/agency/actions';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { errorNotice } from 'calypso/state/notices/actions';
-import useCreateAgencyMutation from '../../agency-details-form/hooks/use-create-agency-mutation';
-import {
-	clearSignupDataFromLocalStorage,
-	getSignupDataFromLocalStorage,
-} from '../../lib/signup-data-to-local-storage';
+import { getSignupDataFromLocalStorage } from '../../lib/signup-data-to-local-storage';
+import useAgencyCreation from './hooks/use-agency-creation';
 import './style.scss';
 
+export const MUTATION_DEBOUNCE_MS = 60000; // 60 seconds
+const POLL_INTERVAL_MS = 5000; // 5 seconds
+
 export default function AgencySignupFinish() {
-	const notificationId = 'a4a-agency-signup-form';
+	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const userLoggedIn = useSelector( isUserLoggedIn );
 	const signupData = getSignupDataFromLocalStorage();
 	const agency = useSelector( getActiveAgency );
-	const translate = useTranslate();
-	const dispatch = useDispatch();
+	const { submitAgencyData } = useAgencyCreation();
 
-	const createAgency = useCreateAgencyMutation( {
-		onSuccess: () => {
-			dispatch( fetchAgencies() );
-			clearSignupDataFromLocalStorage();
-		},
-		onError: ( error: APIError ) => {
-			page( A4A_SIGNUP_LINK );
-			dispatch( errorNotice( error?.message, { id: notificationId } ) );
-		},
-	} );
-
+	// Redirect if agency exists
 	useEffect( () => {
 		if ( agency ) {
-			// Redirect to the sites page if the user already has an agency record.
 			page.redirect( A4A_OVERVIEW_LINK );
 		}
 	}, [ agency ] );
 
+	// Initial submission
 	useEffect( () => {
-		function createAgencyHandler() {
-			// Added to prevent typescript errors and for additional safety
-			if ( ! userLoggedIn || ! signupData ) {
-				page.redirect( A4A_SIGNUP_LINK );
-				return;
-			}
-
-			createAgency.mutate( signupData );
-			dispatch(
-				recordTracksEvent( 'calypso_a4a_create_agency_finish_submit', {
-					first_name: signupData.firstName,
-					last_name: signupData.lastName,
-					name: signupData.agencyName,
-					business_url: signupData.agencyUrl,
-					managed_sites: signupData.managedSites,
-					services_offered: ( signupData.servicesOffered || [] ).join( ',' ),
-					products_offered: ( signupData.productsOffered || [] ).join( ',' ),
-					city: signupData.city,
-					line1: signupData.line1,
-					line2: signupData.line2,
-					country: signupData.country,
-					postal_code: signupData.postalCode,
-					state: signupData.state,
-					referer: signupData.referer,
-				} )
-			);
+		if ( ! userLoggedIn || ! signupData ) {
+			page.redirect( A4A_SIGNUP_LINK );
+			return;
 		}
-		createAgencyHandler();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
+
+		const lastMutationTimestamp = localStorage.getItem( 'createAgencylastMutationTimestamp' );
+		if ( ! lastMutationTimestamp ) {
+			submitAgencyData( signupData );
+		}
+	}, [ userLoggedIn, signupData, submitAgencyData ] );
+
+	// Poll for agency data and retry mutation if needed
+	useInterval(
+		() => {
+			if ( ! agency ) {
+				dispatch( fetchAgencies() );
+
+				// Check if we should retry the mutation
+				const lastMutationTimestamp = localStorage.getItem( 'createAgencylastMutationTimestamp' );
+				if ( lastMutationTimestamp && signupData ) {
+					const timeSinceLastMutation = Date.now() - parseInt( lastMutationTimestamp, 10 );
+					if ( timeSinceLastMutation >= MUTATION_DEBOUNCE_MS ) {
+						submitAgencyData( signupData );
+					}
+				}
+			}
+		},
+		! agency ? POLL_INTERVAL_MS : null
+	);
 
 	return (
 		<div className="agency-signup-finish__wrapper">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pfSQfS-DM-p2

## Proposed Changes

Currently, signup can work as follows:
- `/signup` where user fills the form and it got saved to `localStorage`
- **auth** on wpcom side
- `/signup/finish` where we check if there's data in local storage and submit `mutation` to create agency.

The problem now in this flow due to a corner case, where user can reload `/signup/finish` multiple times, thus submitting `mutation` multiple times.

To fix this, we will save a timestamp to localStorage at the time of mutation. Then, if page is reloaded we will not send any mutation within **1 minute** of the original mutation. Instead, we will `fetch` the agency status every 5 seconds. If after 1 minute still no agency created, mutation will be done again. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link below, open in in `Incognito window` with `/signup` path
- Follow the signup flow
- After navigating to `/signup/finish` refresh the page multiple times
- Check network tab to see `GET /agency` requests.
- Verify using MC tool that only 1 agency is created for user.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?