### PR TITLE
Add theme_color_admin_color_scheme_override env flag and use to update meta theme color tag

### DIFF
--- a/client/layout/color-scheme/index.jsx
+++ b/client/layout/color-scheme/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { getAdminColor } from 'calypso/state/admin-color/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -48,13 +49,14 @@ export function refreshColorScheme( prevColorScheme, nextColorScheme ) {
 
 	if ( nextColorScheme ) {
 		classList.add( `is-${ nextColorScheme }` );
+	}
 
+	if ( config( 'theme_color_override_with_admin_color_scheme' ) ) {
 		const themeColor = getComputedStyle( document.body )
 			.getPropertyValue( '--color-masterbar-background' )
 			.trim();
 		const themeColorMeta = document.querySelector( 'meta[name="theme-color"]' );
-		// We only adjust the `theme-color` meta content value in case we set it in `componentDidMount`
-		if ( themeColorMeta && themeColorMeta.getAttribute( 'data-colorscheme' ) === 'true' ) {
+		if ( themeColorMeta && themeColor ) {
 			themeColorMeta.content = themeColor;
 		}
 	}

--- a/client/layout/color-scheme/index.jsx
+++ b/client/layout/color-scheme/index.jsx
@@ -51,7 +51,7 @@ export function refreshColorScheme( prevColorScheme, nextColorScheme ) {
 		classList.add( `is-${ nextColorScheme }` );
 	}
 
-	if ( config( 'theme_color_override_with_admin_color_scheme' ) ) {
+	if ( config( 'theme_color_admin_color_scheme_override' ) ) {
 		const themeColor = getComputedStyle( document.body )
 			.getPropertyValue( '--color-masterbar-background' )
 			.trim();

--- a/client/layout/color-scheme/index.jsx
+++ b/client/layout/color-scheme/index.jsx
@@ -51,7 +51,7 @@ export function refreshColorScheme( prevColorScheme, nextColorScheme ) {
 		classList.add( `is-${ nextColorScheme }` );
 	}
 
-	if ( config( 'theme_color_admin_color_scheme_override' ) ) {
+	if ( config.isEnabled( 'theme_color_admin_color_scheme_override' ) ) {
 		const themeColor = getComputedStyle( document.body )
 			.getPropertyValue( '--color-masterbar-background' )
 			.trim();

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -201,7 +201,7 @@
 	],
 	"restricted_me_access": true,
 	"theme_color": "",
-	"theme_color_override_with_admin_color_scheme": true,
+	"theme_color_admin_color_scheme_override": true,
 	"reskinned_flows": [
 		"account",
 		"business",

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -201,6 +201,7 @@
 	],
 	"restricted_me_access": true,
 	"theme_color": "",
+	"theme_color_override_with_admin_color_scheme": true,
 	"reskinned_flows": [
 		"account",
 		"business",

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -71,5 +71,6 @@
 	"theme": "a8c-for-agencies",
 	"restricted_me_access": false,
 	"theme_color": "#029CD7",
+	"theme_color_override_with_admin_color_scheme": false,
 	"hotjar_enabled": true
 }

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -71,6 +71,6 @@
 	"theme": "a8c-for-agencies",
 	"restricted_me_access": false,
 	"theme_color": "#029CD7",
-	"theme_color_override_with_admin_color_scheme": false,
+	"theme_color_admin_color_scheme_override": false,
 	"hotjar_enabled": true
 }

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -64,5 +64,6 @@
 	"theme": "a8c-for-agencies",
 	"restricted_me_access": false,
 	"theme_color": "#029CD7",
+	"theme_color_override_with_admin_color_scheme": false,
 	"hotjar_enabled": true
 }

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -64,6 +64,6 @@
 	"theme": "a8c-for-agencies",
 	"restricted_me_access": false,
 	"theme_color": "#029CD7",
-	"theme_color_override_with_admin_color_scheme": false,
+	"theme_color_admin_color_scheme_override": false,
 	"hotjar_enabled": true
 }

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -64,5 +64,6 @@
 	"theme": "a8c-for-agencies",
 	"restricted_me_access": false,
 	"theme_color": "#029CD7",
+	"theme_color_override_with_admin_color_scheme": false,
 	"hotjar_enabled": true
 }

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -64,6 +64,6 @@
 	"theme": "a8c-for-agencies",
 	"restricted_me_access": false,
 	"theme_color": "#029CD7",
