### PR TITLE
[Odie] Give Wapuu a chance

### DIFF
--- a/packages/odie-client/src/components/message/message-content.tsx
+++ b/packages/odie-client/src/components/message/message-content.tsx
@@ -1,6 +1,7 @@
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import Markdown from 'react-markdown';
+import { useOdieAssistantContext } from '../../context';
 import { zendeskMessageConverter } from '../../utils';
 import ChatWithSupportLabel from '../chat-with-support';
 import CustomALink from './custom-a-link';
@@ -24,6 +25,7 @@ export const MessageContent = ( {
 	displayChatWithSupportLabel?: boolean;
 } ) => {
 	const { __ } = useI18n();
+	const { experimentVariationName } = useOdieAssistantContext();
 	const messageClasses = clsx(
 		'odie-chatbox-message',
 		`odie-chatbox-message-${ message.role }`,
@@ -34,6 +36,9 @@ export const MessageContent = ( {
 		'odie-chatbox-message-sources-container',
 		isNextMessageFromSameSender && 'next-chat-message-same-sender'
 	);
+
+	const stopConflatingNegativeRatingWithContactSupport =
+		experimentVariationName === 'give_wapuu_a_chance';
 
 	const isMessageWithOnlyText =
 		message.context?.flags?.hide_disclaimer_content ||
@@ -97,7 +102,8 @@ export const MessageContent = ( {
 							</p>
 						</div>
 					) }
-					{ message.type === 'dislike-feedback' && <DislikeFeedbackMessage /> }
+					{ ! stopConflatingNegativeRatingWithContactSupport &&
+						message.type === 'dislike-feedback' && <DislikeFeedbackMessage /> }
 				</div>
 			</div>
 			{ displayChatWithSupportLabel && <ChatWithSupportLabel /> }

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -45,7 +45,7 @@ interface ChatMessagesProps {
 }
 
 export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
-	const { chat, botNameSlug, isChatLoaded } = useOdieAssistantContext();
+	const { chat, botNameSlug, experimentVariationName, isChatLoaded } = useOdieAssistantContext();
 	const createZendeskConversation = useCreateZendeskConversation();
 	const resetSupportInteraction = useResetSupportInteraction();
 	const [ searchParams, setSearchParams ] = useSearchParams();
@@ -104,6 +104,13 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 		return currentMessage === nextMessage;
 	};
 
+	const stopConflatingNegativeRatingWithContactSupport =
+		experimentVariationName === 'give_wapuu_a_chance';
+
+	const availableStatusWithFeedback = stopConflatingNegativeRatingWithContactSupport
+		? [ 'sending', 'transfer' ]
+		: [ 'sending', 'dislike', 'transfer' ];
+
 	return (
 		<>
 			<div className="chatbox-messages" ref={ messagesContainerRef }>
@@ -134,8 +141,10 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 							/>
 						) ) }
 						<JumpToRecent containerReference={ messagesContainerRef } />
-						{ chat.status === 'dislike' && <DislikeThumb /> }
-						{ [ 'sending', 'dislike', 'transfer' ].includes( chat.status ) && (
+						{ chat.status === 'dislike' && stopConflatingNegativeRatingWithContactSupport && (
+							<DislikeThumb />
+						) }
+						{ availableStatusWithFeedback.includes( chat.status ) && (
 							<div className="odie-chatbox__action-message">
 								{ chat.status === 'sending' && <ThinkingPlaceholder /> }
 								{ chat.status === 'dislike' && <DislikeFeedbackMessage /> }

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -104,10 +104,9 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 		return currentMessage === nextMessage;
 	};
 
-	const stopConflatingNegativeRatingWithContactSupport =
-		experimentVariationName === 'give_wapuu_a_chance';
+	const removeDislike = experimentVariationName === 'give_wapuu_a_chance';
 
-	const availableStatusWithFeedback = stopConflatingNegativeRatingWithContactSupport
+	const availableStatusWithFeedback = removeDislike
 		? [ 'sending', 'transfer' ]
 		: [ 'sending', 'dislike', 'transfer' ];
 
@@ -141,9 +140,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 							/>
 						) ) }
 						<JumpToRecent containerReference={ messagesContainerRef } />
