### PR TITLE
Design picker: Include partial category matches in best matching results

### DIFF
--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -1,6 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useRef, useState } from 'react';
@@ -324,7 +323,6 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	isBigSkyEligible = false,
 } ) => {
 	const translate = useTranslate();
-	const hasEnTranslation = useHasEnTranslation();
 	const { selectedCategoriesWithoutDesignTier } = useDesignPickerFilters();
 
 	const categories = categorization?.categories || [];
@@ -408,11 +406,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 			{ isMultiFilterEnabled && selectedCategoriesWithoutDesignTier.length > 1 && (
 				<DesignCardGroup
 					{ ...designCardProps }
-					title={
-						hasEnTranslation( 'Best theme matches' )
-							? translate( 'Best theme matches' )
-							: translate( 'Best matching themes' )
-					}
+					title={ translate( 'Best matching themes' ) }
 					category="best"
 					designs={ best }
 				/>

--- a/packages/design-picker/src/hooks/use-filtered-designs.ts
+++ b/packages/design-picker/src/hooks/use-filtered-designs.ts
@@ -45,7 +45,7 @@ export const getFilteredDesignsByCategory = (
 
 		// For designs that match all selected categories.
 		// Limit the best matches to at least 2 selected categories.
-		if ( categorySlugs.length > 1 && matchedCount === categorySlugs.length ) {
+		if ( categorySlugs.length > 1 && matchedCount > 1 ) {
 			filteredDesignsByCategory.best.push( design );
 			continue;
 		}
@@ -58,6 +58,21 @@ export const getFilteredDesignsByCategory = (
 			filteredDesignsByCategory[ lastMatchedCategorySlug ].push( design );
 		}
 	}
+
+	// sort best designs by highest number of matched categories
+	filteredDesignsByCategory.best.sort( ( a, b ) => {
+		const aMatchedCategorySlugs = categorySlugs.filter( ( categorySlug ) =>
+			a.categories.map( ( category ) => category.slug ).includes( categorySlug )
+		);
+		const bMatchedCategorySlugs = categorySlugs.filter( ( categorySlug ) =>
+			b.categories.map( ( category ) => category.slug ).includes( categorySlug )
+		);
+
+		return bMatchedCategorySlugs.length - aMatchedCategorySlugs.length;
+	} );
+
+	// limit the best designs to 6
+	filteredDesignsByCategory.best = filteredDesignsByCategory.best.slice( 0, 6 );
 
 	return filteredDesignsByCategory;
 };


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/10222

## Proposed Changes

* Includes partial category matches in best matching results (with at least 2 categories are matched)
* Sorts the best matching results by number of category matches (4, 3, 2 etc..)
* Limits the results to a maximum of 6

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit design picker at: `/setup/site-setup/designSetup?siteSlug=:slug&siteId=:id&categories=blog%2Cnewsletter`
* Try filtering results with multiple categories
* Partial category matching results must be shown (compare with production version)
* Results with highest matching categories must appear first.
* At most 6 results should be shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
