### PR TITLE
Domain management: Handle domain options links for different usage context

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -427,6 +427,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				{ ! isLoading && ! isDomainsEmpty && <GoogleDomainOwnerBanner /> }
 				{ ! isDomainsEmpty ? (
 					<DomainsTable
+						context="domains"
 						isLoadingDomains={ isLoading }
 						domains={ domains }
 						isAllSitesView

--- a/client/sites/overview/components/active-domains-card.tsx
+++ b/client/sites/overview/components/active-domains-card.tsx
@@ -71,6 +71,7 @@ const ActiveDomainsCard: FC = () => {
 
 			<DomainsTable
 				className="hosting-overview__domains-table"
+				context="site"
 				hideCheckbox
 				isLoadingDomains={ isLoading }
 				domains={ data?.domains }

--- a/client/sites/overview/components/active-domains-card.tsx
+++ b/client/sites/overview/components/active-domains-card.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { useSiteDomainsQuery } from '@automattic/data-stores';
 import { DomainsTable, ResponseDomain } from '@automattic/domains-table';
@@ -47,11 +48,16 @@ const ActiveDomainsCard: FC = () => {
 	if ( isJetpackNotAtomic ) {
 		return null;
 	}
+
+	const addDomainsLink = isEnabled( 'calypso/all-domain-management' )
+		? `/start/domain/domain-only`
+		: `/domains/add/${ site?.slug }?redirect_to=${ window.location.pathname }`;
+
 	return (
 		<HostingCard className="hosting-overview__active-domains">
 			<HostingCardHeading title={ translate( 'Active domains' ) }>
 				<HostingCardLinkButton
-					to={ `/domains/add/${ site?.slug }?redirect_to=${ window.location.pathname }` }
+					to={ addDomainsLink }
 					hideOnMobile
 					onClick={ () =>
 						dispatch( recordTracksEvent( 'calypso_overview_add_domain_button_click' ) )

--- a/client/sites/overview/components/active-domains-card.tsx
+++ b/client/sites/overview/components/active-domains-card.tsx
@@ -53,6 +53,10 @@ const ActiveDomainsCard: FC = () => {
 		? `/start/domain/domain-only`
 		: `/domains/add/${ site?.slug }?redirect_to=${ window.location.pathname }`;
 
+	const manageDomainsLink = isEnabled( 'calypso/all-domain-management' )
+		? `/domains/manage`
+		: `/domains/manage/${ site?.slug }`;
+
 	return (
 		<HostingCard className="hosting-overview__active-domains">
 			<HostingCardHeading title={ translate( 'Active domains' ) }>
@@ -66,7 +70,7 @@ const ActiveDomainsCard: FC = () => {
 					{ translate( 'Add new domain' ) }
 				</HostingCardLinkButton>
 				<HostingCardLinkButton
-					to={ `/domains/manage/${ site?.slug }` }
+					to={ manageDomainsLink }
 					onClick={ () =>
 						dispatch( recordTracksEvent( 'calypso_overview_manage_domains_button_click' ) )
 					}

--- a/client/sites/overview/components/active-domains-card.tsx
+++ b/client/sites/overview/components/active-domains-card.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { useSiteDomainsQuery } from '@automattic/data-stores';
 import { DomainsTable, ResponseDomain } from '@automattic/domains-table';
@@ -48,16 +47,11 @@ const ActiveDomainsCard: FC = () => {
 	if ( isJetpackNotAtomic ) {
 		return null;
 	}
-
-	const addDomainsLink = isEnabled( 'calypso/all-domain-management' )
-		? `/start/domain/domain-only`
-		: `/domains/add/${ site?.slug }?redirect_to=${ window.location.pathname }`;
-
 	return (
 		<HostingCard className="hosting-overview__active-domains">
 			<HostingCardHeading title={ translate( 'Active domains' ) }>
 				<HostingCardLinkButton
-					to={ addDomainsLink }
+					to={ `/domains/add/${ site?.slug }?redirect_to=${ window.location.pathname }` }
 					hideOnMobile
 					onClick={ () =>
 						dispatch( recordTracksEvent( 'calypso_overview_add_domain_button_click' ) )

--- a/client/sites/overview/components/active-domains-card.tsx
+++ b/client/sites/overview/components/active-domains-card.tsx
@@ -53,10 +53,6 @@ const ActiveDomainsCard: FC = () => {
 		? `/start/domain/domain-only`
 		: `/domains/add/${ site?.slug }?redirect_to=${ window.location.pathname }`;
 
-	const manageDomainsLink = isEnabled( 'calypso/all-domain-management' )
-		? `/domains/manage`
-		: `/domains/manage/${ site?.slug }`;
-
 	return (
 		<HostingCard className="hosting-overview__active-domains">
 			<HostingCardHeading title={ translate( 'Active domains' ) }>
@@ -70,7 +66,7 @@ const ActiveDomainsCard: FC = () => {
 					{ translate( 'Add new domain' ) }
 				</HostingCardLinkButton>
 				<HostingCardLinkButton
-					to={ manageDomainsLink }
+					to={ `/domains/manage/${ site?.slug }` }
 					onClick={ () =>
 						dispatch( recordTracksEvent( 'calypso_overview_manage_domains_button_click' ) )
 					}

--- a/packages/domains-table/src/domains-table/domains-table-email-indicator.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-email-indicator.tsx
@@ -4,16 +4,19 @@ import { useI18n } from '@wordpress/react-i18n';
 import { type as domainTypes } from '../utils/constants';
 import { getDomainType } from '../utils/get-domain-type';
 import { emailManagementEdit } from '../utils/paths';
+import type { DomainsTableContext } from './domains-table';
 import type { MouseEvent } from 'react';
 
 interface DomainsTableEmailIndicatorProps {
 	domain: PartialDomainData;
 	siteSlug: string;
+	context?: DomainsTableContext;
 }
 
 export const DomainsTableEmailIndicator = ( {
 	domain,
 	siteSlug,
+	context,
 }: DomainsTableEmailIndicatorProps ) => {
 	const { __, _n } = useI18n();
 
@@ -64,7 +67,7 @@ export const DomainsTableEmailIndicator = ( {
 		return (
 			<a
 				className="domains-table-view-email-button"
-				href={ emailManagementEdit( siteSlug, domain.domain ) }
+				href={ emailManagementEdit( siteSlug, domain.domain, context ) }
 				onClick={ ( e: MouseEvent ) => e.stopPropagation() }
 			>
 				{ message }
@@ -79,7 +82,7 @@ export const DomainsTableEmailIndicator = ( {
 	return (
 		<a
 			className="domains-table-add-email-button"
-			href={ emailManagementEdit( siteSlug, domain.domain ) }
+			href={ emailManagementEdit( siteSlug, domain.domain, context ) }
 			onClick={ ( e: MouseEvent ) => e.stopPropagation() }
 		>
 			{ __( '+ Add email' ) }

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -104,7 +104,7 @@ export const DomainsTableRowActions = ( {
 			canManageContactInfo && (
 				<MenuItemLink
 					key="manageContactInfo"
-					href={ domainManagementEditContactInfo( siteSlug, domain.name ) }
+					href={ domainManagementEditContactInfo( siteSlug, domain.name, null, context ) }
 				>
 					{ __( 'Manage contact information' ) }
 				</MenuItemLink>

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -46,6 +46,7 @@ export const DomainsTableRowActions = ( {
 	canSetPrimaryDomainForSite,
 	isSiteOnFreePlan,
 	isSimpleSite,
+	isHostingOverview,
 	context,
 }: DomainsTableRowActionsProps ) => {
 	const {
@@ -87,7 +88,13 @@ export const DomainsTableRowActions = ( {
 			canViewDetails && (
 				<MenuItemLink
 					key="actionDetails"
-					href={ domainManagementLink( domain, siteSlug, isAllSitesView ) }
+					href={ domainManagementLink(
+						domain,
+						siteSlug,
+						isAllSitesView,
+						undefined,
+						isHostingOverview
+					) }
 				>
 					{ domain.type === domainTypes.TRANSFER ? __( 'View transfer' ) : __( 'View settings' ) }
 				</MenuItemLink>

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -18,7 +18,7 @@ import {
 } from '../utils/paths';
 import { shouldUpgradeToMakeDomainPrimary } from '../utils/should-upgrade-to-make-domain-primary';
 import { ResponseDomain } from '../utils/types';
-import { useDomainsTable } from './domains-table';
+import { useDomainsTable, DomainsTableContext } from './domains-table';
 
 export type DomainAction = 'change-site-address' | 'manage-dns-settings' | 'set-primary-address';
 
@@ -36,6 +36,7 @@ interface DomainsTableRowActionsProps {
 	isSiteOnFreePlan: boolean;
 	isSimpleSite: boolean;
 	isHostingOverview?: boolean;
+	context?: DomainsTableContext;
 }
 
 export const DomainsTableRowActions = ( {
@@ -45,7 +46,7 @@ export const DomainsTableRowActions = ( {
 	canSetPrimaryDomainForSite,
 	isSiteOnFreePlan,
 	isSimpleSite,
-	isHostingOverview,
+	context,
 }: DomainsTableRowActionsProps ) => {
 	const {
 		onDomainAction,
@@ -95,7 +96,7 @@ export const DomainsTableRowActions = ( {
 				<MenuItemLink
 					key="manageDNS"
 					onClick={ () => onDomainAction?.( 'manage-dns-settings', domain ) }
-					href={ domainManagementDNS( siteSlug, domain.name, isHostingOverview ) }
+					href={ domainManagementDNS( siteSlug, domain.name, context ) }
 				>
 					{ __( 'Manage DNS' ) }
 				</MenuItemLink>

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -51,6 +51,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 		hasWpcomManagedSslCert,
 	} = useDomainRow( domain );
 	const {
+		context,
 		canSelectAnyDomains,
 		domainsTableColumns,
 		isCompact,
@@ -259,6 +260,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 									isSiteOnFreePlan={ site?.plan?.is_free ?? true }
 									isSimpleSite={ ! site?.is_wpcom_atomic }
 									isHostingOverview={ isHostingOverview }
+									context={ context }
 								/>
 							) }
 						</td>

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -224,7 +224,11 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 				if ( column.name === 'email' ) {
 					return (
 						<td key={ domain.domain + column.name }>
-							<DomainsTableEmailIndicator domain={ domain } siteSlug={ siteSlug } />
+							<DomainsTableEmailIndicator
+								domain={ domain }
+								siteSlug={ siteSlug }
+								context={ context }
+							/>
 						</td>
 					);
 				}

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -72,8 +72,10 @@ interface BaseDomainsTableProps {
 	selectedDomainName?: string;
 	selectedFeature?: string;
 	isHostingOverview?: boolean;
+	context?: DomainsTableContext;
 }
 
+export type DomainsTableContext = 'site' | 'domains' | string;
 export type DomainsTableProps =
 	| ( BaseDomainsTableProps & { isAllSitesView: true } )
 	| ( BaseDomainsTableProps & { isAllSitesView: false; siteSlug: string | null } );
@@ -130,6 +132,7 @@ type Value = {
 	currentlySelectedDomainName?: string;
 	selectedFeature?: string;
 	isHostingOverview?: boolean;
+	context?: DomainsTableContext;
 };
 
 export const DomainsTableStateContext = createContext< Value | undefined >( undefined );
@@ -155,6 +158,7 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 		selectedDomainName,
 		selectedFeature,
 		isHostingOverview = false,
+		context,
 	} = props;
 
 	const [ { sortKey, sortDirection }, setSort ] = useState< {
@@ -458,6 +462,7 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 		currentlySelectedDomainName: selectedDomainName,
 		selectedFeature,
 		isHostingOverview,
+		context,
 	};
 
 	return value;

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import { addQueryArgs } from '@wordpress/url';
 import { stringify } from 'qs';
 import { ResponseDomain } from './types';
+import type { DomainsTableContext } from '../domains-table/domains-table';
 
 export const emailManagementAllSitesPrefix = '/email/all';
 
@@ -193,13 +194,16 @@ export function isUnderEmailManagementAll( path: string ) {
 export function domainManagementDNS(
 	siteName: string,
 	domainName: string,
-	isHostingOverview?: boolean
+	context?: DomainsTableContext
 ) {
-	if ( isHostingOverview ) {
-		return `/overview/site-domain/domain/${ domainName }/dns/${ siteName }`;
+	switch ( context ) {
+		case 'site':
+			return `/overview/site-domain/domain/${ domainName }/dns/${ siteName }`;
+		case 'domains':
+			return `${ domainManagementAllRoot() }/overview/${ domainName }/dns/${ siteName }`;
+		default:
+			return domainManagementEditBase( siteName, domainName, 'dns' );
 	}
-
-	return domainManagementEditBase( siteName, domainName, 'dns' );
 }
 
 export function emailManagementEdit( siteSlug: string, domainName: string ) {

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -214,7 +214,11 @@ export function domainManagementDNS(
 	}
 }
 
-export function emailManagementEdit( siteSlug: string, domainName: string ) {
+export function emailManagementEdit(
+	siteSlug: string,
+	domainName: string,
+	context?: DomainsTableContext
+) {
 	// Encodes only real domain names and not parameter placeholders
 	if ( domainName && ! String( domainName ).startsWith( ':' ) ) {
 		// Encodes domain names so addresses with slashes in the path (e.g. used in site redirects) don't break routing.
@@ -222,5 +226,12 @@ export function emailManagementEdit( siteSlug: string, domainName: string ) {
 		domainName = encodeURIComponent( encodeURIComponent( domainName ) );
 	}
 
-	return '/email/' + domainName + '/manage/' + siteSlug;
+	switch ( context ) {
+		case 'site':
+			return `/overview/site-domain/email/${ domainName }/${ siteSlug }`;
+		case 'domains':
+			return `${ domainManagementAllRoot() }/email/${ domainName }/${ siteSlug }`;
+		default:
+			return '/email/' + domainName + '/manage/' + siteSlug;
+	}
 }

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -117,9 +117,17 @@ export function domainManagementAllRoot() {
 export function domainManagementEditContactInfo(
 	siteName: string,
 	domainName: string,
-	relativeTo: string | null = null
+	relativeTo: string | null = null,
+	context?: DomainsTableContext
 ) {
-	return domainManagementEditBase( siteName, domainName, 'edit-contact-info', relativeTo );
+	switch ( context ) {
+		case 'site':
+			return `/overview/site-domain/contact-info/edit/${ domainName }/${ siteName }`;
+		case 'domains':
+			return `${ domainManagementAllRoot() }/contact-info/edit/${ domainName }/${ siteName }`;
+		default:
+			return domainManagementEditBase( siteName, domainName, 'edit-contact-info', relativeTo );
+	}
 }
 
 export function domainMappingSetup(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98280

## Proposed Changes

* Update the DataTables component to use the context parameter
* Update logic for generating different paths based on context

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Domain Management Revamp project

## Testing Instructions

**Manage DNS - Site context**
- Enable the feature flag by `window.sessionStorage.setItem('flags', 'calypso/all-domain-management')`
- Purchase a blog domain and attach a site with it
- Now go to `/sites` and open this site in flyout
- Select a site
- Scroll to the bottom and open the context option for the associated domain
- Select `Manage DNS` and check if you stay in the same `site` context
<img width="1505" alt="Screenshot 2025-01-16 at 11 28 53" src="https://github.com/user-attachments/assets/e1f07f95-d306-410b-818c-c60686bf3ae8" />

**Manage DNS - Domains context**
- Go to `/domains/manage`
- Open a domain context options
- Select `Manage DNS` and check if you stay on the same `domains` context
<img width="1504" alt="Screenshot 2025-01-16 at 11 26 49" src="https://github.com/user-attachments/assets/e2a95785-3ded-45dc-9006-0ee741a5af75" />

---

**Manage contact information - Site context**
- Follow the same steps described above
- Select `Manage contact information` and check if you stay in the same `site` context

**Manage contact information - Domains context**
- Follow the same steps described above
- Select `Manage contact information` and check if you stay in the same `domains` context

---
**View settings - Site context**
- Follow the same steps described above
- Select `View settings` and check if you stay in the same `site` context

**View settings - Site context**
- Follow the same steps described above
- Select `View settings` and check if you stay in the same `domains` context

---

**Active domain - Site context**
- Follow the same steps described above
- Under the "Email" column
- Select the `# mailboxes` link and check if you stay in the same `site` context
<img width="943" alt="Screenshot 2025-01-16 at 13 12 33" src="https://github.com/user-attachments/assets/42365166-0efe-4a5d-997a-cda43589a8e1" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
