### PR TITLE
Hide filter button for 100 year domains

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -543,6 +543,10 @@ class RegisterDomainStep extends Component {
 			( Array.isArray( this.state.availableTlds ) && this.state.availableTlds.length > 0 ) ||
 			this.state.loadingResults;
 
+		if ( [ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMAIN_FLOW ].includes( this.props.flowName ) ) {
+			return null;
+		}
+
 		return (
 			showFilters && (
 				<DropdownFilters

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -600,6 +600,7 @@
 		.domain-search-results__domain-available-notice {
 			background: transparent;
 			display: flex;
+			margin-left: 0;
 
 			.domain-search-results__domain-available-notice-icon {
 				margin-right: 4px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -471,8 +471,16 @@
 		}
 	}
 
+	.register-domain-step__search-card {
+		background: none;
+	}
+
 	.search-component {
 		overflow: hidden;
+	}
+
+	.search-filters__dropdown-filters {
+		display: none;
 	}
 
 	.token-field__suggestion.is-selected {
@@ -591,6 +599,11 @@
 
 		.domain-search-results__domain-available-notice {
 			background: transparent;
+			display: flex;
+
+			.domain-search-results__domain-available-notice-icon {
+				margin-right: 4px;
+			}
 
 			/* hide transfer link */
 			a {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -479,10 +479,6 @@
 		overflow: hidden;
 	}
 
-	.search-filters__dropdown-filters {
-		display: none;
-	}
-
 	.token-field__suggestion.is-selected {
 		background: var( --studio-gray-100 );
 	}


### PR DESCRIPTION
## Proposed Changes

This PR hides the filter button for the 100-year domain search since we only have a limited set of tlds to offer. The filter doesn't make sense anymore. I also fixed a small bug with the already registered icon/messaging.

**Before**
<img width="1675" alt="image" src="https://github.com/user-attachments/assets/c62c140e-8a31-42af-b5f4-4da4aa9e7f21" />

**After**
<img width="1675" alt="image" src="https://github.com/user-attachments/assets/f6da653d-03cb-4e80-96d7-38838257e838" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/setup/hundred-year-domain/domains?new=filippodt.com&search=yes`
* Visit `/setup/hundred-year-plan/domains?ref=100-year-lp` in the 100 year plan flow
* Check a regular domain search: /start/domain/domain-only?new=filippodt.com&search=yes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
