### PR TITLE
Stats: Store date range shortcut and chart period by site

### DIFF
--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -6,6 +6,8 @@ import qs from 'qs';
 import { findShortcutForRange } from 'calypso/components/date-range/use-shortcuts';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useSelector } from 'calypso/state';
+import getSiteId from 'calypso/state/sites/selectors/get-site-id';
 import DateControl from '../date-control';
 import { DateRangePickerShortcut } from '../date-range/shortcuts';
 
@@ -89,6 +91,7 @@ const StatsDateControl = ( {
 
 	const moment = useLocalizedMoment();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	const siteId = useSelector( ( state ) => getSiteId( state, slug ) );
 
 	/**
 	 * Remove start date from query params if it's out of range.
@@ -156,7 +159,13 @@ const StatsDateControl = ( {
 		} );
 
 		if ( appliedShortcut && appliedShortcut.id ) {
-			localStorage.setItem( 'jetpack_stats_stored_date_range_shortcut_id', appliedShortcut.id );
+			localStorage.setItem(
+				`jetpack_stats_stored_date_range_shortcut_id_${ siteId }`,
+				appliedShortcut.id
+			);
+			// Remove legacy item key.
+			localStorage.removeItem( 'jetpack_stats_stored_date_range_shortcut_id' );
+
 			// Apply the period from the found shortcut.
 			period = appliedShortcut.period;
 		}

--- a/client/components/stats-interval-dropdown/index.jsx
+++ b/client/components/stats-interval-dropdown/index.jsx
@@ -6,8 +6,10 @@ import clsx from 'clsx';
 import { capitalize } from 'lodash';
 import qs from 'qs';
 import { useRef } from 'react';
-import './style.scss';
 import useOutsideClickCallback from 'calypso/lib/use-outside-click-callback';
+import { useSelector } from 'calypso/state';
+import getSiteId from 'calypso/state/sites/selectors/get-site-id';
+import './style.scss';
 
 const StatsIntervalDropdownListing = ( {
 	selected,
@@ -80,6 +82,8 @@ const IntervalDropdown = ( { slug, period, queryParams, intervals, onGatedHandle
 	// New interval listing that preserves date range.
 	// TODO: Figure out how to dismiss on select.
 
+	const siteId = useSelector( ( state ) => getSiteId( state, slug ) );
+
 	function generateNewLink( newPeriod ) {
 		const newRangeQuery = qs.stringify( Object.assign( {}, queryParams, {} ), {
 			addQueryPrefix: true,
@@ -101,7 +105,9 @@ const IntervalDropdown = ( { slug, period, queryParams, intervals, onGatedHandle
 			return;
 		}
 
-		localStorage.setItem( 'jetpack_stats_stored_period', interval );
+		localStorage.setItem( `jetpack_stats_stored_period_${ siteId }`, interval );
+		// Remove legacy item key.
+		localStorage.removeItem( 'jetpack_stats_stored_period' );
 
 		page( generateNewLink( interval ) );
 	}

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -291,9 +291,11 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	const getValidDateOrNullFromInput = ( inputDate, inputKey ) => {
 		// Use the stored chartStart and chartEnd if they are valid when the inputDate is absent.
 		if ( inputDate === undefined ) {
-			const appliedShortcutId = localStorage.getItem(
-				'jetpack_stats_stored_date_range_shortcut_id'
-			);
+			const appliedShortcutId =
+				localStorage.getItem( `jetpack_stats_stored_date_range_shortcut_id_${ siteId }` ) ||
+				// Fallback for the compatibility.
+				localStorage.getItem( 'jetpack_stats_stored_date_range_shortcut_id' );
+
 			const appliedShortcut = supportedShortcutList.find(
 				( shortcut ) => shortcut.id === appliedShortcutId
 			);

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -342,7 +342,9 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 
 	useEffect( () => {
 		// Use the stored period if it's different from the current period.
-		const storedPeriod = localStorage.getItem( 'jetpack_stats_stored_period' );
+		const storedPeriod =
+			localStorage.getItem( `jetpack_stats_stored_period_${ siteId }` ) ||
+			localStorage.getItem( 'jetpack_stats_stored_period' );
 		if (
 			hasSiteLoadedFeatures &&
 			! shouldForceDefaultPeriod &&


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1736489258690049-slack-C82FZ5T4G

## Proposed Changes

* Store the applied date range shortcut ID to LocalStorage **_by site_**
* Store the applied chart period to LocalStorage **_by site_**

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The current stored date range shortcut and chart period are shared between all sites, which might not be adaptable to users having many sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Ensure the previous stored date range shortcut is still applied.
* Choose and apply another date range shortcut.
* Ensure the shortcut works well after refreshing the Traffic page.
* Go to the Traffic page of another site on Calypso.
* Choose and apply another date range shortcut.
* Ensure the applied shortcut does not change the stored date range shortcut of the last step.
* Test for stored chart period as well by the steps above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?