### PR TITLE
Bulk Plugins Management: Adds list view

### DIFF
--- a/client/my-sites/plugins/plugins-dashboard/style.scss
+++ b/client/my-sites/plugins/plugins-dashboard/style.scss
@@ -342,6 +342,31 @@
 	.margin-top-16 {
 		margin-top: 16px;
 	}
+
+	.dataviews-view-list {
+		.dataviews-view-list__media-wrapper {
+			background-color: transparent;
+			&::after {
+				display: none;
+			}
+		}
+		.dataviews-view-list__field-wrapper {
+			.sites-manage-plugin-button {
+				height: auto;
+				color: var( --color-gray-70 );
+			}
+			.components-button.is-secondary {
+				padding: 0;
+				box-shadow: none;
+				height: auto;
+				background-color: transparent;
+				color: var( --color-gray-70 );
+			}
+			.plugin-action-status-container {
+				margin-left: 0;
+			}
+		}
+	}
 }
 
 body.is-section-plugins .hosting-dashboard-layout,

--- a/client/my-sites/plugins/plugins-dashboard/style.scss
+++ b/client/my-sites/plugins/plugins-dashboard/style.scss
@@ -366,6 +366,10 @@
 				margin-left: 0;
 			}
 		}
+
+		li {
+			cursor: inherit;
+		}
 	}
 }
 
@@ -399,5 +403,6 @@ body.is-section-plugins .hosting-dashboard-layout,
 		padding: 0;
 		text-align: start;
 		height: auto;
+		width: 100%;
 	}
 }

