### PR TITLE
Domains Management Revamp: Show the Edit Contact Information subpage in site context

### DIFF
--- a/client/hosting/overview/index.tsx
+++ b/client/hosting/overview/index.tsx
@@ -15,6 +15,7 @@ import {
 	DOMAIN_OVERVIEW,
 	EMAIL_MANAGEMENT,
 } from 'calypso/my-sites/domains/domain-management/domain-overview-pane/constants';
+import { EDIT_CONTACT_INFO } from 'calypso/my-sites/domains/domain-management/subpage-wrapper/subpages';
 import emailController from 'calypso/my-sites/email/controller';
 import {
 	DOTCOM_HOSTING_CONFIG,
@@ -115,6 +116,15 @@ export default function () {
 		controllers: [
 			emailController.emailManagement,
 			domainManagementController.domainManagementPaneView( EMAIL_MANAGEMENT ),
+		],
+	} );
+
+	registerSiteDomainPage( {
+		path: '/overview/site-domain/contact-info/edit/:domain/:site',
+		controllers: [
+			domainManagementController.domainManagementSubpageParams( EDIT_CONTACT_INFO ),
+			domainManagementController.domainManagementEditContactInfo,
+			domainManagementController.domainManagementSubpageView,
 		],
 	} );
 }

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -424,6 +424,7 @@ export default {
 				subpageKey={ pageContext.params.subPageKey }
 				siteName={ pageContext.params.site }
 				domainName={ pageContext.params.domain }
+				inSiteContext={ pageContext.inSiteContext }
 			>
 				{ pageContext.primary }
 			</SubpageWrapper>

--- a/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
@@ -5,11 +5,10 @@ import { useMergeRefs } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useRef } from 'react';
-import SiteFavicon from 'calypso/blocks/site-favicon';
 import NavigationHeader from 'calypso/components/navigation-header';
 import ItemView from 'calypso/layout/hosting-dashboard/item-view';
 import * as paths from 'calypso/my-sites/domains/paths';
-import { getMigrationStatus } from 'calypso/sites-dashboard/utils';
+import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';
 import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
 import {
 	FEATURE_TO_ROUTE_MAP,
@@ -145,9 +144,6 @@ const DomainOverviewPane = ( {
 		} );
 	}, [ selectedFeature, selectedDomainPreview, inSiteContext, selectedDomain, siteSlug ] );
 
