### PR TITLE
Stepper: Avoid calling the submit function of the process step multiple times

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -129,7 +129,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 		if ( hasEmptyActionRun && ! isSubmittedRef.current ) {
 			// Let's ensure the submit function is called only once,
 			// but only for the onboarding flow to mitigate risks.
-			isSubmittedRef.current = flow === 'onboarding' ? true : false;
+			isSubmittedRef.current = flow === 'site-setup' ? true : false;
 			submit?.( {}, ProcessingResult.NO_ACTION );
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -161,7 +161,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 
 			// Let's ensure the submit function is called only once,
 			// but only for the onboarding flow to mitigate risks.
-			isSubmittedRef.current = flow === 'onboarding' ? true : false;
+			isSubmittedRef.current = flow === 'site-setup' ? true : false;
 
 			// Default processing handler.
 			submit?.( destinationState, ProcessingResult.SUCCESS );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -127,7 +127,9 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 	// As for hasActionSuccessfullyRun, in this case we submit the no action result.
 	useEffect( () => {
 		if ( hasEmptyActionRun && ! isSubmittedRef.current ) {
-			isSubmittedRef.current = true;
+			// Let's ensure the submit function is called only once,
+			// but only for the onboarding flow to mitigate risks.
+			isSubmittedRef.current = flow === 'onboarding' ? true : false;
 			submit?.( {}, ProcessingResult.NO_ACTION );
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -157,8 +159,11 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 				wccom_from: getWccomFrom( destinationState ),
 			} );
 
+			// Let's ensure the submit function is called only once,
+			// but only for the onboarding flow to mitigate risks.
+			isSubmittedRef.current = flow === 'onboarding' ? true : false;
+
 			// Default processing handler.
-			isSubmittedRef.current = true;
 			submit?.( destinationState, ProcessingResult.SUCCESS );
 		}
 		// A change in submit() doesn't cause this effect to rerun.

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -13,7 +13,7 @@ import {
 } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
@@ -48,6 +48,28 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 	const [ hasActionSuccessfullyRun, setHasActionSuccessfullyRun ] = useState( false );
 	const [ hasEmptyActionRun, setHasEmptyActionRun ] = useState( false );
 	const [ destinationState, setDestinationState ] = useState( {} );
+
+	/**
+	 * There is a long-term bug here that the `submit` function will be called multiple times if we
+	 * call `resetOnboardStoreWithSkipFlags` after the submit function (e.g.: exitFlow) to reset states
+	 * that are listed as the dependencies of the `recordSignupComplete`, e.g.: goals, selectedDesign, etc.
+	 *
+	 * Here is a possible flow:
+	 * 1. The Design Picker step submits, sets a pending action, and goes to this step
+	 * 2. Run the pending action, and then submit first
+	 * 3. The `submit` may trigger the `exitFlow` function that is defined by each flow
+	 * 4. The `exitFlow` function may set another pending action, and call `resetOnboardStoreWithSkipFlags` function
+	 * 5. The effect to call the `submit` runs again since the `recordSignupComplete` function changes
+	 *
+	 * It's also a reason why we have a hacky to set a pending action to return a Promise that is never resolved.
+	 *
+	 * To resolve this issue, we define a flag to avoid calling the submit function multiple times.
+	 *
+	 * Another way is to remove the recordSignupComplete function from the dependencies of the effect that
+	 * is called when the hasActionSuccessfullyRun flag turns on. But it seems to be better to use an explicit
+	 * flag to avoid the issue and describe it here.
+	 */
+	const isSubmittedRef = useRef( false );
 
 	const recordSignupComplete = useRecordSignupComplete( flow );
 
@@ -104,7 +126,8 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 
 	// As for hasActionSuccessfullyRun, in this case we submit the no action result.
 	useEffect( () => {
-		if ( hasEmptyActionRun ) {
+		if ( hasEmptyActionRun && ! isSubmittedRef.current ) {
+			isSubmittedRef.current = true;
 			submit?.( {}, ProcessingResult.NO_ACTION );
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -112,7 +135,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 
 	// When the hasActionSuccessfullyRun flag turns on, run submit() and fire the sign-up completion event.
 	useEffect( () => {
-		if ( hasActionSuccessfullyRun ) {
+		if ( hasActionSuccessfullyRun && ! isSubmittedRef.current ) {
 			// We should only trigger signup completion for signup flows, so check if we have one.
 			if ( availableFlows[ flow ] ) {
 				availableFlows[ flow ]().then( ( flowExport ) => {
@@ -135,6 +158,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 			} );
 
 			// Default processing handler.
+			isSubmittedRef.current = true;
 			submit?.( destinationState, ProcessingResult.SUCCESS );
 		}
 		// A change in submit() doesn't cause this effect to rerun.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98167

## Proposed Changes

There is a long-term bug here that the `submit` function will be called multiple times if we
call `resetOnboardStoreWithSkipFlags` after the submit function (e.g.: exitFlow) to reset states
that are listed as the dependencies of the `recordSignupComplete`, e.g.: goals, selectedDesign, etc.

Here is a possible flow:
1. The Design Picker step submits, sets a pending action, and goes to this step
2. Run the pending action, and then submit first
3. The submit may trigger the `exitFlow` function that is defined by each flow
4. The `exitFlow` function may set another pending action, and call `resetOnboardStoreWithSkipFlags` function
5. The effect of calling the submit runs again since the recordSignupComplete function changes

It's also a reason why we have a hacky to set a pending action to return a Promise that is never resolved.

---

The issue, https://github.com/Automattic/wp-calypso/issues/98167, was the `exitFlow` might be called multiple times. However, we cleared the onboard state on the first call so the active theme would be reset to the default of the write intent when the pending action was triggered again (the `selectedDesign` became `null` on the second call.

As a result, this PR proposed to define a flag to avoid calling the submit function multiple times in the short term.

Another way is to remove the recordSignupComplete function from the dependencies of the effect that
is called when the hasActionSuccessfullyRun flag turns on. But it seems to be better to use an explicit
flag to avoid the issue and describe it here.

The current solution will affect all flows. If we want to avoid any regression, we can simply add a flag like `isFlowCompleted` to the specific flow (e.g.: site-setup) to return immediately when the `exitFlow` function calls multiple times.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/onboarding with/without goals-first exp
* On the Goals screen, select `Publish a blog` goal
* On the Design Picker screen, select any design
* On the Domain screen, select any domain
* On the Plan screen, select free plan
* When you land on the Launchpad, ensure the preview looks like the design you selected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
