### PR TITLE
E2E tests: update forms field test

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/all-form-fields.ts
@@ -48,7 +48,7 @@ export class AllFormFieldsFlow implements BlockFlow {
 		const remainingBlocksToAdd = [
 			[ 'Name Field', 'Add label…' ],
 			[ 'Email Field', 'Add label…' ],
-			[ 'URL Field', 'Add label…' ],
+			[ 'Website Field', 'Add label…' ],
 			[ 'Date Picker', 'Add label…' ],
 			[ 'Phone Number Field', 'Add label…' ],
 			[ 'Multi-line Text Field', 'Add label…' ],
@@ -92,7 +92,7 @@ export class AllFormFieldsFlow implements BlockFlow {
 			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Text Input Field' ) },
 			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Name Field' ) },
 			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Email Field' ) },
-			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'URL Field' ) },
+			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Website Field' ) },
 			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Phone Number Field' ) },
 			{ type: 'textbox', accessibleName: this.addLabelPrefix( 'Multi-line Text Field' ) },
 			{ type: 'checkbox', accessibleName: this.addLabelPrefix( 'Checkbox' ) },


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Needed for https://github.com/Automattic/jetpack/pull/41029

Original PR failed to deploy due to these tests https://github.com/Automattic/jetpack/pull/40994

## Proposed Changes

* Update label in E2E tests to match change in Jetpack 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
