### PR TITLE
Launchpad: use configured wpcom client for REST requests

### DIFF
--- a/client/landing/stepper/declarative-flow/assembler-first-flow.ts
+++ b/client/landing/stepper/declarative-flow/assembler-first-flow.ts
@@ -6,6 +6,7 @@ import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useQueryTheme } from 'calypso/components/data/query-theme';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
+import wpcom from 'calypso/lib/wp';
 import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { activateOrInstallThenActivate } from 'calypso/state/themes/actions';
@@ -171,7 +172,7 @@ const assemblerFirstFlow: Flow = {
 				}
 
 				case 'plans': {
-					await updateLaunchpadSettings( siteId, {
+					await updateLaunchpadSettings( wpcom, siteId, {
 						checklist_statuses: { plan_completed: true },
 					} );
 
@@ -179,7 +180,7 @@ const assemblerFirstFlow: Flow = {
 				}
 
 				case 'domains': {
-					await updateLaunchpadSettings( siteId, {
+					await updateLaunchpadSettings( wpcom, siteId, {
 						checklist_statuses: { domain_upsell_deferred: true },
 					} );
 

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -15,6 +15,7 @@ import {
 } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
+import wpcom from 'calypso/lib/wp';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { useExitFlow } from '../hooks/use-exit-flow';
 import { useSiteData } from '../hooks/use-site-data';
@@ -152,7 +153,7 @@ const designFirst: Flow = {
 						} );
 
 						if ( providedDependencies?.hasSetPreselectedTheme ) {
-							updateLaunchpadSettings( siteSlug as string, {
+							updateLaunchpadSettings( wpcom, siteSlug as string, {
 								checklist_statuses: { design_completed: true },
 							} );
 
@@ -193,7 +194,7 @@ const designFirst: Flow = {
 				}
 				case 'domains':
 					if ( siteId ) {
-						await updateLaunchpadSettings( siteId, {
+						await updateLaunchpadSettings( wpcom, siteId, {
 							checklist_statuses: { domain_upsell_deferred: true },
 						} );
 					}
@@ -205,21 +206,21 @@ const designFirst: Flow = {
 					return navigate( 'plans' );
 				case 'use-my-domain':
 					if ( siteId ) {
-						await updateLaunchpadSettings( siteId, {
+						await updateLaunchpadSettings( wpcom, siteId, {
 							checklist_statuses: { domain_upsell_deferred: true },
 						} );
 					}
 					return navigate( 'plans' );
 				case 'plans':
 					if ( siteId ) {
-						await updateLaunchpadSettings( siteId, {
+						await updateLaunchpadSettings( wpcom, siteId, {
 							checklist_statuses: { plan_completed: true },
 						} );
 					}
 					return navigate( 'launchpad' );
 				case 'setup-blog':
 					if ( siteId ) {
-						await updateLaunchpadSettings( siteId, {
+						await updateLaunchpadSettings( wpcom, siteId, {
 							checklist_statuses: { setup_blog: true },
 						} );
 					}

--- a/client/landing/stepper/declarative-flow/domain-upsell.ts
+++ b/client/landing/stepper/declarative-flow/domain-upsell.ts
@@ -2,6 +2,7 @@ import { OnboardSelect, updateLaunchpadSettings, useLaunchpad } from '@automatti
 import { addPlanToCart, addProductsToCart, DOMAIN_UPSELL_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
+import wpcom from 'calypso/lib/wp';
 import { useQuery } from '../hooks/use-query';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
@@ -37,7 +38,10 @@ const domainUpsell: Flow = {
 			[]
 		);
 		const { setHideFreePlan } = useDispatch( ONBOARD_STORE );
-		const { data: { launchpad_screen: launchpadScreenOption } = {} } = useLaunchpad( siteSlug );
+		const { data: { launchpad_screen: launchpadScreenOption } = {} } = useLaunchpad(
+			wpcom,
+			siteSlug
+		);
 
 		const returnUrl =
 			launchpadScreenOption === 'skipped'
@@ -61,7 +65,7 @@ const domainUpsell: Flow = {
 						try {
 							const siteIdentifier = siteSlug || siteId;
 							if ( siteIdentifier ) {
-								await updateLaunchpadSettings( siteIdentifier, {
+								await updateLaunchpadSettings( wpcom, siteIdentifier, {
 									checklist_statuses: { domain_upsell_deferred: true },
 								} );
 							}
@@ -77,7 +81,7 @@ const domainUpsell: Flow = {
 						const planCartItem = getPlanCartItem();
 						const domainCartItem = getDomainCartItem();
 						if ( planCartItem && siteSlug && flowName ) {
-							await addPlanToCart( siteSlug, flowName, true, '', planCartItem );
+							await addPlanToCart( wpcom, siteSlug, flowName, true, '', planCartItem );
 						}
 
 						if ( domainCartItem && siteSlug && flowName ) {

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
@@ -1,5 +1,6 @@
 import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { ExperimentAssignment } from '@automattic/explat-client';
+import wpcom from 'calypso/lib/wp';
 
 export const LAUNCHPAD_EXPERIMENT_NAME = 'calypso_onboarding_launchpad_removal_test_2024_08';
 
@@ -30,7 +31,7 @@ export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 
 	const setLaunchpadSkipState = ( siteIdOrSlug: string | number | null ) => {
 		if ( siteIdOrSlug && launchpadStateOnSkip ) {
-			updateLaunchpadSettings( siteIdOrSlug, { launchpad_screen: launchpadStateOnSkip } );
+			updateLaunchpadSettings( wpcom, siteIdOrSlug, { launchpad_screen: launchpadStateOnSkip } );
 		}
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/index.tsx
@@ -8,6 +8,7 @@ import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { urlToSlug } from 'calypso/lib/url';
+import wpcom from 'calypso/lib/wp';
 import SitePreview from '../../components/site-preview';
 import useCelebrationData from './use-celebration-data';
 import type { Step } from '../../types';
@@ -28,7 +29,7 @@ const CelebrationStep: Step = ( { flow, navigation } ) => {
 
 	const {
 		data: { checklist_statuses: checklistStatuses },
-	} = useLaunchpad( siteSlug );
+	} = useLaunchpad( wpcom, siteSlug );
 
 	const {
 		title,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -38,6 +38,7 @@ import { useSourceMigrationStatusQuery } from 'calypso/data/site-migration/use-s
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import wpcom from 'calypso/lib/wp';
 import {
 	retrieveSignupDestination,
 	getSignupCompleteFlowName,
@@ -198,7 +199,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 			const slug = getSignupCompleteSlug();
 
 			if ( planCartItem && slug ) {
-				await addPlanToCart( slug, flow, true, theme, planCartItem );
+				await addPlanToCart( wpcom, slug, flow, true, theme, planCartItem );
 			}
 
 			return {
@@ -212,6 +213,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 
 		const sourceSlug = hasSourceSlug( data ) ? data.sourceSlug : undefined;
 		const site = await createSiteWithCart(
+			wpcom,
 			flow,
 			true,
 			isPaidDomainItem,
@@ -249,7 +251,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 		}
 
 		if ( planCartItem && site?.siteSlug ) {
-			await addPlanToCart( site.siteSlug, flow, true, theme, planCartItem );
+			await addPlanToCart( wpcom, site.siteSlug, flow, true, theme, planCartItem );
 		}
 
 		if ( productCartItems?.length && site?.siteSlug ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -50,6 +50,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useExperiment } from 'calypso/lib/explat';
 import { navigate } from 'calypso/lib/navigate';
 import { urlToSlug } from 'calypso/lib/url';
+import wpcom from 'calypso/lib/wp';
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { getEligibility } from 'calypso/state/automated-transfer/selectors';
 import {
@@ -632,7 +633,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		setSelectedDesign( _selectedDesign );
 
 		if ( siteSlugOrId ) {
-			await updateLaunchpadSettings( siteSlugOrId, {
+			await updateLaunchpadSettings( wpcom, siteSlugOrId, {
 				checklist_statuses: { design_completed: true },
 			} );
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -13,6 +13,7 @@ import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-pa
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { urlToSlug } from 'calypso/lib/url';
+import wpcom from 'calypso/lib/wp';
 import { useSelector, useDispatch } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
@@ -43,7 +44,7 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 	const {
 		isError: launchpadFetchError,
 		data: { launchpad_screen: launchpadScreenOption, checklist: launchpadChecklist } = {},
-	} = useLaunchpad( launchpadKey, siteIntentOption );
+	} = useLaunchpad( wpcom, launchpadKey, siteIntentOption );
 
 	const dispatch = useDispatch();
 	const { saveSiteSettings } = useWPDispatch( SITE_STORE );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -20,6 +20,7 @@ import { type NavigationControls } from 'calypso/landing/stepper/declarative-flo
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { type ResponseDomain } from 'calypso/lib/domains/types';
+import wpcom from 'calypso/lib/wp';
 import RecurringPaymentsPlanAddEditModal from 'calypso/my-sites/earn/components/add-edit-plan-modal';
 import { TYPE_TIER } from 'calypso/my-sites/earn/memberships/constants';
 import { useSelector } from 'calypso/state';
@@ -75,7 +76,7 @@ const Sidebar = ( {
 
 	const {
 		data: { checklist_statuses: checklistStatuses, checklist: launchpadChecklist },
-	} = useLaunchpad( launchpadKey, siteIntentOption, {
+	} = useLaunchpad( wpcom, launchpadKey, siteIntentOption, {
 		onSuccess: sortLaunchpadTasksByCompletionStatus,
 	} );
 
@@ -282,6 +283,7 @@ const Sidebar = ( {
 					</div>
 				) }
 				<LaunchpadInternal
+					wpcom={ wpcom }
 					flow={ flow }
 					site={ site }
 					siteSlug={ launchpadKey }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/content/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/content/index.tsx
@@ -1,10 +1,11 @@
 import { updateLaunchpadSettings } from '@automattic/data-stores/src/queries/use-launchpad';
 import { isNewsletterFlow } from '@automattic/onboarding';
+import wpcom from 'calypso/lib/wp';
 import { TaskAction } from '../../types';
 
 const completeMigrateContentTask = async ( siteSlug: string | null ) => {
 	if ( siteSlug ) {
-		await updateLaunchpadSettings( siteSlug, {
+		await updateLaunchpadSettings( wpcom, siteSlug, {
 			checklist_statuses: { migrate_content: true },
 		} );
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/plan/index.tsx
@@ -11,6 +11,7 @@ import { QueryClient } from '@tanstack/react-query';
 import { ExternalLink } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
+import wpcom from 'calypso/lib/wp';
 import { ADD_TIER_PLAN_HASH } from 'calypso/my-sites/earn/memberships/constants';
 import { getSiteIdOrSlug } from '../../task-helper';
 import { recordGlobalStylesGattingPlanSelectedResetStylesEvent } from '../../tracking';
@@ -102,7 +103,7 @@ const getPlanCompletedTask: TaskAction = ( task, flow, context ) => {
 //TODO: Move the updateLaunchpadSettings to be a hoook and use queryclient to invalidate the hook.
 const completePaidNewsletterTask = async ( siteSlug: string | null, queryClient: QueryClient ) => {
 	if ( siteSlug ) {
-		await updateLaunchpadSettings( siteSlug, {
+		await updateLaunchpadSettings( wpcom, siteSlug, {
 			checklist_statuses: { newsletter_plan_created: true },
 		} );
 		queryClient?.invalidateQueries( { queryKey: [ 'launchpad' ] } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -26,7 +26,7 @@ jest.mock( 'calypso/state/sites/hooks/use-site-global-styles-status', () => ( {
 
 jest.mock( '@automattic/data-stores', () => ( {
 	...jest.requireActual( '@automattic/data-stores' ),
-	useLaunchpad: ( siteSlug, siteIntentOption ) => {
+	useLaunchpad: ( wpcom, siteSlug, siteIntentOption ) => {
 		let checklist = [
 			{ id: 'foo_task', completed: false, disabled: true, title: 'Foo Task' },
 			{ id: 'foo_task_1', completed: true, disabled: true, title: 'Foo Task 1' },

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -116,7 +116,7 @@ jest.mock( 'react-router-dom', () => ( {
 
 jest.mock( '@automattic/data-stores', () => ( {
 	...( jest.requireActual( '@automattic/data-stores' ) as object ),
-	useLaunchpad: ( siteSlug, siteIntentOption ): LaunchpadResponse => {
+	useLaunchpad: ( wpcom, siteSlug, siteIntentOption ): LaunchpadResponse => {
 		let checklist = [];
 
 		switch ( siteIntentOption ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/index.tsx
@@ -5,7 +5,7 @@ import { StepContainer } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import clsx from 'clsx';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
 import useUrlQueryParam from 'calypso/a8c-for-agencies/hooks/use-url-query-param';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -15,6 +15,7 @@ import FormTextarea from 'calypso/components/forms/form-textarea';
 import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import wpcom from 'calypso/lib/wp';
 import { ReadymadeTemplate } from 'calypso/my-sites/patterns/types';
 import generateAIContentForTemplate from './api/generate-content';
 import ReadymadeTemplatePreview from './components/readymade-template-preview';
@@ -34,6 +35,7 @@ const ReadymadeTemplateGenerateContent: React.FC< ReadymadeTemplateGenerateConte
 	siteSlug,
 	next = () => {},
 } ) => {
+	const translate = useTranslate();
 	const [ aiContext, setAiContext ] = useState( '' );
 	const [ numberOfGenerations, setNumberOfGenerations ] = useState( 0 );
 	const [ isGeneratingContent, setIsGeneratingContent ] = useState( false );
@@ -44,7 +46,7 @@ const ReadymadeTemplateGenerateContent: React.FC< ReadymadeTemplateGenerateConte
 	const locale = useLocale();
 
 	const markContentGenerationTaskComplete = () =>
-		updateLaunchpadSettings( siteSlug, {
+		updateLaunchpadSettings( wpcom, siteSlug, {
 			checklist_statuses: { generate_content: true },
 		} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -13,6 +13,7 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
+import wpcom from 'calypso/lib/wp';
 import { getHidePlanPropsBasedOnThemeType } from 'calypso/my-sites/plans-features-main/components/utils/utils';
 import { getSignupCompleteSiteID, getSignupCompleteSlug } from 'calypso/signup/storageUtils';
 import { useSelector, useDispatch as useReduxDispatch } from 'calypso/state';
@@ -108,7 +109,7 @@ export default function PlansStepAdaptor( props: StepProps ) {
 				return setDesignOnSite( site?.ID, defaultDesign, {
 					styleVariation: defaultDesign?.style_variations?.[ 0 ],
 				} ).then( async ( theme: ActiveTheme ) => {
-					await updateLaunchpadSettings( site?.ID || '', {
+					await updateLaunchpadSettings( wpcom, site?.ID || '', {
 						checklist_statuses: { design_completed: false },
 					} );
 					return reduxDispatch( setActiveTheme( site?.ID || -1, theme ) );

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -8,6 +8,7 @@ import { useLaunchpadDecider } from 'calypso/landing/stepper/declarative-flow/in
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
+import wpcom from 'calypso/lib/wp';
 import {
 	clearSignupDestinationCookie,
 	setSignupCompleteSlug,
@@ -94,7 +95,7 @@ const newsletter: Flow = {
 
 		const completeSubscribersTask = async () => {
 			if ( siteSlug ) {
-				await updateLaunchpadSettings( siteSlug, {
+				await updateLaunchpadSettings( wpcom, siteSlug, {
 					checklist_statuses: { subscribers_added: true },
 				} );
 			}

--- a/client/landing/stepper/declarative-flow/readymade-template.tsx
+++ b/client/landing/stepper/declarative-flow/readymade-template.tsx
@@ -140,7 +140,7 @@ const readymadeTemplateFlow: Flow = {
 				}
 
 				case 'plans': {
-					await updateLaunchpadSettings( siteId, {
+					await updateLaunchpadSettings( wpcom, siteId, {
 						checklist_statuses: { plan_completed: true },
 					} );
 
@@ -148,7 +148,7 @@ const readymadeTemplateFlow: Flow = {
 				}
 
 				case 'domains': {
-					await updateLaunchpadSettings( siteId, {
+					await updateLaunchpadSettings( wpcom, siteId, {
 						checklist_statuses: { domain_upsell_deferred: true },
 					} );
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -12,6 +12,7 @@ import { useIsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-b
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { ImporterMainPlatform } from 'calypso/lib/importer/types';
 import { addQueryArgs } from 'calypso/lib/route';
+import wpcom from 'calypso/lib/wp';
 import { useDispatch as reduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getInitialQueryArguments } from 'calypso/state/selectors/get-initial-query-arguments';
@@ -729,7 +730,7 @@ const siteSetupFlow: Flow = {
 
 				// Complete the "Select a design" task only when there is a selected design.
 				const design_completed = selectedDesign?.default ? false : true;
-				await updateLaunchpadSettings( siteSlugOrId, {
+				await updateLaunchpadSettings( wpcom, siteSlugOrId, {
 					checklist_statuses: { design_completed },
 				} );
 
@@ -759,7 +760,7 @@ const siteSetupFlow: Flow = {
 				} )
 					.then( async ( theme: ActiveTheme ) => {
 						const design_completed = selectedDesign?.default ? false : true;
-						await updateLaunchpadSettings( siteSlugOrId, {
+						await updateLaunchpadSettings( wpcom, siteSlugOrId, {
 							checklist_statuses: { design_completed },
 						} );
 						return dispatch( setActiveTheme( siteId, theme ) );

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -13,6 +13,7 @@ import {
 } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
+import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { useExitFlow } from '../hooks/use-exit-flow';
@@ -181,7 +182,7 @@ const startWriting: Flow = {
 				}
 				case 'domains':
 					if ( siteId ) {
-						await updateLaunchpadSettings( siteId, {
+						await updateLaunchpadSettings( wpcom, siteId, {
 							checklist_statuses: { domain_upsell_deferred: true },
 						} );
 					}
@@ -193,21 +194,21 @@ const startWriting: Flow = {
 					return navigate( 'plans' );
 				case 'use-my-domain':
 					if ( siteId ) {
-						await updateLaunchpadSettings( siteId, {
+						await updateLaunchpadSettings( wpcom, siteId, {
 							checklist_statuses: { domain_upsell_deferred: true },
 						} );
 					}
 					return navigate( 'plans' );
 				case 'plans':
 					if ( siteId ) {
-						await updateLaunchpadSettings( siteId, {
+						await updateLaunchpadSettings( wpcom, siteId, {
 							checklist_statuses: { plan_completed: true },
 						} );
 					}
 					return navigate( 'launchpad' );
 				case 'setup-blog':
 					if ( siteId ) {
-						await updateLaunchpadSettings( siteId, {
+						await updateLaunchpadSettings( wpcom, siteId, {
 							checklist_statuses: { setup_blog: true },
 						} );
 					}

--- a/client/landing/stepper/declarative-flow/update-design.ts
+++ b/client/landing/stepper/declarative-flow/update-design.ts
@@ -3,6 +3,7 @@ import { useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { translate } from 'i18n-calypso';
 import { useLaunchpadDecider } from 'calypso/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider';
+import wpcom from 'calypso/lib/wp';
 import {
 	setSignupCompleteSlug,
 	persistSignupDestination,
@@ -38,7 +39,10 @@ const updateDesign: Flow = {
 		const siteSlug = useSiteSlug();
 		const flowToReturnTo = useQuery().get( 'flowToReturnTo' ) || 'free';
 		const { setPendingAction } = useDispatch( ONBOARD_STORE );
-		const { data: { launchpad_screen: launchpadScreenOption } = {} } = useLaunchpad( siteSlug );
+		const { data: { launchpad_screen: launchpadScreenOption } = {} } = useLaunchpad(
+			wpcom,
+			siteSlug
+		);
 
 		const exitFlow = ( to: string ) => {
 			setPendingAction( () => {

--- a/client/landing/stepper/utils/skip-launchpad.ts
+++ b/client/landing/stepper/utils/skip-launchpad.ts
@@ -1,4 +1,5 @@
 import { updateLaunchpadSettings } from '@automattic/data-stores';
+import wpcom from 'calypso/lib/wp';
 
 type SkipLaunchpadProps = {
 	siteId: string | number | null;
@@ -8,7 +9,7 @@ type SkipLaunchpadProps = {
 export const skipLaunchpad = async ( { siteId, siteSlug }: SkipLaunchpadProps ) => {
 	const siteIdOrSlug = siteId || siteSlug;
 	if ( siteIdOrSlug ) {
-		await updateLaunchpadSettings( siteIdOrSlug, { launchpad_screen: 'skipped' } );
+		await updateLaunchpadSettings( wpcom, siteIdOrSlug, { launchpad_screen: 'skipped' } );
 	}
 
 	return window.location.assign( `/home/${ siteIdOrSlug }` );

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/plan-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/plan-product.tsx
@@ -2,12 +2,13 @@ import { isWpComEcommercePlan } from '@automattic/calypso-products';
 import { useLaunchpad } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
 import { useDispatch as useWPDispatch } from '@wordpress/data';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import ThankYouProduct from 'calypso/components/thank-you-v2/product';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
+import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import {
 	getSitePurchases,
@@ -27,6 +28,7 @@ export default function ThankYouPlanProduct( {
 	siteSlug,
 	siteId,
 }: ThankYouPlanProductProps ) {
+	const translate = useTranslate();
 	const isLoadingPurchases = useSelector(
 		( state ) => isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state )
 	);
@@ -48,7 +50,7 @@ export default function ThankYouPlanProduct( {
 
 	const { saveSiteSettings } = useWPDispatch( SITE_STORE );
 
-	const { data: launchpad, isLoading } = useLaunchpad( siteSlug, 'intent-build' );
+	const { data: launchpad, isLoading } = useLaunchpad( wpcom, siteSlug, 'intent-build' );
 
 	const hasRemainingTasks =
 		launchpad && launchpad.checklist

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -7,9 +7,9 @@ import {
 import { Launchpad, type Task } from '@automattic/launchpad';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { type FC } from 'react';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -21,20 +21,17 @@ interface CustomerHomeLaunchpadProps {
 	onSiteLaunched?: () => void;
 }
 
-const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( {
-	checklistSlug,
-	onSiteLaunched,
-}: CustomerHomeLaunchpadProps ) => {
+const CustomerHomeLaunchpad = ( { checklistSlug, onSiteLaunched }: CustomerHomeLaunchpadProps ) => {
 	const launchpadContext = 'customer-home';
 	const siteId = useSelector( getSelectedSiteId );
 	const translate = useTranslate();
 	const siteSlug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) || '' );
 
-	const { mutate: dismiss } = useLaunchpadDismisser( siteSlug, checklistSlug );
+	const { mutate: dismiss } = useLaunchpadDismisser( wpcom, siteSlug, checklistSlug );
 
 	const {
 		data: { checklist, is_dismissed: isDismissed, is_dismissible: isDismissible, title },
-	} = useSortedLaunchpadTasks( siteSlug, checklistSlug, launchpadContext );
+	} = useSortedLaunchpadTasks( wpcom, siteSlug, checklistSlug, launchpadContext );
 
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
@@ -100,6 +97,7 @@ const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( {
 				) }
 			</div>
 			<Launchpad
+				wpcom={ wpcom }
 				siteSlug={ siteSlug }
 				checklistSlug={ checklistSlug }
 				launchpadContext={ launchpadContext }

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -29,9 +29,8 @@ const CustomerHomeLaunchpad = ( { checklistSlug, onSiteLaunched }: CustomerHomeL
 
 	const { mutate: dismiss } = useLaunchpadDismisser( wpcom, siteSlug, checklistSlug );
 
-	const {
-		data: { checklist, is_dismissed: isDismissed, is_dismissible: isDismissible, title },
-	} = useSortedLaunchpadTasks( wpcom, siteSlug, checklistSlug, launchpadContext );
+	const { data } = useSortedLaunchpadTasks( wpcom, siteSlug, checklistSlug, launchpadContext );
+	const { checklist, is_dismissed: isDismissed, is_dismissible: isDismissible, title } = data;
 
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;

--- a/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
@@ -2,6 +2,7 @@ import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { useState } from 'react';
 import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
+import wpcom from 'calypso/lib/wp';
 import { useSelector, useDispatch } from 'calypso/state';
 import { requestSite } from 'calypso/state/sites/actions';
 import { getSite } from 'calypso/state/sites/selectors';
@@ -44,7 +45,7 @@ const LaunchpadPreLaunch = ( props: LaunchpadPreLaunchProps ): JSX.Element => {
 		// currently the action to update site_launch status on atomic doesn't fire
 		// this is a workaround until that is fixed
 		if ( site?.is_wpcom_atomic ) {
-			updateLaunchpadSettings( siteId, {
+			updateLaunchpadSettings( wpcom, siteId, {
 				checklist_statuses: { site_launched: true },
 			} );
 		}

--- a/client/my-sites/customer-home/cards/launchpad/test/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/test/index.tsx
@@ -3,8 +3,8 @@
  */
 import { screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import apiFetch from '@wordpress/api-fetch';
 import React from 'react';
+import wpcom from 'calypso/lib/wp';
 import { reducer as ui } from 'calypso/state/ui/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import CustomerHomeLaunchPad from '../';
@@ -39,14 +39,12 @@ const initialState = {
 	},
 };
 
-// Due to an unknown issue, the following mock is required to <prevent> the following error:
-// TypeError: (0 , _wpcomProxyRequest.canAccessWpcomApis) is not a function
-// Probably there is a test leaking a mock or something like that.
-jest.mock( 'wpcom-proxy-request', () => ( {
-	...jest.requireActual( 'wpcom-proxy-request' ),
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: {
+		get: jest.fn(),
+		put: jest.fn(),
+	},
 } ) );
-
-jest.mock( '@wordpress/api-fetch' );
 
 const render = ( el ) => {
 	return renderWithProvider( el, {
@@ -55,7 +53,7 @@ const render = ( el ) => {
 	} );
 };
 
-const DEFAULT_TAKS_RESPONSE = {
+const DEFAULT_TASKS_RESPONSE = {
 	site_intent: 'build',
 	launchpad_screen: 'off',
 	checklist_statuses: {
@@ -94,7 +92,7 @@ const DEFAULT_TAKS_RESPONSE = {
 
 describe( 'CustomerHomeLaunchPad', () => {
 	beforeAll( () => {
-		jest.mocked( apiFetch ).mockResolvedValue( DEFAULT_TAKS_RESPONSE );
+		jest.mocked( wpcom.req.get ).mockResolvedValue( DEFAULT_TASKS_RESPONSE );
 	} );
 
 	it( 'renders the launchpad title', async () => {
@@ -126,10 +124,10 @@ describe( 'CustomerHomeLaunchPad', () => {
 	describe( 'when the launchpad was previously dismissed', () => {
 		it( "doesn't renders the launchpad", () => {
 			const data = {
-				...DEFAULT_TAKS_RESPONSE,
+				...DEFAULT_TASKS_RESPONSE,
 				is_dismissable: true,
 			};
-			jest.mocked( apiFetch ).mockResolvedValueOnce( data );
+			jest.mocked( wpcom.req.get ).mockResolvedValueOnce( data );
 
 			render( <CustomerHomeLaunchPad checklistSlug="some-check-list" /> );
 
@@ -139,7 +137,7 @@ describe( 'CustomerHomeLaunchPad', () => {
 
 	describe( 'when all tasks are completed', () => {
 		const data = {
-			...DEFAULT_TAKS_RESPONSE,
+			...DEFAULT_TASKS_RESPONSE,
 			checklist: [
 				{
 					id: 'setup_general',
@@ -155,7 +153,7 @@ describe( 'CustomerHomeLaunchPad', () => {
 		};
 
 		beforeEach( () => {
-			jest.mocked( apiFetch ).mockResolvedValueOnce( data );
+			jest.mocked( wpcom.req.get ).mockResolvedValueOnce( data );
 		} );
 
 		it( "doesn't renders skip button", async () => {
@@ -182,12 +180,12 @@ describe( 'CustomerHomeLaunchPad', () => {
 
 	describe( 'when the launchpad is NOT dismissible', () => {
 		const dismissibleTask = {
-			...DEFAULT_TAKS_RESPONSE,
+			...DEFAULT_TASKS_RESPONSE,
 			is_dismissed: false,
 		};
 
 		beforeAll( () => {
-			jest.mocked( apiFetch ).mockResolvedValue( dismissibleTask );
+			jest.mocked( wpcom.req.get ).mockResolvedValue( dismissibleTask );
 		} );
 
 		it( 'renders the dismiss settings menu when the tasks are not completed', () => {

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -3,6 +3,7 @@ import { fetchLaunchpad } from '@automattic/data-stores';
 import { areLaunchpadTasksCompleted } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper';
 import { isRemovedFlow } from 'calypso/landing/stepper/utils/flow-redirect-handler';
 import { getQueryArgs } from 'calypso/lib/query-args';
+import wpcom from 'calypso/lib/wp';
 import { bumpStat } from 'calypso/state/analytics/actions';
 import { fetchModuleList } from 'calypso/state/jetpack/modules/actions';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
@@ -66,7 +67,7 @@ export async function maybeRedirect( context, next ) {
 			launchpad_screen: launchpadScreenOption,
 			site_intent: siteIntentOption,
 			checklist: launchpadChecklist,
-		} = await fetchLaunchpad( slug );
+		} = await fetchLaunchpad( wpcom, slug );
 
 		const shouldShowLaunchpad = ! isRemovedFlow( siteIntentOption );
 

--- a/client/my-sites/earn/hooks/use-earn-launchpad-tasks.ts
+++ b/client/my-sites/earn/hooks/use-earn-launchpad-tasks.ts
@@ -1,5 +1,6 @@
 import { useLaunchpad } from '@automattic/data-stores';
 import { Task } from '@automattic/launchpad';
+import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
 import { getIsConnectedForSiteId } from 'calypso/state/memberships/settings/selectors';
@@ -15,7 +16,7 @@ export const useEarnLaunchpadTasks = () => {
 
 	const {
 		data: { checklist },
-	} = useLaunchpad( site?.slug ?? null, checklistSlug );
+	} = useLaunchpad( wpcom, site?.slug ?? null, checklistSlug );
 
 	const taskFilter = ( tasks: Task[] ): Task[] => {
 		if ( ! tasks ) {

--- a/client/my-sites/earn/launchpad/index.tsx
+++ b/client/my-sites/earn/launchpad/index.tsx
@@ -1,6 +1,7 @@
 import { CircularProgressBar } from '@automattic/components';
 import { Launchpad, type Task } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
+import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
@@ -41,6 +42,7 @@ const EarnLaunchpad = ( { launchpad }: EarnLaunchpadProps ) => {
 				</p>
 			</div>
 			<Launchpad
+				wpcom={ wpcom }
 				siteSlug={ site?.slug ?? null }
 				checklistSlug={ checklistSlug }
 				onPostFilterTasks={ taskFilter }

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -10,6 +10,7 @@ import QueryJetpackSettings from 'calypso/components/data/query-jetpack-settings
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import { protectForm } from 'calypso/lib/protect-form';
 import trackForm from 'calypso/lib/track-form';
+import wpcom from 'calypso/lib/wp';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { activateModule } from 'calypso/state/jetpack/modules/actions';
 import { saveJetpackSettings } from 'calypso/state/jetpack/settings/actions';
@@ -48,12 +49,13 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 			this.props.replaceFields( getFormSettings( this.props.settings, this.props ) );
 
 			// Check if site_title task is completed
-			fetchLaunchpad( this.props.siteSlug, 'intent-build' ).then( ( { checklist_statuses } ) => {
-				this.setState( {
-					...this.state,
-					isSiteTitleTaskCompleted: !! checklist_statuses?.site_title,
-				} );
-			} );
+			fetchLaunchpad( wpcom, this.props.siteSlug, 'intent-build' ).then(
+				( { checklist_statuses } ) => {
+					this.setState( {
+						isSiteTitleTaskCompleted: !! checklist_statuses?.site_title,
+					} );
+				}
+			);
 		}
 
 		componentDidUpdate( prevProps ) {

--- a/client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx
+++ b/client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx
@@ -1,6 +1,7 @@
 import { CircularProgressBar } from '@automattic/components';
 import { Launchpad } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
+import wpcom from 'calypso/lib/wp';
 import { useSubscriberLaunchpadTasks } from 'calypso/my-sites/subscribers/hooks';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -36,6 +37,7 @@ const SubscriberLaunchpad = ( {
 			</div>
 
 			<Launchpad
+				wpcom={ wpcom }
 				siteSlug={ site?.slug ?? null }
 				checklistSlug={ checklistSlug }
 				onPostFilterTasks={ taskFilter }

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -4,6 +4,7 @@ import { translate } from 'i18n-calypso';
 import React, { createContext, useState, useContext, useEffect, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { useDebounce } from 'use-debounce';
+import wpcom from 'calypso/lib/wp';
 import { usePagination } from 'calypso/my-sites/subscribers/hooks';
 import { Subscriber } from 'calypso/my-sites/subscribers/types';
 import { useSelector } from 'calypso/state';
@@ -133,7 +134,7 @@ export const SubscribersPageProvider = ( {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const completeImportSubscribersTask = async () => {
 		if ( selectedSiteSlug ) {
-			await updateLaunchpadSettings( selectedSiteSlug, {
+			await updateLaunchpadSettings( wpcom, selectedSiteSlug, {
 				checklist_statuses: { import_subscribers: true },
 			} );
 		}

--- a/client/my-sites/subscribers/hooks/use-subscriber-launchpad-tasks.ts
+++ b/client/my-sites/subscribers/hooks/use-subscriber-launchpad-tasks.ts
@@ -1,5 +1,6 @@
 import { useLaunchpad } from '@automattic/data-stores';
 import { Task } from '@automattic/launchpad';
+import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
@@ -9,7 +10,7 @@ const useSubscriberLaunchpadTasks = () => {
 
 	const {
 		data: { checklist },
-	} = useLaunchpad( site?.slug ?? null, checklistSlug );
+	} = useLaunchpad( wpcom, site?.slug ?? null, checklistSlug );
 
 	// We can alter the tasks here, keeping this in for future use
 	const taskFilter = ( tasks: Task[] ): Task[] => {

--- a/client/sites/tools/sftp-ssh/sftp-form.tsx
+++ b/client/sites/tools/sftp-ssh/sftp-form.tsx
@@ -10,6 +10,7 @@ import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import wpcom from 'calypso/lib/wp';
 import ReauthRequired from 'calypso/me/reauth-required';
 import { useSelector } from 'calypso/state';
 import {
@@ -159,7 +160,7 @@ export const SftpForm = ( {
 		setIsLoading( true );
 		dispatch( createSftpUser( siteId, currentUserId ) );
 		if ( 'host-site' === siteIntent ) {
-			updateLaunchpadSettings( siteId, {
+			updateLaunchpadSettings( wpcom, siteId, {
 				checklist_statuses: { setup_ssh: true },
 			} );
 		}

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -2,7 +2,6 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
-import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 
 interface APIFetchOptions {
 	global: boolean;
@@ -62,25 +61,22 @@ export type UseLaunchpadOptions = {
 };
 
 export const fetchLaunchpad = (
+	wpcom: any,
 	siteSlug: SiteSlug,
 	checklistSlug?: string | null,
 	launchpadContext?: string
 ): Promise< LaunchpadResponse > => {
 	const slug = encodeURIComponent( siteSlug as string );
-	const checklistSlugEncoded = checklistSlug ? encodeURIComponent( checklistSlug ) : null;
-	const launchpadContextEncoded = launchpadContext ? encodeURIComponent( launchpadContext ) : null;
 	const queryArgs = {
 		_locale: 'user',
-		...( checklistSlug && { checklist_slug: checklistSlugEncoded } ),
-		...( launchpadContext && { launchpad_context: launchpadContextEncoded } ),
+		...( checklistSlug && { checklist_slug: encodeURIComponent( checklistSlug ) } ),
+		...( launchpadContext && { launchpad_context: encodeURIComponent( launchpadContext ) } ),
 	};
 
-	return canAccessWpcomApis()
-		? wpcomRequest( {
+	return wpcom
+		? wpcom.req.get( {
 				path: addQueryArgs( `/sites/${ slug }/launchpad`, queryArgs ),
 				apiNamespace: 'wpcom/v2',
-				apiVersion: '2',
-				method: 'GET',
 		  } )
 		: apiFetch( {
 				global: true,
@@ -115,6 +111,7 @@ const defaultSuccessCallback = ( response: LaunchpadResponse ) => {
 type SiteSlug = string | number | null;
 
 export const useLaunchpad = (
+	wpcom: any,
 	siteSlug: SiteSlug,
 	checklistSlug?: string | null,
 	options?: UseLaunchpadOptions,
@@ -126,7 +123,7 @@ export const useLaunchpad = (
 	return useQuery( {
 		queryKey: key,
 		queryFn: () =>
-			fetchLaunchpad( siteSlug, checklistSlug, launchpad_context ).then( onSuccessCallback ),
+			fetchLaunchpad( wpcom, siteSlug, checklistSlug, launchpad_context ).then( onSuccessCallback ),
 		retry: 3,
 		initialData: {
 			site_intent: '',
@@ -142,6 +139,7 @@ export const useLaunchpad = (
 };
 
 export const useSortedLaunchpadTasks = (
+	wpcom: any,
 	siteSlug: SiteSlug,
 	checklistSlug?: string | null,
 	launchpadContext?: string
@@ -150,20 +148,20 @@ export const useSortedLaunchpadTasks = (
 		onSuccess: sortLaunchpadTasksByCompletionStatus,
 	};
 
-	return useLaunchpad( siteSlug, checklistSlug, launchpadOptions, launchpadContext );
+	return useLaunchpad( wpcom, siteSlug, checklistSlug, launchpadOptions, launchpadContext );
 };
 
 export const updateLaunchpadSettings = (
+	wpcom: any,
 	siteSlug: SiteSlug,
 	settings: LaunchpadUpdateSettings = {}
 ) => {
 	const slug = siteSlug ? encodeURIComponent( siteSlug ) : null;
 
-	return canAccessWpcomApis()
-		? wpcomRequest( {
+	return wpcom
+		? wpcom.req.put( {
 				path: `/sites/${ slug }/launchpad`,
 				apiNamespace: 'wpcom/v2',
-				method: 'PUT',
 				body: settings,
 		  } )
 		: apiFetch( {
@@ -203,13 +201,13 @@ const getDismissParams = ( settings: DismissSettings ) => {
 	}
 };
 
-export const useLaunchpadDismisser = ( siteSlug: SiteSlug, checklistSlug: string ) => {
+export const useLaunchpadDismisser = ( wpcom: any, siteSlug: SiteSlug, checklistSlug: string ) => {
 	const queryClient = useQueryClient();
 	const key = getKey( siteSlug, checklistSlug );
 
 	return useMutation( {
 		mutationFn: ( settings: DismissSettings ) => {
-			return updateLaunchpadSettings( siteSlug, {
+			return updateLaunchpadSettings( wpcom, siteSlug, {
 				is_checklist_dismissed: {
 					slug: checklistSlug,
 					...getDismissParams( settings ),

--- a/packages/help-center/src/components/help-center-launchpad.tsx
+++ b/packages/help-center/src/components/help-center-launchpad.tsx
@@ -31,7 +31,7 @@ export const HelpCenterLaunchpad = () => {
 	const siteIntent = site?.options.site_intent;
 	const siteSlug = useSiteSlug();
 
-	const { data } = useLaunchpad( siteSlug, siteIntent );
+	const { data } = useLaunchpad( null, siteSlug, siteIntent );
 	const totalLaunchpadSteps = data?.checklist?.length || 4;
 	const completeLaunchpadSteps =
 		data?.checklist?.filter( ( checklistItem ) => checklistItem.completed ).length || 1;
@@ -54,9 +54,7 @@ export const HelpCenterLaunchpad = () => {
 				rel="noreferrer"
 				target="_top"
 				aria-label="Link to Launchpad screen"
-				onClick={ () => {
-					handleLaunchpadHelpLinkClick();
-				} }
+				onClick={ handleLaunchpadHelpLinkClick }
 			>
 				<CircularProgressBar
 					size={ 32 }

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -44,8 +44,7 @@
 		"@wordpress/url": "^4.8.0",
 		"clsx": "^2.1.1",
 		"tslib": "^2.3.0",
-		"utility-types": "^3.10.0",
-		"wpcom-proxy-request": "workspace:^"
+		"utility-types": "^3.10.0"
 	},
 	"devDependencies": {
 		"@automattic/calypso-build": "workspace:^",

--- a/packages/launchpad/src/action-components/share-site-modal/index.tsx
+++ b/packages/launchpad/src/action-components/share-site-modal/index.tsx
@@ -10,11 +10,12 @@ import type { SiteDetails } from '@automattic/data-stores';
 import './style.scss';
 
 interface ShareSiteModalProps {
+	wpcom: any;
 	setModalIsOpen: ( isOpen: boolean ) => void;
 	site: SiteDetails | null;
 }
 
-const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
+const ShareSiteModal = ( { wpcom, setModalIsOpen, site }: ShareSiteModalProps ) => {
 	const queryClient = useQueryClient();
 	const getSiteSlug = ( site: SiteDetails | null ): string | null => {
 		if ( ! site ) {
@@ -38,7 +39,7 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 	const copyHandler = async () => {
 		navigator.clipboard.writeText( `https://${ siteSlug }` );
 		if ( siteSlug ) {
-			await updateLaunchpadSettings( siteSlug, {
+			await updateLaunchpadSettings( wpcom, siteSlug, {
 				checklist_statuses: { share_site: true },
 			} );
 		}

--- a/packages/launchpad/src/launchpad-internal.tsx
+++ b/packages/launchpad/src/launchpad-internal.tsx
@@ -7,6 +7,7 @@ import type { Task } from './types';
 import type { SiteDetails, UseLaunchpadOptions } from '@automattic/data-stores';
 
 interface Props {
+	wpcom: any;
 	site?: SiteDetails | null;
 	siteSlug: string | null;
 	checklistSlug: string | null;
@@ -22,6 +23,7 @@ interface Props {
  * Please use the main Launchpad component whenever possible.
  */
 const LaunchpadInternal: FC< Props > = ( {
+	wpcom,
 	flow,
 	site,
 	siteSlug,
@@ -32,6 +34,7 @@ const LaunchpadInternal: FC< Props > = ( {
 	launchpadContext,
 } ) => {
 	const launchpadData = useLaunchpad(
+		wpcom,
 		siteSlug || '',
 		checklistSlug,
 		useLaunchpadOptions,

--- a/packages/launchpad/src/launchpad.tsx
+++ b/packages/launchpad/src/launchpad.tsx
@@ -15,6 +15,7 @@ import type { EventHandlers, Task } from './types';
 export const SITE_STORE = Site.register( { client_id: '', client_secret: '' } );
 
 type LaunchpadProps = {
+	wpcom: any;
 	siteSlug: string | null;
 	checklistSlug: string;
 	launchpadContext: string;
@@ -24,6 +25,7 @@ type LaunchpadProps = {
 };
 
 const Launchpad = ( {
+	wpcom,
 	siteSlug,
 	checklistSlug,
 	launchpadContext,
@@ -33,7 +35,7 @@ const Launchpad = ( {
 }: LaunchpadProps ) => {
 	const {
 		data: { checklist },
-	} = useSortedLaunchpadTasks( siteSlug, checklistSlug, launchpadContext );
+	} = useSortedLaunchpadTasks( wpcom, siteSlug, checklistSlug, launchpadContext );
 
 	const tasklistCompleted = checklist?.every( ( task: Task ) => task.completed ) || false;
 
@@ -49,6 +51,7 @@ const Launchpad = ( {
 
 	const taskFilter = ( tasks: Task[] ) => {
 		const baseTasks = setUpActionsForTasks( {
+			wpcom,
 			tasks,
 			siteSlug,
 			tracksData,
@@ -75,9 +78,10 @@ const Launchpad = ( {
 	return (
 		<>
 			{ shareSiteModalIsOpen && site && (
-				<ShareSiteModal setModalIsOpen={ setShareSiteModalIsOpen } site={ site } />
+				<ShareSiteModal wpcom={ wpcom } setModalIsOpen={ setShareSiteModalIsOpen } site={ site } />
 			) }
 			<LaunchpadInternal
+				wpcom={ wpcom }
 				site={ site }
 				siteSlug={ siteSlug }
 				checklistSlug={ checklistSlug }

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -3,7 +3,6 @@ import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { isMobile } from '@automattic/viewport';
 import { addQueryArgs } from '@wordpress/url';
-import wpcomRequest from 'wpcom-proxy-request';
 import type { LaunchpadTaskActionsProps, Task } from './types';
 
 const TASKS_TO_COMPLETE_ON_CLICK = [
@@ -20,6 +19,7 @@ const TASKS_TO_COMPLETE_ON_CLICK = [
 ];
 
 export const setUpActionsForTasks = ( {
+	wpcom,
 	siteSlug,
 	tasks,
 	tracksData,
@@ -50,7 +50,7 @@ export const setUpActionsForTasks = ( {
 
 			action = () => {
 				if ( siteSlug && TASKS_TO_COMPLETE_ON_CLICK.includes( task.id ) ) {
-					updateLaunchpadSettings( siteSlug, {
+					updateLaunchpadSettings( wpcom, siteSlug, {
 						checklist_statuses: { [ task.id ]: true },
 					} );
 				}
@@ -114,10 +114,9 @@ export const setUpActionsForTasks = ( {
 				case 'blog_launched':
 				case 'link_in_bio_launched':
 					action = async () => {
-						await wpcomRequest( {
+						await wpcom.req.post( {
 							path: `/sites/${ siteSlug }/launch`,
 							apiVersion: '1.1',
-							method: 'post',
 						} );
 						onSiteLaunched?.();
 					};
@@ -128,7 +127,7 @@ export const setUpActionsForTasks = ( {
 					action = () => {
 						// redirects to the site slug home page in a new tab
 						window.open( `https://${ siteSlug }`, '_blank' );
-						updateLaunchpadSettings( siteSlug, {
+						updateLaunchpadSettings( wpcom, siteSlug, {
 							checklist_statuses: { [ task.id ]: true },
 						} );
 					};

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -69,6 +69,7 @@ export type EventHandlers = {
 };
 
 export interface LaunchpadTaskActionsProps {
+	wpcom: any;
 	siteSlug: string | null;
 	tasks: Task[];
 	tracksData: LaunchpadTracksData;

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -6,7 +6,6 @@ import { guessTimezone, getLanguage } from '@automattic/i18n-utils';
 import debugFactory from 'debug';
 import { getLocaleSlug } from 'i18n-calypso';
 import { startsWith, isEmpty } from 'lodash';
-import wpcomRequest from 'wpcom-proxy-request';
 import {
 	setupSiteAfterCreation,
 	isTailoredSignupFlow,
@@ -143,6 +142,7 @@ export const getNewSiteParams = ( params: GetNewSiteParams ) => {
 };
 
 export const createSiteWithCart = async (
+	wpcom: any,
 	flowName: string,
 	userIsLoggedIn: boolean,
 	isPurchasingDomainItem: boolean,
@@ -189,10 +189,9 @@ export const createSiteWithCart = async (
 	const segmentationSurveyAnswersAnonId = localStorage.getItem( 'ss-anon-id' );
 	localStorage.removeItem( 'ss-anon-id' );
 
-	const siteCreationResponse: NewSiteSuccessResponse = await wpcomRequest( {
+	const siteCreationResponse: NewSiteSuccessResponse = await wpcom.req.post( {
 		path: '/sites/new',
 		apiVersion: '1.1',
-		method: 'POST',
 		body: {
 			...newSiteParams,
 			locale,
@@ -225,12 +224,13 @@ export const createSiteWithCart = async (
 	};
 
 	if ( isTailoredSignupFlow( flowName ) || HUNDRED_YEAR_PLAN_FLOW === flowName ) {
-		await setupSiteAfterCreation( { siteId, flowName } );
+		await setupSiteAfterCreation( { wpcom, siteId, flowName } );
 	}
 
 	if ( domainCartItems.length ) {
 		for ( const domainCartItem of domainCartItems ) {
 			await processItemCart(
+				wpcom,
 				siteSlug,
 				isFreeThemePreselected,
 				themeSlugWithRepo,
@@ -256,6 +256,7 @@ function prepareItemForAddingToCart( item: MinimalRequestCartProduct, lastKnownF
 }
 
 export async function addPlanToCart(
+	wpcom: any,
 	siteSlug: string,
 	flowName: string,
 	userIsLoggedIn: boolean,
@@ -270,6 +271,7 @@ export async function addPlanToCart(
 	const isFreeThemePreselected = startsWith( themeSlugWithRepo, 'pub' );
 
 	await processItemCart(
+		wpcom,
 		siteSlug,
 		isFreeThemePreselected,
 		themeSlugWithRepo,
@@ -349,6 +351,7 @@ export async function addProductsToCart(
 }
 
 export async function setThemeOnSite(
+	wpcom: any,
 	siteSlug: string,
 	themeSlugWithRepo: string,
 	themeStyleVariation?: string
@@ -360,9 +363,8 @@ export async function setThemeOnSite(
 	const theme = themeSlugWithRepo.split( '/' )[ 1 ];
 
 	try {
-		await wpcomRequest( {
+		await wpcom.req.post( {
 			path: `/sites/${ siteSlug }/themes/mine`,
-			method: 'POST',
 			apiVersion: '1.1',
 			body: {
 				theme,
@@ -375,6 +377,7 @@ export async function setThemeOnSite(
 }
 
 async function processItemCart(
+	wpcom: any,
 	siteSlug: string,
 	isFreeThemePreselected: boolean,
 	themeSlugWithRepo: string,
@@ -383,10 +386,10 @@ async function processItemCart(
 	newCartItem?: MinimalRequestCartProduct
 ) {
 	if ( ! userIsLoggedIn && isFreeThemePreselected ) {
-		await setThemeOnSite( siteSlug, themeSlugWithRepo );
+		await setThemeOnSite( wpcom, siteSlug, themeSlugWithRepo );
 		newCartItem && ( await addToCartAndProceed( newCartItem, siteSlug, lastKnownFlow ) );
 	} else if ( userIsLoggedIn && isFreeThemePreselected ) {
-		await setThemeOnSite( siteSlug, themeSlugWithRepo );
+		await setThemeOnSite( wpcom, siteSlug, themeSlugWithRepo );
 		newCartItem && ( await addToCartAndProceed( newCartItem, siteSlug, lastKnownFlow ) );
 	} else {
 		newCartItem && ( await addToCartAndProceed( newCartItem, siteSlug, lastKnownFlow ) );

--- a/packages/onboarding/src/setup-tailored-site-after-creation.ts
+++ b/packages/onboarding/src/setup-tailored-site-after-creation.ts
@@ -7,7 +7,6 @@ import {
 	updateLaunchpadSettings,
 } from '@automattic/data-stores';
 import { select, dispatch } from '@wordpress/data';
-import wpcomRequest from 'wpcom-proxy-request';
 import {
 	isLinkInBioFlow,
 	isNewsletterFlow,
@@ -43,11 +42,12 @@ export const base64ImageToBlob = ( base64String: string ) => {
 };
 
 interface SetupOnboardingSiteOptions {
+	wpcom: any;
 	siteId: number;
 	flowName: string | null;
 }
 
-export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSiteOptions ) {
+export function setupSiteAfterCreation( { wpcom, siteId, flowName }: SetupOnboardingSiteOptions ) {
 	// const { resetOnboardStore } = dispatch( ONBOARD_STORE );
 	const goals = ( select( ONBOARD_STORE ) as OnboardSelect ).getGoals();
 	const selectedDesign = ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign();
@@ -78,17 +78,19 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 				if ( selectedDesign && selectedDesign.is_virtual ) {
 					const { assembleSite } = dispatch( SITE_STORE ) as SiteActions;
 					promises.push(
-						wpcomRequest< ActiveTheme[] >( {
-							path: `/sites/${ encodeURIComponent( siteId ) }/themes?status=active`,
-							apiNamespace: 'wp/v2',
-						} ).then( ( activeThemes ) => {
-							assembleSite( String( siteId ), activeThemes[ 0 ].stylesheet, {
-								homeHtml: selectedDesign.recipe?.pattern_html,
-								headerHtml: selectedDesign.recipe?.header_html,
-								footerHtml: selectedDesign.recipe?.footer_html,
-								siteSetupOption: 'assembler-virtual-theme',
-							} );
-						} )
+						wpcom.req
+							.get( {
+								path: `/sites/${ encodeURIComponent( siteId ) }/themes?status=active`,
+								apiNamespace: 'wp/v2',
+							} )
+							.then( ( activeThemes: ActiveTheme[] ) => {
+								assembleSite( String( siteId ), activeThemes[ 0 ].stylesheet, {
+									homeHtml: selectedDesign.recipe?.pattern_html,
+									headerHtml: selectedDesign.recipe?.header_html,
+									footerHtml: selectedDesign.recipe?.footer_html,
+									siteSetupOption: 'assembler-virtual-theme',
+								} );
+							} )
 					);
 				}
 			} else {
@@ -113,30 +115,30 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 		}
 
 		promises.push(
-			wpcomRequest< { updated: object } >( {
-				path: `/sites/${ siteId }/onboarding-customization`,
-				method: 'POST',
-				apiNamespace: 'wpcom/v2',
-				apiVersion: '2',
-				formData,
-			} ).then( () => {
-				recordTracksEvent( 'calypso_signup_site_options_submit', {
-					has_site_title: !! siteTitle,
-					has_tagline: !! siteDescription,
-				} );
-				/**
-				 * We need to wait the site being created, then go to checkout and wait for the user
-				 * to buy the plan before we can set a premium theme to the site. If we reset the store
-				 * here we loose this information.
-				 */
-				// resetOnboardStore();
-			} )
+			wpcom.req
+				.post( {
+					path: `/sites/${ siteId }/onboarding-customization`,
+					apiNamespace: 'wpcom/v2',
+					formData,
+				} )
+				.then( () => {
+					recordTracksEvent( 'calypso_signup_site_options_submit', {
+						has_site_title: !! siteTitle,
+						has_tagline: !! siteDescription,
+					} );
+					/**
+					 * We need to wait the site being created, then go to checkout and wait for the user
+					 * to buy the plan before we can set a premium theme to the site. If we reset the store
+					 * here we loose this information.
+					 */
+					// resetOnboardStore();
+				} )
 		);
 
 		if ( isFreeFlow( flowName ) ) {
 			if ( siteTitle || siteDescription || siteLogo ) {
 				promises.push(
-					updateLaunchpadSettings( siteId, {
+					updateLaunchpadSettings( wpcom, siteId, {
 						checklist_statuses: { setup_free: true },
 					} )
 				);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1358,7 +1358,6 @@ __metadata:
     typescript: "npm:^5.3.3"
     utility-types: "npm:^3.10.0"
     webpack: "npm:^5.97.1"
-    wpcom-proxy-request: "workspace:^"
   peerDependencies:
     "@wordpress/data": ^10.8.0
     "@wordpress/element": ^6.8.0


### PR DESCRIPTION
When packages like `data-stores`, `launchpad` or `onboarding` make WP.com REST requests, they rely on the `wpcom-proxy-request` package to do it. But this is wrong for two reasons. `wpcom-proxy-request` is merely a "driver", a pluggable handler used to configure the `wpcom.js` library, the real client that users should use. User code shouldn't use `wpcom-proxy-request` directly. Second, this handler uses the REST proxy to make requests. But we don't always want that. For example, the Jetpack Cloud app uses OAuth authentication and should use the `wpcom-xhr-request` handler. The REST proxy works reliably only on `wordpress.com` domains, not on `cloud.jetpack.com`.

Here is an example of a Jetpack Cloud bug. In a browser that blocks 3rd party cookies (Safari, Firefox, configured Chrome) go to `cloud.jetpack.com/subscribers/:site` and notice the placeholder that is displayed there for quite a long time:

<img width="641" alt="Screenshot 2025-01-15 at 14 14 49" src="https://github.com/user-attachments/assets/20b69efa-73a1-4834-a692-8e9b1cae3c5a" />

In Network devtool notice requests to the `/sites/:site/launchpad` endpoint and how they fail with an auth error:

<img width="577" alt="Screenshot 2025-01-15 at 14 15 02" src="https://github.com/user-attachments/assets/2a08372f-abf7-488e-8729-79ba9008561d" />

This is because the `launchpad` package uses `wpcom-proxy-request`, and the REST proxy doesn't have access to wordpress.com auth cookies. It should be using OAuth instead.

On a fixed Jetpack Cloud these requests would succeed, and you would see launchpad on the Subscribers page:

<img width="626" alt="Screenshot 2025-01-15 at 15 01 36" src="https://github.com/user-attachments/assets/eea2b001-5a99-4fab-a70a-c84a2bdd076a" />

In this PR, I'm removing calls to `wpcom-proxy-request` from all launchpad-related code, and I'm replacing them with calls to a configured `wpcom` client (`wpcom.req.get( ... )`), where the client is passed from above by the caller.

This leads to a _lot_ of new parameters and prop drilling, which is not very nice. An alternative would be some global variable set at one place, and consumed by many other places. I'm not sure how to achieve that.

There are many more places where a similar refactoring should happen. All the `data-stores`, and many packages in `/packages`. Right now I'm focusing on Launchpad, the PR is already quite huge even with this constraint.

It's worth noting that the Subscriber import UI had the same bug, and it was fixed in #88371 (by @arthur791004) by adding a `token` parameter to the proxy request call. Yes that works, because the REST proxy can also do OAuth when it receives the `token` parameter. But it's a "hacking a hack" approach, because we're patching code that shouldn't be there in the first place.

Thoughts?
