### PR TITLE
Goals First: Prevent `calypso_signup_start` from firing again when user logs in

### DIFF
--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -57,15 +57,16 @@ const onboarding: Flow = {
 			[]
 		);
 
-		// we are only interested in the initial goals value when the user enters the goals step
+		// we are only interested in the initial values and not when they values change
 		const initialGoals = useRef( goals );
+		const initialLoggedOut = useRef( ! userIsLoggedIn );
 
 		return useMemo(
 			() => ( {
 				[ STEPPER_TRACKS_EVENT_SIGNUP_START ]: {
 					is_goals_first: isGoalsAtFrontExperiment.toString(),
 					...( isGoalsAtFrontExperiment && { step: 'goals' } ),
-					is_logged_out: ( ! userIsLoggedIn ).toString(),
+					is_logged_out: initialLoggedOut.current.toString(),
 				},
 				[ STEPPER_TRACKS_EVENT_SIGNUP_STEP_START ]: {
 					...( isGoalsAtFrontExperiment && {
@@ -76,7 +77,7 @@ const onboarding: Flow = {
 					} ),
 				},
 			} ),
-			[ isGoalsAtFrontExperiment, userIsLoggedIn, initialGoals ]
+			[ isGoalsAtFrontExperiment, initialGoals, initialLoggedOut ]
 		);
 	},
 	useSteps() {


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes
The `is_logged_out` prop changes to true when the user logs in, this causes the event to re-trigger as the `useMemo` dependency is changed. This PR prevents that by using a reference in the dependency list instead of the actual value of `is_logged_out` since we are only interested in what the value was when the event was first triggered.

* Use a reference to track `is_logged_out` instead of the actual value.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding`
* Verify the `calypso_signup_start` event is fired
* Go through and create a user
* Verify the `calypso_signup_start` event is not fired again

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
