### PR TITLE
Help Center: Add wait time indicators and refactor button configuration

### DIFF
--- a/packages/help-center/src/components/help-center-feedback-form.tsx
+++ b/packages/help-center/src/components/help-center-feedback-form.tsx
@@ -57,7 +57,12 @@ const HelpCenterFeedbackForm = ( { postId }: { postId: number } ) => {
 		);
 	};
 
-	const handleContactSupportClick = async () => {
+	const handleContactSupportClick = async ( destination: string ) => {
+		recordTracksEvent( 'calypso_odie_chat_get_support', {
+			location: 'article-feedback',
+			destination,
+			is_user_eligible: isUserEligibleForPaidSupport,
+		} );
 		generateContactOnClickEvent( 'chat', 'calypso_helpcenter_feedback_contact_support' );
 		if ( isUserEligibleForPaidSupport ) {
 			await resetSupportInteraction();

--- a/packages/odie-client/src/components/message/dislike-feedback-message.tsx
+++ b/packages/odie-client/src/components/message/dislike-feedback-message.tsx
@@ -7,12 +7,12 @@ import { GetSupport } from './get-support';
 export const DislikeFeedbackMessage = () => {
 	const { botName, isUserEligibleForPaidSupport, trackEvent } = useOdieAssistantContext();
 
-	const handleContactSupportClick = () => {
-		trackEvent( 'chat_dislike_feedback', {
-			force_site_id: true,
-			bot_name: botName,
-			location: 'chat',
+	const handleContactSupportClick = ( destination: string ) => {
+		trackEvent( 'chat_get_support', {
+			location: 'dislike-feedback',
+			destination,
 			is_user_eligible: isUserEligibleForPaidSupport,
+			bot_name: botName,
 		} );
 	};
 

--- a/packages/odie-client/src/components/message/get-support.scss
+++ b/packages/odie-client/src/components/message/get-support.scss
@@ -44,6 +44,20 @@
 .help-center__container-chat .chatbox-messages {
 	.odie__transfer-chat {
 		margin-left: 46px;
+		flex-direction: column;
+    	align-items: flex-start;
+		gap: 8px;
+
+		.odie__transfer-chat--button-container {
+			display: flex;
+			gap: 8px;
+
+			.odie__transfer-chat--wait-time {
+				font-size: 0.75rem;	
+				color: var(--studio-gray-50);
+				align-content: center;
+			}
+		}
 	}
 
 	.help-center__cookie-warning {

--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -14,6 +14,7 @@ interface GetSupportProps {
 interface ButtonConfig {
 	text: string;
 	action: () => Promise< void >;
+	waitTimeText?: string;
 }
 
 export const NewThirdPartyCookiesNotice: React.FC = () => {
@@ -63,36 +64,57 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 		return <NewThirdPartyCookiesNotice />;
 	}
 
-	const getButtonConfig = (): ButtonConfig => {
+	const getButtonConfig = (): ButtonConfig[] => {
 		if ( isUserEligibleForPaidSupport || contextIsUserEligibleForPaidSupport ) {
-			return {
-				text: __( 'Get instant support', __i18n_text_domain__ ),
-				action: async () => {
-					onClickAdditionalEvent?.( 'chat' );
-					await newConversation();
+			return [
+				{
+					text: __( 'Get instant support', __i18n_text_domain__ ),
+					waitTimeText: __( 'Wait < 2 min', __i18n_text_domain__ ),
+					action: async () => {
+						onClickAdditionalEvent?.( 'chat' );
+						await newConversation();
+					},
 				},
-			};
+				{
+					text: __( 'Hear back soon', __i18n_text_domain__ ),
+					waitTimeText: __( 'Wait < 8 hrs', __i18n_text_domain__ ),
+					action: async () => {
+						onClickAdditionalEvent?.( 'email' );
+						await newConversation();
+					},
+				},
+			];
 		}
 
-		return {
-			text: __( 'Ask in our forums', __i18n_text_domain__ ),
-			action: async () => {
-				onClickAdditionalEvent?.( 'forum' );
-				navigate( '/contact-form?mode=FORUM' );
+		return [
+			{
+				text: __( 'Ask in our forums', __i18n_text_domain__ ),
+				action: async () => {
+					onClickAdditionalEvent?.( 'forum' );
+					navigate( '/contact-form?mode=FORUM' );
+				},
 			},
-		};
+		];
 	};
 
 	const buttonConfig = getButtonConfig();
 
-	const handleClick = async ( event: React.MouseEvent< HTMLButtonElement > ) => {
+	const handleClick = async (
+		event: React.MouseEvent< HTMLButtonElement >,
+		button: ButtonConfig
+	) => {
 		event.preventDefault();
-		await buttonConfig.action();
+		await button.action();
 	};
 
 	return (
 		<div className="odie__transfer-chat">
-			<button onClick={ handleClick }>{ buttonConfig.text }</button>
+			{ buttonConfig.map( ( button, index ) => (
+				<div className="odie__transfer-chat--button-container" key={ index }>
+					<button onClick={ ( e ) => handleClick( e, button ) }>{ button.text }</button>
+					<span className="odie__transfer-chat--wait-time">{ button.waitTimeText }</span>
+				</div>
+			) ) }
 		</div>
 	);
 };

--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -1,5 +1,5 @@
-import { localizeUrl } from '@automattic/i18n-utils';
-import { __ } from '@wordpress/i18n';
+import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
+import { __, hasTranslation } from '@wordpress/i18n';
 import { useNavigate } from 'react-router-dom';
 import { useOdieAssistantContext } from '../../context';
 import { useCreateZendeskConversation } from '../../hooks';
@@ -51,6 +51,7 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 		isUserEligibleForPaidSupport: contextIsUserEligibleForPaidSupport,
 		canConnectToZendesk,
 	} = useOdieAssistantContext();
+	const isEnglishLocale = useIsEnglishLocale();
 
 	// Early return if user is already talking to a human
 	if ( chat.provider !== 'odie' ) {
@@ -68,8 +69,14 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 		if ( isUserEligibleForPaidSupport || contextIsUserEligibleForPaidSupport ) {
 			return [
 				{
-					text: __( 'Chat with support', __i18n_text_domain__ ),
-					waitTimeText: __( 'Average wait time < 5 minutes', __i18n_text_domain__ ),
+					text:
+						isEnglishLocale || hasTranslation( 'Chat with support' )
+							? __( 'Chat with support', __i18n_text_domain__ )
+							: __( 'Get instant support', __i18n_text_domain__ ),
+					waitTimeText:
+						isEnglishLocale || hasTranslation( 'Average wait time < 5 minutes' )
+							? __( 'Average wait time < 5 minutes', __i18n_text_domain__ )
+							: undefined,
 					action: async () => {
 						onClickAdditionalEvent?.( 'chat' );
 						await newConversation();
@@ -77,7 +84,10 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 				},
 				{
 					text: __( 'Email support', __i18n_text_domain__ ),
-					waitTimeText: __( 'Average wait time < 8 hours', __i18n_text_domain__ ),
+					waitTimeText:
+						isEnglishLocale || hasTranslation( 'Average wait time < 8 hours' )
+							? __( 'Average wait time < 8 hours', __i18n_text_domain__ )
+							: undefined,
 					action: async () => {
 						onClickAdditionalEvent?.( 'email' );
 						await newConversation();

--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -68,16 +68,16 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 		if ( isUserEligibleForPaidSupport || contextIsUserEligibleForPaidSupport ) {
 			return [
 				{
-					text: __( 'Get instant support', __i18n_text_domain__ ),
-					waitTimeText: __( 'Wait < 2 min', __i18n_text_domain__ ),
+					text: __( 'Chat with support', __i18n_text_domain__ ),
+					waitTimeText: __( 'Average wait time < 5 minutes', __i18n_text_domain__ ),
 					action: async () => {
 						onClickAdditionalEvent?.( 'chat' );
 						await newConversation();
 					},
 				},
 				{
-					text: __( 'Hear back soon', __i18n_text_domain__ ),
-					waitTimeText: __( 'Wait < 8 hrs', __i18n_text_domain__ ),
+					text: __( 'Email support', __i18n_text_domain__ ),
+					waitTimeText: __( 'Average wait time < 8 hours', __i18n_text_domain__ ),
 					action: async () => {
 						onClickAdditionalEvent?.( 'email' );
 						await newConversation();

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -41,7 +41,7 @@ export const UserMessage = ( {
 
 	const handleContactSupportClick = ( destination: string ) => {
 		trackEvent( 'chat_get_support', {
-			location: 'chat',
+			location: 'user-message',
 			destination,
 		} );
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1736960143485029/1736738900.915049-slack-C07D72S1135

## Proposed Changes

* Initial iteration for adding an option to email for support. 
* Both buttons will have the same functionality for now. We added tracking to differentiate the interactions.

<img width="418" alt="image" src="https://github.com/user-attachments/assets/f314b539-aef8-47fd-ab19-e20414d983a8" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Track button usage

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Open the HC and ask for "support" in odie chat.
* Verify that you see two buttons
 
* Verify both buttons start a live chat conversation.
* Verify tracks event is triggered with the correct values (`calypso_odie_chat_get_support`). 
     "Get instant support" - destination: chat
     "Hear back soon" - destination: email
