### PR TITLE
Use Actions API in a4a sites

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -554,7 +554,7 @@ export const JetpackSitesDataViews = ( {
 		[ translate ]
 	);*/
 
-	const actions = useSiteActionsDataViews();
+	const actions = useSiteActionsDataViews( { isLargeScreen } );
 
 	// Update the data packet
 	useEffect( () => {

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -502,59 +502,6 @@ export const JetpackSitesDataViews = ( {
 		};
 	}, [ dataViewsState ] );
 
-	// Actions: Pause Monitor, Resume Monitor, Custom Notification, Reset Notification
-	// todo: Currently not in use until bulk selections are properly implemented.
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	/*const actions = useMemo(
-		() => [
-			{
-				id: 'pause-monitor',
-				label: translate( 'Pause Monitor' ),
-				supportsBulk: true,
-				isEligible( site: SiteData ) {
-					return site.monitor.status === 'active';
-				},
-				callback() {
-					// todo: pause monitor. Param: sites: SiteData[]
-				},
-			},
-			{
-				id: 'resume-monitor',
-				label: translate( 'Resume Monitor' ),
-				supportsBulk: true,
-				isEligible( site: SiteData ) {
-					return site.monitor.status === 'inactive';
-				},
-				callback() {
-					// todo: resume monitor. Param: sites: SiteData[]
-				},
-			},
-			{
-				id: 'custom-notification',
-				label: translate( 'Custom Notification' ),
-				supportsBulk: true,
-				isEligible( site: SiteData ) {
-					return site.monitor.status === 'active';
-				},
-				callback() {
-					// todo: custom notification. Param: sites: SiteData[]
-				},
-			},
-			{
-				id: 'reset-notification',
-				label: translate( 'Reset Notification' ),
-				supportsBulk: true,
-				isEligible( site: SiteData ) {
-					return site.monitor.status === 'active';
-				},
-				callback() {
-					// todo: reset notification. Param: sites: SiteData[]
-				},
-			},
-		],
-		[ translate ]
-	);*/
-
 	const actions = useSiteActionsDataViews( {
 		isLargeScreen,
 		onRefetchSite,

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -554,7 +554,7 @@ export const JetpackSitesDataViews = ( {
 		[ translate ]
 	);*/
 
-	const actions = useSiteActionsDataViews( { isLargeScreen } );
+	const actions = useSiteActionsDataViews( { isLargeScreen, onRefetchSite } );
 
 	// Update the data packet
 	useEffect( () => {

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -20,6 +20,7 @@ import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-
 import { useFetchTestConnections } from '../../hooks/use-fetch-test-connection';
 import useFormattedSites from '../../hooks/use-formatted-sites';
 import SiteActions from '../../site-actions';
+import { useSiteActionsDataViews } from '../../site-actions/use-site-actions';
 import useGetSiteErrors from '../../sites-dataviews/hooks/use-get-site-errors';
 import { AllowedTypes, Site, SiteData } from '../../types';
 import type { Field } from '@wordpress/dataviews';
@@ -553,13 +554,15 @@ export const JetpackSitesDataViews = ( {
 		[ translate ]
 	);*/
 
+	const actions = useSiteActionsDataViews();
+
 	// Update the data packet
 	useEffect( () => {
 		setItemsData( ( prevState: ItemsDataViewsType< SiteData > ) => ( {
 			...prevState,
 			items: sites,
 			fields: fields,
-			//actions: actions,
+			actions,
 			pagination: {
 				totalItems: totalSites,
 				totalPages: totalPages,

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -23,7 +23,7 @@ import SiteActions from '../../site-actions';
 import { useSiteActionsDataViews } from '../../site-actions/use-site-actions';
 import useGetSiteErrors from '../../sites-dataviews/hooks/use-get-site-errors';
 import { AllowedTypes, Site, SiteData } from '../../types';
-import type { Field } from '@wordpress/dataviews';
+import type { Action, Field } from '@wordpress/dataviews';
 import type { MouseEvent, KeyboardEvent } from 'react';
 
 export const JetpackSitesDataViews = ( {
@@ -31,6 +31,7 @@ export const JetpackSitesDataViews = ( {
 	isLoading,
 	isLargeScreen,
 	setDataViewsState,
+	setSelectedSiteFeature,
 	dataViewsState,
 	forceTourExampleSite = false,
 	className,
@@ -554,7 +555,12 @@ export const JetpackSitesDataViews = ( {
 		[ translate ]
 	);*/
 
-	const actions = useSiteActionsDataViews( { isLargeScreen, onRefetchSite } );
+	const actions = useSiteActionsDataViews( {
+		isLargeScreen,
+		onRefetchSite,
+		setDataViewsState,
+		setSelectedSiteFeature,
+	} );
 
 	// Update the data packet
 	useEffect( () => {
@@ -562,7 +568,7 @@ export const JetpackSitesDataViews = ( {
 			...prevState,
 			items: sites,
 			fields: fields,
-			actions,
+			actions: actions as Action< SiteData >[],
 			pagination: {
 				totalItems: totalSites,
 				totalPages: totalPages,
@@ -571,7 +577,7 @@ export const JetpackSitesDataViews = ( {
 			dataViewsState: dataViewsState,
 			selectedItem: dataViewsState.selectedItem,
 		} ) );
-	}, [ fields, dataViewsState, setDataViewsState, data ] ); // add actions when implemented
+	}, [ fields, dataViewsState, setDataViewsState, data, actions ] );
 
 	return <ItemsDataViews data={ itemsData } isLoading={ isLoading } className={ className } />;
 };

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -503,6 +503,7 @@ export const JetpackSitesDataViews = ( {
 	}, [ dataViewsState ] );
 
 	const actions = useSiteActionsDataViews( {
+		isLoading,
 		isLargeScreen,
 		onRefetchSite,
 		setDataViewsState,

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -19,12 +19,10 @@ import { JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE } from 'calypso/jetpack-cl
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { useFetchTestConnections } from '../../hooks/use-fetch-test-connection';
 import useFormattedSites from '../../hooks/use-formatted-sites';
-import SiteActions from '../../site-actions';
 import { useSiteActionsDataViews } from '../../site-actions/use-site-actions';
 import useGetSiteErrors from '../../sites-dataviews/hooks/use-get-site-errors';
 import { AllowedTypes, Site, SiteData } from '../../types';
 import type { Action, Field } from '@wordpress/dataviews';
-import type { MouseEvent, KeyboardEvent } from 'react';
 
 export const JetpackSitesDataViews = ( {
 	data,
@@ -120,7 +118,6 @@ export const JetpackSitesDataViews = ( {
 	const [ monitorRef, setMonitorRef ] = useState< HTMLElement | null >();
 	const [ scanRef, setScanRef ] = useState< HTMLElement | null >();
 	const [ pluginsRef, setPluginsRef ] = useState< HTMLElement | null >();
-	const [ actionsRef ] = useState< HTMLElement | null >();
 
 	const fields = useMemo< Field< SiteData >[] >(
 		() => [
@@ -359,56 +356,6 @@ export const JetpackSitesDataViews = ( {
 				enableHiding: false,
 				enableSorting: false,
 			},
-			{
-				id: 'actions',
-				getValue: ( { item }: { item: SiteData } ) => item.isFavorite,
-				render: ( { item }: { item: SiteData } ) => {
-					if ( isLoading ) {
-						return <TextPlaceholder />;
-					}
-
-					const isDevSite = item.isDevSite ?? false;
-
-					return (
-						<>
-							{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */ }
-							<div
-								className="sites-dataviews__actions"
-								onClick={ ( e: MouseEvent ) => e.stopPropagation() }
-								onKeyDown={ ( e: KeyboardEvent ) => e.stopPropagation() }
-							>
-								{ ( ! item.site.value.sticker?.includes( 'migration-in-progress' ) ||
-									isNotProduction ) && (
-									<>
-										{ ! item.site.error && ! item.site.value.is_simple && (
-											<SiteActions
-												isLargeScreen={ isLargeScreen }
-												isDevSite={ isDevSite }
-												site={ item.site }
-												siteError={ item.site.error }
-												onRefetchSite={ onRefetchSite }
-											/>
-										) }
-									</>
-								) }
-							</div>
-						</>
-					);
-				},
-				// @ts-expect-error -- Need to fix the label type upstream in @wordpress/dataviews to support React elements.
-				label: (
-					<>
-						<span>ACTIONS</span>
-						<GuidedTourStep
-							id="sites-walkthrough-site-preview"
-							tourId="sitesWalkthrough"
-							context={ actionsRef }
-						/>
-					</>
-				),
-				enableHiding: false,
-				enableSorting: false,
-			},
 		],
 		[
 			translate,
@@ -419,15 +366,11 @@ export const JetpackSitesDataViews = ( {
 			monitorRef,
 			scanRef,
 			pluginsRef,
-			actionsRef,
 			isLoading,
 			dataViewsState.selectedItem?.blog_id,
 			openSitePreviewPane,
 			getSiteErrors,
 			renderField,
-			isNotProduction,
-			isLargeScreen,
-			onRefetchSite,
 		]
 	);
 

--- a/client/a8c-for-agencies/sections/sites/site-actions/delete-site-action-modal.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-actions/delete-site-action-modal.tsx
@@ -1,0 +1,134 @@
+import { FormLabel } from '@automattic/components';
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import useDeleteDevSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-delete-dev-site';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import { useDispatch } from 'calypso/state';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import type { SiteData } from '../../../../jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+
+const createDeleteSiteActionModal =
+	( {
+		onRefetchSite,
+		recordTracksEventDeleteSite,
+	}: {
+		onRefetchSite?: () => Promise< unknown >;
+		recordTracksEventDeleteSite: () => void;
+	} ) =>
+	( {
+		items,
+		closeModal,
+		onActionPerformed,
+	}: {
+		items: SiteData[];
+		closeModal: () => void;
+		onActionPerformed?: () => void;
+	} ) => {
+		recordTracksEventDeleteSite();
+
+		const translate = useTranslate();
+		const dispatch = useDispatch();
+		const [ isDisabled, setIsDisabled ] = useState( true ); // Disabled by default - user needs to type the site name to enable the button
+
+		const item = items[ 0 ];
+		const siteName = item.site.value.url;
+		const siteId = item.site.value.a4a_site_id || 0;
+
+		const { mutate: deleteDevSite } = useDeleteDevSiteMutation( siteId, {
+			onSuccess: () => {
+				// Add 1 second delay to refetch sites to give time for site profile to be reindexed properly.
+				setTimeout( () => {
+					onRefetchSite?.()?.then( () => {
+						closeModal?.();
+						onActionPerformed?.();
+						dispatch( successNotice( translate( 'The site has been successfully deleted.' ) ) );
+					} );
+				}, 1000 );
+			},
+			onError: () => {
+				closeModal?.();
+				onActionPerformed?.();
+				dispatch( errorNotice( translate( 'An error occurred while deleting the site.' ) ) );
+			},
+		} );
+
+		const onSubmit = ( event: React.FormEvent ) => {
+			event.preventDefault();
+			deleteDevSite();
+		};
+
+		const handleDeleteConfirmationInputChange = (
+			event: React.ChangeEvent< HTMLInputElement >
+		) => {
+			const value = event.target.value;
+			setIsDisabled( value !== siteName );
+		};
+
+		return (
+			<form onSubmit={ onSubmit }>
+				<p>
+					{ translate( 'Are you sure you want to delete the site {{b}}%(siteName)s{{/b}}?', {
+						args: { siteName },
+						components: {
+							b: <b />,
+						},
+						comment: '%(siteName)s is the site domain',
+					} ) }
+				</p>
+				<p>
+					{ translate(
+						'Deletion is {{strong}}irreversible and will permanently remove all site content{{/strong}} — posts, pages, media, users, authors, domains, purchased upgrades, and premium themes.',
+						{
+							components: {
+								strong: <strong />,
+							},
+						}
+					) }
+				</p>
+				<FormFieldset>
+					<FormLabel htmlFor="site-delete-confirmation-input">
+						{ translate(
+							'Type {{strong}}%(siteName)s{{/strong}} below to confirm you want to delete the site:',
+							{
+								components: {
+									strong: <strong />,
+								},
+								args: { siteName },
+								comment: '%(siteName)s is the site domain',
+							}
+						) }
+					</FormLabel>
+					<FormTextInput
+						name="site-delete-confirmation-input"
+						autoCapitalize="off"
+						aria-required="true"
+						onChange={ handleDeleteConfirmationInputChange }
+					/>
+				</FormFieldset>
+				<HStack justify="right">
+					<Button
+						__next40pxDefaultSize
+						variant="tertiary"
+						onClick={ () => {
+							closeModal?.();
+						} }
+					>
+						{ translate( 'Cancel' ) }
+					</Button>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						type="submit"
+						isDestructive
+						disabled={ isDisabled }
+					>
+						{ translate( 'Delete site' ) }
+					</Button>
+				</HStack>
+			</form>
+		);
+	};
+
+export default createDeleteSiteActionModal;

--- a/client/a8c-for-agencies/sections/sites/site-actions/remove-site-action-modal.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-actions/remove-site-action-modal.tsx
@@ -6,7 +6,7 @@ import { successNotice } from 'calypso/state/notices/actions';
 import type { SiteData } from '../../../../jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 
 const createRemoveSiteActionModal =
-	( onRefetchSite: () => Promise< unknown > ) =>
+	( onRefetchSite?: () => Promise< unknown > ) =>
 	( {
 		items,
 		closeModal,

--- a/client/a8c-for-agencies/sections/sites/site-actions/remove-site-action-modal.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-actions/remove-site-action-modal.tsx
@@ -1,0 +1,84 @@
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import useRemoveSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-remove-site';
+import { useDispatch } from 'calypso/state';
+import { successNotice } from 'calypso/state/notices/actions';
+import type { SiteData } from '../../../../jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+
+const createRemoveSiteActionModal =
+	( onRefetchSite: () => Promise< unknown > ) =>
+	( {
+		items,
+		closeModal,
+		onActionPerformed,
+	}: {
+		items: SiteData[];
+		closeModal: () => void;
+		onActionPerformed?: () => void;
+	} ) => {
+		const translate = useTranslate();
+		const dispatch = useDispatch();
+		const { mutate: removeSite } = useRemoveSiteMutation();
+
+		const item = items[ 0 ];
+		const siteName = item.site.value.url;
+		const siteId = item.site.value.a4a_site_id;
+
+		const onRemoveSite = () => {
+			if ( ! siteId ) {
+				return;
+			}
+
+			removeSite(
+				{ siteId },
+				{
+					onSuccess: () => {
+						// Add 1 second delay to refetch sites to give time for site profile to be reindexed properly.
+						setTimeout( () => {
+							onRefetchSite?.()?.then( () => {
+								closeModal?.();
+								onActionPerformed?.();
+								dispatch( successNotice( translate( 'The site has been successfully removed.' ) ) );
+							} );
+						}, 1000 );
+					},
+				}
+			);
+		};
+
+		const onSubmit = ( event: React.FormEvent ) => {
+			event.preventDefault();
+			onRemoveSite();
+		};
+
+		return (
+			<form onSubmit={ onSubmit }>
+				{ translate(
+					'Are you sure you want to remove the site {{b}}%(siteName)s{{/b}} from the dashboard?',
+					{
+						args: { siteName },
+						components: {
+							b: <b />,
+						},
+						comment: '%(siteName)s is the site name',
+					}
+				) }
+				<HStack justify="right">
+					<Button
+						__next40pxDefaultSize
+						variant="tertiary"
+						onClick={ () => {
+							closeModal?.();
+						} }
+					>
+						{ translate( 'Cancel' ) }
+					</Button>
+					<Button __next40pxDefaultSize variant="primary" type="submit" isDestructive>
+						{ translate( 'Remove site' ) }
+					</Button>
+				</HStack>
+			</form>
+		);
+	};
+
+export default createRemoveSiteActionModal;

--- a/client/a8c-for-agencies/sections/sites/site-actions/remove-site-action-modal.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-actions/remove-site-action-modal.tsx
@@ -6,7 +6,13 @@ import { successNotice } from 'calypso/state/notices/actions';
 import type { SiteData } from '../../../../jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 
 const createRemoveSiteActionModal =
-	( onRefetchSite?: () => Promise< unknown > ) =>
+	( {
+		onRefetchSite,
+		recordTracksEventRemoveSite,
+	}: {
+		onRefetchSite?: () => Promise< unknown >;
+		recordTracksEventRemoveSite: () => void;
+	} ) =>
 	( {
 		items,
 		closeModal,
@@ -19,6 +25,8 @@ const createRemoveSiteActionModal =
 		const translate = useTranslate();
 		const dispatch = useDispatch();
 		const { mutate: removeSite } = useRemoveSiteMutation();
+
+		recordTracksEventRemoveSite();
 
 		const item = items[ 0 ];
 		const siteName = item.site.value.url;

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -208,6 +208,7 @@ export default function useSiteActions( {
 }
 
 type SiteActions = {
+	isLoading: boolean;
 	isLargeScreen: boolean;
 	onRefetchSite?: () => Promise< unknown >;
 	setDataViewsState: ( callback: ( prevState: DataViewsState ) => DataViewsState ) => void;
@@ -215,6 +216,7 @@ type SiteActions = {
 };
 
 export function useSiteActionsDataViews( {
+	isLoading,
 	isLargeScreen,
 	onRefetchSite,
 	setDataViewsState,
@@ -246,6 +248,7 @@ export function useSiteActionsDataViews( {
 		// TODO: review isEligible logic for all actions and make sure there are no duplicate ones.
 		const isNotProduction = config( 'env_id' ) !== 'a8c-for-agencies-production';
 		const canHaveActions = ( item: SiteData ) =>
+			! isLoading &&
 			( ! item.site.value.sticker?.includes( 'migration-in-process' ) || isNotProduction ) &&
 			! item.site.error &&
 			! item.site.value.is_simple;

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -16,6 +16,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import isA4AClientSite from 'calypso/state/sites/selectors/is-a4a-client-site';
 import { JETPACK_ACTIVITY_ID, JETPACK_BACKUP_ID } from '../features/features';
 import SitesDashboardContext from '../sites-dashboard-context';
+import createDeleteSiteActionModal from './delete-site-action-modal';
 import getActionEventName from './get-action-event-name';
 import createRemoveSiteActionModal from './remove-site-action-modal';
 import type { SiteData } from '../../../../jetpack-cloud/sections/agency-dashboard/sites-overview/types';
@@ -263,6 +264,8 @@ export function useSiteActionsDataViews( {
 
 		const recordTracksEventRemoveSite = () =>
 			dispatch( recordTracksEvent( getActionEventName( 'remove_site', isLargeScreen ) ) );
+		const recordTracksEventDeleteSite = () =>
+			dispatch( recordTracksEvent( getActionEventName( 'delete_site', isLargeScreen ) ) );
 
 		return [
 			{
@@ -449,10 +452,9 @@ export function useSiteActionsDataViews( {
 				isEligible( item: SiteData ) {
 					return canHaveActions( item ) && false; // Feature is always disabled, see canDelete above.
 				},
-				callback() {
-					dispatch( recordTracksEvent( getActionEventName( 'delete_site', isLargeScreen ) ) );
-					// TODO: implement modal. See setShowDeleteDevSiteDialog in SiteActions.
-				},
+				RenderModal: createDeleteSiteActionModal( {
+					recordTracksEventDeleteSite,
+				} ),
 			},
 		];
 	}, [

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -208,7 +208,7 @@ export default function useSiteActions( {
 
 type SiteActions = {
 	isLargeScreen: boolean;
-	onRefetchSite: () => Promise< unknown >;
+	onRefetchSite?: () => Promise< unknown >;
 	setDataViewsState: ( callback: ( prevState: DataViewsState ) => DataViewsState ) => void;
 	setSelectedSiteFeature: ( siteFeature: string | undefined ) => void;
 };

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -309,12 +309,7 @@ export function useSiteActionsDataViews( {
 				id: 'issue_license',
 				label: translate( 'Issue new license' ),
 				isEligible( item: SiteData ) {
-					return (
-						canHaveActions( item ) &&
-						! item.site.error &&
-						! isWPComSite( item ) &&
-						! isUrlOnly( item )
-					);
+					return canHaveActions( item ) && ! isWPComSite( item ) && ! isUrlOnly( item );
 				},
 				callback: () => {
 					page( A4A_MARKETPLACE_LINK );
@@ -325,12 +320,7 @@ export function useSiteActionsDataViews( {
 				id: 'view_activity_not_wpcom',
 				label: translate( 'View activity' ),
 				isEligible( item: SiteData ) {
-					return (
-						canHaveActions( item ) &&
-						! isWPComSite( item ) &&
-						! item.site.error &&
-						! isUrlOnly( item )
-					);
+					return canHaveActions( item ) && ! isWPComSite( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
 					const item = items[ 0 ];
@@ -348,12 +338,7 @@ export function useSiteActionsDataViews( {
 				label: translate( 'View activity' ),
 				icon: external,
 				isEligible( item: SiteData ) {
-					return (
-						canHaveActions( item ) &&
-						isWPComSite( item ) &&
-						! item.site.error &&
-						! isUrlOnly( item )
-					);
+					return canHaveActions( item ) && isWPComSite( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
 					page( `https://wordpress.com/activity-log/${ getBlogId( items[ 0 ] ) }` );

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -15,6 +15,7 @@ import isA4AClientSite from 'calypso/state/sites/selectors/is-a4a-client-site';
 import { JETPACK_ACTIVITY_ID, JETPACK_BACKUP_ID } from '../features/features';
 import SitesDashboardContext from '../sites-dashboard-context';
 import getActionEventName from './get-action-event-name';
+import type { SiteData } from '../../../../jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 import type { SiteNode, AllowedActionTypes } from '../types';
 
 type Props = {
@@ -203,7 +204,32 @@ export default function useSiteActions( {
 	] );
 }
 
-const EMPTY_ARRAY: any[] = [];
-export function useSiteActionsDataViews() {
-	return EMPTY_ARRAY;
+type SiteActions = {
+	isLargeScreen: boolean;
+};
+
+export function useSiteActionsDataViews( { isLargeScreen }: SiteActions ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const isUrlOnly = ( item: SiteData ) =>
+		item.site?.value?.sticker?.includes( 'jetpack-manage-url-only-site' );
+	const isWPComSite = ( item: SiteData ) => item.site.value.is_atomic || item.site.value.is_simple;
+
+	return useMemo(
+		() => [
+			{
+				id: 'issue-new-license',
+				label: translate( 'Issue new license' ),
+				isEligible( item: SiteData ) {
+					return ! item.site.error && ! isWPComSite( item ) && ! isUrlOnly( item );
+				},
+				callback: () => {
+					page( A4A_MARKETPLACE_LINK );
+					dispatch( recordTracksEvent( getActionEventName( 'issue_license', isLargeScreen ) ) );
+				},
+			},
+		],
+		[ isLargeScreen, translate, dispatch ]
+	);
 }

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -219,7 +219,18 @@ export function useSiteActionsDataViews( { isLargeScreen }: SiteActions ) {
 	return useMemo(
 		() => [
 			{
-				id: 'issue-new-license',
+				id: 'delete_site',
+				label: translate( 'Delete site' ),
+				isEligible() {
+					return false; // Feature is always disabled, see canDelete above.
+				},
+				callback() {
+					dispatch( recordTracksEvent( getActionEventName( 'delete_site', isLargeScreen ) ) );
+					// TODO: implement modal. See setShowDeleteDevSiteDialog in SiteActions.
+				},
+			},
+			{
+				id: 'issue_license',
 				label: translate( 'Issue new license' ),
 				isEligible( item: SiteData ) {
 					return ! item.site.error && ! isWPComSite( item ) && ! isUrlOnly( item );

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { external, trash } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -241,12 +242,20 @@ export function useSiteActionsDataViews( {
 				: item.site.value.url_with_scheme;
 		};
 
+		// This implements logic that was previously in the Actions field.
+		// TODO: review isEligible logic for all actions and make sure there are no duplicate ones.
+		const isNotProduction = config( 'env_id' ) !== 'a8c-for-agencies-production';
+		const canHaveActions = ( item: SiteData ) =>
+			( ! item.site.value.sticker?.includes( 'migration-in-process' ) || isNotProduction ) &&
+			! item.site.error &&
+			! item.site.value.is_simple;
+
 		return [
 			{
 				label: translate( 'Prepare for launch' ),
 				icon: external,
 				isEligible( item: SiteData ) {
-					return isDevSite( item );
+					return canHaveActions( item ) && isDevSite( item );
 				},
 				callback( items: SiteData[] ) {
 					page( `https://wordpress.com/settings/general/${ getBlogId( items[ 0 ] ) }` );
@@ -260,7 +269,7 @@ export function useSiteActionsDataViews( {
 				label: translate( 'Set up site' ),
 				icon: external,
 				isEligible( item: SiteData ) {
-					return isWPComSite( item ) && ! isUrlOnly( item );
+					return canHaveActions( item ) && isWPComSite( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
 					page( `https://wordpress.com/overview/${ getBlogId( items[ 0 ] ) }` );
@@ -272,7 +281,7 @@ export function useSiteActionsDataViews( {
 				label: translate( 'Change domain' ),
 				icon: external,
 				isEligible( item: SiteData ) {
-					return isWPComSite( item ) && ! isUrlOnly( item );
+					return canHaveActions( item ) && isWPComSite( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
 					page( `https://wordpress.com/domains/manage/${ getBlogId( items[ 0 ] ) }` );
@@ -284,7 +293,7 @@ export function useSiteActionsDataViews( {
 				label: translate( 'Hosting configuration' ),
 				icon: external,
 				isEligible( item: SiteData ) {
-					return isWPComSite( item ) && ! isUrlOnly( item );
+					return canHaveActions( item ) && isWPComSite( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
 					page( `https://wordpress.com/hosting-config/${ getBlogId( items[ 0 ] ) }` );
@@ -297,7 +306,12 @@ export function useSiteActionsDataViews( {
 				id: 'issue_license',
 				label: translate( 'Issue new license' ),
 				isEligible( item: SiteData ) {
-					return ! item.site.error && ! isWPComSite( item ) && ! isUrlOnly( item );
+					return (
+						canHaveActions( item ) &&
+						! item.site.error &&
+						! isWPComSite( item ) &&
+						! isUrlOnly( item )
+					);
 				},
 				callback: () => {
 					page( A4A_MARKETPLACE_LINK );
@@ -308,7 +322,12 @@ export function useSiteActionsDataViews( {
 				id: 'view_activity_not_wpcom',
 				label: translate( 'View activity' ),
 				isEligible( item: SiteData ) {
-					return ! isWPComSite( item ) && ! item.site.error && ! isUrlOnly( item );
+					return (
+						canHaveActions( item ) &&
+						! isWPComSite( item ) &&
+						! item.site.error &&
+						! isUrlOnly( item )
+					);
 				},
 				callback( items: SiteData[] ) {
 					const item = items[ 0 ];
@@ -326,7 +345,12 @@ export function useSiteActionsDataViews( {
 				label: translate( 'View activity' ),
 				icon: external,
 				isEligible( item: SiteData ) {
-					return isWPComSite( item ) && ! item.site.error && ! isUrlOnly( item );
+					return (
+						canHaveActions( item ) &&
+						isWPComSite( item ) &&
+						! item.site.error &&
+						! isUrlOnly( item )
+					);
 				},
 				callback( items: SiteData[] ) {
 					page( `https://wordpress.com/activity-log/${ getBlogId( items[ 0 ] ) }` );
@@ -338,7 +362,12 @@ export function useSiteActionsDataViews( {
 				label: translate( 'Copy this site' ),
 				icon: external,
 				isEligible( item: SiteData ) {
-					return isWPComSite( item ) && hasBackup( item ) && ! isUrlOnly( item );
+					return (
+						canHaveActions( item ) &&
+						isWPComSite( item ) &&
+						hasBackup( item ) &&
+						! isUrlOnly( item )
+					);
 				},
 				callback( items: SiteData[] ) {
 					page( `https://wordpress.com/backup/${ getSiteSlug( items[ 0 ] ) }/clone` );
@@ -349,7 +378,12 @@ export function useSiteActionsDataViews( {
 				id: 'clone_site_not_wpcom',
 				label: translate( 'Copy this site' ),
 				isEligible( item: SiteData ) {
-					return ! isWPComSite( item ) && hasBackup( item ) && ! isUrlOnly( item );
+					return (
+						canHaveActions( item ) &&
+						! isWPComSite( item ) &&
+						hasBackup( item ) &&
+						! isUrlOnly( item )
+					);
 				},
 				callback( items: SiteData[] ) {
 					setDataViewsState( ( prevState: DataViewsState ) => ( {
@@ -366,7 +400,7 @@ export function useSiteActionsDataViews( {
 				label: translate( 'Site settings' ),
 				icon: external,
 				isEligible( item: SiteData ) {
-					return isWPComSite( item ) && ! isUrlOnly( item );
+					return canHaveActions( item ) && isWPComSite( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
 					page( `https://wordpress.com/settings/general/${ getBlogId( items[ 0 ] ) }` );
@@ -377,8 +411,8 @@ export function useSiteActionsDataViews( {
 				id: 'view_site',
 				label: translate( 'View site' ),
 				icon: external,
-				isEligible() {
-					return true;
+				isEligible( item: SiteData ) {
+					return canHaveActions( item ) && true;
 				},
 				callback( items: SiteData[] ) {
 					page( getUrlWithScheme( items[ 0 ] ) );
@@ -390,7 +424,7 @@ export function useSiteActionsDataViews( {
 				label: translate( 'Visit WP Admin' ),
 				icon: external,
 				isEligible( item: SiteData ) {
-					return ! isUrlOnly( item );
+					return canHaveActions( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
 					page( `${ getUrlWithScheme( items[ 0 ] ) }/wp-admin` );
@@ -402,7 +436,7 @@ export function useSiteActionsDataViews( {
 				label: translate( 'Remove site' ),
 				icon: trash,
 				isEligible( item: SiteData ) {
-					return ! isDevSite( item ) && hasRemoveManagedSitesCapability();
+					return canHaveActions( item ) && ! isDevSite( item ) && hasRemoveManagedSitesCapability();
 				},
 				RenderModal: createRemoveSiteActionModal( onRefetchSite ),
 				isDestructive: true,
@@ -410,8 +444,8 @@ export function useSiteActionsDataViews( {
 			{
 				id: 'delete_site',
 				label: translate( 'Delete site' ),
-				isEligible() {
-					return false; // Feature is always disabled, see canDelete above.
+				isEligible( item: SiteData ) {
+					return canHaveActions( item ) && false; // Feature is always disabled, see canDelete above.
 				},
 				callback() {
 					dispatch( recordTracksEvent( getActionEventName( 'delete_site', isLargeScreen ) ) );

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -244,8 +244,15 @@ export function useSiteActionsDataViews( {
 				: item.site.value.url_with_scheme;
 		};
 
-		// This implements logic that was previously in the Actions field.
-		// TODO: review isEligible logic for all actions and make sure there are no duplicate ones.
+		// In the previous field-based Actions implementation (see useSiteActions above),
+		// some of the logic to enable action lived in the Actions field and some other in the isEnabled flag.
+		// This meant that some conditions in isEnabled were redundant (e.g.: "! item.site.error")
+		// or conflicting (checking for "! item.site.value.is_simple" in the field but checking
+		// for "item.site.value.is_simple" in the isEnabled flag).
+		//
+		// canHaveActions represents the logic common to all actions that previously lived in the field,
+		// and isEligible has been updated to remove redundant and conflicting checks,
+		// that's why it's not exactly the same as isEnable above.
 		const isNotProduction = config( 'env_id' ) !== 'a8c-for-agencies-production';
 		const canHaveActions = ( item: SiteData ) =>
 			! isLoading &&

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -1,24 +1,22 @@
 import page from '@automattic/calypso-router';
-import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { external, trash } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useContext, useMemo } from 'react';
 import { DATAVIEWS_LIST } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import useRemoveSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-remove-site';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch, useSelector } from 'calypso/state';
 import { hasAgencyCapability } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { A4AStore } from 'calypso/state/a8c-for-agencies/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { successNotice } from 'calypso/state/notices/actions';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import isA4AClientSite from 'calypso/state/sites/selectors/is-a4a-client-site';
 import { JETPACK_ACTIVITY_ID, JETPACK_BACKUP_ID } from '../features/features';
 import SitesDashboardContext from '../sites-dashboard-context';
 import getActionEventName from './get-action-event-name';
+import createRemoveSiteActionModal from './remove-site-action-modal';
 import type { SiteData } from '../../../../jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 import type { SiteNode, AllowedActionTypes } from '../types';
 
@@ -210,86 +208,10 @@ export default function useSiteActions( {
 
 type SiteActions = {
 	isLargeScreen: boolean;
-	onRefetchSite?: () => Promise< unknown >;
+	onRefetchSite: () => Promise< unknown >;
 	setDataViewsState: ( callback: ( prevState: DataViewsState ) => DataViewsState ) => void;
 	setSelectedSiteFeature: ( siteFeature: string | undefined ) => void;
 };
-
-const createRemoveSiteActionModal =
-	( onRefetchSite: any ) =>
-	( {
-		items,
-		closeModal,
-		onActionPerformed,
-	}: {
-		items: SiteData[];
-		closeModal: () => void;
-		onActionPerformed?: () => void;
-	} ) => {
-		const translate = useTranslate();
-		const dispatch = useDispatch();
-		const { mutate: removeSite } = useRemoveSiteMutation();
-
-		const item = items[ 0 ];
-		const siteName = item.site.value.url;
-		const siteId = item.site.value.a4a_site_id;
-
-		const onRemoveSite = () => {
-			if ( ! siteId ) {
-				return;
-			}
-
-			removeSite(
-				{ siteId },
-				{
-					onSuccess: () => {
-						// Add 1 second delay to refetch sites to give time for site profile to be reindexed properly.
-						setTimeout( () => {
-							onRefetchSite?.()?.then( () => {
-								closeModal?.();
-								onActionPerformed?.();
-								dispatch( successNotice( translate( 'The site has been successfully removed.' ) ) );
-							} );
-						}, 1000 );
-					},
-				}
-			);
-		};
-
-		const onSubmit = ( event: React.FormEvent ) => {
-			event.preventDefault();
-			onRemoveSite();
-		};
-
-		return (
-			<form onSubmit={ onSubmit }>
-				{ translate(
-					'Are you sure you want to remove the site {{b}}%(siteName)s{{/b}} from the dashboard?',
-					{
-						args: { siteName },
-						components: {
-							b: <b />,
-						},
-						comment: '%(siteName)s is the site name',
-					}
-				) }
-				<HStack justify="right">
-					<Button
-						__next40pxDefaultSize
-						variant="tertiary"
-						onClick={ () => {
-							closeModal?.();
-						} }
-					>
-						{ translate( 'Cancel' ) }
-					</Button>
-					<Button __next40pxDefaultSize variant="primary" type="submit" isDestructive>
-						{ translate( 'Remove site' ) }
-					</Button>
-				</HStack>
-			</form>
-		);
-	};
 
 export function useSiteActionsDataViews( {
 	isLargeScreen,

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -261,7 +261,7 @@ export function useSiteActionsDataViews( {
 					return canHaveActions( item ) && isDevSite( item );
 				},
 				callback( items: SiteData[] ) {
-					page( `https://wordpress.com/settings/general/${ getBlogId( items[ 0 ] ) }` );
+					window.open( `https://wordpress.com/settings/general/${ getBlogId( items[ 0 ] ) }` );
 					dispatch(
 						recordTracksEvent( getActionEventName( 'prepare_for_launch', isLargeScreen ) )
 					);
@@ -275,7 +275,7 @@ export function useSiteActionsDataViews( {
 					return canHaveActions( item ) && isWPComSite( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
-					page( `https://wordpress.com/overview/${ getBlogId( items[ 0 ] ) }` );
+					window.open( `https://wordpress.com/overview/${ getBlogId( items[ 0 ] ) }` );
 					dispatch( recordTracksEvent( getActionEventName( 'set_up_site', isLargeScreen ) ) );
 				},
 			},
@@ -287,7 +287,7 @@ export function useSiteActionsDataViews( {
 					return canHaveActions( item ) && isWPComSite( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
-					page( `https://wordpress.com/domains/manage/${ getBlogId( items[ 0 ] ) }` );
+					window.open( `https://wordpress.com/domains/manage/${ getBlogId( items[ 0 ] ) }` );
 					dispatch( recordTracksEvent( getActionEventName( 'change_domain', isLargeScreen ) ) );
 				},
 			},
@@ -299,7 +299,7 @@ export function useSiteActionsDataViews( {
 					return canHaveActions( item ) && isWPComSite( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
-					page( `https://wordpress.com/hosting-config/${ getBlogId( items[ 0 ] ) }` );
+					window.open( `https://wordpress.com/hosting-config/${ getBlogId( items[ 0 ] ) }` );
 					dispatch(
 						recordTracksEvent( getActionEventName( 'hosting_configuration', isLargeScreen ) )
 					);
@@ -341,7 +341,7 @@ export function useSiteActionsDataViews( {
 					return canHaveActions( item ) && isWPComSite( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
-					page( `https://wordpress.com/activity-log/${ getBlogId( items[ 0 ] ) }` );
+					window.open( `https://wordpress.com/activity-log/${ getBlogId( items[ 0 ] ) }` );
 					dispatch( recordTracksEvent( getActionEventName( 'view_activity', isLargeScreen ) ) );
 				},
 			},
@@ -358,7 +358,7 @@ export function useSiteActionsDataViews( {
 					);
 				},
 				callback( items: SiteData[] ) {
-					page( `https://wordpress.com/backup/${ getSiteSlug( items[ 0 ] ) }/clone` );
+					window.open( `https://wordpress.com/backup/${ getSiteSlug( items[ 0 ] ) }/clone` );
 					dispatch( recordTracksEvent( getActionEventName( 'clone_site', isLargeScreen ) ) );
 				},
 			},
@@ -391,7 +391,7 @@ export function useSiteActionsDataViews( {
 					return canHaveActions( item ) && isWPComSite( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
-					page( `https://wordpress.com/settings/general/${ getBlogId( items[ 0 ] ) }` );
+					window.open( `https://wordpress.com/settings/general/${ getBlogId( items[ 0 ] ) }` );
 					dispatch( recordTracksEvent( getActionEventName( 'site_settings', isLargeScreen ) ) );
 				},
 			},
@@ -403,7 +403,7 @@ export function useSiteActionsDataViews( {
 					return canHaveActions( item );
 				},
 				callback( items: SiteData[] ) {
-					page( getUrlWithScheme( items[ 0 ] ) );
+					window.open( getUrlWithScheme( items[ 0 ] ) );
 					dispatch( recordTracksEvent( getActionEventName( 'view_site', isLargeScreen ) ) );
 				},
 			},
@@ -415,7 +415,7 @@ export function useSiteActionsDataViews( {
 					return canHaveActions( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
-					page( `${ getUrlWithScheme( items[ 0 ] ) }/wp-admin` );
+					window.open( `${ getUrlWithScheme( items[ 0 ] ) }/wp-admin` );
 					dispatch( recordTracksEvent( getActionEventName( 'visit_wp_admin', isLargeScreen ) ) );
 				},
 			},

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -261,6 +261,9 @@ export function useSiteActionsDataViews( {
 			! item.site.error &&
 			! item.site.value.is_simple;
 
+		const recordTracksEventRemoveSite = () =>
+			dispatch( recordTracksEvent( getActionEventName( 'remove_site', isLargeScreen ) ) );
+
 		return [
 			{
 				label: translate( 'Prepare for launch' ),
@@ -434,7 +437,10 @@ export function useSiteActionsDataViews( {
 				isEligible( item: SiteData ) {
 					return canHaveActions( item ) && ! isDevSite( item ) && hasRemoveManagedSitesCapability;
 				},
-				RenderModal: createRemoveSiteActionModal( onRefetchSite ),
+				RenderModal: createRemoveSiteActionModal( {
+					onRefetchSite,
+					recordTracksEventRemoveSite,
+				} ),
 				isDestructive: true,
 			},
 			{

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -225,16 +225,16 @@ export function useSiteActionsDataViews( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
+	const hasRemoveManagedSitesCapability = useSelector( ( state: A4AStore ) =>
+		hasAgencyCapability( state, 'a4a_remove_managed_sites' )
+	);
+
 	return useMemo( () => {
 		const isUrlOnly = ( item: SiteData ) =>
 			item.site?.value?.sticker?.includes( 'jetpack-manage-url-only-site' );
 		const isWPComSite = ( item: SiteData ) =>
 			item.site.value.is_atomic || item.site.value.is_simple;
 		const isDevSite = ( item: SiteData ) => item.site.value.a4a_is_dev_site;
-		const hasRemoveManagedSitesCapability = () => {
-			// TODO: implement this based on the item data.
-			return true;
-		};
 		const getBlogId = ( item: SiteData ) => item.site.value.blog_id;
 		const hasBackup = ( item: SiteData ) => item.site.value.has_backup;
 		const getSiteSlug = ( item: SiteData ) => urlToSlug( item.site.value.url );
@@ -439,7 +439,7 @@ export function useSiteActionsDataViews( {
 				label: translate( 'Remove site' ),
 				icon: trash,
 				isEligible( item: SiteData ) {
-					return canHaveActions( item ) && ! isDevSite( item ) && hasRemoveManagedSitesCapability();
+					return canHaveActions( item ) && ! isDevSite( item ) && hasRemoveManagedSitesCapability;
 				},
 				RenderModal: createRemoveSiteActionModal( onRefetchSite ),
 				isDestructive: true,
@@ -457,11 +457,13 @@ export function useSiteActionsDataViews( {
 			},
 		];
 	}, [
-		isLargeScreen,
 		translate,
-		dispatch,
 		onRefetchSite,
+		isLoading,
+		dispatch,
+		isLargeScreen,
 		setDataViewsState,
 		setSelectedSiteFeature,
+		hasRemoveManagedSitesCapability,
 	] );
 }

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -400,7 +400,7 @@ export function useSiteActionsDataViews( {
 				label: translate( 'View site' ),
 				icon: external,
 				isEligible( item: SiteData ) {
-					return canHaveActions( item ) && true;
+					return canHaveActions( item );
 				},
 				callback( items: SiteData[] ) {
 					page( getUrlWithScheme( items[ 0 ] ) );

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -232,8 +232,9 @@ export function useSiteActionsDataViews( {
 	return useMemo( () => {
 		const isUrlOnly = ( item: SiteData ) =>
 			item.site?.value?.sticker?.includes( 'jetpack-manage-url-only-site' );
-		const isWPComSite = ( item: SiteData ) =>
-			item.site.value.is_atomic || item.site.value.is_simple;
+		const isAtomicSite = ( item: SiteData ) => item.site.value.is_atomic;
+		const isSimpleSite = ( item: SiteData ) => item.site.value.is_simple;
+		const isWPComSite = ( item: SiteData ) => isAtomicSite( item ) || isSimpleSite( item );
 		const isDevSite = ( item: SiteData ) => item.site.value.a4a_is_dev_site;
 		const getBlogId = ( item: SiteData ) => item.site.value.blog_id;
 		const hasBackup = ( item: SiteData ) => item.site.value.has_backup;
@@ -279,7 +280,7 @@ export function useSiteActionsDataViews( {
 				label: translate( 'Set up site' ),
 				icon: external,
 				isEligible( item: SiteData ) {
-					return canHaveActions( item ) && isWPComSite( item ) && ! isUrlOnly( item );
+					return canHaveActions( item ) && isAtomicSite( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
 					window.open( `https://wordpress.com/overview/${ getBlogId( items[ 0 ] ) }` );
@@ -291,7 +292,7 @@ export function useSiteActionsDataViews( {
 				label: translate( 'Change domain' ),
 				icon: external,
 				isEligible( item: SiteData ) {
-					return canHaveActions( item ) && isWPComSite( item ) && ! isUrlOnly( item );
+					return canHaveActions( item ) && isAtomicSite( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
 					window.open( `https://wordpress.com/domains/manage/${ getBlogId( items[ 0 ] ) }` );
@@ -303,7 +304,7 @@ export function useSiteActionsDataViews( {
 				label: translate( 'Hosting configuration' ),
 				icon: external,
 				isEligible( item: SiteData ) {
-					return canHaveActions( item ) && isWPComSite( item ) && ! isUrlOnly( item );
+					return canHaveActions( item ) && isAtomicSite( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
 					window.open( `https://wordpress.com/hosting-config/${ getBlogId( items[ 0 ] ) }` );
@@ -316,7 +317,7 @@ export function useSiteActionsDataViews( {
 				id: 'issue_license',
 				label: translate( 'Issue new license' ),
 				isEligible( item: SiteData ) {
-					return canHaveActions( item ) && ! isWPComSite( item ) && ! isUrlOnly( item );
+					return canHaveActions( item ) && ! isAtomicSite( item ) && ! isUrlOnly( item );
 				},
 				callback: () => {
 					page( A4A_MARKETPLACE_LINK );
@@ -327,7 +328,7 @@ export function useSiteActionsDataViews( {
 				id: 'view_activity_not_wpcom',
 				label: translate( 'View activity' ),
 				isEligible( item: SiteData ) {
-					return canHaveActions( item ) && ! isWPComSite( item ) && ! isUrlOnly( item );
+					return canHaveActions( item ) && ! isAtomicSite( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
 					const item = items[ 0 ];
@@ -345,7 +346,7 @@ export function useSiteActionsDataViews( {
 				label: translate( 'View activity' ),
 				icon: external,
 				isEligible( item: SiteData ) {
-					return canHaveActions( item ) && isWPComSite( item ) && ! isUrlOnly( item );
+					return canHaveActions( item ) && isAtomicSite( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
 					window.open( `https://wordpress.com/activity-log/${ getBlogId( items[ 0 ] ) }` );
@@ -359,7 +360,7 @@ export function useSiteActionsDataViews( {
 				isEligible( item: SiteData ) {
 					return (
 						canHaveActions( item ) &&
-						isWPComSite( item ) &&
+						isAtomicSite( item ) &&
 						hasBackup( item ) &&
 						! isUrlOnly( item )
 					);
@@ -375,7 +376,7 @@ export function useSiteActionsDataViews( {
 				isEligible( item: SiteData ) {
 					return (
 						canHaveActions( item ) &&
-						! isWPComSite( item ) &&
+						! isAtomicSite( item ) &&
 						hasBackup( item ) &&
 						! isUrlOnly( item )
 					);
@@ -395,7 +396,7 @@ export function useSiteActionsDataViews( {
 				label: translate( 'Site settings' ),
 				icon: external,
 				isEligible( item: SiteData ) {
-					return canHaveActions( item ) && isWPComSite( item ) && ! isUrlOnly( item );
+					return canHaveActions( item ) && isAtomicSite( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
 					window.open( `https://wordpress.com/settings/general/${ getBlogId( items[ 0 ] ) }` );

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -202,3 +202,8 @@ export default function useSiteActions( {
 		translate,
 	] );
 }
+
+const EMPTY_ARRAY: any[] = [];
+export function useSiteActionsDataViews() {
+	return EMPTY_ARRAY;
+}

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.tsx
@@ -313,57 +313,62 @@ export function useSiteActionsDataViews( {
 		const getBlogId = ( item: SiteData ) => item.site.value.blog_id;
 		const hasBackup = ( item: SiteData ) => item.site.value.has_backup;
 		const getSiteSlug = ( item: SiteData ) => urlToSlug( item.site.value.url );
+		const getUrlWithScheme = ( item: SiteData ) => {
+			return isWPComSite( item )
+				? item.site.value.url_with_scheme.replace( 'wpcomstaging.com', 'wordpress.com' ) // Replace staging domain with wordpress.com if it's a simple site
+				: item.site.value.url_with_scheme;
+		};
 
 		return [
 			{
 				label: translate( 'Prepare for launch' ),
 				icon: external,
+				isEligible( item: SiteData ) {
+					return isDevSite( item );
+				},
 				callback( items: SiteData[] ) {
 					page( `https://wordpress.com/settings/general/${ getBlogId( items[ 0 ] ) }` );
 					dispatch(
 						recordTracksEvent( getActionEventName( 'prepare_for_launch', isLargeScreen ) )
 					);
 				},
-				isEligible( item: SiteData ) {
-					return isDevSite( item );
-				},
 			},
 			{
 				id: 'set_up_site',
 				label: translate( 'Set up site' ),
 				icon: external,
+				isEligible( item: SiteData ) {
+					return isWPComSite( item ) && ! isUrlOnly( item );
+				},
 				callback( items: SiteData[] ) {
 					page( `https://wordpress.com/overview/${ getBlogId( items[ 0 ] ) }` );
 					dispatch( recordTracksEvent( getActionEventName( 'set_up_site', isLargeScreen ) ) );
-				},
-				isEligible( item: SiteData ) {
-					return isWPComSite( item ) && ! isUrlOnly( item );
 				},
 			},
 			{
 				id: 'change_domain',
 				label: translate( 'Change domain' ),
 				icon: external,
+				isEligible( item: SiteData ) {
+					return isWPComSite( item ) && ! isUrlOnly( item );
+				},
 				callback( items: SiteData[] ) {
 					page( `https://wordpress.com/domains/manage/${ getBlogId( items[ 0 ] ) }` );
 					dispatch( recordTracksEvent( getActionEventName( 'change_domain', isLargeScreen ) ) );
-				},
-				isEligible( item: SiteData ) {
-					return isWPComSite( item ) && ! isUrlOnly( item );
 				},
 			},
 			{
 				id: 'hosting_configuration',
 				label: translate( 'Hosting configuration' ),
 				icon: external,
+				isEligible( item: SiteData ) {
+					return isWPComSite( item ) && ! isUrlOnly( item );
+				},
 				callback( items: SiteData[] ) {
 					page( `https://wordpress.com/hosting-config/${ getBlogId( items[ 0 ] ) }` );
 					dispatch(
 						recordTracksEvent( getActionEventName( 'hosting_configuration', isLargeScreen ) )
 					);
-				},
-				isEligible( item: SiteData ) {
-					return isWPComSite( item ) && ! isUrlOnly( item );
 				},
 			},
 			{
@@ -432,6 +437,42 @@ export function useSiteActionsDataViews( {
 					} ) );
 					setSelectedSiteFeature( JETPACK_BACKUP_ID );
 					dispatch( recordTracksEvent( getActionEventName( 'clone_site', isLargeScreen ) ) );
+				},
+			},
+			{
+				id: 'site_settings',
+				label: translate( 'Site settings' ),
+				icon: external,
+				isEligible( item: SiteData ) {
+					return isWPComSite( item ) && ! isUrlOnly( item );
+				},
+				callback( items: SiteData[] ) {
+					page( `https://wordpress.com/settings/general/${ getBlogId( items[ 0 ] ) }` );
+					dispatch( recordTracksEvent( getActionEventName( 'site_settings', isLargeScreen ) ) );
+				},
+			},
+			{
+				id: 'view_site',
+				label: translate( 'View site' ),
+				icon: external,
+				isEligible() {
+					return true;
+				},
+				callback( items: SiteData[] ) {
+					page( getUrlWithScheme( items[ 0 ] ) );
+					dispatch( recordTracksEvent( getActionEventName( 'view_site', isLargeScreen ) ) );
+				},
+			},
+			{
+				id: 'visit_wp_admin',
+				label: translate( 'Visit WP Admin' ),
+				icon: external,
+				isEligible( item: SiteData ) {
+					return ! isUrlOnly( item );
+				},
+				callback( items: SiteData[] ) {
+					page( `${ getUrlWithScheme( items[ 0 ] ) }/wp-admin` );
+					dispatch( recordTracksEvent( getActionEventName( 'visit_wp_admin', isLargeScreen ) ) );
 				},
 			},
 			{

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.tsx
@@ -315,14 +315,12 @@ export function useSiteActionsDataViews( {
 		return [
 			{
 				label: translate( 'Prepare for launch' ),
-				supportsBulk: false,
+				icon: external,
 				callback( items: SiteData[] ) {
+					page( `https://wordpress.com/settings/general/${ getBlogId( items[ 0 ] ) }` );
 					dispatch(
 						recordTracksEvent( getActionEventName( 'prepare_for_launch', isLargeScreen ) )
 					);
-
-					const blog_id = items[ 0 ].site.value.blog_id;
-					window.open( `https://wordpress.com/settings/general/${ blog_id }`, '_blank' );
 				},
 				isEligible( item: SiteData ) {
 					return isDevSite( item );
@@ -331,12 +329,10 @@ export function useSiteActionsDataViews( {
 			{
 				id: 'set_up_site',
 				label: translate( 'Set up site' ),
-				supportsBulk: false,
+				icon: external,
 				callback( items: SiteData[] ) {
+					page( `https://wordpress.com/overview/${ getBlogId( items[ 0 ] ) }` );
 					dispatch( recordTracksEvent( getActionEventName( 'set_up_site', isLargeScreen ) ) );
-
-					const blog_id = items[ 0 ].site.value.blog_id;
-					window.open( `https://wordpress.com/overview/${ blog_id }`, '_blank' );
 				},
 				isEligible( item: SiteData ) {
 					return isWPComSite( item ) && ! isUrlOnly( item );
@@ -345,12 +341,10 @@ export function useSiteActionsDataViews( {
 			{
 				id: 'change_domain',
 				label: translate( 'Change domain' ),
-				supportsBulk: false,
+				icon: external,
 				callback( items: SiteData[] ) {
+					page( `https://wordpress.com/domains/manage/${ getBlogId( items[ 0 ] ) }` );
 					dispatch( recordTracksEvent( getActionEventName( 'change_domain', isLargeScreen ) ) );
-
-					const blog_id = items[ 0 ].site.value.blog_id;
-					window.open( `https://wordpress.com/domains/manage/${ blog_id }`, '_blank' );
 				},
 				isEligible( item: SiteData ) {
 					return isWPComSite( item ) && ! isUrlOnly( item );
@@ -359,14 +353,12 @@ export function useSiteActionsDataViews( {
 			{
 				id: 'hosting_configuration',
 				label: translate( 'Hosting configuration' ),
-				supportsBulk: false,
+				icon: external,
 				callback( items: SiteData[] ) {
+					page( `https://wordpress.com/hosting-config/${ getBlogId( items[ 0 ] ) }` );
 					dispatch(
 						recordTracksEvent( getActionEventName( 'hosting_configuration', isLargeScreen ) )
 					);
-
-					const blog_id = items[ 0 ].site.value.blog_id;
-					window.open( `https://wordpress.com/hosting-config/${ blog_id }`, '_blank' );
 				},
 				isEligible( item: SiteData ) {
 					return isWPComSite( item ) && ! isUrlOnly( item );

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.tsx
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
-import { trash } from '@wordpress/icons';
+import { external, trash } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useContext, useMemo } from 'react';
 import { DATAVIEWS_LIST } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
@@ -210,7 +210,9 @@ export default function useSiteActions( {
 
 type SiteActions = {
 	isLargeScreen: boolean;
-	onRefetchSite?: any;
+	onRefetchSite?: () => Promise< unknown >;
+	setDataViewsState: ( callback: ( prevState: DataViewsState ) => DataViewsState ) => void;
+	setSelectedSiteFeature: ( siteFeature: string | undefined ) => void;
 };
 
 const createRemoveSiteActionModal =
@@ -289,7 +291,12 @@ const createRemoveSiteActionModal =
 		);
 	};
 
-export function useSiteActionsDataViews( { isLargeScreen, onRefetchSite }: SiteActions ) {
+export function useSiteActionsDataViews( {
+	isLargeScreen,
+	onRefetchSite,
+	setDataViewsState,
+	setSelectedSiteFeature,
+}: SiteActions ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -303,6 +310,7 @@ export function useSiteActionsDataViews( { isLargeScreen, onRefetchSite }: SiteA
 			// TODO: implement this based on the item data.
 			return true;
 		};
+		const getBlogId = ( item: SiteData ) => item.site.value.blog_id;
 
 		return [
 			{
@@ -376,6 +384,35 @@ export function useSiteActionsDataViews( { isLargeScreen, onRefetchSite }: SiteA
 				},
 			},
 			{
+				id: 'view_activity_wpcom',
+				label: translate( 'View activity' ),
+				isEligible( item: SiteData ) {
+					return ! isWPComSite( item ) && ! item.site.error && ! isUrlOnly( item );
+				},
+				callback( items: SiteData[] ) {
+					const item = items[ 0 ];
+					setDataViewsState( ( prevState: DataViewsState ) => ( {
+						...prevState,
+						selectedItem: item.site?.value,
+						type: DATAVIEWS_LIST,
+					} ) );
+					setSelectedSiteFeature( JETPACK_ACTIVITY_ID );
+					dispatch( recordTracksEvent( getActionEventName( 'view_activity', isLargeScreen ) ) );
+				},
+			},
+			{
+				id: 'view_activity_external',
+				label: translate( 'View activity' ),
+				icon: external,
+				isEligible( item: SiteData ) {
+					return isWPComSite( item ) && ! item.site.error && ! isUrlOnly( item );
+				},
+				callback( items: SiteData[] ) {
+					page( `https://wordpress.com/activity-log/${ getBlogId( items[ 0 ] ) }` );
+					dispatch( recordTracksEvent( getActionEventName( 'view_activity', isLargeScreen ) ) );
+				},
+			},
+			{
 				id: 'remove_site',
 				label: translate( 'Remove site' ),
 				icon: trash,
@@ -397,5 +434,12 @@ export function useSiteActionsDataViews( { isLargeScreen, onRefetchSite }: SiteA
 				},
 			},
 		];
-	}, [ isLargeScreen, translate, dispatch, onRefetchSite ] );
+	}, [
+		isLargeScreen,
+		translate,
+		dispatch,
+		onRefetchSite,
+		setDataViewsState,
+		setSelectedSiteFeature,
+	] );
 }

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.tsx
@@ -306,6 +306,65 @@ export function useSiteActionsDataViews( { isLargeScreen, onRefetchSite }: SiteA
 
 		return [
 			{
+				label: translate( 'Prepare for launch' ),
+				supportsBulk: false,
+				callback( items: SiteData[] ) {
+					dispatch(
+						recordTracksEvent( getActionEventName( 'prepare_for_launch', isLargeScreen ) )
+					);
+
+					const blog_id = items[ 0 ].site.value.blog_id;
+					window.open( `https://wordpress.com/settings/general/${ blog_id }`, '_blank' );
+				},
+				isEligible( item: SiteData ) {
+					return isDevSite( item );
+				},
+			},
+			{
+				id: 'set_up_site',
+				label: translate( 'Set up site' ),
+				supportsBulk: false,
+				callback( items: SiteData[] ) {
+					dispatch( recordTracksEvent( getActionEventName( 'set_up_site', isLargeScreen ) ) );
+
+					const blog_id = items[ 0 ].site.value.blog_id;
+					window.open( `https://wordpress.com/overview/${ blog_id }`, '_blank' );
+				},
+				isEligible( item: SiteData ) {
+					return isWPComSite( item ) && ! isUrlOnly( item );
+				},
+			},
+			{
+				id: 'change_domain',
+				label: translate( 'Change domain' ),
+				supportsBulk: false,
+				callback( items: SiteData[] ) {
+					dispatch( recordTracksEvent( getActionEventName( 'change_domain', isLargeScreen ) ) );
+
+					const blog_id = items[ 0 ].site.value.blog_id;
+					window.open( `https://wordpress.com/domains/manage/${ blog_id }`, '_blank' );
+				},
+				isEligible( item: SiteData ) {
+					return isWPComSite( item ) && ! isUrlOnly( item );
+				},
+			},
+			{
+				id: 'hosting_configuration',
+				label: translate( 'Hosting configuration' ),
+				supportsBulk: false,
+				callback( items: SiteData[] ) {
+					dispatch(
+						recordTracksEvent( getActionEventName( 'hosting_configuration', isLargeScreen ) )
+					);
+
+					const blog_id = items[ 0 ].site.value.blog_id;
+					window.open( `https://wordpress.com/hosting-config/${ blog_id }`, '_blank' );
+				},
+				isEligible( item: SiteData ) {
+					return isWPComSite( item ) && ! isUrlOnly( item );
+				},
+			},
+			{
 				id: 'issue_license',
 				label: translate( 'Issue new license' ),
 				isEligible( item: SiteData ) {

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.tsx
@@ -1,5 +1,6 @@
 import page from '@automattic/calypso-router';
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { trash } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useContext, useMemo } from 'react';
 import { DATAVIEWS_LIST } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
@@ -292,17 +293,18 @@ export function useSiteActionsDataViews( { isLargeScreen, onRefetchSite }: SiteA
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const isUrlOnly = ( item: SiteData ) =>
-		item.site?.value?.sticker?.includes( 'jetpack-manage-url-only-site' );
-	const isWPComSite = ( item: SiteData ) => item.site.value.is_atomic || item.site.value.is_simple;
-	const isDevSite = ( item: SiteData ) => item.site.value.a4a_is_dev_site;
-	const hasRemoveManagedSitesCapability = () => {
-		// TODO: implement this based on the item data.
-		return true;
-	};
+	return useMemo( () => {
+		const isUrlOnly = ( item: SiteData ) =>
+			item.site?.value?.sticker?.includes( 'jetpack-manage-url-only-site' );
+		const isWPComSite = ( item: SiteData ) =>
+			item.site.value.is_atomic || item.site.value.is_simple;
+		const isDevSite = ( item: SiteData ) => item.site.value.a4a_is_dev_site;
+		const hasRemoveManagedSitesCapability = () => {
+			// TODO: implement this based on the item data.
+			return true;
+		};
 
-	return useMemo(
-		() => [
+		return [
 			{
 				id: 'delete_site',
 				label: translate( 'Delete site' ),
@@ -317,8 +319,9 @@ export function useSiteActionsDataViews( { isLargeScreen, onRefetchSite }: SiteA
 			{
 				id: 'remove_site',
 				label: translate( 'Remove site' ),
+				icon: trash,
 				isEligible( item: SiteData ) {
-					return ! isDevSite( item ) && hasRemoveManagedSitesCapability( item );
+					return ! isDevSite( item ) && hasRemoveManagedSitesCapability();
 				},
 				RenderModal: createRemoveSiteActionModal( onRefetchSite ),
 				isDestructive: true,
@@ -334,7 +337,6 @@ export function useSiteActionsDataViews( { isLargeScreen, onRefetchSite }: SiteA
 					dispatch( recordTracksEvent( getActionEventName( 'issue_license', isLargeScreen ) ) );
 				},
 			},
-		],
-		[ isLargeScreen, translate, dispatch ]
-	);
+		];
+	}, [ isLargeScreen, translate, dispatch, onRefetchSite ] );
 }

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.tsx
@@ -306,14 +306,14 @@ export function useSiteActionsDataViews( { isLargeScreen, onRefetchSite }: SiteA
 
 		return [
 			{
-				id: 'delete_site',
-				label: translate( 'Delete site' ),
-				isEligible() {
-					return false; // Feature is always disabled, see canDelete above.
+				id: 'issue_license',
+				label: translate( 'Issue new license' ),
+				isEligible( item: SiteData ) {
+					return ! item.site.error && ! isWPComSite( item ) && ! isUrlOnly( item );
 				},
-				callback() {
-					dispatch( recordTracksEvent( getActionEventName( 'delete_site', isLargeScreen ) ) );
-					// TODO: implement modal. See setShowDeleteDevSiteDialog in SiteActions.
+				callback: () => {
+					page( A4A_MARKETPLACE_LINK );
+					dispatch( recordTracksEvent( getActionEventName( 'issue_license', isLargeScreen ) ) );
 				},
 			},
 			{
@@ -327,14 +327,14 @@ export function useSiteActionsDataViews( { isLargeScreen, onRefetchSite }: SiteA
 				isDestructive: true,
 			},
 			{
-				id: 'issue_license',
-				label: translate( 'Issue new license' ),
-				isEligible( item: SiteData ) {
-					return ! item.site.error && ! isWPComSite( item ) && ! isUrlOnly( item );
+				id: 'delete_site',
+				label: translate( 'Delete site' ),
+				isEligible() {
+					return false; // Feature is always disabled, see canDelete above.
 				},
-				callback: () => {
-					page( A4A_MARKETPLACE_LINK );
-					dispatch( recordTracksEvent( getActionEventName( 'issue_license', isLargeScreen ) ) );
+				callback() {
+					dispatch( recordTracksEvent( getActionEventName( 'delete_site', isLargeScreen ) ) );
+					// TODO: implement modal. See setShowDeleteDevSiteDialog in SiteActions.
 				},
 			},
 		];

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.tsx
@@ -378,7 +378,7 @@ export function useSiteActionsDataViews( {
 				},
 			},
 			{
-				id: 'view_activity_wpcom',
+				id: 'view_activity_not_wpcom',
 				label: translate( 'View activity' ),
 				isEligible( item: SiteData ) {
 					return ! isWPComSite( item ) && ! item.site.error && ! isUrlOnly( item );
@@ -395,7 +395,7 @@ export function useSiteActionsDataViews( {
 				},
 			},
 			{
-				id: 'view_activity_external',
+				id: 'view_activity_wpcom',
 				label: translate( 'View activity' ),
 				icon: external,
 				isEligible( item: SiteData ) {

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.tsx
@@ -1,14 +1,17 @@
 import page from '@automattic/calypso-router';
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useContext, useMemo } from 'react';
 import { DATAVIEWS_LIST } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useRemoveSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-remove-site';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch, useSelector } from 'calypso/state';
 import { hasAgencyCapability } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { A4AStore } from 'calypso/state/a8c-for-agencies/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { successNotice } from 'calypso/state/notices/actions';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import isA4AClientSite from 'calypso/state/sites/selectors/is-a4a-client-site';
@@ -206,15 +209,97 @@ export default function useSiteActions( {
 
 type SiteActions = {
 	isLargeScreen: boolean;
+	onRefetchSite?: any;
 };
 
-export function useSiteActionsDataViews( { isLargeScreen }: SiteActions ) {
+const createRemoveSiteActionModal =
+	( onRefetchSite: any ) =>
+	( {
+		items,
+		closeModal,
+		onActionPerformed,
+	}: {
+		items: SiteData[];
+		closeModal: () => void;
+		onActionPerformed?: () => void;
+	} ) => {
+		const translate = useTranslate();
+		const dispatch = useDispatch();
+		const { mutate: removeSite } = useRemoveSiteMutation();
+
+		const item = items[ 0 ];
+		const siteName = item.site.value.url;
+		const siteId = item.site.value.a4a_site_id;
+
+		const onRemoveSite = () => {
+			if ( ! siteId ) {
+				return;
+			}
+
+			removeSite(
+				{ siteId },
+				{
+					onSuccess: () => {
+						// Add 1 second delay to refetch sites to give time for site profile to be reindexed properly.
+						setTimeout( () => {
+							onRefetchSite?.()?.then( () => {
+								closeModal?.();
+								onActionPerformed?.();
+								dispatch( successNotice( translate( 'The site has been successfully removed.' ) ) );
+							} );
+						}, 1000 );
+					},
+				}
+			);
+		};
+
+		const onSubmit = ( event: React.FormEvent ) => {
+			event.preventDefault();
+			onRemoveSite();
+		};
+
+		return (
+			<form onSubmit={ onSubmit }>
+				{ translate(
+					'Are you sure you want to remove the site {{b}}%(siteName)s{{/b}} from the dashboard?',
+					{
+						args: { siteName },
+						components: {
+							b: <b />,
+						},
+						comment: '%(siteName)s is the site name',
+					}
+				) }
+				<HStack justify="right">
+					<Button
+						__next40pxDefaultSize
+						variant="tertiary"
+						onClick={ () => {
+							closeModal?.();
+						} }
+					>
+						{ translate( 'Cancel' ) }
+					</Button>
+					<Button __next40pxDefaultSize variant="primary" type="submit" isDestructive>
+						{ translate( 'Remove site' ) }
+					</Button>
+				</HStack>
+			</form>
+		);
+	};
+
+export function useSiteActionsDataViews( { isLargeScreen, onRefetchSite }: SiteActions ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	const isUrlOnly = ( item: SiteData ) =>
 		item.site?.value?.sticker?.includes( 'jetpack-manage-url-only-site' );
 	const isWPComSite = ( item: SiteData ) => item.site.value.is_atomic || item.site.value.is_simple;
+	const isDevSite = ( item: SiteData ) => item.site.value.a4a_is_dev_site;
+	const hasRemoveManagedSitesCapability = () => {
+		// TODO: implement this based on the item data.
+		return true;
+	};
 
 	return useMemo(
 		() => [
@@ -228,6 +313,15 @@ export function useSiteActionsDataViews( { isLargeScreen }: SiteActions ) {
 					dispatch( recordTracksEvent( getActionEventName( 'delete_site', isLargeScreen ) ) );
 					// TODO: implement modal. See setShowDeleteDevSiteDialog in SiteActions.
 				},
+			},
+			{
+				id: 'remove_site',
+				label: translate( 'Remove site' ),
+				isEligible( item: SiteData ) {
+					return ! isDevSite( item ) && hasRemoveManagedSitesCapability( item );
+				},
+				RenderModal: createRemoveSiteActionModal( onRefetchSite ),
+				isDestructive: true,
 			},
 			{
 				id: 'issue_license',

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.tsx
@@ -311,6 +311,8 @@ export function useSiteActionsDataViews( {
 			return true;
 		};
 		const getBlogId = ( item: SiteData ) => item.site.value.blog_id;
+		const hasBackup = ( item: SiteData ) => item.site.value.has_backup;
+		const getSiteSlug = ( item: SiteData ) => urlToSlug( item.site.value.url );
 
 		return [
 			{
@@ -402,6 +404,34 @@ export function useSiteActionsDataViews( {
 				callback( items: SiteData[] ) {
 					page( `https://wordpress.com/activity-log/${ getBlogId( items[ 0 ] ) }` );
 					dispatch( recordTracksEvent( getActionEventName( 'view_activity', isLargeScreen ) ) );
+				},
+			},
+			{
+				id: 'clone_site_wpcom',
+				label: translate( 'Copy this site' ),
+				icon: external,
+				isEligible( item: SiteData ) {
+					return isWPComSite( item ) && hasBackup( item ) && ! isUrlOnly( item );
+				},
+				callback( items: SiteData[] ) {
+					page( `https://wordpress.com/backup/${ getSiteSlug( items[ 0 ] ) }/clone` );
+					dispatch( recordTracksEvent( getActionEventName( 'clone_site', isLargeScreen ) ) );
+				},
+			},
+			{
+				id: 'clone_site_not_wpcom',
+				label: translate( 'Copy this site' ),
+				isEligible( item: SiteData ) {
+					return ! isWPComSite( item ) && hasBackup( item ) && ! isUrlOnly( item );
+				},
+				callback( items: SiteData[] ) {
+					setDataViewsState( ( prevState: DataViewsState ) => ( {
+						...prevState,
+						selectedItem: items[ 0 ].site.value,
+						type: DATAVIEWS_LIST,
+					} ) );
+					setSelectedSiteFeature( JETPACK_BACKUP_ID );
+					dispatch( recordTracksEvent( getActionEventName( 'clone_site', isLargeScreen ) ) );
 				},
 			},
 			{

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -54,6 +54,7 @@ export default function SitesDashboard() {
 	const {
 		dataViewsState,
 		setDataViewsState,
+		setSelectedSiteFeature,
 		initialSelectedSiteUrl,
 		selectedSiteFeature,
 		selectedCategory: category,
@@ -288,6 +289,7 @@ export default function SitesDashboard() {
 						isLoading={ isLoading }
 						isLargeScreen={ isLargeScreen || false }
 						setDataViewsState={ setDataViewsState }
+						setSelectedSiteFeature={ setSelectedSiteFeature }
 						dataViewsState={ dataViewsState }
 						onRefetchSite={ refetch }
 					/>

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/interfaces.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/interfaces.ts
@@ -16,6 +16,7 @@ export interface SitesDataViewsProps {
 	isLargeScreen: boolean;
 	isLoading: boolean;
 	setDataViewsState: ( callback: ( prevState: DataViewsState ) => DataViewsState ) => void;
+	setSelectedSiteFeature: ( siteFeature: string | undefined ) => void;
 	dataViewsState: DataViewsState;
 	onRefetchSite?: () => Promise< unknown >;
 }


### PR DESCRIPTION
Depends on https://github.com/Automattic/wp-calypso/pull/98469 and https://github.com/Automattic/wp-calypso/pull/98491
Dependency for https://github.com/Automattic/wp-calypso/pull/96470

## Proposed Changes

This PR removes the Actions field in the A4A/sites screen in favor of using the Actions API.

Actions:

- [x] Prepare for launch
- [x] Set up site
- [x] Change domain
- [x] Hosting configuration
- [x] Issue new license
- [x] View activity
- [x] Copy this site
- [x] Site settings
- [x] View site
- [x] Visit WP Admin
- [x] Remove site
- [x] Delete site

## Why are these changes being made?

While working on updating the packages for calypso (including DataViews), the field-based actions won't work properly in the list view (A4A Sites). https://github.com/Automattic/wp-calypso/pull/96470

By transforming the field-based actions into proper DataViews actions, they'll work fine in the list view and we can proceed with the package update.

## Testing Instructions

See call for testing at p5j4vm-4Z3-p2.

Test via the "Automattic for Agencies" [live link](https://github.com/Automattic/wp-calypso/pull/98276#issuecomment-2587135855) below, or set up a development environment:

- Add `127.0.0.1 agencies.localhost` to your `/etc/hosts` if you don't have it yet.
- Run the agencies using the demo account:

```js
yarn && yarn start-a8c-for-agencies
```
- Visit http://agencies.localhost:3000/sites
- Compare this site with the production site and verify the same actions are listed in the different site types (simple, atomic, developer).

## Screenshots for translation

<img width="414" alt="Screenshot 2025-01-21 at 08 57 58" src="https://github.com/user-attachments/assets/83be9a73-da59-4b03-8ef4-6965ee86f959" />
