### PR TITLE
[Brand update] Replace font with proxima-vara in Woo screens

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1283,10 +1283,7 @@ $breakpoint-mobile: 660px;
 
 		h1,
 		h2,
-		h3,
-		h4,
-		h5,
-		h6 {
+		h3 {
 			font-family: var(--woo-font-family-header);
 			font-feature-settings: "ss01" on, "salt" on;
 		}
@@ -1729,6 +1726,7 @@ $breakpoint-mobile: 660px;
 			margin-top: 0;
 
 			h1.magic-login__form-header {
+				font-family: var(--woo-font-family-header);
 				color: var(--studio-gray-100);
 				text-align: center;
 				font-size: 2.25rem;
@@ -2254,10 +2252,7 @@ $breakpoint-mobile: 660px;
 
 	h1,
 	h2,
-	h3,
-	h4,
-	h5,
-	h6 {
+	h3 {
 		font-feature-settings: "ss04";
 	}
 

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -92,6 +92,7 @@ $breakpoint-mobile: 660px;
 	--woo-purple-50: #7f54b3;
 	--woo-purple-60: #674399;
 	--woo-purple-70: #533582;
+	--woo-font-family-header: proxima-nova, sans-serif;
 	$woo-label-color: #50575e;
 	$woo-gray-100: #101517;
 	$woo-gray-40: #787c82;
@@ -110,10 +111,6 @@ $breakpoint-mobile: 660px;
 
 	background: #fff;
 	min-height: 100%;
-
-	* {
-		font-family: proxima-nova, sans-serif;
-	}
 
 	&.layout.is-section-login {
 		min-height: 100%;
@@ -1285,10 +1282,18 @@ $breakpoint-mobile: 660px;
 		}
 
 		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6 {
+			font-family: var(--woo-font-family-header);
+			font-feature-settings: "ss01" on, "salt" on;
+		}
+
+		h1,
 		h3 {
 			color: var(--studio-gray-100);
-			font-feature-settings: "ss01" on, "salt" on;
-			font-family: proxima-nova, sans-serif;
 			text-align: center;
 			font-size: 2.25rem;
 			font-weight: 700;
@@ -1725,8 +1730,6 @@ $breakpoint-mobile: 660px;
 
 			h1.magic-login__form-header {
 				color: var(--studio-gray-100);
-				font-feature-settings: "ss01" on, "salt" on;
-				font-family: proxima-nova, sans-serif;
 				text-align: center;
 				font-size: 2.25rem;
 				font-weight: 700;
@@ -2247,6 +2250,16 @@ $breakpoint-mobile: 660px;
 	--woo-purple-50: #720EEC;
 	--woo-purple-60: #6108CE;
 	--woo-purple-70: #5007AA;
+	--woo-font-family-header: proxima-vara, 'Proxima Fallback', sans-serif;
+
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
+		font-feature-settings: "ss04";
+	}
 
 	.masterbar__woo {
 		.masterbar__woo-nav {

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -542,6 +542,7 @@ function setUpCSP( req, res, next ) {
 			'*.wp.com',
 			'https://fonts.gstatic.com',
 			'use.typekit.net',
+			'https://woocommerce.com',
 			'data:', // should remove 'data:' ASAP
 		],
 		'media-src': [ "'self'" ],

--- a/packages/typography/styles/woo-commerce.scss
+++ b/packages/typography/styles/woo-commerce.scss
@@ -10,15 +10,6 @@
 	src: url(https://woocommerce.com/wp-content/themes/woo/fonts/proxima-vara/ProximaVara.woff2) format('woff2 supports variations'), url(https://woocommerce.com/wp-content/themes/woo/fonts/proxima-vara/ProximaVara.woff2) format('woff2-variations');
 }
 
-/* The Proxima Vara font will fallback to the name 'Proxima Nova' since its used as inline on many pages. */
-@font-face {
-	font-display: swap;
-	font-family: proxima-nova;
-	font-style: normal;
-	font-weight: 400 700;
-	src: url(https://woocommerce.com/wp-content/themes/woo/fonts/proxima-vara/ProximaVara.woff2) format('woff2 supports variations'), url(https://woocommerce.com/wp-content/themes/woo/fonts/proxima-vara/ProximaVara.woff2) format('woff2-variations');
-}
-
 @font-face {
 	ascent-override: 95%;
 	font-family: 'Proxima Fallback';

--- a/packages/typography/styles/woo-commerce.scss
+++ b/packages/typography/styles/woo-commerce.scss
@@ -1,5 +1,31 @@
 @import "./variables";
 
+
+/* Proxima Vara Font */
+@font-face {
+	font-display: swap;
+	font-family: proxima-vara;
+	font-style: normal;
+	font-weight: 400 700;
+	src: url(https://woocommerce.com/wp-content/themes/woo/fonts/proxima-vara/ProximaVara.woff2) format('woff2 supports variations'), url(https://woocommerce.com/wp-content/themes/woo/fonts/proxima-vara/ProximaVara.woff2) format('woff2-variations');
+}
+
+/* The Proxima Vara font will fallback to the name 'Proxima Nova' since its used as inline on many pages. */
+@font-face {
+	font-display: swap;
+	font-family: proxima-nova;
+	font-style: normal;
+	font-weight: 400 700;
+	src: url(https://woocommerce.com/wp-content/themes/woo/fonts/proxima-vara/ProximaVara.woff2) format('woff2 supports variations'), url(https://woocommerce.com/wp-content/themes/woo/fonts/proxima-vara/ProximaVara.woff2) format('woff2-variations');
+}
+
+@font-face {
+	ascent-override: 95%;
+	font-family: 'Proxima Fallback';
+	size-adjust: 99.9%;
+	src: local('Arial');
+}
+
 $woo-title-font: "Proxima Nova", $sans;
 
 $woo-font-headline-large: rem(54px);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98191


## Proposed Changes

- Load the Proxima Vara from WooCommerce.com.
- Apply the Proxima Vara fonts to glyph to use ss04 on all WooCommerce.com auth screens (Login, Signup, Reset password, Authorize account) when rebranding feature flag is enabled.
- Add woocommerce.com to font-src in the CSP header.

![Screenshot 2025-01-16 at 11 29 28](https://github.com/user-attachments/assets/3ccaed59-349a-45a7-9977-6b56419ae494)

![Screenshot 2025-01-16 at 11 46 10](https://github.com/user-attachments/assets/7c87c452-7eb5-4a83-b31d-c239be716a89)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To make the auth screens look more consistent with the new brand.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Use the Calypso Live link or local calypso env

- For Calypso Live, open the browser console and run `window.sessionStorage.setItem( 'flags', 'woocommerce/rebrand-2-0,woocommerce/core-profiler-passwordless-auth,woo/passwordless' );`

1. Go to https://woocommerce.com
2. Click on `Login` button
3. Replace the URL host with local or calypso live host
4. Check if the heading text is using Proxima Vara fonts with ss04 feature settings on all auth screens  (Login, Signup, Reset password, Authorize account) .


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
