### PR TITLE
Stats: Remove conditional checks for Subscribers tab

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -15,15 +15,9 @@ import { useNoticeVisibilityQuery } from 'calypso/my-sites/stats/hooks/use-notic
 import { shouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isGoogleMyBusinessLocationConnectedSelector from 'calypso/state/selectors/is-google-my-business-location-connected';
-import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isSiteStore from 'calypso/state/selectors/is-site-store';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import {
-	getJetpackStatsAdminVersion,
-	getSiteOption,
-	isJetpackSite,
-	isSimpleSite,
-} from 'calypso/state/sites/selectors';
+import { getJetpackStatsAdminVersion, getSiteOption } from 'calypso/state/sites/selectors';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import {
 	updateModuleToggles,
@@ -142,15 +136,7 @@ class StatsNavigation extends Component {
 	};
 
 	isValidItem = ( item ) => {
-		const {
-			isGoogleMyBusinessLocationConnected,
-			isStore,
-			isWordAds,
-			isSubscriptionsModuleActive,
-			isSimple,
-			isSiteJetpackNotAtomic,
-			siteId,
-		} = this.props;
+		const { isGoogleMyBusinessLocationConnected, isStore, isWordAds, siteId } = this.props;
 
 		switch ( item ) {
 			case 'wordads':
@@ -170,11 +156,6 @@ class StatsNavigation extends Component {
 				if ( 'undefined' === typeof siteId ) {
 					return false;
 				}
-
-				// The value of isSubscriptionsModuleActive is null in Odyssey Stats so we default to showing the tab.
-				// Maintains existing behaviour inside wp-admin for self-hosted sites.
-				// For DotCom sites, it will only be shown on Simple sites or if subs are enabled.
-				return isSiteJetpackNotAtomic || isSimple || isSubscriptionsModuleActive;
 
 			default:
 				return true;
@@ -317,9 +298,6 @@ export default connect(
 			isWordAds:
 				getSiteOption( state, siteId, 'wordads' ) &&
 				canCurrentUser( state, siteId, 'manage_options' ),
-			isSubscriptionsModuleActive: isJetpackModuleActive( state, siteId, 'subscriptions' ),
-			isSimple: isSimpleSite( state, siteId ),
-			isSiteJetpackNotAtomic: isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } ),
 			hasVideoPress: siteHasFeature( state, siteId, 'videopress' ),
 			siteId,
 			pageModuleToggles: getModuleToggles( state, siteId, [ selectedItem ] ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

https://github.com/Automattic/wp-calypso/issues/98268

## Proposed Changes

Reverting the conditional display of the Subscribers tab. The current approach is preventing Atomic sites using the "Classic style" UI toggle from viewing the page.

Additionally, per discussions [here](https://github.com/Automattic/wp-calypso/pull/98144#issuecomment-2581726150), hiding the tab based on the state of the Subscribers module probably isn't the correct approach as the page presents both email subs & WordPress.com Reader followers. Therefore it still have useful data to present even when email subs are disabled.

Possible follow-up/improvement would be to hide just the email stats on the page based on the state of the Subscribers module.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Quick fix to make sure the Subscribers tab remains accessible to Atomic sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Currently Atomic sites using `/wp-admin` are effected so to properly test that environment, you'll need to follow option 2 or 3 per these docs: PCYsg-Pp7-p2

- Visit the Traffic page for an Atomic site.
- Enable the "Classic style" UI toggle per [this comment](https://github.com/Automattic/wp-calypso/issues/98268#issuecomment-2590907706).
- Return to the Traffic page. The URL path should now include `/wp-admin`.
- Confirm the Subs tab is visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?