### PR TITLE
Domains: Change "I have a domain text" to keep consistency.

### DIFF
--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -46,7 +46,7 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 		line = translate( 'You have no domains added to this site.' );
 		action = translate( 'Search for a domain' );
 		actionURL = domainAddNew( selectedSite.slug );
-		secondaryAction = translate( 'I have a domain' );
+		secondaryAction = translate( 'Use a domain I own' );
 		secondaryActionURL = domainUseMyDomain( selectedSite.slug );
 		contentType = 'paid_plan_with_no_free_domain_credits';
 	}
@@ -74,7 +74,7 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 		}
 		action = translate( 'Search for a domain' );
 		actionURL = domainAddNew( selectedSite.slug );
-		secondaryAction = translate( 'I have a domain' );
+		secondaryAction = translate( 'Use a domain I own' );
 		secondaryActionURL = domainUseMyDomain( selectedSite.slug, {
 			redirectTo: `/domains/manage/${ selectedSite.slug }`,
 		} );

--- a/packages/calypso-e2e/src/lib/pages/domains-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/domains-page.ts
@@ -3,7 +3,7 @@ import { Page } from 'playwright';
 const selectors = {
 	// Domain actions
 	searchForDomainButton: `a:text-matches("search", "i")`,
-	useADomainIOwnButton: `text=I have a domain`,
+	useADomainIOwnButton: `text=Use a domain I own`,
 
 	// Purchased domains
 	purchasedDomains: ( domain: string ) => `div.card:has-text("${ domain }")`,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #95830

## Proposed Changes

* Change text from "I have a domain" to "Use a domain I own" to match the button selector on the top on the page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To keep consistency in `/domains/manage/` page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You need a personal site at minimum, without claiming the free domain.
* Go to Hosting > Domains.
* Check at the botton of the page that the button has the same text than the top selector.

Before:
![Screenshot 2025-01-13 at 15 15 53](https://github.com/user-attachments/assets/09bba4a1-f813-432f-b203-9ffdbd01f999)



After:
![Screenshot 2025-01-13 at 15 14 34](https://github.com/user-attachments/assets/2e213ac9-f4c4-4f60-acc3-5241b4fd605d)

![Screenshot 2025-01-13 at 15 14 37](https://github.com/user-attachments/assets/40ceb08d-7010-4fd1-883b-cf52d6400328)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
