### PR TITLE
Stats: Avoid users to click on “Apply” when using shortcuts

### DIFF
--- a/client/components/date-control/types.d.ts
+++ b/client/components/date-control/types.d.ts
@@ -9,7 +9,7 @@ interface DateControlProps {
 		daysInRange: number;
 	};
 	shortcutList: DateRangePickerShortcut[];
-	onShortcutClick: ( shortcut: DateRangePickerShortcut ) => void;
+	onShortcutClick: ( shortcut: DateRangePickerShortcut, closePopoverAndCommit: () => void ) => void;
 	tooltip?: string;
 	overlay?: JSX.Element;
 }

--- a/client/components/date-range/index.js
+++ b/client/components/date-range/index.js
@@ -437,6 +437,11 @@ export class DateRange extends Component {
 		this.props.onDateSelect && this.props.onDateSelect( startDate, endDate );
 	};
 
+	// Expose closePopoverAndCommit to the parent component for shortcut clicks.
+	handleShortcutClick = ( shortcut ) => {
+		this.props.onShortcutClick( shortcut, this.closePopoverAndCommit );
+	};
+
 	/**
 	 * Renders the Popover component
 	 * @returns {import('react').Element} the Popover component
@@ -493,7 +498,7 @@ export class DateRange extends Component {
 								locked={ !! this.props.overlay }
 								startDate={ this.state.startDate }
 								endDate={ this.state.endDate }
-								onShortcutClick={ this.props.onShortcutClick } // for tracking shortcut clicks
+								onShortcutClick={ this.handleShortcutClick } // for tracking shortcut clicks
 							/>
 						</div>
 					) }

--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -175,7 +175,10 @@ const StatsDateControl = ( {
 	};
 
 	// handler for shortcut clicks
-	const onShortcutClickHandler = ( shortcut: DateRangePickerShortcut ) => {
+	const onShortcutClickHandler = (
+		shortcut: DateRangePickerShortcut,
+		closePopoverAndCommit: () => void
+	) => {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 
 		if ( shortcut.isGated ) {
@@ -187,6 +190,7 @@ const StatsDateControl = ( {
 				);
 		} else {
 			recordTracksEvent( eventNames[ event_from ][ shortcut.id as EventNameKey ] );
+			closePopoverAndCommit();
 		}
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Apply the same behavior when clicking the shortcut as the `Apply` button of the date range picker.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* A part of improvements from p1HpG7-vox-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Open the date range picker.
* Click on any of the shortcuts.
* Ensure the corresponding date range is immediately applied to redirect to the new chart.
* Open the date range picker.
* Choose a custom range of dates.
* Ensure the change is applied after clicking the Apply button.

https://github.com/user-attachments/assets/8cbb8228-03d9-4164-9168-87bac125cba5

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?