### PR TITLE
Domains Management Revamp: Add email plans comparison subpage to site context

### DIFF
--- a/client/hosting/overview/index.tsx
+++ b/client/hosting/overview/index.tsx
@@ -21,6 +21,7 @@ import {
 	ADD_DNS_RECORD,
 	EDIT_DNS_RECORD,
 	ADD_FORWARDING_EMAIL,
+	COMPARE_EMAIL_PROVIDERS,
 	EDIT_CONTACT_INFO,
 } from 'calypso/my-sites/domains/domain-management/subpage-wrapper/subpages';
 import emailController from 'calypso/my-sites/email/controller';
@@ -176,6 +177,15 @@ export default function () {
 		controllers: [
 			domainManagementController.domainManagementSubpageParams( ADD_FORWARDING_EMAIL ),
 			emailController.emailManagementAddEmailForwards,
+			domainManagementController.domainManagementSubpageView,
+		],
+	} );
+
+	registerSiteDomainPage( {
+		path: '/overview/site-domain/email/:domain/compare/:site',
+		controllers: [
+			domainManagementController.domainManagementSubpageParams( COMPARE_EMAIL_PROVIDERS ),
+			emailController.emailManagementInDepthComparison,
 			domainManagementController.domainManagementSubpageView,
 		],
 	} );

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/add-fowarding-email-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/add-fowarding-email-header.tsx
@@ -6,6 +6,7 @@ import { domainManagementAllOverview } from 'calypso/my-sites/domains/paths';
 import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
 import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';
 import { useSelector } from 'calypso/state';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSite } from 'calypso/state/sites/selectors';
 import { CustomHeaderComponentType } from './custom-header-component-type';
 
