### PR TITLE
Performance Profiler: Add a guard to prevent invalid performance urls from being saved.

### DIFF
--- a/client/hosting/performance/hooks/usePerformanceReport.ts
+++ b/client/hosting/performance/hooks/usePerformanceReport.ts
@@ -4,6 +4,12 @@ import { useUrlPerformanceInsightsQuery } from 'calypso/data/site-profiler/use-u
 import { TabType } from 'calypso/performance-profiler/components/header';
 
 function isValidURL( url: string ) {
+    try {
+        new URL(url);
+        return true;
+    } catch {
+        return false;
+    }
 	return /^(https?:\/\/)?([a-z0-9-]+\.)+[a-z]{2,}(:[0-9]{1,5})?(\/[^\s]*)?$/i.test( url );
 }
 

--- a/client/hosting/performance/hooks/usePerformanceReport.ts
+++ b/client/hosting/performance/hooks/usePerformanceReport.ts
@@ -1,17 +1,8 @@
+import { URL } from 'url';
 import { useState, useCallback, useEffect } from 'react';
 import { useUrlBasicMetricsQuery } from 'calypso/data/site-profiler/use-url-basic-metrics-query';
 import { useUrlPerformanceInsightsQuery } from 'calypso/data/site-profiler/use-url-performance-insights';
 import { TabType } from 'calypso/performance-profiler/components/header';
