### PR TITLE
Remove Caribou code owner check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -101,26 +101,6 @@
 /packages/data-stores/add-ons @Automattic/martech-decepticons
 /packages/data-stores/wpcom-plans-ui @Automattic/martech-decepticons
 
-# Importing
-/client/my-sites/importer @Automattic/caribou
-/client/blocks/import @Automattic/caribou
-/client/blocks/import-light @Automattic/caribou
-/client/landing/stepper/declarative-flow/import-flow.ts @Automattic/caribou
-/client/landing/stepper/declarative-flow/internals/steps-repository/import @Automattic/caribou
-/client/landing/stepper/declarative-flow/internals/steps-repository/import-list @Automattic/caribou
-/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready @Automattic/caribou
-/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-not @Automattic/caribou
-/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview @Automattic/caribou
-/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-wpcom @Automattic/caribou
-/client/landing/stepper/declarative-flow/internals/steps-repository/importer @Automattic/caribou
-/client/landing/stepper/declarative-flow/internals/steps-repository/importer-blogger @Automattic/caribou
-/client/landing/stepper/declarative-flow/internals/steps-repository/importer-medium @Automattic/caribou
-/client/landing/stepper/declarative-flow/internals/steps-repository/importer-squarespace @Automattic/caribou
-/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wix @Automattic/caribou
-/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wordpress @Automattic/caribou
-/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler @Automattic/caribou
-/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker @Automattic/caribou
-
 # Support
 /packages/help-center @Automattic/vertex
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1736860147408909-slack-C02NWDZBL0H

## Proposed Changes

* Remove Caribou code owner check since the team is disbanded now.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review should be enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?