### PR TITLE
Enhance input active/focus styles in WCCOM auth screens

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -2262,10 +2262,14 @@ $breakpoint-mobile: 660px;
 	input[type="tel"].form-text-input,
 	textarea.form-text-input {
 		border: 1px solid var(--studio-gray-30);
+
 		&:focus,
+		&:focus-visible,
 		&:hover,
-		&:focus:hover {
-			border: 1px solid var(--woo-purple-40);
+		&:active {
+			border: 1px solid transparent;
+			box-shadow: inset 0 0 0 2px var(--woo-purple-40);
+			outline: none;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98204

## Proposed Changes

* Update WooCommerce.com auth screens to use the thicker style for active state by adding a box shadow and removing the border. This approach is the same as the current implementation of WCCOM checkout screens.

<img width="1147" alt="Screenshot 2025-01-14 at 14 14 28" src="https://github.com/user-attachments/assets/37a2ce25-244b-4796-a94a-7ac5ff464036" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Match the design

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso live link or local environment. - For Calypso Live, open the browser console and run `window.sessionStorage.setItem( 'flags', 'woocommerce/rebrand-2-0,woocommerce/core-profiler-passwordless-auth,woo/passwordless' );`
* Go to `/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D49c18f325f670d3d61e48aaa8eedc73250e809d2d2b0ca35df6cf8f9532250e8%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1`
* Refresh the page
* Confirm that the input has 2px shadow when focused or active on the login/Signup/Forgot Password screens ([Figma](https://www.figma.com/design/Ph6WVCPfQ442Qxrz4x6du0/WooCommerce.com-Components?node-id=8967-9044&t=b04CnOPPsatppgtS-0))

<img width="1147" alt="Screenshot 2025-01-14 at 14 06 02" src="https://github.com/user-attachments/assets/296ef819-a86a-4d54-b079-25b34e6e74b8" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
