### PR TITLE
Performance Profiler: Fix continuous loader being shown

### DIFF
--- a/client/hosting/performance/hooks/usePerformanceReport.ts
+++ b/client/hosting/performance/hooks/usePerformanceReport.ts
@@ -59,6 +59,8 @@ export const usePerformanceReport = (
 
 	const performanceInsights = data?.pagespeed;
 
+	const isReportFailed = ( report: unknown ) => report === 'failed';
+
 	const mobileReport =
 		typeof performanceInsights?.mobile === 'string' ? undefined : performanceInsights?.mobile;
 	const desktopReport =
@@ -66,8 +68,16 @@ export const usePerformanceReport = (
 
 	const performanceReport = activeTab === 'mobile' ? mobileReport : desktopReport;
 
-	const desktopLoaded = typeof performanceInsights?.desktop === 'object';
-	const mobileLoaded = typeof performanceInsights?.mobile === 'object';
+	const desktopLoaded =
+		typeof performanceInsights?.desktop === 'object' || performanceInsights?.desktop === 'failed';
+	const mobileLoaded =
+		typeof performanceInsights?.mobile === 'object' || performanceInsights?.mobile === 'failed';
+
+	const isError =
+		isBasicMetricsError ||
+		isInsightsError ||
+		isReportFailed( performanceInsights?.mobile ) ||
+		isReportFailed( performanceInsights?.desktop );
 
 	const getHashOrToken = (
 		hash: string | undefined,
@@ -105,7 +115,7 @@ export const usePerformanceReport = (
 			isLoadingBasicMetrics ||
 			isLoadingInsights ||
 			( activeTab === 'mobile' ? ! mobileLoaded : ! desktopLoaded ),
-		isError: isBasicMetricsError || isInsightsError,
+		isError,
 		isBasicMetricsFetched,
 		testAgain,
 		isRetesting: retestState !== 'idle',

--- a/client/hosting/performance/test/use-performance-report.test.ts
+++ b/client/hosting/performance/test/use-performance-report.test.ts
@@ -92,4 +92,65 @@ describe( 'usePerformanceReport', () => {
 		} );
 		expect( mockSetIsSaving ).toHaveBeenCalledWith( true );
 	} );
+
+	it( 'should set isLoading=false and isError=true when report fails', () => {
+		( useUrlPerformanceInsightsQuery as jest.Mock ).mockReturnValue( {
+			data: {
+				pagespeed: {
+					mobile: 'failed',
+					desktop: 'failed',
+				},
+			},
+			status: 'success',
+			isError: false,
+			isLoading: false,
+		} );
+
+		const { result } = renderHook( () =>
+			usePerformanceReport(
+				mockSetIsSaving,
+				mockRefetchPages,
+				mockSavePerformanceReportUrl,
+				'123',
+				{ url: 'test.com', hash: 'test-hash' },
+				'mobile'
+			)
+		);
+
+		expect( result.current.isLoading ).toBe( false );
+		expect( result.current.isError ).toBe( true );
+	} );
+
+	it( 'should handle successful report correctly', () => {
+		( useUrlPerformanceInsightsQuery as jest.Mock ).mockReturnValue( {
+			data: {
+				pagespeed: {
+					mobile: {
+						performance: 90,
+					},
+					desktop: {
+						performance: 85,
+					},
+				},
+			},
+			status: 'success',
+			isError: false,
+			isLoading: false,
+		} );
+
+		const { result } = renderHook( () =>
+			usePerformanceReport(
+				mockSetIsSaving,
+				mockRefetchPages,
+				mockSavePerformanceReportUrl,
+				'123',
+				{ url: 'test.com', hash: 'test-hash' },
+				'mobile'
+			)
+		);
+
+		expect( result.current.isLoading ).toBe( false );
+		expect( result.current.isError ).toBe( false );
+		expect( result.current.performanceReport?.performance ).toEqual( 90 );
+	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/10107

## Proposed Changes
This issue is not easily reproducible without modifying the backend result to return the error state, what's happening is that the performance report end point can sometimes return report in a "failed" state i.e instead of the report being an object it is a string with `failed`, we did not account for this so when it happens the the report is not flagged as in an error state and the `Getting report..` loader continues to be shown instead of showing the error and allowing the user to retry.

* Check for those `failed` report and remove the loader to show the error message.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites/performance`
* Use chrome dev-tools to override content
* Find the `/site-profiler/metrics/advanced/insights` endpoint, right click and override content
* Set content similar to what's shown in the image below
![image](https://github.com/user-attachments/assets/47409a02-6b5b-45c9-b618-f4e2a37a51d2)
* On prod, the `Getting report..` loader keeps showing
* Apply fix and you should see the error banner



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
