### PR TITLE
Security Settings: Display actual password status

### DIFF
--- a/client/me/security-checkup/password.jsx
+++ b/client/me/security-checkup/password.jsx
@@ -17,13 +17,13 @@ class SecurityCheckupPassword extends Component {
 
 		if ( userSettings.is_passwordless_user ) {
 			return {
-				description: translate( 'You do not have a password configured.' ),
+				description: translate( 'You don’t have a password set.' ),
 				materialIcon: getWarningIcon(),
 			};
 		}
 
 		return {
-			description: translate( 'You have a password configured, but can change it at any time.' ),
+			description: translate( 'You have a password set, but you can change it at any time.' ),
 			materialIcon: getOKIcon(),
 		};
 	}

--- a/client/me/security-checkup/password.jsx
+++ b/client/me/security-checkup/password.jsx
@@ -1,7 +1,10 @@
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import { getOKIcon } from './icons.js';
+import { connect } from 'react-redux';
+import getUserSettings from 'calypso/state/selectors/get-user-settings';
+import hasUserSettings from 'calypso/state/selectors/has-user-settings';
+import { getOKIcon, getWarningIcon } from './icons.js';
 import SecurityCheckupNavigationItem from './navigation-item';
 
 class SecurityCheckupPassword extends Component {
@@ -9,17 +12,32 @@ class SecurityCheckupPassword extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
-	render() {
-		const { translate } = this.props;
+	getDescriptionAndIcon() {
+		const { translate, userSettings } = this.props;
 
-		const description = translate(
-			'You have a password configured, but can change it at any time.'
-		);
+		if ( userSettings.is_passwordless_user ) {
+			return {
+				description: translate( 'You do not have a password configured.' ),
+				materialIcon: getWarningIcon(),
+			};
+		}
+
+		return {
+			description: translate( 'You have a password configured, but can change it at any time.' ),
+			materialIcon: getOKIcon(),
+		};
+	}
+
+	render() {
+		const { translate, areUserSettingsLoaded } = this.props;
+
+		if ( ! areUserSettingsLoaded ) {
+			return <SecurityCheckupNavigationItem isPlaceholder />;
+		}
 
 		return (
 			<SecurityCheckupNavigationItem
-				description={ description }
-				materialIcon={ getOKIcon() }
+				{ ...this.getDescriptionAndIcon() }
 				path="/me/security/password"
 				text={ translate( 'Password' ) }
 			/>
@@ -27,4 +45,7 @@ class SecurityCheckupPassword extends Component {
 	}
 }
 
-export default localize( SecurityCheckupPassword );
+export default connect( ( state ) => ( {
+	areUserSettingsLoaded: hasUserSettings( state ),
+	userSettings: getUserSettings( state ),
+} ) )( localize( SecurityCheckupPassword ) );


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/62978.

## Proposed Changes

Check the `is_passwordless_user` field from settings to determine whether or not a password is set in the account instead of hardcoding the message.

@fditrapani @nuriapenya could you please check if the copy here makes sense or we want something else? I was wondering if we could display something related to their auth method. Example: "You do not have a password set because you're registered through Google" or "You do not have a password set because you're logging in through magic links."

I don't know that we can identify _which_ mechanisms they're picking, though. So maybe a generic message could work better.

## Testing Instructions

Proxy yourself to your sandbox and apply this branch to it: 170128-ghe-Automattic/wpcom.

### User and password

Enter `/me/security` using your A8C account or any account created with the user and password method and verify that you see the "password set" message in the security checklist:

![image](https://github.com/user-attachments/assets/707992d6-ca2c-4059-ad34-6526b62119be)


### Passwordless mode

Create or log in with a passwordless account and enter `/me/security`. You should see the "password not set" message:

![image](https://github.com/user-attachments/assets/a6f19473-c416-4b63-8bf2-aa38173c4ade)

**Upon clicking the checklist item and defining a password, subsequent `/me/security` visits should show the "password set" message.**

### Social login

Create or log in with a social account (Google, Apple, GitHub) and enter `/me/security`. You should see the "password not set" message:

![image](https://github.com/user-attachments/assets/a6f19473-c416-4b63-8bf2-aa38173c4ade)

**Upon clicking the checklist item and defining a password, subsequent `/me/security` visits should show the "password set" message.**