### PR TITLE
Remove always-true subscription-gifting feature flag

### DIFF
--- a/client/sites/settings/site/subscription-gifting.jsx
+++ b/client/sites/settings/site/subscription-gifting.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { WPCOM_FEATURES_SUBSCRIPTION_GIFTING } from '@automattic/calypso-products/src';
 import { Button, CompactCard } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
@@ -26,7 +25,7 @@ export default function SubscriptionGiftingForm( {
 	);
 	const isWpcomStagingSite = useSelectedSiteSelector( isSiteWpcomStaging );
 
-	if ( ! isEnabled( 'subscription-gifting' ) || ! hasSubscriptionGifting || isWpcomStagingSite ) {
+	if ( ! hasSubscriptionGifting || isWpcomStagingSite ) {
 		return;
 	}
 

--- a/config/development.json
+++ b/config/development.json
@@ -222,7 +222,6 @@
 		"stats/paid-wpcom-v3": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-importer": true,
-		"subscription-gifting": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -145,7 +145,6 @@
 		"stats/paid-wpcom-v2": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-importer": true,
-		"subscription-gifting": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,

--- a/config/production.json
+++ b/config/production.json
@@ -193,7 +193,6 @@
 		"stats/paid-wpcom-v3": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-importer": true,
-		"subscription-gifting": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -188,7 +188,6 @@
 		"stats/paid-wpcom-v3": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-importer": true,
-		"subscription-gifting": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -186,7 +186,6 @@
 		"stats/paid-wpcom-v3": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-importer": true,
-		"subscription-gifting": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,


### PR DESCRIPTION
Removes the `subscription-gifting` feature flag that is on in all environments.

**How to test:**
Go to `/settings/general/:site` and verify that the subscrption gifting setting is there:

<img width="728" alt="Screenshot 2025-01-14 at 8 17 58" src="https://github.com/user-attachments/assets/89c2d1f8-fc1b-4e35-ada0-dcc2a0b3ac4e" />

Also verify that this UI is not used anywhere in Jetpack Cloud. The feature flag was not enabled in JP Cloud environments and we want to be sure we are not enabling it accidentally.