### PR TITLE
Fix behavior of clicking on domain link

### DIFF
--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -80,6 +80,8 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 	const domainTypeText =
 		currentDomainData && getDomainTypeText( currentDomainData, __, domainInfoContext.DOMAIN_ROW );
 
+	const isAllDomainManagementEnabled = config.isEnabled( 'calypso/all-domain-management' );
+
 	const domainManagementLink = isManageableDomain
 		? getDomainManagementLink(
 				domain,
@@ -105,8 +107,6 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 	};
 
 	const handleSelect = () => {
-		const isAllDomainManagementEnabled = config.isEnabled( 'calypso/all-domain-management' );
-
 		if ( isAllDomainManagementEnabled && ( isHostingOverview || isAllSitesView ) ) {
 			page.show( domainManagementLink );
 			return;
@@ -114,6 +114,9 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 
 		window.location.href = domainManagementLink;
 	};
+
+	const handleDomainLinkClick = ( e: MouseEvent ) =>
+		isAllDomainManagementEnabled ? e.preventDefault() : e.stopPropagation();
 
 	return (
 		<tr
@@ -156,7 +159,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 								<a
 									className="domains-table__domain-name"
 									href={ domainManagementLink }
-									onClick={ ( e: MouseEvent ) => e.stopPropagation() }
+									onClick={ handleDomainLinkClick }
 								>
 									{ domain.domain }
 								</a>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98286

## Proposed Changes

* Fix behavior of when domain's link

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To prevent reloading unnecessarily

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure you have at least one domain
- Enable the revamped view entering window.sessionStorage.setItem('flags', 'calypso/all-domain-management') in console
- Reload the page
- Go to calypso.localhost:3000/domains/manage and click on the row of the domain (not the title link itself of the domain)
- It will open in the new revamped view without reloading the page, with some animation sliding
- Go back to the domains list and directly click on the domain's name link
- This page should load the same way it did when you clicked on the row

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
