### PR TITLE
Stepper: ignore ref changes when customizing calypso_signup_start

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
 import { STEPPER_TRACKS_EVENT_SIGNUP_START } from 'calypso/landing/stepper/constants';
 import recordSignupStart from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-signup-start';
 import useSnakeCasedKeys from 'calypso/landing/stepper/utils/use-snake-cased-keys';
@@ -16,8 +15,6 @@ interface Props {
 }
 
 export const useSignUpStartTracking = ( { flow }: Props ) => {
-	const [ queryParams ] = useSearchParams();
-	const ref = queryParams.get( 'ref' ) || '';
 	const flowName = flow.name;
 	const flowVariant = flow.variantSlug;
 	const isSignupFlow = flow.isSignupFlow;
@@ -50,6 +47,9 @@ export const useSignUpStartTracking = ( { flow }: Props ) => {
 			return;
 		}
 
+		// Read the ref here to avoid re-rendering the hook when it changes.
+		const ref = new URLSearchParams( window.location.search ).get( 'ref' ) || '';
+
 		recordSignupStart( {
 			flow: flowName,
 			ref,
@@ -58,5 +58,5 @@ export const useSignUpStartTracking = ( { flow }: Props ) => {
 				...( flowVariant && { flow_variant: flowVariant } ),
 			},
 		} );
-	}, [ isSignupFlow, flowName, ref, signupStartEventProps, isLoading, flowVariant ] );
+	}, [ isSignupFlow, flowName, signupStartEventProps, isLoading, flowVariant ] );
 };

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
@@ -43,11 +43,14 @@ const render = ( { flow, queryParams = {} } ) => {
 				flow,
 			} ),
 		{
-			wrapper: ( { children } ) => (
-				<MemoryRouter initialEntries={ [ addQueryArgs( `/setup/${ flow.name }`, queryParams ) ] }>
-					{ children }
-				</MemoryRouter>
-			),
+			wrapper: ( { children } ) => {
+				// The hook depends on window.location.search to determine the query params.
+				Reflect.deleteProperty( global.window, 'location' );
+				window.location = new URL(
+					'https://example.com/' + addQueryArgs( `/setup/${ flow.name }`, queryParams )
+				) as unknown as Location;
+				return <MemoryRouter initialEntries={ [ '/setup' ] }>{ children }</MemoryRouter>;
+			},
 		}
 	);
 };


### PR DESCRIPTION
### Testing Instructions

1. Go to 22138-explat-experiment
2. Save the treatment bookmarklet.
3. While incognito, go to Calypso My Home `/` (don't go to the flow URL, the experiment assignment will be cached).
4. Open DevTools > Network and filter by calypso_signup_start.
5. Click the bookmarklet.
6. Visit /setup/onboarding?ref=lohp.
8. You should see a single instance of calypso_signup_start.
9. Go on to sign up.
10. After auth, you shouldn't seemore instances of calypso_signup_start.