### PR TITLE
Domain management: Show Add/Edit DNS subpages in site context

### DIFF
--- a/client/hosting/overview/index.tsx
+++ b/client/hosting/overview/index.tsx
@@ -17,6 +17,7 @@ import {
 } from 'calypso/my-sites/domains/domain-management/domain-overview-pane/constants';
 import {
 	DNS_RECORDS,
+	EDIT_DNS_RECORD,
 	ADD_FORWARDING_EMAIL,
 	EDIT_CONTACT_INFO,
 } from 'calypso/my-sites/domains/domain-management/subpage-wrapper/subpages';
@@ -129,6 +130,15 @@ export default function () {
 			domainManagementController.domainManagementSubpageParams( DNS_RECORDS ),
 			domainManagementController.domainManagementDns,
 			domainManagementController.domainManagementSubpageView,
+		],
+	} );
+
+	registerSiteDomainPage( {
+		path: '/overview/site-domain/domain/:domain/dns/edit/:site',
+		controllers: [
+			domainManagementController.domainManagementSubpageParams( EDIT_DNS_RECORD ),
+			domainManagementController.domainManagementDnsEditRecord,
+			domainManagementController.domainManagementPaneView( DOMAIN_OVERVIEW ),
 		],
 	} );
 

--- a/client/hosting/overview/index.tsx
+++ b/client/hosting/overview/index.tsx
@@ -139,7 +139,7 @@ export default function () {
 		controllers: [
 			domainManagementController.domainManagementSubpageParams( ADD_DNS_RECORD ),
 			domainManagementController.domainManagementDnsEditRecord,
-			domainManagementController.domainManagementPaneView( DOMAIN_OVERVIEW ),
+			domainManagementController.domainManagementSubpageView,
 		],
 	} );
 
@@ -148,7 +148,7 @@ export default function () {
 		controllers: [
 			domainManagementController.domainManagementSubpageParams( EDIT_DNS_RECORD ),
 			domainManagementController.domainManagementDnsEditRecord,
-			domainManagementController.domainManagementPaneView( DOMAIN_OVERVIEW ),
+			domainManagementController.domainManagementSubpageView,
 		],
 	} );
 

--- a/client/hosting/overview/index.tsx
+++ b/client/hosting/overview/index.tsx
@@ -17,6 +17,7 @@ import {
 } from 'calypso/my-sites/domains/domain-management/domain-overview-pane/constants';
 import {
 	DNS_RECORDS,
+	ADD_DNS_RECORD,
 	EDIT_DNS_RECORD,
 	ADD_FORWARDING_EMAIL,
 	EDIT_CONTACT_INFO,
@@ -130,6 +131,15 @@ export default function () {
 			domainManagementController.domainManagementSubpageParams( DNS_RECORDS ),
 			domainManagementController.domainManagementDns,
 			domainManagementController.domainManagementSubpageView,
+		],
+	} );
+
+	registerSiteDomainPage( {
+		path: '/overview/site-domain/domain/:domain/dns/add/:site',
+		controllers: [
+			domainManagementController.domainManagementSubpageParams( ADD_DNS_RECORD ),
+			domainManagementController.domainManagementDnsEditRecord,
+			domainManagementController.domainManagementPaneView( DOMAIN_OVERVIEW ),
 		],
 	} );
 

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-record-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-record-header.tsx
@@ -4,8 +4,7 @@ import { translate } from 'i18n-calypso';
 import React, { useMemo } from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import NavigationHeader from 'calypso/components/navigation-header';
-import { domainManagementAllOverview } from 'calypso/my-sites/domains/paths';
-import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
+import { domainManagementAllOverview, domainManagementDns } from 'calypso/my-sites/domains/paths';
 import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';
 import { useSelector } from 'calypso/state';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -46,8 +45,8 @@ const DnsRecordHeader: CustomHeaderComponentType = ( {
 				),
 			},
 			{
-				label: translate( 'Email' ),
-				href: getEmailManagementPath( selectedSiteSlug, selectedDomainName, currentRoute ),
+				label: translate( 'DNS records' ),
+				href: domainManagementDns( selectedSiteSlug, selectedDomainName, currentRoute ),
 			},
 			{
 				label: context === 'add' ? addDnsRecordTitle : editDnsRecordTitle,
@@ -66,7 +65,7 @@ const DnsRecordHeader: CustomHeaderComponentType = ( {
 		}
 
 		return baseNavigationItems;
-	}, [ inSiteContext, selectedDomainName, selectedSiteSlug, site, translate ] );
+	}, [ context, currentRoute, inSiteContext, selectedDomainName, selectedSiteSlug, site ] );
 
 	return (
 		<NavigationHeader

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-record-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-record-header.tsx
@@ -1,8 +1,15 @@
 import { localizeUrl } from '@automattic/i18n-utils';
+import { SiteExcerptData } from '@automattic/sites';
 import { translate } from 'i18n-calypso';
-import React from 'react';
+import React, { useMemo } from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import NavigationHeader from 'calypso/components/navigation-header';
+import { domainManagementAllOverview } from 'calypso/my-sites/domains/paths';
+import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
+import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';
+import { useSelector } from 'calypso/state';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getSite } from 'calypso/state/sites/selectors';
 import { CustomHeaderComponentType } from './custom-header-component-type';
 
 export const addDnsRecordTitle = translate( 'Add a new DNS record' );
