### PR TITLE
Dev helpers: Use React 18 createRoot API

### DIFF
--- a/client/lib/account-settings-helper/index.jsx
+++ b/client/lib/account-settings-helper/index.jsx
@@ -1,5 +1,5 @@
 import languages from '@automattic/languages';
-import ReactDom from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { useInView } from 'react-intersection-observer';
 import { Provider, useDispatch, useSelector } from 'react-redux';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
@@ -61,9 +61,8 @@ export function AccountSettingsHelper() {
 	);
 }
 export default ( element, store ) =>
-	ReactDom.render(
+	createRoot( element ).render(
 		<Provider store={ store }>
 			<AccountSettingsHelper />
-		</Provider>,
-		element
+		</Provider>
 	);

--- a/client/lib/auth-helper/index.jsx
+++ b/client/lib/auth-helper/index.jsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import ReactDom from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import './style.scss';
 
@@ -40,4 +40,4 @@ function AuthHelper() {
 	);
 }
 
-export default ( element ) => ReactDom.render( <AuthHelper />, element );
+export default ( element ) => createRoot( element ).render( <AuthHelper /> );

--- a/client/lib/features-helper/index.js
+++ b/client/lib/features-helper/index.js
@@ -1,4 +1,4 @@
-import ReactDom from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import FeatureList from './feature-list';
 
 import './style.scss';
@@ -7,5 +7,5 @@ import './style.scss';
  * @param element HTML Element
  */
 export default function injectFeatureHelper( element ) {
-	ReactDom.render( <FeatureList />, element );
+	createRoot( element ).render( <FeatureList /> );
 }

--- a/client/lib/preferences-helper/index.js
+++ b/client/lib/preferences-helper/index.js
@@ -1,14 +1,13 @@
-import ReactDom from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 import PreferenceList from './preference-list';
 
 import './style.scss';
 
 export default function injectPreferenceHelper( element, store ) {
-	ReactDom.render(
+	createRoot( element ).render(
 		<Provider store={ store }>
 			<PreferenceList />
-		</Provider>,
-		element
+		</Provider>
 	);
 }

--- a/client/lib/react-query-devtools-helper/index.jsx
+++ b/client/lib/react-query-devtools-helper/index.jsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useEffect, useState } from 'react';
-import ReactDom from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { setStoredItem, getStoredItem } from 'calypso/lib/browser-storage';
 
 import './style.scss';
@@ -59,4 +59,4 @@ function ReactQueryDevtoolsHelper() {
 	);
 }
 
-export default ( element ) => ReactDom.render( <ReactQueryDevtoolsHelper />, element );
+export default ( element ) => createRoot( element ).render( <ReactQueryDevtoolsHelper /> );

--- a/client/lib/store-sandbox-helper/index.tsx
+++ b/client/lib/store-sandbox-helper/index.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ToggleControl } from '@wordpress/components';
 import { useState, useEffect } from 'react';
-import ReactDom from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import useStoreSandboxStatusQuery from 'calypso/data/store-sandbox/use-store-sandbox-status';
 import wp from 'calypso/lib/wp';
 
@@ -74,9 +74,8 @@ export function StoreSandboxHelper() {
 	);
 }
 export default ( element: HTMLElement ) =>
-	ReactDom.render(
+	createRoot( element ).render(
 		<QueryClientProvider client={ new QueryClient() }>
 			<StoreSandboxHelper />
-		</QueryClientProvider>,
-		element
+		</QueryClientProvider>
 	);


### PR DESCRIPTION
## Proposed Changes

Use React 18's `createRoot` API for all of the dev helpers.

I'm intentionally targeting only the helpers, since the other instances of `ReactDom.render()` need to be addressed and tested separately.

## Why are these changes being made?

Currently, the dev helpers use the legacy React 17 rendering. 
In order to prepare for React 19, we need to fully upgrade to React 18 features.
This PR is a step in that direction.

## Testing Instructions
Verify all the dev helpers still work well:

![Screenshot 2025-01-13 at 11 25 16](https://github.com/user-attachments/assets/da5b752d-df67-4eb4-91e4-363b4c767dcb)

Most of those warnings should also disappear from the console:
![Screenshot 2025-01-13 at 11 25 28](https://github.com/user-attachments/assets/b5756062-3440-4140-be1c-59fcb2fe0235)
