### PR TITLE
Domains Management Revamp: Show the Add Forward Email subpage in site context

### DIFF
--- a/client/hosting/overview/index.tsx
+++ b/client/hosting/overview/index.tsx
@@ -15,7 +15,10 @@ import {
 	DOMAIN_OVERVIEW,
 	EMAIL_MANAGEMENT,
 } from 'calypso/my-sites/domains/domain-management/domain-overview-pane/constants';
-import { EDIT_CONTACT_INFO } from 'calypso/my-sites/domains/domain-management/subpage-wrapper/subpages';
+import {
+	ADD_FORWARDING_EMAIL,
+	EDIT_CONTACT_INFO,
+} from 'calypso/my-sites/domains/domain-management/subpage-wrapper/subpages';
 import emailController from 'calypso/my-sites/email/controller';
 import {
 	DOTCOM_HOSTING_CONFIG,
@@ -124,6 +127,15 @@ export default function () {
 		controllers: [
 			domainManagementController.domainManagementSubpageParams( EDIT_CONTACT_INFO ),
 			domainManagementController.domainManagementEditContactInfo,
+			domainManagementController.domainManagementSubpageView,
+		],
+	} );
+
+	registerSiteDomainPage( {
+		path: '/overview/site-domain/email/:domain/forwarding/add/:site',
+		controllers: [
+			domainManagementController.domainManagementSubpageParams( ADD_FORWARDING_EMAIL ),
+			emailController.emailManagementAddEmailForwards,
 			domainManagementController.domainManagementSubpageView,
 		],
 	} );

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/add-fowarding-email-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/add-fowarding-email-header.tsx
@@ -1,25 +1,67 @@
+import { SiteExcerptData } from '@automattic/sites';
 import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import NavigationHeader from 'calypso/components/navigation-header';
