### PR TITLE
Update survey model button colors to match admin theme color

### DIFF
--- a/client/components/survey-modal/style.scss
+++ b/client/components/survey-modal/style.scss
@@ -95,7 +95,7 @@
 
 				.modal-survey-notice__popup-content-buttons-ok {
 					padding: 8px 14px;
-					background: var(--studio-blue-50);
+					background: var(--wp-admin-theme-color, #3858e9);
 					color: var(--studio-white);
 					font-size: rem(14px);
 					line-height: 20px;
@@ -104,7 +104,7 @@
 
 				.modal-survey-notice__popup-content-buttons-cancel {
 					padding: 8px 14px;
-					color: var(--studio-blue-50);
+					color: var(--wp-admin-theme-color, #3858e9);
 					text-align: center;
 					font-size: rem(14px);
 					line-height: 20px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/10226

## Proposed Changes

* Update the background color for primary and color for secondary button to admin theme color.

| Before | After |
| --- | --- |
| <img width="394" alt="image" src="https://github.com/user-attachments/assets/b24a84df-200d-4648-87bf-183c3c222663" /> | <img width="451" alt="image" src="https://github.com/user-attachments/assets/4b5a0a99-c8b0-4a14-9d74-dffddc9cfcd6" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To match with rest of the UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit site deployments (for an atomic site), and make sure there exists at least one deployment.
* Clear the cookie `github-deployments` if exists
* Verify the Github deployment survey model button colors.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
