### PR TITLE
A4A > Marketplace: Product card redesign

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/multi-product-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/multi-product-card/index.tsx
@@ -1,4 +1,5 @@
-import { Button } from '@automattic/components';
+import { isEnabled } from '@automattic/calypso-config';
+import { Button } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -156,6 +157,8 @@ export default function MultiProductCard( props: Props ) {
 		return isSelected ? translate( 'Added to cart' ) : translate( 'Add to cart' );
 	}, [ asReferral, isSelected, translate ] );
 
+	const isRedesign = isEnabled( 'a4a-product-page-redesign' );
+
 	return (
 		<>
 			<div
@@ -175,14 +178,16 @@ export default function MultiProductCard( props: Props ) {
 							<div className="product-card__heading">
 								<h3 className="product-card__title">{ getProductShortTitle( product, true ) }</h3>
 
-								<MultipleChoiceQuestion
-									name={ `${ product.family_slug }-variant-options` }
-									question={ translate( 'Select variant:' ) }
-									answers={ variantOptions }
-									selectedAnswerId={ product.slug }
-									onAnswerChange={ onChangeOption }
-									shouldShuffleAnswers={ false }
-								/>
+								{ ! isRedesign && (
+									<MultipleChoiceQuestion
+										name={ `${ product.family_slug }-variant-options` }
+										question={ translate( 'Select variant:' ) }
+										answers={ variantOptions }
+										selectedAnswerId={ product.slug }
+										onAnswerChange={ onChangeOption }
+										shouldShuffleAnswers={ false }
+									/>
+								) }
 
 								<div className="product-card__pricing is-compact">
 									<ProductPriceWithDiscount
@@ -193,14 +198,25 @@ export default function MultiProductCard( props: Props ) {
 									/>
 								</div>
 
+								{ isRedesign && (
+									<MultipleChoiceQuestion
+										name={ `${ product.family_slug }-variant-options` }
+										question={ translate( 'Select variant:' ) }
+										answers={ variantOptions }
+										selectedAnswerId={ product.slug }
+										onAnswerChange={ onChangeOption }
+										shouldShuffleAnswers={ false }
+									/>
+								) }
+
 								<div className="product-card__description">{ productDescription }</div>
 							</div>
 						</div>
 					</div>
 					<div className="product-card__buttons">
 						<Button
-							className="product-card__select-button"
-							primary={ ! isSelected }
+							className={ clsx( { 'product-card__select-button': ! isRedesign } ) }
+							variant={ ! isSelected ? 'primary' : 'secondary' }
 							tabIndex={ -1 }
 						>
 							{ isSelected && <Icon icon={ check } /> }
@@ -211,6 +227,7 @@ export default function MultiProductCard( props: Props ) {
 								customText={ translate( 'View details' ) }
 								productName={ getProductShortTitle( product ) }
 								onClick={ onShowLightbox }
+								showIcon={ ! isRedesign }
 							/>
 						) }
 					</div>

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/index.tsx
@@ -1,4 +1,5 @@
-import { Button } from '@automattic/components';
+import { isEnabled } from '@automattic/calypso-config';
+import { Button } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -130,6 +131,8 @@ export default function ProductCard( props: Props ) {
 		return isSelected ? translate( 'Remove from cart' ) : translate( 'Add to cart' );
 	}, [ asReferral, isSelected, translate ] );
 
+	const isRedesign = isEnabled( 'a4a-product-page-redesign' );
+
 	return (
 		<>
 			<div
@@ -167,8 +170,8 @@ export default function ProductCard( props: Props ) {
 					</div>
 					<div className="product-card__buttons">
 						<Button
-							className="product-card__select-button"
-							primary={ ! isSelected }
+							className={ clsx( { 'product-card__select-button': ! isRedesign } ) }
+							variant={ ! isSelected ? 'primary' : 'secondary' }
 							tabIndex={ -1 }
 						>
 							{ isSelected && <Icon icon={ check } /> }
@@ -179,6 +182,7 @@ export default function ProductCard( props: Props ) {
 								customText={ translate( 'View details' ) }
 								productName={ productTitle }
 								onClick={ onShowLightbox }
+								showIcon={ ! isRedesign }
 							/>
 						) }
 					</div>

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/style.scss
@@ -230,3 +230,66 @@
 	}
 }
 
