### PR TITLE
Remove style variation upgrade badge tooltip

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/index.js
+++ b/client/components/theme-tier/theme-tier-badge/index.js
@@ -11,7 +11,6 @@ import ThemeTierBundledBadge from './theme-tier-bundled-badge';
 import ThemeTierCommunityBadge from './theme-tier-community-badge';
 import ThemeTierFreeBadge from './theme-tier-free-badge';
 import ThemeTierPartnerBadge from './theme-tier-partner-badge';
-import ThemeTierStyleVariationBadge from './theme-tier-style-variation-badge';
 import ThemeTierUpgradeBadge from './theme-tier-upgrade-badge';
 
 import './style.scss';
@@ -19,7 +18,6 @@ import './style.scss';
 export default function ThemeTierBadge( {
 	canGoToCheckout = true,
 	className = '',
-	isLockedStyleVariation,
 	showUpgradeBadge = true,
 	themeId,
 	showPartnerPrice = false,
@@ -39,10 +37,6 @@ export default function ThemeTierBadge( {
 
 		if ( BUNDLED_THEME === themeType ) {
 			return <ThemeTierBundledBadge />;
-		}
-
-		if ( isLockedStyleVariation ) {
-			return <ThemeTierStyleVariationBadge />;
 		}
 
 		if ( DOT_ORG_THEME === themeType ) {

--- a/client/components/theme-tier/theme-tier-badge/index.js
+++ b/client/components/theme-tier/theme-tier-badge/index.js
@@ -11,6 +11,7 @@ import ThemeTierBundledBadge from './theme-tier-bundled-badge';
 import ThemeTierCommunityBadge from './theme-tier-community-badge';
 import ThemeTierFreeBadge from './theme-tier-free-badge';
 import ThemeTierPartnerBadge from './theme-tier-partner-badge';
+import ThemeTierStyleVariationBadge from './theme-tier-style-variation-badge';
 import ThemeTierUpgradeBadge from './theme-tier-upgrade-badge';
 
 import './style.scss';
@@ -18,6 +19,7 @@ import './style.scss';
 export default function ThemeTierBadge( {
 	canGoToCheckout = true,
 	className = '',
+	isLockedStyleVariation,
 	showUpgradeBadge = true,
 	themeId,
 	showPartnerPrice = false,
@@ -37,6 +39,10 @@ export default function ThemeTierBadge( {
 
 		if ( BUNDLED_THEME === themeType ) {
 			return <ThemeTierBundledBadge />;
+		}
+
+		if ( isLockedStyleVariation ) {
+			return <ThemeTierStyleVariationBadge />;
 		}
 
 		if ( DOT_ORG_THEME === themeType ) {

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -1,10 +1,8 @@
 import { Card, Button, Gridicon } from '@automattic/components';
 import {
 	DesignPreviewImage,
-	PREMIUM_THEME,
 	ThemeCard,
 	isDefaultGlobalStylesVariationSlug,
-	isLockedStyleVariation,
 } from '@automattic/design-picker';
 import { localize } from 'i18n-calypso';
 import { isEmpty, isEqual } from 'lodash';
@@ -325,17 +323,9 @@ export class Theme extends Component {
 	};
 
 	renderBadge = () => {
-		const { selectedStyleVariation, shouldLimitGlobalStyles, theme } = this.props;
+		const { theme } = this.props;
 
-		const isPremiumTheme = theme.theme_tier?.slug === PREMIUM_THEME;
-
-		const isLocked = isLockedStyleVariation( {
-			isPremiumTheme,
-			styleVariationSlug: selectedStyleVariation?.slug,
-			shouldLimitGlobalStyles,
-		} );
-
-		return <ThemeTierBadge themeId={ theme.id } isLockedStyleVariation={ isLocked } />;
+		return <ThemeTierBadge themeId={ theme.id } />;
 	};
 
 	render() {

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -36,7 +36,6 @@ exports[`Theme rendering should match snapshot 1`] = `
         </span>
       </h2>
       <components--theme-tier-badge
-        islockedstylevariation="false"
         themeid="twentyseventeen"
       />
     </div>


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #95471 and closes https://github.com/Automattic/wp-calypso/issues/98324 

## Proposed Changes
Remove style variation upgrade badge tooltip


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The default style upgrade tooltip was removed, so we should also remove it for the style variations to be consistent.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to https://wordpress.com/themes in an incognito window. 
- Hover or click an Upgrade badge
- The Upgrade badge for theme style variations should **not** have a tooltip (as implemented in https://github.com/Automattic/wp-calypso/pull/98082).
- Click a theme style variation (colored circle under theme image)
- Hover or click an Upgrade badge
- There should not be a tooltip


| Before | After |
| ---- | ----- |
| ![image](https://github.com/user-attachments/assets/31c347ae-611a-46b0-bce0-d01c1aeef53f) | ![image](https://github.com/user-attachments/assets/3750b1b5-4b9e-453a-9e1a-252a925eaf59) |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
