### PR TITLE
Reader: Auto-launch onboarding on first visit

### DIFF
--- a/client/reader/onboarding/constants.tsx
+++ b/client/reader/onboarding/constants.tsx
@@ -1,2 +1,3 @@
 export const READER_ONBOARDING_PREFERENCE_KEY = 'has_completed_reader_onboarding';
+export const READER_ONBOARDING_SEEN_PREFERENCE_KEY = 'has_seen_reader_onboarding';
 export const READER_ONBOARDING_TRACKS_EVENT_PREFIX = 'calypso_reader_onboarding_';

--- a/client/reader/onboarding/index.tsx
+++ b/client/reader/onboarding/index.tsx
@@ -62,6 +62,9 @@ const ReaderOnboarding = ( {
 	const closeInterestsModal = () => {
 		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_close` );
 		setIsInterestsModalOpen( false );
+		if ( ! hasSeenOnboarding ) {
+			dispatch( savePreference( READER_ONBOARDING_SEEN_PREFERENCE_KEY, true ) );
+		}
 	};
 
 	const openDiscoverModal = () => {
@@ -98,7 +101,6 @@ const ReaderOnboarding = ( {
 	useEffect( () => {
 		if ( shouldShowOnboarding && ! hasSeenOnboarding ) {
 			openInterestsModal();
-			dispatch( savePreference( READER_ONBOARDING_SEEN_PREFERENCE_KEY, true ) );
 		}
 	}, [ shouldShowOnboarding, hasSeenOnboarding, dispatch ] );
 

--- a/client/reader/onboarding/index.tsx
+++ b/client/reader/onboarding/index.tsx
@@ -5,16 +5,18 @@ import { Checklist, ChecklistItem, Task } from '@automattic/launchpad';
 import { translate } from 'i18n-calypso';
 import React, { useState, useEffect } from 'react';
 import {
+	READER_ONBOARDING_SEEN_PREFERENCE_KEY,
 	READER_ONBOARDING_PREFERENCE_KEY,
 	READER_ONBOARDING_TRACKS_EVENT_PREFIX,
 } from 'calypso/reader/onboarding/constants';
 import InterestsModal from 'calypso/reader/onboarding/interests-modal';
 import SubscribeModal from 'calypso/reader/onboarding/subscribe-modal';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import {
 	getCurrentUserDate,
 	isCurrentUserEmailVerified,
 } from 'calypso/state/current-user/selectors';
+import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
 
@@ -33,9 +35,14 @@ const ReaderOnboarding = ( {
 	const hasCompletedOnboarding = useSelector( ( state ) =>
 		getPreference( state, READER_ONBOARDING_PREFERENCE_KEY )
 	);
+	const hasSeenOnboarding = useSelector( ( state ) =>
+		getPreference( state, READER_ONBOARDING_SEEN_PREFERENCE_KEY )
+	);
 	const preferencesLoaded = useSelector( hasReceivedRemotePreferences );
 	const userRegistrationDate = useSelector( getCurrentUserDate );
 	const isEmailVerified = useSelector( isCurrentUserEmailVerified );
+
+	const dispatch = useDispatch();
 
 	const shouldShowOnboarding =
 		forceShow ||
@@ -45,20 +52,6 @@ const ReaderOnboarding = ( {
 			userRegistrationDate &&
 			isEmailVerified &&
 			new Date( userRegistrationDate ) >= new Date( '2024-10-01T00:00:00Z' ) );
-
-	// Track if user viewed Reader Onboarding.
-	useEffect( () => {
-		if ( shouldShowOnboarding ) {
-			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }viewed` );
-		}
-	}, [ shouldShowOnboarding ] );
-
-	// Notify the parent component if onboarding will render.
-	onRender?.( shouldShowOnboarding );
-
-	if ( ! shouldShowOnboarding ) {
-		return null;
-	}
 
 	// Modal state handlers with tracking.
 	const openInterestsModal = () => {
@@ -93,6 +86,28 @@ const ReaderOnboarding = ( {
 		} );
 		task?.actionDispatch?.();
 	};
+
+	// Track if user viewed Reader Onboarding.
+	useEffect( () => {
+		if ( shouldShowOnboarding ) {
+			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }viewed` );
+		}
+	}, [ shouldShowOnboarding, dispatch ] );
+
+	// Auto-open the interests modal if onboarding should render and it has never been opened before
+	useEffect( () => {
+		if ( shouldShowOnboarding && ! hasSeenOnboarding ) {
+			openInterestsModal();
+			dispatch( savePreference( READER_ONBOARDING_SEEN_PREFERENCE_KEY, true ) );
+		}
+	}, [ shouldShowOnboarding, hasSeenOnboarding, dispatch ] );
+
+	// Notify the parent component if onboarding will render.
+	onRender?.( shouldShowOnboarding );
+
+	if ( ! shouldShowOnboarding ) {
+		return null;
+	}
 
 	const taskOneCompleted = followedTags ? followedTags.length > 2 : false;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/loop#302

## Proposed Changes

* Auto-opens onboarding modal if onboarding should be shown and the user has never opened onboarding before

https://github.com/user-attachments/assets/ab0962f7-3994-447c-8585-dfbed281e0cd

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When visiting the Reader for the first time, it makes sense to be automatically taken through onboarding to subscribe to topics and sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new account that is eligible for onboarding (created after 2024-10-01, email verified)
* Navigate to /read
* Onboarding modal should automatically open
* It should not auto-open after you close the modal, even if you cancel and don't finish onboarding

You can toggle this state via the preferences to test with the same account:
<img width="931" alt="image" src="https://github.com/user-attachments/assets/b65d930b-8af3-4703-bd1c-71a89c6574f7" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
