### PR TITLE
A4A > Signup: Disable the submit button during form validation

### DIFF
--- a/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
@@ -131,11 +131,13 @@ export default function AgencyDetailsForm( {
 		]
 	);
 
+	const isRequestInProgress = isLoading || isValidating;
+
 	const handleSubmit = useCallback(
 		async ( e: React.SyntheticEvent ) => {
 			e.preventDefault();
 
-			if ( ! showCountryFields || isLoading ) {
+			if ( ! showCountryFields || isRequestInProgress ) {
 				return;
 			}
 
@@ -154,7 +156,7 @@ export default function AgencyDetailsForm( {
 
 			onSubmit( payload );
 		},
-		[ showCountryFields, isLoading, onSubmit, payload, validate ]
+		[ showCountryFields, isRequestInProgress, onSubmit, payload, validate ]
 	);
 
 	const getServicesOfferedOptions = () => {
@@ -240,7 +242,7 @@ export default function AgencyDetailsForm( {
 								setFirstName( event.target.value );
 								updateValidationError( { firstName: undefined } );
 							} }
-							disabled={ isLoading }
+							disabled={ isRequestInProgress }
 						/>
 						<div
 							className={ clsx( 'agency-details-form__footer-error', {
@@ -262,7 +264,7 @@ export default function AgencyDetailsForm( {
 								setLastName( event.target.value );
 								updateValidationError( { lastName: undefined } );
 							} }
-							disabled={ isLoading }
+							disabled={ isRequestInProgress }
 						/>
 						<div
 							className={ clsx( 'agency-details-form__footer-error', {
@@ -285,7 +287,7 @@ export default function AgencyDetailsForm( {
 							setAgencyName( event.target.value );
 							updateValidationError( { agencyName: undefined } );
 						} }
-						disabled={ isLoading }
+						disabled={ isRequestInProgress }
 					/>
 					<div
 						className={ clsx( 'agency-details-form__footer-error', {
@@ -307,7 +309,7 @@ export default function AgencyDetailsForm( {
 							setAgencyUrl( event.target.value );
 							updateValidationError( { agencyUrl: undefined } );
 						} }
-						disabled={ isLoading }
+						disabled={ isRequestInProgress }
 					/>
 					<div
 						className={ clsx( 'agency-details-form__footer-error', {
@@ -327,6 +329,7 @@ export default function AgencyDetailsForm( {
 						id="user_type"
 						value={ userType }
 						onChange={ handleSetUserType }
+						disabled={ isRequestInProgress }
 					>
 						<option value="agency_owner">{ translate( "I'm an agency owner" ) }</option>
 						<option value="developer_at_agency">
@@ -352,6 +355,7 @@ export default function AgencyDetailsForm( {
 								id="managed_sites"
 								value={ managedSites }
 								onChange={ handleSetManagedSites }
+								disabled={ isRequestInProgress }
 							>
 								<option value="1-5">{ translate( '1-5' ) }</option>
 								<option value="6-20">{ translate( '6-20' ) }</option>
@@ -376,6 +380,7 @@ export default function AgencyDetailsForm( {
 								// // Using 'as any' to bypass TypeScript type checks due to a known and intentional type mismatch between
 								// the expected custom event type for `onChange` and the standard event types.
 								onChange={ handleSetServicesOffered as any }
+								disabled={ isRequestInProgress }
 							/>
 						</FormFieldset>
 						<FormFieldset>
@@ -390,6 +395,7 @@ export default function AgencyDetailsForm( {
 								// // Using 'as any' to bypass TypeScript type checks due to a known and intentional type mismatch between
 								// the expected custom event type for `onChange` and the standard event types.
 								onChange={ handleSetProductsOffered as any }
+								disabled={ isRequestInProgress }
 							/>
 						</FormFieldset>
 						<FormFieldset>
@@ -401,7 +407,7 @@ export default function AgencyDetailsForm( {
 										updateValidationError( { country: undefined } );
 									} }
 									options={ countryOptions }
-									disabled={ isLoading }
+									disabled={ isRequestInProgress }
 									label={ translate( 'Country' ) }
 								/>
 							) }
@@ -422,7 +428,7 @@ export default function AgencyDetailsForm( {
 									value={ addressState }
 									onChange={ ( value ) => setAddressState( value ?? '' ) }
 									options={ stateOptions }
-									disabled={ isLoading }
+									disabled={ isRequestInProgress }
 									allowReset={ false }
 									label={ translate( 'State' ) }
 								/>
@@ -440,7 +446,7 @@ export default function AgencyDetailsForm( {
 									setLine1( event.target.value );
 									updateValidationError( { line1: undefined } );
 								} }
-								disabled={ isLoading }
+								disabled={ isRequestInProgress }
 							/>
 							<div
 								className={ clsx( 'agency-details-form__footer-error', {
@@ -459,7 +465,7 @@ export default function AgencyDetailsForm( {
 								onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
 									setLine2( event.target.value )
 								}
-								disabled={ isLoading }
+								disabled={ isRequestInProgress }
 							/>
 						</FormFieldset>
 						<FormFieldset>
@@ -473,7 +479,7 @@ export default function AgencyDetailsForm( {
 									setCity( event.target.value );
 									updateValidationError( { city: undefined } );
 								} }
-								disabled={ isLoading }
+								disabled={ isRequestInProgress }
 							/>
 
 							{ !! validationError?.city && (
@@ -493,7 +499,7 @@ export default function AgencyDetailsForm( {
 								onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
 									setPostalCode( event.target.value )
 								}
-								disabled={ isLoading }
+								disabled={ isRequestInProgress }
 							/>
 						</FormFieldset>
 
@@ -507,7 +513,7 @@ export default function AgencyDetailsForm( {
 								phoneInputProps={ {
 									'data-testid': 'a4a-signup-phone-number-input',
 								} }
-								isDisabled={ noCountryList }
+								isDisabled={ noCountryList || isRequestInProgress }
 								countriesList={ countriesList }
 								initialCountryCode={ phone.countryCode }
 								initialPhoneNumber={ phone.phoneNumber }
@@ -544,8 +550,8 @@ export default function AgencyDetailsForm( {
 								primary
 								type="submit"
 								className="company-details-form__submit"
-								disabled={ ! showCountryFields || isLoading || isValidating }
-								busy={ isLoading || isValidating }
+								disabled={ ! showCountryFields || isRequestInProgress }
+								busy={ isRequestInProgress }
 							>
 								{ submitLabel }
 							</Button>

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
@@ -78,6 +78,7 @@ export default function AgencyDetailsForm( {
 	const [ userType, setUserType ] = useState( initialValues?.userType ?? 'agency_owner' );
 	const [ servicesOffered, setServicesOffered ] = useState( initialValues?.servicesOffered ?? [] );
 	const [ productsOffered, setProductsOffered ] = useState( initialValues?.productsOffered ?? [] );
+	const [ isValidating, setIsValidating ] = useState( false );
 
 	const { validate, validationError, updateValidationError } = useSignupFormValidation();
 
@@ -138,7 +139,11 @@ export default function AgencyDetailsForm( {
 				return;
 			}
 
+			// Set the validation flag to true to show loading to restrict the user from submitting the form multiple times
+			setIsValidating( true );
 			const error = await validate( payload );
+			setIsValidating( false );
+
 			if ( error ) {
 				// Scrolling only for fields positioned on top
 				if ( error.firstName || error.lastName || error.agencyName || error.agencyUrl ) {
@@ -539,8 +544,8 @@ export default function AgencyDetailsForm( {
 								primary
 								type="submit"
 								className="company-details-form__submit"
-								disabled={ ! showCountryFields || isLoading }
-								busy={ isLoading }
+								disabled={ ! showCountryFields || isLoading || isValidating }
+								busy={ isLoading || isValidating }
 							>
 								{ submitLabel }
 							</Button>


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1650

## Proposed Changes

This PR: 
- Disables the signup submit button during the form validation. 
- Disables all the fields when it's validating or submitting the form.

## Why are these changes being made?

* To prevent users from submitting the form multiple times when the form validation is happening. 

## Testing Instructions

* Switch to the branch locally 
* Create a new WPCOM user > Signup for A4A using incognito window(if required) 
* Enter all the values > (Optional) Add throttle preset (3G) from the network tab to make the request slow (screenshot below) > Click the "Continue" button > Verify the button is disabled when the request is in progress to validate the business URL. Also, verify all the fields are disabled when it's validating or submitting the form.

<img width="479" alt="Screenshot 2025-01-14 at 10 49 15 AM" src="https://github.com/user-attachments/assets/b017d8a1-a555-446d-93b6-8a6141f0df1b" />


https://github.com/user-attachments/assets/85cec71e-f93c-439d-98b8-b5c0a77d66d2



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
