### PR TITLE
Initial PoC of using the add-new-site component on /sites

### DIFF
--- a/client/components/add-new-site/button.tsx
+++ b/client/components/add-new-site/button.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 
 type Props = {
 	showMainButtonLabel: boolean;
+	mainButtonLabelText?: string;
 	isMenuVisible: boolean;
 	toggleMenu: () => void;
 	popoverMenuContext: React.RefObject< HTMLButtonElement >;
@@ -13,11 +14,13 @@ type Props = {
 
 const AddNewSiteButton: React.FC< Props > = ( {
 	showMainButtonLabel,
+	mainButtonLabelText,
 	isMenuVisible,
 	toggleMenu,
 	popoverMenuContext,
 } ) => {
 	const translate = useTranslate();
+	const mainButtonLabel = mainButtonLabelText || translate( 'Add sites' );
 
 	return (
 		<Button
@@ -27,7 +30,7 @@ const AddNewSiteButton: React.FC< Props > = ( {
 			onClick={ toggleMenu }
 		>
 			<>
-				{ showMainButtonLabel ? translate( 'Add sites' ) : null }
+				{ showMainButtonLabel ? mainButtonLabel : null }
 				<Gridicon
 					className={ clsx(
 						{ reverse: showMainButtonLabel && isMenuVisible },

--- a/client/components/add-new-site/content/index.tsx
+++ b/client/components/add-new-site/content/index.tsx
@@ -13,7 +13,13 @@ const AddNewSiteContent = ( props: AddNewSiteContentProps ) => {
 			/>
 		);
 	}
-	return null;
+	return (
+		<AsyncLoad
+			{ ...props }
+			require="calypso/components/add-new-site/content/site-list"
+			placeholder={ null }
+		/>
+	);
 };
 
 export default AddNewSiteContent;

--- a/client/components/add-new-site/content/site-list/index.tsx
+++ b/client/components/add-new-site/content/site-list/index.tsx
@@ -1,0 +1,22 @@
+import AddNewSiteSiteListMenuItems from 'calypso/components/add-new-site/menu-items/site-list';
+import AddNewSitePopover from 'calypso/components/add-new-site/popover';
+import type { AddNewSiteContentProps } from 'calypso/components/add-new-site/types';
+
+const AddNewSiteSiteList = ( {
+	isMenuVisible,
+	popoverMenuContext,
+	setMenuVisible,
+	toggleMenu,
+}: AddNewSiteContentProps ) => {
+	return (
+		<AddNewSitePopover
+			isMenuVisible={ isMenuVisible }
+			toggleMenu={ toggleMenu }
+			popoverMenuContext={ popoverMenuContext }
+		>
+			<AddNewSiteSiteListMenuItems setMenuVisible={ setMenuVisible } />
+		</AddNewSitePopover>
+	);
+};
+
+export default AddNewSiteSiteList;

--- a/client/components/add-new-site/content/site-list/index.tsx
+++ b/client/components/add-new-site/content/site-list/index.tsx
@@ -5,7 +5,6 @@ import type { AddNewSiteContentProps } from 'calypso/components/add-new-site/typ
 const AddNewSiteSiteList = ( {
 	isMenuVisible,
 	popoverMenuContext,
-	setMenuVisible,
 	toggleMenu,
 }: AddNewSiteContentProps ) => {
 	return (
@@ -14,7 +13,7 @@ const AddNewSiteSiteList = ( {
 			toggleMenu={ toggleMenu }
 			popoverMenuContext={ popoverMenuContext }
 		>
-			<AddNewSiteSiteListMenuItems setMenuVisible={ setMenuVisible } />
+			<AddNewSiteSiteListMenuItems />
 		</AddNewSitePopover>
 	);
 };

--- a/client/components/add-new-site/menu-items/site-list.tsx
+++ b/client/components/add-new-site/menu-items/site-list.tsx
@@ -56,6 +56,7 @@ const AddNewSiteSiteListMenuItems = () => {
 						},
 					} }
 				/>
+				{ /* TODO: Do we really need a Pressable menu item? */ }
 				<AddNewSiteMenuItem
 					icon={ <img src={ pressableIcon } alt="Pressable" /> }
 					heading="Pressable"

--- a/client/components/add-new-site/menu-items/site-list.tsx
+++ b/client/components/add-new-site/menu-items/site-list.tsx
@@ -93,7 +93,8 @@ const AddNewSiteSiteListMenuItems = () => {
 						disabled={ ! popoverOfferEnabled }
 						buttonProps={ {
 							onClick: () => {
-								// TODO
+								recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_offer' );
+								window.location.href = 'https://wordpress.com/pricing/';
 							},
 						} }
 					>

--- a/client/components/add-new-site/menu-items/site-list.tsx
+++ b/client/components/add-new-site/menu-items/site-list.tsx
@@ -4,11 +4,8 @@ import { WordPressLogo, JetpackLogo } from '@automattic/components';
 import { download, reusableBlock, Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
 // TODO: This will need to be updated to use whatever image we decide on.
 import devSiteBanner from 'calypso/assets/images/a8c-for-agencies/dev-site-banner.svg';
-import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
 import AddNewSiteMenuItem from 'calypso/components/add-new-site/menu-item';
 import AddNewSitePopoverColumn from 'calypso/components/add-new-site/popover-column';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -16,8 +13,6 @@ import { TRACK_SOURCE_NAME } from 'calypso/sites-dashboard/utils';
 
 const AddNewSiteSiteListMenuItems = () => {
 	const translate = useTranslate();
-
-	const pressableOwnership = usePressableOwnershipType();
 
 	const popoverOfferEnabled = true;
 	const popoverCardEnabled = true;
@@ -49,19 +44,6 @@ const AddNewSiteSiteListMenuItems = () => {
 							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_jetpack' );
 							page( `/jetpack/connect?cta_from=${ TRACK_SOURCE_NAME }&cta_id=add-site` );
 						},
-					} }
-				/>
-				{ /* TODO: Do we really need a Pressable menu item? */ }
-				<AddNewSiteMenuItem
-					icon={ <img src={ pressableIcon } alt="Pressable" /> }
-					heading="Pressable"
-					description={ translate( 'Bring your theme, plugins, and content to WordPress.com.' ) }
-					buttonProps={ {
-						href:
-							pressableOwnership === 'regular'
-								? 'https://my.pressable.com/agency/auth'
-								: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
-						target: pressableOwnership === 'regular' ? '_blank' : undefined,
 					} }
 				/>
 			</AddNewSitePopoverColumn>

--- a/client/components/add-new-site/menu-items/site-list.tsx
+++ b/client/components/add-new-site/menu-items/site-list.tsx
@@ -38,7 +38,8 @@ const AddNewSiteSiteListMenuItems = () => {
 					) }
 					buttonProps={ {
 						onClick: () => {
-							// TODO
+							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_wordpress' );
+							page( '/start?source=sites-dashboard&ref=topbar' );
 						},
 					} }
 				/>

--- a/client/components/add-new-site/menu-items/site-list.tsx
+++ b/client/components/add-new-site/menu-items/site-list.tsx
@@ -1,0 +1,140 @@
+import config from '@automattic/calypso-config';
+import { WordPressLogo, JetpackLogo } from '@automattic/components';
+import { download, reusableBlock, Icon } from '@wordpress/icons';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { useContext, useCallback } from 'react';
+import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useFetchDevLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-dev-licenses';
+import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
+// TODO: This will need to be updated to use whatever image we decide on.
+import devSiteBanner from 'calypso/assets/images/a8c-for-agencies/dev-site-banner.svg';
+import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
+import AddNewSiteContext from 'calypso/components/add-new-site/context';
+import AddNewSiteMenuItem from 'calypso/components/add-new-site/menu-item';
+import AddNewSitePopoverColumn from 'calypso/components/add-new-site/popover-column';
+import { preventWidows } from 'calypso/lib/formatting';
+import type { AddNewSiteMenuItemsProps } from 'calypso/components/add-new-site/types';
+
+const AddNewSiteSiteListMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) => {
+	const translate = useTranslate();
+
+	const { setVisibleModalType } = useContext( AddNewSiteContext );
+
+	const pressableOwnership = usePressableOwnershipType();
+
+	const { data: devLicenses } = useFetchDevLicenses();
+
+	const hasAvailableDevSites = devLicenses?.available > 0;
+
+	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
+
+	const handleOnClick = useCallback(
+		( modalType: string ) => {
+			setVisibleModalType( modalType );
+			setMenuVisible( false );
+		},
+		[ setVisibleModalType, setMenuVisible ]
+	);
+
+	return (
+		<>
+			<AddNewSitePopoverColumn heading={ translate( 'Add a new site' ) }>
+				<AddNewSiteMenuItem
+					icon={ <WordPressLogo /> }
+					heading={ translate( 'WordPress.com' ) }
+					description={ preventWidows(
+						translate( 'Build and grow your site, all in one powerful platform.' )
+					) }
+					buttonProps={ {
+						onClick: () => {
+							// TODO
+						},
+					} }
+				/>
+				<AddNewSiteMenuItem
+					icon={ <JetpackLogo /> }
+					heading={ translate( 'Via the Jetpack plugin' ) }
+					description={ preventWidows(
+						translate( 'Install the Jetpack plugin on an existing site' )
+					) }
+					buttonProps={ {
+						onClick: () => {
+							handleOnClick( 'jetpack-connection' );
+						},
+					} }
+				/>
+				<AddNewSiteMenuItem
+					icon={ <img src={ pressableIcon } alt="Pressable" /> }
+					heading="Pressable"
+					description={ translate( 'Bring your theme, plugins, and content to WordPress.com.' ) }
+					buttonProps={ {
+						href:
+							pressableOwnership === 'regular'
+								? 'https://my.pressable.com/agency/auth'
+								: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
+						target: pressableOwnership === 'regular' ? '_blank' : undefined,
+					} }
+				/>
+			</AddNewSitePopoverColumn>
+			<AddNewSitePopoverColumn heading={ translate( 'Migrate & Import' ) }>
+				<AddNewSiteMenuItem
+					icon={ <Icon icon={ reusableBlock } size={ 18 } /> }
+					heading="Migrate"
+					description={ preventWidows(
+						translate( 'Bring your theme, plugins, and content to WordPress.com.' )
+					) }
+					buttonProps={ {
+						onClick: () => {
+							// TODO
+						},
+					} }
+				/>
+				<AddNewSiteMenuItem
+					icon={ <Icon icon={ download } size={ 18 } /> }
+					heading="Import"
+					description={ preventWidows(
+						translate( 'Use a backup file to import your content into a new site.' )
+					) }
+					buttonProps={ {
+						onClick: () => {
+							// TODO
+						},
+					} }
+				/>
+			</AddNewSitePopoverColumn>
+			{ devSitesEnabled && (
+				<AddNewSitePopoverColumn>
+					<AddNewSiteMenuItem
+						isBanner
+						icon={ <img src={ devSiteBanner } alt="Get a Free Domain and Up to 55% off" /> }
+						heading={ translate( 'Get a Free Domain and Up to 55% off' ) }
+						description={ preventWidows(
+							translate(
+								'Save up to 55% on annual plans and get a free custom domain for a year. Your next site is just a step away.'
+							)
+						) }
+						disabled={ ! hasAvailableDevSites }
+						buttonProps={ {
+							onClick: () => {
+								// TODO
+							},
+						} }
+					>
+						<div>
+							<div
+								className={ clsx( 'add-new-site-popover__cta', {
+									disabled: ! hasAvailableDevSites,
+								} ) }
+							>
+								{ translate( 'Unlock Offer' ) }
+							</div>
+						</div>
+					</AddNewSiteMenuItem>
+				</AddNewSitePopoverColumn>
+			) }
+		</>
+	);
+};
+
+export default AddNewSiteSiteListMenuItems;

--- a/client/components/add-new-site/menu-items/site-list.tsx
+++ b/client/components/add-new-site/menu-items/site-list.tsx
@@ -1,12 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { WordPressLogo, JetpackLogo } from '@automattic/components';
 import { download, reusableBlock, Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import useFetchDevLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-dev-licenses';
 import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
 // TODO: This will need to be updated to use whatever image we decide on.
 import devSiteBanner from 'calypso/assets/images/a8c-for-agencies/dev-site-banner.svg';
@@ -21,11 +19,8 @@ const AddNewSiteSiteListMenuItems = () => {
 
 	const pressableOwnership = usePressableOwnershipType();
 
-	const { data: devLicenses } = useFetchDevLicenses();
-
-	const hasAvailableDevSites = devLicenses?.available > 0;
-
-	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
+	const popoverOfferEnabled = true;
+	const popoverCardEnabled = true;
 
 	return (
 		<>
@@ -102,7 +97,7 @@ const AddNewSiteSiteListMenuItems = () => {
 					} }
 				/>
 			</AddNewSitePopoverColumn>
-			{ devSitesEnabled && (
+			{ popoverCardEnabled && (
 				<AddNewSitePopoverColumn>
 					<AddNewSiteMenuItem
 						isBanner
@@ -113,7 +108,7 @@ const AddNewSiteSiteListMenuItems = () => {
 								'Save up to 55% on annual plans and get a free custom domain for a year. Your next site is just a step away.'
 							)
 						) }
-						disabled={ ! hasAvailableDevSites }
+						disabled={ ! popoverOfferEnabled }
 						buttonProps={ {
 							onClick: () => {
 								// TODO
@@ -123,7 +118,7 @@ const AddNewSiteSiteListMenuItems = () => {
 						<div>
 							<div
 								className={ clsx( 'add-new-site-popover__cta', {
-									disabled: ! hasAvailableDevSites,
+									disabled: ! popoverOfferEnabled,
 								} ) }
 							>
 								{ translate( 'Unlock Offer' ) }

--- a/client/components/add-new-site/menu-items/site-list.tsx
+++ b/client/components/add-new-site/menu-items/site-list.tsx
@@ -1,25 +1,23 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
 import { WordPressLogo, JetpackLogo } from '@automattic/components';
 import { download, reusableBlock, Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useContext, useCallback } from 'react';
 import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useFetchDevLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-dev-licenses';
 import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
 // TODO: This will need to be updated to use whatever image we decide on.
 import devSiteBanner from 'calypso/assets/images/a8c-for-agencies/dev-site-banner.svg';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
-import AddNewSiteContext from 'calypso/components/add-new-site/context';
 import AddNewSiteMenuItem from 'calypso/components/add-new-site/menu-item';
 import AddNewSitePopoverColumn from 'calypso/components/add-new-site/popover-column';
 import { preventWidows } from 'calypso/lib/formatting';
-import type { AddNewSiteMenuItemsProps } from 'calypso/components/add-new-site/types';
+import { TRACK_SOURCE_NAME } from 'calypso/sites-dashboard/utils';
 
-const AddNewSiteSiteListMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) => {
+const AddNewSiteSiteListMenuItems = () => {
 	const translate = useTranslate();
-
-	const { setVisibleModalType } = useContext( AddNewSiteContext );
 
 	const pressableOwnership = usePressableOwnershipType();
 
@@ -28,14 +26,6 @@ const AddNewSiteSiteListMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsPro
 	const hasAvailableDevSites = devLicenses?.available > 0;
 
 	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
-
-	const handleOnClick = useCallback(
-		( modalType: string ) => {
-			setVisibleModalType( modalType );
-			setMenuVisible( false );
-		},
-		[ setVisibleModalType, setMenuVisible ]
-	);
 
 	return (
 		<>
@@ -60,7 +50,8 @@ const AddNewSiteSiteListMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsPro
 					) }
 					buttonProps={ {
 						onClick: () => {
-							handleOnClick( 'jetpack-connection' );
+							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_jetpack' );
+							page( `/jetpack/connect?cta_from=${ TRACK_SOURCE_NAME }&cta_id=add-site` );
 						},
 					} }
 				/>

--- a/client/components/add-new-site/menu-items/site-list.tsx
+++ b/client/components/add-new-site/menu-items/site-list.tsx
@@ -78,7 +78,10 @@ const AddNewSiteSiteListMenuItems = () => {
 					) }
 					buttonProps={ {
 						onClick: () => {
-							// TODO
+							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_migrate' );
+							page(
+								'/setup/hosted-site-migration/site-migration-identify?source=sites-dashboard&ref=topbar&action=migrate'
+							);
 						},
 					} }
 				/>
@@ -90,7 +93,10 @@ const AddNewSiteSiteListMenuItems = () => {
 					) }
 					buttonProps={ {
 						onClick: () => {
-							// TODO
+							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_import' );
+							page(
+								'/setup/hosted-site-migration/site-migration-identify?source=sites-dashboard&ref=topbar&action=import'
+							);
 						},
 					} }
 				/>

--- a/client/components/add-new-site/style.scss
+++ b/client/components/add-new-site/style.scss
@@ -128,12 +128,13 @@ button, a {
 
 		.add-new-site__popover-button-heading {
 			font-size: rem(14px);
+			font-weight: 600;
 		}
 
 		.add-new-site__popover-button-description {
 			font-size: rem(12px);
 			font-weight: 400;
-			color: var(--color-accent);
+			color: var(--color-text-black);
 			padding-top: 4px;
 		}
 	}

--- a/client/sites/components/sites-dashboard-header.scss
+++ b/client/sites/components/sites-dashboard-header.scss
@@ -1,0 +1,23 @@
+.sites-dashboard-header {
+	.add-new-site__button {
+		&.is-secondary {
+			background-color: rgb(56, 88, 233);
+			border-color: rgb(56, 88, 233);
+			color: rgb(255, 255, 255);
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+			font-style: normal;
+			font-weight: 400;
+			line-height: 22px
+		}
+
+		outline: none;
+		border-radius: 2px 0 0 2px;
+		-moz-osx-font-smoothing: grayscale;
+
+	}
+
+	.components-button.is-secondary:hover {
+		color: rgb(255, 255, 255);
+		background-color: rgb(33, 69, 230);
+	}
+} 

--- a/client/sites/components/sites-dashboard-header.tsx
+++ b/client/sites/components/sites-dashboard-header.tsx
@@ -1,18 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { JetpackLogo } from '@automattic/components';
-import { useMobileBreakpoint } from '@automattic/viewport-react';
-import { css } from '@emotion/css';
 import styled from '@emotion/styled';
-import { download, Icon } from '@wordpress/icons';
-import { useI18n } from '@wordpress/react-i18n';
-import { addQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
 import { useState, useRef } from 'react';
+import AddNewSiteButton from 'calypso/components/add-new-site/button';
 import AddNewSiteContent from 'calypso/components/add-new-site/content';
-import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import SplitButton from 'calypso/components/split-button';
-import { MEDIA_QUERIES, TRACK_SOURCE_NAME } from 'calypso/sites-dashboard/utils';
-import { useSitesDashboardImportSiteUrl } from '../hooks/use-sites-dashboard-import-site-url';
-import { LinkWithRedirect } from './link-with-redirect';
+import { MEDIA_QUERIES } from 'calypso/sites-dashboard/utils';
 import 'calypso/components/add-new-site/style.scss';
 
 interface SitesDashboardHeaderProps {
@@ -45,71 +37,10 @@ export const PageBodyBottomContainer = styled.div( {
 	},
 } );
 
-const responsiveButtonStyles = {
-	alignItems: 'center',
-	fontSize: '12px',
-	display: 'inline-flex',
-	height: '28px',
-	lineHeight: '14px',
-	padding: '0 12px',
-};
-
-const AddNewSiteSplitButton = styled( SplitButton )< { isMobile: boolean } >`
-	.split-button__main {
-		border-radius: 2px 0 0 2px;
-		-webkit-font-smoothing: antialiased;
-
-		.rtl & {
-			border-radius: 0 2px 2px 0;
-		}
-	}
-
-	.split-button__toggle {
-		border-radius: ${ ( { isMobile } ) => ( isMobile ? '2px' : '0 2px 2px 0' ) };
-
-		.rtl & {
-			border-radius: ${ ( { isMobile } ) => ( isMobile ? '2px' : '2px 0 0 2px' ) };
-		}
-	}
-
-	.sites-dashboard__layout:not( .preview-hidden ) & {
-		.split-button__main,
-		.split-button__toggle {
-			${ responsiveButtonStyles }
-		}
-
-		.split-button__toggle .gridicon {
-			top: 2px;
-		}
-	}
-`;
-
-const DownloadIcon = styled( Icon )`
-	margin-right: 8px;
-	vertical-align: bottom;
-
-	.rtl & {
-		margin-right: 0;
-		margin-left: 8px;
-	}
-`;
-
-const popoverHoverStyles = css`
-	&:hover,
-	&:focus {
-		fill: var( --color-text-inverted );
-	}
-`;
-
 const SitesDashboardHeader: React.FC< SitesDashboardHeaderProps > = ( { isPreviewPaneOpen } ) => {
-	const { __ } = useI18n();
-	const isMobile = useMobileBreakpoint();
 	const [ isMenuVisible, setMenuVisible ] = useState( false );
 	const popoverMenuContext = useRef( null );
-
-	const importSiteUrl = useSitesDashboardImportSiteUrl( {
-		ref: 'topbar',
-	} );
+	const translate = useTranslate();
 
 	const toggleMenu = () => {
 		setMenuVisible( ( isVisible ) => ! isVisible );
@@ -118,43 +49,16 @@ const SitesDashboardHeader: React.FC< SitesDashboardHeaderProps > = ( { isPrevie
 	return (
 		<PageHeader>
 			<HeaderControls>
-				<AddNewSiteSplitButton
-					primary={ ! isPreviewPaneOpen }
-					whiteSeparator={ ! isPreviewPaneOpen }
-					className="sites-add-new-site-split-button"
-					label={ __( 'Add new site' ) }
-					onClick={ () => {
+				<AddNewSiteButton
+					showMainButtonLabel={ ! isPreviewPaneOpen }
+					mainButtonLabelText={ translate( 'Add new site' ) }
+					isMenuVisible={ isMenuVisible }
+					toggleMenu={ () => {
 						recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_add' );
 						toggleMenu();
 					} }
-					toggleIcon={ isMobile ? 'plus' : undefined }
-					isMobile={ isMobile }
-					ref={ popoverMenuContext }
-				>
-					<PopoverMenuItem
-						onClick={ () => {
-							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_jetpack' );
-						} }
-						href={ addQueryArgs( '/jetpack/connect', {
-							cta_from: TRACK_SOURCE_NAME,
-							cta_id: 'add-site',
-						} ) }
-					>
-						<JetpackLogo className="gridicon" size={ 18 } />
-						<span>{ __( 'Add Jetpack to a self-hosted site' ) }</span>
-					</PopoverMenuItem>
-					<PopoverMenuItem
-						className={ `${ popoverHoverStyles }` }
-						onClick={ () => {
-							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_import' );
-						} }
-						href={ importSiteUrl }
-						itemComponent={ LinkWithRedirect }
-					>
-						<DownloadIcon icon={ download } size={ 18 } />
-						<span>{ __( 'Import an existing site' ) }</span>
-					</PopoverMenuItem>
-				</AddNewSiteSplitButton>
+					popoverMenuContext={ popoverMenuContext }
+				/>
 
 				<AddNewSiteContent
 					isMenuVisible={ isMenuVisible }

--- a/client/sites/components/sites-dashboard-header.tsx
+++ b/client/sites/components/sites-dashboard-header.tsx
@@ -6,12 +6,14 @@ import styled from '@emotion/styled';
 import { download, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
+import { useState, useRef } from 'react';
+import AddNewSiteContent from 'calypso/components/add-new-site/content';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SplitButton from 'calypso/components/split-button';
-import { useAddNewSiteUrl } from 'calypso/lib/paths/use-add-new-site-url';
 import { MEDIA_QUERIES, TRACK_SOURCE_NAME } from 'calypso/sites-dashboard/utils';
 import { useSitesDashboardImportSiteUrl } from '../hooks/use-sites-dashboard-import-site-url';
 import { LinkWithRedirect } from './link-with-redirect';
+import 'calypso/components/add-new-site/style.scss';
 
 interface SitesDashboardHeaderProps {
 	isPreviewPaneOpen: boolean;
@@ -102,15 +104,16 @@ const popoverHoverStyles = css`
 const SitesDashboardHeader: React.FC< SitesDashboardHeaderProps > = ( { isPreviewPaneOpen } ) => {
 	const { __ } = useI18n();
 	const isMobile = useMobileBreakpoint();
-
-	const createSiteUrl = useAddNewSiteUrl( {
-		source: TRACK_SOURCE_NAME,
-		ref: 'topbar',
-	} );
+	const [ isMenuVisible, setMenuVisible ] = useState( false );
+	const popoverMenuContext = useRef( null );
 
 	const importSiteUrl = useSitesDashboardImportSiteUrl( {
 		ref: 'topbar',
 	} );
+
+	const toggleMenu = () => {
+		setMenuVisible( ( isVisible ) => ! isVisible );
+	};
 
 	return (
 		<PageHeader>
@@ -122,10 +125,11 @@ const SitesDashboardHeader: React.FC< SitesDashboardHeaderProps > = ( { isPrevie
 					label={ __( 'Add new site' ) }
 					onClick={ () => {
 						recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_add' );
+						toggleMenu();
 					} }
-					href={ createSiteUrl }
 					toggleIcon={ isMobile ? 'plus' : undefined }
 					isMobile={ isMobile }
+					ref={ popoverMenuContext }
 				>
 					<PopoverMenuItem
 						onClick={ () => {
@@ -151,6 +155,13 @@ const SitesDashboardHeader: React.FC< SitesDashboardHeaderProps > = ( { isPrevie
 						<span>{ __( 'Import an existing site' ) }</span>
 					</PopoverMenuItem>
 				</AddNewSiteSplitButton>
+
+				<AddNewSiteContent
+					isMenuVisible={ isMenuVisible }
+					toggleMenu={ toggleMenu }
+					popoverMenuContext={ popoverMenuContext }
+					setMenuVisible={ setMenuVisible }
+				/>
 			</HeaderControls>
 		</PageHeader>
 	);

--- a/client/sites/components/sites-dashboard-header.tsx
+++ b/client/sites/components/sites-dashboard-header.tsx
@@ -17,6 +17,7 @@ import { MEDIA_QUERIES, TRACK_SOURCE_NAME } from 'calypso/sites-dashboard/utils'
 import { useSitesDashboardImportSiteUrl } from '../hooks/use-sites-dashboard-import-site-url';
 import { LinkWithRedirect } from './link-with-redirect';
 import 'calypso/components/add-new-site/style.scss';
+import './sites-dashboard-header.scss';
 
 interface SitesDashboardHeaderProps {
 	isPreviewPaneOpen: boolean;
@@ -123,7 +124,7 @@ const SitesDashboardHeader: React.FC< SitesDashboardHeaderProps > = ( { isPrevie
 	};
 
 	return (
-		<PageHeader>
+		<PageHeader className="sites-dashboard-header">
 			<HeaderControls>
 				{ isDriveMigrationEnabled && (
 					<>

--- a/client/sites/components/sites-dashboard-header.tsx
+++ b/client/sites/components/sites-dashboard-header.tsx
@@ -1,10 +1,21 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
+import { JetpackLogo } from '@automattic/components';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { css } from '@emotion/css';
 import styled from '@emotion/styled';
+import { download, Icon } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useRef } from 'react';
 import AddNewSiteButton from 'calypso/components/add-new-site/button';
 import AddNewSiteContent from 'calypso/components/add-new-site/content';
-import { MEDIA_QUERIES } from 'calypso/sites-dashboard/utils';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import SplitButton from 'calypso/components/split-button';
+import { useAddNewSiteUrl } from 'calypso/lib/paths/use-add-new-site-url';
+import { MEDIA_QUERIES, TRACK_SOURCE_NAME } from 'calypso/sites-dashboard/utils';
+import { useSitesDashboardImportSiteUrl } from '../hooks/use-sites-dashboard-import-site-url';
+import { LinkWithRedirect } from './link-with-redirect';
 import 'calypso/components/add-new-site/style.scss';
 
 interface SitesDashboardHeaderProps {
@@ -37,10 +48,75 @@ export const PageBodyBottomContainer = styled.div( {
 	},
 } );
 
+const responsiveButtonStyles = {
+	alignItems: 'center',
+	fontSize: '12px',
+	display: 'inline-flex',
+	height: '28px',
+	lineHeight: '14px',
+	padding: '0 12px',
+};
+
+const AddNewSiteSplitButton = styled( SplitButton )< { isMobile: boolean } >`
+	.split-button__main {
+		border-radius: 2px 0 0 2px;
+		-webkit-font-smoothing: antialiased;
+
+		.rtl & {
+			border-radius: 0 2px 2px 0;
+		}
+	}
+
+	.split-button__toggle {
+		border-radius: ${ ( { isMobile } ) => ( isMobile ? '2px' : '0 2px 2px 0' ) };
+
+		.rtl & {
+			border-radius: ${ ( { isMobile } ) => ( isMobile ? '2px' : '2px 0 0 2px' ) };
+		}
+	}
+
+	.sites-dashboard__layout:not( .preview-hidden ) & {
+		.split-button__main,
+		.split-button__toggle {
+			${ responsiveButtonStyles }
+		}
+
+		.split-button__toggle .gridicon {
+			top: 2px;
+		}
+	}
+`;
+
+const DownloadIcon = styled( Icon )`
+	margin-right: 8px;
+	vertical-align: bottom;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 8px;
+	}
+`;
+
+const popoverHoverStyles = css`
+	&:hover,
+	&:focus {
+		fill: var( --color-text-inverted );
+	}
+`;
+
 const SitesDashboardHeader: React.FC< SitesDashboardHeaderProps > = ( { isPreviewPaneOpen } ) => {
 	const [ isMenuVisible, setMenuVisible ] = useState( false );
 	const popoverMenuContext = useRef( null );
 	const translate = useTranslate();
+	const isDriveMigrationEnabled = config.isEnabled( 'sites/drive-migrations' );
+	const isMobile = useMobileBreakpoint();
+	const createSiteUrl = useAddNewSiteUrl( {
+		source: TRACK_SOURCE_NAME,
+		ref: 'topbar',
+	} );
+	const importSiteUrl = useSitesDashboardImportSiteUrl( {
+		ref: 'topbar',
+	} );
 
 	const toggleMenu = () => {
 		setMenuVisible( ( isVisible ) => ! isVisible );
@@ -49,23 +125,65 @@ const SitesDashboardHeader: React.FC< SitesDashboardHeaderProps > = ( { isPrevie
 	return (
 		<PageHeader>
 			<HeaderControls>
-				<AddNewSiteButton
-					showMainButtonLabel={ ! isPreviewPaneOpen }
-					mainButtonLabelText={ translate( 'Add new site' ) }
-					isMenuVisible={ isMenuVisible }
-					toggleMenu={ () => {
-						recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_add' );
-						toggleMenu();
-					} }
-					popoverMenuContext={ popoverMenuContext }
-				/>
+				{ isDriveMigrationEnabled && (
+					<>
+						<AddNewSiteButton
+							showMainButtonLabel={ ! isPreviewPaneOpen }
+							mainButtonLabelText={ translate( 'Add new site' ) }
+							isMenuVisible={ isMenuVisible }
+							toggleMenu={ () => {
+								recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_add' );
+								toggleMenu();
+							} }
+							popoverMenuContext={ popoverMenuContext }
+						/>
 
-				<AddNewSiteContent
-					isMenuVisible={ isMenuVisible }
-					toggleMenu={ toggleMenu }
-					popoverMenuContext={ popoverMenuContext }
-					setMenuVisible={ setMenuVisible }
-				/>
+						<AddNewSiteContent
+							isMenuVisible={ isMenuVisible }
+							toggleMenu={ toggleMenu }
+							popoverMenuContext={ popoverMenuContext }
+							setMenuVisible={ setMenuVisible }
+						/>
+					</>
+				) }
+				{ ! isDriveMigrationEnabled && (
+					<AddNewSiteSplitButton
+						primary={ ! isPreviewPaneOpen }
+						whiteSeparator={ ! isPreviewPaneOpen }
+						className="sites-add-new-site-split-button"
+						label={ translate( 'Add new site' ) }
+						onClick={ () => {
+							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_add' );
+						} }
+						href={ createSiteUrl }
+						toggleIcon={ isMobile ? 'plus' : undefined }
+						isMobile={ isMobile }
+					>
+						<PopoverMenuItem
+							onClick={ () => {
+								recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_jetpack' );
+							} }
+							href={ addQueryArgs( '/jetpack/connect', {
+								cta_from: TRACK_SOURCE_NAME,
+								cta_id: 'add-site',
+							} ) }
+						>
+							<JetpackLogo className="gridicon" size={ 18 } />
+							<span>{ translate( 'Add Jetpack to a self-hosted site' ) }</span>
+						</PopoverMenuItem>
+						<PopoverMenuItem
+							className={ `${ popoverHoverStyles }` }
+							onClick={ () => {
+								recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_import' );
+							} }
+							href={ importSiteUrl }
+							itemComponent={ LinkWithRedirect }
+						>
+							<DownloadIcon icon={ download } size={ 18 } />
+							<span>{ translate( 'Import an existing site' ) }</span>
+						</PopoverMenuItem>
+					</AddNewSiteSplitButton>
+				) }
 			</HeaderControls>
 		</PageHeader>
 	);


### PR DESCRIPTION
Project Thread: paYKcK-5M0-p2
Feedback Thread: paYKcK-5Mi-p2

## Proposed Changes

This updates `/sites` to display a similar add-new-site popover to what we're currently using on A4A.

<img width="1167" alt="CleanShot 2025-01-14 at 15 13 58@2x" src="https://github.com/user-attachments/assets/fc185a81-9be9-41af-80ca-17663eb816b1" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The idea is to give users more options to add a site and try and drive more migrations.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This can be tested locally or using the calypso.live link or running calypso locally.

* Go to `/sites?flags=sites%2Fdrive-migrations` and click "Add new site". You should see the new popover.

**NOTE: There are some known CSS issues that will be resolved in future PRs. Since this is behind a feature flag, there is no risk to existing users.*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?