### PR TITLE
Analytics: Handle JSON stringify errors

### DIFF
--- a/client/lib/analytics/ad-tracking/debug.js
+++ b/client/lib/analytics/ad-tracking/debug.js
@@ -1,18 +1,22 @@
 export function circularReferenceSafeJSONStringify( json, space ) {
-	let cache = [];
-	const str = JSON.stringify(
-		json,
-		function ( key, value ) {
-			if ( typeof value === 'object' && value !== null ) {
-				if ( cache.indexOf( value ) !== -1 ) {
-					return 'Circular reference';
+	try {
+		let cache = [];
+		const str = JSON.stringify(
+			json,
+			function ( key, value ) {
+				if ( typeof value === 'object' && value !== null ) {
+					if ( cache.indexOf( value ) !== -1 ) {
+						return 'Circular reference';
+					}
+					cache.push( value );
 				}
-				cache.push( value );
-			}
-			return value;
-		},
-		space
-	);
-	cache = null;
-	return str;
+				return value;
+			},
+			space
+		);
+		cache = null;
+		return str;
+	} catch ( e ) {
+		return 'Error: ' + e.message;
+	}
 }


### PR DESCRIPTION
## Proposed Changes

Handle errors in JSON stringify when debugging analytics.

## Why are these changes being made?

Just handling potential errors.

See https://github.com/Automattic/wp-calypso/pull/98326 and #98464

## Testing Instructions

Same as https://github.com/Automattic/wp-calypso/pull/98326.