@@ -16,6 +17,7 @@ const AddForwardingEmailHeader: CustomHeaderComponentType = ( {
 } ) => {
 	const translate = useTranslate();
 	const site = useSelector( ( state ) => getSite( state, selectedSiteSlug ) as SiteExcerptData );
+	const currentRoute = useSelector( getCurrentRoute );
 
 	const navigationItems = useMemo( () => {
 		const baseNavigationItems = [
@@ -24,7 +26,7 @@ const AddForwardingEmailHeader: CustomHeaderComponentType = ( {
 				href: domainManagementAllOverview(
 					selectedSiteSlug,
 					selectedDomainName,
-					null,
+					currentRoute,
 					inSiteContext
 				),
 			},
@@ -33,7 +35,7 @@ const AddForwardingEmailHeader: CustomHeaderComponentType = ( {
 				href: getEmailManagementPath(
 					selectedSiteSlug,
 					selectedDomainName,
-					null,
+					currentRoute,
 					undefined,
 					inSiteContext
 				),

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/compare-email-providers.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/compare-email-providers.tsx
@@ -1,43 +1,65 @@
-import { localizeUrl } from '@automattic/i18n-utils';
+import { SiteExcerptData } from '@automattic/sites';
 import { translate } from 'i18n-calypso';
-import React from 'react';
-import ExternalLink from 'calypso/components/external-link';
+import { useMemo } from 'react';
 import NavigationHeader from 'calypso/components/navigation-header';
+import { domainManagementAllOverview } from 'calypso/my-sites/domains/paths';
+import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
+import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';
+import { useSelector } from 'calypso/state';
+import { getSite } from 'calypso/state/sites/selectors';
 import { CustomHeaderComponentType } from './custom-header-component-type';
-
-export const addDnsRecordTitle = translate( 'Add a new DNS record' );
-export const editDnsRecordTitle = translate( 'Edit DNS record' );
-export const addDnsRecordsSubtitle = translate(
-	'DNS records change how your domain works. {{a}}Learn more{{/a}}.',
-	{
-		components: {
-			a: (
-				<ExternalLink href={ localizeUrl( 'https://wordpress.com/support/domains/custom-dns/' ) } />
-			),
-		},
-	}
-);
 
 const CompareEmailProvidersHeader: CustomHeaderComponentType = ( {
 	selectedDomainName,
 	selectedSiteSlug,
+	inSiteContext,
 } ) => {
+	const site = useSelector( ( state ) => getSite( state, selectedSiteSlug ) as SiteExcerptData );
+
+	const navigationItems = useMemo( () => {
+		const baseNavigationItems = [
+			{
+				label: selectedDomainName,
+				href: domainManagementAllOverview(
+					selectedSiteSlug,
+					selectedDomainName,
+					null,
+					inSiteContext
+				),
+			},
+			{
+				label: translate( 'Email' ),
+				href: getEmailManagementPath(
+					selectedSiteSlug,
+					selectedDomainName,
+					null,
+					undefined,
+					inSiteContext
+				),
+			},
+			{
+				label: translate( 'Compare plans' ),
+			},
+		];
+
+		if ( inSiteContext ) {
+			return [
+				{
+					label: site?.name || selectedDomainName,
+					href: `/overview/${ selectedSiteSlug }`,
+					icon: <SiteIcon site={ site } viewType="breadcrumb" disableClick />,
+				},
+				...baseNavigationItems,
+			];
+		}
+
+		return baseNavigationItems;
+	}, [ inSiteContext, selectedDomainName, selectedSiteSlug, site ] );
+
 	return (
 		<NavigationHeader
 			className="navigation-header__breadcrumb"
-			navigationItems={ [
-				{
-					label: selectedDomainName,
-					href: `/domains/manage/all/overview/${ selectedDomainName }/${ selectedSiteSlug }`,
-				},
-				{
-					label: translate( 'Email' ),
-					href: `/domains/manage/all/email/${ selectedDomainName }/${ selectedSiteSlug }`,
-				},
-				{
-					label: translate( 'Compare plans' ),
-				},
-			] }
+			navigationItems={ navigationItems }
 		/>
 	);
 };

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/compare-email-providers.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/compare-email-providers.tsx
@@ -6,6 +6,7 @@ import { domainManagementAllOverview } from 'calypso/my-sites/domains/paths';
 import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
 import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';
 import { useSelector } from 'calypso/state';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSite } from 'calypso/state/sites/selectors';
 import { CustomHeaderComponentType } from './custom-header-component-type';
 
@@ -15,6 +16,7 @@ const CompareEmailProvidersHeader: CustomHeaderComponentType = ( {
 	inSiteContext,
 } ) => {
 	const site = useSelector( ( state ) => getSite( state, selectedSiteSlug ) as SiteExcerptData );
+	const currentRoute = useSelector( getCurrentRoute );
 
 	const navigationItems = useMemo( () => {
 		const baseNavigationItems = [
@@ -23,7 +25,7 @@ const CompareEmailProvidersHeader: CustomHeaderComponentType = ( {
 				href: domainManagementAllOverview(
 					selectedSiteSlug,
 					selectedDomainName,
-					null,
+					currentRoute,
 					inSiteContext
 				),
 			},
@@ -32,7 +34,7 @@ const CompareEmailProvidersHeader: CustomHeaderComponentType = ( {
 				href: getEmailManagementPath(
 					selectedSiteSlug,
 					selectedDomainName,
-					null,
+					currentRoute,
 					undefined,
 					inSiteContext
 				),

--- a/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
@@ -174,6 +174,10 @@
                 padding-top: 12px;
             }
         }
+
+        @media ( max-width: $break-small ) {
+            padding: 8px;
+        }
     }
 
 	&.subpage-wrapper--add-mailbox {

--- a/client/my-sites/domains/domain-management/subpage-wrapper/subpages.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/subpages.tsx
@@ -40,6 +40,7 @@ const SUBPAGE_TO_PARAMS_MAP: Record< string, SubpageWrapperParamsType > = {
 	},
 	[ COMPARE_EMAIL_PROVIDERS ]: {
 		CustomHeader: CompareEmailProvidersHeader,
+		showBackButton: false,
 	},
 	[ DNS_RECORDS ]: {
 		CustomHeader: DNSRecordsHeader,

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -175,7 +175,7 @@ export default {
 					selectedDomainName={ pageContext.params.domain }
 					selectedIntervalLength={ castIntervalLength( pageContext.query.interval ) }
 					source={ pageContext.query.source }
-					context={ pageContext.section.name }
+					showBackButton={ pageContext.params.showBackButton }
 				/>
 			</CalypsoShoppingCartProvider>
 		);

--- a/client/my-sites/email/email-providers-comparison/billing-interval-toggle/style.scss
+++ b/client/my-sites/email/email-providers-comparison/billing-interval-toggle/style.scss
@@ -67,7 +67,7 @@
 	}
 }
 
-.emails-save-paying-annually__popover {
+.emails-save-paying-annually__popover.popover {
 	z-index: z-index("root", ".masterbar") - 1;
 
 	.popover__inner {

--- a/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
@@ -35,7 +35,7 @@ const EmailProvidersInDepthComparison = ( {
 	selectedDomainName,
 	selectedIntervalLength = IntervalLength.ANNUALLY,
 	source,
-	context,
+	showBackButton = true,
 }: EmailProvidersInDepthComparisonProps ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -45,7 +45,6 @@ const EmailProvidersInDepthComparison = ( {
 	const selectedSite = useSelector( getSelectedSite );
 	const cartKey = useCartKey();
 	const shoppingCartManager = useShoppingCart( cartKey );
-	const hideNavigation = context === 'domains';
 	const isDomainInCart = hasDomainInCart( shoppingCartManager.responseCart, selectedDomainName );
 
 	const changeIntervalLength = ( newIntervalLength: IntervalLength ) => {
@@ -98,7 +97,7 @@ const EmailProvidersInDepthComparison = ( {
 	return (
 		<Main wideLayout>
 			<QueryProductsList />
-			{ ! hideNavigation && (
+			{ showBackButton && (
 				<EmailUpsellNavigation
 					backUrl={
 						isDomainInCart

--- a/client/my-sites/email/email-providers-comparison/in-depth/types.ts
+++ b/client/my-sites/email/email-providers-comparison/in-depth/types.ts
@@ -41,7 +41,7 @@ export type EmailProvidersInDepthComparisonProps = {
 	selectedDomainName: string;
 	selectedIntervalLength?: IntervalLength;
 	source?: string;
-	context?: string;
+	showBackButton?: boolean;
 };
 
 export type LearnMoreLinkProps = {

--- a/client/my-sites/email/paths.ts
+++ b/client/my-sites/email/paths.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { stringify } from 'qs';
 import {
 	isUnderDomainManagementAll,
@@ -212,8 +211,12 @@ export const getEmailInDepthComparisonPath = (
 	source?: string,
 	intervalLength?: string
 ) => {
-	if ( isEnabled( 'calypso/all-domain-management' ) && isUnderDomainManagementAll( relativeTo ) ) {
-		return `${ domainsManagementPrefix }/${ domainName }/compare/${ siteName }${ buildQueryString( {
+	if ( isUnderDomainManagementAll( relativeTo ) ) {
+		const prefix = isUnderDomainSiteContext( relativeTo )
+			? emailSiteContextPrefix
+			: domainsManagementPrefix;
+
+		return `${ prefix }/${ domainName }/compare/${ siteName }${ buildQueryString( {
 			interval: intervalLength,
 			referrer: relativeTo,
 			source,

--- a/client/my-sites/email/test/paths.ts
+++ b/client/my-sites/email/test/paths.ts
@@ -194,6 +194,12 @@ describe( 'path helper functions', () => {
 				relativeTo
 			) }`
 		);
+		const relativeToSiteDomain = '/overview/site-domain/email';
+		expect( getEmailInDepthComparisonPath( siteName, domainName, relativeToSiteDomain ) ).toEqual(
+			`/overview/site-domain/email/${ domainName }/compare/${ siteName }?referrer=${ encodeURIComponent(
+				relativeToSiteDomain
+			) }`
+		);
 	} );
 
 	it( 'getMailboxesPath', () => {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/98275

## Proposed Changes

* Add email plans comparison subpage to the site context.

## Why are these changes being made?

* This is part of the Domain Management Revamp project: pfuQfP-13x-p2

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/sites?flags=calypso/all-domain-management.
* Click on a site with a domain previously configured and without email configured.
* Scroll down to the domains table and click on the domain.
* You should see the domain overview page within the site context.
* Click on the Email tab.
* Click on "See how they compare" link.
* The plans comparison page should be rendered in the site context.
* Select one of the email plans.
* It should return to the Email overview page with the correct plan expanded, and it should continue in the site context.
* Go back to the plans comparison page.
* Switch to Monthly plans and select a different plan.
* It should return to the Email overview page with the correct interval selected and the plan expanded, and it should continue in the site context.
* Test the navigation using the breadcrumb, it should continue in the site context.
* Perform regression tests in the domain context.
* The page should behave the same, and the navigation should stay within the domain context.
* Go to the old UI and perform regression tests (WP Admin -> Hosting -> Email).
* The page should work as before, without changes in visual or behavior.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
