### PR TITLE
A4A: Fix has Pressable existing plan logic

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type.ts
@@ -7,17 +7,11 @@ export default function usePressableOwnershipType() {
 
 	const pressableOwnership = useMemo( () => {
 		// Agencies can have pressable through A4A Licenses or via Pressable itself
-		const hasPressablePlan = !! activeAgency?.third_party?.pressable?.pressable_id;
+		const hasPressablePlan =
+			!! activeAgency?.third_party?.pressable?.pressable_id &&
+			activeAgency?.third_party?.pressable?.a4a_id;
 
-		if ( ! hasPressablePlan ) {
-			return 'none';
-		}
-
-		// If the agency has a regular Pressable plan (not brought through A4A marketplace), A4A id is null.
-		const hasRegularPressablePlan =
-			hasPressablePlan && activeAgency?.third_party?.pressable?.a4a_id === null;
-
-		return hasRegularPressablePlan ? 'regular' : 'agency';
+		return hasPressablePlan ? 'agency' : 'none';
 	}, [ activeAgency ] );
 
 	return pressableOwnership;


### PR DESCRIPTION
This PR resolves the logic for identifying the current Pressable plan. At present, users cannot upgrade through the UI if the current agency has existing Pressable account. 

<img width="537" alt="Screenshot 2025-01-13 at 9 22 54 PM" src="https://github.com/user-attachments/assets/81a9ebac-f0cd-44df-9d72-4e66bacbbac0" />



## Proposed Changes

* Update the `usePressableOwnershipType` hook logic so it checks for existing pressable plan with an existing account.

## Why are these changes being made?

* If an agency already has a Pressable account, you cannot buy a plan through A4A.

## Testing Instructions

* Create a Pressable account and using the same email create an agency user.
* Go to the `/marketplace/hosting/pressable` page.
* Confirm you can purchase a plan.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
