### PR TITLE
Reader: fix incorrect blog id in Tracks events

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -264,11 +264,16 @@ export class FullPostView extends Component {
 		if ( this.readingStartTime && post.ID ) {
 			const endTime = Math.floor( Date.now() );
 			const engagementTime = endTime - this.readingStartTime;
-			recordTrackForPost( 'calypso_reader_article_engaged_time', post, {
-				context: 'full-post',
-				engagement_time: engagementTime / 1000,
-				path: this.mountedPath,
-			} );
+			recordTrackForPost(
+				'calypso_reader_article_engaged_time',
+				post,
+				{
+					context: 'full-post',
+					engagement_time: engagementTime / 1000,
+					path: this.mountedPath,
+				},
+				{ pathnameOverride: this.mountedPath }
+			);
 			// check if the user exited early
 			this.checkFastExit( post, engagementTime );
 		}
@@ -300,11 +305,16 @@ export class FullPostView extends Component {
 
 		if ( this.scrollableContainer && post.ID ) {
 			const maxScrollDepth = this.scrollTracker.getMaxScrollDepthAsPercentage();
-			recordTrackForPost( 'calypso_reader_article_scroll_depth', post, {
-				context: 'full-post',
-				scroll_depth: maxScrollDepth,
-				path: this.mountedPath,
-			} );
+			recordTrackForPost(
+				'calypso_reader_article_scroll_depth',
+				post,
+				{
+					context: 'full-post',
+					scroll_depth: maxScrollDepth,
+					path: this.mountedPath,
+				},
+				{ pathnameOverride: this.mountedPath }
+			);
 		}
 	};
 
@@ -317,22 +327,32 @@ export class FullPostView extends Component {
 		const hasCompleted = maxScrollDepth >= 90; // User has read 90% of the post
 
 		if ( this.scrollableContainer && post.ID && ! hasCompleted ) {
-			recordTrackForPost( 'calypso_reader_article_exit_before_completion', post, {
-				context: 'full-post',
-				scroll_depth: maxScrollDepth,
-				path: this.mountedPath,
-			} );
+			recordTrackForPost(
+				'calypso_reader_article_exit_before_completion',
+				post,
+				{
+					context: 'full-post',
+					scroll_depth: maxScrollDepth,
+					path: this.mountedPath,
+				},
+				{ pathnameOverride: this.mountedPath }
+			);
 		}
 	};
 
 	trackFastExit = ( post, elapsedSeconds, fastExitThreshold ) => {
-		recordTrackForPost( 'calypso_reader_article_fast_exit', post, {
-			context: 'full-post',
-			estimated_reading_time: post.minutes_to_read,
-			elapsed_seconds: elapsedSeconds,
-			fast_exit_threshold: fastExitThreshold,
-			path: this.mountedPath,
-		} );
+		recordTrackForPost(
+			'calypso_reader_article_fast_exit',
+			post,
+			{
+				context: 'full-post',
+				estimated_reading_time: post.minutes_to_read,
+				elapsed_seconds: elapsedSeconds,
+				fast_exit_threshold: fastExitThreshold,
+				path: this.mountedPath,
+			},
+			{ pathnameOverride: this.mountedPath }
+		);
 	};
 
 	checkFastExit = ( post = null, engagementTime ) => {

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -93,12 +93,14 @@ export class FullPostView extends Component {
 		isWPForTeamsItem: PropTypes.bool,
 		hasOrganization: PropTypes.bool,
 		layout: PropTypes.oneOf( [ 'default', 'recent' ] ),
+		currentPath: PropTypes.string,
 	};
 
 	hasScrolledToCommentAnchor = false;
 	readerMainWrapper = createRef();
 	commentsWrapper = createRef();
 	postContentWrapper = createRef();
+	mountedPath;
 
 	state = {
 		isSuggestedFollowsModalOpen: false,
@@ -119,6 +121,7 @@ export class FullPostView extends Component {
 		this.setReadingStartTime();
 		this.attemptToSendPageView();
 		this.maybeDisableAppBanner();
+		this.mountedPath = this.props.currentPath;
 
 		this.checkForCommentAnchor();
 
@@ -264,6 +267,7 @@ export class FullPostView extends Component {
 			recordTrackForPost( 'calypso_reader_article_engaged_time', post, {
 				context: 'full-post',
 				engagement_time: engagementTime / 1000,
+				path: this.mountedPath,
 			} );
 			// check if the user exited early
 			this.checkFastExit( post, engagementTime );
@@ -299,6 +303,7 @@ export class FullPostView extends Component {
 			recordTrackForPost( 'calypso_reader_article_scroll_depth', post, {
 				context: 'full-post',
 				scroll_depth: maxScrollDepth,
+				path: this.mountedPath,
 			} );
 		}
 	};
@@ -315,6 +320,7 @@ export class FullPostView extends Component {
 			recordTrackForPost( 'calypso_reader_article_exit_before_completion', post, {
 				context: 'full-post',
 				scroll_depth: maxScrollDepth,
+				path: this.mountedPath,
 			} );
 		}
 	};
@@ -325,6 +331,7 @@ export class FullPostView extends Component {
 			estimated_reading_time: post.minutes_to_read,
 			elapsed_seconds: elapsedSeconds,
 			fast_exit_threshold: fastExitThreshold,
+			path: this.mountedPath,
 		} );
 	};
 
@@ -833,6 +840,7 @@ export default connect(
 		const { feedId, blogId, postId } = ownProps;
 		const postKey = pickBy( { feedId: +feedId, blogId: +blogId, postId: +postId } );
 		const post = getPostByKey( state, postKey ) || { _state: 'pending' };
+		const currentPath = state.route.path.current;
 
 		const { site_ID: siteId, is_external: isExternal } = post;
 
@@ -843,6 +851,7 @@ export default connect(
 			post,
 			liked: isLikedPost( state, siteId, post.ID ),
 			postKey,
+			currentPath,
 		};
 
 		if ( ! isExternal && siteId ) {

--- a/client/lib/analytics/super-props.js
+++ b/client/lib/analytics/super-props.js
@@ -30,7 +30,9 @@ const getSuperProps = ( reduxStore ) => ( eventProperties ) => {
 	}
 
 	const path = eventProperties.path ?? getCurrentRoute( state );
-	const omitSelectedSite = ! eventProperties.force_site_id && shouldReportOmitBlogId( path );
+	const omitSelectedSite =
+		( ! eventProperties.force_site_id && shouldReportOmitBlogId( path ) ) ||
+		path.startsWith( '/read' ); // Reader events need to track the blog that is being read, not the user's selected site
 	const selectedSite = omitSelectedSite
 		? null
 		: getSelectedSite( state ) || getSite( state, getSiteSlugOrIdFromURLSearchParams() );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/loop#320

## Proposed Changes

* Omit setting the `blog_id` in analytics `superProps()` for Reader paths
* Attach the path the `FullPostView` component is first mounted under to Tracks events that fire _after_ the route changes, i.e. the new engagement Tracks events.
* Supply the mounted path as the `pathnameOverride` option so the `ui_algo` event property is correct.

https://github.com/user-attachments/assets/d0fc0150-3380-463a-8fc7-9318e57cfa1a

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See Automattic/loop#320.

The blog id did not match the post id in certain Reader Tracks events. This is because the blog id of the current user's selected site (the site they are currently managing on wp.com) was overwriting the blog id that was being set in the Reader tracks events.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open your browser's network tab to quickly verify the correct data is being sent to Tracks
* You can do this by filtering all document requests by "pixel". The Tracks events will be a request for a `.gif` file with the data as query params

<img width="1041" alt="image" src="https://github.com/user-attachments/assets/8be2300a-f2bf-4ad9-982c-1d3288c207a9" />

* Navigate to `/read`
* In the new "two-column" layout, you should see the events `calypso_reader_article_scroll_depth` and `calypso_reader_article_engaged_time` fire every time you select a new post or new feed. You may also see `calypso_reader_article_exit_before_completion` and/or `calypso_reader_article_fast_exit` fire depending how long you spend on the post.
* Clear your network entries and navigate to some other, non-Reader page and check the events. They should have the correct blog id, _not_ your own blog's id.
* Repeat these steps for the "stream" layout view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
