### PR TITLE
Created initial structure to My Home Launchpad using the entire home

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { SET_UP_EMAIL_AUTHENTICATION_FOR_YOUR_DOMAIN } from '@automattic/urls';
@@ -50,6 +51,7 @@ import {
 } from 'calypso/state/sites/selectors';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import LaunchpadPreLaunch from './cards/launchpad/pre-launch';
 import CelebrateLaunchModal from './components/celebrate-launch-modal';
 
 import './style.scss';
@@ -293,27 +295,31 @@ const Home = ( {
 	return (
 		<Main wideLayout className="customer-home__main">
 			<PageViewTracker path="/home/:site" title={ translate( 'My Home' ) } />
-			<DocumentHead title={ translate( 'My Home' ) } />
-			{ siteId && isJetpack && isPossibleJetpackConnectionProblem && (
-				<JetpackConnectionHealthBanner siteId={ siteId } />
+			{ ! config.isEnabled( 'home-launchpad' ) && (
+				<>
+					<DocumentHead title={ translate( 'My Home' ) } />
+					{ siteId && isJetpack && isPossibleJetpackConnectionProblem && (
+						<JetpackConnectionHealthBanner siteId={ siteId } />
+					) }
+					{ header }
+					{ ! isLoading && ! layout && homeLayoutError && (
+						<TrackComponentView
+							eventName="calypso_customer_home_my_site_view_layout_error"
+							eventProperties={ {
+								site_id: siteId,
+								error: homeLayoutError?.message ?? 'Layout is not available.',
+							} }
+						/>
+					) }
+				</>
 			) }
-			{ header }
-			{ ! isLoading && ! layout && homeLayoutError ? (
-				<TrackComponentView
-					eventName="calypso_customer_home_my_site_view_layout_error"
-					eventProperties={ {
-						site_id: siteId,
-						error: homeLayoutError?.message ?? 'Layout is not available.',
-					} }
-				/>
-			) : null }
-
 			{ renderStudioSyncNotice() }
 			{ renderUnverifiedEmailNotice() }
 			{ renderDnsSettingsDiagnosticNotice() }
 
 			{ isLoading && <div className="customer-home__loading-placeholder"></div> }
-			{ ! isLoading && layout && ! homeLayoutError ? (
+			{ config.isEnabled( 'home-launchpad' ) && <LaunchpadPreLaunch></LaunchpadPreLaunch> }
+			{ ! isLoading && layout && ! homeLayoutError && ! config.isEnabled( 'home-launchpad' ) && (
 				<>
 					<Primary cards={ layout?.primary } />
 					<div className="customer-home__layout">
@@ -329,7 +335,7 @@ const Home = ( {
 						</div>
 					</div>
 				</>
-			) : null }
+			) }
 			{ celebrateLaunchModalIsOpen && (
 				<CelebrateLaunchModal
 					setModalIsOpen={ setCelebrateLaunchModalIsOpen }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -90,6 +90,9 @@ const Home = ( {
 	const customDomain = customDomains?.length ? customDomains[ 0 ] : undefined;
 	const primaryDomain = customDomains?.find( ( domain ) => domain.isPrimary );
 
+	const homeLaunchpad =
+		config.isEnabled( 'home-launchpad' ) && getQueryArgs().launchpadOnly === 'true';
+
 	const {
 		data: domainDiagnosticData,
 		isFetching: isFetchingDomainDiagnostics,
@@ -318,8 +321,8 @@ const Home = ( {
 			{ renderDnsSettingsDiagnosticNotice() }
 
 			{ isLoading && <div className="customer-home__loading-placeholder"></div> }
-			{ config.isEnabled( 'home-launchpad' ) && <LaunchpadPreLaunch></LaunchpadPreLaunch> }
-			{ ! isLoading && layout && ! homeLayoutError && ! config.isEnabled( 'home-launchpad' ) && (
+			{ homeLaunchpad && <LaunchpadPreLaunch></LaunchpadPreLaunch> }
+			{ ! isLoading && layout && ! homeLayoutError && ! homeLaunchpad && (
 				<>
 					<Primary cards={ layout?.primary } />
 					<div className="customer-home__layout">

--- a/config/development.json
+++ b/config/development.json
@@ -77,6 +77,7 @@
 		"help": true,
 		"help/gpt-response": true,
 		"home/layout-dev": true,
+		"home-launchpad": false,
 		"hosting-server-settings-enhancements": true,
 		"hosting/datacenter-picker": true,
 		"i18n/community-translator": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -43,6 +43,7 @@
 		"global-styles/on-personal-plan": false,
 		"help": true,
 		"home/layout-dev": true,
+		"home-launchpad": false,
 		"hosting-server-settings-enhancements": true,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,

--- a/config/production.json
+++ b/config/production.json
@@ -55,6 +55,7 @@
 		"global-styles/on-personal-plan": false,
 		"help": true,
 		"help/gpt-response": true,
+		"home-launchpad": false,
 		"hosting-server-settings-enhancements": true,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -55,6 +55,7 @@
 		"global-styles/on-personal-plan": false,
 		"help": true,
 		"help/gpt-response": true,
+		"home-launchpad": false,
 		"hosting-server-settings-enhancements": true,
 		"i18n/empathy-mode": true,
 		"importer/site-backups": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -62,6 +62,7 @@
 		"help": true,
 		"help/gpt-response": true,
 		"home/layout-dev": true,
+		"home-launchpad": false,
 		"hosting/datacenter-picker": true,
 		"hosting-server-settings-enhancements": true,
 		"i18n/translation-scanner": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98348 and https://github.com/Automattic/wp-calypso/issues/98349

## Proposed Changes

* We're adding a new feature flag called `home-launchpad` which will add support to the Launchpad using the entire Home
* Hide all home content except the Launchpad when the feature flag `home-launchpad` and the `launchpadOnly` get parameter is received at the home page

**Note**: We're adding both the feature flag + URL parameter because in the following iterations, some components will use the feature flag to behave differently and the /home page will use both parameters. With this feature flag we can easily isolate the deliverables of this project.

<img width="1131" alt="image" src="https://github.com/user-attachments/assets/f6251895-3d2d-48a5-9ac1-8bcd688b0c60" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of Launchpad In My Home project: pet6gk-1T7-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to your home page and add the following parameters to it: `?flags=home-launchpad&launchpadOnly=true`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?