### PR TITLE
Chart tooltip: disable pointer events to fix glitchy tooltip

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -358,6 +358,9 @@ $y-axis-padding: 0 20px;
 // Chart tooltip
 
 .chart__tooltip {
+	// The tooltip doesn't trigger pointer events to allow causing a premature
+	// mouseleave event when the tooltip is hovered over
+	pointer-events: none;
 	.popover__inner {
 		width: 230px;
 		text-align: left;

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -358,7 +358,7 @@ $y-axis-padding: 0 20px;
 // Chart tooltip
 
 .chart__tooltip {
-	// The tooltip doesn't trigger pointer events to allow causing a premature
+	// The tooltip doesn't trigger pointer events to prevent causing a premature
 	// mouseleave event when the tooltip is hovered over
 	pointer-events: none;
 	.popover__inner {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/82305


## Proposed Changes

* Ignore pointer evens on the the chart tooltip

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

On trunk, the tooltip is shown / hidden based on the `mouseenter` and `mouseleave` events. When the tooltip appears on top of the chart, when the user hovers over the tooltip it causes the `mouseleave` event to fire on the chart, which hides the tooltip. This results in a frustrating experience, where the tooltip can be very short lived and sometimes even flicker.

Ignoring pointer events on the tooltip solves the issue, since hovering the tooltip won't cause the `mouseleave` event on the chart.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Load the Calypso customer home for a site that received views recently
- Zoom in so that the page can be scrolled enough to the point that the chart sits on the bottom edge of the viewport (this step is necessary to make sure that the tooltip renders on top of the chart)
- Hover over the bars, and make sure that the tooltip shows correctly
- Hovering over the tooltip should not cause the tooltip from hiding
- The tooltip for a given chart bar is only shown/hidden when the cursor enters/leaves the bar

The same chart can be found in a few other places:
- the dedicated stats page (click the "Stats" link in the main sidebar)
- the email stats (follow instructions from [this PR](https://github.com/Automattic/wp-calypso/pull/72068))
- the store stats for a site with WooCommerce enables (see instructions from [this PR](https://github.com/Automattic/wp-calypso/pull/69661, hopefully still up to date)
- 

Make sure that the same behaviour applies in this page too.

### Before (trunk)

https://github.com/user-attachments/assets/f4373c79-3599-4007-83d6-6999e294efad

### After (this PR)

https://github.com/user-attachments/assets/033e4009-23f8-4c6a-95f1-d99803be7949

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