-
-function isValidURL( url: string ) {
-    try {
-        new URL(url);
-        return true;
-    } catch {
-        return false;
-    }
-	return /^(https?:\/\/)?([a-z0-9-]+\.)+[a-z]{2,}(:[0-9]{1,5})?(\/[^\s]*)?$/i.test( url );
-}
 
 export const usePerformanceReport = (
 	setIsSavingPerformanceReportUrl: ( isSaving: boolean ) => void,
@@ -39,7 +30,7 @@ export const usePerformanceReport = (
 	const { final_url: finalUrl, token } = basicMetrics || {};
 
 	useEffect( () => {
-		if ( token && finalUrl && isValidURL( finalUrl ) ) {
+		if ( token && finalUrl && URL.canParse( finalUrl ) ) {
 			setIsSavingPerformanceReportUrl( true );
 			savePerformanceReportUrl( currentPageId, { url: finalUrl, hash: token } )
 				.then( () => {

--- a/client/hosting/performance/hooks/usePerformanceReport.ts
+++ b/client/hosting/performance/hooks/usePerformanceReport.ts
@@ -1,0 +1,110 @@
+import { useState, useCallback, useEffect } from 'react';
+import { useUrlBasicMetricsQuery } from 'calypso/data/site-profiler/use-url-basic-metrics-query';
+import { useUrlPerformanceInsightsQuery } from 'calypso/data/site-profiler/use-url-performance-insights';
+import { TabType } from 'calypso/performance-profiler/components/header';
+
+function isValidURL( url: string ) {
+	return /^(https?:\/\/)?([a-z0-9-]+\.)+[a-z]{2,}(:[0-9]{1,5})?(\/[^\s]*)?$/i.test( url );
+}
+
+export const usePerformanceReport = (
+	setIsSavingPerformanceReportUrl: ( isSaving: boolean ) => void,
+	refetchPages: () => void,
+	savePerformanceReportUrl: (
+		pageId: string,
+		wpcom_performance_report_url: { url: string; hash: string }
+	) => Promise< void >,
+	currentPageId: string,
+	wpcom_performance_report_url: { url: string; hash: string } | undefined,
+	activeTab: TabType
+) => {
+	const { url = '', hash = '' } = wpcom_performance_report_url || {};
+
+	const [ retestState, setRetestState ] = useState( 'idle' );
+
+	const {
+		data: basicMetrics,
+		isError: isBasicMetricsError,
+		isFetched: isBasicMetricsFetched,
+		isLoading: isLoadingBasicMetrics,
+		refetch: requeueAdvancedMetrics,
+	} = useUrlBasicMetricsQuery( url, hash, true );
+
+	const { final_url: finalUrl, token } = basicMetrics || {};
+
+	useEffect( () => {
+		if ( token && finalUrl && isValidURL( finalUrl ) ) {
+			setIsSavingPerformanceReportUrl( true );
+			savePerformanceReportUrl( currentPageId, { url: finalUrl, hash: token } )
+				.then( () => {
+					refetchPages();
+				} )
+				.finally( () => {
+					setIsSavingPerformanceReportUrl( false );
+				} );
+		}
+		// We only want to run this effect when the token changes.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ token ] );
+
+	const {
+		data,
+		status: insightsStatus,
+		isError: isInsightsError,
+		isLoading: isLoadingInsights,
+	} = useUrlPerformanceInsightsQuery( url, token ?? hash );
+
+	const performanceInsights = data?.pagespeed;
+
+	const mobileReport =
+		typeof performanceInsights?.mobile === 'string' ? undefined : performanceInsights?.mobile;
+	const desktopReport =
+		typeof performanceInsights?.desktop === 'string' ? undefined : performanceInsights?.desktop;
+
+	const performanceReport = activeTab === 'mobile' ? mobileReport : desktopReport;
+
+	const desktopLoaded = typeof performanceInsights?.desktop === 'object';
+	const mobileLoaded = typeof performanceInsights?.mobile === 'object';
+
+	const getHashOrToken = (
+		hash: string | undefined,
+		token: string | undefined,
+		isReportLoaded: boolean
+	) => {
+		if ( hash ) {
+			return hash;
+		} else if ( token && isReportLoaded ) {
+			return token;
+		}
+		return '';
+	};
+
+	const testAgain = useCallback( async () => {
+		setRetestState( 'queueing-advanced' );
+		const result = await requeueAdvancedMetrics();
+		setRetestState( 'polling-for-insights' );
+		return result;
+	}, [ requeueAdvancedMetrics ] );
+
+	if (
+		retestState === 'polling-for-insights' &&
+		insightsStatus === 'success' &&
+		( activeTab === 'mobile' ? mobileLoaded : desktopLoaded )
+	) {
+		setRetestState( 'idle' );
+	}
+
+	return {
+		performanceReport,
+		url: finalUrl ?? url,
+		hash: getHashOrToken( hash, token, activeTab === 'mobile' ? mobileLoaded : desktopLoaded ),
+		isLoading:
+			isLoadingBasicMetrics ||
+			isLoadingInsights ||
+			( activeTab === 'mobile' ? ! mobileLoaded : ! desktopLoaded ),
+		isError: isBasicMetricsError || isInsightsError,
+		isBasicMetricsFetched,
+		testAgain,
+		isRetesting: retestState !== 'idle',
+	};
+};

--- a/client/hosting/performance/hooks/usePerformanceReport.ts
+++ b/client/hosting/performance/hooks/usePerformanceReport.ts
@@ -1,8 +1,14 @@
-import { URL } from 'url';
 import { useState, useCallback, useEffect } from 'react';
 import { useUrlBasicMetricsQuery } from 'calypso/data/site-profiler/use-url-basic-metrics-query';
 import { useUrlPerformanceInsightsQuery } from 'calypso/data/site-profiler/use-url-performance-insights';
 import { TabType } from 'calypso/performance-profiler/components/header';
+
+function isValidURL( url: string ) {
+	if ( 'canParse' in URL ) {
+		return URL.canParse( url );
+	}
+	return /^(https?:\/\/)?([a-z0-9-]+\.)+[a-z]{2,}(:[0-9]{1,5})?(\/[^\s]*)?$/i.test( url );
+}
 
 export const usePerformanceReport = (
 	setIsSavingPerformanceReportUrl: ( isSaving: boolean ) => void,
@@ -30,7 +36,7 @@ export const usePerformanceReport = (
 	const { final_url: finalUrl, token } = basicMetrics || {};
 
 	useEffect( () => {
-		if ( token && finalUrl && URL.canParse( finalUrl ) ) {
+		if ( token && finalUrl && isValidURL( finalUrl ) ) {
 			setIsSavingPerformanceReportUrl( true );
 			savePerformanceReportUrl( currentPageId, { url: finalUrl, hash: token } )
 				.then( () => {

--- a/client/hosting/performance/test/use-performance-report.test.ts
+++ b/client/hosting/performance/test/use-performance-report.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useUrlBasicMetricsQuery } from 'calypso/data/site-profiler/use-url-basic-metrics-query';
+import { useUrlPerformanceInsightsQuery } from 'calypso/data/site-profiler/use-url-performance-insights';
+import { usePerformanceReport } from '../hooks/usePerformanceReport';
+
+jest.mock( 'calypso/data/site-profiler/use-url-basic-metrics-query' );
+jest.mock( 'calypso/data/site-profiler/use-url-basic-metrics-query' );
+jest.mock( 'calypso/data/site-profiler/use-url-performance-insights' );
+
+describe( 'usePerformanceReport', () => {
+	const mockSetIsSaving = jest.fn();
+	const mockRefetchPages = jest.fn();
+	const mockSavePerformanceReportUrl = jest.fn().mockResolvedValue( undefined );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		( useUrlBasicMetricsQuery as jest.Mock ).mockReturnValue( {
+			data: null,
+			isError: false,
+			isFetched: false,
+			isLoading: false,
+			refetch: jest.fn(),
+		} );
+
+		( useUrlPerformanceInsightsQuery as jest.Mock ).mockReturnValue( {
+			data: null,
+			status: 'idle',
+			isError: false,
+			isLoading: false,
+		} );
+	} );
+
+	it( 'should not call savePerformanceReportUrl when finalUrl is not a valid URL but token exists', () => {
+		( useUrlBasicMetricsQuery as jest.Mock ).mockReturnValue( {
+			data: {
+				final_url: 'false',
+				token: 'some-token',
+			},
+			isError: false,
+			isFetched: true,
+			isLoading: false,
+			refetch: jest.fn(),
+		} );
+
+		renderHook( () =>
+			usePerformanceReport(
+				mockSetIsSaving,
+				mockRefetchPages,
+				mockSavePerformanceReportUrl,
+				'123',
+				{ url: 'test.com', hash: 'test-hash' },
+				'mobile'
+			)
+		);
+
+		expect( mockSavePerformanceReportUrl ).not.toHaveBeenCalled();
+		expect( mockSetIsSaving ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should call savePerformanceReportUrl when finalUrl is a valid URL and token exists', () => {
+		// Mock the basic metrics query to return valid finalUrl and token
+		( useUrlBasicMetricsQuery as jest.Mock ).mockReturnValue( {
+			data: {
+				final_url: 'https://final-url.com',
+				token: 'valid-token',
+			},
+			isError: false,
+			isFetched: true,
+			isLoading: false,
+			refetch: jest.fn(),
+		} );
+
+		renderHook( () =>
+			usePerformanceReport(
+				mockSetIsSaving,
+				mockRefetchPages,
+				mockSavePerformanceReportUrl,
+				'123',
+				{ url: 'test.com', hash: 'test-hash' },
+				'mobile'
+			)
+		);
+
+		expect( mockSavePerformanceReportUrl ).toHaveBeenCalledWith( '123', {
+			url: 'https://final-url.com',
+			hash: 'valid-token',
+		} );
+		expect( mockSetIsSaving ).toHaveBeenCalledWith( true );
+	} );
+} );


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/97206

## Proposed Changes
There are times when the `final_url` returned from the basic metric endpoint is `false` and this cause an issue where the `performance_url` is saved as `https://false&hash=` this results in the user being unable to rerun the report without first clearing the invalid url from the database. This issue so far is not reproducible but this PR adds a `guard` to prevent the invalid url from being saved.

* check that url is valid before saving.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To mitigate against invalid urls being saved as reported by some users.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure you are still able to run performance report at `/sites/performance`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
