### PR TITLE
Domain management: Show Add new mailbox subpages in site context

### DIFF
--- a/client/hosting/overview/index.tsx
+++ b/client/hosting/overview/index.tsx
@@ -16,6 +16,7 @@ import {
 	EMAIL_MANAGEMENT,
 } from 'calypso/my-sites/domains/domain-management/domain-overview-pane/constants';
 import {
+	ADD_MAILBOX,
 	DNS_RECORDS,
 	ADD_DNS_RECORD,
 	EDIT_DNS_RECORD,
@@ -121,6 +122,15 @@ export default function () {
 		path: '/overview/site-domain/email/:domain/:site',
 		controllers: [
 			emailController.emailManagement,
+			domainManagementController.domainManagementPaneView( EMAIL_MANAGEMENT ),
+		],
+	} );
+
+	registerSiteDomainPage( {
+		path: '/overview/site-domain/email/:domain/titan/new/:site',
+		controllers: [
+			domainManagementController.domainManagementSubpageParams( ADD_MAILBOX ),
+			emailController.emailManagementNewTitanAccount,
 			domainManagementController.domainManagementPaneView( EMAIL_MANAGEMENT ),
 		],
 	} );

--- a/client/hosting/overview/index.tsx
+++ b/client/hosting/overview/index.tsx
@@ -131,7 +131,7 @@ export default function () {
 		controllers: [
 			domainManagementController.domainManagementSubpageParams( ADD_MAILBOX ),
 			emailController.emailManagementNewTitanAccount,
-			domainManagementController.domainManagementPaneView( EMAIL_MANAGEMENT ),
+			domainManagementController.domainManagementSubpageView,
 		],
 	} );
 

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/add-mailbox-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/add-mailbox-header.tsx
@@ -1,33 +1,59 @@
+import { SiteExcerptData } from '@automattic/sites';
 import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import NavigationHeader from 'calypso/components/navigation-header';
