### PR TITLE
Remove duplicate views: Enable for all a12s (Calypso)

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -399,7 +399,12 @@ export const redirectIfDuplicatedView = ( wpAdminPath ) => async ( context, next
 
 	loadExperimentAssignment( aaTestName );
 	const duplicateViewsExperimentAssignment = await loadExperimentAssignment( experimentName );
-	if ( isE2ETest() || duplicateViewsExperimentAssignment.variationName === 'treatment' ) {
+
+	if (
+		config( 'env_id' ) !== 'production' ||
+		isE2ETest() ||
+		duplicateViewsExperimentAssignment.variationName === 'treatment'
+	) {
 		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );
 		const wpAdminUrl = getSiteAdminUrl( state, siteId, wpAdminPath );


### PR DESCRIPTION
## Proposed Changes

Enables the "Remove duplicate views" experiment in Calypso for all Automatticians.

Because we don't have good tools in Calypso to detect if the current user is an a11n, this PR simply checks the environment and forces the experiment on all envs except production.

That way, a12s (who typically visit Calypso in the `stage` environment), will have the experiment enabled.

See pbxNRc-4Ls-p2

## Why are these changes being made?

Because a12s are currently getting the control variant, which is only given to 10% of users.

## Testing Instructions

- Go to the experiment (22167-explat-experiment) and assign yourself to control
- Use the Calypso live link below
- Go to any of the removed Calypso paths:
  - /posts/:site
  - /pages/:site
  - /comments/:site
  - ...
- Make sure you're redirected to WP Admin

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?