### PR TITLE
Fix/design picker layout

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -19,17 +19,7 @@ $container-padding-large: 48px;
 			padding-inline-start: $container-padding-large;
 			padding-inline-end: $container-padding-large;
 		}
-
-		.setup-container__big-sky-container {
-			position: absolute;
-			top: $container-padding-small;
-			right: $container-padding-small;
-
-			@include break-small {
-				display: none;
-			}
-		}
-
+		
 		.step-container__content {
 			margin-top: 32px;
 		}
@@ -66,7 +56,7 @@ $container-padding-large: 48px;
 		.formatted-header {
 			margin: 0;
 			flex-grow: 1;
-			text-align: start;
+			text-align: center;
 
 			.formatted-header__title {
 				@include onboarding-font-recoleta;
@@ -75,7 +65,7 @@ $container-padding-large: 48px;
 				font-size: 2.15rem; /* stylelint-disable-line scales/font-sizes */
 				font-weight: 400;
 				padding: 0;
-				text-align: start;
+				text-align: center;
 				margin: 0;
 
 				@include break-large {
@@ -85,7 +75,7 @@ $container-padding-large: 48px;
 
 			.formatted-header__subtitle {
 				padding: 0;
-				text-align: start;
+				text-align: center;
 				color: $gray-60;
 				font-size: 1rem;
 				margin: 12px 0 32px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -78,7 +78,7 @@ $container-padding-large: 48px;
 				text-align: center;
 				color: $gray-60;
 				font-size: 1rem;
-				margin: 12px 0 32px;
+				margin: 8px 0 32px;
 				line-height: 24px;
 			}
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -46,7 +46,6 @@ import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
 import { ThemeUpgradeModal as UpgradeModal } from 'calypso/components/theme-upgrade-modal';
 import { ActiveTheme, useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
 import { useIsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-big-sky-eligible';
-import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useExperiment } from 'calypso/lib/explat';
 import { navigate } from 'calypso/lib/navigate';
@@ -931,19 +930,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		navigate( `/setup/site-setup/launch-big-sky?siteSlug=${ siteSlug }&siteId=${ site?.ID }` );
 	}
 
-	const bigSkyButton = isBigSkyEligible && (
-		<>
-			<Button onClick={ onDesignWithAI }>{ translate( 'Design with AI' ) }</Button>
-			<TrackComponentView
-				eventName="calypso_design_picker_big_sky_button_impression"
-				eventProperties={ commonFilterProperties }
-			/>
-		</>
-	);
-
 	const stepContent = (
 		<>
-			<div className="setup-container__big-sky-container">{ bigSkyButton }</div>
 			<UnifiedDesignPicker
 				designs={ designs }
 				locale={ locale }

--- a/packages/components/src/responsive-toolbar-group/style.scss
+++ b/packages/components/src/responsive-toolbar-group/style.scss
@@ -74,7 +74,7 @@
 }
 
 .responsive-toolbar-group__swipe {
-	width: 100%;
+	width: calc(100% + 20px);
 
 	.responsive-toolbar-group__swipe-list {
 		padding: 0 8px;

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -7,11 +7,17 @@
 	justify-content: space-between;
 	flex-direction: column;
 	gap: 10px;
-	margin-bottom: 40px;
+	margin-bottom: 16px;
 
 	@include break-medium {
+		margin-bottom: 24px;
+	}
+
+	@include break-large {
 		flex-direction: row;
-		align-items: flex-end;
+		align-items: center;
+		justify-content: center;
+		margin-bottom: 40px;
 		gap: 24px;
 	}
 
@@ -43,12 +49,8 @@
 				background-color: var(--studio-wordpress-blue);
 			}
 
-			&:hover {
-				opacity: 0.95;
-			}
-
-			&:active {
-				opacity: 0.9;
+			&:hover::before {
+				background-color: var(--studio-wordpress-blue-60);
 			}
 		}
 	}
@@ -86,8 +88,19 @@
 	.design-picker__category-group {
 		display: flex;
 		flex-direction: column;
-		&.grow {
-			flex-grow: 1;
+
+		@include break-large {
+			flex-direction: row;
+			align-items: center;
+			gap: 8px;
+
+			&.design-picker__category-group--flex {
+				flex: 0 0 43%;
+			}
+
+			&.design-picker__category-group--grow {
+				flex-grow: 1;
+			}
 		}
 
 		.design-picker__category-group-content {
@@ -95,6 +108,10 @@
 			align-items: center;
 			flex-wrap: wrap;
 			gap: 8px 16px;
+
+			@include break-large{
+				flex-grow: 1;
+			}
 		}
 	}
 
@@ -117,7 +134,7 @@
 	.design-picker__design-with-ai {
 		display: none;
 		
-		@include break-small {
+		@include break-large {
 			display: block;
 		}
 	}

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -91,7 +91,8 @@
 			gap: 8px;
 
 			&.design-picker__category-group--flex {
-				flex: 0 1 40%;
+				min-width: 480px;
+				display: inline-flex;
 			}
 
 			&.design-picker__category-group--grow {

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -7,11 +7,7 @@
 	justify-content: space-between;
 	flex-direction: column;
 	gap: 10px;
-	margin-bottom: 16px;
-
-	@include break-medium {
-		margin-bottom: 24px;
-	}
+	margin-bottom: 24px;
 
 	@include break-large {
 		flex-direction: row;

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -91,7 +91,7 @@
 			gap: 8px;
 
 			&.design-picker__category-group--flex {
-				flex: 0 0 43%;
+				flex: 0 1 40%;
 			}
 
 			&.design-picker__category-group--grow {
@@ -129,6 +129,9 @@
 
 	.design-picker__design-with-ai {
 		display: none;
+		margin-bottom: 0;
+		padding-top: 6px; // vertically align with filters
+		padding-bottom: 6px;
 		
 		@include break-large {
 			display: block;

--- a/packages/design-picker/src/components/design-preview-image/index.tsx
+++ b/packages/design-picker/src/components/design-preview-image/index.tsx
@@ -61,9 +61,9 @@ const DesignPreviewImage: FC< DesignPreviewImageProps > = ( {
 			alt=""
 			options={ getMShotOptions( {
 				scrollable: false,
-				highRes: ! isMobile,
-				isMobile,
-				oldHighResImageLoading,
+				highRes: true,
+				isMobile: false,
+				oldHighResImageLoading: ! isMobile,
 			} ) }
 			scrollable={ false }
 		/>

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -27,11 +27,21 @@
 	}
 
 	.design-picker__design-card-group {
+		margin-bottom: 24px;
+
+		@include break-medium {
+			margin-bottom: 40px;
+		}
+
+		@include break-large {
+			margin-bottom: 64px;
+		}
+		
 		.design-picker__design-card-title {
 			position: sticky;
 			top: 0;
 			padding: 16px 12px 12px;
-			margin: -16px -12px 0;
+			margin: 0 -12px 0;
 			color: var(--studio-black);
 			background-color: var(--color-body-background);
 			font-size: $font-title-small;
@@ -47,7 +57,11 @@
 		}
 
 		.design-picker__grid {
-			margin-bottom: 32px;
+			margin-bottom: 24px;
+
+			@include break-medium {
+				margin-bottom: 32px;
+			}
 		}
 
 		.theme-card__info {
@@ -57,11 +71,6 @@
 			@include break-small {
 				margin-top: 12px;
 			}
-		}
-
-		.design-picker__design-card-group-footer {
-			margin-top: -12px;
-			margin-bottom: 36px;
 		}
 	}
 
@@ -121,7 +130,7 @@
 			@include break-medium {
 				grid-template-columns: 1fr 1fr;
 				column-gap: 40px;
-				row-gap: 48px;
+				row-gap: 40px;
 			}
 		}
 
@@ -311,11 +320,6 @@
 			}
 		}
 	}
-
-	.design-button-container .design-picker__design-option .design-picker__image-frame:hover::after,
-	.theme-card--is-actionable .theme-card__image:hover::after {
-		background-color: rgba(255, 255, 255, 0.72);
-	}
 }
 
 .design-button-container {
@@ -393,11 +397,12 @@
 
 	.design-picker__grid {
 		@supports ( display: grid ) {
-			row-gap: 48px;
+			row-gap: 24px;
 
 			@include break-medium {
 				grid-template-columns: 1fr 1fr 1fr;
 				column-gap: 40px;
+				row-gap: 40px;
 			}
 		}
 	}

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -52,21 +52,24 @@ $theme-card-info-margin-top: 16px;
 }
 
 .theme-card__image-container {
-	border: 1px solid rgba(0, 0, 0, 0.1);
-	box-shadow: 0 15px 25px rgba(0, 0, 0, 0.05);
+	box-shadow: 0 12px 20px rgba(0, 0, 0, 0.04);
+	border: 1px solid rgba(220,220,222,0.4);
 	overflow: hidden;
 	padding-top: 74%;
 	position: relative;
+	border-radius: 4px;
+	transition: transform 100ms ease-out;
 }
 
 .theme-card--is-actionable {
 	.theme-card__image {
+		transition: transform 300ms ease-in-out;
+		
 		&:hover,
 		&:focus {
-			opacity: 0.9;
+			transform: scale(1.03);
 
 			.theme-card__image-label {
-				opacity: 1;
 				animation: theme-card__image-label 150ms ease-in-out;
 			}
 		}

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -272,16 +272,24 @@ const DesignCardGroup = ( {
 interface DesignPickerFilterGroupProps {
 	title?: string;
 	grow?: boolean;
+	isBigSkyEligible?: boolean;
 	children: React.ReactNode;
 }
 
 const DesignPickerFilterGroup: React.FC< DesignPickerFilterGroupProps > = ( {
 	title,
 	grow,
+	isBigSkyEligible,
 	children,
 } ) => {
 	return (
-		<div className={ clsx( 'design-picker__category-group', { grow } ) }>
+		<div
+			className={ clsx( 'design-picker__category-group', {
+				// eslint-disable-next-line eqeqeq
+				'design-picker__category-group--flex': grow && ! isBigSkyEligible,
+				'design-picker__category-group--grow': isBigSkyEligible,
+			} ) }
+		>
 			<div className="design-picker__category-group-label">{ title }</div>
 			<div className="design-picker__category-group-content">{ children }</div>
 		</div>
@@ -379,7 +387,11 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 					</DesignPickerFilterGroup>
 				) }
 				{ categorization && categoryTopics.length && (
-					<DesignPickerFilterGroup title={ isMultiFilterEnabled ? translate( 'Topic' ) : '' } grow>
+					<DesignPickerFilterGroup
+						title={ isMultiFilterEnabled ? translate( 'Topic' ) : '' }
+						grow={ ! isBigSkyEligible }
+						isBigSkyEligible={ isBigSkyEligible }
+					>
 						<DesignPickerCategoryFilter
 							categories={ isMultiFilterEnabled ? categoryTopics : categorization.categories }
 							onSelect={ categorization.onSelect }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/98176, https://github.com/Automattic/wp-calypso/issues/98170, https://github.com/Automattic/wp-calypso/issues/98283

## Proposed Changes

This PR introduces a number of updates:
- Cleans up and improves the spacing between sections
- Improves the Theme thumbnail quality (they're currently blurry)
- Updates the title alignment of the design picker to match the alignment for all the other screens
- Fixes an issue on mobile where the filters appear cut off
- Fixes an overlapping issue for Big Sky on mobile (in this case, I've removed it temporarily for mobile and will assess a better way to promote big sky on mobile)
- Some quality improvements to rollovers and thumbnail details

**Before: Desktop**

<img width="1611" alt="image" src="https://github.com/user-attachments/assets/e6c23de8-620d-4853-91ba-6518acdec52c" />

<img width="1611" alt="image" src="https://github.com/user-attachments/assets/46ee806b-1fbb-425f-afb2-8c6e209d0a7e" />


**After: Desktop**

<img width="1611" alt="image" src="https://github.com/user-attachments/assets/eeeba36e-f47b-4d1d-986b-e870832da62b" />

<img width="1611" alt="image" src="https://github.com/user-attachments/assets/9e03df8a-0532-478c-a5ac-292025c0e32f" />

**Before: Mobile**

<img width="1493" alt="image" src="https://github.com/user-attachments/assets/246ea83d-5009-46b9-87f4-7d486f12f9f9" />

**After: Mobile**

<img width="1491" alt="image" src="https://github.com/user-attachments/assets/49245c18-3acd-444a-a262-b53d5f3aae6b" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go through our onboarding until you reach the design picker step. Compare it against production. If possible, try upgrade to Premium before viewing the design picker to see the Big sky updates. You can use the following URL after your site is updates (just replace the URL):

`/setup/site-setup/designSetup?siteSlug=aaa4315.wordpress.com&categories=blog%2Cnewsletter%2Cbusiness%2Clink-in-bio`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
