### PR TITLE
Clean-up: Remove feature flag theme/assembler-first

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -228,7 +228,6 @@
 		"themes/premium": true,
 		"themes/subscription-purchases": true,
 		"themes/text-search-lots": true,
-		"themes/assembler-first": true,
 		"titan/iframe-control-panel": false,
 		"two-factor/enhanced-security": true,
 		"upgrades/redirect-payments": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -152,7 +152,6 @@
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/text-search-lots": true,
-		"themes/assembler-first": true,
 		"two-factor/enhanced-security": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/production.json
+++ b/config/production.json
@@ -199,7 +199,6 @@
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/text-search-lots": true,
-		"themes/assembler-first": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -195,7 +195,6 @@
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/text-search-lots": true,
-		"themes/assembler-first": true,
 		"two-factor/enhanced-security": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -192,7 +192,6 @@
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/text-search-lots": true,
-		"themes/assembler-first": true,
 		"two-factor/enhanced-security": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -1,6 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useRef, useState } from 'react';
@@ -324,7 +323,6 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	isBigSkyEligible = false,
 } ) => {
 	const translate = useTranslate();
-	const hasEnTranslation = useHasEnTranslation();
 	const { selectedCategoriesWithoutDesignTier } = useDesignPickerFilters();
 
 	const categories = categorization?.categories || [];
@@ -408,11 +406,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 			{ isMultiFilterEnabled && selectedCategoriesWithoutDesignTier.length > 1 && (
 				<DesignCardGroup
 					{ ...designCardProps }
-					title={
-						hasEnTranslation( 'Best theme matches' )
-							? translate( 'Best theme matches' )
-							: translate( 'Best matching themes' )
-					}
+					title={ translate( 'Best matching themes' ) }
 					category="best"
 					designs={ best }
 				/>

--- a/packages/design-picker/src/hooks/use-filtered-designs.ts
+++ b/packages/design-picker/src/hooks/use-filtered-designs.ts
@@ -45,7 +45,7 @@ export const getFilteredDesignsByCategory = (
 
 		// For designs that match all selected categories.
 		// Limit the best matches to at least 2 selected categories.
-		if ( categorySlugs.length > 1 && matchedCount === categorySlugs.length ) {
+		if ( categorySlugs.length > 1 && matchedCount > 1 ) {
 			filteredDesignsByCategory.best.push( design );
 			continue;
 		}
@@ -58,6 +58,21 @@ export const getFilteredDesignsByCategory = (
 			filteredDesignsByCategory[ lastMatchedCategorySlug ].push( design );
 		}
 	}
+
+	// sort best designs by highest number of matched categories
+	filteredDesignsByCategory.best.sort( ( a, b ) => {
+		const aMatchedCategorySlugs = categorySlugs.filter( ( categorySlug ) =>
+			a.categories.map( ( category ) => category.slug ).includes( categorySlug )
+		);
+		const bMatchedCategorySlugs = categorySlugs.filter( ( categorySlug ) =>
+			b.categories.map( ( category ) => category.slug ).includes( categorySlug )
+		);
+
+		return bMatchedCategorySlugs.length - aMatchedCategorySlugs.length;
+	} );
+
+	// limit the best designs to 6
+	filteredDesignsByCategory.best = filteredDesignsByCategory.best.slice( 0, 6 );
 
 	return filteredDesignsByCategory;
 };


### PR DESCRIPTION
## Proposed Changes

Feature flag theme/assembler-first is enabled in all environments so it can be removed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

p58i-j6R-p2 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

n/a

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?