### PR TITLE
Remove JetpackMonitor from Security settings page, update styles

### DIFF
--- a/client/hosting/server-settings/style.scss
+++ b/client/hosting/server-settings/style.scss
@@ -98,15 +98,12 @@
 	}
 }
 
-// Jetpack downtime monitoring hack: Duplicates style from site-settings/style.scss
-.site-settings__child-settings {
+// Downtime monitoring indent child toggles
+.jetpack-monitor-settings__child-settings {
 	margin: 16px 48px 0;
 }
 
-// Jetpack downtime monitoring hack: Duplicates style from site-settings/style.scss
-.support-info + .jetpack-module-toggle,
-.support-info + .components-toggle-control,
-.support-info + .custom-content-types__module-settings,
-.support-info + .verbum-comments-toggle {
+// Downtime monitoring duplicates style from site-settings/style.scss
+.support-info + .jetpack-module-toggle {
 	display: flex;
 }

--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -1,14 +1,13 @@
 import config from '@automattic/calypso-config';
-import { Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
+import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import SupportInfo from 'calypso/components/support-info';
 import withSiteMonitorSettings from 'calypso/data/site-monitor/with-site-monitor-settings';
 import JetpackModuleToggle from 'calypso/my-sites/site-settings/jetpack-module-toggle';
-import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import isActivatingJetpackModule from 'calypso/state/selectors/is-activating-jetpack-module';
 import isDeactivatingJetpackModule from 'calypso/state/selectors/is-deactivating-jetpack-module';
@@ -87,34 +86,32 @@ class SiteSettingsFormJetpackMonitor extends Component {
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<div className="site-settings__security-settings">
+			<PanelCard className="jetpack-monitor-settings">
 				<QueryJetpackModules siteId={ siteId } />
 
-				<SettingsSectionHeader title={ translate( 'Downtime monitoring' ) } />
+				<PanelCardHeading>{ translate( 'Downtime monitoring' ) }</PanelCardHeading>
 
-				<Card className="jetpack-monitor-settings">
-					<SupportInfo
-						text={ translate(
-							'Jetpack will continuously monitor your site, and alert you the moment downtime is detected.'
-						) }
-						link="https://jetpack.com/support/monitor/"
-					/>
+				<SupportInfo
+					text={ translate(
+						'Jetpack will continuously monitor your site, and alert you the moment downtime is detected.'
+					) }
+					link="https://jetpack.com/support/monitor/"
+				/>
 
-					<JetpackModuleToggle
-						siteId={ siteId }
-						moduleSlug="monitor"
-						label={ translate(
-							'Get alerts if your site goes offline. We’ll let you know when it’s back up, too.'
-						) }
-						disabled={ this.disableForm() }
-					/>
+				<JetpackModuleToggle
+					siteId={ siteId }
+					moduleSlug="monitor"
+					label={ translate(
+						'Get alerts if your site goes offline. We’ll let you know when it’s back up, too.'
+					) }
+					disabled={ this.disableForm() }
+				/>
 
-					<div className="site-settings__child-settings">
-						{ this.settingsMonitorEmailCheckbox() }
-						{ this.settingsMonitorWpNoteCheckbox() }
-					</div>
-				</Card>
-			</div>
+				<div className="jetpack-monitor-settings__child-settings">
+					{ this.settingsMonitorEmailCheckbox() }
+					{ this.settingsMonitorWpNoteCheckbox() }
+				</div>
+			</PanelCard>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -8,7 +8,6 @@ import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import JetpackMonitor from 'calypso/my-sites/site-settings/form-jetpack-monitor';
 import FormSecurity from 'calypso/my-sites/site-settings/form-security';
 import JetpackCredentials from 'calypso/my-sites/site-settings/jetpack-credentials';
 import JetpackCredentialsBanner from 'calypso/my-sites/site-settings/jetpack-credentials-banner';
@@ -64,7 +63,6 @@ export const SiteSettingsSecurity = ( {
 			<SiteSettingsNavigation site={ site } section="security" />
 			{ showCredentials && <JetpackCredentials /> }
 			{ showJetpackBanner && <JetpackCredentialsBanner siteSlug={ site.slug } /> }
-			<JetpackMonitor />
 			<FormSecurity />
 		</Main>
 	);


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/98250

## Proposed Changes

* Follows up on https://github.com/Automattic/wp-calypso/pull/98250 to fix card styling and remove old option placement.

## Testing Instructions

Atomic site

Before

![Screenshot 2025-01-14 at 17-14-25 Server Settings ‹ Site Title — WordPress com](https://github.com/user-attachments/assets/4e604cf0-24cb-4024-8bb3-b2226c3fe4a0)

After

![Screenshot(31)](https://github.com/user-attachments/assets/f58d1e66-a973-4249-af3e-c480677ede56)

Before
![Screenshot 2025-01-14 at 17-20-27 Security Settings ‹ Site Title — WordPress com](https://github.com/user-attachments/assets/c27a821b-ace2-4072-a700-d110c810250c)

After
![Screenshot 2025-01-14 at 17-20-46 Security Settings ‹ Site Title — WordPress com](https://github.com/user-attachments/assets/d7434f07-397a-485e-a21d-465708d9904b)
