### PR TITLE
A4A > Referrals: Update Referral link lifespan disclaimer to 7 days

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -249,7 +249,7 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 
 			<div className="checkout__summary-notice-item">
 				{ translate(
-					'{{b}}Important:{{/b}} Your referral order link is only valid for {{u}}12 hours{{/u}}. Please notify your client to complete the payment within this timeframe to avoid expiration.',
+					'{{b}}Important:{{/b}} Your referral order link is only valid for {{u}}7 days{{/u}}. Please notify your client to complete the payment within this timeframe to avoid expiration.',
 					{
 						components: {
 							b: <b />,


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1658

## Proposed Changes

This PR updates the disclaimer for the referral cart lifespan from 12 hours to 7 days. 


## Why are these changes being made?

We got some direct feedback from a partner agency: `this referral would be so much more useful if it can stay for 2 weeks. or at least 1 week..`


## Testing Instructions

* Open the A4A live link
* Go to Marketplace > Toggle the refer mode > Add a few products > Go to Checkout and verify that the referral lifespan disclaimer is updated to 7 days as shown below
* It is being updated it: 169917-ghe-Automattic/wpcom

<img width="1728" alt="Screenshot 2025-01-13 at 2 54 47 PM" src="https://github.com/user-attachments/assets/1ab87f77-149e-4fc2-b522-85bba618fcaa" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?