### PR TITLE
Stats: Minor style updates to chart tooltips

### DIFF
--- a/client/my-sites/stats/modernized-tooltip-styles.scss
+++ b/client/my-sites/stats/modernized-tooltip-styles.scss
@@ -74,7 +74,6 @@
 			font-size: $font-body-extra-small;
 			margin-bottom: 0;
 			padding-left: 30px;
-			text-decoration: underline;
 
 			.label {
 				height: auto;

--- a/client/my-sites/stats/modernized-tooltip-styles.scss
+++ b/client/my-sites/stats/modernized-tooltip-styles.scss
@@ -35,6 +35,12 @@
 		font-size: $font-body-small;
 		padding: 16px 24px;
 
+		// Default tooltip is 230px wide. We need a bit more room
+		// to account for longer date labels and post titles.
+		width: fit-content;
+		min-width: 230px;
+		max-width: 300px;
+
 		ul {
 			li {
 				font-size: $font-body-small;

--- a/client/my-sites/stats/modernized-tooltip-styles.scss
+++ b/client/my-sites/stats/modernized-tooltip-styles.scss
@@ -82,6 +82,10 @@
 				letter-spacing: inherit;
 				word-break: break-word;
 			}
+			// Override the default gradient.
+			.value::before {
+				background: none;
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: https://github.com/Automattic/red-team/issues/295

## Proposed Changes

* Removes the text decoration from the post titles as they aren't clickable
* Removes the gradient from post titles
* Updates width constraints to account for longer titles

### Before

<img width="728" alt="SCR-20250113-nfeu" src="https://github.com/user-attachments/assets/1f5d1aca-37b2-4813-b07d-150883e48c3e" />

### After

<img width="723" alt="SCR-20250113-pfor" src="https://github.com/user-attachments/assets/652d150c-e3bb-4ad7-a043-c6f68714eab9" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes visual glitch and improves readability.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Spin up the Calypso Live site.
2. Visit the Traffic page for a site with recent posts.
3. Scrub the chart until you see a tooltip with post titles.
4. Confirm the underline & gradient are gone.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
