### PR TITLE
Help Center: Persist the Help Center open state

### DIFF
--- a/apps/help-center/help-center-gutenberg.js
+++ b/apps/help-center/help-center-gutenberg.js
@@ -8,6 +8,7 @@ import { useMediaQuery } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useState, useReducer } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
+import { useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { useCanvasMode } from './hooks/use-canvas-mode';
 import { getEditorType } from './utils';
@@ -24,6 +25,7 @@ function HelpCenterContent() {
 	const show = useSelect( ( select ) => select( 'automattic/help-center' ).isHelpCenterShown() );
 
 	const canvasMode = useCanvasMode();
+	const previousCanvasMode = useRef( canvasMode );
 
 	const handleToggleHelpCenter = useCallback( () => {
 		recordTracksEvent( `calypso_inlinehelp_${ show ? 'close' : 'show' }`, {
@@ -44,13 +46,16 @@ function HelpCenterContent() {
 
 	useEffect( () => {
 		// Close the Help Center when the canvas mode changes.
-		setShowHelpCenter( false );
+		if ( previousCanvasMode.current !== canvasMode ) {
+			setShowHelpCenter( false );
 
-		// Force to re-render to ensure the sidebar is available.
-		if ( canvasMode === 'view' ) {
-			forceUpdate();
+			// Force to re-render to ensure the sidebar is available.
+			if ( canvasMode === 'view' ) {
+				forceUpdate();
+			}
+			previousCanvasMode.current = canvasMode;
 		}
-	}, [ canvasMode ] );
+	}, [ canvasMode, previousCanvasMode, setShowHelpCenter ] );
 
 	const closeCallback = useCallback( () => setShowHelpCenter( false ), [ setShowHelpCenter ] );
 

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -35,6 +35,7 @@ jest.mock( '../redesign-v2/pages/plan-only', () => () => (
 jest.mock( '../redesign-v2/pages/generic', () => () => (
 	<div data-testid="component--generic-thank-you" />
 ) );
+jest.mock( '@wordpress/api-fetch' );
 
 const translate = ( x ) => x;
 

--- a/client/my-sites/checkout/upsell-nudge/test/upsell-nudge.tsx
+++ b/client/my-sites/checkout/upsell-nudge/test/upsell-nudge.tsx
@@ -28,6 +28,10 @@ import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import UpsellNudge, { BUSINESS_PLAN_UPGRADE_UPSELL, PROFESSIONAL_EMAIL_UPSELL } from '../index';
 import type { StoredPaymentMethodCard } from '../../../../lib/checkout/payment-methods';
 
+jest.mock( 'wpcom-proxy-request', () => ( {
+	__esModule: true,
+} ) );
+
 jest.mock( '@automattic/calypso-router', () => jest.fn() );
 jest.mock( '@automattic/data-stores', () => ( {
 	...jest.requireActual( '@automattic/data-stores' ),

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -1,5 +1,6 @@
+import { default as apiFetchPromise } from '@wordpress/api-fetch';
 import { apiFetch } from '@wordpress/data-controls';
-import { canAccessWpcomApis } from 'wpcom-proxy-request';
+import { default as wpcomRequestPromise, canAccessWpcomApis } from 'wpcom-proxy-request';
 import { GeneratorReturnType } from '../mapped-types';
 import { SiteDetails } from '../site';
 import { wpcomRequest } from '../wpcom-request-controls';
@@ -99,6 +100,26 @@ export const setShowMessagingWidget = ( show: boolean ) =>
 	} ) as const;
 
 export const setShowHelpCenter = function* ( show: boolean ) {
+	if ( canAccessWpcomApis() ) {
+		// Use the promise version to do that action without waiting for the result.
+		wpcomRequestPromise( {
+			path: `/me/preferences`,
+			apiNamespace: 'wpcom/v2',
+			method: 'PUT',
+			body: {
+				calypso_preferences: { help_center_open: show },
+			},
+		} );
+	} else {
+		// Use the promise version to do that action without waiting for the result.
+		apiFetchPromise( {
+			global: true,
+			path: `/help-center/open-state`,
+			method: 'PUT',
+			data: { help_center_open: show },
+		} as APIFetchOptions );
+	}
+
 	if ( ! show ) {
 		yield setNavigateToRoute( undefined );
 	} else {

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -100,25 +100,27 @@ export const setShowMessagingWidget = ( show: boolean ) =>
 	} ) as const;
 
 export const setShowHelpCenter = function* ( show: boolean ) {
-	if ( canAccessWpcomApis() ) {
-		// Use the promise version to do that action without waiting for the result.
-		wpcomRequestPromise( {
-			path: `/me/preferences`,
-			apiNamespace: 'wpcom/v2',
-			method: 'PUT',
-			body: {
-				calypso_preferences: { help_center_open: show },
-			},
-		} );
-	} else {
-		// Use the promise version to do that action without waiting for the result.
-		apiFetchPromise( {
-			global: true,
-			path: `/help-center/open-state`,
-			method: 'PUT',
-			data: { help_center_open: show },
-		} as APIFetchOptions );
-	}
+	try {
+		if ( canAccessWpcomApis() ) {
+			// Use the promise version to do that action without waiting for the result.
+			wpcomRequestPromise( {
+				path: `/me/preferences`,
+				apiNamespace: 'wpcom/v2',
+				method: 'PUT',
+				body: {
+					calypso_preferences: { help_center_open: show },
+				},
+			} );
+		} else {
+			// Use the promise version to do that action without waiting for the result.
+			apiFetchPromise( {
+				global: true,
+				path: `/help-center/open-state`,
+				method: 'PUT',
+				data: { help_center_open: show },
+			} as APIFetchOptions );
+		}
+	} catch {}
 
 	if ( ! show ) {
 		yield setNavigateToRoute( undefined );

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -4,6 +4,7 @@ import { default as wpcomRequestPromise, canAccessWpcomApis } from 'wpcom-proxy-
 import { GeneratorReturnType } from '../mapped-types';
 import { SiteDetails } from '../site';
 import { wpcomRequest } from '../wpcom-request-controls';
+import { isE2ETest } from '.';
 import type { APIFetchOptions } from './types';
 import type { SupportInteraction } from '@automattic/odie-client/src/types';
 
@@ -100,27 +101,29 @@ export const setShowMessagingWidget = ( show: boolean ) =>
 	} ) as const;
 
 export const setShowHelpCenter = function* ( show: boolean ) {
-	try {
-		if ( canAccessWpcomApis() ) {
-			// Use the promise version to do that action without waiting for the result.
-			wpcomRequestPromise( {
-				path: `/me/preferences`,
-				apiNamespace: 'wpcom/v2',
-				method: 'PUT',
-				body: {
-					calypso_preferences: { help_center_open: show },
-				},
-			} );
-		} else {
-			// Use the promise version to do that action without waiting for the result.
-			apiFetchPromise( {
-				global: true,
-				path: `/help-center/open-state`,
-				method: 'PUT',
-				data: { help_center_open: show },
-			} as APIFetchOptions );
-		}
-	} catch {}
+	if ( ! isE2ETest() ) {
+		try {
+			if ( canAccessWpcomApis() ) {
+				// Use the promise version to do that action without waiting for the result.
+				wpcomRequestPromise( {
+					path: `/me/preferences`,
+					apiNamespace: 'wpcom/v2',
+					method: 'PUT',
+					body: {
+						calypso_preferences: { help_center_open: show },
+					},
+				} );
+			} else {
+				// Use the promise version to do that action without waiting for the result.
+				apiFetchPromise( {
+					global: true,
+					path: `/help-center/open-state`,
+					method: 'PUT',
+					data: { help_center_open: show },
+				} as APIFetchOptions );
+			}
+		} catch {}
+	}
 
 	if ( ! show ) {
 		yield setNavigateToRoute( undefined );

--- a/packages/data-stores/src/help-center/index.ts
+++ b/packages/data-stores/src/help-center/index.ts
@@ -5,6 +5,7 @@ import { controls as wpcomRequestControls } from '../wpcom-request-controls';
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
+import { isHelpCenterShown } from './resolvers';
 import * as selectors from './selectors';
 export type { State };
 
@@ -20,6 +21,7 @@ export function register(): typeof STORE_KEY {
 			controls: { ...controls, ...wpcomRequestControls },
 			selectors,
 			persist: [ 'message', 'userDeclaredSite', 'userDeclaredSiteUrl', 'subject' ],
+			resolvers: { isHelpCenterShown },
 		} );
 		isRegistered = true;
 	}

--- a/packages/data-stores/src/help-center/index.ts
+++ b/packages/data-stores/src/help-center/index.ts
@@ -11,6 +11,12 @@ export type { State };
 
 let isRegistered = false;
 
+// All end-to-end tests use a custom user agent containing this string.
+const E2E_USER_AGENT = 'wp-e2e-tests';
+
+export const isE2ETest = () =>
+	typeof window !== 'undefined' && window.navigator.userAgent.includes( E2E_USER_AGENT );
+
 export function register(): typeof STORE_KEY {
 	registerPlugins();
 
@@ -21,7 +27,8 @@ export function register(): typeof STORE_KEY {
 			controls: { ...controls, ...wpcomRequestControls },
 			selectors,
 			persist: [ 'message', 'userDeclaredSite', 'userDeclaredSiteUrl', 'subject' ],
-			resolvers: { isHelpCenterShown },
+			// Don't persist the open state for e2e users, because parallel tests will start interfering with each other.
+			resolvers: isE2ETest() ? undefined : { isHelpCenterShown },
 		} );
 		isRegistered = true;
 	}

--- a/packages/data-stores/src/help-center/resolvers.ts
+++ b/packages/data-stores/src/help-center/resolvers.ts
@@ -1,0 +1,26 @@
+import { apiFetch } from '@wordpress/data-controls';
+import { canAccessWpcomApis } from 'wpcom-proxy-request';
+import { wpcomRequest } from '../wpcom-request-controls';
+import type { APIFetchOptions } from './types';
+
+export function* isHelpCenterShown() {
+	const preferences: {
+		help_center_open: boolean;
+	} = canAccessWpcomApis()
+		? yield wpcomRequest( {
+				path: '/me/preferences',
+				apiNamespace: 'wpcom/v2',
+		  } )
+		: yield apiFetch( {
+				global: true,
+				path: `/help-center/open-state`,
+		  } as APIFetchOptions );
+
+	// We only want to auto-open, we don't want to auto-close (and potentially overrule the user's action).
+	if ( preferences.help_center_open ) {
+		return {
+			type: 'HELP_CENTER_SET_SHOW',
+			show: true,
+		} as const;
+	}
+}

--- a/packages/data-stores/src/help-center/resolvers.ts
+++ b/packages/data-stores/src/help-center/resolvers.ts
@@ -4,23 +4,25 @@ import { wpcomRequest } from '../wpcom-request-controls';
 import type { APIFetchOptions } from './types';
 
 export function* isHelpCenterShown() {
-	const preferences: {
-		help_center_open: boolean;
-	} = canAccessWpcomApis()
-		? yield wpcomRequest( {
-				path: '/me/preferences',
-				apiNamespace: 'wpcom/v2',
-		  } )
-		: yield apiFetch( {
-				global: true,
-				path: `/help-center/open-state`,
-		  } as APIFetchOptions );
+	try {
+		const preferences: {
+			help_center_open: boolean;
+		} = canAccessWpcomApis()
+			? yield wpcomRequest( {
+					path: '/me/preferences',
+					apiNamespace: 'wpcom/v2',
+			  } )
+			: yield apiFetch( {
+					global: true,
+					path: `/help-center/open-state`,
+			  } as APIFetchOptions );
 
-	// We only want to auto-open, we don't want to auto-close (and potentially overrule the user's action).
-	if ( preferences.help_center_open ) {
-		return {
-			type: 'HELP_CENTER_SET_SHOW',
-			show: true,
-		} as const;
-	}
+		// We only want to auto-open, we don't want to auto-close (and potentially overrule the user's action).
+		if ( preferences.help_center_open ) {
+			return {
+				type: 'HELP_CENTER_SET_SHOW',
+				show: true,
+			} as const;
+		}
+	} catch {}
 }

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -39,7 +39,6 @@ global.fetch = jest.fn( () =>
 jest.mock( 'wpcom-proxy-request', () => ( {
 	__esModule: true,
 	canAccessWpcomApis: jest.fn(),
-	default: jest.fn(),
 } ) );
 
 global.matchMedia = jest.fn( ( query ) => ( {

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -38,6 +38,8 @@ global.fetch = jest.fn( () =>
 // module because it accesses the `document` global.
 jest.mock( 'wpcom-proxy-request', () => ( {
 	__esModule: true,
+	canAccessWpcomApis: jest.fn(),
+	default: jest.fn(),
 } ) );
 
 global.matchMedia = jest.fn( ( query ) => ( {

--- a/test/e2e/specs/help-center/help-center__calypso.ts
+++ b/test/e2e/specs/help-center/help-center__calypso.ts
@@ -45,6 +45,10 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )( 'Help Center in Calyp
 	 * These tests check the general interaction with the Help Center popover.
 	 */
 	describe( 'General Interaction', () => {
+		afterAll( async () => {
+			await helpCenterComponent.closePopover();
+		} );
+
 		it( 'is initially closed', async () => {
 			expect( await helpCenterComponent.isVisible() ).toBeFalsy();
 		} );

--- a/test/e2e/specs/help-center/help-center__calypso.ts
+++ b/test/e2e/specs/help-center/help-center__calypso.ts
@@ -45,10 +45,6 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )( 'Help Center in Calyp
 	 * These tests check the general interaction with the Help Center popover.
 	 */
 	describe( 'General Interaction', () => {
-		afterAll( async () => {
-			await helpCenterComponent.closePopover();
-		} );
-
 		it( 'is initially closed', async () => {
 			expect( await helpCenterComponent.isVisible() ).toBeFalsy();
 		} );


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/97919

## Proposed Changes

This stores the Help Center open state in the preferences store. 

## Why are these changes being made?
To keep the session going when users move from Calypso to wp-admin.

## Testing Instructions

### Simple sites & Calypso

1. in `apps/help-center` run `yarn dev --sync`.
2. Go to simple-site/wp-admin/post-new.php
3. Open the Help Center.
4. Open the live link.
5. The Help Center should pop open.

### Atomic sites
1. Apply https://github.com/Automattic/jetpack/pull/41126 to your Atomic dev site.
2. Go to atomic-site/wp-admin/post-new.php.
3. The Help Center should pop open.
