### PR TITLE
Analytics: Fix circular references in ad tracking debug

### DIFF
--- a/client/lib/analytics/ad-tracking/ad-track-registration.js
+++ b/client/lib/analytics/ad-tracking/ad-track-registration.js
@@ -1,6 +1,7 @@
 import { refreshCountryCodeCookieGdpr } from 'calypso/lib/analytics/utils';
 import { mayWeTrackByTracker } from '../tracker-buckets';
 import { debug, TRACKING_IDS } from './constants';
+import { circularReferenceSafeJSONStringify } from './debug';
 import { recordParamsInFloodlightGtag } from './floodlight';
 import { loadTrackingScripts } from './load-tracking-scripts';
 
@@ -69,5 +70,8 @@ export async function adTrackRegistration() {
 		window.twq( ...params );
 	}
 
-	debug( 'adTrackRegistration: dataLayer:', JSON.stringify( window.dataLayer, null, 2 ) );
+	debug(
+		'adTrackRegistration: dataLayer:',
+		circularReferenceSafeJSONStringify( window.dataLayer, 2 )
+	);
 }

--- a/client/lib/analytics/ad-tracking/ad-track-signup-complete.js
+++ b/client/lib/analytics/ad-tracking/ad-track-signup-complete.js
@@ -3,6 +3,7 @@ import { v4 as uuid } from 'uuid';
 import { costToUSD, refreshCountryCodeCookieGdpr } from 'calypso/lib/analytics/utils';
 import { mayWeTrackByTracker } from '../tracker-buckets';
 import { debug, TRACKING_IDS, ICON_MEDIA_SIGNUP_PIXEL_URL } from './constants';
+import { circularReferenceSafeJSONStringify } from './debug';
 import { recordParamsInFloodlightGtag } from './floodlight';
 import { loadTrackingScripts } from './load-tracking-scripts';
 
@@ -163,5 +164,5 @@ export async function adTrackSignupComplete( { isNewUserSite } ) {
 		window.twq( ...params );
 	}
 
-	debug( 'recordSignup: dataLayer:', JSON.stringify( window.dataLayer, null, 2 ) );
+	debug( 'recordSignup: dataLayer:', circularReferenceSafeJSONStringify( window.dataLayer, 2 ) );
 }

--- a/client/lib/analytics/ad-tracking/debug.js
+++ b/client/lib/analytics/ad-tracking/debug.js
@@ -1,0 +1,16 @@
+export function circularReferenceSafeJSONStringify( json, space ) {
+	function removeCircularRefs( input ) {
+		let i = 0;
+
+		return function ( key, value ) {
+			if ( i !== 0 && typeof input === 'object' && typeof value === 'object' && input === value ) {
+				return '[Circular reference]';
+			}
+
+			++i;
+
+			return value;
+		};
+	}
+	return JSON.stringify( json, removeCircularRefs( json ), space );
+}

--- a/client/lib/analytics/ad-tracking/load-tracking-scripts.js
+++ b/client/lib/analytics/ad-tracking/load-tracking-scripts.js
@@ -21,6 +21,7 @@ import {
 	REDDIT_TRACKING_SCRIPT_URL,
 	WPCOM_REDDIT_PIXEL_ID,
 } from './constants';
+import { circularReferenceSafeJSONStringify } from './debug';
 import { setup } from './setup';
 
 export const loadTrackingScripts = attemptLoad( async () => {
@@ -50,7 +51,10 @@ export const loadTrackingScripts = attemptLoad( async () => {
 	initLoadedTrackingScripts();
 
 	// uses JSON.stringify for consistency with recordOrder()
-	debug( 'loadTrackingScripts: dataLayer:', JSON.stringify( window.dataLayer, null, 2 ) );
+	debug(
+		'loadTrackingScripts: dataLayer:',
+		circularReferenceSafeJSONStringify( window.dataLayer, 2 )
+	);
 
 	return scripts;
 } );

--- a/client/lib/analytics/ad-tracking/record-add-to-cart.js
+++ b/client/lib/analytics/ad-tracking/record-add-to-cart.js
@@ -4,6 +4,7 @@ import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import { mayWeTrackByTracker } from '../tracker-buckets';
 import { debug, TRACKING_IDS } from './constants';
 import { recordInCriteo } from './criteo';
+import { circularReferenceSafeJSONStringify } from './debug';
 import { recordParamsInFloodlightGtag } from './floodlight';
 import { loadTrackingScripts } from './load-tracking-scripts';
 
@@ -137,5 +138,5 @@ export async function recordAddToCart( cartItem ) {
 		window.pintrk( ...params );
 	}
 
-	debug( 'recordAddToCart: dataLayer:', JSON.stringify( window.dataLayer, null, 2 ) );
+	debug( 'recordAddToCart: dataLayer:', circularReferenceSafeJSONStringify( window.dataLayer, 2 ) );
 }

--- a/client/lib/analytics/ad-tracking/record-order.ts
+++ b/client/lib/analytics/ad-tracking/record-order.ts
@@ -13,6 +13,7 @@ import {
 	ICON_MEDIA_ORDER_PIXEL_URL,
 } from './constants';
 import { cartToCriteoItems, recordInCriteo } from './criteo';
+import { circularReferenceSafeJSONStringify } from './debug';
 import { recordParamsInFloodlightGtag } from './floodlight';
 import {
 	fireEcommercePurchase as fireEcommercePurchaseGA4,
@@ -166,7 +167,7 @@ export async function recordOrder(
 	// Uses JSON.stringify() to print the expanded object because during localhost or .live testing after firing this
 	// event we redirect the user to wordpress.com which causes a domain change preventing the expanding and inspection
 	// of any object in the JS console since they are no longer available.
-	debug( 'recordOrder: dataLayer:', JSON.stringify( window.dataLayer, null, 2 ) );
+	debug( 'recordOrder: dataLayer:', circularReferenceSafeJSONStringify( window.dataLayer, 2 ) );
 }
 
 /**

--- a/client/lib/analytics/ad-tracking/retarget.js
+++ b/client/lib/analytics/ad-tracking/retarget.js
@@ -6,6 +6,7 @@ import {
 	ICON_MEDIA_RETARGETING_PIXEL_URL,
 	YAHOO_GEMINI_AUDIENCE_BUILDING_PIXEL_URL,
 } from './constants';
+import { circularReferenceSafeJSONStringify } from './debug';
 import { recordPageViewInFloodlight } from './floodlight';
 import { loadTrackingScripts } from './load-tracking-scripts';
 
@@ -127,5 +128,5 @@ export async function retarget( urlPath ) {
 	}
 
 	// uses JSON.stringify for consistency with recordOrder()
-	debug( 'retarget: dataLayer:', JSON.stringify( window.dataLayer, null, 2 ) );
+	debug( 'retarget: dataLayer:', circularReferenceSafeJSONStringify( window.dataLayer, 2 ) );
 }


### PR DESCRIPTION
## Proposed Changes

Fixes circular references in `JSON.stringify()` when calling `debug` in analytics ad tracking.

## Why are these changes being made?

To fix errors like this: https://a8c.sentry.io/issues/3230674634/?project=6313676&referrer=project-issue-stream

## Testing Instructions

* Enable verbose messages in your dev console
* Set `localStorage.setItem('debug', 'calypso:analytics:ad-tracking')`
* Verify `http://calypso.localhost:3000/read/subscriptions/comments` still logs something. Will likely be `undefined` if testing locally. 
