### PR TITLE
Masterbar: Update colors so they match Modern (default) color scheme.

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -59,10 +59,10 @@ $brand-text: "SF Pro Text", $sans;
 		--color-sidebar-gridicon-selected-fill: var(--color-sidebar-menu-selected-text);
 		--color-sidebar-tooltip-background: var(--color-sidebar-menu-hover-background);
 		--color-sidebar-tooltip-text: var(--color-sidebar-menu-hover-text);
-		--color-masterbar-unread-dot-background: #e65054;
-		--color-masterbar-background: var(--studio-gray-90);
-		--color-masterbar-text: var(--studio-gray-10);
-		--color-masterbar-icon: var(--studio-gray-10);
+		--color-masterbar-unread-dot-background: var(--studio-wordpress-blue-20);
+		--color-masterbar-background: #1e1e1e; // From "Modern" color scheme.
+		--color-masterbar-text: #fff; // From "Modern" color scheme.
+		--color-masterbar-icon: #fff; // From "Modern" color scheme.
 		--color-masterbar-submenu-text: var(--color-sidebar-text);
 		--color-masterbar-submenu-hover-text: var(--color-accent);
 		--color-global-masterbar-submenu-background: var(--studio-white);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_global.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_global.scss
@@ -13,7 +13,7 @@ WPCom Global theme, Modern theme adjusted for use in calypso non site contexts
 	--theme-icon-color: #ece6f6; /* Direct from wp-admin */
 	--theme-highlight-color: #3858e9; /* Direct from wp-admin */
 	--theme-highlight-color-rgb: 56, 88, 233; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
-	--theme-notification-color: #3858e9; /* Direct from wp-admin */
+	--theme-notification-color: var(--studio-wordpress-blue-20);
 
 	/* Theme highlight monochromatic palette */
 	--theme-highlight-color-0: #d5dffa;

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
@@ -31,7 +31,7 @@ Uses custom theme highlight monochromatic palette for primary + accent
 	--theme-icon-color: #f3f1f1; /* $icon-color */
 	--theme-highlight-color: #3858e9; /* $highlight-color */
 	--theme-highlight-color-rgb: 56, 88, 233; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
-	--theme-notification-color: #3858e9; /* Direct from wp-admin */
+	--theme-notification-color: var(--studio-wordpress-blue-20);
 
 	/* Theme highlight monochromatic palette */
 	--theme-highlight-color-0: #d5dffa;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8519

## Proposed Changes

Updates masterbar colors to match the Modern color scheme, which is the default admin color scheme.

### Before

![Screenshot 2025-01-17 at 14 29 57](https://github.com/user-attachments/assets/268bd228-91ff-415a-b728-5c0c363ddd41)

![Screenshot 2025-01-17 at 14 30 04](https://github.com/user-attachments/assets/2e39215b-76c4-49df-8fc2-fe0a655f7120)

![Screenshot 2025-01-17 at 14 30 36](https://github.com/user-attachments/assets/f912a574-e02d-4f5b-ab0d-228a8981f9f5)


### After

![Screenshot 2025-01-17 at 14 25 21](https://github.com/user-attachments/assets/b61481eb-00f7-4a50-94d8-fa4c41b811b5)

![Screenshot 2025-01-17 at 14 25 31](https://github.com/user-attachments/assets/7156b70a-d82e-4fc2-b2d8-ff903d17de0b)

![Screenshot 2025-01-17 at 14 25 59](https://github.com/user-attachments/assets/bb679f8c-7e9d-40fa-aed7-aed27a09faeb)


## Why are these changes being made?

There are color scheme colors from individual site installs, and then global Calypso styles. Over time, colors have drifted out of sync, likely as default admin color schemes have been updated, and changed. 

This PR fixes issues with the Modern color scheme (there was a contrast issue with the unread bell), and syncs up the color schemes applied to Calypso (Reader, Me, Sites) so they match the default Modern color scheme. 

That specifically includes updating the grays. The default shades of gray in the WordPress design system (as defined [here](https://github.com/WordPress/gutenberg/blob/trunk/packages/base-styles/_colors.scss)) are not yet in Color Studio, and must therefore be defined inline. CC: @Automattic/dotcom-design 

## Testing Instructions

Apply the PR, then test the wp-admin sections, such as Users > Profile, as well as Reader, Me, and Sites, to see if the colors of the adminbar/masterbar match.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
