### PR TITLE
Pattern Library: Add resize handle tooltip

### DIFF
--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -22,7 +22,6 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
 import type { Pattern, PatternGalleryProps } from 'calypso/my-sites/patterns/types';
 import type { Dispatch, SetStateAction } from 'react';
-
 import './style.scss';
 
 export const GRID_VIEW_VIEWPORT_WIDTH = 1200;
@@ -372,6 +371,20 @@ function PatternPreviewFragment( {
 	);
 }
 
+function PatternPreviewResizerHandle() {
+	const translate = useTranslate();
+	const tooltipText = translate( 'Resize', {
+		comment: 'Tooltip text in Pattern Library for pattern preview resize handle',
+		textOnly: true,
+	} );
+
+	return (
+		<Tooltip delay={ 300 } placement="top" text={ tooltipText }>
+			<div className="pattern-preview__resizer-handle" />
+		</Tooltip>
+	);
+}
+
 export function PatternPreview( props: PatternPreviewProps ) {
 	const { isResizable, pattern } = props;
 	const { category, patternTypeFilter } = usePatternsContext();
@@ -410,6 +423,10 @@ export function PatternPreview( props: PatternPreviewProps ) {
 				bottomRight: false,
 				bottomLeft: false,
 				topLeft: false,
+			} }
+			handleComponent={ {
+				left: <PatternPreviewResizerHandle />,
+				right: <PatternPreviewResizerHandle />,
 			} }
 			handleWrapperClass="pattern-preview__resizer"
 			minWidth={ 335 }

--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -22,6 +22,7 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
 import type { Pattern, PatternGalleryProps } from 'calypso/my-sites/patterns/types';
 import type { Dispatch, SetStateAction } from 'react';
+
 import './style.scss';
 
 export const GRID_VIEW_VIEWPORT_WIDTH = 1200;

--- a/client/my-sites/patterns/components/pattern-preview/style.scss
+++ b/client/my-sites/patterns/components/pattern-preview/style.scss
@@ -184,26 +184,27 @@
 		right: initial;
 		top: 3.4rem;
 
+		&::before,
 		&::after {
-			background-color: var(--studio-gray-20);
-			border-radius: 3px;
-			box-shadow: none;
-			height: 70px;
-			max-height: 90%;
-			right: 50%;
-			top: 50%;
-			transform: translate(50%, -50%);
-			transition: background-color 0.2s linear;
-			width: 6px;
-		}
-
-		&:hover::after,
-		&:active::after {
-			background-color: var(--studio-gray-40);
-		}
-
-		&::before {
 			content: none;
+		}
+	}
+
+	.pattern-preview__resizer-handle {
+		background-color: var(--studio-gray-20);
+		border-radius: 3px;
+		box-shadow: none;
+		height: 70px;
+		max-height: 90%;
+		position: absolute;
+		right: 50%;
+		top: 50%;
+		transform: translate(50%, -50%);
+		transition: background-color 0.2s linear;
+		width: 6px;
+
+		&:hover {
+			background-color: var(--studio-gray-40);
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6582
Follow-up to https://github.com/Automattic/wp-calypso/pull/98087

## Proposed Changes

I overlooked adding a tooltip to the Pattern Library preview resize handle in https://github.com/Automattic/wp-calypso/pull/98087. This PR fixes that.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To help clarify the purpose of the resize handle, which isn't universally understood at first glance.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/patterns/about`
2. Ensure that the resize handle next to the pattern previews displays a tooltip when you hover it and that it works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
