### PR TITLE
Fix tracking for block drag and drop events

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -381,6 +381,32 @@ const maybeTrackPatternInsertion = ( actionData, additionalData ) => {
 };
 
 /**
+ * Track block drag and drop events.
+ * @param {Array} clientIds - Array of client IDs of the blocks being dragged.
+ * @param {string} fromRootClientId - Root client ID from where the blocks are dragged.
+ * @param {string} toRootClientId - Root client ID to where the blocks are dropped.
+ * @returns {void}
+ */
+const trackBlockDragDrop = ( clientIds, fromRootClientId, toRootClientId ) => {
+	const isDragging = select( 'core/block-editor' ).isDraggingBlocks();
+
+	// moveBlocksToPosition action is called when moving given blocks
+	// to a new position. This could be used in various scenarios such
+	// as mover arrows in the block toolbar, drag and drop, etc.
+	// Therefore this tracking ignore actions that are not related to
+	// dragging blocks.
+	if ( ! isDragging ) {
+		return;
+	}
+
+	getBlocksTracker( 'wpcom_block_moved_via_dragging' )(
+		clientIds,
+		fromRootClientId,
+		toRootClientId
+	);
+};
+
+/**
  * Track block insertion.
  * @param {Object | Array} blocks block instance object or an array of such objects
  * @param {Array} args additional insertBlocks data e.g. metadata containing pattern name.
@@ -906,7 +932,7 @@ const REDUX_TRACKING = {
 		moveBlocksDown: getBlocksTracker( 'wpcom_block_moved_down' ),
 		removeBlocks: trackBlockRemoval,
 		removeBlock: trackBlockRemoval,
-		moveBlockToPosition: getBlocksTracker( 'wpcom_block_moved_via_dragging' ),
+		moveBlocksToPosition: trackBlockDragDrop,
 		insertBlock: trackBlockInsertion,
 		insertBlocks: trackBlockInsertion,
 		replaceBlock: trackBlockReplacement,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/54353


⚠️ The code here is the src of the changes to the app. The actual built changes are deployed in 170105-ghe-Automattic/wpcom. Please see that PR.

-------

## Proposed Changes

* Fix broken tracking for the `wpcom_block_moved_via_dragging` event.
* Use a custom event tracking action that 
    - uses the correct `moveBlocksToPosition` (plural) action.
    - differentiates "drag and drop" moves from other types of "block move" actions by checking the store state for blocks being dragged

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently action not firing because `moveBlockToPosition` is not utilised in Gutenberg core codebase when handling drag and drop. Must have been once but not anymore.
* Ensures that when any tracking fires it first checks whether the `moveBlocksToPosition` action is being called when `isDraggingBlocks` is `true`. This ensures that we only track drag and drop "moves".

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Very carefully follow the debug setup instructions at PCYsg-nrf-p2. Note thuis is very easy to get wrong so please check carefully and reach out to @getdave if stuck.
* Ensure you are using the `wp-admin` version of the editor. Easiest way is to go to the Site Editor as this appears to always load in `wp-adnin`. Otherwise just follow the instructions at the end of the `Debugging` section of PCYsg-nrf-p2 to access the Post editor via `wp-admin` as opposed to Calypso.
* Add some random blocks
* Drag some blocks around and see tracking debugging events fired (`wpcom-block-editor:analytics:tracks Recording event 'wpcom_block_moved_via_dragging' with actual....`).
* Try dragging multiple blocks. Check for multiple events fired.
* Now place your cursor on the last block in the editor and hit `ENTER`. Check that **no events** are fired even though t[he Gutenberg codebase uses the `moveBlocksToPosition` action for this as well](https://github.com/WordPress/gutenberg/blob/130b6e248da39012d3018862ef7153ce3ff81bef/packages/block-library/src/paragraph/use-enter.js#L82).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?