### PR TITLE
My Home doesn't navigate to launchpad if that's where it came from

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -76,7 +76,8 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 
 	function redirectToSiteHome( siteSlug: string | null, flow: string | null ) {
 		recordTracksEvent( 'calypso_launchpad_redirect_to_home', { flow: flow } );
-		window.location.replace( `/home/${ siteSlug }` );
+		// Query param is a guard to prevent infinite loops (#98122)
+		window.location.replace( `/home/${ siteSlug }?from=full-launchpad` );
 	}
 
 	useEffect( () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/index.tsx
@@ -188,7 +188,9 @@ describe( 'Launchpad', () => {
 					`/setup/link-in-bio/launchpad?siteSlug=${ siteSlug }`
 				);
 				expect( replaceMock ).toHaveBeenCalledTimes( 1 );
-				expect( replaceMock ).toHaveBeenCalledWith( `/home/${ siteSlug }` );
+				expect( replaceMock ).toHaveBeenCalledWith(
+					expect.stringMatching( `/home/${ siteSlug }` )
+				);
 			} );
 		} );
 
@@ -205,7 +207,9 @@ describe( 'Launchpad', () => {
 					{},
 					`/setup/link-in-bio/launchpad?siteSlug=${ siteSlug }`
 				);
-				expect( replaceMock ).toHaveBeenCalledWith( `/home/${ siteSlug }` );
+				expect( replaceMock ).toHaveBeenCalledWith(
+					expect.stringMatching( `/home/${ siteSlug }` )
+				);
 			} );
 		} );
 

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -3,6 +3,7 @@ import { fetchLaunchpad } from '@automattic/data-stores';
 import { areLaunchpadTasksCompleted } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper';
 import { isRemovedFlow } from 'calypso/landing/stepper/utils/flow-redirect-handler';
 import { getQueryArgs } from 'calypso/lib/query-args';
+import { bumpStat } from 'calypso/state/analytics/actions';
 import { fetchModuleList } from 'calypso/state/jetpack/modules/actions';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
@@ -40,7 +41,7 @@ export async function maybeRedirect( context, next ) {
 		return;
 	}
 
-	const { verified, courseSlug } = getQueryArgs() || {};
+	const { verified, courseSlug, from } = getQueryArgs() || {};
 
 	// The courseSlug is to display pages with onboarding videos for learning,
 	// so we should not redirect the page to launchpad.
@@ -75,11 +76,16 @@ export async function maybeRedirect( context, next ) {
 			launchpadScreenOption === 'full' &&
 			! areLaunchpadTasksCompleted( launchpadChecklist, isSiteLaunched )
 		) {
-			// The new stepper launchpad onboarding flow isn't registered within the "page"
-			// client-side router, so page.redirect won't work. We need to use the
-			// traditional window.location Web API.
-			redirectToLaunchpad( slug, siteIntentOption, verified );
-			return;
+			if ( from === 'full-launchpad' ) {
+				// A guard to prevent infinite loops (#98122)
+				context.store.dispatch( bumpStat( 'calypso_customer_home_launchpad_infinite_loop_guard' ) );
+			} else {
+				// The new stepper launchpad onboarding flow isn't registered within the "page"
+				// client-side router, so page.redirect won't work. We need to use the
+				// traditional window.location Web API.
+				redirectToLaunchpad( slug, siteIntentOption, verified );
+				return;
+			}
 		}
 	} catch ( error ) {}
 

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -78,7 +78,12 @@ export async function maybeRedirect( context, next ) {
 		) {
 			if ( from === 'full-launchpad' ) {
 				// A guard to prevent infinite loops (#98122)
-				context.store.dispatch( bumpStat( 'calypso_customer_home_launchpad_infinite_loop_guard' ) );
+				context.store.dispatch(
+					bumpStat(
+						'calypso_customer_home_launchpad_infinite_loop_guard',
+						site?.launch_status ?? 'null'
+					)
+				);
 			} else {
 				// The new stepper launchpad onboarding flow isn't registered within the "page"
 				// client-side router, so page.redirect won't work. We need to use the


### PR DESCRIPTION
A mitigation for the issue in #98122

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add query param when fullscreen launchpad auto redirects to My Home because it thinks the launchpad is complete/has been skipped
* My Home doesn't redirect to the fullscreen launchpad when the query param is present.
* Added a bump stat to see how often this happens

This doesn't fix the underlying problem of why My Home thinks it should go to the full screen launchpad while the launchpad thinks it should go to My Home. Just noting that this may all become moot when the North Star onboarding flow eventually removes the fullscreen launchpad.

Since the underlying problem isn't fixed, there's no telling whether the underlying out-of-sync data will get back in sync again. For example, if the user clicks `My Home` in the sidebar, then the user may be quickly redirected to launchpad and back to My Home again. But it's

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We haven't got to the root of this issue, but even if only 1% of flows have this issue, when there are 1000s of signups that's a lot of users being affected.

Being locked out of the fullscreen launchpad is better than being locked out of My Home (or being stuck in a loop).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

We haven't got reliable reproducible steps for #98122 so the easiest way to test this is by testing locally and tweaking the code to force the loop behaviour.

* Add `true` to [this `if` statement](https://github.com/Automattic/wp-calypso/blob/fdd9bd6a61c239576156e857b5b60a8ee9a0a6ef/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx#L64-L68) so the redirect always happens in the launchpad
* Use `localStorage.setItem( 'debug', 'calypso:analytics:mc' );` (MC stats are disabled in local dev, so this is the easiest way to see the fired event)
* Create a site and confirm the launchpad takes you straight to My Home, no loop
* Click on My Home in the menu, you briefly go to the launchpad and back again
* Confirm the `calypso_customer_home_launchpad_infinite_loop_guard` stat is sent by checking the console

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
