### PR TITLE
Goals First: Prevent `calypso_signup_start` from firing multiple times

### DIFF
--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -57,7 +57,7 @@ const onboarding: Flow = {
 			[]
 		);
 
-		return useMemo(
+		const memoizedBase = useMemo(
 			() => ( {
 				[ STEPPER_TRACKS_EVENT_SIGNUP_START ]: {
 					is_goals_first: isGoalsAtFrontExperiment.toString(),
@@ -68,11 +68,18 @@ const onboarding: Flow = {
 					...( isGoalsAtFrontExperiment && {
 						is_goals_first: isGoalsAtFrontExperiment.toString(),
 					} ),
-					...( goals.length && { goals: goals.join( ',' ) } ),
 				},
 			} ),
-			[ isGoalsAtFrontExperiment, userIsLoggedIn, goals ]
+			[ isGoalsAtFrontExperiment, userIsLoggedIn ]
 		);
+
+		return {
+			...memoizedBase,
+			[ STEPPER_TRACKS_EVENT_SIGNUP_STEP_START ]: {
+				...memoizedBase[ STEPPER_TRACKS_EVENT_SIGNUP_STEP_START ],
+				...( goals.length && { goals: goals.join( ',' ) } ),
+			},
+		};
 	},
 	useSteps() {
 		// We have already checked the value has loaded in useAssertConditions

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -57,6 +57,8 @@ const onboarding: Flow = {
 			[]
 		);
 
+		const stringifiedGoals = goals.length && goals?.join( ',' );
+
 		const memoizedBase = useMemo(
 			() => ( {
 				[ STEPPER_TRACKS_EVENT_SIGNUP_START ]: {
@@ -77,7 +79,7 @@ const onboarding: Flow = {
 			...memoizedBase,
 			[ STEPPER_TRACKS_EVENT_SIGNUP_STEP_START ]: {
 				...memoizedBase[ STEPPER_TRACKS_EVENT_SIGNUP_STEP_START ],
-				...( goals.length && { goals: goals.join( ',' ) } ),
+				...( stringifiedGoals && { goals: stringifiedGoals } ),
 			},
 		};
 	},

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -2,7 +2,7 @@ import { OnboardSelect, Onboard, UserSelect } from '@automattic/data-stores';
 import { ONBOARDING_FLOW, clearStepPersistedState } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, useRef } from 'react';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { pathToUrl } from 'calypso/lib/url';
 import {
@@ -57,9 +57,9 @@ const onboarding: Flow = {
 			[]
 		);
 
-		const stringifiedGoals = goals.length && goals?.join( ',' );
+		const initialGoals = useRef( goals );
 
-		const memoizedBase = useMemo(
+		return useMemo(
 			() => ( {
 				[ STEPPER_TRACKS_EVENT_SIGNUP_START ]: {
 					is_goals_first: isGoalsAtFrontExperiment.toString(),
@@ -70,18 +70,13 @@ const onboarding: Flow = {
 					...( isGoalsAtFrontExperiment && {
 						is_goals_first: isGoalsAtFrontExperiment.toString(),
 					} ),
+					...( initialGoals.current.length && {
+						goals: initialGoals.current.join( ',' ),
+					} ),
 				},
 			} ),
-			[ isGoalsAtFrontExperiment, userIsLoggedIn ]
+			[ isGoalsAtFrontExperiment, userIsLoggedIn, initialGoals ]
 		);
-
-		return {
-			...memoizedBase,
-			[ STEPPER_TRACKS_EVENT_SIGNUP_STEP_START ]: {
-				...memoizedBase[ STEPPER_TRACKS_EVENT_SIGNUP_STEP_START ],
-				...( stringifiedGoals && { goals: stringifiedGoals } ),
-			},
-		};
 	},
 	useSteps() {
 		// We have already checked the value has loaded in useAssertConditions

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -57,6 +57,7 @@ const onboarding: Flow = {
 			[]
 		);
 
+		// we are only interested in the initial goals value when the user enters the goals step
 		const initialGoals = useRef( goals );
 
 		return useMemo(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

The `calypso_signup_start` event gets fired multiple times when goals are selected, this is because list of goals are apart of the memoization dependency in the `useTracksEventProps` hook. As a result each time the user changes the goals the memoization is invalidated and so the event is fired again.

* Remove the goals selection from the dependency so that `calypso_signup_start` is fired once. 

See for more information https://github.com/Automattic/wp-calypso/pull/98097#issuecomment-2579440677

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  go to `/setup/onboarding` 
* Choose multiple goals and verify that the `calypso_signup_start` is fired once
* Go to the next step and verify the event is not fired again and that the selected goals are recorded in `calypso_signup_step_start` for the design,domain steps.




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
