### PR TITLE
Stats: fix summary locations selector style

### DIFF
--- a/client/my-sites/stats/summary/style.scss
+++ b/client/my-sites/stats/summary/style.scss
@@ -1,6 +1,9 @@
 @import "@wordpress/base-styles/breakpoints";
+@import "../modernized-mixins";
 
 .stats-summary-view {
+	@include segmented-controls;
+
 	.highlight-cards-heading {
 		@media (min-width: 661px) and (max-width: 1380px) {
 			margin-left: 32px;

--- a/client/my-sites/stats/summary/style.scss
+++ b/client/my-sites/stats/summary/style.scss
@@ -46,3 +46,7 @@
 		}
 	}
 }
+
+.stats-module-locations__tabs {
+	width: 100%;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/jetpack-roadmap#2123.

## Proposed Changes

* Makes the locations selector style in the summary page consistent with the one in the default Stats page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* (p1HpG7-rpL-p2)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Access the Calypso Live preview linked below.
- Access the Stats summary page in the new `/locations/` implementation, like `/stats/day/locations/jetpack.com`
- Confirm the `Countries`/`Regions`/`Cities` selector style is consistent with the one in the default Stats page under the feature flag at `/stats/day/jetpack.com?flags=stats/locations`

| Before | After |
| - | - |
| <img width="965" alt="image" src="https://github.com/user-attachments/assets/7de174a8-8d4b-4f36-af0d-d8335be878c6" /> | <img width="965" alt="image" src="https://github.com/user-attachments/assets/52bbbdf2-60e7-492d-a5f1-1bd2fd77d7a3" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