-	"theme_color_override_with_admin_color_scheme": false,
+	"theme_color_admin_color_scheme_override": false,
 	"hotjar_enabled": true
 }

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -66,5 +66,6 @@
 	"theme": "a8c-for-agencies",
 	"restricted_me_access": false,
 	"theme_color": "#029CD7",
+	"theme_color_override_with_admin_color_scheme": false,
 	"hotjar_enabled": true
 }

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -66,6 +66,6 @@
 	"theme": "a8c-for-agencies",
 	"restricted_me_access": false,
 	"theme_color": "#029CD7",
-	"theme_color_override_with_admin_color_scheme": false,
+	"theme_color_admin_color_scheme_override": false,
 	"hotjar_enabled": true
 }

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -112,6 +112,6 @@
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f",
-	"theme_color_override_with_admin_color_scheme": false,
+	"theme_color_admin_color_scheme_override": false,
 	"hotjar_enabled": true
 }

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -112,5 +112,6 @@
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f",
+	"theme_color_override_with_admin_color_scheme": false,
 	"hotjar_enabled": true
 }

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -105,5 +105,5 @@
 	"theme": "jetpack-cloud",
 	"hotjar_enabled": true,
 	"theme_color": "#2fb41f",
-	"theme_color_override_with_admin_color_scheme": false
+	"theme_color_admin_color_scheme_override": false
 }

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -104,5 +104,6 @@
 	"site_filter": [ "jetpack", "atomic", "wpcom" ],
 	"theme": "jetpack-cloud",
 	"hotjar_enabled": true,
-	"theme_color": "#2fb41f"
+	"theme_color": "#2fb41f",
+	"theme_color_override_with_admin_color_scheme": false
 }

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -108,6 +108,6 @@
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f",
-	"theme_color_override_with_admin_color_scheme": false,
+	"theme_color_admin_color_scheme_override": false,
 	"hotjar_enabled": true
 }

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -108,5 +108,6 @@
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f",
+	"theme_color_override_with_admin_color_scheme": false,
 	"hotjar_enabled": true
 }

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -109,6 +109,6 @@
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f",
-	"theme_color_override_with_admin_color_scheme": false,
+	"theme_color_admin_color_scheme_override": false,
 	"hotjar_enabled": true
 }

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -109,5 +109,6 @@
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f",
+	"theme_color_override_with_admin_color_scheme": false,
 	"hotjar_enabled": true
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #98335

Needs #98380 to be merged first

## Proposed Changes

* Add a new `theme_color_admin_color_scheme_override` environment config option
* Use it to enable/disable updating the `<meta name="theme-color" />` tag dynamically on the client whenever a user updates the admin color scheme

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To match the desired behavior described in #98335. This feature is currently broken, as the `data-colorscheme` attribute that the logic relies is not applied in the code anymore (probably removed my mistake in a previous refactor).

This PR reinstates the behavior, but it changes the logic: instead of relying on the `theme-color` being defined or not (which is fragile and unclear), it uses a dedicated environment config option. Not only this logic is more clear, but it is also compatible with the changes being proposed in #98380

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load calypso in any wordpress.com environments
* Observe the initial value of the `<meta name="theme-color" />` tag in the page
* Change the admin color scheme (by visiting `/wp-admin/profile.php`)
* Verify that the interface changes color dynamically as a color scheme is chosen
* Save the user preferences and go back to calypso UI
* Observe the new value of the `<meta name="theme-color" />` tag and make sure it follows the main color of the new chosen theme
* Change the `theme_color_admin_color_scheme_override` to `false` for the relevant environment (eg development), and make sure that the `<meta name="theme-color" />` tag doesn't follow the admin color scheme
* A4A and jetpack cloud environments should also keep the value of the `<meta name="theme-color" />` tag fixed, ie. they should not update it to follow any changes from the admin color scheme.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
