### PR TITLE
Stats: Fix bug with module visibility not matching dropdown

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -46,6 +46,7 @@ import hasLoadedSiteFeatures from 'calypso/state/selectors/has-loaded-site-featu
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { getModuleToggles } from 'calypso/state/stats/module-toggles/selectors';
@@ -155,6 +156,25 @@ const getDefaultDaysForPeriod = ( period ) => {
 	}
 };
 
+function useModuleVisibilitySettings( siteId ) {
+	const moduleToggles = useSelector( ( state ) => getModuleToggles( state, siteId, 'traffic' ) );
+	const hasVideoPress = useSelector( ( state ) => siteHasFeature( state, siteId, 'videopress' ) );
+
+	const defaultModuleSettings = AVAILABLE_PAGE_MODULES.traffic.map( ( module ) => {
+		if ( module.key === 'videos' && ! hasVideoPress ) {
+			return { ...module, defaultValue: false, disabled: true };
+		}
+		return module;
+	} );
+
+	const defaultModuleVisibility = {};
+	defaultModuleSettings.forEach( ( module ) => {
+		defaultModuleVisibility[ module.key ] = module.defaultValue;
+	} );
+
+	return { ...defaultModuleVisibility, ...moduleToggles };
+}
+
 function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...props } ) {
 	const dispatch = useDispatch();
 	const { period } = props.period;
@@ -173,12 +193,13 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 	const isSitePrivate = useSelector( ( state ) => isPrivateSite( state, siteId ) );
 	const slug = useSelector( getSelectedSiteSlug );
-	const moduleToggles = useSelector( ( state ) => getModuleToggles( state, siteId, 'traffic' ) );
 	const momentSiteZone = useSelector( ( state ) => getMomentSiteZone( state, siteId ) );
 
 	const upsellModalView = useSelector(
 		( state ) => config.isEnabled( 'stats/paid-wpcom-v2' ) && getUpsellModalView( state, siteId )
 	);
+
+	const moduleToggles = useModuleVisibilitySettings( siteId );
 
 	const {
 		supportsPlanUsage,

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -199,7 +199,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		( state ) => config.isEnabled( 'stats/paid-wpcom-v2' ) && getUpsellModalView( state, siteId )
 	);
 
-	const moduleToggles = useModuleVisibilitySettings( siteId );
+	const moduleVisibility = useModuleVisibilitySettings( siteId );
 
 	const {
 		supportsPlanUsage,
@@ -304,7 +304,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	const isModuleHidden = ( moduleName ) => {
 		// Determine which modules are hidden.
 		// @TODO: Rearrange the layout of modules to be more flexible with hidden blocks.
-		if ( HIDDABLE_MODULES.includes( moduleName ) && moduleToggles[ moduleName ] === false ) {
+		if ( HIDDABLE_MODULES.includes( moduleName ) && moduleVisibility[ moduleName ] === false ) {
 			return true;
 		}
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Previously the defaults for module visibility where ignored when determining which modules to display on the Traffic page. If a value was set via the API, then a value would be returned and the page would draw correctly. On a new site the API can return an empty result (nothing has been stored yet) which results the page showing both Authors & Videos modules and the dropdown showing both as disabled.

These changes fix the visibility checks on the Traffic page to correctly apply the default configuration, followed by site features, and then any stored results from the API.

Of note, the dropdown appears to have a similar bug where it doesn't show the correct state initially.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Traffic page on a new site.
* Check the network tab for the `/modules` request. If the result is empty, the Authors module should be visible while the Videos module should be hidden. An empty result looks like this: `{"traffic":[]}`
* If the results are not empty, the module visibility should match the results. ie: . `{"traffic":{"authors": false}}` would mean the Authors module should not be visible.

In my testing with a new Dotcom site (no plan), both the Authors and Videos modules should be hidden by default. In production Authors is hidden but Videos is visible. On this branch both modules are correctly hidden.

With a new self-hosted site, the API returns an empty result so visibility is determined by the defaults. That means Authors are visible and Videos are hidden (overridden by site features check). This works correctly on this branch but not in production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
