### PR TITLE
fix /me/get-apps link for Studio on mobile

### DIFF
--- a/client/blocks/get-apps/apps-config.tsx
+++ b/client/blocks/get-apps/apps-config.tsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, Substitution } from 'i18n-calypso';
 import Apple from 'calypso/assets/images/icons/apple-logo.svg';
 import DesktopAppLogo from 'calypso/assets/images/icons/desktop-app-logo.svg';
 import Linux from 'calypso/assets/images/icons/linux-logo.svg';
@@ -34,6 +34,7 @@ export interface DesktopAppConfig {
 	logoName: string;
 	title: string;
 	subtitle: string;
+	link: Substitution;
 	platforms: Partial< Record< PlatformType, PlatformConfig > >;
 	isPrimary?: boolean;
 }
@@ -103,6 +104,11 @@ export const createWordPressDesktopConfig = (
 		subtitle: translate(
 			'The full WordPress.com experience packaged as an app for your laptop or desktop.'
 		),
+		link: translate( 'Visit {{a}}desktop.wordpress.com{{/a}} on your desktop.', {
+			components: {
+				a: <a href="https://desktop.wordpress.com" />,
+			},
+		} ),
 		platforms: {
 			[ PlatformType.MacIntel ]: {
 				...platformConfigs[ PlatformType.MacIntel ],
@@ -144,6 +150,11 @@ export const createWordPressStudioConfig = (
 		logoName: 'studio-app-logo',
 		title: translate( 'Studio by WordPress.com' ),
 		subtitle: translate( 'A fast, free way to develop locally with WordPress.' ),
+		link: translate( 'Visit {{a}}developer.wordpress.com/studio{{/a}} on your desktop.', {
+			components: {
+				a: <a href="https://developer.wordpress.com/studio/" />,
+			},
+		} ),
 		isPrimary: true,
 		platforms: {
 			[ PlatformType.MacIntel ]: {

--- a/client/blocks/get-apps/desktop-download-options.tsx
+++ b/client/blocks/get-apps/desktop-download-options.tsx
@@ -39,15 +39,7 @@ export const DesktopDownloadOptions: React.FC< Props > = ( {
 	const translate = useTranslate();
 
 	if ( isMobile ) {
-		return (
-			<div className="get-apps__desktop-link">
-				{ translate( 'Visit {{a}}desktop.wordpress.com{{/a}} on your desktop.', {
-					components: {
-						a: <a href="https://desktop.wordpress.com" />,
-					},
-				} ) }
-			</div>
-		);
+		return <div className="get-apps__desktop-link">{ appConfig.link }</div>;
 	}
 
 	return (

--- a/client/blocks/get-apps/style.scss
+++ b/client/blocks/get-apps/style.scss
@@ -74,10 +74,6 @@ main.get-apps {
 	}
 
 	.get-apps__desktop-link {
-		display: flex;
-		flex-direction: row;
-		align-items: center;
-		gap: 3px;
 		font-size: $font-body-extra-small;
 	}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6983
Follow-up to https://github.com/Automattic/wp-calypso/pull/98159

## Proposed Changes

* Fix link and text shown on mobile for the Studio apps

## Why are these changes being made?

* The wrong link is being shown at the moment

## Testing Instructions

1. On mobile devices:
   * Visit the Get Apps section
   * Verify that the desktop link displays correctly for WordPress.com Desktop
   * Verify that the desktop link displays correctly for Studio by WordPress.com
   * Ensure links are clickable and direct to the correct URLs:
     - WordPress Desktop: https://desktop.wordpress.com
     - Studio: https://developer.wordpress.com/studio/

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
