### PR TITLE
Stats: Update feedback modal with a link to our support form

### DIFF
--- a/client/my-sites/stats/feedback/modal/index.tsx
+++ b/client/my-sites/stats/feedback/modal/index.tsx
@@ -130,9 +130,27 @@ const FeedbackModal: React.FC< ModalProps > = ( { siteId, onClose } ) => {
 				</h1>
 
 				<div className="stats-feedback-modal__text">
-					{ translate(
-						'We value your opinion and would love to hear more about your experience. Please share any specific thoughts or suggestions you have to improve Jetpack.'
-					) }
+					<p>
+						{ translate(
+							'We value your opinion and would love to hear more about your experience. Please share any specific thoughts or suggestions you have to improve Jetpack.'
+						) }
+					</p>
+					<p>
+						{ translate(
+							'Note: This form is for general feedback only. If you need a reply from our Happiness Engineers, please use our {{link}}contact form{{/link}} to get in touch.',
+							{
+								components: {
+									link: (
+										<a
+											target="_blank"
+											rel="noreferrer"
+											href="https://jetpack.com/contact-support/"
+										/>
+									),
+								},
+							}
+						) }
+					</p>
 				</div>
 				<TextareaControl
 					rows={ 5 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

p1735290475805319-slack-C82FZ5T4G

## Proposed Changes

Updates the copy in the Feedback modal to note this isn't a support channel and includes a link to the support form on Jetpack.com.

<img width="722" alt="SCR-20250116-mser" src="https://github.com/user-attachments/assets/1710b6f8-a581-4c24-9e15-4f322355e3a9" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Per linked Slack convo, some users are getting in touch with support issues (ie: needs a reply or follow-up) via the feedback flow. Hoping this helps clarify this is not for support.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live link.
* Visit a site which meets the feedback requirements. (10k+ traffic or a paid plan)
* Click the button in the prompt or inline Feedback card to bring up the Feedback modal.
* Confirm the new copy is present.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?