### PR TITLE
Add feature flag for drive migrations modal

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -205,6 +205,7 @@
 		"site-indicator": true,
 		"site-profiler/metrics": true,
 		"sites/dashboard-survey": true,
+		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": false,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -133,6 +133,7 @@
 		"signup/social-first": true,
 		"site-indicator": true,
 		"site-profiler/metrics": true,
+		"sites/drive-migrations": false,
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,

--- a/config/production.json
+++ b/config/production.json
@@ -174,6 +174,7 @@
 		"signup/social-first": true,
 		"site-indicator": true,
 		"site-profiler/metrics": false,
+		"sites/drive-migrations": false,
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -171,6 +171,7 @@
 		"signup/social-first": true,
 		"site-indicator": true,
 		"site-profiler/metrics": false,
+		"sites/drive-migrations": false,
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,

--- a/config/test.json
+++ b/config/test.json
@@ -125,6 +125,7 @@
 		"signup/social": true,
 		"signup/social-first": true,
 		"site-indicator": true,
+		"sites/drive-migrations": false,
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -169,6 +169,7 @@
 		"site-indicator": true,
 		"site-profiler/metrics": true,
 		"sites/dashboard-survey": true,
+		"sites/drive-migrations": false,
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1736967118374689/1735856236.155919-slack-C06FCT6EEHH

## Proposed Changes

Create a feature flag called `sites/drive-migrations` for the new add site button on `/sites`. More context in this Slack thread p1736967118374689/1735856236.155919-slack-C06FCT6EEHH

[This PR](https://github.com/Automattic/wp-calypso/pull/98378) should use this flag.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run `yarn feature-search drive-migrations` and verify you get the following output:
<img width="1217" alt="image" src="https://github.com/user-attachments/assets/77edadfc-193c-4170-8d6e-bd8f4b0c5ee9" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?