### PR TITLE
Staging sites: Add `Delete staging site` button to the `Staging Site` tab (when managing staging site)

### DIFF
--- a/client/sites/tools/staging-site/components/staging-site-card/index.js
+++ b/client/sites/tools/staging-site/components/staging-site-card/index.js
@@ -31,7 +31,7 @@ import { useCheckStagingSiteStatus } from '../../hooks/use-check-staging-site-st
 import { useDeleteStagingSite } from '../../hooks/use-delete-staging-site';
 import { useGetLockQuery, USE_STAGING_SITE_LOCK_QUERY_KEY } from '../../hooks/use-get-lock-query';
 import { useHasValidQuotaQuery } from '../../hooks/use-has-valid-quota';
-import { useStagingSite, USE_STAGING_SITE_QUERY_KEY } from '../../hooks/use-staging-site';
+import { useStagingSite } from '../../hooks/use-staging-site';
 import { usePullFromStagingMutation, usePushToStagingMutation } from '../../hooks/use-staging-sync';
 import { CardContentWrapper } from './card-content/card-content-wrapper';
 import { ManageStagingSiteCardContent } from './card-content/manage-staging-site-card-content';
@@ -246,13 +246,12 @@ export const StagingSiteCard = ( {
 	useEffect( () => {
 		// If we are done with the transfer, and we have not errored we want to set the action to NONE, and display a success notice.
 		if ( stagingSiteStatus === StagingSiteStatus.REVERTED ) {
-			queryClient.invalidateQueries( [ USE_STAGING_SITE_QUERY_KEY, siteId ] );
 			dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.NONE ) );
 			dispatch(
 				successNotice( __( 'Staging site deleted.' ), { id: stagingSiteDeleteSuccessNoticeId } )
 			);
 		}
-	}, [ __, dispatch, queryClient, siteId, stagingSiteStatus ] );
+	}, [ __, dispatch, siteId, stagingSiteStatus ] );
 
 	useEffect( () => {
 		setProgress( ( prevProgress ) => {

--- a/client/sites/tools/staging-site/components/staging-site-card/index.js
+++ b/client/sites/tools/staging-site/components/staging-site-card/index.js
@@ -31,7 +31,7 @@ import { useCheckStagingSiteStatus } from '../../hooks/use-check-staging-site-st
 import { useDeleteStagingSite } from '../../hooks/use-delete-staging-site';
 import { useGetLockQuery, USE_STAGING_SITE_LOCK_QUERY_KEY } from '../../hooks/use-get-lock-query';
 import { useHasValidQuotaQuery } from '../../hooks/use-has-valid-quota';
-import { useStagingSite } from '../../hooks/use-staging-site';
+import { useStagingSite, USE_STAGING_SITE_QUERY_KEY } from '../../hooks/use-staging-site';
 import { usePullFromStagingMutation, usePushToStagingMutation } from '../../hooks/use-staging-sync';
 import { CardContentWrapper } from './card-content/card-content-wrapper';
 import { ManageStagingSiteCardContent } from './card-content/manage-staging-site-card-content';
@@ -246,12 +246,13 @@ export const StagingSiteCard = ( {
 	useEffect( () => {
 		// If we are done with the transfer, and we have not errored we want to set the action to NONE, and display a success notice.
 		if ( stagingSiteStatus === StagingSiteStatus.REVERTED ) {
+			queryClient.invalidateQueries( [ USE_STAGING_SITE_QUERY_KEY, siteId ] );
 			dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.NONE ) );
 			dispatch(
 				successNotice( __( 'Staging site deleted.' ), { id: stagingSiteDeleteSuccessNoticeId } )
 			);
 		}
-	}, [ __, dispatch, siteId, stagingSiteStatus ] );
+	}, [ __, dispatch, queryClient, siteId, stagingSiteStatus ] );
 
 	useEffect( () => {
 		setProgress( ( prevProgress ) => {

--- a/client/sites/tools/staging-site/components/staging-site-card/index.js
+++ b/client/sites/tools/staging-site/components/staging-site-card/index.js
@@ -394,11 +394,20 @@ export const StagingSiteCard = ( {
 		addStagingSite();
 	}, [ dispatch, siteId, addStagingSite ] );
 
-	const onDeleteClick = useCallback( () => {
+	const initiateDelete = useCallback( () => {
 		dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.INITIATE_REVERTING ) );
 		setProgress( 0.1 );
 		deleteStagingSite();
 	}, [ dispatch, siteId, deleteStagingSite ] );
+
+	const shouldDelete = !! sessionStorage.getItem( 'deleteStagingSite' );
+
+	useEffect( () => {
+		if ( shouldDelete && siteId && stagingSites?.length && ! isLoadingStagingSites ) {
+			sessionStorage.removeItem( 'deleteStagingSite' );
+			initiateDelete();
+		}
+	}, [ initiateDelete, shouldDelete, siteId, stagingSites, isLoadingStagingSites ] );
 
 	const { pushToStaging } = usePushToStagingMutation( siteId, stagingSite?.id, {
 		onSuccess: () => {
@@ -488,7 +497,7 @@ export const StagingSiteCard = ( {
 			<ManageStagingSiteCardContent
 				stagingSite={ stagingSite }
 				siteId={ siteId }
-				onDeleteClick={ onDeleteClick }
+				onDeleteClick={ initiateDelete }
 				onPushClick={ pushToStaging }
 				onPullClick={ pullFromStaging }
 				isButtonDisabled={ disabled || isSyncInProgress }

--- a/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
@@ -108,7 +108,7 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 			return;
 		}
 		sessionStorage.setItem( 'deleteStagingSite', 'true' );
-		navigate( `/staging-site/${ urlToSlug( productionSite.url ) }` );
+		showSitesPage( `/staging-site/${ urlToSlug( productionSite.url ) }` );
 	};
 
 	const DeleteStagingSiteButton = () => (

--- a/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
@@ -10,18 +10,10 @@ import { urlToSlug } from 'calypso/lib/url';
 import { showSitesPage } from 'calypso/sites/components/sites-dashboard';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-<<<<<<< HEAD
 import { getSiteUrl } from 'calypso/state/sites/selectors';
-=======
-import getSiteUrl from 'calypso/state/selectors/get-site-url';
-import { setStagingSiteStatus } from 'calypso/state/staging-site/actions';
-import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
->>>>>>> f1eb4d401b9 (Add `Delete staging site` button to the staging site)
 import { getIsSyncingInProgress } from 'calypso/state/sync/selectors/get-is-syncing-in-progress';
 import { IAppState } from 'calypso/state/types';
-import { useDeleteStagingSite } from '../../hooks/use-delete-staging-site';
 import { useProductionSiteDetail, ProductionSite } from '../../hooks/use-production-site-detail';
 import { usePullFromStagingMutation, usePushToStagingMutation } from '../../hooks/use-staging-sync';
 import { CardContentWrapper } from './card-content/card-content-wrapper';
@@ -55,7 +47,6 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 	const [ syncError, setSyncError ] = useState< string | null >( null );
-	const [ deleteError, setDeleteError ] = useState< string | null >( null );
 	const stagingSiteUrl = useSelector( ( state ) => getSiteUrl( state, siteId ) );
 
 	const {
@@ -112,45 +103,15 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 		},
 	} );
 
-	const {
-		deleteStagingSite,
-		isLoading: isDeleting,
-		isReverting,
-	} = useDeleteStagingSite( {
-		siteId: productionSite?.id as number,
-		stagingSiteId: siteId,
-		transferStatus: null,
-		onMutate: () => {
-			// After the mutation starts, wait a bit for the deletion to be initiated
-			setTimeout( () => {
-				// Fetch the automated transfer status to update the UI state
-				dispatch( fetchAutomatedTransferStatus( siteId ) );
-				// Then redirect to the staging site page
-				navigate( `/staging-site/${ urlToSlug( productionSite?.url || '' ) }` );
-			}, 1000 );
-		},
-		onError: ( error ) => {
-			dispatch(
-				recordTracksEvent( 'calypso_hosting_configuration_staging_site_delete_failure', {
-					code: error.code,
-				} )
-			);
-			setDeleteError( error.code );
-		},
-	} );
-
 	const handleDeleteClick = () => {
-		dispatch(
-			setStagingSiteStatus( productionSite?.id as number, StagingSiteStatus.INITIATE_REVERTING )
-		);
-		deleteStagingSite();
+		sessionStorage.setItem( 'deleteStagingSite', 'true' );
+		navigate( `/staging-site/${ urlToSlug( productionSite?.url || '' ) }` );
 	};
 
 	const DeleteStagingSiteButton = () => (
 		<ConfirmationModal
-			disabled={ disabled || isSyncInProgress || isDeleting || isReverting }
+			disabled={ disabled || isSyncInProgress }
 			onConfirm={ handleDeleteClick }
-			isBusy={ isDeleting }
 			isScary
 			modalTitle={ translate( 'Confirm staging site deletion' ) }
 			modalMessage={ translate(
@@ -204,13 +165,7 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 	};
 
 	let cardContent;
-	if ( deleteError ) {
-		cardContent = (
-			<Notice status="is-error" showDismiss={ false }>
-				{ translate( 'Failed to delete staging site. Please try again.' ) }
-			</Notice>
-		);
-	} else if ( ! isLoading && productionSite ) {
+	if ( ! isLoading && productionSite ) {
 		cardContent = getManageStagingSiteContent( productionSite );
 	} else if ( isLoading ) {
 		cardContent = <LoadingPlaceholder />;

--- a/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
@@ -31,9 +31,13 @@ import { LoadingPlaceholder } from './loading-placeholder';
 
 const ActionButtons = styled.div( {
 	display: 'flex',
-	'@media ( max-width: 768px )': {
+	gap: '1em',
+
+	'@media screen and (max-width: 768px)': {
+		gap: '0.5em',
 		flexDirection: 'column',
-		alignItems: 'stretch',
+		'.button': { flexGrow: 1 },
+		alignSelf: 'stretch',
 	},
 } );
 

--- a/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { localize } from 'i18n-calypso';
@@ -10,14 +10,23 @@ import { urlToSlug } from 'calypso/lib/url';
 import { showSitesPage } from 'calypso/sites/components/sites-dashboard';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+<<<<<<< HEAD
 import { getSiteUrl } from 'calypso/state/sites/selectors';
+=======
+import getSiteUrl from 'calypso/state/selectors/get-site-url';
+import { setStagingSiteStatus } from 'calypso/state/staging-site/actions';
+import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
+>>>>>>> f1eb4d401b9 (Add `Delete staging site` button to the staging site)
 import { getIsSyncingInProgress } from 'calypso/state/sync/selectors/get-is-syncing-in-progress';
 import { IAppState } from 'calypso/state/types';
+import { useDeleteStagingSite } from '../../hooks/use-delete-staging-site';
 import { useProductionSiteDetail, ProductionSite } from '../../hooks/use-production-site-detail';
 import { usePullFromStagingMutation, usePushToStagingMutation } from '../../hooks/use-staging-sync';
 import { CardContentWrapper } from './card-content/card-content-wrapper';
 import { SiteSyncCard } from './card-content/staging-sync-card';
+import { ConfirmationModal } from './confirmation-modal';
 import { LoadingPlaceholder } from './loading-placeholder';
 
 const ActionButtons = styled.div( {
@@ -42,6 +51,7 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 	const [ syncError, setSyncError ] = useState< string | null >( null );
+	const [ deleteError, setDeleteError ] = useState< string | null >( null );
 	const stagingSiteUrl = useSelector( ( state ) => getSiteUrl( state, siteId ) );
 
 	const {
@@ -98,6 +108,58 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 		},
 	} );
 
+	const {
+		deleteStagingSite,
+		isLoading: isDeleting,
+		isReverting,
+	} = useDeleteStagingSite( {
+		siteId: productionSite?.id as number,
+		stagingSiteId: siteId,
+		transferStatus: null,
+		onMutate: () => {
+			// After the mutation starts, wait a bit for the deletion to be initiated
+			setTimeout( () => {
+				// Fetch the automated transfer status to update the UI state
+				dispatch( fetchAutomatedTransferStatus( siteId ) );
+				// Then redirect to the staging site page
+				navigate( `/staging-site/${ urlToSlug( productionSite?.url || '' ) }` );
+			}, 1000 );
+		},
+		onError: ( error ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_hosting_configuration_staging_site_delete_failure', {
+					code: error.code,
+				} )
+			);
+			setDeleteError( error.code );
+		},
+	} );
+
+	const handleDeleteClick = () => {
+		dispatch(
+			setStagingSiteStatus( productionSite?.id as number, StagingSiteStatus.INITIATE_REVERTING )
+		);
+		deleteStagingSite();
+	};
+
+	const DeleteStagingSiteButton = () => (
+		<ConfirmationModal
+			disabled={ disabled || isSyncInProgress || isDeleting || isReverting }
+			onConfirm={ handleDeleteClick }
+			isBusy={ isDeleting }
+			isScary
+			modalTitle={ translate( 'Confirm staging site deletion' ) }
+			modalMessage={ translate(
+				'Are you sure you want to delete the staging site? This action cannot be undone.'
+			) }
+			confirmLabel={ translate( 'Delete staging site' ) }
+			cancelLabel={ translate( 'Cancel' ) }
+		>
+			<Gridicon icon="trash" />
+			<span>{ translate( 'Delete staging site' ) }</span>
+		</ConfirmationModal>
+	);
+
 	const getLoadingErrorContent = ( message: string ) => {
 		return (
 			<Notice status="is-error" showDismiss={ false }>
@@ -117,6 +179,7 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 					>
 						<span>{ __( 'Switch to production site' ) }</span>
 					</Button>
+					<DeleteStagingSiteButton />
 				</ActionButtons>
 				<SyncActionsContainer>
 					<SiteSyncCard
@@ -137,7 +200,13 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 	};
 
 	let cardContent;
-	if ( ! isLoading && productionSite ) {
+	if ( deleteError ) {
+		cardContent = (
+			<Notice status="is-error" showDismiss={ false }>
+				{ translate( 'Failed to delete staging site. Please try again.' ) }
+			</Notice>
+		);
+	} else if ( ! isLoading && productionSite ) {
 		cardContent = getManageStagingSiteContent( productionSite );
 	} else if ( isLoading ) {
 		cardContent = <LoadingPlaceholder />;

--- a/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
@@ -104,8 +104,11 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 	} );
 
 	const handleDeleteClick = () => {
+		if ( ! productionSite?.url ) {
+			return;
+		}
 		sessionStorage.setItem( 'deleteStagingSite', 'true' );
-		navigate( `/staging-site/${ urlToSlug( productionSite?.url || '' ) }` );
+		navigate( `/staging-site/${ urlToSlug( productionSite.url ) }` );
 	};
 
 	const DeleteStagingSiteButton = () => (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/9974.

## Proposed Changes

In this PR I am proposing a solution that adds `Delete staging site` button to the `Staging site` tab when we are managing that specific staging site:

![Markup on 2025-01-20 at 15:16:23](https://github.com/user-attachments/assets/fc573cbb-e369-4f65-b27a-a2214aeb4bdf)

The proposed solution works as follows:

1. Renders the `Delete staging site` button with confirmation modal.
2. When user confirms the action, a `deleteStagingSite` value is stored in the session storage and the user is navigated to the `Staging Site` tab on the Production site page.
3.  The `deleteStagingSite` value from the session storage is checked and deleted (as it is no longer necessary) and the staging site deletion is triggered.
4. The staging site revert / deletion process continues and completes.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/dotcom-forge/issues/9974

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply the PR branch and build the app.
2. On an existing Atomic site create a new staging site.
3. Navigate to the `Staging Site` tab of the staging site and try to delete the staging site.
4. The staging site should get deleted correctly.
5. Try to create another staging site and this time delete it from the `Staging Site` tab of the production site.
6. The staging site should get deleted correctly. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
