### PR TITLE
Clean-up: Remove feature flags signup/design-picker-preview-{colors,fonts}

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -196,8 +196,6 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/design-picker-preview-colors": true,
-		"signup/design-picker-preview-fonts": true,
 		"signup/professional-email-step": false,
 		"signup/social": true,
 		"signup/social-first": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -125,8 +125,6 @@
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
-		"signup/design-picker-preview-colors": true,
-		"signup/design-picker-preview-fonts": true,
 		"signup/professional-email-step": false,
 		"signup/social": true,
 		"signup/social-first": true,

--- a/config/production.json
+++ b/config/production.json
@@ -166,8 +166,6 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/design-picker-preview-colors": true,
-		"signup/design-picker-preview-fonts": true,
 		"signup/professional-email-step": false,
 		"signup/social": true,
 		"signup/social-first": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -163,8 +163,6 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/design-picker-preview-colors": true,
-		"signup/design-picker-preview-fonts": true,
 		"signup/professional-email-step": false,
 		"signup/social": true,
 		"signup/social-first": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -160,8 +160,6 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/design-picker-preview-colors": true,
-		"signup/design-picker-preview-fonts": true,
 		"signup/professional-email-step": false,
 		"signup/social": true,
 		"signup/social-first": true,

--- a/packages/design-preview/src/hooks/use-screens.tsx
+++ b/packages/design-preview/src/hooks/use-screens.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { isDefaultGlobalStylesVariationSlug } from '@automattic/design-picker';
 import {
 	GlobalStylesVariations,
@@ -90,8 +89,7 @@ const useScreens = ( {
 					variations.length === 0 &&
 					// Disable Colors for themes that don't play well with them. See pbxlJb-4cl-p2 for more context.
 					! isVirtual &&
-					! COLOR_VARIATIONS_BLOCK_LIST.includes( stylesheet ) &&
-					isEnabled( 'signup/design-picker-preview-colors' ) && {
+					! COLOR_VARIATIONS_BLOCK_LIST.includes( stylesheet ) && {
 						slug: 'color-palettes',
 						checked: !! selectedColorVariation,
 						icon: color,
@@ -119,8 +117,7 @@ const useScreens = ( {
 						onSubmit: onScreenSubmit,
 					},
 				variations &&
-					variations.length === 0 &&
-					isEnabled( 'signup/design-picker-preview-fonts' ) && {
+					variations.length === 0 && {
 						slug: 'font-pairings',
 						checked: !! selectedFontVariation,
 						icon: typography,


### PR DESCRIPTION
## Proposed Changes

Feature flags signup/design-picker-preview-colors, and signup/design-picker-preview-fonts are enabled in all environments so they can be removed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

p58i-j6R-p2 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Smoke-test the onboarding design picker.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?