### PR TITLE
Plans Spotlight: Align action button with a flexbox

### DIFF
--- a/packages/plans-grid-next/src/components/features-grid/spotlight-plan.scss
+++ b/packages/plans-grid-next/src/components/features-grid/spotlight-plan.scss
@@ -1,9 +1,5 @@
-@import "../../shared";
-
-.plans-grid-next.is-medium {
-	.plan-features-2023-grid__plan-spotlight {
-		.plans-grid-next-action-button {
-			width: 200px;
-		}
+.plan-features-2023-grid__plan-spotlight {
+	.plans-grid-next-action-button {
+		width: 200px;
 	}
 }

--- a/packages/plans-grid-next/src/components/features-grid/spotlight-plan.scss
+++ b/packages/plans-grid-next/src/components/features-grid/spotlight-plan.scss
@@ -1,5 +1,9 @@
-.plan-features-2023-grid__plan-spotlight {
-	.plans-grid-next-action-button {
-		width: 200px;
+@import "../../shared";
+
+.plans-grid-next.is-medium {
+	.plan-features-2023-grid__plan-spotlight {
+		.plans-grid-next-action-button {
+			width: 200px;
+		}
 	}
 }

--- a/packages/plans-grid-next/src/components/features-grid/spotlight-plan.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/spotlight-plan.tsx
@@ -44,28 +44,32 @@ const SpotlightPlan = ( {
 
 	return (
 		<div className={ spotlightPlanClasses }>
-			<PlanLogos renderedGridPlans={ [ gridPlanForSpotlight ] } isInSignup={ false } />
-			<PlanHeaders renderedGridPlans={ [ gridPlanForSpotlight ] } />
-			{ isNotFreePlan && <PlanTagline renderedGridPlans={ [ gridPlanForSpotlight ] } /> }
-			{ isNotFreePlan && (
-				<PlanPrices
+			<div>
+				<PlanLogos renderedGridPlans={ [ gridPlanForSpotlight ] } isInSignup={ false } />
+				<PlanHeaders renderedGridPlans={ [ gridPlanForSpotlight ] } />
+				{ isNotFreePlan && <PlanTagline renderedGridPlans={ [ gridPlanForSpotlight ] } /> }
+				{ isNotFreePlan && (
+					<PlanPrices
+						renderedGridPlans={ [ gridPlanForSpotlight ] }
+						currentSitePlanSlug={ currentSitePlanSlug }
+					/>
+				) }
+				{ isNotFreePlan && <BillingTimeframes renderedGridPlans={ [ gridPlanForSpotlight ] } /> }
+				<PlanFeaturesList
 					renderedGridPlans={ [ gridPlanForSpotlight ] }
-					currentSitePlanSlug={ currentSitePlanSlug }
+					featureGroupSlug={ FEATURE_GROUP_STORAGE }
+					onStorageAddOnClick={ onStorageAddOnClick }
+					showUpgradeableStorage={ showUpgradeableStorage }
 				/>
-			) }
-			{ isNotFreePlan && <BillingTimeframes renderedGridPlans={ [ gridPlanForSpotlight ] } /> }
-			<PlanFeaturesList
-				renderedGridPlans={ [ gridPlanForSpotlight ] }
-				featureGroupSlug={ FEATURE_GROUP_STORAGE }
-				onStorageAddOnClick={ onStorageAddOnClick }
-				showUpgradeableStorage={ showUpgradeableStorage }
-			/>
-			<TopButtons
-				renderedGridPlans={ [ gridPlanForSpotlight ] }
-				isInSignup={ isInSignup }
-				currentSitePlanSlug={ currentSitePlanSlug }
-				planActionOverrides={ planActionOverrides }
-			/>
+			</div>
+			<div className="spotlight-plan__buttons">
+				<TopButtons
+					renderedGridPlans={ [ gridPlanForSpotlight ] }
+					isInSignup={ isInSignup }
+					currentSitePlanSlug={ currentSitePlanSlug }
+					planActionOverrides={ planActionOverrides }
+				/>
+			</div>
 		</div>
 	);
 };

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -270,11 +270,12 @@
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 5px;
     display: flex;
+    justify-content: space-between;
 
 	div.spotlight-plan__buttons  {
 		display: flex;
 		align-items: center;
-		margin-top: -70px;
+		justify-content: center;
 	}
 
 	div.plan-features-2023-grid__table-item {

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -268,15 +268,17 @@
 	margin-bottom: 64px;
 	border: 1px solid #e0e0e0;
 	/* stylelint-disable-next-line scales/radii */
-	border-radius: 0 0 5px 5px;
+	border-radius: 5px;
+    display: flex;
+
+	div.spotlight-plan__buttons  {
+		display: flex;
+		align-items: center;
+		margin-top: -70px;
+	}
+
 	div.plan-features-2023-grid__table-item {
 		border: none;
-		&.is-top-buttons {
-			position: absolute;
-			top: 46px;
-			right: 0;
-			border-left: 0;
-		}
 
 		&.plan-features-2023-grid__header-billing-info {
 			padding-bottom: 16px;
@@ -288,6 +290,10 @@
 
 		&.popular-plan-parent-class .plan-features-2023-grid__popular-badge {
 			padding-bottom: 23px;
+			@include plans-grid-medium-large {
+				position: unset;
+				border: none;
+			}
 		}
 
 		.plan-features-2023-grid__header-title {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Fixes Automattic/wp-calypso#97567
- Fixes Automattic/wp-calypso#86607

## Proposed Changes

* Move spotlight plan button to flex container instead of using absolute placement

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug reports raised above and better display of elements

<img width="1039" alt="image" src="https://github.com/user-attachments/assets/8a0f01b4-ff91-4752-8985-fa131ea8df5f" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the plans page and make sure the spotlight plan works well on Free plan and Business plan in resolutions 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
