### PR TITLE
Domain management: Create existing site-picker page for domain context

### DIFF
--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/transfer-other-site-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/transfer-other-site-header.tsx
@@ -1,0 +1,68 @@
+import { SiteExcerptData } from '@automattic/sites';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import NavigationHeader from 'calypso/components/navigation-header';
+import { domainManagementAllOverview } from 'calypso/my-sites/domains/paths';
+import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
+import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';
+import { useSelector } from 'calypso/state';
+import { getSite } from 'calypso/state/sites/selectors';
+import { CustomHeaderComponentType } from './custom-header-component-type';
+
+const TransferOtherSiteHeader: CustomHeaderComponentType = ( {
+	selectedDomainName,
+	selectedSiteSlug,
+	inSiteContext,
+} ) => {
+	const translate = useTranslate();
+	const site = useSelector( ( state ) => getSite( state, selectedSiteSlug ) as SiteExcerptData );
+
+	const navigationItems = useMemo( () => {
+		const baseNavigationItems = [
+			{
+				label: selectedDomainName,
+				href: domainManagementAllOverview(
+					selectedSiteSlug,
+					selectedDomainName,
+					null,
+					inSiteContext
+				),
+			},
+			{
+				label: translate( 'Attach' ),
+				href: getEmailManagementPath(
+					selectedSiteSlug,
+					selectedDomainName,
+					null,
+					undefined,
+					inSiteContext
+				),
+			},
+			{
+				label: translate( 'Existing site' ),
+			},
+		];
+
+		if ( inSiteContext ) {
+			return [
+				{
+					label: site?.name || selectedDomainName,
+					href: `/overview/${ selectedSiteSlug }`,
+					icon: <SiteIcon site={ site } viewType="breadcrumb" disableClick />,
+				},
+				...baseNavigationItems,
+			];
+		}
+
+		return baseNavigationItems;
+	}, [ inSiteContext, selectedDomainName, selectedSiteSlug, site, translate ] );
+
+	return (
+		<NavigationHeader
+			className="navigation-header__breadcrumb"
+			navigationItems={ navigationItems }
+		/>
+	);
+};
+
+export default TransferOtherSiteHeader;

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/transfer-other-site-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/transfer-other-site-header.tsx
@@ -2,8 +2,10 @@ import { SiteExcerptData } from '@automattic/sites';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import NavigationHeader from 'calypso/components/navigation-header';
-import { domainManagementAllOverview } from 'calypso/my-sites/domains/paths';
-import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
+import {
+	domainManagementAllOverview,
+	domainManagementTransfer,
+} from 'calypso/my-sites/domains/paths';
 import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';
 import { useSelector } from 'calypso/state';
 import { getSite } from 'calypso/state/sites/selectors';
@@ -30,13 +32,7 @@ const TransferOtherSiteHeader: CustomHeaderComponentType = ( {
 			},
 			{
 				label: translate( 'Attach' ),
-				href: getEmailManagementPath(
-					selectedSiteSlug,
-					selectedDomainName,
-					null,
-					undefined,
-					inSiteContext
-				),
+				href: domainManagementTransfer( selectedSiteSlug, selectedDomainName ),
 			},
 			{
 				label: translate( 'Existing site' ),

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/transfer-other-site-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/transfer-other-site-header.tsx
@@ -2,10 +2,7 @@ import { SiteExcerptData } from '@automattic/sites';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import NavigationHeader from 'calypso/components/navigation-header';
-import {
-	domainManagementAllOverview,
-	domainManagementTransfer,
-} from 'calypso/my-sites/domains/paths';
+import { domainManagementAllOverview } from 'calypso/my-sites/domains/paths';
 import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';
 import { useSelector } from 'calypso/state';
 import { getSite } from 'calypso/state/sites/selectors';
@@ -31,11 +28,7 @@ const TransferOtherSiteHeader: CustomHeaderComponentType = ( {
 				),
 			},
 			{
-				label: translate( 'Attach' ),
-				href: domainManagementTransfer( selectedSiteSlug, selectedDomainName ),
-			},
-			{
-				label: translate( 'Existing site' ),
+				label: translate( 'Attach to an existing site' ),
 			},
 		];
 

--- a/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
@@ -204,6 +204,21 @@
             }
         }
 	}
+
+	&.subpage-wrapper--transfer-other-site {
+		.transfer-domain-to-other-site__card > p {
+			font-size: 1.25rem;
+			margin-bottom: 1.25rem;
+
+			strong {
+				font-weight: 500;
+			}
+		}
+
+		.domain__main-placeholder {
+			max-width: $break-xlarge;
+		}
+	}
 }
 
 .is-bulk-all-domains-page .layout__content .main,

--- a/client/my-sites/domains/domain-management/subpage-wrapper/subpages.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/subpages.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import TransferOtherSiteHeader from 'calypso/my-sites/domains/domain-management/subpage-wrapper/headers/transfer-other-site-header';
 import AddForwardingEmailHeader from './headers/add-fowarding-email-header';
 import MailboxHeader from './headers/add-mailbox-header';
 import CompareEmailProvidersHeader from './headers/compare-email-providers';
@@ -30,6 +31,7 @@ export const DNS_RECORDS = 'dns-records';
 export const ADD_DNS_RECORD = 'add-dns-record';
 export const EDIT_DNS_RECORD = 'edit-dns-record';
 export const EDIT_CONTACT_INFO = 'edit-contact-info';
