### PR TITLE
Stop showing daily prompt modal on editor screen

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -232,8 +232,8 @@ function getPressThisData( query ) {
 }
 
 function getBloggingPromptData( query ) {
-	const { answer_prompt, new_prompt } = query;
-	return answer_prompt || new_prompt ? { answer_prompt, new_prompt } : null;
+	const { answer_prompt } = query;
+	return answer_prompt ? { answer_prompt } : null;
 }
 
 function getAnchorFmData( query ) {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -321,8 +321,7 @@ const siteSetupFlow: Flow = {
 					const intent = params[ 0 ];
 					switch ( intent ) {
 						case 'firstPost': {
-							const exitUrl = addQueryArgs( { new_prompt: true }, `/post/${ siteSlug }` );
-							return exitFlow( exitUrl );
+							return exitFlow( `/post/${ siteSlug }` );
 						}
 						case 'courses': {
 							return navigate( 'courses' );

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -126,7 +126,7 @@ const startWriting: Flow = {
 
 						return redirect(
 							`https://${ providedDependencies?.siteSlug }/wp-admin/post-new.php?` +
-								`${ START_WRITING_FLOW }=true&origin=${ siteOrigin }&new_prompt=true` +
+								`${ START_WRITING_FLOW }=true&origin=${ siteOrigin }` +
 								`&postFlowUrl=${ getPostFlowUrl( {
 									flow: START_WRITING_FLOW,
 									siteId: providedDependencies?.siteId as string,
@@ -157,7 +157,7 @@ const startWriting: Flow = {
 
 						return redirect(
 							`https://${ providedDependencies?.siteSlug }/wp-admin/post-new.php?` +
-								`${ START_WRITING_FLOW }=true&origin=${ siteOrigin }&new_prompt=true` +
+								`${ START_WRITING_FLOW }=true&origin=${ siteOrigin }` +
 								`&postFlowUrl=${ getPostFlowUrl( {
 									flow: START_WRITING_FLOW,
 									siteId: providedDependencies?.siteId as string,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/326

## Proposed Changes

Remove `new_prompt` query param from the url which will stop showing daily prompt modal on editor screen.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Removed in favour of showing inline placeholder text.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to https://wordpress.com/post/mehmoodak2.wordpress.com?new_prompt=true and verify modal is appearing.
- Pull this PR locally or use calypso live link.
- Go to calypso.localhost:3000/post/mehmoodak2.wordpress.com?new_prompt=true and verify modal is not appearing.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
