### PR TITLE
Save cookie banner cookie across subdomains

### DIFF
--- a/packages/calypso-analytics/src/utils/set-tracking-prefs.ts
+++ b/packages/calypso-analytics/src/utils/set-tracking-prefs.ts
@@ -22,6 +22,7 @@ const setTrackingPrefs = ( newPrefs: TrackingPrefsData ): TrackingPrefs => {
 	document.cookie = cookie.serialize( TRACKING_PREFS_COOKIE_V2, JSON.stringify( newOptions ), {
 		path: '/',
 		maxAge: COOKIE_MAX_AGE,
+		domain: '.wordpress.com',
 	} );
 
 	return newOptions;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes ##94071

## Proposed Changes

* Add a domain to the cookie setting for the `setTrackingPrefs` util so that cookies are also applying to subdomains of that domain

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because previously `setTrackingPrefs` omitted to set any domain and this resulted in only the current domain being set for the cookie.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a local calypso running under wpcalypso.wordpress.com
2. Checkout this PR
3. Edit your development config and set cookie_banner to true
4. Restart the calypso watcher
5. Have a sandboxed website
6. Visit wpcalypso.wordpress.com and delete the sensitive_pixel_options cookie via developer tools
7. Refresh
8. **You should see the cookie banner**
9. Accept all
10. Make sure your selected website is the sandboxed one (via hosting options)
11. Visit Settings > Media (this takes you out of Calypso)
12. **You should not the cookie banner**

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
