### PR TITLE
Storybook: Add required styles for `@automattic/components`

### DIFF
--- a/packages/components/.storybook/preview.js
+++ b/packages/components/.storybook/preview.js
@@ -1,0 +1,1 @@
+import './style.scss';

--- a/packages/components/.storybook/style.scss
+++ b/packages/components/.storybook/style.scss
@@ -1,0 +1,2 @@
+@import '@wordpress/components/build-style/style';
+@import '@automattic/calypso-color-schemes';

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -28,6 +28,10 @@ const CallToAction = () => (
 );
 ```
 
+Some components require CSS styles from `@wordpress/components`, which you will need to load in order for them to appear correctly. Within WordPress, add the `wp-components` stylesheet as a dependency of your plugin's stylesheet. See [wp_enqueue_style documentation](https://developer.wordpress.org/reference/functions/wp_enqueue_style/#parameters) for how to specify dependencies.
+
+In non-WordPress projects, import the `build-style/style.css` file directly, located at `node_modules/@wordpress/components/build-style/style.css`.
+
 ## Development Workflow
 
 This package is developed as part of the Calypso monorepo. Run `yarn`


### PR DESCRIPTION
Related to #76007 #75167

## Proposed Changes

Add required stylesheets for the isolated `@automattic/components` Storybook.

## Why are these changes being made?

`@automattic/components` needs to be usable in other A8C applications, not just in this `wp-calypso` repo. That means we need to ensure that component styles are sufficiently encapsulated for a non-Calypso consumer.

The current root-level Storybook [loads](https://github.com/Automattic/wp-calypso/blob/trunk/.storybook/index.scss) a lot of stylesheets, including styles for the Calypso client and others that are not documented as required in the `@automattic/components` README. This makes it impossible to verify that `@automattic/components` is shipping with sufficient styles/instructions to render reliably in other environments.

## Testing Instructions

`yarn workspace @automattic/components run storybook` and see that some components (e.g. `Button` or `SearchableDropdown`) and see that they are rendering closer to how they are intended.

Note that some styles are still missing — we'll need to start identifying them and filling the gaps. We'll need to figure out how to design our Storybook tooling so we can test that they render reliably in different environments.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
