### PR TITLE
Reader: Allow username in user profile route /read/users/:userId|username

### DIFF
--- a/client/reader/user-stream/controller.tsx
+++ b/client/reader/user-stream/controller.tsx
@@ -1,5 +1,6 @@
 import { ReactElement } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
+import wpcom from 'calypso/lib/wp';
 import { trackPageLoad, trackScrollPage } from 'calypso/reader/controller-helper';
 import type { AppState } from 'calypso/types';
 
@@ -15,49 +16,69 @@ interface Context {
 
 const analyticsPageTitle = 'Reader';
 
+const isNumeric = ( value: string ): boolean => /^\d+$/.test( value );
+
+async function resolveUserId( userIdentifier: string ): Promise< string > {
+	if ( isNumeric( userIdentifier ) ) {
+		return userIdentifier;
+	}
+
+	try {
+		const userData = await wpcom.req.get( `/users/${ encodeURIComponent( userIdentifier ) }/` );
+		return userData.ID.toString();
+	} catch ( error ) {
+		return userIdentifier; // Fallback to original identifier if lookup fails
+	}
+}
+
 export function userPosts( context: Context, next: () => void ): void {
-	const userId = context.params.user_id;
-	const basePath = '/read/users/:user_id';
-	const fullAnalyticsPageTitle = analyticsPageTitle + ' > User > ' + userId + ' > Posts';
-	const mcKey = 'user_posts';
-	const streamKey = 'user:' + userId;
+	const userIdentifier = context.params.user_id;
 
-	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+	resolveUserId( userIdentifier ).then( ( userId ) => {
+		const basePath = '/read/users/:user_id';
+		const fullAnalyticsPageTitle = analyticsPageTitle + ' > User > ' + userId + ' > Posts';
+		const mcKey = 'user_posts';
+		const streamKey = 'user:' + userId;
 
-	context.primary = (
-		<AsyncLoad
-			require="calypso/reader/user-stream"
-			key={ 'user-posts-' + userId }
-			streamKey={ streamKey }
-			userId={ userId }
-			trackScrollPage={ trackScrollPage.bind(
-				null,
-				basePath,
-				fullAnalyticsPageTitle,
-				analyticsPageTitle,
-				mcKey
-			) }
-			placeholder={ null }
-		/>
-	);
-	next();
+		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+
+		context.primary = (
+			<AsyncLoad
+				require="calypso/reader/user-stream"
+				key={ 'user-posts-' + userId }
+				streamKey={ streamKey }
+				userId={ userId }
+				trackScrollPage={ trackScrollPage.bind(
+					null,
+					basePath,
+					fullAnalyticsPageTitle,
+					analyticsPageTitle,
+					mcKey
+				) }
+				placeholder={ null }
+			/>
+		);
+		next();
+	} );
 }
 
 export function userLists( context: Context, next: () => void ): void {
-	const userId = context.params.user_id;
-	const basePath = '/read/users/:user_id/lists';
-	const fullAnalyticsPageTitle = analyticsPageTitle + ' > User > ' + userId + ' > Lists';
-	const mcKey = 'user_lists';
+	const userIdentifier = context.params.user_id;
 
-	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+	resolveUserId( userIdentifier ).then( ( userId ) => {
+		const basePath = '/read/users/:user_id/lists';
+		const fullAnalyticsPageTitle = analyticsPageTitle + ' > User > ' + userId + ' > Lists';
+		const mcKey = 'user_lists';
 
-	context.primary = (
-		<AsyncLoad
-			require="calypso/reader/user-stream"
-			key={ 'user-lists-' + userId }
-			userId={ userId }
-		/>
-	);
+		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-	next();
+		context.primary = (
+			<AsyncLoad
+				require="calypso/reader/user-stream"
+				key={ 'user-lists-' + userId }
+				userId={ userId }
+			/>
+		);
+		next();
+	} );
 }

--- a/client/reader/user-stream/index.tsx
+++ b/client/reader/user-stream/index.tsx
@@ -66,13 +66,17 @@ export function UserStream( { userId, requestUser, user, streamKey, isLoading }:
 
 	const renderContent = (): React.ReactNode => {
 		const basePath = currentPath.split( '?' )[ 0 ];
+		const basePathParts = basePath.split( '/' );
+		const isListsPath = basePathParts[ basePathParts.length - 1 ] === 'lists';
 
-		switch ( basePath ) {
-			case `/read/users/${ userId }`:
-				return <UserPosts streamKey={ streamKey as string } />;
-			case `/read/users/${ userId }/lists`:
-				return <UserLists />;
+		if ( isListsPath ) {
+			return <UserLists />;
 		}
+
+		if ( ! streamKey ) {
+			return null;
+		}
+		return <UserPosts streamKey={ streamKey } />;
 	};
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
Requires this update the API endpoint: 169835-ghe-Automattic/wpcom

## Proposed Changes

* This PR accepts a username in the read/users/ route. If a string is detected instead of an int, we look up the userId based on what we assume is the username, then finish the request using the userId we looked up.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because having your usernames in the URL is cool! 😄 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You need to load the API endpoint changes on your sandbox: 169835-ghe-Automattic/wpcom
* Sandbox the API
* Then load this branch locally or using Calypso Live
* Go to read/users/dreagan or /read/users/1351218 -- They should have the same results

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?