### PR TITLE
Domains management: Adjust EmailHome component for hosting-overview context

### DIFF
--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.tsx
@@ -101,7 +101,7 @@ function EmailPlanMailboxesList( {
 							/>
 							{ context === 'email' && <EmailForwardSecondaryDetails mailbox={ mailbox } /> }
 						</div>
-						{ context === 'domains' && (
+						{ ( context === 'domains' || context === 'hosting-overview' ) && (
 							<div className="email-plan-mailboxes-list__mailbox-list-item-main">
 								<EmailForwardSecondaryDetails
 									mailbox={ mailbox }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/97963

## Proposed Changes

* Adjust the EmailHome component to support `site-context`

## Why are these changes being made?

* Domain Management Revamp

## Testing Instructions

- Enable the feature flag by `window.sessionStorage.setItem('flags', 'calypso/all-domain-management')`
- Purchase a blog domain and attach a site with it.
- Add at least one google mailbox with the domain
- Now go to `calypso.localhost:3000/sites` and open this site in flyout
- Scroll to bottom and click on the row to open the domain in site context
- Switch to the Emails tab
- Ensure the page looks the same as when it's not in site-context
- Check domains with Titan, Google, and no mailboxes

<img width="1139" alt="Screenshot 2025-01-10 at 18 18 18" src="https://github.com/user-attachments/assets/ff9410d5-7102-4b30-899b-0c7e8a551ddd" />

<img width="1138" alt="Screenshot 2025-01-10 at 18 19 17" src="https://github.com/user-attachments/assets/9f41436d-18c5-4993-a50c-15aae7cfc5bc" />

<img width="1138" alt="Screenshot 2025-01-10 at 18 19 50" src="https://github.com/user-attachments/assets/77b95cfe-6e2b-40fa-bb28-34386aeeacf5" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
