### PR TITLE
Bulk actions notification improvements

### DIFF
--- a/client/my-sites/domains/domain-management/dataviews/components/bulk-update-notice.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/components/bulk-update-notice.tsx
@@ -55,13 +55,18 @@ export const BulkUpdateNotice = () => {
 				);
 			}
 
+			const message =
+				job.success.length > 1
+					? translate( 'Bulk domain updates finished successfully.' )
+					: translate( 'Domain update finished successfully.' );
+
 			return (
 				<Notice
 					key={ job.id }
 					status="is-success"
 					onDismissClick={ () => handleDismissNotice( job.id ) }
 				>
-					{ translate( 'Bulk domain updates finished successfully.' ) }
+					{ message }
 				</Notice>
 			);
 		} );

--- a/client/my-sites/domains/domain-management/dataviews/domains-dataviews.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/domains-dataviews.tsx
@@ -79,23 +79,25 @@ export const DomainsDataViews = ( {
 
 	const layout = sidebarMode ? { list: {} } : { table: {} };
 	return (
-		<div className={ clsx( 'domains-dataviews', { 'domains-dataviews-list': sidebarMode } ) }>
+		<>
 			{ ! sidebarMode && <BulkUpdateNotice /> }
-			<DataViews
-				data={ domainsToDisplay }
-				fields={ fields }
-				onChangeView={ ( newView ) => setView( () => newView ) }
-				view={ view }
-				actions={ actions }
-				search
-				searchLabel={ translate( 'Search by domain…' ) }
-				paginationInfo={ paginationInfo }
-				getItemId={ getDomainId }
-				selection={ selectedDomain ? [ getDomainId( selectedDomain ) ] : selectedIds }
-				onChangeSelection={ setSelectedIds }
-				isLoading={ isLoading }
-				defaultLayouts={ layout }
-			/>
-		</div>
+			<div className={ clsx( 'domains-dataviews', { 'domains-dataviews-list': sidebarMode } ) }>
+				<DataViews
+					data={ domainsToDisplay }
+					fields={ fields }
+					onChangeView={ ( newView ) => setView( () => newView ) }
+					view={ view }
+					actions={ actions }
+					search
+					searchLabel={ translate( 'Search by domain…' ) }
+					paginationInfo={ paginationInfo }
+					getItemId={ getDomainId }
+					selection={ selectedDomain ? [ getDomainId( selectedDomain ) ] : selectedIds }
+					onChangeSelection={ setSelectedIds }
+					isLoading={ isLoading }
+					defaultLayouts={ layout }
+				/>
+			</div>
+		</>
 	);
 };


### PR DESCRIPTION
Built on top of https://github.com/Automattic/wp-calypso/pull/98456

## Proposed Changes

* Fix showing bulk action notification: don't hide the toolbar at the bottom.
* Show the successful message depending on the quantity of affected domains.

## Why are these changes being made?

* Fix appearance and have better communication.

## Testing Instructions

* Turn on feature flags in your browser's console: `window.sessionStorage.setItem('flags', ['calypso/all-domain-management', 'calypso/domains-dataviews'])`.
* Go to http://calypso.localhost:3000/plugins/manage
* Make sure you have at least two domains for bulk actions. Perhaps you should own them.
* Tick both domains and click on auto-renew button at the bottom (two arrows icon).
* Wait until the bulk action notification appears.
* Make sure the toolbar at the bottom (with bulk actions) didn't disappear.
* Make sure the message was "Bulk domain updates finished successfully.".
* Now tick only one domain (or use actions menu for a domain) and perform the same auto-renew action.
* Wait for the notification and make sure the message was: "Domain update finished successfully."

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
