### PR TITLE
Fix the slide open animation of flyout in domains page

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain-dashboard-layout.tsx
+++ b/client/my-sites/domains/domain-management/components/domain-dashboard-layout.tsx
@@ -3,6 +3,9 @@ import LayoutColumn from 'calypso/layout/hosting-dashboard/column';
 import DomainManagement from 'calypso/my-sites/domains/domain-management';
 import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
 
+// Add Dotcom specific styles
+import 'calypso/sites/components/dotcom-style.scss';
+
 type DomainDashboardLayoutProps = {
 	innerContent: React.ReactNode;
 	selectedDomainName: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98329

## Proposed Changes

* Fix slide out animation not working in domains list when directly loaded

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- Domain management revamp

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Enable the feature flag by window.sessionStorage.setItem('flags', 'calypso/all-domain-management')
- Reload the `calypso.localhost:3000/domains/manage`
- Click on a domain row
- Make sure it opens with a slide animation

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