+export const TRANSFER_OTHER_SITE = 'transfer-other-site';
 
 // Subpage params map
 const SUBPAGE_TO_PARAMS_MAP: Record< string, SubpageWrapperParamsType > = {
@@ -71,6 +73,10 @@ const SUBPAGE_TO_PARAMS_MAP: Record< string, SubpageWrapperParamsType > = {
 		showFormHeader: false,
 		showPageHeader: false,
 		customFormHeader: __( 'New mailbox' ),
+	},
+	[ TRANSFER_OTHER_SITE ]: {
+		CustomHeader: TransferOtherSiteHeader,
+		showPageHeader: false,
 	},
 };
 

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -131,10 +131,11 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 		const { selectedSite, selectedDomainName, currentRoute, showHeader } = this.props;
 		const slug = selectedSite?.slug;
 		const componentClassName = 'transfer-domain-to-other-site';
+
 		if ( ! this.isDataReady() ) {
 			return (
 				<DomainMainPlaceholder
-					breadcrumbs={ this.renderHeader }
+					breadcrumbs={ showHeader && this.renderHeader }
 					backHref={ domainManagementTransfer( slug, selectedDomainName, currentRoute ) }
 				/>
 			);

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -128,7 +128,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 	}
 
 	render() {
-		const { selectedSite, selectedDomainName, currentRoute } = this.props;
+		const { selectedSite, selectedDomainName, currentRoute, showHeader } = this.props;
 		const slug = selectedSite?.slug;
 		const componentClassName = 'transfer-domain-to-other-site';
 		if ( ! this.isDataReady() ) {
@@ -147,7 +147,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 					group={ componentClassName }
 					section={ componentClassName }
 				/>
-				{ this.renderHeader() }
+				{ showHeader && this.renderHeader() }
 				<div className={ `${ componentClassName }__container` }>
 					<div className={ `${ componentClassName }__main` }>{ this.renderSection() }</div>
 				</div>
@@ -267,6 +267,7 @@ export default connect(
 			domain = getSelectedDomain( ownProps );
 		}
 		const siteId = getSelectedSiteId( state );
+
 		return {
 			currentRoute: getCurrentRoute( state ),
 			currentUserCanManage: typeof domain === 'object' && domain.currentUserCanManage,
@@ -276,6 +277,7 @@ export default connect(
 			isDomainOnly: isDomainOnlySite( state, siteId ),
 			isMapping: Boolean( domain ) && isMappedDomain( domain ),
 			sites: getSites( state ) as TransferDomainToOtherSiteStateProps[ 'sites' ],
+			showHeader: ownProps?.context?.params?.showPageHeader ?? true,
 		};
 	},
 	{

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/types.ts
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/types.ts
@@ -24,6 +24,9 @@ export type TransferDomainToOtherSitePassedProps = {
 	selectedDomainName: string;
 	selectedSite: SiteDataExtraInfo;
 	children?: React.ReactNode;
+	context?: {
+		params?: { [ key: string ]: any };
+	};
 };
 
 // state props
@@ -36,6 +39,7 @@ export type TransferDomainToOtherSiteStateProps = {
 	isDomainOnly: Maybe< boolean >;
 	isMapping: boolean;
 	sites: SiteDetails[];
+	showHeader?: boolean;
 };
 // state props added by redux connect
 export type TransferDomainToOtherSiteStateToProps = (

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -24,6 +24,7 @@ import {
 	ADD_DNS_RECORD,
 	EDIT_DNS_RECORD,
 	EDIT_CONTACT_INFO,
+	TRANSFER_OTHER_SITE,
 } from './domain-management/subpage-wrapper/subpages';
 import * as paths from './paths';
 
@@ -492,6 +493,18 @@ export default function () {
 		navigation,
 		domainManagementController.domainManagementSubpageParams( ADD_MAILBOX ),
 		emailController.emailManagementNewTitanAccount,
+		domainManagementController.domainManagementSubpageView,
+		domainManagementController.domainDashboardLayout,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		paths.domainManagementOverviewRoot() + '/:domain/transfer/other-site/:site',
+		siteSelection,
+		navigation,
+		domainManagementController.domainManagementSubpageParams( TRANSFER_OTHER_SITE ),
+		domainManagementController.domainManagementTransferToOtherSite,
 		domainManagementController.domainManagementSubpageView,
 		domainManagementController.domainDashboardLayout,
 		makeLayout,

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -358,6 +358,10 @@ export function domainManagementTransferToAnyUser( siteName, domainName, relativ
  * @param {string?} relativeTo
  */
 export function domainManagementTransferToOtherSite( siteName, domainName, relativeTo = null ) {
+	if ( isUnderDomainManagementOverview( relativeTo ) ) {
+		return domainManagementOverviewRoot() + '/' + domainName + '/transfer/other-site/' + siteName;
+	}
+
 	return domainManagementTransferBase( siteName, domainName, 'other-site', relativeTo );
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98213

## Proposed Changes

* Creates existing site-picker subpage within domain context

## Why are these changes being made?

* Domain Management Revamp project

## Testing Instructions

* Enable the `calypso/all-domain-management` flag
* Go to the `/domains/manage` page
* Select a domain without an attached site
* Press the "Attach to an existing site" button
* Check if there is an "Attach" subpage
* Check the subpage breadcrumbs

<img width="1253" alt="Screenshot 2025-01-17 at 16 33 47" src="https://github.com/user-attachments/assets/9e095f78-fc2b-4efa-9db3-1f1d50b93b7f" />

<img width="1728" alt="Screenshot 2025-01-17 at 16 36 22" src="https://github.com/user-attachments/assets/1e8ad07d-6ac3-4c4c-bb9a-5a0a9fef112d" />

Breadcrumbs:
<img width="908" alt="Screenshot 2025-01-20 at 13 38 46" src="https://github.com/user-attachments/assets/0304b980-e9c6-42c9-9393-c6ecb9532384" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
