### PR TITLE
Subscriptions: fix incorrect error check

### DIFF
--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -62,8 +62,12 @@ const useSubscriberRemoveMutation = (
 				try {
 					await wpcom.req.post( `/sites/${ siteId }/followers/${ subscriber.user_id }/delete` );
 				} catch ( e ) {
-					if ( ( e as ApiResponseError )?.error !== 'not_found' && subscriber.subscription_id ) {
-						throw new Error( 'Something went wrong while unsubscribing.' );
+					// Only throw if subscription_id is empty
+					if ( ( e as ApiResponseError )?.error === 'not_found' && ! subscriber.subscription_id ) {
+						throw new Error( ( e as ApiResponseError )?.message );
+					} else {
+						// Throw for any other error
+						throw new Error( ( e as ApiResponseError )?.message );
 					}
 				}
 			}


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack/issues/40850
Related to https://github.com/Automattic/wp-calypso/pull/98066

## Proposed Changes

* Fix check for subscriber delete error

## Why are these changes being made?

The check was not clear and was inverted. The error was running when it should have continued on.

## Testing Instructions

1. Using local link go to /subscribers.
2. Delete a user and make sure it removes the subscriber.