### PR TITLE
Staging sites: Update error notice message when Studio import is in progress

### DIFF
--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-site-sync-loading-bar-card-content.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-site-sync-loading-bar-card-content.tsx
@@ -11,7 +11,7 @@ const StyledLoadingBar = styled( LoadingBar )( {
 
 type CardContentProps = {
 	progress: number;
-	siteToSync: 'production' | 'staging' | null;
+	siteToSync: 'production' | 'staging';
 };
 
 export const StagingSiteSyncLoadingBarCardContent = ( {
@@ -30,16 +30,12 @@ export const StagingSiteSyncLoadingBarCardContent = ( {
 			: translate(
 					'We are updating the production site. We’ll email the site owner once it is ready.'
 			  );
-	} else if ( siteToSync === 'staging' ) {
+	} else {
 		message = isOwner
 			? translate( 'We are updating your staging site. We’ll email you once it is ready.' )
 			: translate(
 					'We are updating the staging site. We’ll email the site owner once it is ready.'
 			  );
-	} else {
-		message = isOwner
-			? translate( 'We are updating your site. We’ll email you once it is ready.' )
-			: translate( 'We are updating the site. We’ll email the site owner once it is ready.' );
 	}
 
 	return (

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
@@ -351,15 +351,15 @@ const SyncCardContainer = ( {
 	currentSiteType: 'production' | 'staging';
 	progress: number;
 	isSyncInProgress: boolean;
-	siteToSync: 'production' | 'staging' | null;
+	siteToSync: 'production' | 'staging';
 	siteUrls: SyncCardProps[ 'siteUrls' ];
 	error?: string | null;
 	onRetry?: () => void;
 } ) => {
 	const translate = useTranslate();
 	const siteSlug = useSelector( getSelectedSiteSlug );
-	const isJetpackConnectionError = useIsJetpackConnectionSyncError( error ) && siteToSync;
-	const isFailedSyncError = useIsFailedSyncError( error ) && siteToSync;
+	const isJetpackConnectionError = useIsJetpackConnectionSyncError( error );
+	const isFailedSyncError = useIsFailedSyncError( error );
 
 	return (
 		<StagingSyncCardBody>
@@ -426,11 +426,11 @@ const SyncCardContainer = ( {
 									? translate(
 											'We couldn’t synchronize the %s environment. Studio push operation is currently in progress.',
 											{
-												args: [ siteToSync ?? '' ],
+												args: [ siteToSync ],
 											}
 									  )
 									: translate( 'We couldn’t synchronize the %s environment.', {
-											args: [ siteToSync ?? '' ],
+											args: [ siteToSync ],
 									  } )
 							}
 						>
@@ -533,12 +533,8 @@ export const SiteSyncCard = ( {
 		( selectedItems.length === 0 && selectedOption === actionForType ) ||
 		selectedOption === null;
 
-	let siteToSync: 'production' | 'staging' | null = null;
-	if ( targetSite ) {
-		siteToSync = targetSite;
-	} else {
-		siteToSync = selectedOption === actionForType ? 'production' : 'staging';
-	}
+	const siteToSync: 'production' | 'staging' =
+		targetSite || ( selectedOption === actionForType ? 'production' : 'staging' );
 
 	useEffect( () => {
 		if ( selectedOption && status === SiteSyncStatus.COMPLETED && ! syncError ) {

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
@@ -421,9 +421,18 @@ const SyncCardContainer = ( {
 							status="is-error"
 							icon="mention"
 							showDismiss={ false }
-							text={ translate( 'We couldn’t synchronize the %s environment.', {
-								args: [ siteToSync ?? '' ],
-							} ) }
+							text={
+								error === 'studio_import_in_progress'
+									? translate(
+											'We couldn’t synchronize the %s environment. Studio push operation is currently in progress.',
+											{
+												args: [ siteToSync ?? '' ],
+											}
+									  )
+									: translate( 'We couldn’t synchronize the %s environment.', {
+											args: [ siteToSync ?? '' ],
+									  } )
+							}
 						>
 							<NoticeAction onClick={ () => onRetry?.() }>
 								{ translate( 'Try Again' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/10008.

## Proposed Changes

* update error notice message when Studio import is in progress

![Markup on 2025-01-10 at 14:40:12](https://github.com/user-attachments/assets/4106f475-a34c-4819-a043-dee56a487a86)

> [!NOTE]
> I originally aimed to adjust the error logic on a deeper level (as can be seen in https://github.com/Automattic/wp-calypso/pull/98156), but then decided to adjust the error message only.
> 
> The changes proposed in this PR are much simpler and solve the issue without touching the error logic.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- https://github.com/Automattic/dotcom-forge/issues/10008.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create an Atomic site and ensure it also has a staging site attached (http://calypso.localhost:3000/staging-site/{site-slug}).
2. Open the Studio app and connect the Atomic site to one of your local sites.
3. Initiate the Push operation to your staging site and wait until the `Applying changes...` status message displays above the progress bar.
4. Head over to the http://calypso.localhost:3000/staging-site/{site-slug} settings page and try to initiate the sync from production to the staging site.
5. The process should fail with the new error message - as can be seen in the screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
