### PR TITLE
Stats: fix empty Locations section

### DIFF
--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -131,7 +131,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 		/>
 	);
 
-	const hasLocationData = Array.isArray( data ) && data.length;
+	const hasLocationData = Array.isArray( data ) && data.length > 0;
 
 	return (
 		<>

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -131,6 +131,8 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 		/>
 	);
 
+	const hasLocationData = Array.isArray( data ) && data.length;
+
 	return (
 		<>
 			{ ! shouldGateStatsModule && siteId && statType && (
@@ -139,7 +141,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 			{ isRequestingData && (
 				<StatsCardSkeleton isLoading={ isRequestingData } title={ title } type={ 3 } withHero />
 			) }
-			{ ( ( ! isRequestingData && ! isError && data ) || shouldGateStatsModule ) && (
+			{ ( ( ! isRequestingData && ! isError && hasLocationData ) || shouldGateStatsModule ) && (
 				// show data or an overlay
 				<>
 					{ /* @ts-expect-error TODO: Refactor StatsListCard with TypeScript. */ }
@@ -189,25 +191,22 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 					/>
 				</>
 			) }
-			{ ! isRequestingData &&
-				Array.isArray( data ) &&
-				! data?.length &&
-				! shouldGateStatsModule && (
-					// show empty state
-					<StatsCard
-						title={ translate( 'Locations' ) }
-						isEmpty
-						emptyMessage={ emptyMessage }
-						footerAction={
-							summaryUrl
-								? {
-										url: summaryUrl,
-										label: translate( 'View more' ),
-								  }
-								: undefined
-						}
-					/>
-				) }
+			{ ! isRequestingData && ! hasLocationData && ! shouldGateStatsModule && (
+				// show empty state
+				<StatsCard
+					title={ translate( 'Locations' ) }
+					isEmpty
+					emptyMessage={ emptyMessage }
+					footerAction={
+						summaryUrl
+							? {
+									url: summaryUrl,
+									label: translate( 'View more' ),
+							  }
+							: undefined
+					}
+				/>
+			) }
 		</>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/jetpack-roadmap#2122.

## Proposed Changes

* Fix the location data check to avoid rendering the Locations section with no data, which ended-up duplicating empty blocks.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* (p1HpG7-rpL-p2)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Access the Calypso Live preview linked below.
- Access the Stats page of a website in a period that has NO meaningful data, like `/stats/day/cicerosletters.wordpress.com?flags=stats%2Flocations&chartStart=2025-01-09&chartEnd=2025-01-13`
- Go to the Locations section, ensure it doesn't appear duplicated.

| Before | After |
| - | - |
| <img width="963" alt="image" src="https://github.com/user-attachments/assets/a64fa42b-c945-407e-ab91-1fb364ee5cbb" /> | <img width="973" alt="image" src="https://github.com/user-attachments/assets/d0d51b78-39fc-47b5-957d-e5af7394d94b" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
