### PR TITLE
Add site setting to hide the Action Bar

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -7,6 +7,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/account-settings/',
 		post_id: 80368,
 	},
+	'action-bar': {
+		link: 'https://wordpress.com/support/action-bar/',
+		post_id: 319993,
+	},
 	'admin-interface-style': {
 		link: 'https://wordpress.com/support/set-your-admin-interface-style/',
 		post_id: 386651,

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -362,25 +362,25 @@ export class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
-	showActionbar() {
+	hideActionbar() {
 		const { translate, fields, updateFields } = this.props;
 		return (
 			<FormFieldset>
-				<FormLabel htmlFor="site-settings__wpcom_show_action_bar">
+				<FormLabel htmlFor="site-settings__wpcom_hide_action_bar">
 					{ translate( 'Action Bar visibility' ) }
 				</FormLabel>
 				<ToggleControl
-					id="site-settings__wpcom_show_action_bar"
+					id="site-settings__wpcom_hide_action_bar"
 					__nextHasNoMarginBottom
-					label={ translate( 'Show the Action Bar on the front end of the site.' ) }
-					checked={ !! fields?.wpcom_show_action_bar }
+					label={ translate( 'Hide the Action Bar on the front end of the site.' ) }
+					checked={ !! fields?.wpcom_hide_action_bar }
 					onChange={ ( newValue ) => {
-						updateFields( { wpcom_show_action_bar: newValue ? 1 : undefined } );
+						updateFields( { wpcom_hide_action_bar: newValue } );
 					} }
 				/>
 				<FormSettingExplanation>
 					<a href="https://en.support.wordpress.com/action-bar/">
-						{ translate( 'Learn more about Action Bar.' ) }
+						{ translate( 'Learn more about the Action Bar.' ) }
 					</a>
 				</FormSettingExplanation>
 			</FormFieldset>
@@ -442,7 +442,7 @@ export class SiteSettingsFormGeneral extends Component {
 								{ this.blogAddress() }
 								{ this.languageOptions() }
 								{ this.Timezone() }
-								{ this.showActionbar() }
+								{ this.hideActionbar() }
 								{ siteIsJetpack && this.WordPressVersion() }
 							</form>
 						</Card>
@@ -497,7 +497,7 @@ const getFormSettings = ( settings ) => {
 		wpcom_gifting_subscription: false,
 		admin_url: '',
 		is_fully_managed_agency_site: true,
-		wpcom_show_action_bar: 1,
+		wpcom_hide_action_bar: false,
 	};
 
 	if ( ! settings ) {
@@ -522,7 +522,7 @@ const getFormSettings = ( settings ) => {
 		wpcom_locked_mode: settings.wpcom_locked_mode,
 		wpcom_public_coming_soon: settings.wpcom_public_coming_soon,
 		wpcom_gifting_subscription: !! settings.wpcom_gifting_subscription,
-		wpcom_show_action_bar: settings.wpcom_show_action_bar,
+		wpcom_hide_action_bar: settings.wpcom_hide_action_bar,
 	};
 
 	// handling `gmt_offset` and `timezone_string` values

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -442,7 +442,7 @@ export class SiteSettingsFormGeneral extends Component {
 								{ this.blogAddress() }
 								{ this.languageOptions() }
 								{ this.Timezone() }
-								{ this.hideActionbar() }
+								{ ! siteIsJetpack && this.hideActionbar() }
 								{ siteIsJetpack && this.WordPressVersion() }
 							</form>
 						</Card>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -1,6 +1,7 @@
 import { Card, Button, FormLabel, Gridicon } from '@automattic/components';
 import { guessTimezone, localizeUrl } from '@automattic/i18n-utils';
 import languages from '@automattic/languages';
+import { ToggleControl } from '@wordpress/components';
 import clsx from 'clsx';
 import { flowRight, get } from 'lodash';
 import { Component, Fragment } from 'react';
@@ -361,6 +362,31 @@ export class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
+	showActionbar() {
+		const { translate, fields, updateFields } = this.props;
+		return (
+			<FormFieldset>
+				<FormLabel htmlFor="site-settings__wpcom_show_action_bar">
+					{ translate( 'Action Bar visibility' ) }
+				</FormLabel>
+				<ToggleControl
+					id="site-settings__wpcom_show_action_bar"
+					__nextHasNoMarginBottom
+					label={ translate( 'Show the Action Bar on the front end of the site.' ) }
+					checked={ !! fields?.wpcom_show_action_bar }
+					onChange={ ( newValue ) => {
+						updateFields( { wpcom_show_action_bar: newValue ? 1 : undefined } );
+					} }
+				/>
+				<FormSettingExplanation>
+					<a href="https://en.support.wordpress.com/action-bar/">
+						{ translate( 'Learn more about Action Bar.' ) }
+					</a>
+				</FormSettingExplanation>
+			</FormFieldset>
+		);
+	}
+
 	recordTracksEventForTrialNoticeClick = () => {
 		const { recordTracksEvent, isSiteOnECommerceTrial } = this.props;
 		const eventName = isSiteOnECommerceTrial
@@ -416,6 +442,7 @@ export class SiteSettingsFormGeneral extends Component {
 								{ this.blogAddress() }
 								{ this.languageOptions() }
 								{ this.Timezone() }
+								{ this.showActionbar() }
 								{ siteIsJetpack && this.WordPressVersion() }
 							</form>
 						</Card>
@@ -470,6 +497,7 @@ const getFormSettings = ( settings ) => {
 		wpcom_gifting_subscription: false,
 		admin_url: '',
 		is_fully_managed_agency_site: true,
+		wpcom_show_action_bar: 1,
 	};
 
 	if ( ! settings ) {
@@ -494,6 +522,7 @@ const getFormSettings = ( settings ) => {
 		wpcom_locked_mode: settings.wpcom_locked_mode,
 		wpcom_public_coming_soon: settings.wpcom_public_coming_soon,
 		wpcom_gifting_subscription: !! settings.wpcom_gifting_subscription,
+		wpcom_show_action_bar: settings.wpcom_show_action_bar,
 	};
 
 	// handling `gmt_offset` and `timezone_string` values

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -11,6 +11,7 @@ import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormInput from 'calypso/components/forms/form-text-input';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import SiteLanguagePicker from 'calypso/components/language-picker/site-language-picker';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
@@ -372,16 +373,21 @@ export class SiteSettingsFormGeneral extends Component {
 				<ToggleControl
 					id="site-settings__wpcom_hide_action_bar"
 					__nextHasNoMarginBottom
-					label={ translate( 'Hide the Action Bar on the front end of the site.' ) }
+					label={ translate( 'Hide the Action Bar.' ) }
 					checked={ !! fields?.wpcom_hide_action_bar }
 					onChange={ ( newValue ) => {
 						updateFields( { wpcom_hide_action_bar: newValue } );
 					} }
 				/>
 				<FormSettingExplanation>
-					<a href="https://en.support.wordpress.com/action-bar/">
-						{ translate( 'Learn more about the Action Bar.' ) }
-					</a>
+					{ translate(
+						'The Action Bar can be found in the lower right corner of any WordPress.com website you’re viewing. {{a}}Learn more{{/a}}.',
+						{
+							components: {
+								a: <InlineSupportLink showIcon={ false } supportContext="action-bar" />,
+							},
+						}
+					) }
 				</FormSettingExplanation>
 			</FormFieldset>
 		);

--- a/client/sites/settings/site/index.tsx
+++ b/client/sites/settings/site/index.tsx
@@ -69,7 +69,7 @@ const getFormSettings = ( settings: any ) => {
 		wpcom_locked_mode: false,
 		wpcom_public_coming_soon: '',
 		wpcom_gifting_subscription: false,
-		wpcom_show_action_bar: 1,
+		wpcom_hide_action_bar: false,
 		is_fully_managed_agency_site: true,
 	};
 
@@ -87,7 +87,7 @@ const getFormSettings = ( settings: any ) => {
 		wpcom_public_coming_soon: settings.wpcom_public_coming_soon,
 		wpcom_gifting_subscription: !! settings.wpcom_gifting_subscription,
 		is_fully_managed_agency_site: settings.is_fully_managed_agency_site,
-		wpcom_show_action_bar: settings.wpcom_show_action_bar,
+		wpcom_hide_action_bar: settings.wpcom_hide_action_bar,
 	};
 	return formSettings;
 };

--- a/client/sites/settings/site/index.tsx
+++ b/client/sites/settings/site/index.tsx
@@ -69,6 +69,7 @@ const getFormSettings = ( settings: any ) => {
 		wpcom_locked_mode: false,
 		wpcom_public_coming_soon: '',
 		wpcom_gifting_subscription: false,
+		wpcom_show_action_bar: 1,
 		is_fully_managed_agency_site: true,
 	};
 
@@ -86,6 +87,7 @@ const getFormSettings = ( settings: any ) => {
 		wpcom_public_coming_soon: settings.wpcom_public_coming_soon,
 		wpcom_gifting_subscription: !! settings.wpcom_gifting_subscription,
 		is_fully_managed_agency_site: settings.is_fully_managed_agency_site,
+		wpcom_show_action_bar: settings.wpcom_show_action_bar,
 	};
 	return formSettings;
 };

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -93,6 +93,6 @@ export const SITE_REQUEST_OPTIONS = [
 	'is_commercial',
 	'is_commercial_reasons',
 	'wpcom_admin_interface',
-	'wpcom_hide_action_bar',
 	'wpcom_classic_early_release',
+	'wpcom_hide_action_bar',
 ].join();

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -93,5 +93,6 @@ export const SITE_REQUEST_OPTIONS = [
 	'is_commercial',
 	'is_commercial_reasons',
 	'wpcom_admin_interface',
+	'wpcom_show_action_bar',
 	'wpcom_classic_early_release',
 ].join();

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -93,6 +93,6 @@ export const SITE_REQUEST_OPTIONS = [
 	'is_commercial',
 	'is_commercial_reasons',
 	'wpcom_admin_interface',
-	'wpcom_show_action_bar',
+	'wpcom_hide_action_bar',
 	'wpcom_classic_early_release',
 ].join();

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -73,6 +73,7 @@ export interface CreateSiteParams {
 		is_blank_canvas?: boolean;
 		is_videopress_initial_purchase?: boolean;
 		wpcom_admin_interface?: string;
+		wpcom_show_action_bar?: number;
 	};
 }
 

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -73,7 +73,7 @@ export interface CreateSiteParams {
 		is_blank_canvas?: boolean;
 		is_videopress_initial_purchase?: boolean;
 		wpcom_admin_interface?: string;
-		wpcom_show_action_bar?: number;
+		wpcom_hide_action_bar?: boolean;
 	};
 }
 
@@ -302,6 +302,7 @@ export interface SiteDetailsOptions {
 	is_commercial?: boolean | null;
 	is_commercial_reasons?: string[];
 	wpcom_admin_interface?: string;
+	wpcom_hide_action_bar?: boolean;
 }
 
 export type SiteOption = keyof NonNullable< SiteDetails[ 'options' ] >;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/53830

This PR adds a new general setting (wpcom_hide_action_bar) to conditionally show the Action Bar on the front end of a site. The default value will be falsy to preserve the current behavior that Action Bar is shown.

The main issue will need 1 more PRs to be complete that I'll create and link shortly:

1. 169996-ghe-Automattic/wpcom to add the check for this option and not enqueue the Action Bar. Additionally it handles the setting in classic wp-admin interface.
2. [Jetpack PR ](https://github.com/Automattic/jetpack/pull/41123)to update the settings REST endpoint for Calypso UI


### Notes
3. Some other options are being tracked. Should it be the case for this one too?


## Testing Instructions

You need to test this PR with the other linked PRs. 
1. Go to general settings and update the value 
2. Go to the front-end and observe that the Action Bar is rendered based on that option.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?