### PR TITLE
Define "theme_color" config option for all wpcom environments

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -15,6 +15,7 @@
 	"boom_analytics_enabled": false,
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "development",
+	"theme_color": "#1D2327",
 	"hotjar_enabled": true,
 	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -168,5 +168,6 @@
 	"boom_analytics_enabled": true,
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "horizon",
+	"theme_color": "#1D2327",
 	"hotjar_enabled": true
 }

--- a/config/production.json
+++ b/config/production.json
@@ -210,5 +210,6 @@
 	"boom_analytics_enabled": true,
 	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "production",
+	"theme_color": "#1D2327",
 	"hotjar_enabled": true
 }

--- a/config/stage.json
+++ b/config/stage.json
@@ -206,5 +206,6 @@
 	"boom_analytics_enabled": true,
 	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "stage",
+	"theme_color": "#1D2327",
 	"hotjar_enabled": true
 }

--- a/config/test.json
+++ b/config/test.json
@@ -15,6 +15,7 @@
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "development",
 	"google_recaptcha_site_key": "",
+	"theme_color": "#1D2327",
 	"hotjar_enabled": true,
 	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -203,5 +203,6 @@
 	"boom_analytics_enabled": true,
 	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "wpcalypso",
+	"theme_color": "#1D2327",
 	"hotjar_enabled": true
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #98335

## Proposed Changes

* Define the `theme_color` environment config option in wordpress.com environments
* The value chosen is `#1D2327`, ie. the default background color used for the sidebar and masterbar UI

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

As explained in #98335, defining the variable prevents invalid markup in the `manifest.json` file and in the generated HTML (specifically the `<meta name="theme-color" />` tag)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load calypso in the development environment 
* In the browser console, notice that the warning about invalid `manifest.json` properties is not shown anymore (while it is currently shown on `trunk`)
* Load the `manifest.json` file (`/calypso/manifest.json`) and check that the `theme_color` and `background_color` properties are defined (`#1D2327`)
  * Optionally, try to install the website as a PWA and observe that the `theme_color` and `background_color` properties are applied by the browser when using the PWA
* Inspect the HTML code, check that the `<meta name="theme-color" />` tag has a valid `content` attribute (`#1D2327`)
  * Optionally, load the page in Mac OS Safari with the compact tab layout preference enabled, and make sure that the theme color is applied to the browser UI
* The following should apply in all wordpress.com environments
* The a4a and jetpack cloud environments should be unaffected and use the same `theme_color` config option as on `trunk`

> [!Note]
> In the wordpress.com environment, there is an expectation that when the user changes the admin color scheme, the `<meta name="theme-color" />` tag gets updated too (while this shouldn't happen in the a4a and jetpack cloud environments). However, this feature is not working as expected in `trunk` either (as reported in #98335).
> I am planning to address the issue in a separate PR (https://github.com/Automattic/wp-calypso/pull/98381)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
