### PR TITLE
Assisted Migration: Add Help link on the top right corner

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
@@ -21,10 +21,9 @@ interface CredentialsFormProps {
 		siteInfo?: UrlData | undefined,
 		applicationPasswordsInfo?: ApplicationPasswordsInfo
 	) => void;
-	onSkip: () => void;
 }
 
-export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip } ) => {
+export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
 
@@ -115,16 +114,6 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 						{ getContinueButtonText() }
 					</NextButton>
 				</div>
-			</div>
-
-			<div className="site-migration-credentials__skip">
-				<button
-					className="button navigation-link step-container__navigation-link has-underline is-borderless"
-					onClick={ onSkip }
-					type="button"
-				>
-					{ translate( 'I need help, please contact me' ) }
-				</button>
 			</div>
 		</form>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/need-help-link.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/need-help-link.tsx
@@ -1,12 +1,12 @@
 import { Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 
-export const NeedHelpLink = ( { onSkip }: { onSkip: () => void } ) => {
+export const NeedHelpLink = ( { onHelpLinkClicked }: { onHelpLinkClicked: () => void } ) => {
 	return (
 		<span className="site-migration-credentials__need-help-link">
 			{ translate( 'Need help? {{button}}Let us guide you{{/button}}', {
 				components: {
-					button: <Button variant="link" onClick={ onSkip } type="button" />,
+					button: <Button variant="link" onClick={ onHelpLinkClicked } type="button" />,
 				},
 			} ) }
 		</span>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/need-help-link.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/need-help-link.tsx
@@ -1,0 +1,14 @@
+import { Button } from '@wordpress/components';
+import { translate } from 'i18n-calypso';
+
+export const NeedHelpLink = ( { onSkip }: { onSkip: () => void } ) => {
+	return (
+		<span className="site-migration-credentials__need-help-link">
+			{ translate( 'Need help? {{button}}Let us guide you{{/button}}', {
+				components: {
+					button: <Button variant="link" onClick={ onSkip } type="button" />,
+				},
+			} ) }
+		</span>
+	);
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -10,6 +10,7 @@ import { useUpdateMigrationStatus } from 'calypso/data/site-migration/landing/us
 import { useSiteIdParam } from 'calypso/landing/stepper/hooks/use-site-id-param';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { CredentialsForm } from './components/credentials-form';
+import { NeedHelpLink } from './components/need-help-link';
 import { ApplicationPasswordsInfo } from './types';
 import type { Step } from '../../types';
 import './style.scss';
@@ -95,6 +96,7 @@ const SiteMigrationCredentials: Step = function ( { navigation } ) {
 				}
 				stepContent={ <CredentialsForm onSubmit={ handleSubmit } onSkip={ handleSkip } /> }
 				recordTracksEvent={ recordTracksEvent }
+				customizedActionButtons={ <NeedHelpLink onSkip={ handleSkip } /> }
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -94,9 +94,9 @@ const SiteMigrationCredentials: Step = function ( { navigation } ) {
 						align="center"
 					/>
 				}
-				stepContent={ <CredentialsForm onSubmit={ handleSubmit } onSkip={ handleSkip } /> }
+				stepContent={ <CredentialsForm onSubmit={ handleSubmit } /> }
 				recordTracksEvent={ recordTracksEvent }
-				customizedActionButtons={ <NeedHelpLink onSkip={ handleSkip } /> }
+				customizedActionButtons={ <NeedHelpLink onHelpLinkClicked={ handleSkip } /> }
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -145,3 +145,9 @@ $blueberry-color: #3858e9;
 		}
 	}
 }
+
+.site-migration-credentials__need-help-link {
+	.components-button {
+		font-size: 0.875rem;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -59,7 +59,7 @@ const backupFileInput = () => getByLabelText( 'Backup file location' );
 //TODO: it requires a testid because there is no accessible name, it is an issue with the component
 const specialInstructionsInput = () => getByTestId( 'special-instructions-textarea' );
 const specialInstructionsButton = () => getByRole( 'button', { name: 'Special instructions' } );
-const skipButton = () => getByRole( 'button', { name: /I need help, please contact me/ } );
+const skipButton = () => getByRole( 'button', { name: /Let us guide you/ } );
 
 const fillAllFields = async () => {
 	await userEvent.click( credentialsOption() );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Adds the Help link in the top right corner on the Site Analyze step. Clicking on the button should create the ticket for the user.

![Captura de Tela 2025-01-13 às 19 16 14](https://github.com/user-attachments/assets/efc554d9-ab88-4c4d-b42a-c48e59123f0d)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*  I realized that we are missing the Help link on the top right corner, as the design suggested: F8foKv974Gc5dTHSh0i0Wo-fi-648_7452

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link below
* Go through the Migration flow until you reach the "Tell us about your WordPress site" step
* Note the right in the top right corner and click on the link.
* You should be redirected to the Instruction page, and the ZD ticket should be created

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?