-						{ chat.status === 'dislike' && stopConflatingNegativeRatingWithContactSupport && (
-							<DislikeThumb />
-						) }
+						{ chat.status === 'dislike' && ! removeDislike && <DislikeThumb /> }
 						{ availableStatusWithFeedback.includes( chat.status ) && (
 							<div className="odie-chatbox__action-message">
 								{ chat.status === 'sending' && <ThinkingPlaceholder /> }

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -104,9 +104,9 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 		return currentMessage === nextMessage;
 	};
 
-	const removeDislike = experimentVariationName === 'give_wapuu_a_chance';
+	const removeDislikeStatus = experimentVariationName === 'give_wapuu_a_chance';
 
-	const availableStatusWithFeedback = removeDislike
+	const availableStatusWithFeedback = removeDislikeStatus
 		? [ 'sending', 'transfer' ]
 		: [ 'sending', 'dislike', 'transfer' ];
 
@@ -140,7 +140,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 							/>
 						) ) }
 						<JumpToRecent containerReference={ messagesContainerRef } />
-						{ chat.status === 'dislike' && ! removeDislike && <DislikeThumb /> }
+						{ chat.status === 'dislike' && ! removeDislikeStatus && <DislikeThumb /> }
 						{ availableStatusWithFeedback.includes( chat.status ) && (
 							<div className="odie-chatbox__action-message">
 								{ chat.status === 'sending' && <ThinkingPlaceholder /> }

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -22,17 +22,25 @@ export const UserMessage = ( {
 	message: Message;
 	isMessageWithoutEscalationOption?: boolean;
 } ) => {
-	const { isUserEligibleForPaidSupport, trackEvent, chat } = useOdieAssistantContext();
+	const { isUserEligibleForPaidSupport, trackEvent, chat, experimentVariationName } =
+		useOdieAssistantContext();
 
 	const hasCannedResponse = message.context?.flags?.canned_response;
-	const isRequestingHumanSupport = message.context?.flags?.forward_to_human_support;
+	const isRequestingHumanSupport = message.context?.flags?.forward_to_human_support ?? false;
 	const hasFeedback = !! message?.rating_value;
 	const isBot = message.role === 'bot';
 	const isConnectedToZendesk = chat?.provider === 'zendesk';
 	const isPositiveFeedback =
 		hasFeedback && message && message.rating_value && +message.rating_value === 1;
-	const showExtraContactOptions =
-		( hasFeedback && ! isPositiveFeedback ) || isRequestingHumanSupport;
+
+	const isExperimentGiveWapuuAChance = experimentVariationName === 'give_wapuu_a_chance';
+
+	let showExtraContactOptions = false;
+	if ( isExperimentGiveWapuuAChance ) {
+		showExtraContactOptions = isRequestingHumanSupport;
+	} else {
+		showExtraContactOptions = ( hasFeedback && ! isPositiveFeedback ) || isRequestingHumanSupport;
+	}
 
 	const forwardMessage = isUserEligibleForPaidSupport
 		? ODIE_FORWARD_TO_ZENDESK_MESSAGE

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -47,6 +47,10 @@ export const UserMessage = ( {
 		showExtraContactOptions = ( hasFeedback && ! isPositiveFeedback ) || isRequestingHumanSupport;
 	}
 
+	const showDirectEscalationLink = isExperimentGiveWapuuAChance
+		? hasUserEverEscalatedToHumanSupport
+		: ! ( hasFeedback && ! isPositiveFeedback ) || isRequestingHumanSupport;
+
 	const forwardMessage = isUserEligibleForPaidSupport
 		? ODIE_FORWARD_TO_ZENDESK_MESSAGE
 		: ODIE_FORWARD_TO_FORUMS_MESSAGE;
@@ -96,9 +100,7 @@ export const UserMessage = ( {
 					}
 				) }
 			</div>
-			{ ! showExtraContactOptions && hasUserEverEscalatedToHumanSupport && (
-				<DirectEscalationLink messageId={ message.message_id } />
-			) }
+			{ showDirectEscalationLink && <DirectEscalationLink messageId={ message.message_id } /> }
 			{ ! isConnectedToZendesk && (
 				<WasThisHelpfulButtons message={ message } isDisliked={ isDisliked } />
 			) }

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -22,8 +22,13 @@ export const UserMessage = ( {
 	message: Message;
 	isMessageWithoutEscalationOption?: boolean;
 } ) => {
-	const { isUserEligibleForPaidSupport, trackEvent, chat, experimentVariationName } =
-		useOdieAssistantContext();
+	const {
+		isUserEligibleForPaidSupport,
+		hasUserEverEscalatedToHumanSupport,
+		trackEvent,
+		chat,
+		experimentVariationName,
+	} = useOdieAssistantContext();
 
 	const hasCannedResponse = message.context?.flags?.canned_response;
 	const isRequestingHumanSupport = message.context?.flags?.forward_to_human_support ?? false;
@@ -91,7 +96,9 @@ export const UserMessage = ( {
 					}
 				) }
 			</div>
-			{ ! showExtraContactOptions && <DirectEscalationLink messageId={ message.message_id } /> }
+			{ ! showExtraContactOptions && hasUserEverEscalatedToHumanSupport && (
+				<DirectEscalationLink messageId={ message.message_id } />
+			) }
 			{ ! isConnectedToZendesk && (
 				<WasThisHelpfulButtons message={ message } isDisliked={ isDisliked } />
 			) }

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -97,6 +97,13 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 	const { mainChatState, setMainChatState } = useGetCombinedChat( canConnectToZendesk );
 
 	/**
+	 * Has the user ever escalated to get human support?
+	 */
+	const hasUserEverEscalatedToHumanSupport = mainChatState?.messages.some(
+		( message ) => message.context?.flags?.forward_to_human_support
+	);
+
+	/**
 	 * Tracking event.
 	 * Handler to make sure all requests are the same.
 	 */
@@ -185,6 +192,7 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 				experimentVariationName,
 				isUserEligibleForPaidSupport,
 				canConnectToZendesk,
+				hasUserEverEscalatedToHumanSupport,
 				odieBroadcastClientId,
 				selectedSiteId,
 				selectedSiteURL,

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -38,6 +38,7 @@ export const OdieAssistantContext = createContext< OdieAssistantContextInterface
 	clearChat: noop,
 	currentUser: { display_name: 'Me' },
 	experimentVariationName: null,
+	hasUserEverEscalatedToHumanSupport: false,
 	isChatLoaded: false,
 	isMinimized: false,
 	isUserEligibleForPaidSupport: false,

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -37,12 +37,14 @@ export const OdieAssistantContext = createContext< OdieAssistantContextInterface
 	canConnectToZendesk: false,
 	clearChat: noop,
 	currentUser: { display_name: 'Me' },
+	experimentVariationName: null,
 	isChatLoaded: false,
 	isMinimized: false,
 	isUserEligibleForPaidSupport: false,
 	odieBroadcastClientId: '',
 	setChat: noop,
 	setChatStatus: noop,
+	setExperimentVariationName: noop,
 	setMessageLikedStatus: noop,
 	setWaitAnswerToFirstMessageFromHumanSupport: noop,
 	trackEvent: noop,
@@ -83,6 +85,10 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 			isChatLoaded: store.getIsChatLoaded(),
 		};
 	}, [] );
