### PR TITLE
Help Center: Hide support name in chat messages.

### DIFF
--- a/packages/help-center/src/components/help-center-support-chat-message.tsx
+++ b/packages/help-center/src/components/help-center-support-chat-message.tsx
@@ -47,6 +47,7 @@ export const HelpCenterSupportChatMessage = ( {
 	const helpCenterContextSectionName = helpCenterContext.sectionName;
 	const { data: supportInteraction } = useGetSupportInteractionById( supportInteractionId );
 	const { setCurrentSupportInteraction } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const messageDisplayName = message.role === 'business' ? 'Happiness Engineer' : displayName;
 
 	const renderAvatar = () => {
 		if ( message.role === 'business' ) {
@@ -91,7 +92,7 @@ export const HelpCenterSupportChatMessage = ( {
 				</div>
 				<div className="help-center-support-chat__conversation-sub-information">
 					<span className="help-center-support-chat__conversation-information-name">
-						{ displayName }
+						{ messageDisplayName }
 					</span>
 					<Icon
 						size={ 2 }

--- a/packages/help-center/src/components/help-center-support-chat-message.tsx
+++ b/packages/help-center/src/components/help-center-support-chat-message.tsx
@@ -47,7 +47,8 @@ export const HelpCenterSupportChatMessage = ( {
 	const helpCenterContextSectionName = helpCenterContext.sectionName;
 	const { data: supportInteraction } = useGetSupportInteractionById( supportInteractionId );
 	const { setCurrentSupportInteraction } = useDataStoreDispatch( HELP_CENTER_STORE );
-	const messageDisplayName = message.role === 'business' ? 'Happiness Engineer' : displayName;
+	const messageDisplayName =
+		message.role === 'business' ? __( 'Happiness Engineer', __i18n_text_domain__ ) : displayName;
 
 	const renderAvatar = () => {
 		if ( message.role === 'business' ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/wp-calypso/issues/98164

## Proposed Changes

* Update the support agent name in conversation messages to `Happiness Engineer` instead of their actual name.


Before:

<img width="413" alt="CleanShot 2025-01-10 at 16 55 46@2x" src="https://github.com/user-attachments/assets/da82e012-c24f-40ed-a77c-8d144f3dcb70" />

<img width="413" alt="CleanShot 2025-01-10 at 17 10 16@2x" src="https://github.com/user-attachments/assets/8def9454-da8f-4066-899e-6d4e1fb21f81" />



After:

<img width="412" alt="CleanShot 2025-01-10 at 16 51 46@2x" src="https://github.com/user-attachments/assets/92f2d1f4-fd0c-4f8b-8e62-3e18c1417fec" />

<img width="416" alt="CleanShot 2025-01-10 at 16 52 04@2x" src="https://github.com/user-attachments/assets/00d470bf-97a9-4d50-9676-f4936feb3e8f" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Hide support name which can be used for malicious intent.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Verify existing messages in the recent conversations and chat history sections display `Happiness Engineer` instead of the support agent's name.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
