### PR TITLE
Jetpack Cloud: remove GlobalNotifications

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -63,7 +63,6 @@ import {
 } from 'calypso/state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
 import { getColorScheme, getColorSchemeFromCurrentQuery, refreshColorScheme } from './color-scheme';
-import GlobalNotifications from './global-notifications';
 import LayoutLoader from './loader';
 import { shouldLoadInlineHelp, handleScroll } from './utils';
 
@@ -427,7 +426,9 @@ class Layout extends Component {
 				{ config.isEnabled( 'legal-updates-banner' ) && (
 					<AsyncLoad require="calypso/blocks/legal-updates-banner" placeholder={ null } />
 				) }
-				{ ! isA8CForAgencies() && <GlobalNotifications /> }
+				{ ! isA8CForAgencies() && ! isJetpackCloud() && (
+					<AsyncLoad require="calypso/layout/global-notifications" placeholder={ null } />
+				) }
 				{ shouldEnableCommandPalette && (
 					<AsyncLoad require="calypso/layout/command-palette" placeholder={ null } />
 				) }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -426,7 +426,7 @@ class Layout extends Component {
 				{ config.isEnabled( 'legal-updates-banner' ) && (
 					<AsyncLoad require="calypso/blocks/legal-updates-banner" placeholder={ null } />
 				) }
-				{ ! isA8CForAgencies() && ! isJetpackCloud() && (
+				{ config.isEnabled( 'layout/global-notifications' ) && (
 					<AsyncLoad require="calypso/layout/global-notifications" placeholder={ null } />
 				) }
 				{ shouldEnableCommandPalette && (

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -63,6 +63,7 @@ import {
 } from 'calypso/state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
 import { getColorScheme, getColorSchemeFromCurrentQuery, refreshColorScheme } from './color-scheme';
+import GlobalNotifications from './global-notifications';
 import LayoutLoader from './loader';
 import { shouldLoadInlineHelp, handleScroll } from './utils';
 
@@ -426,9 +427,7 @@ class Layout extends Component {
 				{ config.isEnabled( 'legal-updates-banner' ) && (
 					<AsyncLoad require="calypso/blocks/legal-updates-banner" placeholder={ null } />
 				) }
-				{ config.isEnabled( 'layout/global-notifications' ) && (
-					<AsyncLoad require="calypso/layout/global-notifications" placeholder={ null } />
-				) }
+				{ config.isEnabled( 'layout/global-notifications' ) && <GlobalNotifications /> }
 				{ shouldEnableCommandPalette && (
 					<AsyncLoad require="calypso/layout/command-palette" placeholder={ null } />
 				) }

--- a/config/development.json
+++ b/config/development.json
@@ -118,6 +118,7 @@
 		"launchpad/new-task-definition-parser/videopress": true,
 		"launchpad/new-task-definition-parser/link-in-bio": true,
 		"layout/app-banner": true,
+		"layout/global-notifications": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -71,6 +71,7 @@
 		"launchpad-updates": false,
 		"launchpad/new-task-definition-parser": true,
 		"layout/app-banner": true,
+		"layout/global-notifications": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,

--- a/config/production.json
+++ b/config/production.json
@@ -94,6 +94,7 @@
 		"launchpad/new-task-definition-parser/newsletter": true,
 		"launchpad/new-task-definition-parser/link-in-bio": true,
 		"layout/app-banner": true,
+		"layout/global-notifications": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -91,6 +91,7 @@
 		"launchpad/new-task-definition-parser/build": true,
 		"launchpad/new-task-definition-parser/link-in-bio": true,
 		"layout/app-banner": true,
+		"layout/global-notifications": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,

--- a/config/test.json
+++ b/config/test.json
@@ -75,6 +75,7 @@
 		"launchpad/new-task-definition-parser/build": true,
 		"launchpad/new-task-definition-parser/link-in-bio": true,
 		"layout/app-banner": true,
+		"layout/global-notifications": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/site-level-user-profile": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -87,6 +87,7 @@
 		"lasagna": true,
 		"launchpad-updates": false,
 		"layout/app-banner": true,
+		"layout/global-notifications": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,


### PR DESCRIPTION
This patch removes `<GlobalNotifications>` from Jetpack Cloud layout. The Jetpack Cloud UI doesn't have any masterbar and the notifications are never shown. But the component is loaded and it's issuing redundant network requests to `/rest/v1.1/notifications` and establishes a WebSocket connection to `/rest/v1.1/pinghub/wpcom/me/newest-note-data` (visible in Network devtool).

This patch is very similar to #97712 which removed notifications from A4A.

An alternative implementation would be to create a feature flag for this feature (`layout/notifications`), defining the flag in the `config/*.json` files and checking for the flag instead.

**How to test:** Load Jetpack Cloud and verify that the `/notifications` REST requests are no longer issued.