### PR TITLE
Fix migration flow from white screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
@@ -1,4 +1,5 @@
 import { OnboardSelect } from '@automattic/data-stores';
+import { HOSTED_SITE_MIGRATION_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from 'react';
 import { generatePath, createPath, useMatch, useNavigate } from 'react-router';
@@ -110,8 +111,14 @@ export const useFlowNavigation = ( flow: Flow ): FlowNavigation => {
 				...extraData,
 			} );
 
+			// For HOSTED_SITE_MIGRATION_FLOW, we must use the flow.variantSlug instead of flow.name
+			// to prevent navigation errors.
+			const exceptionFlowsToUseVariantSlug = [ HOSTED_SITE_MIGRATION_FLOW ];
+
 			const newPath = generatePath( `/:flow/:step/:lang?`, {
-				flow: flow.name,
+				flow: exceptionFlowsToUseVariantSlug.includes( flow.variantSlug ?? '' )
+					? flow.variantSlug ?? ''
+					: flow.name,
 				lang,
 				step: nextStep,
 			} );

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
@@ -1,5 +1,4 @@
 import { OnboardSelect } from '@automattic/data-stores';
-import { HOSTED_SITE_MIGRATION_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from 'react';
 import { generatePath, createPath, useMatch, useNavigate } from 'react-router';
@@ -47,6 +46,7 @@ export const useFlowNavigation = ( flow: Flow ): FlowNavigation => {
 	const match = useMatch( '/:flow/:step?/:lang?' );
 	const { step: currentStepSlug = null, lang = null } = match?.params || {};
 	const [ currentSearchParams ] = useSearchParams();
+	const flowName = flow.variantSlug ?? flow.name;
 	const steps = flow.useSteps();
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const stepsSlugs = steps.map( ( step ) => step.slug );
@@ -63,7 +63,7 @@ export const useFlowNavigation = ( flow: Flow ): FlowNavigation => {
 				// In-stepper auth.
 				if ( flow.__experimentalUseBuiltinAuth ) {
 					const signInPath = generatePath( `/:flow/:step/:lang?`, {
-						flow: flow.name,
+						flow: flowName,
 						lang,
 						step: PRIVATE_STEPS.USER.slug,
 					} );
@@ -80,7 +80,7 @@ export const useFlowNavigation = ( flow: Flow ): FlowNavigation => {
 				const nextStepPath = createPath( {
 					// We have to include /setup, as this URL should be absolute and we can't use `useHref`.
 					pathname: generatePath( `/setup/:flow/:step/:lang?`, {
-						flow: flow.name,
+						flow: flowName,
 						lang,
 						step: nextStep,
 					} ),
@@ -111,14 +111,8 @@ export const useFlowNavigation = ( flow: Flow ): FlowNavigation => {
 				...extraData,
 			} );
 
-			// For HOSTED_SITE_MIGRATION_FLOW, we must use the flow.variantSlug instead of flow.name
-			// to prevent navigation errors.
-			const exceptionFlowsToUseVariantSlug = [ HOSTED_SITE_MIGRATION_FLOW ];
-
 			const newPath = generatePath( `/:flow/:step/:lang?`, {
-				flow: exceptionFlowsToUseVariantSlug.includes( flow.variantSlug ?? '' )
-					? flow.variantSlug ?? ''
-					: flow.name,
+				flow: flowName,
 				lang,
 				step: nextStep,
 			} );
@@ -144,7 +138,7 @@ export const useFlowNavigation = ( flow: Flow ): FlowNavigation => {
 	return {
 		navigate: customNavigate,
 		params: {
-			flow: flow.name,
+			flow: flowName,
 			step: currentStepSlug,
 		},
 		search: currentSearchParams,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/98243

## Proposed Changes

* Use `flow.variantSlug` instead of `flow.name` for `hosted-site-migration` flow

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* p1736747265983289-slack-C02FMH4G8

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open https://wordpress.com/sites
2. Open the 'Add new site' dropdown menu, and select 'Import an existing site'

Path 1:
Enter a valid site url for a live website and submit the form, then observe the 'Scanning your site' message and loading animation

1. Go to migrate flow for WP sites
![WP@2x](https://github.com/user-attachments/assets/50bffe89-efc8-4c02-a10a-ead5f0e8c4d9)

2. Go to platform selection for sites from other platform
![platform selection@2x](https://github.com/user-attachments/assets/7d23e0c5-af88-4f36-a64b-8ffaa8af42de)


Path 2:
Click 'pick your current platform from a list'

1. Go to platform selection

![platform selection@2x](https://github.com/user-attachments/assets/7d23e0c5-af88-4f36-a64b-8ffaa8af42de)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?