### PR TITLE
Fix hundred year domain spacing on mobile

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -446,6 +446,8 @@
 	}
 
 	.step-container__header {
+		margin-bottom: 0;
+
 		@include break-small {
 			margin-bottom: 40px;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
@@ -157,6 +157,8 @@ const StyledFoldableCard = styled( FoldableCard )`
 	}
 
 	&.card.foldable-card {
+		background: var( --studio-gray-100 );
+		color: var( --studio-gray-0 );
 		margin: 0;
 		.foldable-card__header {
 			.foldable-card__main {


### PR DESCRIPTION
## Proposed Changes

This PR fixes another spacing and colour issue for the 100-year domain and 100-year plan flows:

Before:
<img width="1057" alt="image" src="https://github.com/user-attachments/assets/cfddf04a-7002-44f2-8a30-f85de0b49b03" />

Appears when you go from step to step:
<img width="1037" alt="image" src="https://github.com/user-attachments/assets/3760b132-d868-4fb2-9294-7b137f31e089" />


After:
<img width="979" alt="image" src="https://github.com/user-attachments/assets/8b662b61-efcb-4818-a221-f1ab64d22c99" />

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/b4376b17-bbbc-4476-80f9-758e4deca2cb" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* For the domain spacing, try a search on mobile by visiting `/setup/hundred-year-domain/domains`
* For the plans, visit `/setup/hundred-year-plan/diy-or-difm` and select I'll create my site on my own (the header will change colour).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
