### PR TITLE
Stats: Override the query period for custom ranges on Summary pages

### DIFF
--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -89,11 +89,14 @@ class StatsSummary extends Component {
 		};
 
 		// Update query with date range if it provided.
+		// Note that we force the period to 'day' for custom date ranges as other periods do not make sense
+		// in the context of our updated Traffic page and do not match the results as shown there.
 		const dateRange = this.props.dateRange;
 		if ( dateRange ) {
 			query.start_date = dateRange.startDate.format( 'YYYY-MM-DD' );
 			query.date = dateRange.endDate.format( 'YYYY-MM-DD' );
 			query.summarize = 1;
+			query.period = 'day'; // Override for custom date ranges.
 		}
 
 		const moduleQuery = merge( {}, statsQueryOptions, query );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

https://github.com/Automattic/jpop-issues/issues/9461

## Proposed Changes

If a Summary page is dealing with a custom date range, override the period value so the results match those shown on the Traffic page. ie: We want a summarized day query for the number of days requested. We do not want week, month, or other period-based results.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Without these changes, the Summary pages for authors, clicks, posts, referrers, & videos show results that do not match those shown on the Traffic page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Traffic page.
* Set a custom range that of more than 30 days. This should cause the period to automatically update from Days to Weeks. If not, pick Weeks as the period.
* Pick a module (like Authors) and note the results.
* Click the "View all" link for the module.
* Confirm the results on the Summary page match those from the Traffic page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
