### PR TITLE
Add a redirect middleware to redirect /log-in/lostpassword for wordpress.com

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -300,3 +300,36 @@ export function redirectJetpack( context, next ) {
 	}
 	next();
 }
+
+/**
+ * Redirect clients to use PHP lost password. Excludes WooCommerce and Tumblr Blaze Pro.
+ * @param {Object} context - The context object containing request parameters and query strings.
+ * @param {Object} context.params - The parameters from the URL, including the action.
+ * @param {Object} context.query - The query string from the URL, including the `redirect_to` URL.
+ * @param {Function} next - The next middleware function to call if conditions are met.
+ * @returns {void} Redirects the user or calls the `next()` middleware.
+ */
+export function redirectLostPassword( context, next ) {
+	const { action } = context.params;
+	const { redirect_to } = context.query;
+
+	if ( action !== 'lostpassword' ) {
+		next();
+		return;
+	}
+
+	/**
+	 * The redirect_to URI will be set if it's WooCommerce.
+	 */
+
+	const exclusions = [ 'blazepro.tumblr.com', 'woocommerce.com' ];
+
+	if (
+		redirect_to === undefined ||
+		! exclusions.some( ( exclusion ) => redirect_to.includes( exclusion ) )
+	) {
+		return context.redirect( 301, '/wp-login.php?action=lostpassword' );
+	}
+
+	next();
+}

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -1,11 +1,15 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
-import { isGravPoweredOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { isGravPoweredOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { SOCIAL_HANDOFF_CONNECT_ACCOUNT } from 'calypso/state/action-types';
 import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
 import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
+import getIsWooPasswordless from 'calypso/state/selectors/get-is-woo-passwordless';
+import isWooPasswordlessJPCFlow from 'calypso/state/selectors/is-woo-passwordless-jpc-flow';
 import MagicLogin from './magic-login';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
 import HandleEmailedLinkFormJetpackConnect from './magic-login/handle-emailed-link-form-jetpack-connect';
@@ -304,26 +308,27 @@ export function redirectJetpack( context, next ) {
 /**
  * Redirect clients to use PHP lost password. Excludes WooCommerce and Tumblr Blaze Pro.
  * @param {Object} context - The context object containing request parameters and query strings.
- * @param {Object} context.params - The parameters from the URL, including the action.
- * @param {Object} context.query - The query string from the URL, including the `redirect_to` URL.
  * @param {Function} next - The next middleware function to call if conditions are met.
  * @returns {void} Either redirects the user or invokes the `next()` middleware function.
  */
 export function redirectLostPassword( context, next ) {
 	const { action } = context.params;
-	const { redirect_to } = context.query;
 
 	if ( action !== 'lostpassword' ) {
 		next();
 		return;
 	}
 
-	const exclusions = [ 'blazepro.tumblr.com', 'woocommerce.com' ];
+	const state = context.store.getState();
+	const oauth2Client = getCurrentOAuth2Client( state );
 
-	if (
-		redirect_to === undefined ||
-		! exclusions.some( ( exclusion ) => redirect_to.includes( exclusion ) )
-	) {
+	const shouldRedirectToLostPassword = () =>
+		! getIsBlazePro( state ) &&
+		! getIsWooPasswordless( state ) &&
+		! isWooOAuth2Client( oauth2Client ) &&
+		! isWooPasswordlessJPCFlow( state );
+
+	if ( shouldRedirectToLostPassword() ) {
 		return context.redirect( 301, '/wp-login.php?action=lostpassword' );
 	}
 

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -8,7 +8,6 @@ import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
 import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
-import getIsWooPasswordless from 'calypso/state/selectors/get-is-woo-passwordless';
 import isWooPasswordlessJPCFlow from 'calypso/state/selectors/is-woo-passwordless-jpc-flow';
 import MagicLogin from './magic-login';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
@@ -324,7 +323,6 @@ export function redirectLostPassword( context, next ) {
 
 	const shouldRedirectToLostPassword = () =>
 		! getIsBlazePro( state ) &&
-		! getIsWooPasswordless( state ) &&
 		! isWooOAuth2Client( oauth2Client ) &&
 		! isWooPasswordlessJPCFlow( state );
 

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -318,10 +318,6 @@ export function redirectLostPassword( context, next ) {
 		return;
 	}
 
-	/**
-	 * The redirect_to URI will be set if it's WooCommerce.
-	 */
-
 	const exclusions = [ 'blazepro.tumblr.com', 'woocommerce.com' ];
 
 	if (

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -307,7 +307,7 @@ export function redirectJetpack( context, next ) {
  * @param {Object} context.params - The parameters from the URL, including the action.
  * @param {Object} context.query - The query string from the URL, including the `redirect_to` URL.
  * @param {Function} next - The next middleware function to call if conditions are met.
- * @returns {void} Redirects the user or calls the `next()` middleware.
+ * @returns {void} Either redirects the user or invokes the `next()` middleware function.
  */
 export function redirectLostPassword( context, next ) {
 	const { action } = context.params;

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -17,6 +17,7 @@ import {
 	magicLoginUse,
 	redirectJetpack,
 	redirectDefaultLocale,
+	redirectLostPassword,
 } from './controller';
 import redirectLoggedIn from './redirect-logged-in';
 import { setShouldServerSideRenderLogin, ssrSetupLocaleLogin, setMetaTags } from './ssr';
@@ -118,6 +119,7 @@ export default ( router ) => {
 		login,
 		setShouldServerSideRenderLogin,
 		ssrSetupLocaleLogin,
-		makeLoggedOutLayout
+		makeLoggedOutLayout,
+		redirectLostPassword
 	);
 };

--- a/client/login/test/controller.js
+++ b/client/login/test/controller.js
@@ -1,5 +1,10 @@
 import page from '@automattic/calypso-router';
+import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
+import getIsWooPasswordless from 'calypso/state/selectors/get-is-woo-passwordless';
+import isWooPasswordlessJPCFlow from 'calypso/state/selectors/is-woo-passwordless-jpc-flow';
 import { redirectJetpack, redirectLostPassword, login } from '../controller';
 
 jest.mock( 'calypso/state/oauth2-clients/actions', () => ( {
@@ -10,6 +15,31 @@ jest.mock( 'calypso/state/oauth2-clients/actions', () => ( {
 jest.mock( 'calypso/state/oauth2-clients/selectors', () => ( {
 	...jest.requireActual( 'calypso/state/oauth2-clients/selectors' ),
 	getOAuth2Client: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/oauth2-clients', () => ( {
+	...jest.requireActual( 'calypso/lib/oauth2-clients' ),
+	isWooOAuth2Client: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/oauth2-clients/ui/selectors', () => ( {
+	...jest.requireActual( 'calypso/state/oauth2-clients/ui/selectors' ),
+	getCurrentOAuth2Client: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/selectors/get-is-blaze-pro', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/selectors/get-is-woo-passwordless', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/selectors/is-woo-passwordless-jpc-flow', () => ( {
+	__esModule: true,
+	default: jest.fn(),
 } ) );
 
 jest.mock( '@automattic/calypso-router' );
@@ -114,9 +144,15 @@ describe( 'redirectLostPassword', () => {
 		context = {
 			params: {},
 			query: {},
+			store: {
+				getState: jest.fn(),
+			},
 			redirect: jest.fn(),
 		};
 		next = jest.fn();
+
+		// Reset all mocks before each test
+		jest.clearAllMocks();
 	} );
 
 	it( 'should call next() if action is not "lostpassword"', () => {
@@ -128,27 +164,11 @@ describe( 'redirectLostPassword', () => {
 		expect( context.redirect ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should redirect to "/wp-login.php?action=lostpassword" if redirect_to is undefined', () => {
+	it( 'should call next() if isWooOAuth2Client returns true', () => {
 		context.params.action = 'lostpassword';
-
-		redirectLostPassword( context, next );
-
-		expect( context.redirect ).toHaveBeenCalledWith( 301, '/wp-login.php?action=lostpassword' );
-	} );
-
-	it( 'should redirect to "/wp-login.php?action=lostpassword" if redirect_to does not include the WooCommerce URI', () => {
-		context.params.action = 'lostpassword';
-		context.query.redirect_to = 'https://example.com/some-other-uri';
-
-		redirectLostPassword( context, next );
-
-		expect( context.redirect ).toHaveBeenCalledWith( 301, '/wp-login.php?action=lostpassword' );
-	} );
-
-	it( 'should not redirect if redirect_to includes the WooCommerce URI', () => {
-		context.params.action = 'lostpassword';
-		context.query.redirect_to =
-			'https://example.com?redirect_uri=https://woocommerce.com/wc-api/wpcom-signin';
+		context.store.getState.mockReturnValueOnce( {} );
+		getCurrentOAuth2Client.mockReturnValueOnce( 'mocked-client' );
+		isWooOAuth2Client.mockReturnValueOnce( true );
 
 		redirectLostPassword( context, next );
 
@@ -156,14 +176,17 @@ describe( 'redirectLostPassword', () => {
 		expect( next ).toHaveBeenCalled();
 	} );
 
-	it( 'should not redirect if redirect_to includes the Blaze Pro URI', () => {
+	it( 'should redirect to "/wp-login.php?action=lostpassword" if none of the conditions are true', () => {
 		context.params.action = 'lostpassword';
-		context.query.redirect_to =
-			'https://example.com?redirect_uri=https://blazepro.tumblr.com/auth/connected';
+		context.store.getState.mockReturnValueOnce( {} );
+		getIsBlazePro.mockReturnValueOnce( false );
+		getIsWooPasswordless.mockReturnValueOnce( false );
+		isWooOAuth2Client.mockReturnValueOnce( false );
+		isWooPasswordlessJPCFlow.mockReturnValueOnce( false );
 
 		redirectLostPassword( context, next );
 
-		expect( context.redirect ).not.toHaveBeenCalled();
-		expect( next ).toHaveBeenCalled();
+		expect( context.redirect ).toHaveBeenCalledWith( 301, '/wp-login.php?action=lostpassword' );
+		expect( next ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/login/test/controller.js
+++ b/client/login/test/controller.js
@@ -3,7 +3,6 @@ import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
-import getIsWooPasswordless from 'calypso/state/selectors/get-is-woo-passwordless';
 import isWooPasswordlessJPCFlow from 'calypso/state/selectors/is-woo-passwordless-jpc-flow';
 import { redirectJetpack, redirectLostPassword, login } from '../controller';
 
@@ -180,7 +179,6 @@ describe( 'redirectLostPassword', () => {
 		context.params.action = 'lostpassword';
 		context.store.getState.mockReturnValueOnce( {} );
 		getIsBlazePro.mockReturnValueOnce( false );
-		getIsWooPasswordless.mockReturnValueOnce( false );
 		isWooOAuth2Client.mockReturnValueOnce( false );
 		isWooPasswordlessJPCFlow.mockReturnValueOnce( false );
 

--- a/client/login/test/controller.js
+++ b/client/login/test/controller.js
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
-import { redirectJetpack, login } from '../controller';
+import { redirectJetpack, redirectLostPassword, login } from '../controller';
 
 jest.mock( 'calypso/state/oauth2-clients/actions', () => ( {
 	...jest.requireActual( 'calypso/state/oauth2-clients/actions' ),
@@ -102,6 +102,68 @@ describe( 'login', () => {
 		await login( context, next );
 
 		expect( getOAuth2Client ).toHaveBeenCalledWith( state, '1234' );
+		expect( next ).toHaveBeenCalled();
+	} );
+} );
+
+describe( 'redirectLostPassword', () => {
+	let context;
+	let next;
+
+	beforeEach( () => {
+		context = {
+			params: {},
+			query: {},
+			redirect: jest.fn(),
+		};
+		next = jest.fn();
+	} );
+
+	it( 'should call next() if action is not "lostpassword"', () => {
+		context.params.action = 'someOtherAction';
+
+		redirectLostPassword( context, next );
+
+		expect( next ).toHaveBeenCalled();
+		expect( context.redirect ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should redirect to "/wp-login.php?action=lostpassword" if redirect_to is undefined', () => {
+		context.params.action = 'lostpassword';
+
+		redirectLostPassword( context, next );
+
+		expect( context.redirect ).toHaveBeenCalledWith( 301, '/wp-login.php?action=lostpassword' );
+	} );
+
+	it( 'should redirect to "/wp-login.php?action=lostpassword" if redirect_to does not include the WooCommerce URI', () => {
+		context.params.action = 'lostpassword';
+		context.query.redirect_to = 'https://example.com/some-other-uri';
+
+		redirectLostPassword( context, next );
+
+		expect( context.redirect ).toHaveBeenCalledWith( 301, '/wp-login.php?action=lostpassword' );
+	} );
+
+	it( 'should not redirect if redirect_to includes the WooCommerce URI', () => {
+		context.params.action = 'lostpassword';
+		context.query.redirect_to =
+			'https://example.com?redirect_uri=https://woocommerce.com/wc-api/wpcom-signin';
+
+		redirectLostPassword( context, next );
+
+		expect( context.redirect ).not.toHaveBeenCalled();
+		expect( next ).toHaveBeenCalled();
+	} );
+
+	it( 'should not redirect if redirect_to includes the Blaze Pro URI', () => {
+		context.params.action = 'lostpassword';
+		context.query.redirect_to =
+			'https://example.com?redirect_uri=https://blazepro.tumblr.com/auth/connected';
+
+		redirectLostPassword( context, next );
+
+		expect( context.redirect ).not.toHaveBeenCalled();
 		expect( next ).toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
Fixes #96291

## Proposed Changes

This PR adds a redirect function called `redirectLostPassword` to redirect WordPress.com users to `wp-login.php?action=lostpassword`.

## Why are these changes being made?

You can read more details in #96291, but in short WooCommerce and Blaze Pro use `/log-in/lostpassword` for password resets. WordPress.com does not. Much of the functionality was introduced #68885, although originally limited to WooCommerce clients only. A regression was introduced in #93163 which exposed the "Forgot Password" URL on WordPress.com. That regression was fixed in #96506. 
 
However, since [the route is public](https://github.com/Automattic/wp-calypso/blob/25ffc5a36f7de9a3eeee49c210d3778c70449afa/client/login/index.web.js#L109) to all Calypso clients, WordPress.com users can still navigate to that URL. If they navigate to that page, the styles and [functionality are broken](https://github.com/Automattic/wp-calypso/issues/95066). 

## Considerations

This may be a naive approach. 

It makes the assumption that `blazepro.tumblr.com` and `woocommerce.com` will exist in the `redirect_to` portion of the query. Should either of those clients update their redirect URLs to not include their domains, those users will be redirected to `wp-login.php?action=lostpassword`.

Ideally, the context would already be set, but I don't see that happening anywhere yet.

Alternatively, I could have updated WooCommerce and Blaze Pro's dynamic routes to identify themselves better but thought that may introduce more risk and I'm not that familiar with the codebase yet.

I'm open to other ideas. 

## Testing Instructions

Note: I was only able to set up testing by mapping WordPress.com to local calypso. 

So assuming that configuration:

**Test Default WordPress.com reset**
* Navigate to `/log-in/` on WordPress.com.
* Click "Lost your password?"
* Expect to end up on `wp-login.php?lostpassword`.

**Test Default WordPress.com reset redirect**
* Enter `wordpress.com/log-in/lostpassword`
* Expect to end up on `wp-login.php?lostpassword`.

**Test WooCommerce.com reset**
* Go to woocommerce.com
* Click "Log in" in the header
* Notice you are on WordPress.com
* Click "Lost your password"
* Expect to still be on `wordpress.com/log-in/lostpassword`

**Test Blaze Pro reset**
* Go to https://blazepro.com/
* Click "Get Started"
* Click "Log in to Blaze Pro"
* Notice you are on WordPress.com
* Click "Lost your password"
* Expect to still be on `wordpress.com/log-in/lostpassword`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
