### PR TITLE
Reader: remove non-functional property filters from Recent feed

### DIFF
--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -51,7 +51,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 	const [ view, setView ] = useState< View >( {
 		type: 'list',
 		search: '',
-		fields: [ 'icon', 'post' ],
+		fields: [],
 		perPage: 10,
 		page: 1,
 		layout: {
@@ -236,7 +236,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 						onChangeView={ ( newView ) =>
 							setView( {
 								type: newView.type,
-								fields: newView.fields ?? [],
+								fields: [],
 								layout: view.layout,
 								perPage: newView.perPage,
 								page: newView.page,

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -146,7 +146,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 				enableGlobalSearch: true,
 			},
 		],
-		[ getPostFromItem ]
+		[ getPostFromItem, handleItemFocus ]
 	);
 
 	const fetchData = useCallback( () => {
@@ -226,14 +226,14 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 					<NavigationHeader title={ translate( 'Recent' ) }>{ viewToggle }</NavigationHeader>
 				</div>
 				<aside className="recent-feed__list-column-content">
-					<DataViews
-						getItemId={ ( item: ReaderPost, index = 0 ) =>
+					<DataViews< ReaderPost | PaddingItem >
+						getItemId={ ( item: ReaderPost | PaddingItem, index = 0 ) =>
 							item.postId?.toString() ?? `item-${ index }`
 						}
-						view={ view as View }
+						view={ view }
 						fields={ fields }
 						data={ shownData }
-						onChangeView={ ( newView: View ) =>
+						onChangeView={ ( newView ) =>
 							setView( {
 								type: newView.type,
 								fields: newView.fields ?? [],


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #98427

## Proposed Changes

* Configure the DataViews component to not be concerned with filtering by fields
* In effect, this will configure the component to not render the filter controls

| Before | After |
|-|-|
| <img width="1840" alt="image" src="https://github.com/user-attachments/assets/04ab2a53-1095-489b-8c86-c249ab502d33" /> | <img width="1840" alt="image" src="https://github.com/user-attachments/assets/c20ea9e7-af3f-40ce-9b79-8906ace1cbdc" /> |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The DataViews filter controls were being displayed but because we don't need them, they are non-functional and useless. Removing them cleans up the UI and reduces confusion/appearance that things are broken

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/read`
* Make sure the "two-column" layout is selected
* Open the DataViews settings panel by clicking the "gear" icon
* Ensure the "Properties" settings are not present
* Ensure no regressions have ocurred

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
