### PR TITLE
A4A: Partner Directory: Update the Jetpack.com Partner Directory label

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/lib/get-brand-meta.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/lib/get-brand-meta.tsx
@@ -53,7 +53,7 @@ export const getBrandMeta = ( brand: string, agency?: Agency | null ): BrandMeta
 				icon: <JetpackLogo />,
 				url: 'https://jetpack.com/development-services/',
 				urlProfile: `https://jetpack.com/development-services/${ agencySlug }/${ agencyId }`,
-				isAvailable: false,
+				isAvailable: true,
 			};
 		default:
 			return {


### PR DESCRIPTION
## Proposed Changes

This PR simply enables the Jetpack.com Partner Directory label status. We used to show a "coming soon" message in the UI, but as the directory is now public we can update it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

- Open the Automattic for Agencies live link
- Submit a new application for Jetpack.com directory
- Approve your application, but make sure to hide it right after that so that it's not listed on the public directories
- Visit the partner-directory/dashboard and verify the "Coming soon" message is no longer displayed for Jetpack.com directory

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
