### PR TITLE
Domain management: Show the DNS subpage in site context

### DIFF
--- a/client/hosting/overview/index.tsx
+++ b/client/hosting/overview/index.tsx
@@ -128,7 +128,7 @@ export default function () {
 		controllers: [
 			domainManagementController.domainManagementSubpageParams( DNS_RECORDS ),
 			domainManagementController.domainManagementDns,
-			domainManagementController.domainManagementPaneView( DOMAIN_OVERVIEW ),
+			domainManagementController.domainManagementSubpageView,
 		],
 	} );
 

--- a/client/hosting/overview/index.tsx
+++ b/client/hosting/overview/index.tsx
@@ -123,6 +123,14 @@ export default function () {
 	} );
 
 	registerSiteDomainPage( {
+		path: '/overview/site-domain/domain/:domain/dns/:site',
+		controllers: [
+			domainManagementController.domainManagementDns,
+			domainManagementController.domainManagementPaneView( DOMAIN_OVERVIEW ),
+		],
+	} );
+
+	registerSiteDomainPage( {
 		path: '/overview/site-domain/contact-info/edit/:domain/:site',
 		controllers: [
 			domainManagementController.domainManagementSubpageParams( EDIT_CONTACT_INFO ),

--- a/client/hosting/overview/index.tsx
+++ b/client/hosting/overview/index.tsx
@@ -16,6 +16,7 @@ import {
 	EMAIL_MANAGEMENT,
 } from 'calypso/my-sites/domains/domain-management/domain-overview-pane/constants';
 import {
+	DNS_RECORDS,
 	ADD_FORWARDING_EMAIL,
 	EDIT_CONTACT_INFO,
 } from 'calypso/my-sites/domains/domain-management/subpage-wrapper/subpages';
@@ -125,6 +126,7 @@ export default function () {
 	registerSiteDomainPage( {
 		path: '/overview/site-domain/domain/:domain/dns/:site',
 		controllers: [
+			domainManagementController.domainManagementSubpageParams( DNS_RECORDS ),
 			domainManagementController.domainManagementDns,
 			domainManagementController.domainManagementPaneView( DOMAIN_OVERVIEW ),
 		],

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -594,7 +594,7 @@ const Settings = ( {
 		} );
 	};
 
-	const renderTranferInMappedDomainSection = () => {
+	const renderTransferInMappedDomainSection = () => {
 		if ( ! ( domain?.isEligibleForInboundTransfer && domain?.type === domainTypes.MAPPED ) ) {
 			return null;
 		}
@@ -751,7 +751,7 @@ const Settings = ( {
 				{ renderStatusSection() }
 				{ renderGravatarSection() }
 				{ renderDetailsSection() }
-				{ renderTranferInMappedDomainSection() }
+				{ renderTransferInMappedDomainSection() }
 				{ renderDiagnosticsSection() }
 				{ renderSetAsPrimaryDomainSection() }
 				{ renderNameServersSection() }

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -507,7 +507,7 @@ const Settings = ( {
 		return renderSecurityAccordion();
 	};
 
-	const renderContactInformationSecion = () => {
+	const renderContactInformationSection = () => {
 		if ( ! domain ) {
 			return null;
 		}
@@ -757,7 +757,7 @@ const Settings = ( {
 				{ renderNameServersSection() }
 				{ renderDnsRecords() }
 				{ renderForwardingSection() }
-				{ renderContactInformationSecion() }
+				{ renderContactInformationSection() }
 				{ renderContactVerificationSection() }
 				{ renderDnssecSection() }
 				{ renderDomainSecuritySection() }

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-records-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-records-header.tsx
@@ -1,36 +1,16 @@
 import { localizeUrl } from '@automattic/i18n-utils';
+import { SiteExcerptData } from '@automattic/sites';
 import { translate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import NavigationHeader from 'calypso/components/navigation-header';
+import { domainManagementAllOverview } from 'calypso/my-sites/domains/paths';
+import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
+import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';
+import { useSelector } from 'calypso/state';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getSite } from 'calypso/state/sites/selectors';
 import { CustomHeaderComponentType } from './custom-header-component-type';
-
-const DNSRecordsHeader: CustomHeaderComponentType = ( {
-	selectedDomainName,
-	selectedSiteSlug,
-} ) => (
-	<NavigationHeader
-		className="navigation-header__breadcrumb"
-		navigationItems={ [
-			{
-				label: selectedDomainName,
-				href: `/domains/manage/all/overview/${ selectedDomainName }/${ selectedSiteSlug }`,
-			},
-			{
-				label: translate( 'DNS records' ),
-			},
-		] }
-		title={ translate( 'DNS records' ) }
-		subtitle={ translate( 'DNS records change how your domain works. {a}Learn more{/a}', {
-			components: {
-				a: (
-					<ExternalLink
-						href={ localizeUrl( 'https://wordpress.com/support/domains/custom-dns/' ) }
-					/>
-				),
-			},
-		} ) }
-	/>
-);
 
 // Override the title and subtitle for the DNS records page
 const dnsRecordsTitle = translate( 'DNS records' );
@@ -44,6 +24,58 @@ const dnsRecordsSubtitle = translate(
 		},
 	}
 );
+
+const DNSRecordsHeader: CustomHeaderComponentType = ( {
+	selectedDomainName,
+	selectedSiteSlug,
+	inSiteContext,
+} ) => {
+	const site = useSelector( ( state ) => getSite( state, selectedSiteSlug ) as SiteExcerptData );
+	const currentRoute = useSelector( getCurrentRoute );
+
+	const navigationItems = useMemo( () => {
+		const baseNavigationItems = [
+			{
+				label: selectedDomainName,
+				href: domainManagementAllOverview(
+					selectedSiteSlug,
+					selectedDomainName,
+					null,
+					inSiteContext
+				),
+			},
+			{
+				label: translate( 'Email' ),
+				href: getEmailManagementPath( selectedSiteSlug, selectedDomainName, currentRoute ),
+			},
+			{
+				label: translate( 'DNS records' ),
+			},
+		];
+
+		if ( inSiteContext ) {
+			return [
+				{
+					label: site?.name || selectedDomainName,
+					href: `/overview/${ selectedSiteSlug }`,
+					icon: <SiteIcon site={ site } viewType="breadcrumb" disableClick />,
+				},
+				...baseNavigationItems,
+			];
+		}
+
+		return baseNavigationItems;
+	}, [ inSiteContext, selectedDomainName, selectedSiteSlug, site, translate ] );
+
+	return (
+		<NavigationHeader
+			className="navigation-header__breadcrumb"
+			navigationItems={ navigationItems }
+			title={ dnsRecordsTitle }
+			subtitle={ dnsRecordsSubtitle }
+		/>
+	);
+};
 
 export default DNSRecordsHeader;
 

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-records-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-records-header.tsx
@@ -5,10 +5,8 @@ import { useMemo } from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { domainManagementAllOverview } from 'calypso/my-sites/domains/paths';
-import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
 import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';
 import { useSelector } from 'calypso/state';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSite } from 'calypso/state/sites/selectors';
 import { CustomHeaderComponentType } from './custom-header-component-type';
 
@@ -31,7 +29,6 @@ const DNSRecordsHeader: CustomHeaderComponentType = ( {
 	inSiteContext,
 } ) => {
 	const site = useSelector( ( state ) => getSite( state, selectedSiteSlug ) as SiteExcerptData );
-	const currentRoute = useSelector( getCurrentRoute );
 
 	const navigationItems = useMemo( () => {
 		const baseNavigationItems = [
@@ -45,11 +42,7 @@ const DNSRecordsHeader: CustomHeaderComponentType = ( {
 				),
 			},
 			{
-				label: translate( 'Email' ),
-				href: getEmailManagementPath( selectedSiteSlug, selectedDomainName, currentRoute ),
-			},
-			{
-				label: translate( 'DNS records' ),
+				label: dnsRecordsTitle,
 			},
 		];
 

--- a/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
@@ -2,10 +2,15 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
-.domains-overview.main .subpage-wrapper {
+.domains-overview.main .subpage-wrapper,
+.domains-overview.main .site-preview-pane.domains-overview__details {
 	display: flex;
 	flex-direction: column;
 	height: 100%;
+
+	.navigation-header__actions, .foldable-card__action {
+		flex-grow: initial;
+	}
 
 	.form-text-input-with-affixes .form-text-input {
 		border-radius: 2px 0 0 2px;

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -224,7 +224,9 @@ export function domainManagementEmail( siteName, domainName ) {
  * @param {string?} relativeTo
  */
 export function domainManagementDns( siteName, domainName, relativeTo = null ) {
-	if ( isUnderDomainManagementOverview( relativeTo ) ) {
+	if ( relativeTo?.startsWith( '/overview/site-domain/' ) ) {
+		return `/overview/site-domain/domain/${ domainName }/dns/${ siteName }`;
+	} else if ( isUnderDomainManagementOverview( relativeTo ) ) {
 		return domainManagementOverviewRoot() + '/' + domainName + '/dns/' + siteName;
 	}
 

--- a/client/sites/overview/components/active-domains-card.tsx
+++ b/client/sites/overview/components/active-domains-card.tsx
@@ -78,7 +78,6 @@ const ActiveDomainsCard: FC = () => {
 				isHostingOverview
 				useMobileCards={ forceMobile }
 				siteSlug={ site?.slug ?? null }
-				isHostingOverview
 				userCanSetPrimaryDomains={ userCanSetPrimaryDomains }
 				onDomainAction={ ( action, domain ) => {
 					if ( action === 'set-primary-address' && site ) {

--- a/client/sites/overview/components/active-domains-card.tsx
+++ b/client/sites/overview/components/active-domains-card.tsx
@@ -75,6 +75,7 @@ const ActiveDomainsCard: FC = () => {
 				isLoadingDomains={ isLoading }
 				domains={ data?.domains }
 				isAllSitesView={ false }
+				isHostingOverview
 				useMobileCards={ forceMobile }
 				siteSlug={ site?.slug ?? null }
 				isHostingOverview

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -35,6 +35,7 @@ interface DomainsTableRowActionsProps {
 	canSetPrimaryDomainForSite: boolean;
 	isSiteOnFreePlan: boolean;
 	isSimpleSite: boolean;
+	isHostingOverview?: boolean;
 }
 
 export const DomainsTableRowActions = ( {
@@ -44,6 +45,7 @@ export const DomainsTableRowActions = ( {
 	canSetPrimaryDomainForSite,
 	isSiteOnFreePlan,
 	isSimpleSite,
+	isHostingOverview,
 }: DomainsTableRowActionsProps ) => {
 	const {
 		onDomainAction,
@@ -93,7 +95,7 @@ export const DomainsTableRowActions = ( {
 				<MenuItemLink
 					key="manageDNS"
 					onClick={ () => onDomainAction?.( 'manage-dns-settings', domain ) }
-					href={ domainManagementDNS( siteSlug, domain.name ) }
+					href={ domainManagementDNS( siteSlug, domain.name, isHostingOverview ) }
 				>
 					{ __( 'Manage DNS' ) }
 				</MenuItemLink>

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -255,6 +255,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 									}
 									isSiteOnFreePlan={ site?.plan?.is_free ?? true }
 									isSimpleSite={ ! site?.is_wpcom_atomic }
+									isHostingOverview={ isHostingOverview }
 								/>
 							) }
 						</td>

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -196,8 +196,9 @@ export function domainManagementDNS(
 	isHostingOverview?: boolean
 ) {
 	if ( isHostingOverview ) {
-		return `${ domainManagementAllRoot() }/overview/${ domainName }/dns/${ siteName }`;
+		return `/overview/site-domain/domain/${ domainName }/dns/${ siteName }`;
 	}
+
 	return domainManagementEditBase( siteName, domainName, 'dns' );
 }
 

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -190,7 +190,14 @@ export function isUnderEmailManagementAll( path: string ) {
 	return path?.startsWith( emailManagementAllSitesPrefix + '/' );
 }
 
-export function domainManagementDNS( siteName: string, domainName: string ) {
+export function domainManagementDNS(
+	siteName: string,
+	domainName: string,
+	isHostingOverview?: boolean
+) {
+	if ( isHostingOverview ) {
+		return `${ domainManagementAllRoot() }/overview/${ domainName }/dns/${ siteName }`;
+	}
 	return domainManagementEditBase( siteName, domainName, 'dns' );
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #97967

## Proposed Changes

* Update method to generate path based on the context

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Domains management revamp

## Testing Instructions

- Enable the feature flag by `window.sessionStorage.setItem('flags', 'calypso/all-domain-management')`
- Purchase a blog domain and attach a site with it.
- Now go to calypso.localhost:3000/sites and open this site in flyout
- Scroll to the bottom and click on the row to open the domain in site context
- Open the DNS Records section and click on the "Manage" button
- Check if the screen is rendered in the site-context
<img width="1181" alt="Screenshot 2025-01-14 at 19 13 04" src="https://github.com/user-attachments/assets/b437b1b4-9606-45f3-af06-3aca5007a2cf" />

- Enable the feature flag by `window.sessionStorage.setItem('flags', 'calypso/all-domain-management')`
- Purchase a blog domain and attach a site with it.
- Now go to `calypso.localhost:3000/sites` and open this site in flyout
- Scroll to the bottom, open the context menu, and select "Manage DNS"
- Check if you stay in the same context

<img width="1245" alt="Screenshot 2025-01-10 at 12 45 25" src="https://github.com/user-attachments/assets/732fb488-dfc1-41ad-bafa-c37e093513c8" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