+.products-overview-v2 {
+	.product-card__heading {
+		gap: 12px;
+	}
+
+	.product-card__inner {
+		border-radius: 8px; /* stylelint-disable-line scales/radii */
+		border-color: #ddd;
+		padding: 16px;
+	}
+
+	.product-card__title {
+		// TODO: Replace with Heading LG
+		font-size: rem(15px);
+		font-weight: 500;
+		line-height: 1.3;
+	}
+
+	.product-price-with-discount__price {
+		// TODO: Replace with Heading XL
+		font-size: rem(20px);
+		font-weight: 500;
+		line-height: 1.2;
+	}
+
+	.product-price-with-discount__price-interval {
+		// TODO: Replace with Body MD
+		font-size: rem(13px);
+		font-weight: 400;
+		line-height: 1.5;
+	}
+
+	.product-card__pricing {
+		margin: 0;
+	}
+
+	.product-card__description {
+		// TODO: Replace with Body LG
+		font-size: rem(15px);
+		font-weight: 400;
+		line-height: 1.6;
+
+		color: var(--color-neutral-80);
+		margin: 0;
+	}
+
+	// TODO: Create a new component for
+	// this on A4A when we remove the feature flag
+	.license-lightbox-link {
+		font-size: rem(13px);
+		font-weight: 400;
+		line-height: 1.5;
+		text-decoration: none;
+		color: var(--color-primary);
+	}
+}
+
+.product-card__types {
+	display: flex;
+	gap: 0.5rem;
+	margin-block-start: 4px;
+}
+

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox-link/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox-link/index.tsx
@@ -10,12 +10,14 @@ type Props = {
 	productName: string;
 	customText?: string;
 	onClick: ( e: React.MouseEvent< HTMLElement > ) => void;
+	showIcon?: boolean;
 };
 
 const LicenseLightboxLink: FunctionComponent< Props > = ( {
 	productName,
 	customText,
 	onClick,
+	showIcon = true,
 } ) => {
 	const translate = useTranslate();
 
@@ -37,7 +39,7 @@ const LicenseLightboxLink: FunctionComponent< Props > = ( {
 					  } ) }
 			</span>
 
-			<img className="license-lightbox-link-icon" src={ ModalLinkIcon } alt="" />
+			{ showIcon && <img className="license-lightbox-link-icon" src={ ModalLinkIcon } alt="" /> }
 		</Button>
 	);
 };


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1639

## Proposed Changes

This PR updates the product cards on the marketplace according to the new design.

## Why are these changes being made?

* To match the UI with the latest product page redesign

Note: We will add the badges in a different PR. We also need to decide if we want to continue with the existing design for the discount. @madebynoam 

## Testing Instructions

* Open the A4A live link
* Go to Marketplace: Products > Append the URL with ?flags=-a4a-product-page-redesign and verify it matches the production version. There is a slight difference in the width, which is negligible and ignored. 
* Remove the feature flag > Verify the product cards are updated, as shown below. 

<img width="1728" alt="Screenshot 2025-01-17 at 10 27 26 AM" src="https://github.com/user-attachments/assets/b1352d61-e370-4a53-bd1b-58514b8638e6" />

<img width="1728" alt="Screenshot 2025-01-17 at 10 27 36 AM" src="https://github.com/user-attachments/assets/8bf4e828-7ee6-46fd-85af-58551e3dee45" />

<img width="1728" alt="Screenshot 2025-01-17 at 10 28 21 AM" src="https://github.com/user-attachments/assets/5aa9e48f-de20-4019-b221-145b305d4c70" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
