### PR TITLE
Stats: Resolve date range shortcut conflicts

### DIFF
--- a/client/components/date-range/use-shortcuts.ts
+++ b/client/components/date-range/use-shortcuts.ts
@@ -74,7 +74,7 @@ export const getShortcuts = createSelector(
 				id: 'month_to_date',
 				label: translate( 'Month to date' ),
 				startDate: siteToday.clone().startOf( 'month' ).format( DATE_FORMAT ),
-				endDate: siteTodayStr,
+				endDate: siteToday.clone().endOf( 'month' ).format( DATE_FORMAT ),
 				period: DATERANGE_PERIOD.DAY,
 			},
 			{
@@ -83,19 +83,18 @@ export const getShortcuts = createSelector(
 				startDate: siteToday
 					.clone()
 					.startOf( 'month' )
-					.subtract( 11, 'months' )
+					.subtract( 12, 'months' )
 					.format( DATE_FORMAT ),
-				endDate: siteTodayStr,
+				endDate: siteToday.clone().endOf( 'month' ).subtract( 1, 'months' ).format( DATE_FORMAT ),
 				period: DATERANGE_PERIOD.MONTH,
 			},
-			// Temporarily hide this shortcut before we resolve the issue of identifying shortcuts.
-			// {
-			// 	id: 'year_to_date',
-			// 	label: translate( 'Year to date' ),
-			// 	startDate: siteToday.clone().startOf( 'year' ).format( DATE_FORMAT ),
-			// 	endDate: siteTodayStr,
-			// 	period: DATERANGE_PERIOD.MONTH,
-			// },
+			{
+				id: 'year_to_date',
+				label: translate( 'Year to date' ),
+				startDate: siteToday.clone().startOf( 'year' ).format( DATE_FORMAT ),
+				endDate: siteToday.clone().endOf( 'year' ).format( DATE_FORMAT ),
+				period: DATERANGE_PERIOD.MONTH,
+			},
 			{
 				id: 'last_3_years',
 				label: translate( 'Last 3 years' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This is the follow-up PR for https://github.com/Automattic/wp-calypso/pull/98160.

## Proposed Changes

* Change the date range of the shortcut `Month to date` from the start date to the end date of this month.
* Change the date range of the shortcut `Year to date` from the start date to the end date of this year.
* Change the date range of the shortcut `Last 12 months` to 12 months until the last month.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* According to the current definition of shortcuts, there would be date range conflicts between shortcuts, making some shortcuts unselectable.
  * `Today` conflicts with `Month to date` on the 1st of every month.
  * `Last 7 Days` conflicts with `Month to date` on the 7th of every month.
  * `Last 30 Days` conflicts with `Month to date` on the 30th of every month, excluding February.
  * `Last 12 months` conflicts with `Year to date` on every day of December.
  * `Month to date` conflicts with `Year to date` on every day of January.
* This PR aims to redefine `Month to date`, `Year to date`, and `Last 12 months` shortcuts to eliminate date range conflicts.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Open the date range picker.
* Ensure the `Month to date`, `Year to date`, and `Last 12 months` shortcuts apply newly defined date ranges.

#### Month to date
<img width="1268" alt="截圖 2025-01-15 凌晨1 06 45" src="https://github.com/user-attachments/assets/b9a9f055-3a7b-4ad7-9c38-5803bdc911fa" />

#### Year to date
<img width="1275" alt="截圖 2025-01-15 凌晨1 07 01" src="https://github.com/user-attachments/assets/e058dc1d-bf0c-44cf-9d1c-86f48237ffa4" />

#### Last 12 months
<img width="1270" alt="截圖 2025-01-15 凌晨1 06 54" src="https://github.com/user-attachments/assets/7046d5aa-95a5-41fe-8058-ad2fe852b85f" />

* Ensure there are no longer any conflicts between shortcuts.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
