### PR TITLE
Add downtime monitoring to site settings

### DIFF
--- a/client/hosting/server-settings/main.tsx
+++ b/client/hosting/server-settings/main.tsx
@@ -29,6 +29,7 @@ import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { TrialAcknowledgeModal } from 'calypso/my-sites/plans/trials/trial-acknowledge/acknowlege-modal';
 import { WithOnclickTrialRequest } from 'calypso/my-sites/plans/trials/trial-acknowledge/with-onclick-trial-request';
 import TrialBanner from 'calypso/my-sites/plans/trials/trial-banner';
+import JetpackMonitor from 'calypso/my-sites/site-settings/form-jetpack-monitor';
 import SiteAdminInterface from 'calypso/my-sites/site-settings/site-admin-interface';
 import CacheCard from 'calypso/sites/settings/caching/form';
 import DefensiveModeCard from 'calypso/sites/settings/web-server/defensive-mode-form';
@@ -101,6 +102,7 @@ type AllCardsProps = {
 	isBusinessTrial?: boolean;
 	siteId: number | null;
 	siteSlug: string | null;
+	isJetpack: boolean | null;
 };
 
 const AllCards = ( {
@@ -108,6 +110,7 @@ const AllCards = ( {
 	isBasicHostingDisabled,
 	siteId,
 	siteSlug,
+	isJetpack,
 }: AllCardsProps ) => {
 	const allCards: CardEntry[] = [
 		{
@@ -153,6 +156,14 @@ const AllCards = ( {
 		content: <WebServerSettingsCard disabled={ isAdvancedHostingDisabled } />,
 		type: 'advanced',
 	} );
+
+	if ( isJetpack && siteId ) {
+		allCards.push( {
+			feature: 'jetpack-monitor',
+			content: <JetpackMonitor />,
+			type: 'basic',
+		} );
+	}
 
 	const availableTypes: CardEntry[ 'type' ][] = [];
 
@@ -282,6 +293,7 @@ const ServerSettings = ( { fetchUpdatedData }: ServerSettingsProps ) => {
 							isBusinessTrial={ isBusinessTrial && ! hasTransfer }
 							siteId={ siteId }
 							siteSlug={ siteSlug }
+							isJetpack={ isJetpack }
 						/>
 					</MasonryGrid>
 				</WrapperComponent>

--- a/client/hosting/server-settings/main.tsx
+++ b/client/hosting/server-settings/main.tsx
@@ -29,7 +29,6 @@ import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { TrialAcknowledgeModal } from 'calypso/my-sites/plans/trials/trial-acknowledge/acknowlege-modal';
 import { WithOnclickTrialRequest } from 'calypso/my-sites/plans/trials/trial-acknowledge/with-onclick-trial-request';
 import TrialBanner from 'calypso/my-sites/plans/trials/trial-banner';
-import JetpackMonitor from 'calypso/my-sites/site-settings/form-jetpack-monitor';
 import SiteAdminInterface from 'calypso/my-sites/site-settings/site-admin-interface';
 import CacheCard from 'calypso/sites/settings/caching/form';
 import DefensiveModeCard from 'calypso/sites/settings/web-server/defensive-mode-form';
@@ -102,7 +101,6 @@ type AllCardsProps = {
 	isBusinessTrial?: boolean;
 	siteId: number | null;
 	siteSlug: string | null;
-	isJetpack: boolean | null;
 };
 
 const AllCards = ( {
@@ -110,7 +108,6 @@ const AllCards = ( {
 	isBasicHostingDisabled,
 	siteId,
 	siteSlug,
-	isJetpack,
 }: AllCardsProps ) => {
 	const allCards: CardEntry[] = [
 		{
@@ -156,14 +153,6 @@ const AllCards = ( {
 		content: <WebServerSettingsCard disabled={ isAdvancedHostingDisabled } />,
 		type: 'advanced',
 	} );
-
-	if ( isJetpack && siteId ) {
-		allCards.push( {
-			feature: 'jetpack-monitor',
-			content: <JetpackMonitor />,
-			type: 'basic',
-		} );
-	}
 
 	const availableTypes: CardEntry[ 'type' ][] = [];
 
@@ -293,7 +282,6 @@ const ServerSettings = ( { fetchUpdatedData }: ServerSettingsProps ) => {
 							isBusinessTrial={ isBusinessTrial && ! hasTransfer }
 							siteId={ siteId }
 							siteSlug={ siteSlug }
-							isJetpack={ isJetpack }
 						/>
 					</MasonryGrid>
 				</WrapperComponent>

--- a/client/hosting/server-settings/style.scss
+++ b/client/hosting/server-settings/style.scss
@@ -97,3 +97,16 @@
 		transform: rotate(360deg);
 	}
 }
+
+// Jetpack downtime monitoring hack: Duplicates style from site-settings/style.scss
+.site-settings__child-settings {
+	margin: 16px 48px 0;
+}
+
+// Jetpack downtime monitoring hack: Duplicates style from site-settings/style.scss
+.support-info + .jetpack-module-toggle,
+.support-info + .components-toggle-control,
+.support-info + .custom-content-types__module-settings,
+.support-info + .verbum-comments-toggle {
+	display: flex;
+}

--- a/client/hosting/server-settings/style.scss
+++ b/client/hosting/server-settings/style.scss
@@ -97,16 +97,3 @@
 		transform: rotate(360deg);
 	}
 }
-
-// Jetpack downtime monitoring hack: Duplicates style from site-settings/style.scss
-.site-settings__child-settings {
-	margin: 16px 48px 0;
-}
-
-// Jetpack downtime monitoring hack: Duplicates style from site-settings/style.scss
-.support-info + .jetpack-module-toggle,
-.support-info + .components-toggle-control,
-.support-info + .custom-content-types__module-settings,
-.support-info + .verbum-comments-toggle {
-	display: flex;
-}

--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import GeneralForm from 'calypso/my-sites/site-settings/form-general';
-import JetpackMonitor from 'calypso/my-sites/site-settings/form-jetpack-monitor';
 import SiteTools from 'calypso/sites/settings/administration/tools';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
@@ -17,7 +16,6 @@ const SiteSettingsGeneral = ( { site, isWPForTeamsSite, isP2Hub, isWpcomStagingS
 	<div className="site-settings__main general-settings">
 		{ site && <GeneralForm site={ site } /> }
 		{ isWPForTeamsSite && isP2Hub && <P2PreapprovedDomainsForm siteId={ site?.ID } /> }
-		{ ! isWpcomStagingSite && ! isEnabled( 'untangling/hosting-menu' ) && <JetpackMonitor /> }
 		{ ! isWpcomStagingSite && ! isEnabled( 'untangling/hosting-menu' ) && (
 			<SiteTools headerTitle={ translate( 'Site tools' ) } source={ SOURCE_SETTINGS_GENERAL } />
 		) }

--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import GeneralForm from 'calypso/my-sites/site-settings/form-general';
+import JetpackMonitor from 'calypso/my-sites/site-settings/form-jetpack-monitor';
 import SiteTools from 'calypso/sites/settings/administration/tools';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
@@ -16,6 +17,7 @@ const SiteSettingsGeneral = ( { site, isWPForTeamsSite, isP2Hub, isWpcomStagingS
 	<div className="site-settings__main general-settings">
 		{ site && <GeneralForm site={ site } /> }
 		{ isWPForTeamsSite && isP2Hub && <P2PreapprovedDomainsForm siteId={ site?.ID } /> }
+		{ ! isWpcomStagingSite && ! isEnabled( 'untangling/hosting-menu' ) && <JetpackMonitor /> }
 		{ ! isWpcomStagingSite && ! isEnabled( 'untangling/hosting-menu' ) && (
 			<SiteTools headerTitle={ translate( 'Site tools' ) } source={ SOURCE_SETTINGS_GENERAL } />
 		) }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/98188

Todo:
- [x] Revert the revert
- [x] Remove from Site (general) Settings section
- [x] ~Consider hiding the new placement in server settings (SMP) from those not in the treatment group~ We decided it's not worth it. p1736747647206859/1736742960.758409-slack-CRWCHQGUB

## Proposed Changes

* Moves Jetpack Downtime Monitoring options that refer to dotcom user account email / notifications to Site Settings

## Testing Instructions

* View site settings with an atomic site, see the full Jetpack Downtime Monitoring option toggles present
* View site settings with a Jetpack self hosted site, see the full Jetpack Downtime Monitoring option toggles present

![Screenshot 2025-01-13 at 16-31-02 Site Settings ‹ Site Title — WordPress com](https://github.com/user-attachments/assets/04e92b7e-289b-45ba-aecb-9d8498e672ce)