-	const isMigrationPending = getMigrationStatus( site ) === 'pending';
-	const faviconFallback = isMigrationPending ? 'migration' : 'first-grapheme';
-
 	return (
 		<>
 			{ inSiteContext && (
@@ -157,7 +153,7 @@ const DomainOverviewPane = ( {
 							{
 								label: site.name || selectedDomain,
 								href: `/overview/${ siteSlug }`,
-								icon: <SiteFavicon blogId={ site.ID } size={ 24 } fallback={ faviconFallback } />,
+								icon: <SiteIcon site={ site } viewType="breadcrumb" disableClick />,
 							},
 							{
 								label: selectedDomain,

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/edit-contact-info-page-content.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/edit-contact-info-page-content.tsx
@@ -44,7 +44,7 @@ const EditContactInfoPageContent = ( {
 	}
 
 	const backUrl = isUnderDomainManagementAll( currentRoute )
-		? domainManagementAllOverview( selectedSite?.slug ?? '', selectedDomainName )
+		? domainManagementAllOverview( selectedSite?.slug ?? '', selectedDomainName, currentRoute )
 		: domainManagementEdit( selectedSite?.slug ?? '', selectedDomainName, currentRoute );
 
 	return (

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import TwoColumnsLayout from 'calypso/components/domains/layout/two-columns-layout';
 import ExternalLink from 'calypso/components/external-link';
@@ -12,11 +12,7 @@ import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import DomainHeader from 'calypso/my-sites/domains/domain-management/components/domain-header';
-import {
-	domainManagementEdit,
-	domainManagementList,
-	isUnderDomainManagementAll,
-} from 'calypso/my-sites/domains/paths';
+import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import isRequestingWhois from 'calypso/state/selectors/is-requesting-whois';
 import { IAppState } from 'calypso/state/types';
@@ -31,6 +27,7 @@ const EditContactInfoPage = ( {
 	isRequestingWhois,
 	selectedDomainName,
 	selectedSite,
+	context = { showPageHeader: true },
 }: EditContactInfoPageProps ) => {
 	const translate = useTranslate();
 
@@ -47,13 +44,8 @@ const EditContactInfoPage = ( {
 		return ! getSelectedDomain( { domains, selectedDomainName } ) || isRequestingWhois;
 	};
 
-	const isAllDomainManagementScreen = useMemo(
-		() => isUnderDomainManagementAll( currentRoute ),
-		[ currentRoute ]
-	);
-
 	const renderHeader = () => {
-		if ( ! selectedSite || isAllDomainManagementScreen ) {
+		if ( ! selectedSite ) {
 			return null;
 		}
 
@@ -65,7 +57,7 @@ const EditContactInfoPage = ( {
 
 		const items = [
 			{
-				label: isAllDomainManagementScreen ? translate( 'All Domains' ) : translate( 'Domains' ),
+				label: translate( 'Domains' ),
 				href: domainManagementList(
 					selectedSite?.slug,
 					currentRoute,
@@ -101,7 +93,7 @@ const EditContactInfoPage = ( {
 			/>
 		);
 
-		return isAllDomainManagementScreen ? <Card>{ pageContent }</Card> : pageContent;
+		return <Card>{ pageContent }</Card>;
 	};
 
 	const renderSidebar = () => {
@@ -162,7 +154,7 @@ const EditContactInfoPage = ( {
 	return (
 		<Main className="edit-contact-info-page" wideLayout>
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
-			{ renderHeader() }
+			{ context?.showPageHeader && renderHeader() }
 			<TwoColumnsLayout content={ renderContent() } sidebar={ renderSidebar() } />
 		</Main>
 	);

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/types.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/types.tsx
@@ -6,6 +6,9 @@ export type EditContactInfoPageProps = {
 	isRequestingWhois: boolean;
 	selectedDomainName: string;
 	selectedSite: SiteDetails | null;
+	context?: {
+		showPageHeader?: boolean;
+	};
 };
 
 export type EditContactInfoPageContentProps = {

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -142,7 +142,8 @@
 
 // The `/domains/manage` page
 // Generic domains table styles should go in `packages/domains-table/src/domains-table/style.scss`
-.is-bulk-all-domains-page .layout__content {
+.is-bulk-all-domains-page .layout__content,
+.is-domain-in-site-context .layout__content {
 	overflow: auto;
 	.main {
 		.navigation-header {

--- a/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
@@ -187,7 +187,11 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ) => {
 	const { selectedDomainName, canManageConsent, currentRoute, readOnly, isHundredYearDomain } =
 		props;
 	const editContactInfoLink = isUnderDomainManagementOverview( currentRoute )
-		? domainManagementAllEditContactInfo( props.selectedSite.slug, props.selectedDomainName )
+		? domainManagementAllEditContactInfo(
+				props.selectedSite.slug,
+				props.selectedDomainName,
+				currentRoute
+		  )
 		: domainManagementEditContactInfo(
 				props.selectedSite.slug,
 				props.selectedDomainName,

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/contact-information-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/contact-information-header.tsx
@@ -1,0 +1,64 @@
+import { SiteExcerptData } from '@automattic/sites';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import NavigationHeader from 'calypso/components/navigation-header';
+import { domainManagementAllOverview } from 'calypso/my-sites/domains/paths';
+import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';
+import { useSelector } from 'calypso/state';
+import { getSite } from 'calypso/state/sites/selectors';
+import { CustomHeaderComponentType } from './custom-header-component-type';
+
+const ContactInformationHeader: CustomHeaderComponentType = ( {
+	selectedDomainName,
+	selectedSiteSlug,
+	inSiteContext,
+} ) => {
+	const translate = useTranslate();
+	const site = useSelector( ( state ) => getSite( state, selectedSiteSlug ) as SiteExcerptData );
+
+	const navigationItems = useMemo( () => {
+		const baseNavigationItems = [
+			{
+				label: selectedDomainName,
+				href: domainManagementAllOverview(
+					selectedSiteSlug,
+					selectedDomainName,
+					null,
+					inSiteContext
+				),
+			},
+			{
+				label: translate( 'Contact information' ),
+			},
+		];
+
+		if ( inSiteContext ) {
+			return [
+				{
+					label: site?.name || selectedDomainName,
+					href: `/overview/${ selectedSiteSlug }`,
+					icon: <SiteIcon site={ site } viewType="breadcrumb" disableClick />,
+				},
+				...baseNavigationItems,
+			];
+		}
+
+		return baseNavigationItems;
+	}, [ inSiteContext, selectedDomainName, selectedSiteSlug, site, translate ] );
+
+	return (
+		<>
+			<NavigationHeader
+				className="navigation-header__breadcrumb"
+				navigationItems={ navigationItems }
+			/>
+			<NavigationHeader
+				className="navigation-header__title"
+				title={ translate( 'Contact information' ) }
+				subtitle={ translate( "Manage your domain's contact details." ) }
+			/>
+		</>
+	);
+};
+
+export default ContactInformationHeader;

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/custom-header-component-type.ts
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/custom-header-component-type.ts
@@ -2,4 +2,5 @@ export type CustomHeaderComponentType = React.ComponentType< {
 	selectedDomainName: string;
 	selectedSiteSlug: string;
 	context?: string;
+	inSiteContext?: boolean;
 } >;

--- a/client/my-sites/domains/domain-management/subpage-wrapper/index.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/index.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import NavigationHeader from 'calypso/components/navigation-header';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { domainManagementAllOverview } from 'calypso/my-sites/domains/paths';
 import { getSubpageParams } from './subpages';
 import './style.scss';
@@ -9,18 +10,27 @@ type SubpageWrapperProps = {
 	subpageKey: string;
 	siteName: string;
 	domainName: string;
+	inSiteContext?: boolean;
 };
 
-const SubpageWrapper = ( { children, subpageKey, siteName, domainName }: SubpageWrapperProps ) => {
+const SubpageWrapper = ( {
+	children,
+	subpageKey,
+	siteName,
+	domainName,
+	inSiteContext,
+}: SubpageWrapperProps ) => {
 	const { CustomHeader, title, subtitle, context } = getSubpageParams( subpageKey ) || {};
 
 	if ( CustomHeader ) {
 		return (
 			<div className={ clsx( 'subpage-wrapper', `subpage-wrapper--${ subpageKey }` ) }>
+				<BodySectionCssClass bodyClass={ [ 'is-domain-in-site-context' ] } />
 				<CustomHeader
 					selectedDomainName={ domainName }
 					selectedSiteSlug={ siteName }
 					context={ context }
+					inSiteContext={ inSiteContext }
 				/>
 				<div className="subpage-wrapper__content">{ children }</div>
 			</div>
@@ -40,6 +50,7 @@ const SubpageWrapper = ( { children, subpageKey, siteName, domainName }: Subpage
 
 		return (
 			<div className={ clsx( 'subpage-wrapper', `subpage-wrapper--${ subpageKey }` ) }>
+				<BodySectionCssClass bodyClass={ [ 'is-domain-in-site-context' ] } />
 				<NavigationHeader
 					className="subpage-wrapper__header"
 					navigationItems={ breadcrumbItems }

--- a/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
@@ -38,6 +38,14 @@
 		}
 	}
 
+    .email-forwards-add,
+    .edit-contact-info-page {
+		.button {
+			padding: 10px 24px;
+			border-radius: 4px;
+		}
+    }
+
 	.email-forwards-add {
 		.card {
 			border-radius: 4px;
@@ -50,11 +58,6 @@
 			margin-top: 0;
 			margin-bottom: 16px;
 		}
-
-		.button {
-			padding: 10px 24px;
-			border-radius: 4px;
-		}
 	}
 
 	.edit-contact-info-page {
@@ -66,6 +69,10 @@
 		.contact-details-form-fields {
 			padding: 0;
 		}
+
+        .contact-details-form-fields__submit-button {
+            margin-right: 16px;
+        }
 	}
 
     .dns-records {
@@ -194,7 +201,8 @@
 	}
 }
 
-.is-bulk-all-domains-page .layout__content .main {
+.is-bulk-all-domains-page .layout__content .main,
+.is-domain-in-site-context .layout__content .main {
     .navigation-header {
         &__breadcrumb,
         &__title {
@@ -202,6 +210,8 @@
         }
 
         &__breadcrumb {
+            padding-top: 24px;
+
             @media ( max-width: $break-medium ) {
                 padding-top: 16px;
             }

--- a/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
@@ -214,6 +214,15 @@
 
             @media ( max-width: $break-medium ) {
                 padding-top: 16px;
+
+                .breadcrumbs li {
+                    > a,
+                    > span {
+                        word-break: break-word;
+                        overflow-wrap: break-word;
+                        white-space: normal;
+                    }
+                }
             }
         }
 

--- a/client/my-sites/domains/domain-management/subpage-wrapper/subpages.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/subpages.tsx
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import AddForwardingEmailHeader from './headers/add-fowarding-email-header';
 import MailboxHeader from './headers/add-mailbox-header';
 import CompareEmailProvidersHeader from './headers/compare-email-providers';
+import ContactInformationHeader from './headers/contact-information-header';
 import { CustomHeaderComponentType } from './headers/custom-header-component-type';
 import DnsRecordHeader, {
 	addDnsRecordTitle,
@@ -48,8 +49,8 @@ const SUBPAGE_TO_PARAMS_MAP: Record< string, SubpageWrapperParamsType > = {
 		showDetails: false,
 	},
 	[ EDIT_CONTACT_INFO ]: {
-		title: __( 'Contact information' ),
-		subtitle: __( "Manage your domain's contact details." ),
+		CustomHeader: ContactInformationHeader,
+		showPageHeader: false,
 	},
 	[ ADD_DNS_RECORD ]: {
 		CustomHeader: DnsRecordHeader,

--- a/client/my-sites/domains/domain-management/subpage-wrapper/test/index.test.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/test/index.test.tsx
@@ -4,12 +4,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import SubpageWrapper from '../index';
-import {
-	ADD_FORWARDING_EMAIL,
-	EDIT_CONTACT_INFO,
-	ADD_DNS_RECORD,
-	EDIT_DNS_RECORD,
-} from '../subpages';
+import { ADD_FORWARDING_EMAIL, ADD_DNS_RECORD, EDIT_DNS_RECORD } from '../subpages';
 
 jest.mock( 'component-file-picker', () => () => <div>File Picker</div> );
 
@@ -55,21 +50,6 @@ describe( 'SubpageWrapper', () => {
 		);
 
 		expect( screen.getByText( 'Hello' ) ).toBeInTheDocument();
-	} );
-
-	it( 'should render breadcrumbs', () => {
-		const { container } = render(
-			<SubpageWrapper subpageKey={ EDIT_CONTACT_INFO } siteName="site.com" domainName="domain.com">
-				<span>Hello</span>
-			</SubpageWrapper>
-		);
-
-		expect( container.querySelector( '.breadcrumbs li:first-child' )?.textContent ).toContain(
-			'domain.com'
-		);
-		expect( container.querySelector( '.breadcrumbs li:last-child' )?.textContent ).toContain(
-			'Contact information'
-		);
 	} );
 
 	it( 'should render Add DNS subpage breadcrumbs', () => {

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -57,14 +57,21 @@ function domainManagementTransferBase(
 }
 
 export function isUnderDomainManagementAll( path ) {
-	return path?.startsWith( domainManagementAllRoot() + '/' ) || path === domainManagementRoot();
+	return (
+		path?.startsWith( domainManagementAllRoot() + '/' ) ||
+		path?.startsWith( domainSiteContextRoot() + '/' )
+	);
 }
 
 export function isUnderDomainManagementOverview( path ) {
 	return (
 		path?.startsWith( domainManagementOverviewRoot() + '/' ) ||
-		path?.startsWith( '/overview/site-domain/' )
+		path?.startsWith( domainSiteContextRoot() + '/domain/' )
 	);
+}
+
+export function isUnderDomainSiteContext( path ) {
+	return path?.startsWith( domainSiteContextRoot() + '/' );
 }
 
 export function domainAddNew( siteName, searchTerm ) {
@@ -91,6 +98,10 @@ export function domainManagementAllRoot() {
 
 export function domainManagementOverviewRoot() {
 	return domainManagementAllRoot() + '/overview';
+}
+
+export function domainSiteContextRoot() {
+	return '/overview/site-domain';
 }
 
 export function domainManagementAllEmailRoot() {
@@ -144,17 +155,33 @@ export function domainManagementEditContactInfo( siteName, domainName, relativeT
 /**
  * @param {string} siteName
  * @param {string} domainName
+ * @param {string?} relativeTo
  */
-export function domainManagementAllOverview( siteName, domainName ) {
-	return domainManagementOverviewRoot() + '/' + domainName + '/' + siteName;
+export function domainManagementAllOverview(
+	siteName,
+	domainName,
+	relativeTo = null,
+	inSiteContext = false
+) {
+	if ( inSiteContext || isUnderDomainSiteContext( relativeTo ) ) {
+		return `${ domainSiteContextRoot() }/domain/${ domainName }/${ siteName }`;
+	}
+
+	return `${ domainManagementOverviewRoot() }/${ domainName }/${ siteName }`;
 }
 
 /**
  * @param {string} siteName
  * @param {string} domainName
+ * @param {string?} relativeTo
  */
-export function domainManagementAllEditContactInfo( siteName, domainName ) {
-	return domainManagementAllRoot() + '/contact-info/edit/' + domainName + '/' + siteName;
+export function domainManagementAllEditContactInfo( siteName, domainName, relativeTo = null ) {
+	const pathSegment = `contact-info/edit/${ domainName }/${ siteName }`;
+	const rootPath = isUnderDomainSiteContext( relativeTo )
+		? domainSiteContextRoot()
+		: domainManagementAllRoot();
+
+	return `${ rootPath }/${ pathSegment }`;
 }
 
 export function domainManagementAllEditSelectedContactInfo() {

--- a/client/sites/components/sites-dataviews/site-icon.tsx
+++ b/client/sites/components/sites-dataviews/site-icon.tsx
@@ -18,13 +18,15 @@ export default function SiteIcon( {
 	site,
 	openSitePreviewPane,
 	viewType,
+	disableClick,
 }: {
 	site: SiteExcerptData;
-	openSitePreviewPane: (
+	openSitePreviewPane?: (
 		site: SiteExcerptData,
 		source: 'site_field' | 'action' | 'list_row_click' | 'environment_switcher'
 	) => void;
-	viewType: 'list' | 'table' | 'grid';
+	viewType: 'list' | 'table' | 'grid' | 'breadcrumb';
+	disableClick?: boolean;
 } ) {
 	const { adminUrl } = useSiteAdminInterfaceData( site.ID );
 	const isP2Site = site.options?.theme_slug && isP2Theme( site.options?.theme_slug );
@@ -52,13 +54,28 @@ export default function SiteIcon( {
 	const isMigrationPending = getMigrationStatus( site ) === 'pending';
 	const siteTitle = isMigrationPending ? translate( 'Incoming Migration' ) : site.title;
 
+	const size = React.useMemo( () => {
+		switch ( viewType ) {
+			case 'list':
+				return 52;
+			case 'breadcrumb':
+				return 24;
+			default:
+				return 32;
+		}
+	}, [ viewType ] );
+
 	return (
-		<ThumbnailLink title={ siteTitle } onClick={ onClick } className="sites-dataviews__site-icon">
+		<ThumbnailLink
+			title={ siteTitle }
+			onClick={ disableClick ? undefined : onClick }
+			className="sites-dataviews__site-icon"
+		>
 			<SiteFavicon
 				className="sites-site-favicon"
 				blogId={ site.ID }
 				fallback={ isMigrationPending ? 'migration' : 'first-grapheme' }
-				size={ viewType === 'list' ? 52 : 32 }
+				size={ size }
 			/>
 		</ThumbnailLink>
 	);


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/97966

## Proposed Changes

* Update `SiteIcon` component to support breadcrumb styles.
* Apply the `SiteIcon` component to the breadcrumb for domain subpages within the site context.
* Create a route for the Edit Contact Information subpage in the site context and update paths.
* Update styles to match the page in the domain context.
* Additional style fixes to match design on Figma.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of the Domain Management Revamp project: pfuQfP-13x-p2.

## Testing Instructions

* Apply this PR to your local.
* Go to http://calypso.localhost:3000/sites?flags=calypso/all-domain-management.
* Click on a site with a domain previously configured.
* Scroll down to the domains table and click on the domain.
* You should see the domain overview page within the site context.
* Expand the Contact information card and click Edit.
* You should see the Edit Contact Information subpage within the site context.
* Edit some information and click Save contact info.
* You should be redirected to the domain overview page within the site context.
* Go back to the Edit Contact Information and click cancel.
* You should also be redirected to the domain overview page within the site context.
* Go back to the Edit Contact Information and navigate using the breadcrumb.
* It should behave correctly, keeping the navigation within the site context.
* Perform regression tests on the Edit Contact Information in the domain context.
* Perform regression tests on the Edit Contact Information in the previous layout.
* Make sure the `SiteIcon` changes didn't affect anywhere else where it's used, mostly icons in the sites list.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?