### PR TITLE
Remove duplicate views: Implement A/A test (Calypso)

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -394,9 +394,11 @@ export const ssrSetupLocale = ( _context, next ) => {
 };
 
 export const redirectIfDuplicatedView = ( wpAdminPath ) => async ( context, next ) => {
-	const duplicateViewsExperimentAssignment = await loadExperimentAssignment(
-		'calypso_post_onboarding_holdout_120924'
-	);
+	const experimentName = 'calypso_post_onboarding_holdout_120924';
+	const aaTestName = 'calypso_post_onboarding_aa_150125';
+
+	loadExperimentAssignment( aaTestName );
+	const duplicateViewsExperimentAssignment = await loadExperimentAssignment( experimentName );
 	if ( isE2ETest() || duplicateViewsExperimentAssignment.variationName === 'treatment' ) {
 		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );


### PR DESCRIPTION
## Proposed Changes

Implements an A/A test to validate that the "Remove duplicate views" experiment works as expected in Calypso.

See p1736957876238999/1736840785.753609-slack-C04DZ8M0GHW

## Why are these changes being made?

Because new ExPlat client implementations need to be A/A tested.

## Testing Instructions

N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
