### PR TITLE
Masterbar: fix invalid HTML markup

### DIFF
--- a/client/layout/masterbar/item.tsx
+++ b/client/layout/masterbar/item.tsx
@@ -60,8 +60,7 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 		isOpenForNonMouseFlow: false,
 	};
 
-	componentButtonRef = React.createRef< HTMLButtonElement >();
-	componentDivRef = React.createRef< HTMLDivElement >();
+	wrapperRef = React.createRef< HTMLDivElement >();
 
 	_preloaded = false;
 
@@ -191,12 +190,8 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 		}
 
 		// Check refs to see if the touch event started inside our component, if it didn't, close the menu.
-		const isInComponentButtonRef = this.componentButtonRef.current?.contains(
-			event.target as Node
-		);
-		const isInComponentDivRef = this.componentDivRef.current?.contains( event.target as Node );
-
-		if ( ! isInComponentButtonRef && ! isInComponentDivRef ) {
+		const isInWrapper = this.wrapperRef.current?.contains( event.target as Node );
+		if ( ! isInWrapper ) {
 			this.setState( { isOpenForNonMouseFlow: false } );
 		}
 	};
@@ -221,49 +216,42 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 			disabled: this.props.disabled,
 		};
 
-		if ( this.props.url && ! this.props.subItems ) {
-			return (
+		const MenuItem = ( props: React.HTMLAttributes< HTMLElement > ) =>
+			this.props.url ? (
 				<a
-					{ ...attributes }
 					href={ this.props.url }
 					ref={ this.props.innerRef as LegacyRef< HTMLAnchorElement > }
-				>
-					{ this.renderChildren() }
-				</a>
+					{ ...props }
+				/>
+			) : (
+				<button ref={ this.props.innerRef as LegacyRef< HTMLButtonElement > } { ...props } />
 			);
-		}
 
-		if ( this.props.url && this.props.subItems ) {
-			return (
-				<button
-					{ ...attributes }
-					ref={ this.componentButtonRef }
-					onKeyDown={ this.toggleMenuByKey }
-				>
-					<a
-						href={ this.props.url }
-						ref={ this.props.innerRef as LegacyRef< HTMLAnchorElement > }
-						onTouchEnd={ this.toggleMenuByTouch }
-						tabIndex={ -1 }
-					>
-						{ this.renderChildren() }
-					</a>
-					{ this.renderSubItems() }
-				</button>
-			);
-		}
+		// Differences:
+		// - the wrapper div is always rendered, even when props.url is set
+		// - the menu item is either a `button` or an `a` (no `a` nested in `button`)'
+		// - as a consequence, `componentButtonRef` is not necessary anymore
+
+		// Notes to self:
+		// - TODO: revisit closeMenuOnOutsideInteraction logic
+		// - is onTouchEnd necessary?
+		// - are we ok without tabindex = -1?
+		// - is always rendering the wrapper ok?
 
 		return (
-			<div className={ this.props.wrapperClassName } ref={ this.componentDivRef }>
-				<button
+			<div
+				className={ clsx( 'masterbar__item-wrapper', this.props.wrapperClassName ) }
+				ref={ this.wrapperRef }
+			>
+				<MenuItem
 					{ ...attributes }
-					ref={ this.props.innerRef as LegacyRef< HTMLButtonElement > }
-					onKeyDown={ this.props.subItems && this.toggleMenuByKey }
-					onTouchEnd={ this.props.subItems && this.toggleMenuByTouch }
+					onKeyDown={ this.props.subItems ? this.toggleMenuByKey : undefined }
+					// Is this necessary
+					onTouchEnd={ this.props.subItems ? this.toggleMenuByTouch : undefined }
 				>
 					{ this.renderChildren() }
-					{ this.renderSubItems() }
-				</button>
+				</MenuItem>
+				{ /* { this.renderSubItems() } */ }
 			</div>
 		);
 	}

--- a/client/layout/masterbar/item.tsx
+++ b/client/layout/masterbar/item.tsx
@@ -234,8 +234,8 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 			>
 				<MenuItem
 					{ ...attributes }
