### PR TITLE
Redirect /settings/security/:site to Jetpack security settings

### DIFF
--- a/client/my-sites/site-settings/settings-security/index.js
+++ b/client/my-sites/site-settings/settings-security/index.js
@@ -1,13 +1,22 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	redirectIfDuplicatedView as _redirectIfDuplicatedView,
+} from 'calypso/controller';
 import { navigation, siteSelection } from 'calypso/my-sites/controller';
 import { setScroll, siteSettings } from 'calypso/my-sites/site-settings/settings-controller';
 import { security } from './controller';
+
+const redirectIfDuplicatedView = ( context, next ) => {
+	_redirectIfDuplicatedView( 'admin.php?page=jetpack#security' )( context, next );
+};
 
 export default function () {
 	page(
 		'/settings/security/:site_id',
 		siteSelection,
+		redirectIfDuplicatedView,
 		navigation,
 		setScroll,
 		siteSettings,


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/98249

## Proposed Changes

* Redirects /settings/security/:site to Jetpack security settings when the user is in the hold out experiment

## Testing Instructions

- Load /settings/security/:site for an atomic site, you should see security settings
- Load again after adding yourself to the experiment treatment group 22167-explat-experiment, you should be redirected to Jetpack security settings.