### PR TITLE
Redirect users to /domains/add when cart is cleared in EmailUpsell flow.

### DIFF
--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -54,13 +54,13 @@ const CheckoutMasterbar = ( {
 	const { responseCart, replaceProductsInCart } = useShoppingCart( cartKey );
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
 
-	const closeAndLeave = ( userHasClearedCart: boolean = false ) =>
+	const closeAndLeave = ( options?: { userHasClearedCart?: boolean } ) =>
 		leaveCheckout( {
 			siteSlug,
 			forceCheckoutBackUrl,
 			previousPath,
 			tracksEvent: 'calypso_masterbar_close_clicked',
-			userHasClearedCart: userHasClearedCart,
+			userHasClearedCart: options?.userHasClearedCart ?? false,
 		} );
 
 	const clickClose = () => {
@@ -79,7 +79,9 @@ const CheckoutMasterbar = ( {
 	const modalSecondaryText = translate( 'Empty cart' );
 	const clearCartAndLeave = () => {
 		replaceProductsInCart( [] );
-		closeAndLeave( true );
+		closeAndLeave( {
+			userHasClearedCart: true,
+		} );
 	};
 
 	const showCloseButton = isLeavingAllowed && checkoutType === 'wpcom';

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -54,13 +54,13 @@ const CheckoutMasterbar = ( {
 	const { responseCart, replaceProductsInCart } = useShoppingCart( cartKey );
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
 
-	const closeAndLeave = ( clearedCart: boolean = false ) =>
+	const closeAndLeave = ( userHasClearedCart: boolean = false ) =>
 		leaveCheckout( {
 			siteSlug,
 			forceCheckoutBackUrl,
 			previousPath,
 			tracksEvent: 'calypso_masterbar_close_clicked',
-			clearedCart: clearedCart,
+			userHasClearedCart: userHasClearedCart,
 		} );
 
 	const clickClose = () => {

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -54,12 +54,13 @@ const CheckoutMasterbar = ( {
 	const { responseCart, replaceProductsInCart } = useShoppingCart( cartKey );
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
 
-	const closeAndLeave = () =>
+	const closeAndLeave = ( clearedCart: boolean = false ) =>
 		leaveCheckout( {
 			siteSlug,
 			forceCheckoutBackUrl,
 			previousPath,
 			tracksEvent: 'calypso_masterbar_close_clicked',
+			clearedCart: clearedCart,
 		} );
 
 	const clickClose = () => {
@@ -78,7 +79,7 @@ const CheckoutMasterbar = ( {
 	const modalSecondaryText = translate( 'Empty cart' );
 	const clearCartAndLeave = () => {
 		replaceProductsInCart( [] );
-		closeAndLeave();
+		closeAndLeave( true );
 	};
 
 	const showCloseButton = isLeavingAllowed && checkoutType === 'wpcom';

--- a/client/my-sites/checkout/src/hooks/use-remove-from-cart-and-redirect.ts
+++ b/client/my-sites/checkout/src/hooks/use-remove-from-cart-and-redirect.ts
@@ -29,6 +29,7 @@ export default function useRemoveFromCartAndRedirect(
 			createUserAndSiteBeforeTransaction,
 			previousPath: customizedPreviousPath || previousPath,
 			tracksEvent: 'calypso_empty_cart_redirect',
+			userHasClearedCart: true,
 		} );
 	}, [
 		createUserAndSiteBeforeTransaction,

--- a/client/my-sites/checkout/src/lib/leave-checkout.ts
+++ b/client/my-sites/checkout/src/lib/leave-checkout.ts
@@ -22,12 +22,14 @@ export const leaveCheckout = ( {
 	previousPath,
 	tracksEvent,
 	createUserAndSiteBeforeTransaction,
+	clearedCart = false,
 }: {
 	siteSlug?: string;
 	forceCheckoutBackUrl?: string;
 	previousPath?: string;
 	tracksEvent: string;
 	createUserAndSiteBeforeTransaction?: boolean;
+	clearedCart?: boolean;
 } ): void => {
 	recordTracksEvent( tracksEvent );
 	debug( 'leaving checkout with args', {
@@ -69,14 +71,18 @@ export const leaveCheckout = ( {
 	}
 
 	let closeUrl = siteSlug ? '/plans/' + siteSlug : '/start';
-
 	if (
 		previousPath &&
 		'' !== previousPath &&
 		previousPath !== window.location.href &&
 		! previousPath.includes( '/checkout/' )
 	) {
-		closeUrl = previousPath;
+		// If the previous page was the email upsell page, then we want to close the modal and go back to the domain page.
+		if ( clearedCart && /\/domains\/add\/[^/]+\/email\/[^/]+\?/.test( previousPath ) ) {
+			closeUrl = '/domains/add/' + siteSlug;
+		} else {
+			closeUrl = previousPath;
+		}
 	}
 
 	try {

--- a/client/my-sites/checkout/src/lib/leave-checkout.ts
+++ b/client/my-sites/checkout/src/lib/leave-checkout.ts
@@ -16,6 +16,33 @@ import { sendMessageToOpener } from './popup';
 
 const debug = debugFactory( 'calypso:leave-checkout' );
 
+const getCloseURL = ( {
+	clearedCart,
+	previousPath,
+	siteSlug,
+}: {
+	clearedCart: boolean;
+	previousPath?: string;
+	siteSlug?: string;
+} ): string => {
+	if (
+		previousPath &&
+		previousPath !== '' &&
+		previousPath !== window.location.href &&
+		! previousPath.includes( '/checkout/' )
+	) {
+		/* Regex to match /domains/add/abc123/email/def456? */
+		const emailUpsellRegex = /\/domains\/add\/[^/]+\/email\/[^/]+(\?|\/|$)/;
+
+		if ( clearedCart && emailUpsellRegex.test( previousPath ) ) {
+			return '/domains/add/' + siteSlug;
+		}
+		return previousPath;
+	}
+
+	return siteSlug ? '/plans/' + siteSlug : '/start';
+};
+
 export const leaveCheckout = ( {
 	siteSlug,
 	forceCheckoutBackUrl,
@@ -70,20 +97,7 @@ export const leaveCheckout = ( {
 		return;
 	}
 
-	let closeUrl = siteSlug ? '/plans/' + siteSlug : '/start';
-	if (
-		previousPath &&
-		'' !== previousPath &&
-		previousPath !== window.location.href &&
-		! previousPath.includes( '/checkout/' )
-	) {
-		// If the previous page was the email upsell page, then we want to close the modal and go back to the domain page.
-		if ( clearedCart && /\/domains\/add\/[^/]+\/email\/[^/]+\?/.test( previousPath ) ) {
-			closeUrl = '/domains/add/' + siteSlug;
-		} else {
-			closeUrl = previousPath;
-		}
-	}
+	const closeUrl = getCloseURL( { clearedCart, previousPath, siteSlug } );
 
 	try {
 		const searchParams = new URLSearchParams( window.location.search );

--- a/client/my-sites/checkout/src/lib/leave-checkout.ts
+++ b/client/my-sites/checkout/src/lib/leave-checkout.ts
@@ -17,11 +17,11 @@ import { sendMessageToOpener } from './popup';
 const debug = debugFactory( 'calypso:leave-checkout' );
 
 const getCloseURL = ( {
-	clearedCart,
+	userHasClearedCart,
 	previousPath,
 	siteSlug,
 }: {
-	clearedCart: boolean;
+	userHasClearedCart: boolean;
 	previousPath?: string;
 	siteSlug?: string;
 } ): string => {
@@ -34,7 +34,7 @@ const getCloseURL = ( {
 		/* Regex to match /domains/add/abc123/email/def456? */
 		const emailUpsellRegex = /\/domains\/add\/[^/]+\/email\/[^/]+(\?|\/|$)/;
 
-		if ( clearedCart && emailUpsellRegex.test( previousPath ) ) {
+		if ( userHasClearedCart && emailUpsellRegex.test( previousPath ) ) {
 			return '/domains/add/' + siteSlug;
 		}
 		return previousPath;
@@ -49,14 +49,14 @@ export const leaveCheckout = ( {
 	previousPath,
 	tracksEvent,
 	createUserAndSiteBeforeTransaction,
-	clearedCart = false,
+	userHasClearedCart = false,
 }: {
 	siteSlug?: string;
 	forceCheckoutBackUrl?: string;
 	previousPath?: string;
 	tracksEvent: string;
 	createUserAndSiteBeforeTransaction?: boolean;
-	clearedCart?: boolean;
+	userHasClearedCart?: boolean;
 } ): void => {
 	recordTracksEvent( tracksEvent );
 	debug( 'leaving checkout with args', {
@@ -97,7 +97,7 @@ export const leaveCheckout = ( {
 		return;
 	}
 
-	const closeUrl = getCloseURL( { clearedCart, previousPath, siteSlug } );
+	const closeUrl = getCloseURL( { userHasClearedCart, previousPath, siteSlug } );
 
 	try {
 		const searchParams = new URLSearchParams( window.location.search );

--- a/client/my-sites/checkout/src/test/leave-checkout.ts
+++ b/client/my-sites/checkout/src/test/leave-checkout.ts
@@ -124,21 +124,6 @@ describe( 'leaveCheckout', () => {
 
 			expect( navigate ).toHaveBeenCalledWith( previousPath );
 		} );
-
-		it( 'returns to previousPath if email upsell cart is not emptied', () => {
-			const siteSlug = 'mywpsite.wordpress.com';
-			const domain = 'my-search-domain';
-			const previousPath = `/domains/add/${ domain }/email/${ siteSlug }?`;
-
-			leaveCheckout( {
-				siteSlug: siteSlug,
-				tracksEvent: 'checkout_cancel',
-				previousPath: previousPath,
-				userHasClearedCart: false,
-			} );
-
-			expect( navigate ).toHaveBeenCalledWith( previousPath );
-		} );
 	} );
 } );
 

--- a/client/my-sites/checkout/src/test/leave-checkout.ts
+++ b/client/my-sites/checkout/src/test/leave-checkout.ts
@@ -70,7 +70,7 @@ describe( 'leaveCheckout', () => {
 			leaveCheckout( {
 				siteSlug: siteSlug,
 				tracksEvent: 'checkout_cancel',
-				clearedCart: true,
+				userHasClearedCart: true,
 			} );
 
 			expect( navigate ).toHaveBeenCalledWith( `/plans/${ siteSlug }` );
@@ -79,7 +79,7 @@ describe( 'leaveCheckout', () => {
 		it( 'returns to /start if missing site slug', () => {
 			leaveCheckout( {
 				tracksEvent: 'checkout_cancel',
-				clearedCart: true,
+				userHasClearedCart: true,
 			} );
 
 			expect( navigate ).toHaveBeenCalledWith( '/start' );
@@ -92,7 +92,7 @@ describe( 'leaveCheckout', () => {
 				siteSlug: siteSlug,
 				tracksEvent: 'checkout_cancel',
 				previousPath: '/domains/add/my-search-domain/email/mywpsite.wordpress.com?',
-				clearedCart: true,
+				userHasClearedCart: true,
 			} );
 
 			expect( navigate ).toHaveBeenCalledWith( `/domains/add/${ siteSlug }` );
@@ -104,7 +104,7 @@ describe( 'leaveCheckout', () => {
 			leaveCheckout( {
 				tracksEvent: 'checkout_cancel',
 				previousPath: previousPath,
-				clearedCart: false,
+				userHasClearedCart: false,
 			} );
 
 			expect( navigate ).toHaveBeenCalledWith( previousPath );
@@ -119,7 +119,7 @@ describe( 'leaveCheckout', () => {
 				siteSlug: siteSlug,
 				tracksEvent: 'checkout_cancel',
 				previousPath: previousPath,
-				clearedCart: false,
+				userHasClearedCart: false,
 			} );
 
 			expect( navigate ).toHaveBeenCalledWith( previousPath );
@@ -134,7 +134,7 @@ describe( 'leaveCheckout', () => {
 				siteSlug: siteSlug,
 				tracksEvent: 'checkout_cancel',
 				previousPath: previousPath,
-				clearedCart: false,
+				userHasClearedCart: false,
 			} );
 
 			expect( navigate ).toHaveBeenCalledWith( previousPath );

--- a/client/my-sites/checkout/src/test/leave-checkout.ts
+++ b/client/my-sites/checkout/src/test/leave-checkout.ts
@@ -62,6 +62,84 @@ describe( 'leaveCheckout', () => {
 			expect( navigate ).not.toHaveBeenCalledWith( '/\\example.com' );
 		} );
 	} );
+
+	describe( 'getCloseURL handling', () => {
+		it( 'returns to plans page when previous path is empty', () => {
+			const siteSlug = 'mywpsite.wordpress.com';
+
+			leaveCheckout( {
+				siteSlug: siteSlug,
+				tracksEvent: 'checkout_cancel',
+				clearedCart: true,
+			} );
+
+			expect( navigate ).toHaveBeenCalledWith( `/plans/${ siteSlug }` );
+		} );
+
+		it( 'returns to /start if missing site slug', () => {
+			leaveCheckout( {
+				tracksEvent: 'checkout_cancel',
+				clearedCart: true,
+			} );
+
+			expect( navigate ).toHaveBeenCalledWith( '/start' );
+		} );
+
+		it( 'returns to domain page when previous page is email upsell and cart is emptied', () => {
+			const siteSlug = 'mywpsite.wordpress.com';
+
+			leaveCheckout( {
+				siteSlug: siteSlug,
+				tracksEvent: 'checkout_cancel',
+				previousPath: '/domains/add/my-search-domain/email/mywpsite.wordpress.com?',
+				clearedCart: true,
+			} );
+
+			expect( navigate ).toHaveBeenCalledWith( `/domains/add/${ siteSlug }` );
+		} );
+
+		it( 'returns to previousPath', () => {
+			const previousPath = `/previous-path`;
+
+			leaveCheckout( {
+				tracksEvent: 'checkout_cancel',
+				previousPath: previousPath,
+				clearedCart: false,
+			} );
+
+			expect( navigate ).toHaveBeenCalledWith( previousPath );
+		} );
+
+		it( 'returns to previousPath if email upsell and cart is not emptied', () => {
+			const siteSlug = 'mywpsite.wordpress.com';
+			const domain = 'my-search-domain';
+			const previousPath = `/domains/add/${ domain }/email/${ siteSlug }?`;
+
+			leaveCheckout( {
+				siteSlug: siteSlug,
+				tracksEvent: 'checkout_cancel',
+				previousPath: previousPath,
+				clearedCart: false,
+			} );
+
+			expect( navigate ).toHaveBeenCalledWith( previousPath );
+		} );
+
+		it( 'returns to previousPath if email upsell cart is not emptied', () => {
+			const siteSlug = 'mywpsite.wordpress.com';
+			const domain = 'my-search-domain';
+			const previousPath = `/domains/add/${ domain }/email/${ siteSlug }?`;
+
+			leaveCheckout( {
+				siteSlug: siteSlug,
+				tracksEvent: 'checkout_cancel',
+				previousPath: previousPath,
+				clearedCart: false,
+			} );
+
+			expect( navigate ).toHaveBeenCalledWith( previousPath );
+		} );
+	} );
 } );
 
 describe( 'isRelativeUrl', () => {


### PR DESCRIPTION
Fixes: #84228

## Proposed Changes
When a user clears their cart at checkout after coming from the domainEmail upsell flow, they encounter an error when attempting to add an email after being redirected there.

This PR updates `leaveCheckout` to return users to `/domain/add` if they have cleared their cart and are coming from the Email Upsell flow.

### Changes:
 - Pass a new optional property `userHasClearedCart` to `leaveCheckout` to determine whether the user has chosen to clear their cart.
 - Add `getCloseURL` function to encapsulate `closeUrl` logic.
    -  Add regex to determine if previousPath was the email upsell path and return to `/domain/add` if users have cleared their cart.

## Why are these changes being made?

Ideally, we wouldn't need to add flow-specific logic to `leaveCheckout`. It would be best to redirect users who arrive on `/domains/add/{domain}/email/{site}` before rendering the page. 

Currently when users clear their cart, we call [replaceProductsInCart](https://github.com/Automattic/wp-calypso/blob/0e13e0f7405b0ee040247f6e7f488e1a2a8c44e0/client/layout/masterbar/checkout.tsx#L80) and immediately redirect the user. Often, users arrive at their next route before the cart has fully cleared. We therefore can't simply check the cart early and redirect. They EmailUpsell view will flash.

We therefore have three choices:
- Run `replaceProductsInCart` synchronously, then check cart on upsell page load.
- Suspend rendering the email upsell view until cart actions have all resolved.
- Direct users in leaveCheckout.

### Run `replaceProductsInCart` synchronously

Unfortunately, this doesn't work because users will see the empty cart state flash before they are redirected.

### Suspend rendering the email upsell

This approach is more predictable and how other pages in upsells flows work. However, this will introduce more delays in rendering the page. As it is, the email upsell page loads fast and is snappy. This is a much better experience for upsells. We don't want users to wait for an upsell they may not want.

### Direct users in leaveCheckout [Implemented in this PR]

I went with this approach. If feels like the quickest win that doesn't add delays in the purchase flow or introduce any large refactors. 

It isn't without some compromise though. 

I decided to use a regex to determine if the users came from the domain flow. I considered using [domainAddEmailUpsell](https://github.com/Automattic/wp-calypso/blob/0e13e0f7405b0ee040247f6e7f488e1a2a8c44e0/client/my-sites/domains/paths.js#L91) but since we don't have access to `context.params` to determine the domain the were adding, I didn't see an easy way to compare the URLs. There may be a way to do it with the flow name but that also requires access to `context` or maybe there's a way to get the context?

There's also one use case that isn't handled. If a user clears their cart but makes their way back to the upsell page, they will get an error if they add an email. I don't think that use case would be common and I'm not convinced we need to handle it.


## Testing Instructions

Using an account with no domain yet.

**Test Emptying Cart**
1. From `Upgrade->Domains` click "Just search for a domain"
2. Add Domain
3. Skip email upsell
4. At checkout, click "X" and empty cart
5. Confirm you are redirected to `/domains/add`

**Test Leave Items in Cart**
1. From `Upgrade->Domains` click "Just search for a domain"
2. Add Domain
3. Skip email upsell
4. At checkout, click "X" and leave items
5. Confirm you are on the email upsell page.

**Test Add Plan flow, empty cart**
1. From `Upgrade->Plans` click "Upgrade" on a plan
2. At checkout, click "X" and empty cart
3. Expect to be back on the plan page

Re-run the test but choose "Leave Items" in cart, expect the same result.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