-					onKeyDown={ this.props.subItems ? this.toggleMenuByKey : undefined }
-					onTouchEnd={ this.props.subItems ? this.toggleMenuByTouch : undefined }
+					onKeyDown={ this.props.subItems && this.toggleMenuByKey }
+					onTouchEnd={ this.props.subItems && this.toggleMenuByTouch }
 				>
 					{ this.renderChildren() }
 				</MenuItem>

--- a/client/layout/masterbar/item.tsx
+++ b/client/layout/masterbar/item.tsx
@@ -227,17 +227,6 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 				<button ref={ this.props.innerRef as LegacyRef< HTMLButtonElement > } { ...props } />
 			);
 
-		// Differences:
-		// - the wrapper div is always rendered, even when props.url is set
-		// - the menu item is either a `button` or an `a` (no `a` nested in `button`)'
-		// - as a consequence, `componentButtonRef` is not necessary anymore
-
-		// Notes to self:
-		// - TODO: revisit closeMenuOnOutsideInteraction logic
-		// - is onTouchEnd necessary?
-		// - are we ok without tabindex = -1?
-		// - is always rendering the wrapper ok?
-
 		return (
 			<div
 				className={ clsx( 'masterbar__item-wrapper', this.props.wrapperClassName ) }
@@ -246,7 +235,6 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 				<MenuItem
 					{ ...attributes }
 					onKeyDown={ this.props.subItems ? this.toggleMenuByKey : undefined }
-					// Is this necessary
 					onTouchEnd={ this.props.subItems ? this.toggleMenuByTouch : undefined }
 				>
 					{ this.renderChildren() }

--- a/client/layout/masterbar/item.tsx
+++ b/client/layout/masterbar/item.tsx
@@ -251,7 +251,7 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 				>
 					{ this.renderChildren() }
 				</MenuItem>
-				{ /* { this.renderSubItems() } */ }
+				{ this.renderSubItems() }
 			</div>
 		);
 	}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -59,11 +59,15 @@ body.is-mobile-app-view {
 		padding-top: 10px;
 		padding-bottom: 40px;
 
+		.masterbar__item-wrapper:first-child {
+			flex: none;
+		}
+
 		.masterbar__item:hover {
 			background: transparent;
 			text-decoration: underline;
 		}
-		.masterbar__item:last-child {
+		.masterbar__item-wrapper:last-child .masterbar__item {
 			margin-left: 6px;
 			margin-right: 12px;
 			background-color: #fff;
@@ -74,26 +78,28 @@ body.is-mobile-app-view {
 				color: var(--color-sidebar-text);
 			}
 		}
-		.masterbar__item:last-child:hover {
+		.masterbar__item-wrapper:last-child:hover .masterbar__item {
 			background: #fff;
 			text-decoration: none;
 		}
-		.masterbar__item:last-child:hover .masterbar__item-content {
+		.masterbar__item-wrapper:last-child:hover .masterbar__item-content {
 			color: var(--color-sidebar-text);
 		}
 		@media only screen and (max-width: 781px) {
 			padding-top: 0;
 
 			.masterbar__login-links {
-				.masterbar__item {
-					height: 30px;
-					line-height: 30px;
-					width: unset !important;
-					padding: 0 8px;
-					margin: 8px 8px 0 0;
+				.masterbar__item-wrapper {
+					.masterbar__item {
+						height: 30px;
+						line-height: 30px;
+						width: unset !important;
+						padding: 0 8px;
+						margin: 8px 8px 0 0;
 
-					.masterbar__item-content {
-						display: block !important;
+						.masterbar__item-content {
+							display: block !important;
+						}
 					}
 				}
 			}
@@ -198,7 +204,6 @@ body.is-mobile-app-view {
 	align-items: center;
 	color: var(--color-masterbar-text);
 	font-size: $masterbar-font-size;
-	gap: 5px;
 	height: var(--masterbar-height);
 	line-height: var(--masterbar-height);
 	padding: 0 8px;
@@ -237,7 +242,7 @@ body.is-mobile-app-view {
 		}
 	}
 
-	.masterbar__item-subitems {
+	& + .masterbar__item-subitems {
 		margin: 0;
 		padding: 6px 0;
 		box-shadow: 0 3px 5px rgba(0, 0, 0, 0.2);
@@ -258,6 +263,7 @@ body.is-mobile-app-view {
 			white-space: nowrap;
 			min-width: 140px;
 			line-height: 2;
+
 			a,
 			button {
 				display: inline-block;
@@ -356,7 +362,7 @@ body.is-mobile-app-view {
 			fill: var(--color-masterbar-highlight);
 		}
 
-		.masterbar__item-subitems {
+		& + .masterbar__item-subitems {
 			display: block;
 			z-index: 99999;
 		}
@@ -449,8 +455,12 @@ body.is-mobile-app-view {
 	}
 
 	@media only screen and (max-width: 781px) {
-		font-size: $masterbar-mobile-font-size;
 		padding: 0;
+
+		&,
+		& + .masterbar__item-subitems {
+			font-size: $masterbar-mobile-font-size;
+		}
 
 		&:not(.masterbar__item--always-show-content) {
 			width: 46px;
@@ -721,51 +731,22 @@ body.is-mobile-app-view {
 		gap: 5px;
 	}
 
-	.gravatar {
-		border: 1px solid var(--color-masterbar-border);
-		border-radius: unset;
-		margin-left: 1px;
+	&,
+	+ .masterbar__item-subitems {
+		.gravatar {
+			border: 1px solid var(--color-masterbar-border);
+			border-radius: unset;
+			margin-left: 1px;
 
-		@media only screen and (max-width: 781px) {
-			width: 26px;
-			height: 26px;
-			margin-left: 4px;
-		}
-	}
-
-	.masterbar__item-howdy-account-wrapper {
-		display: flex;
-		flex-direction: row;
-		gap: 12px;
-		padding: 4px 3px;
-
-		.masterbar__item-howdy-account-gravatar {
-			border: none;
-			flex-basis: auto;
-			max-width: 50%;
-		}
-
-		.masterbar__item-howdy-account-details {
-			flex-basis: auto;
-			flex-grow: 0;
-			flex-shrink: 0;
-			max-width: 50%;
-			display: flex;
-			flex-direction: column;
-			align-items: flex-start;
-			padding: 3px 5px;
-			margin: 0;
-			line-height: 18px;
-
-			.username {
-				font-size: 11px; /* stylelint-disable-line declaration-property-unit-allowed-list */
-				line-height: 14px;
-				margin-bottom: 4px;
+			@media only screen and (max-width: 781px) {
+				width: 26px;
+				height: 26px;
+				margin-left: 4px;
 			}
 		}
 	}
 
-	.masterbar__item-subitems {
+	+ .masterbar__item-subitems {
 		min-width: 264px !important;
 		max-height: 94px;
 		padding: 12px 0;
@@ -774,39 +755,73 @@ body.is-mobile-app-view {
 			min-width: 100% !important;
 			max-height: 100%;
 		}
-	}
 
-	.masterbar__item-subitems-item {
-		&.account-link,
-		&.logout-link {
-			position: relative;
-			float: left;
-			top: -5px;
-			left: 85px;
+		.masterbar__item-howdy-account-wrapper {
+			display: flex;
+			flex-direction: row;
+			gap: 12px;
+			padding: 4px 3px;
+
+			.masterbar__item-howdy-account-gravatar {
+				border: none;
+				flex-basis: auto;
+				max-width: 50%;
+			}
+
+			.masterbar__item-howdy-account-details {
+				flex-basis: auto;
+				flex-grow: 0;
+				flex-shrink: 0;
+				max-width: 50%;
+				display: flex;
+				flex-direction: column;
+				align-items: flex-start;
+				padding: 3px 5px;
+				margin: 0;
+				line-height: 18px;
+
+				.username {
+					font-size: 11px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+					line-height: 14px;
+					margin-bottom: 4px;
+				}
+			}
+		}
+
+		.masterbar__item-subitems-item {
+			&.account-link,
+			&.logout-link {
+				position: relative;
+				float: left;
+				top: -5px;
+				left: 85px;
+			}
 		}
 	}
 
 	@media only screen and (max-width: 781px) {
 		.masterbar__item-howdy-howdy,
-		.masterbar__item-howdy-account-gravatar {
+		+ .masterbar__item-subitems .masterbar__item-howdy-account-gravatar {
 			display: none;
 		}
 
-		.masterbar__item-howdy-account-details {
-			padding: 0 !important;
-		}
-
-		.masterbar__item-subitems-item {
-
-			min-width: 100% !important;
-			&.account-link {
-				top: -10px;
-				left: 0;
+		+ .masterbar__item-subitems {
+			.masterbar__item-howdy-account-details {
+				padding: 0 !important;
 			}
 
-			&.logout-link {
-				top: -10px;
-				left: 0;
+			.masterbar__item-subitems-item {
+
+				min-width: 100% !important;
+				&.account-link {
+					top: -10px;
+					left: 0;
+				}
+
+				&.logout-link {
+					top: -10px;
+					left: 0;
+				}
 			}
 		}
 	}
@@ -823,7 +838,7 @@ body.is-mobile-app-view {
 	}
 
 	@include breakpoint-deprecated( ">480px" ) {
-		.masterbar__item:last-child {
+		.masterbar__item-wrapper:last-child .masterbar__item {
 			margin-right: 20px;
 		}
 	}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -356,6 +356,7 @@ body.is-mobile-app-view {
 
 	// The hover colors are supposed to be the same as those in wp-admin.
 	&:hover,
+	&:has(+ .masterbar__item-subitems:hover),
 	&.is-open {
 		svg path,
 		.gridicon {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -137,7 +137,7 @@ body.is-mobile-app-view {
 
 	@include breakpoint-deprecated( ">480px" ) {
 		flex: 2;
-		.masterbar__item {
+		.masterbar__item-wrapper {
 			flex: 0 0 auto;
 		}
 	}
@@ -188,13 +188,17 @@ body.is-mobile-app-view {
 	white-space: nowrap;
 }
 
-.masterbar__item {
+.masterbar__item-wrapper {
+	position: relative;
 	flex: 1;
+}
+
+.masterbar__item {
 	display: flex;
 	align-items: center;
-	position: relative;
 	color: var(--color-masterbar-text);
 	font-size: $masterbar-font-size;
+	gap: 5px;
 	height: var(--masterbar-height);
 	line-height: var(--masterbar-height);
 	padding: 0 8px;
@@ -210,6 +214,7 @@ body.is-mobile-app-view {
 	&.masterbar__item-my-site,
 	&.masterbar__item-my-site-actions {
 		padding-left: 7px;
+		gap: 6px;
 	}
 
 	@media only screen and (max-width: 781px) {
@@ -226,23 +231,10 @@ body.is-mobile-app-view {
 	}
 
 	&.has-subitems {
-		display: block;
 		&:hover,
 		&.is-open {
 			z-index: 2;
 		}
-	}
-
-	> a {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		gap: 5px;
-	}
-
-	&.masterbar__item-my-site-actions > a,
-	&.masterbar__item-my-site > a {
-		gap: 6px;
 	}
 
 	.masterbar__item-subitems {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #98365

## Proposed Changes

- Move master bar subitems from being children of the parent menu item to being siblings
- Do not render interactive elements such as `button` and `a` as children of `button`
- Normalize the markup, always rendering the item wrapper — this makes it more predictable

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The current structure generates invalid (`button` rendered as a child of another `button`) and generally inaccessible (interactive elements like `a` as children of `button`) HTML markup


> [!note]
> This PR only aims at fixing the most critical issue (invalid markup) with the masterbar markup. As documented in #98365, **the master bar semantics and general accessibility are still far from ideal — but that should be tackled in separate PRs**. Given the effort required for that potential refactor, we should discuss our options carefully before embarking on that endeavour, especially given how we're slowly showing wp-admin screens over calypso ones.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load Calypso in a variety of pages/scenarios:
  * Logged out: eg. `/discover`
  * Logged in: eg. home page
  * With paid items in the cart
* Test on multiple viewport sizes
* Test both pointer, keyboard, and touchscreen interactions

In all of these scenarios:
- [ ] The master bar should not include invalid HTML markup (`button` or `a` as a child of `button`)
- [ ] The error in the browser console about `button` rendered inside a `button` currently displayed on `trunk` should be gone
- [ ] The look&feel and the UX should be the same as on `trunk`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
