### PR TITLE
Stats: Present an error message if requests fail on Subscribers page

### DIFF
--- a/client/my-sites/stats/pages/subscribers/index.tsx
+++ b/client/my-sites/stats/pages/subscribers/index.tsx
@@ -22,6 +22,18 @@ import SubscribersChartSection, { PeriodType } from '../../stats-subscribers-cha
 import SubscribersHighlightSection from '../../stats-subscribers-highlight-section';
 import type { Moment } from 'moment';
 
+function StatsSubscribersPageError() {
+	const translate = useTranslate();
+	const message = translate( 'An error occurred while loading your subscriber stats.' );
+	const classes = clsx( 'stats-module__placeholder', 'is-void' );
+
+	return (
+		<div className={ classes }>
+			<p>{ message }</p>
+		</div>
+	);
+}
+
 interface StatsSubscribersPageProps {
 	period: {
 		// Subscribers page only use this period but other properties and this format is needed for StatsModule to construct a URL to email's summary page
@@ -63,7 +75,7 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 	);
 
 	// TODO: Pass subscribersTotals as props to SubscribersHighlightSection to avoid duplicate queries.
-	const { data: subscribersTotals, isLoading } = useSubscribersTotalsQueries( siteId );
+	const { data: subscribersTotals, isLoading, isError } = useSubscribersTotalsQueries( siteId );
 	const isSimple = useSelector( isSimpleSite );
 	const hasNoSubscriberOtherThanAdmin =
 		! subscribersTotals?.total ||
@@ -98,7 +110,9 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 				></NavigationHeader>
 				<StatsNavigation selectedItem="subscribers" siteId={ siteId } slug={ siteSlug } />
 				{ isLoading && <StatsModulePlaceholder className="is-subscriber-page" isLoading /> }
+				{ isError && <StatsSubscribersPageError /> }
 				{ ! isLoading &&
+					! isError &&
 					( showLaunchpad ? (
 						emptyComponent
 					) : (

--- a/client/my-sites/stats/pages/subscribers/index.tsx
+++ b/client/my-sites/stats/pages/subscribers/index.tsx
@@ -24,12 +24,22 @@ import type { Moment } from 'moment';
 
 function StatsSubscribersPageError() {
 	const translate = useTranslate();
-	const message = translate( 'An error occurred while loading your subscriber stats.' );
 	const classes = clsx( 'stats-module__placeholder', 'is-void' );
 
 	return (
 		<div className={ classes }>
-			<p>{ message }</p>
+			<p>
+				{ translate(
+					'An error occurred while loading your subscriber stats. If you continue to have issues loading this page, please get in touch via our {{link}}contact form{{/link}} for assistance.',
+					{
+						components: {
+							link: (
+								<a target="_blank" rel="noreferrer" href="https://jetpack.com/contact-support/" />
+							),
+						},
+					}
+				) }
+			</p>
 		</div>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

p1734387302331999-slack-C0438NHCLSY

## Proposed Changes

If the API requests fail, present an error message instead of the import UI (which is potentially dangerous). We don't want the user to attempt a new import in this case.

<img width="723" alt="SCR-20250115-rmwc" src="https://github.com/user-attachments/assets/a52ea1e1-5760-4f3e-9409-40d8a7054708" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See above.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live link.
* Visit the Stats dashboard.
* Test against en.blog.wordpress.com: `/stats/subscribers/en.blog.wordpress.com`
* Confirm the error message is shown instead of the import UI

Of note, en.blog.wordpress.com is currently blocked as it the underlying API requests are not performant enough so it should always return an error unless running against your sandbox.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?