### PR TITLE
Fix padding in the Agency Tiers celebration modal on Safari

### DIFF
--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/celebration-modal/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/celebration-modal/style.scss
@@ -92,6 +92,7 @@ $announcement-blue: #032836;
 		flex-direction: column;
 		padding-block-end: 16px;
 		padding-inline-end: 0;
+		z-index: 1; // Place modal content above the overlapping video on Safari
 	}
 
 	.a4a-themed-modal__sidebar-image-container {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Adds an explicit `z-index: 1` to celebration modal content

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The agency tier celebration modal looks like this on Safari.

![CleanShot 2025-01-14 at 14 06 47@2x](https://github.com/user-attachments/assets/1377a2d0-43af-410d-b27e-8100550cb48c)

The video on the left of the modal is intentionally oversized so that the video goes right to the margins of the modal. However on Safari the oversized video goes overtop of the modal's text content box. On Chrome the video element has an implicit `overflow-clip-margin: content-box` rule, but the rule isn't supported on Safari. So maybe that's it?

Adding an explicit `z-index` ensures the text content box sits on top of the oversized video.

![CleanShot 2025-01-14 at 14 30 03@2x](https://github.com/user-attachments/assets/9494f27c-f2cc-40cb-af69-898ac35c60c2)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The modal appears as soon as you land on the agency dashboard: `agencies.automattic.com`

Here's the instructions for dev'ing on the agency dashboard locally
https://github.com/Automattic/wp-calypso/blob/c4d80f4740eaf1f1e571c28a070b821850142916/client/a8c-for-agencies/README.md#L3

If you've seen the modal in the past and dismissed it then the modal won't appear automatically. In this case you can clear the saved preference which prevents the modal from appearing.
![CleanShot 2025-01-14 at 14 15 58@2x](https://github.com/user-attachments/assets/36a3f0cb-c0c6-45ff-8e4b-66fd9cdf2d30)

If the modal _still_ isn't appearing during testing, you might need to hard code this logic which prevents the modal appearing for users who are already using the new "agency tier" feature. https://github.com/Automattic/wp-calypso/blob/c4d80f4740eaf1f1e571c28a070b821850142916/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/celebration-modal/index.tsx#L69-L73

Ensure the modal still looks correct in Safari, Chrome, and FF

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
