### PR TITLE
Stats: Update threshold for feedback prompts

### DIFF
--- a/client/my-sites/stats/feedback/index.tsx
+++ b/client/my-sites/stats/feedback/index.tsx
@@ -262,7 +262,7 @@ function StatsFeedbackController( { siteId }: FeedbackProps ) {
 	);
 }
 
-const FEEDBACK_HIGH_TRAFFIC_SITE_THRESHOLD = 10000;
+const FEEDBACK_HIGH_TRAFFIC_SITE_THRESHOLD = 1000;
 
 function getHighTrafficThreshold() {
 	const value = Number( localStorage.getItem( 'StatsHighTrafficThreshold' ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

- Initial project thread: pejTkB-1Lb-p2
- Updated discussions: pbNhbs-bVb-p2#comment-24747

**Note:** Do not merge until we have approval in the linked P2. Until then, this PR will remain a DRAFT.

## Proposed Changes

Drop the high-traffic threshold from 10k to 1k visits. All sites with more than 1k visits in the past 30 days will now see the feedback prompts.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of our effort to solicit feedback and positive reviews.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the Calypso Live link.
* Visit the Traffic page for any self-hosted site. You can test via Calypso by manually updating the URL path to this format: `/stats/day/SITE_SLUG` — Otherwise Calypso will redirect you to `/wp-admin`.
* If the site has more than 1k views in the past 30 days, you should see the inline feedback card at the bottom of the page. 
* If you have not previously dismissed the popup prompt, it should display after a short delay.
* Sites with 1k+ views will always show the inline prompt at the bottom of the page.
* Sites with less than that threshold will only show the inline prompt at the bottom of the page if they have a commercial plan. ie: Sites with a plan can always access the feedback UI, regardless of traffic.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?