### PR TITLE
Track the domain connect provider in the connect-domain-step

### DIFF
--- a/client/components/domains/connect-domain-step/index.jsx
+++ b/client/components/domains/connect-domain-step/index.jsx
@@ -81,13 +81,15 @@ function ConnectDomainStep( {
 
 	const dispatch = useDispatch();
 	const recordMappingSetupTracksEvent = useCallback(
-		( resolvedPageSlug ) => {
+		( resolvedPageSlug, supportsOurDomainConnectTemplate, domainConnectProviderId ) => {
 			dispatch(
 				recordTracksEvent( 'calypso_domain_mapping_setup_page_view', {
 					domain,
 					page_slug: resolvedPageSlug,
 					query_error: queryError,
 					query_error_description: queryErrorDescription,
+					supports_our_domain_connect_template: supportsOurDomainConnectTemplate,
+					domain_connect_provider_id: domainConnectProviderId,
 				} )
 			);
 		},
@@ -189,7 +191,11 @@ function ConnectDomainStep( {
 					domain
 				);
 				setPageSlug( resolvedPageSlug );
-				recordMappingSetupTracksEvent( resolvedPageSlug );
+				recordMappingSetupTracksEvent(
+					resolvedPageSlug,
+					!! data?.domain_connect_apply_wpcom_hosting,
+					data?.domain_connect_provider_id
+				);
 				statusRef.current.hasLoadedStatusInfo = { [ domain ]: true };
 			} )
 			.catch( ( error ) => setDomainSetupInfoError( { error } ) )


### PR DESCRIPTION
We want to better track the usage of Domain Connect and what providers do not support our templates

## Proposed Changes

* Add `supports_our_domain_connect_template` and `domain_connect_provider_id` properties in the tracks events

## Why are these changes being made?

* Tracking the usage of the Domain Connect protocol and which providers don't support our templates

## Testing Instructions

* test with this branch 170203-ghe-Automattic/wpcom 

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?