+
+	const [ experimentVariationName, setExperimentVariationName ] = useState<
+		string | null | undefined
+	>( null );
 
 	/**
 	 * The main chat thread.
@@ -176,6 +182,7 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 				extraContactOptions,
 				isChatLoaded,
 				isMinimized,
+				experimentVariationName,
 				isUserEligibleForPaidSupport,
 				canConnectToZendesk,
 				odieBroadcastClientId,
@@ -183,6 +190,7 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 				selectedSiteURL,
 				userFieldMessage,
 				setChatStatus,
+				setExperimentVariationName,
 				setMessageLikedStatus,
 				setWaitAnswerToFirstMessageFromHumanSupport,
 				trackEvent,

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -34,8 +34,15 @@ export const useSendOdieMessage = () => {
 	const internal_message_id = generateUUID();
 	const queryClient = useQueryClient();
 
-	const { botNameSlug, selectedSiteId, version, setChat, odieBroadcastClientId, setChatStatus } =
-		useOdieAssistantContext();
+	const {
+		botNameSlug,
+		selectedSiteId,
+		version,
+		setChat,
+		odieBroadcastClientId,
+		setChatStatus,
+		setExperimentVariationName,
+	} = useOdieAssistantContext();
 
 	const addMessage = ( message: Message | Message[], props?: Partial< Chat > ) => {
 		setChat( ( prevChat ) => ( {
@@ -111,7 +118,7 @@ export const useSendOdieMessage = () => {
 				type: 'message',
 				context: returnedChat.messages[ 0 ].context,
 			};
-
+			setExperimentVariationName( returnedChat.experiment_name );
 			addMessage( botMessage, { odieId: returnedChat.chat_id } );
 			broadcastOdieMessage( botMessage, odieBroadcastClientId );
 		},

--- a/packages/odie-client/src/hooks/use-auto-scroll.ts
+++ b/packages/odie-client/src/hooks/use-auto-scroll.ts
@@ -2,13 +2,17 @@ import { RefObject, useEffect, useRef } from 'react';
 import { useOdieAssistantContext } from '../context';
 
 export const useAutoScroll = ( messagesContainerRef: RefObject< HTMLDivElement > ) => {
-	const { chat } = useOdieAssistantContext();
+	const { chat, experimentVariationName } = useOdieAssistantContext();
 	const debounceTimeoutRef = useRef< number >( 500 );
 	const debounceTimeoutIdRef = useRef< number | null >( null );
 	const lastChatStatus = useRef< string | null >( null );
 	useEffect( () => {
 		const messageCount = chat.messages.length;
 		if ( messageCount < 1 || chat.status === 'loading' ) {
+			return;
+		}
+
+		if ( experimentVariationName === 'give_wapuu_a_chance' && chat.status === 'dislike' ) {
 			return;
 		}
 

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -10,6 +10,7 @@ export type OdieAssistantContextInterface = {
 	chat: Chat;
 	clearChat: () => void;
 	currentUser: CurrentUser;
+	experimentVariationName: string | undefined | null;
 	isMinimized?: boolean;
 	isUserEligibleForPaidSupport: boolean;
 	extraContactOptions?: ReactNode;
@@ -18,6 +19,7 @@ export type OdieAssistantContextInterface = {
 	selectedSiteURL?: string | null;
 	userFieldMessage?: string | null;
 	waitAnswerToFirstMessageFromHumanSupport: boolean;
+	setExperimentVariationName: ( variationName: string | null | undefined ) => void;
 	setMessageLikedStatus: ( message: Message, liked: boolean ) => void;
 	setChat: ( chat: Chat | SetStateAction< Chat > ) => void;
 	setChatStatus: ( status: ChatStatus ) => void;
@@ -156,7 +158,12 @@ export type Message = {
 
 export type ChatStatus = 'loading' | 'loaded' | 'sending' | 'dislike' | 'transfer' | 'closed';
 
-export type ReturnedChat = { chat_id: number; messages: Message[]; wpcom_user_id: number };
+export type ReturnedChat = {
+	chat_id: number;
+	messages: Message[];
+	wpcom_user_id: number;
+	experiment_name: string | undefined | null;
+};
 
 export type OdieChat = {
 	messages: Message[];

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -11,6 +11,7 @@ export type OdieAssistantContextInterface = {
 	clearChat: () => void;
 	currentUser: CurrentUser;
 	experimentVariationName: string | undefined | null;
+	hasUserEverEscalatedToHumanSupport: boolean;
 	isMinimized?: boolean;
 	isUserEligibleForPaidSupport: boolean;
 	extraContactOptions?: ReactNode;


### PR DESCRIPTION
## Proposed Changes

Adds experiment code changes for `'give_wapuu_a_chance_odie'`

## Why are these changes being made?
- Adds several changes for the user: Stop conflating the negative rating with the direct escalation path
- Stops showing the direct escalation link unless user has asked a question that might be solvable or not by the AI

## Testing Instructions
1. Adding yourself the experiment mentioned above
2. Open a new conversation and ask the assistant to get to contact support directly
3. Assert that it asks you to first describe the issue
4. (If you want, try to keep cheating to get the user support without adding context to your issue)
5. Assert that once you gave enough context, you can already ask for human support and get the button for contacting human support
6. Assert that the button for escalating does not how up anymore when rating negatively a message

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
