### PR TITLE
Make the account restore button more prominent

### DIFF
--- a/client/me/account-close/closed.jsx
+++ b/client/me/account-close/closed.jsx
@@ -76,27 +76,14 @@ function AccountDeletedPage() {
 					}
 				/>
 				<div className="account-deleted__buttons">
-					<Button variant="secondary" onClick={ onCancelClick }>
+					{ config.isEnabled( 'me/account-restore' ) && restoreToken && (
+						<Button variant="secondary" onClick={ onRestoreClick } isBusy={ isRestoring }>
+							{ translate( 'I made a mistake! Restore my account' ) }
+						</Button>
+					) }
+					<Button variant="link" onClick={ onCancelClick } className="account-deleted__button-link">
 						{ translate( 'Return to WordPress.com' ) }
 					</Button>
-					{ config.isEnabled( 'me/account-restore' ) &&
-						restoreToken &&
-						( isRestoring ? (
-							<div className="account-deleted__restoring">
-								<Spinner />
-								<span className="account-deleted__restoring-text">
-									{ translate( 'Restoring your account' ) }
-								</span>
-							</div>
-						) : (
-							<Button
-								variant="link"
-								className="account-deleted__button-link"
-								onClick={ onRestoreClick }
-							>
-								{ translate( 'I made a mistake! Restore my account' ) }
-							</Button>
-						) ) }
 				</div>
 			</BlankCanvas.Content>
 		</BlankCanvas>

--- a/client/me/account-close/closed.jsx
+++ b/client/me/account-close/closed.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button, Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -67,16 +66,12 @@ function AccountDeletedPage() {
 				<FormattedHeader
 					brandFont
 					headerText={ translate( 'Your account has been deleted' ) }
-					subHeaderText={
-						config.isEnabled( 'me/account-restore' )
-							? translate(
-									'Thanks for flying with WordPress.com. You have 30 days to restore your account if you change your mind.'
-							  )
-							: translate( 'Thanks for flying with WordPress.com.' )
-					}
+					subHeaderText={ translate(
+						'Thanks for flying with WordPress.com. You have 30 days to restore your account if you change your mind.'
+					) }
 				/>
 				<div className="account-deleted__buttons">
-					{ config.isEnabled( 'me/account-restore' ) && restoreToken && (
+					{ restoreToken && (
 						<Button variant="secondary" onClick={ onRestoreClick } isBusy={ isRestoring }>
 							{ translate( 'I made a mistake! Restore my account' ) }
 						</Button>

--- a/config/development.json
+++ b/config/development.json
@@ -145,7 +145,6 @@
 		"marketplace-test": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
-		"me/account-restore": true,
 		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -92,7 +92,6 @@
 		"marketplace-reviews-notification": false,
 		"marketplace-test": false,
 		"me/account/color-scheme-picker": true,
-		"me/account-restore": true,
 		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,

--- a/config/production.json
+++ b/config/production.json
@@ -120,7 +120,6 @@
 		"marketplace-test": false,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
-		"me/account-restore": true,
 		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -117,7 +117,6 @@
 		"marketplace-test": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
-		"me/account-restore": true,
 		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -113,7 +113,6 @@
 		"marketplace-test": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
-		"me/account-restore": true,
 		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/10246

## Proposed Changes

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/user-attachments/assets/d2aec53e-7897-4601-93f3-c23ca306b2e4">  | <img src="https://github.com/user-attachments/assets/549e8548-d14d-467e-8b2b-02871341b2a6">|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pdtkmj-3fU-p2#comment-6179

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a non-a11n account
* Go to /me/account/close and delete the account
* Check the updated layout
* Restore the account to make sure nothing breaks

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?