+import { domainManagementAllOverview } from 'calypso/my-sites/domains/paths';
+import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
+import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';
+import { useSelector } from 'calypso/state';
+import { getSite } from 'calypso/state/sites/selectors';
 import { CustomHeaderComponentType } from './custom-header-component-type';
 
 const AddForwardingEmailHeader: CustomHeaderComponentType = ( {
 	selectedDomainName,
 	selectedSiteSlug,
+	inSiteContext,
 } ) => {
 	const translate = useTranslate();
+	const site = useSelector( ( state ) => getSite( state, selectedSiteSlug ) as SiteExcerptData );
+
+	const navigationItems = useMemo( () => {
+		const baseNavigationItems = [
+			{
+				label: selectedDomainName,
+				href: domainManagementAllOverview(
+					selectedSiteSlug,
+					selectedDomainName,
+					null,
+					inSiteContext
+				),
+			},
+			{
+				label: translate( 'Email' ),
+				href: getEmailManagementPath(
+					selectedDomainName,
+					selectedSiteSlug,
+					null,
+					null,
+					inSiteContext
+				),
+			},
+			{
+				label: translate( 'Contact information' ),
+			},
+		];
+
+		if ( inSiteContext ) {
+			return [
+				{
+					label: site?.name || selectedDomainName,
+					href: `/overview/${ selectedSiteSlug }`,
+					icon: <SiteIcon site={ site } viewType="breadcrumb" disableClick />,
+				},
+				...baseNavigationItems,
+			];
+		}
+
+		return baseNavigationItems;
+	}, [ inSiteContext, selectedDomainName, selectedSiteSlug, site, translate ] );
+
 	return (
 		<>
 			<NavigationHeader
 				className="navigation-header__breadcrumb"
-				navigationItems={ [
-					{
-						label: selectedDomainName,
-						href: `/domains/manage/all/email/${ selectedDomainName }/${ selectedSiteSlug }`,
-					},
-					{
-						label: translate( 'Add email forwarding' ),
-					},
-				] }
+				navigationItems={ navigationItems }
 			/>
 			<NavigationHeader
 				className="navigation-header__title"

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/add-fowarding-email-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/add-fowarding-email-header.tsx
@@ -34,12 +34,12 @@ const AddForwardingEmailHeader: CustomHeaderComponentType = ( {
 					selectedDomainName,
 					selectedSiteSlug,
 					null,
-					null,
+					undefined,
 					inSiteContext
 				),
 			},
 			{
-				label: translate( 'Contact information' ),
+				label: translate( 'Add email forwarding' ),
 			},
 		];
 

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/add-fowarding-email-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/add-fowarding-email-header.tsx
@@ -31,8 +31,8 @@ const AddForwardingEmailHeader: CustomHeaderComponentType = ( {
 			{
 				label: translate( 'Email' ),
 				href: getEmailManagementPath(
-					selectedDomainName,
 					selectedSiteSlug,
+					selectedDomainName,
 					null,
 					undefined,
 					inSiteContext

--- a/client/my-sites/domains/domain-management/subpage-wrapper/test/index.test.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/test/index.test.tsx
@@ -3,14 +3,42 @@
  */
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
 import SubpageWrapper from '../index';
 import { ADD_FORWARDING_EMAIL, ADD_DNS_RECORD, EDIT_DNS_RECORD } from '../subpages';
 
 jest.mock( 'component-file-picker', () => () => <div>File Picker</div> );
 
+const initialState = {
+	sites: {
+		items: {
+			1: {
+				ID: 1,
+				URL: 'example.wordpress.com',
+				plan: {
+					product_slug: 'free_plan',
+				},
+				options: {
+					is_wpforteams_site: false,
+				},
+			},
+		},
+	},
+	ui: {
+		selectedSiteId: 1,
+	},
+};
+
+const mockStore = configureStore();
+const store = mockStore( initialState );
+
+const wrapper = ( { children } ) => <Provider store={ store }>{ children }</Provider>;
+const renderWithWrapper = ( component ) => render( component, { wrapper } );
+
 describe( 'SubpageWrapper', () => {
 	it( 'should render the children', () => {
-		render(
+		renderWithWrapper(
 			<SubpageWrapper
 				subpageKey={ ADD_FORWARDING_EMAIL }
 				siteName="site.com"
@@ -24,7 +52,7 @@ describe( 'SubpageWrapper', () => {
 	} );
 
 	it( 'should render the children with the subpage header', () => {
-		render(
+		renderWithWrapper(
 			<SubpageWrapper
 				subpageKey={ ADD_FORWARDING_EMAIL }
 				siteName="site.com"
@@ -43,7 +71,7 @@ describe( 'SubpageWrapper', () => {
 	} );
 
 	it( 'should render the children without the subpage header', () => {
-		render(
+		renderWithWrapper(
 			<SubpageWrapper subpageKey="non-existent" siteName="site.com" domainName="domain.com">
 				<span>Hello</span>
 			</SubpageWrapper>
@@ -53,7 +81,7 @@ describe( 'SubpageWrapper', () => {
 	} );
 
 	it( 'should render Add DNS subpage breadcrumbs', () => {
-		const { container } = render(
+		const { container } = renderWithWrapper(
 			<SubpageWrapper subpageKey={ ADD_DNS_RECORD } siteName="site.com" domainName="domain.com">
 				<span>Hello</span>
 			</SubpageWrapper>
@@ -68,7 +96,7 @@ describe( 'SubpageWrapper', () => {
 	} );
 
 	it( 'should render Edit DNS subpage breadcrumbs', () => {
-		const { container } = render(
+		const { container } = renderWithWrapper(
 			<SubpageWrapper subpageKey={ EDIT_DNS_RECORD } siteName="site.com" domainName="domain.com">
 				<span>Hello</span>
 			</SubpageWrapper>

--- a/client/my-sites/email/paths.ts
+++ b/client/my-sites/email/paths.ts
@@ -1,6 +1,11 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { stringify } from 'qs';
-import { isUnderDomainManagementAll, domainManagementRoot } from 'calypso/my-sites/domains/paths';
+import {
+	isUnderDomainManagementAll,
+	isUnderDomainSiteContext,
+	domainManagementRoot,
+	domainSiteContextRoot,
+} from 'calypso/my-sites/domains/paths';
 
 type QueryStringParameters = { [ key: string ]: string | undefined };
 
@@ -14,6 +19,7 @@ type EmailPathUtilityFunction = (
 export const emailManagementPrefix = '/email';
 export const emailManagementAllSitesPrefix = '/email/all';
 export const domainsManagementPrefix = '/domains/manage/all/email';
+export const emailSiteContextPrefix = `${ domainSiteContextRoot() }/email`;
 
 export function isUnderEmailManagementAll( path?: string | null ) {
 	return path?.startsWith( emailManagementAllSitesPrefix + '/' );
@@ -78,7 +84,11 @@ export const getAddEmailForwardsPath: EmailPathUtilityFunction = (
 	urlParameters
 ) => {
 	if ( isUnderDomainManagementAll( relativeTo ) ) {
-		return `${ domainsManagementPrefix }/${ domainName }/forwarding/add/${ siteName }${ buildQueryString(
+		const prefix = isUnderDomainSiteContext( relativeTo )
+			? emailSiteContextPrefix
+			: domainsManagementPrefix;
+
+		return `${ prefix }/${ domainName }/forwarding/add/${ siteName }${ buildQueryString(
 			urlParameters
 		) }`;
 	}
@@ -155,13 +165,17 @@ export const getTitanControlPanelRedirectPath: EmailPathUtilityFunction = (
 export const getEmailManagementPath: EmailPathUtilityFunction = (
 	siteName,
 	domainName,
-	relativeTo,
-	urlParameters
+	relativeTo = null,
+	urlParameters = {},
+	inSiteContext = false
 ) => {
-	if ( isEnabled( 'calypso/all-domain-management' ) && isUnderDomainManagementAll( relativeTo ) ) {
-		return `${ domainsManagementPrefix }/${ siteName }/${ domainName }${ buildQueryString(
-			urlParameters
-		) }`;
+	if ( inSiteContext || isUnderDomainManagementAll( relativeTo ) ) {
+		const prefix =
+			inSiteContext || isUnderDomainSiteContext( relativeTo )
+				? emailSiteContextPrefix
+				: domainsManagementPrefix;
+
+		return `${ prefix }/${ domainName }/${ siteName }${ buildQueryString( urlParameters ) }`;
 	}
 
 	return getPath( siteName, domainName, 'manage', relativeTo, urlParameters );

--- a/client/my-sites/email/paths.ts
+++ b/client/my-sites/email/paths.ts
@@ -13,7 +13,8 @@ type EmailPathUtilityFunction = (
 	siteName: string | null | undefined,
 	domainName?: string | null,
 	relativeTo?: string | null,
-	urlParameters?: QueryStringParameters
+	urlParameters?: QueryStringParameters,
+	inSiteContext?: boolean
 ) => string;
 
 export const emailManagementPrefix = '/email';

--- a/client/my-sites/email/test/paths.ts
+++ b/client/my-sites/email/test/paths.ts
@@ -43,6 +43,11 @@ describe( 'path helper functions', () => {
 		expect( getAddEmailForwardsPath( ':site', ':domain', domainsManagementPrefix ) ).toEqual(
 			'/domains/manage/all/email/:domain/forwarding/add/:site'
 		);
+
+		const relativeTo = '/overview/site-domain/email';
+		expect( getAddEmailForwardsPath( siteName, domainName, relativeTo ) ).toEqual(
+			`/overview/site-domain/email/${ domainName }/forwarding/add/${ siteName }`
+		);
 	} );
 
 	it( 'getAddGSuiteUsersPath', () => {
@@ -135,6 +140,16 @@ describe( 'path helper functions', () => {
 		expect( getEmailManagementPath( ':site' ) ).toEqual( '/email/:site' );
 		expect( getEmailManagementPath( siteName, null ) ).toEqual( `/email/${ siteName }` );
 		expect( getEmailManagementPath( null, null ) ).toEqual( '/email' );
+
+		const relativeTo = '/domains/manage/all/email';
+		expect( getEmailManagementPath( siteName, domainName, relativeTo ) ).toEqual(
+			`/domains/manage/all/email/${ domainName }/${ siteName }`
+		);
+
+		const inSiteContext = true;
+		expect( getEmailManagementPath( siteName, domainName, relativeTo, {}, inSiteContext ) ).toEqual(
+			`/overview/site-domain/email/${ domainName }/${ siteName }`
+		);
 	} );
 
 	it( 'getForwardingPath', () => {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/98048

## Proposed Changes

* Show the Add Forward Email subpage in the site context.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of the Domain Management Revamp project: pfuQfP-13x-p2.

## Testing Instructions

* Apply this PR to your local.
* Go to http://calypso.localhost:3000/sites?flags=calypso/all-domain-management.
* Click on a site with a domain previously configured and without email configured.
* Scroll down to the domains table and click on the domain.
* You should see the domain overview page within the site context.
* Click on the Emails tab.
* Scroll down and click to add a Forwarding Email.
* You should be redirected to the Add Forwarding Email subpage within the site context.
* Add a forwarding email and click to submit.
* You should be redirected back to the email tab.
* Go back to the Add Forwarding Email page.
* Click to cancel.
* You should also be redirected to the email tab.
* Go back to the Add Forwarding Email page.
* Navigate using the breadcrumb and see the items behave as expected.
* The navigation should happen within the site context.
* Perform regression tests on the Add Forwarding Email page in the domain context.
* Perform regression tests on the Add Forwarding Email page in the old layout.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?