### PR TITLE
Signup: Fix undefined step component in `/start`

### DIFF
--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -86,6 +86,8 @@ export function getStepModuleMap() {
 export async function getStepComponent( stepName ) {
 	const moduleName = stepNameToModuleName[ stepName ];
 	if ( ! moduleName ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Error: unknown `stepName` to retrieve the component for.' );
 		return;
 	}
 	const module = await import(

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -85,6 +85,9 @@ export function getStepModuleMap() {
 }
 export async function getStepComponent( stepName ) {
 	const moduleName = stepNameToModuleName[ stepName ];
+	if ( ! moduleName ) {
+		return;
+	}
 	const module = await import(
 		/* webpackChunkName: "async-load-signup-steps-[request]" */
 		/* webpackInclude: /signup\/steps\/[0-9a-z/-]+\/index\.[j|t]sx$/ */

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -259,7 +259,8 @@ export default {
 
 			window.location.replace( url );
 			// skip the rest to avoid the `page.redirect` call below.
-			next();
+			// Don't call next() here, we don't need the subsequent middlewares to run.
+			// next();
 			return;
 		}
 


### PR DESCRIPTION
## Proposed Changes

This PR updates `getStepComponent()` to import the component module only if it exists.

Currently, when someone tries to access `/start` as a logged-out user, an uncaught error is thrown.

## Why are these changes being made?

This PR fixes one of the [top Calypso errors](https://sentry.io/organizations/a8c/issues/6171151397/?project=6313676) in Sentry (68K errors for the past 14 days): 

Could potentially be a reason for tracks / analytics not working properly.

## Testing Instructions

* Open `/start` as a logged out user.
* Verify you no longer see the error:

![Screenshot 2025-01-13 at 13 25 25](https://github.com/user-attachments/assets/14981231-403b-43b1-a2b0-38a58da2e44b)

* Verify that as you proceed through the signup flows, the next step continues to be preloaded correctly.