### PR TITLE
Add support doc links to account restored banner

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -183,6 +183,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/user-roles/#adding-users-to-your-site',
 		post_id: 1221,
 	},
+	'invite-people': {
+		link: 'https://wordpress.com/support/invite-people/',
+		post_id: 1221,
+	},
 	'manage-profile': {
 		link: 'https://wordpress.com/support/manage-my-profile/',
 		post_id: 19775,
@@ -282,6 +286,10 @@ const contextLinks = {
 	purchases: {
 		link: 'https://wordpress.com/support/manage-purchases/',
 		post_id: 111349,
+	},
+	'restore-site': {
+		link: 'https://wordpress.com/support/delete-site/#restore-a-deleted-site',
+		post_id: 14411,
 	},
 	'reusable-blocks': {
 		link: 'https://wordpress.com/support/wordpress-editor/blocks/reusable-block/',

--- a/client/sites/components/sites-dashboard-banners/use-restore-sites-reminder-banner.tsx
+++ b/client/sites/components/sites-dashboard-banners/use-restore-sites-reminder-banner.tsx
@@ -1,6 +1,7 @@
 import { NoticeBanner } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import { useState } from 'react';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './styles.scss';
@@ -35,7 +36,17 @@ export function useRestoreSitesBanner() {
 				>
 					<div>
 						{ translate(
-							'You’ll need to invite any users that previously had access to your sites.'
+							`{{restoreSiteLink}}Restore sites{{/restoreSiteLink}} from the action menu. You'll also need to {{invitePeopleLink}}invite any users{{/invitePeopleLink}} that previously had access to your sites.`,
+							{
+								components: {
+									restoreSiteLink: (
+										<InlineSupportLink showIcon={ false } supportContext="restore-site" />
+									),
+									invitePeopleLink: (
+										<InlineSupportLink showIcon={ false } supportContext="invite-people" />
+									),
+								},
+							}
 						) }
 					</div>
 				</NoticeBanner>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/10248

## Proposed Changes

* Update copy and add support doc links to make the banner clearer

![banner@2x](https://github.com/user-attachments/assets/86464468-0450-43b2-bcf0-44d4b1b65aec)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites?restored=true
* Support doc links point to the right docs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
