### PR TITLE
Help Center: Fix article feedback in /sites

### DIFF
--- a/packages/help-center/src/components/help-center-feedback-form.tsx
+++ b/packages/help-center/src/components/help-center-feedback-form.tsx
@@ -20,7 +20,7 @@ const HelpCenterFeedbackForm = ( { postId }: { postId: number } ) => {
 
 	const { data } = useSupportStatus();
 	const isUserEligibleForPaidSupport = Boolean( data?.eligibility?.is_user_eligible );
-	const { site } = useHelpCenterContext();
+	const { canConnectToZendesk } = useHelpCenterContext();
 	const navigate = useNavigate();
 	const resetSupportInteraction = useResetSupportInteraction();
 	const { startNewInteraction } = useManageSupportInteraction();
@@ -80,7 +80,7 @@ const HelpCenterFeedbackForm = ( { postId }: { postId: number } ) => {
 			{ startedFeedback !== null && answerValue === 1 && (
 				<p>{ __( 'Great! Thanks.', __i18n_text_domain__ ) }</p>
 			) }
-			{ startedFeedback !== null && answerValue === 2 && site && (
+			{ startedFeedback !== null && answerValue === 2 && (
 				<>
 					<div className="odie-chatbox-dislike-feedback-message">
 						<p>
@@ -93,6 +93,7 @@ const HelpCenterFeedbackForm = ( { postId }: { postId: number } ) => {
 					<GetSupport
 						onClickAdditionalEvent={ handleContactSupportClick }
 						isUserEligibleForPaidSupport={ isUserEligibleForPaidSupport }
+						canConnectToZendesk={ canConnectToZendesk }
 					/>
 				</>
 			) }

--- a/packages/odie-client/src/components/message/get-support.scss
+++ b/packages/odie-client/src/components/message/get-support.scss
@@ -1,38 +1,56 @@
-
-
-.help-center__container-chat .chatbox-messages .odie__transfer-chat,
-.help-center-article-content .help-center-feedback__form .odie__transfer-chat {
-	display: flex;
-	width: 100%;
-	padding-bottom: 16px;
-
-	button {
-		border-radius: 2px;
-		border: 1px solid var(--studio-gray-10);
-		background: var(--studio-white);
+.help-center__container-chat .chatbox-messages,
+.help-center-article-content .help-center-feedback__form {
+	.odie__transfer-chat {
 		display: flex;
-		height: 40px;
-		padding: 8px 14px;
-		justify-content: center;
-		align-items: center;
-		gap: 4px;
-		color: var(--studio-gray-70);
+		width: 100%;
+		padding-bottom: 16px;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 8px;
 
-		&:hover {
-			border: 1px solid var(--studio-gray-20);
-			cursor: pointer;
+		.odie__transfer-chat--button-container {
+			display: flex;
+			gap: 8px;
+
+			.odie__transfer-chat--wait-time {
+				font-size: 0.75rem;
+				color: var( --studio-gray-50 );
+				align-content: center;
+			}
 		}
 
-		&:focus,
-		&:active {
-			outline: none;
+		button {
+			border-radius: 2px;
+			border: 1px solid var( --studio-gray-10 );
+			background: var( --studio-white );
+			display: flex;
+			height: 40px;
+			padding: 8px 14px;
+			justify-content: center;
+			align-items: center;
+			gap: 4px;
+			color: var( --studio-gray-70 );
+
+			&:hover {
+				border: 1px solid var( --studio-gray-20 );
+				cursor: pointer;
+			}
+
+			&:focus,
+			&:active {
+				outline: none;
+			}
 		}
+	}
+
+	.help-center__cookie-warning {
+		margin-top: 16px;
 	}
 }
 
 .help-center__cookie-warning {
-	background-color: var(--studio-yellow-0);
-	border-left: 4px solid var(--studio-yellow-20);
+	background-color: var( --studio-yellow-0 );
+	border-left: 4px solid var( --studio-yellow-20 );
 	padding: 8px 16px;
 	margin-bottom: 30px;
 
@@ -41,26 +59,6 @@
 	}
 }
 
-.help-center__container-chat .chatbox-messages {
-	.odie__transfer-chat {
-		margin-left: 46px;
-		flex-direction: column;
-    	align-items: flex-start;
-		gap: 8px;
-
-		.odie__transfer-chat--button-container {
-			display: flex;
-			gap: 8px;
-
-			.odie__transfer-chat--wait-time {
-				font-size: 0.75rem;	
-				color: var(--studio-gray-50);
-				align-content: center;
-			}
-		}
-	}
-
-	.help-center__cookie-warning {
-		margin-top: 16px;
-	}
+.help-center__container-chat .chatbox-messages .odie__transfer-chat {
+	margin-left: 46px;
 }

--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -9,6 +9,7 @@ import './get-support.scss';
 interface GetSupportProps {
 	onClickAdditionalEvent?: ( destination: string ) => void;
 	isUserEligibleForPaidSupport?: boolean;
+	canConnectToZendesk?: boolean;
 }
 
 interface ButtonConfig {
@@ -43,13 +44,14 @@ export const NewThirdPartyCookiesNotice: React.FC = () => {
 export const GetSupport: React.FC< GetSupportProps > = ( {
 	onClickAdditionalEvent,
 	isUserEligibleForPaidSupport,
+	canConnectToZendesk = false,
 } ) => {
 	const navigate = useNavigate();
 	const newConversation = useCreateZendeskConversation();
 	const {
 		chat,
 		isUserEligibleForPaidSupport: contextIsUserEligibleForPaidSupport,
-		canConnectToZendesk,
+		canConnectToZendesk: contextCanConnectToZendesk,
 	} = useOdieAssistantContext();
 	const isEnglishLocale = useIsEnglishLocale();
 
@@ -59,7 +61,7 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 	}
 
 	if (
-		! canConnectToZendesk &&
+		! ( canConnectToZendesk || contextCanConnectToZendesk ) &&
 		( isUserEligibleForPaidSupport || contextIsUserEligibleForPaidSupport )
 	) {
 		return <NewThirdPartyCookiesNotice />;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/10264

## Proposed Changes

There is a bug in pages without a siteSlug, like `/sites`, where the buttons to contact support are not showed when clicking the thumbs down here at the end of an article: 

![image](https://github.com/user-attachments/assets/e7646304-58c4-4252-86b5-32e604bd1f22)

This PR:
- removes the check for site
- adjust the styling of the buttons
- fix the context for `canConnectToZendesk` not correct outside of Odie.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/a3d270a6-710e-4397-9670-dba982f75f78) | ![image](https://github.com/user-attachments/assets/a137c77c-811a-4a54-9c52-e2b6da817373) | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Live Link
* Open an article, reach the bottom and click on thumbs down
* You should be able to see the buttons
* Clicking on a button should bring you to the chat.