### PR TITLE
Update theme tier badges

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
@@ -27,10 +27,6 @@ export default function ThemeTierPlanUpgradeBadge( { showPartnerPrice } ) {
 	const isUpdatedBadgeDesign = useIsUpdatedBadgeDesign();
 
 	const getLabel = () => {
-		if ( ! isUpdatedBadgeDesign ) {
-			return translate( 'Upgrade' );
-		}
-
 		if ( showPartnerPrice && subscriptionPrices.month ) {
 			const fullLabel = translate( 'Available on %(planName)s plus %(price)s/month', {
 				args: {

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -1,4 +1,4 @@
-import { Card, Button, Gridicon } from '@automattic/components';
+import { Badge, Card, Button, Gridicon } from '@automattic/components';
 import {
 	DesignPreviewImage,
 	PREMIUM_THEME,
@@ -6,18 +6,20 @@ import {
 	isDefaultGlobalStylesVariationSlug,
 	isLockedStyleVariation,
 } from '@automattic/design-picker';
-import { localize } from 'i18n-calypso';
+import { localize, translate } from 'i18n-calypso';
 import { isEmpty, isEqual } from 'lodash';
 import photon from 'photon';
 import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
 import { connect } from 'react-redux';
 import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
+import ThemeTierFreeBadge from 'calypso/components/theme-tier/theme-tier-badge/theme-tier-free-badge';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { updateThemes } from 'calypso/state/themes/actions/theme-update';
+import { useIsThemeAllowedOnSite } from 'calypso/state/themes/hooks/use-is-theme-allowed-on-site';
 import { isExternallyManagedTheme as getIsExternallyManagedTheme } from 'calypso/state/themes/selectors';
 import { setThemesBookmark } from 'calypso/state/themes/themes-ui/actions';
 import ThemeMoreButton from './more-button';
@@ -154,8 +156,7 @@ export class Theme extends Component {
 	}
 
 	renderScreenshot() {
-		const { isExternallyManagedTheme, selectedStyleVariation, theme, siteSlug, translate } =
-			this.props;
+		const { isExternallyManagedTheme, selectedStyleVariation, theme, siteSlug } = this.props;
 		const { isScreenshotLoaded } = this.state;
 		const { description, screenshot } = theme;
 
@@ -232,7 +233,7 @@ export class Theme extends Component {
 	};
 
 	renderUpdateAlert = () => {
-		const { isUpdated, isUpdating, errorOnUpdate, theme, translate } = this.props;
+		const { isUpdated, isUpdating, errorOnUpdate, theme } = this.props;
 
 		if ( ! theme.update && ! isUpdated && ! isUpdating && ! errorOnUpdate ) {
 			return;
@@ -325,7 +326,7 @@ export class Theme extends Component {
 	};
 
 	renderBadge = () => {
-		const { selectedStyleVariation, shouldLimitGlobalStyles, theme } = this.props;
+		const { selectedStyleVariation, shouldLimitGlobalStyles, theme, isThemeAllowed } = this.props;
 
 		const isPremiumTheme = theme.theme_tier?.slug === PREMIUM_THEME;
 
@@ -334,6 +335,16 @@ export class Theme extends Component {
 			styleVariationSlug: selectedStyleVariation?.slug,
 			shouldLimitGlobalStyles,
 		} );
+
+		const isFreeTheme = theme.theme_tier?.slug === 'free';
+
+		if ( isFreeTheme ) {
+			return <ThemeTierFreeBadge />;
+		}
+
+		if ( isThemeAllowed ) {
+			return <Badge type="info">{ translate( 'Included with plan' ) }</Badge>;
+		}
 
 		return <ThemeTierBadge themeId={ theme.id } isLockedStyleVariation={ isLocked } />;
 	};
@@ -391,5 +402,12 @@ const ConnectedTheme = connect(
 
 export default ( props ) => {
 	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( props.siteId );
-	return <ConnectedTheme { ...props } shouldLimitGlobalStyles={ shouldLimitGlobalStyles } />;
+	const isThemeAllowed = useIsThemeAllowedOnSite( props.siteId, props.theme.id );
+	return (
+		<ConnectedTheme
+			{ ...props }
+			shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
+			isThemeAllowed={ isThemeAllowed }
+		/>
+	);
 };

--- a/packages/design-picker/src/components/theme-card/index.tsx
+++ b/packages/design-picker/src/components/theme-card/index.tsx
@@ -125,8 +125,8 @@ const ThemeCard = forwardRef(
 							<span>{ name }</span>
 						</h2>
 						{ ! isActive && badge && <>{ badge }</> }
-						{ optionsMenu && <div className="theme-card__info-options">{ optionsMenu }</div> }
 						{ isActive && <ActiveBadge /> }
+						{ optionsMenu && <div className="theme-card__info-options">{ optionsMenu }</div> }
 					</div>
 				</div>
 			</Card>

--- a/packages/design-picker/src/components/theme-card/index.tsx
+++ b/packages/design-picker/src/components/theme-card/index.tsx
@@ -1,7 +1,7 @@
 import { Card } from '@automattic/components';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
-import { forwardRef, useMemo, Suspense, lazy } from 'react';
+import { forwardRef, useMemo } from 'react';
 import type { StyleVariation } from '../../types';
 import type { Ref } from 'react';
 import './style.scss';
@@ -25,8 +25,6 @@ interface ThemeCardProps {
 	onStyleVariationClick?: ( styleVariation: StyleVariation ) => void;
 	onStyleVariationMoreClick?: () => void;
 }
-
-const StyleVariationBadges = lazy( () => import( '../style-variation-badges' ) );
 
 const ActiveBadge = () => {
 	return (
@@ -61,15 +59,12 @@ const ThemeCard = forwardRef(
 			banner,
 			badge,
 			styleVariations = [],
-			selectedStyleVariation,
 			optionsMenu,
 			isActive,
 			isLoading,
 			isSoftLaunched,
 			onClick,
 			onImageClick,
-			onStyleVariationClick,
-			onStyleVariationMoreClick,
 		}: ThemeCardProps,
 		forwardedRef: Ref< any > // eslint-disable-line @typescript-eslint/no-explicit-any
 	) => {
@@ -129,17 +124,6 @@ const ThemeCard = forwardRef(
 						<h2 className="theme-card__info-title">
 							<span>{ name }</span>
 						</h2>
-						{ ! optionsMenu && (
-							<Suspense fallback={ null }>
-								<StyleVariationBadges
-									className="theme-card__info-style-variations"
-									variations={ styleVariations }
-									selectedVariation={ selectedStyleVariation }
-									onMoreClick={ onStyleVariationMoreClick }
-									onClick={ onStyleVariationClick }
-								/>
-							</Suspense>
-						) }
 						{ ! isActive && badge && <>{ badge }</> }
 						{ optionsMenu && <div className="theme-card__info-options">{ optionsMenu }</div> }
 						{ isActive && <ActiveBadge /> }

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -25,13 +25,6 @@ $theme-card-info-margin-top: 16px;
 		}
 	}
 
-	.theme-card__info-badge-container {
-		position: absolute;
-		bottom: 0;
-		display: flex;
-		flex-basis: 100%;
-	}
-
 	.theme-card__info-badge-active {
 		display: flex;
 		background-color: var(--color-primary);
@@ -223,7 +216,7 @@ $theme-card-info-margin-top: 16px;
 	text-rendering: optimizeLegibility;
 	-webkit-font-smoothing: antialiased;
 
-	&-badge, .theme-tier-badge {
+	&-badge, .theme-tier-badge, .theme-card__info-badge-container {
 		border-radius: 20px;  /* stylelint-disable-line scales/radii */
 		flex: 0 0 auto;
 		text-transform: none;
@@ -237,6 +230,18 @@ $theme-card-info-margin-top: 16px;
 			background-color: var(--color-primary-0);
 			color: var(--color-neutral-100);
 		}
+	}
+
+	.badge--info {
+		background: #EBEEFC;
+		color: var(--studio-wordpress-blue);
+	}
+
+	.theme-tier-badge .premium-badge {
+		background: transparent;
+		color: var(--studio-gray-80);
+		padding: 0;
+		font-weight: 400;
 	}
 }
 

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -223,7 +223,7 @@ $theme-card-info-margin-top: 16px;
 	text-rendering: optimizeLegibility;
 	-webkit-font-smoothing: antialiased;
 
-	&-badge {
+	&-badge, .theme-tier-badge {
 		border-radius: 20px;  /* stylelint-disable-line scales/radii */
 		flex: 0 0 auto;
 		text-transform: none;
@@ -231,6 +231,7 @@ $theme-card-info-margin-top: 16px;
 		font-weight: 600;
 		line-height: 20px;
 		padding: 0 10px;
+		margin-right: -20px;
 
 		&-active {
 			background-color: var(--color-primary-0);
@@ -270,21 +271,6 @@ $theme-card-info-margin-top: 16px;
 	white-space: nowrap;
 	width: 0;
 	text-overflow: ellipsis;
-}
-
-.theme-card__info-style-variations {
-	align-items: center;
-	display: flex;
-	font-size: 0;
-	gap: 4px;
-	height: 24px;
-
-	.style-variation__badge-wrapper,
-	.style-variation__badge-more-wrapper {
-		&:focus-visible span {
-			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2), 0 0 0 2px var(--color-primary-light);
-		}
-	}
 }
 
 .theme-card__info-options,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #95471

Follow-up of https://github.com/Automattic/wp-calypso/pull/98082

## Proposed Changes

- [x] Add an "Included with plan" badge
- [x] Style the "free" badge to look the same as the badge in the design picker
- [ ] Fix styling of "Active" badge and options menu (with the updated design these two elements are sat too close to each other)
- [ ] Decide whether the `isUpdatedBadgeDesign` logic should be removed altogether
- [ ] For partner themes, show "Available on Business" unless you're on the Business or Commerce plans, in which case, just show the price
- [ ] Ensure badges on theme details page are consistent
- [ ] Ensure badges on showcase are consistent

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Implements the designs described in https://github.com/Automattic/wp-calypso/issues/95471#issuecomment-2529511388.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
