### PR TITLE
Reader Profile: Add empty user profile content

### DIFF
--- a/client/reader/user-stream/index.tsx
+++ b/client/reader/user-stream/index.tsx
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
@@ -26,6 +27,8 @@ type UserStreamState = {
 };
 
 export function UserStream( { userId, requestUser, user, streamKey, isLoading }: UserStreamProps ) {
+	const translate = useTranslate();
+
 	useEffect( () => {
 		requestUser( userId );
 	}, [ userId, requestUser ] );
@@ -38,9 +41,9 @@ export function UserStream( { userId, requestUser, user, streamKey, isLoading }:
 		return (
 			<EmptyContent
 				illustration="/calypso/images/illustrations/illustration-404.svg"
-				title="Uh oh. User not found."
-				line="Sorry, the user you were looking for could not be found."
-				action="Return to Reader"
+				title={ translate( 'Uh oh. User not found.' ) }
+				line={ translate( 'Sorry, the user you were looking for could not be found.' ) }
+				action={ translate( 'Return to Reader' ) }
 				actionURL="/read"
 				className="user-profile__404"
 			/>

--- a/client/reader/user-stream/index.tsx
+++ b/client/reader/user-stream/index.tsx
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
 import { useEffect } from 'react';
 import { connect } from 'react-redux';
+import EmptyContent from 'calypso/components/empty-content';
 import { UserData } from 'calypso/lib/user/user';
 import UserLists from 'calypso/reader/user-stream/views/lists';
 import UserPosts from 'calypso/reader/user-stream/views/posts';
@@ -29,8 +30,21 @@ export function UserStream( { userId, requestUser, user, streamKey, isLoading }:
 		requestUser( userId );
 	}, [ userId, requestUser ] );
 
-	if ( isLoading || ! user ) {
+	if ( isLoading ) {
 		return <></>;
+	}
+
+	if ( ! user ) {
+		return (
+			<EmptyContent
+				illustration="/calypso/images/illustrations/illustration-404.svg"
+				title="Uh oh. User not found."
+				line="Sorry, the user you were looking for could not be found."
+				action="Return to Reader"
+				actionURL="/read"
+				className="user-profile__404"
+			/>
+		);
 	}
 
 	const currentPath = page.current;

--- a/client/reader/user-stream/style.scss
+++ b/client/reader/user-stream/style.scss
@@ -5,6 +5,12 @@
 		}
 	}
 
+	.user-profile__404.empty-content {
+		max-width: initial;
+		margin: initial;
+		padding-top: initial;
+	}
+
 	div.user-profile__content {
 		main.main.is-user-stream {
 			padding: 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pe7F0s-2nU-p2

## Proposed Changes

* If a user does not exist, display an empty content message.

Before | After
--|--
<img width="1718" alt="Screenshot 2025-01-13 at 3 00 50 PM" src="https://github.com/user-attachments/assets/842cc57d-3e76-4626-a631-401a5f7b0fd1" />  | <img width="1720" alt="Screenshot 2025-01-13 at 3 01 08 PM" src="https://github.com/user-attachments/assets/8224c556-bdd4-4016-9c19-082e0772604a" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* I expect the user profile URL will be directly manipulated often, so having empty content when a user does not exist will improve the user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to a user profile that exists /read/users/1351218 - Confirm it continues to work
* Go to a user profile that does not exist /read/users/1351x218 - Confirm you see the empty content message

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?