@@ -22,36 +29,51 @@ const DnsRecordHeader: CustomHeaderComponentType = ( {
 	selectedDomainName,
 	selectedSiteSlug,
 	context = 'add',
+	inSiteContext,
 } ) => {
+	const site = useSelector( ( state ) => getSite( state, selectedSiteSlug ) as SiteExcerptData );
+	const currentRoute = useSelector( getCurrentRoute );
+
+	const navigationItems = useMemo( () => {
+		const baseNavigationItems = [
+			{
+				label: selectedDomainName,
+				href: domainManagementAllOverview(
+					selectedSiteSlug,
+					selectedDomainName,
+					null,
+					inSiteContext
+				),
+			},
+			{
+				label: translate( 'Email' ),
+				href: getEmailManagementPath( selectedSiteSlug, selectedDomainName, currentRoute ),
+			},
+			{
+				label: context === 'add' ? addDnsRecordTitle : editDnsRecordTitle,
+			},
+		];
+
+		if ( inSiteContext ) {
+			return [
+				{
+					label: site?.name || selectedDomainName,
+					href: `/overview/${ selectedSiteSlug }`,
+					icon: <SiteIcon site={ site } viewType="breadcrumb" disableClick />,
+				},
+				...baseNavigationItems,
+			];
+		}
+
+		return baseNavigationItems;
+	}, [ inSiteContext, selectedDomainName, selectedSiteSlug, site, translate ] );
+
 	return (
 		<NavigationHeader
 			className="navigation-header__breadcrumb"
-			navigationItems={ [
-				{
-					label: selectedDomainName,
-					href: `/domains/manage/all/overview/${ selectedDomainName }/${ selectedSiteSlug }`,
-				},
-				{
-					label: translate( 'DNS records' ),
-					href: `/domains/manage/all/overview/${ selectedDomainName }/dns/${ selectedSiteSlug }`,
-				},
-				{
-					label:
-						context === 'add'
-							? translate( 'Add a new DNS record' )
-							: translate( 'Edit DNS record' ),
-				},
-			] }
+			navigationItems={ navigationItems }
 			title={ translate( 'DNS records' ) }
-			subtitle={ translate( 'DNS records change how your domain works. {a}Learn more{/a}', {
-				components: {
-					a: (
-						<ExternalLink
-							href={ localizeUrl( 'https://wordpress.com/support/domains/custom-dns/' ) }
-						/>
-					),
-				},
-			} ) }
+			subtitle={ addDnsRecordsSubtitle }
 		/>
 	);
 };

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -239,7 +239,9 @@ export function domainManagementDns( siteName, domainName, relativeTo = null ) {
  * @param {string?} relativeTo
  */
 export function domainManagementDnsAddRecord( siteName, domainName, relativeTo = null ) {
-	if ( isUnderDomainManagementOverview( relativeTo ) ) {
+	if ( relativeTo?.startsWith( '/overview/site-domain/' ) ) {
+		return `/overview/site-domain/domain/${ domainName }/dns/add/${ siteName }`;
+	} else if ( isUnderDomainManagementOverview( relativeTo ) ) {
 		return domainManagementOverviewRoot() + '/' + domainName + '/dns/add/' + siteName;
 	}
 

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -254,7 +254,9 @@ export function domainManagementDnsEditRecord(
 ) {
 	let path;
 
-	if ( isUnderDomainManagementOverview( relativeTo ) ) {
+	if ( relativeTo?.startsWith( '/overview/site-domain/' ) ) {
+		path = `/overview/site-domain/domain/${ domainName }/dns/edit/${ siteName }`;
+	} else if ( isUnderDomainManagementOverview( relativeTo ) ) {
 		path = domainManagementOverviewRoot() + '/' + domainName + '/dns/edit/' + siteName;
 	} else {
 		path = domainManagementEditBase( siteName, domainName, 'edit-dns-record', relativeTo );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/98047

## Proposed Changes

* Register paths and show Add/Edit DNS subpages

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Domain management revamp project

## Testing Instructions

- Enable the feature flag by `window.sessionStorage.setItem('flags', 'calypso/all-domain-management')`
- Purchase a blog domain and attach a site with it.
- Now go to `calypso.localhost:3000/sites` and open this site in flyout
- Scroll to bottom and click on the row to open the domain in site context
- Open the DNS Records section and click on the "Manage" button
- Open the context menu of a DNS record and try to edit it, or click on the button on top to add a new DNS record

<img width="1185" alt="Screenshot 2025-01-14 at 19 44 44" src="https://github.com/user-attachments/assets/28ebb040-c6d0-48cc-b74d-a6a67376e1f7" />
<img width="1186" alt="Screenshot 2025-01-14 at 19 45 04" src="https://github.com/user-attachments/assets/f20e8849-c315-4bcd-8a2a-a990ce185606" />




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
