### PR TITLE
Domain management: Enhance DNS update action by including domain name and managing submi…

### DIFF
--- a/client/state/domains/dns/actions.js
+++ b/client/state/domains/dns/actions.js
@@ -85,7 +85,7 @@ export const applyDnsTemplate = ( domainName, provider, service, variables ) => 
 
 export const updateDns =
 	( domainName, recordsToAdd, recordsToRemove, restoreDefaultARecords ) => ( dispatch ) => {
-		dispatch( { type: DOMAINS_DNS_UPDATE, recordsToAdd, recordsToRemove } );
+		dispatch( { type: DOMAINS_DNS_UPDATE, domainName, recordsToAdd, recordsToRemove } );
 
 		const updateResult = updateDnsRequest( domainName, {
 			records_to_add: recordsToAdd,

--- a/client/state/domains/dns/reducer.js
+++ b/client/state/domains/dns/reducer.js
@@ -219,6 +219,7 @@ export default function reducer( state = {}, action ) {
 			break;
 		case DOMAINS_DNS_UPDATE:
 			state = updateDomainState( state, action.domainName, {
+				isSubmittingForm: true,
 				isFetching: true,
 			} );
 			break;
@@ -227,11 +228,13 @@ export default function reducer( state = {}, action ) {
 				records: action.records,
 				isFetching: false,
 				hasLoadedFromServer: true,
+				isSubmittingForm: false,
 			} );
 			break;
 		case DOMAINS_DNS_UPDATE_FAILED:
 			state = updateDomainState( state, action.domainName, {
 				isFetching: false,
+				isSubmittingForm: false,
 			} );
 			break;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/wp-calypso/issues/98201

## Proposed Changes

* Enhance DNS update action by including domain name and managing submission state

<img width="830" alt="CleanShot 2025-01-14 at 14 42 46@2x" src="https://github.com/user-attachments/assets/a1e472c2-e7dc-4093-9ae3-6a9303a6f4b8" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve UI and button styling/state consistency.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link.
* Navigate to `/domains/manage` and click `Manage DNS` under the Actions columns dropdown for one of your domains
* Modify the `CNAME` type entry and click the `Update DNS record`. You're able to submit it without changing anything.
* Verify the `Update DNS record` button is disabled after submission until it completes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
