### PR TITLE
Stats: relocate title and dynamically update it

### DIFF
--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -13,7 +13,6 @@ import { useShouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate
 import { QueryStatsParams } from 'calypso/my-sites/stats/hooks/utils';
 import StatsListCard from 'calypso/my-sites/stats/stats-list/stats-list-card';
 import StatsModulePlaceholder from 'calypso/my-sites/stats/stats-module/placeholder';
-import statsStrings from 'calypso/my-sites/stats/stats-strings';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
@@ -49,7 +48,6 @@ interface StatsModuleLocationsProps {
 }
 
 const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summaryUrl } ) => {
-	const { locations: moduleStrings } = statsStrings();
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const statType = 'statsCountryViews';
@@ -79,6 +77,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 	};
 
 	const geoMode = GEO_MODES[ selectedOption ];
+	const title = optionLabels[ selectedOption ]?.selectLabel;
 
 	const {
 		data = [],
@@ -138,19 +137,14 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 				<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
 			) }
 			{ isRequestingData && (
-				<StatsCardSkeleton
-					isLoading={ isRequestingData }
-					title={ moduleStrings.title }
-					type={ 3 }
-					withHero
-				/>
+				<StatsCardSkeleton isLoading={ isRequestingData } title={ title } type={ 3 } withHero />
 			) }
 			{ ( ( ! isRequestingData && ! isError && data ) || shouldGateStatsModule ) && (
 				// show data or an overlay
 				<>
 					{ /* @ts-expect-error TODO: Refactor StatsListCard with TypeScript. */ }
 					<StatsListCard
-						title={ moduleStrings.title }
+						title={ title }
 						titleNodes={
 							<StatsInfoArea>
 								{ translate( 'Stats on visitors and their {{link}}viewing location{{/link}}.', {

--- a/packages/components/src/horizontal-bar-list/stats-card.scss
+++ b/packages/components/src/horizontal-bar-list/stats-card.scss
@@ -24,6 +24,11 @@
 
 	.stats-card--hero {
 		padding-bottom: $card-vertical-space;
+
+		@media (min-width: $break-medium) {
+			min-height: 512px;
+			min-width: 860px;
+		}
 	}
 
 	.stats-card-header {

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -56,10 +56,7 @@ const StatsCard = ( {
 		<div
 			className={ `${ BASE_CLASS_NAME }-header ${ headerClassName } ${ BASE_CLASS_NAME }-header--split` }
 		>
-			<div className={ `${ BASE_CLASS_NAME }-header--main` }>
-				{ titleNode }
-				{ toggleControl }
-			</div>
+			<div className={ `${ BASE_CLASS_NAME }-header--main` }> { toggleControl } </div>
 			{ ! isEmpty && (
 				<div className={ `${ BASE_CLASS_NAME }--column-header` }>
 					<div className={ `${ BASE_CLASS_NAME }--column-header__left` } key="left">
@@ -87,7 +84,12 @@ const StatsCard = ( {
 			} ) }
 		>
 			<div className={ `${ BASE_CLASS_NAME }__content` }>
-				{ !! heroElement && <div className={ `${ BASE_CLASS_NAME }--hero` }>{ heroElement }</div> }
+				{ !! heroElement && (
+					<div className={ `${ BASE_CLASS_NAME }--hero` }>
+						{ splitHeader && <div className={ `${ BASE_CLASS_NAME }-header` }>{ titleNode }</div> }
+						{ heroElement }
+					</div>
+				) }
 				<div className={ `${ BASE_CLASS_NAME }--header-and-body` }>
 					{ splitHeader ? splitHeaderNode : simpleHeaderNode }
 					<div


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/jetpack-roadmap#2119.

## Proposed Changes

* Move the section title to the left panel and dynamically updated it based on the selected location scope.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* (p1HpG7-rpL-p2)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Access the Calypso Live preview linked below.
- Access the Stats page of a website that has meaningful data, like `/stats/day/jetpack.com?flags=stats/locations`
- Check the map, confirm the title is above it and that it shows the selected `Countries`/`Regions`/`Cities` location scope.

### Column layout

| Before | After |
| - | - |
| <img width="1195" alt="image" src="https://github.com/user-attachments/assets/4217ebb3-6d56-4de8-95d0-2022fd491cab" /> | <img width="1196" alt="image" src="https://github.com/user-attachments/assets/f34102e3-70db-40f5-8491-f39d1e6c22d7" /> |

### Row layout

| Before | After |
| - | - |
| <img width="956" alt="image" src="https://github.com/user-attachments/assets/3741e4d1-3ebf-40ff-855e-ddf44d80a4fb" /> | <img width="954" alt="image" src="https://github.com/user-attachments/assets/efd5c494-e382-443a-9178-975df86bbba7" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