--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -30,7 +30,7 @@ interface Props {
 
 const defaultLayouts = { table: {} };
 
-const pluginsListFields = [ 'plugins', 'sites', 'update' ];
+const pluginsFields = [ 'plugins', 'sites', 'update' ];
 
 const openPluginSitesPane = ( plugin: Plugin ) => {
 	recordTracksEvent( 'calypso_plugins_list_open_plugin_sites_pane', {
@@ -54,7 +54,8 @@ export default function PluginsListDataViews( {
 		( plugin ) => plugin.status?.includes( PLUGINS_STATUS.UPDATE )
 	).length;
 
-	const fields = useFields( bulkActionDialog, openPluginSitesPane );
+	const fields = useFields( bulkActionDialog, openPluginSitesPane, shouldUseListView );
+	const visibleFields = shouldUseListView ? [ 'icon', ...pluginsFields ] : pluginsFields;
 	const actions = useActions( bulkActionDialog );
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( () => {
@@ -62,10 +63,11 @@ export default function PluginsListDataViews( {
 			...initialDataViewsState,
 			perPage: 15,
 			search: initialSearch,
-			fields: pluginsListFields,
+			fields: visibleFields,
 			type: shouldUseListView ? DATAVIEWS_LIST : DATAVIEWS_TABLE,
 			layout: {
 				primaryField: 'plugins',
+				mediaField: 'icon',
 				styles: {
 					plugins: {
 						width: '60%',
@@ -91,6 +93,7 @@ export default function PluginsListDataViews( {
 		// Sets the correct fields when route changes or viewport changes
 		setDataViewsState( {
 			...dataViewsState,
+			fields: visibleFields,
 			type: shouldUseListView ? DATAVIEWS_LIST : DATAVIEWS_TABLE,
 		} );
 
@@ -99,6 +102,7 @@ export default function PluginsListDataViews( {
 			const shouldUseListView = pluginSlug !== undefined || ! matches;
 			setDataViewsState( {
 				...dataViewsState,
+				fields: visibleFields,
 				type: shouldUseListView ? DATAVIEWS_LIST : DATAVIEWS_TABLE,
 			} );
 		} );

--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -1,10 +1,12 @@
 import pagejs from '@automattic/calypso-router';
+import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
 import { Button } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import {
 	DATAVIEWS_LIST,
+	DATAVIEWS_TABLE,
 	initialDataViewsState,
 } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
@@ -29,14 +31,6 @@ interface Props {
 const defaultLayouts = { table: {} };
 
 const pluginsListFields = [ 'plugins', 'sites', 'update' ];
-const pluginViewFields = [ 'plugins' ];
-
-const getFieldsPerView = ( pluginSlug: string | null ) => {
-	// if ( pluginSlug ) {
-	// 	return pluginViewFields;
-	// }
-	return pluginsListFields;
-};
 
 const openPluginSitesPane = ( plugin: Plugin ) => {
 	recordTracksEvent( 'calypso_plugins_list_open_plugin_sites_pane', {
@@ -54,6 +48,8 @@ export default function PluginsListDataViews( {
 	bulkActionDialog,
 }: Props ) {
 	const translate = useTranslate();
+	const isDesktopView = isDesktop();
+	const shouldUseListView = pluginSlug !== undefined || ! isDesktopView;
 	const pluginUpdateCount = currentPlugins.filter(
 		( plugin ) => plugin.status?.includes( PLUGINS_STATUS.UPDATE )
 	).length;
@@ -61,33 +57,55 @@ export default function PluginsListDataViews( {
 	const fields = useFields( bulkActionDialog, openPluginSitesPane );
 	const actions = useActions( bulkActionDialog );
 
-	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( () => ( {
-		...initialDataViewsState,
-		perPage: 15,
-		search: initialSearch,
-		fields: getFieldsPerView( pluginSlug ),
-		type: DATAVIEWS_LIST,
-		layout: {
-			primaryField: 'plugins',
-			styles: {
-				plugins: {
-					width: '60%',
-					minWidth: '300px',
-				},
-				sites: {
-					width: '70px',
-				},
-				update: {
-					minWidth: '200px',
-				},
-				actions: {
-					width: '50px',
+	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( () => {
+		return {
+			...initialDataViewsState,
+			perPage: 15,
+			search: initialSearch,
+			fields: pluginsListFields,
+			type: shouldUseListView ? DATAVIEWS_LIST : DATAVIEWS_TABLE,
+			layout: {
+				primaryField: 'plugins',
+				styles: {
+					plugins: {
+						width: '60%',
+						minWidth: '300px',
+					},
+					sites: {
+						width: '70px',
+					},
+					update: {
+						minWidth: '200px',
+					},
+					actions: {
+						width: '50px',
+					},
 				},
 			},
-		},
-	} ) );
+		};
+	} );
 
 	const [ isFilteringUpdates, setIsFilteringUpdates ] = useState( false );
+
+	useEffect( () => {
+		// Sets the correct fields when route changes or viewport changes
+		setDataViewsState( {
+			...dataViewsState,
+			type: shouldUseListView ? DATAVIEWS_LIST : DATAVIEWS_TABLE,
+		} );
+
+		// Subscribe to viewport changes
+		const unsubscribe = subscribeIsDesktop( ( matches ) => {
+			const shouldUseListView = pluginSlug !== undefined || ! matches;
+			setDataViewsState( {
+				...dataViewsState,
+				type: shouldUseListView ? DATAVIEWS_LIST : DATAVIEWS_TABLE,
+			} );
+		} );
+
+		return () => unsubscribe();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ pluginSlug ] );
 
 	const header = (
 		<>
@@ -128,15 +146,6 @@ export default function PluginsListDataViews( {
 			onSearch && onSearch( dataViewsState.search || '' );
 		}
 	}, [ dataViewsState.search, onSearch, initialSearch ] );
-
-	// useEffect( () => {
-	// 	// Sets the correct fields when route changes
-	// 	setDataViewsState( {
-	// 		...dataViewsState,
-	// 		fields: getFieldsPerView( pluginSlug ),
-	// 	} );
-	// 	// eslint-disable-next-line react-hooks/exhaustive-deps
-	// }, [ pluginSlug ] );
 
 	useEffect( () => {
 		if (

--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -3,7 +3,10 @@ import { Button } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
-import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import {
+	DATAVIEWS_LIST,
+	initialDataViewsState,
+} from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import QueryDotorgPlugins from 'calypso/components/data/query-dotorg-plugins';
 import { DataViews } from 'calypso/components/dataviews';
@@ -29,9 +32,9 @@ const pluginsListFields = [ 'plugins', 'sites', 'update' ];
 const pluginViewFields = [ 'plugins' ];
 
 const getFieldsPerView = ( pluginSlug: string | null ) => {
-	if ( pluginSlug ) {
-		return pluginViewFields;
-	}
+	// if ( pluginSlug ) {
+	// 	return pluginViewFields;
+	// }
 	return pluginsListFields;
 };
 
@@ -63,7 +66,9 @@ export default function PluginsListDataViews( {
 		perPage: 15,
 		search: initialSearch,
 		fields: getFieldsPerView( pluginSlug ),
+		type: DATAVIEWS_LIST,
 		layout: {
+			primaryField: 'plugins',
 			styles: {
 				plugins: {
 					width: '60%',
@@ -124,14 +129,14 @@ export default function PluginsListDataViews( {
 		}
 	}, [ dataViewsState.search, onSearch, initialSearch ] );
 
-	useEffect( () => {
-		// Sets the correct fields when route changes
-		setDataViewsState( {
-			...dataViewsState,
-			fields: getFieldsPerView( pluginSlug ),
-		} );
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ pluginSlug ] );
+	// useEffect( () => {
+	// 	// Sets the correct fields when route changes
+	// 	setDataViewsState( {
+	// 		...dataViewsState,
+	// 		fields: getFieldsPerView( pluginSlug ),
+	// 	} );
+	// 	// eslint-disable-next-line react-hooks/exhaustive-deps
+	// }, [ pluginSlug ] );
 
 	useEffect( () => {
 		if (

--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -55,7 +55,8 @@ export default function PluginsListDataViews( {
 	).length;
 
 	const fields = useFields( bulkActionDialog, openPluginSitesPane, shouldUseListView );
-	const visibleFields = shouldUseListView ? [ 'icon', ...pluginsFields ] : pluginsFields;
+	const visibleFields = ( shouldUseListView: boolean ) =>
+		shouldUseListView ? [ 'icon', ...pluginsFields ] : pluginsFields;
 	const actions = useActions( bulkActionDialog );
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( () => {
@@ -63,7 +64,7 @@ export default function PluginsListDataViews( {
 			...initialDataViewsState,
 			perPage: 15,
 			search: initialSearch,
-			fields: visibleFields,
+			fields: visibleFields( shouldUseListView ),
 			type: shouldUseListView ? DATAVIEWS_LIST : DATAVIEWS_TABLE,
 			layout: {
 				primaryField: 'plugins',
@@ -93,7 +94,7 @@ export default function PluginsListDataViews( {
 		// Sets the correct fields when route changes or viewport changes
 		setDataViewsState( {
 			...dataViewsState,
-			fields: visibleFields,
+			fields: visibleFields( shouldUseListView ),
 			type: shouldUseListView ? DATAVIEWS_LIST : DATAVIEWS_TABLE,
 		} );
 
@@ -102,7 +103,7 @@ export default function PluginsListDataViews( {
 			const shouldUseListView = pluginSlug !== undefined || ! matches;
 			setDataViewsState( {
 				...dataViewsState,
-				fields: visibleFields,
+				fields: visibleFields( shouldUseListView ),
 				type: shouldUseListView ? DATAVIEWS_LIST : DATAVIEWS_TABLE,
 			} );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9854

## Proposed Changes

* Used `list` type for the plugins list dataview when opening the sites list pane or when viewport is smaller than `960px`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The changes aim to make the navigation friendlier, especially in mobile viewports 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
 
* Go to `/plugins/manage/sites`
* See how the plugin list changes to list view and back to table view when you navigate to a specific plugin or when the viewport gets < 960px

|Before | After|
|-------|------|
|![CleanShot 2025-01-13 at 21 11 11](https://github.com/user-attachments/assets/aff84c2d-1ce5-4e59-8cde-ebb2975c953f)|![CleanShot 2025-01-13 at 21 11 25](https://github.com/user-attachments/assets/7d7d23df-b2b2-48ed-92e5-a1dbc51f75d3)|
|![CleanShot 2025-01-13 at 21 26 20](https://github.com/user-attachments/assets/a68e571d-3771-4333-8c2b-2dbcae366b28)|![CleanShot 2025-01-13 at 21 26 31](https://github.com/user-attachments/assets/f7632e52-dea1-4a93-a251-dcb7297537ff)|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