-import {
-	domainManagementAllEmailRoot,
-	domainManagementOverviewRoot,
-} from 'calypso/my-sites/domains/paths';
+import { domainManagementOverviewRoot } from 'calypso/my-sites/domains/paths';
+import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
+import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';
+import { useSelector } from 'calypso/state';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getSite } from 'calypso/state/sites/selectors';
 import { CustomHeaderComponentType } from './custom-header-component-type';
 
 const AddMailboxHeader: CustomHeaderComponentType = ( {
 	selectedDomainName,
 	selectedSiteSlug,
+	inSiteContext,
 } ) => {
 	const translate = useTranslate();
+	const site = useSelector( ( state ) => getSite( state, selectedSiteSlug ) as SiteExcerptData );
+	const currentRoute = useSelector( getCurrentRoute );
+
+	const navigationItems = useMemo( () => {
+		const baseNavigationItems = [
+			{
+				label: translate( 'Email' ),
+				href: getEmailManagementPath( selectedSiteSlug, selectedDomainName, currentRoute ),
+			},
+			{
+				label: translate( 'Add new mailbox' ),
+			},
+		];
+
+		if ( inSiteContext ) {
+			return [
+				{
+					label: site?.name || selectedDomainName,
+					href: `/overview/${ selectedSiteSlug }`,
+					icon: <SiteIcon site={ site } viewType="breadcrumb" disableClick />,
+				},
+				...baseNavigationItems,
+			];
+		}
+		return [
+			{
+				label: selectedDomainName,
+				href: `${ domainManagementOverviewRoot() }/${ selectedDomainName }/${ selectedSiteSlug }`,
+			},
+			...baseNavigationItems,
+		];
+	}, [ inSiteContext, selectedDomainName, selectedSiteSlug, site, translate ] );
+
 	return (
 		<>
 			<NavigationHeader
 				className="navigation-header__breadcrumb"
-				navigationItems={ [
-					{
-						label: selectedDomainName,
-						href: `${ domainManagementOverviewRoot() }/${ selectedDomainName }/${ selectedSiteSlug }`,
-					},
-					{
-						label: 'Emails',
-						href: `${ domainManagementAllEmailRoot() }/${ selectedDomainName }/${ selectedSiteSlug }`,
-					},
-					{
-						label: translate( 'Add new mailbox' ),
-					},
-				] }
+				navigationItems={ navigationItems }
 			/>
 			<NavigationHeader
 				className="navigation-header__title"

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/add-mailbox-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/add-mailbox-header.tsx
@@ -22,6 +22,10 @@ const AddMailboxHeader: CustomHeaderComponentType = ( {
 	const navigationItems = useMemo( () => {
 		const baseNavigationItems = [
 			{
+				label: selectedDomainName,
+				href: `${ domainManagementOverviewRoot() }/${ selectedDomainName }/${ selectedSiteSlug }`,
+			},
+			{
 				label: translate( 'Email' ),
 				href: getEmailManagementPath( selectedSiteSlug, selectedDomainName, currentRoute ),
 			},
@@ -40,14 +44,8 @@ const AddMailboxHeader: CustomHeaderComponentType = ( {
 				...baseNavigationItems,
 			];
 		}
-		return [
-			{
-				label: selectedDomainName,
-				href: `${ domainManagementOverviewRoot() }/${ selectedDomainName }/${ selectedSiteSlug }`,
-			},
-			...baseNavigationItems,
-		];
-	}, [ inSiteContext, selectedDomainName, selectedSiteSlug, site, translate ] );
+		return baseNavigationItems;
+	}, [ currentRoute, inSiteContext, selectedDomainName, selectedSiteSlug, site, translate ] );
 
 	return (
 		<>

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -487,7 +487,7 @@ export default function () {
 	);
 
 	page(
-		paths.domainManagementAllEmailRoot() + '/:site/titan/new/:domain',
+		paths.domainManagementAllEmailRoot() + '/:domain/titan/new/:site',
 		siteSelection,
 		navigation,
 		domainManagementController.domainManagementSubpageParams( ADD_MAILBOX ),

--- a/client/my-sites/email/add-mailboxes/index.tsx
+++ b/client/my-sites/email/add-mailboxes/index.tsx
@@ -20,7 +20,9 @@ import { TITAN_PROVIDER_NAME } from 'calypso/lib/titan/constants';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import {
 	domainManagementAllEmailRoot,
+	domainSiteContextRoot,
 	isUnderDomainManagementAll,
+	isUnderDomainSiteContext,
 } from 'calypso/my-sites/domains/paths';
 import AddEmailAddressesCardPlaceholder from 'calypso/my-sites/email/add-mailboxes/add-users-placeholder';
 import EmailProviderPricingNotice from 'calypso/my-sites/email/add-mailboxes/email-provider-pricing-notice';
@@ -328,7 +330,10 @@ const MailboxesForm = ( {
 
 		if ( isUnderDomainManagementAll( currentRoute ) ) {
 			const newEmail = mailboxOperations.mailboxes[ 0 ].getAsCartItem().email;
-			const redirectTo = `${ domainManagementAllEmailRoot() }/${ selectedDomainName }/${ selectedSiteSlug }?new-email=${ newEmail }`;
+			const redirectTo = isUnderDomainSiteContext( currentRoute )
+				? `${ domainSiteContextRoot() }/email/${ selectedDomainName }/${ selectedSiteSlug }?new-email=${ newEmail }`
+				: `${ domainManagementAllEmailRoot() }/${ selectedDomainName }/${ selectedSiteSlug }?new-email=${ newEmail }`;
+
 			checkoutPath += '?redirect_to=' + encodeURIComponent( redirectTo );
 		}
 

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -449,10 +449,10 @@
 /**
  * Context: All Domain Management
  */
-.wpcom-site .hosting-dashboard-item-view__content .context-all-domain-management, /* For Domain and Email related pages under site context. */
+.wpcom-site .hosting-dashboard-layout.sites-dashboard  .hosting-dashboard-item-view__content .context-all-domain-management, /* For Domain and Email related pages under site context. */
 .context-all-domain-management {
 	&.main {
-		margin-left: 0;
+		margin: 0 auto;
 		width: 100%;
 
 		header.domains-email__navigation-header.navigation-header {

--- a/client/my-sites/email/paths.ts
+++ b/client/my-sites/email/paths.ts
@@ -138,7 +138,11 @@ export const getNewTitanAccountPath: EmailPathUtilityFunction = (
 	relativeTo,
 	urlParameters
 ) => {
-	if ( isUnderDomainManagementAll( relativeTo ) ) {
+	if ( relativeTo?.startsWith( '/overview/site-domain/' ) ) {
+		return `/overview/site-domain/email/${ domainName }/titan/new/${ siteName }${ buildQueryString(
+			urlParameters
+		) }`;
+	} else if ( isUnderDomainManagementAll( relativeTo ) ) {
 		return `${ domainsManagementPrefix }/${ domainName }/titan/new/${ siteName }${ buildQueryString(
 			urlParameters
 		) }`;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/98270

## Proposed Changes

- Show the Add Mailbox subpage inside the site context

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Domain Management Revamp project

## Testing Instructions

- Enable the feature flag by `window.sessionStorage.setItem('flags', 'calypso/all-domain-management')`
- Purchase a blog domain and attach a site with it.
- Purchase one or more mailboxes for this domain
- Now go to `calypso.localhost:3000/sites` and open this site in flyout
- Scroll to the bottom and click on the row to open the domain in the site context
- Switch to the Emails tab, and click on the link to add a new email, it should open in the site-context layout when clicked from the site's context
- Check the breadcrumbs link
- Create a mailbox and check the success redirection

<img width="1002" alt="Screenshot 2025-01-14 at 17 52 44" src="https://github.com/user-attachments/assets/7e3092bf-2838-47d4-91fa-34dd5de81b89" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
