### PR TITLE
WIP: Billing history list add view receipt modal

### DIFF
--- a/client/me/purchases/billing-history/billing-history-list-data-view.tsx
+++ b/client/me/purchases/billing-history/billing-history-list-data-view.tsx
@@ -27,7 +27,7 @@ export default function BillingHistoryListDataView( {
 	const transactions = useSelector( getPastBillingTransactions );
 	const isLoading = useSelector( isRequestingBillingTransactions );
 	const viewState = useViewStateUpdate();
-	const receiptActions = useReceiptActions( getReceiptUrlFor );
+	const receiptActions = useReceiptActions();
 
 	const actions = receiptActions.map( ( action ) => ( {
 		...action,

--- a/client/me/purchases/billing-history/billing-history-list-data-view.tsx
+++ b/client/me/purchases/billing-history/billing-history-list-data-view.tsx
@@ -17,13 +17,7 @@ import './style-data-view.scss';
 
 const DEFAULT_LAYOUT = { table: {} };
 
-export interface BillingHistoryListProps {
-	getReceiptUrlFor: ( receiptId: string ) => string;
-}
-
-export default function BillingHistoryListDataView( {
-	getReceiptUrlFor,
-}: BillingHistoryListProps ) {
+export default function BillingHistoryListDataView() {
 	const transactions = useSelector( getPastBillingTransactions );
 	const isLoading = useSelector( isRequestingBillingTransactions );
 	const viewState = useViewStateUpdate();

--- a/client/me/purchases/billing-history/hooks/use-receipt-actions.ts
+++ b/client/me/purchases/billing-history/hooks/use-receipt-actions.ts
@@ -1,37 +1,23 @@
-import pageRedirect from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
+import { createElement, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { sendBillingReceiptEmail } from 'calypso/state/billing-transactions/actions';
+import type { Action, ActionModal } from '@wordpress/dataviews';
 import type { BillingTransaction } from 'calypso/state/billing-transactions/types';
 import type { IAppState } from 'calypso/state/types';
-import type { Action } from 'redux';
+import type { Action as ReduxAction } from 'redux';
 import type { ThunkDispatch } from 'redux-thunk';
 
 function recordClickEvent( eventAction: string ): void {
 	recordGoogleEvent( 'Me', eventAction );
 }
 
-export type ReceiptAction = {
-	id: 'view-receipt' | 'email-receipt';
-	label: string;
-	isPrimary: boolean;
+export type ReceiptAction = ( Action< BillingTransaction > | ActionModal< BillingTransaction > ) & {
 	iconName: string;
-	callback: ( items: BillingTransaction[] ) => void;
 };
 
-type AppDispatch = ThunkDispatch< IAppState, undefined, Action >;
-
-function handleViewReceipt(
-	items: BillingTransaction[],
-	getReceiptUrlFor: ( receiptId: string ) => string
-): void {
-	if ( ! items?.length || ! items[ 0 ]?.id ) {
-		return;
-	}
-	pageRedirect.redirect( getReceiptUrlFor( items[ 0 ].id ) );
-}
+type AppDispatch = ThunkDispatch< IAppState, undefined, ReduxAction >;
 
 function handleEmailReceipt( items: BillingTransaction[], dispatch: AppDispatch ): void {
 	if ( ! items?.length || ! items[ 0 ]?.id ) {
@@ -42,7 +28,7 @@ function handleEmailReceipt( items: BillingTransaction[], dispatch: AppDispatch 
 }
 
 export function useReceiptActions(
-	getReceiptUrlFor: ( receiptId: string ) => string
+	getReceiptUrlFor?: ( receiptId: string ) => string
 ): ReceiptAction[] {
 	const dispatch = useDispatch< AppDispatch >();
 	const translate = useTranslate();
@@ -54,7 +40,15 @@ export function useReceiptActions(
 				label: translate( 'View receipt' ),
 				isPrimary: true,
 				iconName: 'pages',
-				callback: ( items: BillingTransaction[] ) => handleViewReceipt( items, getReceiptUrlFor ),
+				modalHeader: translate( 'View receipt' ),
+				modalProps: {
+					size: 'large',
+				},
+				RenderModal: ( props ) => {
+					const ReceiptModal = require( '../receipt-modal' ).default;
+					const [ item ] = props.items;
+					return createElement( ReceiptModal, { item, closeModal: props.closeModal } );
+				},
 			},
 			{
 				id: 'email-receipt',
@@ -64,6 +58,6 @@ export function useReceiptActions(
 				callback: ( items: BillingTransaction[] ) => handleEmailReceipt( items, dispatch ),
 			},
 		],
-		[ dispatch, getReceiptUrlFor, translate ]
+		[ dispatch, translate ]
 	);
 }

--- a/client/me/purchases/billing-history/hooks/use-receipt-actions.ts
+++ b/client/me/purchases/billing-history/hooks/use-receipt-actions.ts
@@ -27,9 +27,7 @@ function handleEmailReceipt( items: BillingTransaction[], dispatch: AppDispatch 
 	dispatch( sendBillingReceiptEmail( items[ 0 ].id ) );
 }
 
-export function useReceiptActions(
-	getReceiptUrlFor?: ( receiptId: string ) => string
-): ReceiptAction[] {
+export function useReceiptActions(): ReceiptAction[] {
 	const dispatch = useDispatch< AppDispatch >();
 	const translate = useTranslate();
 

--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -30,7 +30,7 @@ export function BillingHistoryContent( {
 	return (
 		<Card className="billing-history__receipts">
 			{ useDataViewBillingHistoryList ? (
-				<BillingHistoryListDataView getReceiptUrlFor={ getReceiptUrlFor } />
+				<BillingHistoryListDataView />
 			) : (
 				<BillingHistoryList header siteId={ siteId } getReceiptUrlFor={ getReceiptUrlFor } />
 			) }

--- a/client/me/purchases/billing-history/receipt-modal.tsx
+++ b/client/me/purchases/billing-history/receipt-modal.tsx
@@ -1,0 +1,202 @@
+import { FormLabel } from '@automattic/components';
+import { formatCurrency } from '@automattic/format-currency';
+import { Button } from '@wordpress/components';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { useState, useCallback } from 'react';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import TextareaAutosize from 'calypso/components/textarea-autosize';
+import { useTaxName } from 'calypso/my-sites/checkout/src/hooks/use-country-list';
+import { useDispatch } from 'calypso/state';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { getTransactionTermLabel, transactionIncludesTax } from './utils';
+import type { BillingTransaction } from 'calypso/state/billing-transactions/types';
+
+import './style-modal.scss';
+
+interface ReceiptModalProps {
+	item: BillingTransaction;
+	closeModal: () => void;
+}
+
+function ReceiptLabels( { hideDetailsLabelOnPrint }: { hideDetailsLabelOnPrint?: boolean } ) {
+	const translate = useTranslate();
+
+	const labelContent = translate(
+		'Use this field to add your billing information (eg. business address) before printing.'
+	);
+
+	return (
+		<div>
+			<FormLabel
+				htmlFor="billing-history__billing-details-textarea"
+				className={ clsx( { 'receipt__no-print': hideDetailsLabelOnPrint } ) }
+			>
+				{ translate( 'Billing Details' ) }
+			</FormLabel>
+			<div
+				className="billing-history__billing-details-description"
+				id="billing-history__billing-details-description"
+			>
+				{ labelContent }
+			</div>
+		</div>
+	);
+}
+
+function BillingDetails( { transaction }: { transaction: BillingTransaction } ) {
+	const [ hideDetailsLabelOnPrint, setHideDetailsLabelOnPrint ] = useState( true );
+	const onChange = useCallback(
+		( e: React.ChangeEvent< HTMLTextAreaElement > ) => {
+			const value = e.target.value.trim();
+			if ( hideDetailsLabelOnPrint && value.length > 0 ) {
+				setHideDetailsLabelOnPrint( false );
+			} else if ( ! hideDetailsLabelOnPrint && value.length === 0 ) {
+				setHideDetailsLabelOnPrint( true );
+			}
+		},
+		[ hideDetailsLabelOnPrint, setHideDetailsLabelOnPrint ]
+	);
+
+	const defaultValue =
+		transaction.cc_name === 'Not Stored' && transaction.cc_email === 'Not Stored'
+			? ''
+			: `${ transaction.cc_name !== 'Not Stored' ? transaction.cc_name || '' : '' }\n${
+					transaction.cc_email !== 'Not Stored' ? transaction.cc_email || '' : ''
+			  }`.trim();
+
+	return (
+		<li className="billing-history__billing-details">
+			<ReceiptLabels hideDetailsLabelOnPrint={ hideDetailsLabelOnPrint } />
+			<TextareaAutosize
+				className="billing-history__billing-details-editable"
+				aria-labelledby="billing-history__billing-details-description"
+				id="billing-history__billing-details-textarea"
+				rows={ 1 }
+				defaultValue={ defaultValue }
+				onChange={ onChange }
+			/>
+		</li>
+	);
+}
+
+export default function ReceiptModal( { item }: ReceiptModalProps ) {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+	const taxName = useTaxName( item.tax_country_code );
+	const reduxDispatch = useDispatch();
+
+	const handlePrintClick = () => {
+		reduxDispatch(
+			recordGoogleEvent( 'Me', 'Clicked on Print Receipt Button in Billing History Receipt' )
+		);
+		window.print();
+	};
+
+	return (
+		<div className="billing-history-receipt-modal">
+			<div className="billing-history__app-overview">
+				<img src={ item.icon } title={ item.service } alt={ item.service } />
+				<h2>
+					{ item.service }
+					<small>
+						{ translate( 'by %(organization)s', {
+							args: { organization: item.org },
+						} ) }
+					</small>
+					<small className="billing-history__organization-address">{ item.address }</small>
+				</h2>
+				<span className="billing-history__transaction-date">
+					{ moment( item.date ).format( 'll' ) }
+				</span>
+			</div>
+
+			<div className="billing-history__receipt-details">
+				<div className="billing-history__receipt-detail">
+					<strong>{ translate( 'Receipt ID' ) }</strong>
+					<span>{ item.id }</span>
+				</div>
+				{ item.pay_ref && (
+					<div className="billing-history__receipt-detail">
+						<strong>{ translate( 'Transaction ID' ) }</strong>
+						<span>{ item.pay_ref }</span>
+					</div>
+				) }
+				<div className="billing-history__receipt-detail">
+					<strong>{ translate( 'Payment Method' ) }</strong>
+					<span>
+						{ item.cc_type } { item.cc_num }
+					</span>
+				</div>
+				<BillingDetails transaction={ item } />
+			</div>
+
+			<div className="billing-history__receipt">
+				<h4>{ translate( 'Order summary' ) }</h4>
+				<table className="billing-history__receipt-line-items">
+					<thead>
+						<tr>
+							<th className="billing-history__receipt-desc">{ translate( 'Description' ) }</th>
+							<th className="billing-history__receipt-amount">{ translate( 'Amount' ) }</th>
+						</tr>
+					</thead>
+					<tbody>
+						{ item.items.map( ( receiptItem ) => {
+							const termLabel = getTransactionTermLabel( receiptItem, translate );
+							return (
+								<tr key={ receiptItem.id }>
+									<td className="billing-history__receipt-item-name">
+										<span>{ receiptItem.variation }</span>
+										<small>({ receiptItem.type_localized })</small>
+										{ termLabel && <em>{ termLabel }</em> }
+										{ receiptItem.domain && <em>{ receiptItem.domain }</em> }
+									</td>
+									<td className="billing-history__receipt-amount">
+										{ formatCurrency( receiptItem.amount_integer, item.currency, {
+											isSmallestUnit: true,
+											stripZeros: true,
+										} ) }
+									</td>
+								</tr>
+							);
+						} ) }
+						{ transactionIncludesTax( item ) && (
+							<tr>
+								<td colSpan={ 2 }>
+									<div className="billing-history__transaction-tax-amount">
+										<span>{ taxName ?? translate( 'Tax' ) }</span>
+										<span>
+											{ formatCurrency( item.tax_integer, item.currency, {
+												isSmallestUnit: true,
+												stripZeros: true,
+											} ) }
+										</span>
+									</div>
+								</td>
+							</tr>
+						) }
+					</tbody>
+					<tfoot>
+						<tr>
+							<td className="billing-history__receipt-desc">
+								<strong>{ translate( 'Total paid:' ) }</strong>
+							</td>
+							<td className="billing-history__receipt-amount billing-history__total-amount">
+								{ formatCurrency( item.amount_integer, item.currency, {
+									isSmallestUnit: true,
+									stripZeros: true,
+								} ) }
+							</td>
+						</tr>
+					</tfoot>
+				</table>
+			</div>
+
+			<div className="billing-history__receipt-links">
+				<Button variant="primary" onClick={ handlePrintClick }>
+					{ translate( 'Print Receipt' ) }
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/client/me/purchases/billing-history/receipt-modal.tsx
+++ b/client/me/purchases/billing-history/receipt-modal.tsx
@@ -4,12 +4,12 @@ import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import TextareaAutosize from 'calypso/components/textarea-autosize';
+import { PARTNER_PAYPAL_EXPRESS, PARTNER_PAYPAL_PPCP } from 'calypso/lib/checkout/payment-methods';
 import { useTaxName } from 'calypso/my-sites/checkout/src/hooks/use-country-list';
 import { useDispatch } from 'calypso/state';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
-import { getTransactionTermLabel, transactionIncludesTax } from './utils';
+import { getTransactionTermLabel, transactionIncludesTax, formatDisplayDate } from './utils';
 import type { BillingTransaction } from 'calypso/state/billing-transactions/types';
 
 import './style-modal.scss';
@@ -44,7 +44,7 @@ function ReceiptLabels( { hideDetailsLabelOnPrint }: { hideDetailsLabelOnPrint?:
 	);
 }
 
-function BillingDetails( { transaction }: { transaction: BillingTransaction } ) {
+function BillingDetails() {
 	const [ hideDetailsLabelOnPrint, setHideDetailsLabelOnPrint ] = useState( true );
 	const onChange = useCallback(
 		( e: React.ChangeEvent< HTMLTextAreaElement > ) => {
@@ -58,31 +58,53 @@ function BillingDetails( { transaction }: { transaction: BillingTransaction } ) 
 		[ hideDetailsLabelOnPrint, setHideDetailsLabelOnPrint ]
 	);
 
-	const defaultValue =
-		transaction.cc_name === 'Not Stored' && transaction.cc_email === 'Not Stored'
-			? ''
-			: `${ transaction.cc_name !== 'Not Stored' ? transaction.cc_name || '' : '' }\n${
-					transaction.cc_email !== 'Not Stored' ? transaction.cc_email || '' : ''
-			  }`.trim();
-
 	return (
-		<li className="billing-history__billing-details">
+		<div className="billing-history__billing-details">
 			<ReceiptLabels hideDetailsLabelOnPrint={ hideDetailsLabelOnPrint } />
 			<TextareaAutosize
 				className="billing-history__billing-details-editable"
 				aria-labelledby="billing-history__billing-details-description"
 				id="billing-history__billing-details-textarea"
 				rows={ 1 }
-				defaultValue={ defaultValue }
+				defaultValue=""
 				onChange={ onChange }
 			/>
-		</li>
+		</div>
+	);
+}
+
+function ReceiptPaymentMethod( { transaction }: { transaction: BillingTransaction } ) {
+	const translate = useTranslate();
+	let text;
+
+	if (
+		transaction.pay_part === PARTNER_PAYPAL_EXPRESS ||
+		transaction.pay_part === PARTNER_PAYPAL_PPCP
+	) {
+		text = translate( 'PayPal' );
+	} else if ( 'XXXX' !== transaction.cc_num ) {
+		text = translate( '%(cardType)s ending in %(cardNum)s', {
+			args: {
+				cardType:
+					transaction.cc_display_brand?.replace( '_', ' ' ).toUpperCase() ??
+					transaction.cc_type.toUpperCase(),
+				cardNum: transaction.cc_num,
+			},
+		} );
+	} else {
+		return null;
+	}
+
+	return (
+		<div className="billing-history__receipt-detail">
+			<strong>{ translate( 'Payment Method' ) }</strong>
+			<span>{ text }</span>
+		</div>
 	);
 }
 
 export default function ReceiptModal( { item }: ReceiptModalProps ) {
 	const translate = useTranslate();
-	const moment = useLocalizedMoment();
 	const taxName = useTaxName( item.tax_country_code );
 	const reduxDispatch = useDispatch();
 
@@ -107,7 +129,7 @@ export default function ReceiptModal( { item }: ReceiptModalProps ) {
 					<small className="billing-history__organization-address">{ item.address }</small>
 				</h2>
 				<span className="billing-history__transaction-date">
-					{ moment( item.date ).format( 'll' ) }
+					{ formatDisplayDate( new Date( item.date ) ) }
 				</span>
 			</div>
 
@@ -122,13 +144,8 @@ export default function ReceiptModal( { item }: ReceiptModalProps ) {
 						<span>{ item.pay_ref }</span>
 					</div>
 				) }
-				<div className="billing-history__receipt-detail">
-					<strong>{ translate( 'Payment Method' ) }</strong>
-					<span>
-						{ item.cc_type } { item.cc_num }
-					</span>
-				</div>
-				<BillingDetails transaction={ item } />
+				<ReceiptPaymentMethod transaction={ item } />
+				<BillingDetails />
 			</div>
 
 			<div className="billing-history__receipt">

--- a/client/me/purchases/billing-history/style-modal.scss
+++ b/client/me/purchases/billing-history/style-modal.scss
@@ -1,0 +1,140 @@
+@media print {
+
+	body > *:not(.components-modal__screen-overlay),
+	.components-modal__screen-overlay > *:not(.components-modal__frame),
+	.components-modal__frame > *:not(.components-modal__content),
+	.components-modal__header,
+	.components-modal__header-heading-container,
+	.interface-interface-skeleton__header,
+	.interface-interface-skeleton__footer,
+	.interface-interface-skeleton__sidebar,
+	.interface-interface-skeleton__secondary-sidebar {
+		display: none !important;
+	}
+
+	.components-modal__content {
+		position: static !important;
+		transform: none !important;
+		margin: 0 !important;
+		padding: 0 !important;
+		height: auto !important;
+		box-shadow: none !important;
+		background: none !important;
+		overflow: visible !important;
+		width: 100% !important;
+	}
+
+	.components-modal__frame {
+		position: static !important;
+		transform: none !important;
+		height: auto !important;
+		max-height: none !important;
+		background: none !important;
+		box-shadow: none !important;
+		overflow: visible !important;
+		width: 100% !important;
+		margin: 0 !important;
+		top: 0 !important;
+	}
+
+	.billing-history-receipt-modal {
+		margin: 0;
+		padding: 20px;
+		width: 100%;
+		max-width: none;
+		position: static !important;
+		overflow: visible !important;
+		
+		.billing-history__receipt-links {
+			display: none !important;
+		}
+
+		.billing-history__billing-details-description {
+			display: none !important;
+		}
+
+		.billing-history__billing-details-editable {
+			background: transparent;
+			border: 0;
+			padding: 0;
+			margin: 0;
+		}
+
+		.receipt__no-print {
+			display: none !important;
+		}
+
+		.billing-history__receipt-line-items {
+			width: 100%;
+			border-collapse: collapse;
+		}
+	}
+
+	body {
+		font-family: $sans;
+		margin: 0 !important;
+		padding: 0 !important;
+	}
+
+	@page {
+		margin: 20px;
+	}
+}
+
+.billing-history-receipt-modal {
+	.billing-history__billing-details {
+		margin: 15px 0;
+	}
+
+    .billing-history__receipt-detail {
+        color: var(--color-neutral-50);
+        display: block;
+        font-size: 0.75rem;
+        margin: 0 5px 0 0;
+        text-transform: uppercase;
+    }
+
+    .billing-history__receipt-detail strong {
+        display: block;
+        font-weight: 600;
+    }
+
+    .billing-history__receipt-detail span {
+        display: block;
+        margin-bottom: 10px;
+    }
+
+	.billing-history__billing-details-description {
+		display: block;
+		font-size: $font-body-small;
+		font-style: italic;
+		margin-bottom: 5px;
+	}
+
+	.billing-history__billing-details-editable {
+		width: 100%;
+		min-height: 20px;
+		padding: 8px;
+		border: 1px solid var(--color-neutral-20);
+		border-radius: 2px;
+		font-size: $font-body-small;
+		resize: vertical;
+	}
+    
+}
+
+.dataviews-action-modal__view-receipt {
+	@media ( min-width: 600px ) {
+		.components-modal__frame.has-size-small {
+			max-width: 840vw;
+			width: 80vw;
+		}
+	}
+
+    @media (min-width: 960px) {
+		.components-modal__frame {
+			max-height: 80vh;
+			height: 80vh;
+		}
+    }
+}


### PR DESCRIPTION
Related to https://github.com/Automattic/payments-florin/issues/739

## Proposed Changes

* The DataViews component has a modal feature built into it.  This PR replaces the receipt view in the Billing History component with the modal view.

More details in a bit....

## Why are these changes being made?

*

## Testing Instructions

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
