### PR TITLE
Storybook: Fix CSF parsing error

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -20,4 +20,4 @@ storybookConfig.previewHead = ( head ) => `
 	</script>
 `;
 
-module.exports = storybookConfig;
+module.exports = { ...storybookConfig };

--- a/packages/calypso-storybook/README.md
+++ b/packages/calypso-storybook/README.md
@@ -4,9 +4,16 @@ Default config for Storybook
 
 ## Usage
 
-Create a file `./.storybook/main.js` in your package with this content
+Create a file `./.storybook/main.js` in your package with this content:
 
-```
+```js
 const storybookDefaultConfig = require( '@automattic/calypso-storybook' );
+module.exports = { ...storybookDefaultConfig() };
+```
+
+Note that the default export must be statically analyzable as an object expression, in order to avoid a [CSF parsing error](https://github.com/storybookjs/storybook/issues/26778) from Storybook.
+
+```js
+// ❌ This will cause a CSF parsing error
 module.exports = storybookDefaultConfig();
 ```

--- a/packages/components/.storybook/main.js
+++ b/packages/components/.storybook/main.js
@@ -1,1 +1,2 @@
-module.exports = require( '@automattic/calypso-storybook' )();
+const storybookDefaultConfig = require( '@automattic/calypso-storybook' );
+module.exports = { ...storybookDefaultConfig() };

--- a/packages/composite-checkout/.storybook/main.js
+++ b/packages/composite-checkout/.storybook/main.js
@@ -1,9 +1,11 @@
 const { join } = require( 'path' );
 const storybookDefaultConfig = require( '@automattic/calypso-storybook' );
 
-module.exports = storybookDefaultConfig( {
-	stories: [ '../demo' ],
-	webpackAliases: {
-		'@automattic/composite-checkout': join( __dirname, '../src/public-api.ts' ),
-	},
-} );
+module.exports = {
+	...storybookDefaultConfig( {
+		stories: [ '../demo' ],
+		webpackAliases: {
+			'@automattic/composite-checkout': join( __dirname, '../src/public-api.ts' ),
+		},
+	} ),
+};

--- a/packages/plans-grid-next/.storybook/main.js
+++ b/packages/plans-grid-next/.storybook/main.js
@@ -1,11 +1,13 @@
 const storybookDefaultConfig = require( '@automattic/calypso-storybook' );
 
-module.exports = storybookDefaultConfig( {
-	staticDirs: [ '../static' ],
-	webpackAliases: {
-		// We are mocking wpcom-proxy-request because calls to wpcomRequest() (eg. inside the
-		// usePlans hook) are not working with MSW. This is a temporary workaround until we can
-		// figure out why.
-		[ 'wpcom-proxy-request' ]: require.resolve( '../src/__mocks__/wpcom-proxy-request.js' ),
-	},
-} );
+module.exports = {
+	...storybookDefaultConfig( {
+		staticDirs: [ '../static' ],
+		webpackAliases: {
+			// We are mocking wpcom-proxy-request because calls to wpcomRequest() (eg. inside the
+			// usePlans hook) are not working with MSW. This is a temporary workaround until we can
+			// figure out why.
+			[ 'wpcom-proxy-request' ]: require.resolve( '../src/__mocks__/wpcom-proxy-request.js' ),
+		},
+	} ),
+};

--- a/packages/privacy-toolset/.storybook/main.js
+++ b/packages/privacy-toolset/.storybook/main.js
@@ -1,3 +1,3 @@
 const storybookDefaultConfig = require( '@automattic/calypso-storybook' );
 
-module.exports = storybookDefaultConfig();
+module.exports = { ...storybookDefaultConfig() };

--- a/packages/search/.storybook/main.js
+++ b/packages/search/.storybook/main.js
@@ -2,10 +2,12 @@ const webpack = require( 'webpack' );
 const path = require( 'path' );
 const storybookDefaultConfig = require( '@automattic/calypso-storybook' );
 
-module.exports = storybookDefaultConfig( {
-	plugins: [
-		new webpack.ProvidePlugin( {
-			process: 'process/browser.js',
-		} ),
-	],
-} );
+module.exports = {
+	...storybookDefaultConfig( {
+		plugins: [
+			new webpack.ProvidePlugin( {
+				process: 'process/browser.js',
+			} ),
+		],
+	} ),
+};


### PR DESCRIPTION
## Proposed Changes

Fixes all the CSF parsing errors when launching Storybook.

## Why are these changes being made?

It clutters the log output, making it harder to notice more important errors.

![CSF parsing errors from Storybook](https://github.com/user-attachments/assets/95ed3bba-60d1-42d4-891b-4bf424a8c38e)

This is actually a bug in Storybook (https://github.com/storybookjs/storybook/issues/26778), but we'll add workarounds on our side since it's pretty simple.

## Testing Instructions

Check that there are no more CSF parsing errors in every Storybook instance.

- `yarn storybook:start` for the main instance
- `yarn workspace @automattic/components run storybook`
- `yarn workspace @automattic/composite-checkout run storybook`
- `yarn workspace @automattic/launchpad run storybook`
- `yarn workspace @automattic/plans-grid-next run storybook`
- `yarn workspace @automattic/privacy-toolset run storybook`
- `yarn workspace @automattic/search run storybook`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

