### PR TITLE
A4A: Load schedule call link from company record.

### DIFF
--- a/client/a8c-for-agencies/data/agencies/use-fetch-schedule-call-link.ts
+++ b/client/a8c-for-agencies/data/agencies/use-fetch-schedule-call-link.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+export default function useFetchScheduleCallLink() {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useQuery( {
+		queryKey: [ 'agency-schedule-call-link', agencyId ],
+		queryFn: () =>
+			wpcom.req.get( {
+				apiNamespace: 'wpcom/v2',
+				path: `/agency/${ agencyId }/schedule-call-link`,
+			} ),
+		enabled: false,
+		refetchOnWindowFocus: false,
+	} );
+}

--- a/client/a8c-for-agencies/sections/overview/sidebar/growth-accelerator/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/growth-accelerator/index.tsx
@@ -70,6 +70,7 @@ export default function OverviewSidebarGrowthAccelerator() {
 					className="overview__growth-accelerator-footer-schedule-call"
 					variant="primary"
 					disabled={ isFetchingScheduleCallLink }
+					isBusy={ isFetchingScheduleCallLink }
 					onClick={ onRequestCallClick }
 				>
 					{ translate( 'Schedule a call' ) }

--- a/client/a8c-for-agencies/sections/overview/sidebar/growth-accelerator/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/growth-accelerator/index.tsx
@@ -3,6 +3,7 @@ import { Button, Icon } from '@wordpress/components';
 import { external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
+import useFetchScheduleCallLink from 'calypso/a8c-for-agencies/data/agencies/use-fetch-schedule-call-link';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
@@ -18,10 +19,22 @@ export default function OverviewSidebarGrowthAccelerator() {
 
 	const dispatch = useDispatch();
 
+	const { refetch: fetchScheduleCallLink, isFetching: isFetchingScheduleCallLink } =
+		useFetchScheduleCallLink();
+
 	const onRequestCallClick = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_overview_growth_accelerator_schedule_call_click' ) );
 		dispatch( savePreference( GROWTH_ACCELERATOR_REQUESTED_PREFERENCE, true ) );
-	}, [ dispatch ] );
+
+		fetchScheduleCallLink().then( ( result ) => {
+			window.open(
+				result.data
+					? result.data
+					: 'https://savvycal.com/automattic-for-agencies/agency-success?utm_campaign=overview',
+				'_blank'
+			);
+		} );
+	}, [ dispatch, fetchScheduleCallLink ] );
 
 	const onNotInterestedClick = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_overview_growth_accelerator_not_interested_click' ) );
@@ -56,9 +69,7 @@ export default function OverviewSidebarGrowthAccelerator() {
 				<Button
 					className="overview__growth-accelerator-footer-schedule-call"
 					variant="primary"
-					href="https://savvycal.com/automattic-for-agencies/agency-success?utm_campaign=overview"
-					target="_blank"
-					rel="noopener noreferrer"
+					disabled={ isFetchingScheduleCallLink }
 					onClick={ onRequestCallClick }
 				>
 					{ translate( 'Schedule a call' ) }

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -166,7 +166,7 @@
 
 	.components-button.is-primary,
 	.button.is-primary {
-		&,
+		&:not( :disabled ),
 		&:focus:not(:disabled) {
 			background-color: var(--color-primary-50);
 			border-color: var(--color-primary-50);


### PR DESCRIPTION
This PR updates the 'Schedule a call' link to load from the backend endpoint.

**NOTE: This needs to be tested with WPCOM PR 170039** 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1625

## Proposed Changes

* Load the link from the backend endpoint by implementing a query hook. This hook is not preloaded to avoid performing this operation since it is costly on the backend side. We only want it to be fetched when the button is clicked.

## Why are these changes being made?

* We have various representatives handling this based on the agency, so it's crucial to use a unique scheduling link to connect with the appropriate representative.

## Testing Instructions

* See **WPCOM PR 170039** to set up the backend.
* Use the A4A live link and go to the `/overview` page.
* Click the 'Schedule a call' button in the Growth Accelerator card.
<img width="530" alt="Screenshot 2025-01-14 at 11 31 30 PM" src="https://github.com/user-attachments/assets/8cacc13d-7181-48e3-b505-562013235bba" />
* Confirm that the link is loaded from the backend.
* If you don't see the Growth accelerator card, please reset the `a4a_growth_accelerator_dismissed` preference.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
