### PR TITLE
Help Center: Fix chat in migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/help-center/async.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/help-center/async.tsx
@@ -1,11 +1,11 @@
-import { HelpCenter } from '@automattic/data-stores';
+import { HelpCenter, User as UserStore } from '@automattic/data-stores';
 import { useDispatch } from '@wordpress/data';
 import { useCallback } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
-const AsyncHelpCenter = () => {
+const AsyncHelpCenter: React.FC< { user: UserStore.CurrentUser | undefined } > = ( { user } ) => {
 	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
 
 	const handleClose = useCallback( () => {
@@ -23,6 +23,7 @@ const AsyncHelpCenter = () => {
 			require="@automattic/help-center?stepper"
 			placeholder={ null }
 			handleClose={ handleClose }
+			currentUser={ user }
 		/>
 	);
 };

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -173,7 +173,7 @@ window.AppBoot = async () => {
 							id="notices"
 						/>
 					</BrowserRouter>
-					<AsyncHelpCenter />
+					<AsyncHelpCenter user={ user as UserStore.CurrentUser } />
 					{ 'development' === process.env.NODE_ENV && (
 						<AsyncLoad require="calypso/components/webpack-build-monitor" placeholder={ null } />
 					) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/98350

## Proposed Changes

* Pass the current user to the async loader of the Help Center when in the checkout modal.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The current user was not passed to the Help Center context in Stepper.
* That Help Center is loaded when we use the checkout modal.
* The `hosted-site-migration` flow uses the checkout modal.
* When loading the chat in checkout, it appeared blank:

![image](https://github.com/user-attachments/assets/c67d00ce-8a5f-4482-b9c3-c161fdc48359)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a Jurassic site ([jurassic.ninja](https://jurassic.ninja/)).
- Go to /setup/hosted-site-migration.
- Import the Jurassic site.
- Reach the `site-migration-upgrade-plan` and click to upgrade your plan
- During checkout, click on `Visit Help Center` and click on `Still need help?``
- You should see Odie in action


## Notes

If the user is not passed, the chat should not just be blank. We should manage this.
