### PR TITLE
Remove the window.AppBoot function

### DIFF
--- a/client/boot/app.js
+++ b/client/boot/app.js
@@ -5,6 +5,4 @@ import { bootApp } from './common';
 
 import 'calypso/assets/stylesheets/style.scss';
 
-window.AppBoot = () => {
-	bootApp( 'Calypso' );
-};
+bootApp( 'Calypso' );

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -246,9 +246,6 @@ class Document extends Component {
 					{ entrypoint.js.map( ( asset ) => (
 						<script key={ asset } src={ asset } />
 					) ) }
-					<script nonce={ inlineScriptNonce } type="text/javascript">
-						window.AppBoot();
-					</script>
 					<script
 						nonce={ inlineScriptNonce }
 						dangerouslySetInnerHTML={ {

--- a/client/landing/login/index.js
+++ b/client/landing/login/index.js
@@ -17,7 +17,8 @@ import 'calypso/assets/stylesheets/style.scss';
 // goofy import for environment badge, which is SSR'd
 import 'calypso/components/environment-badge/style.scss';
 
-const boot = ( currentUser ) => {
+async function main() {
+	const currentUser = await initializeCurrentUser();
 	const store = createStore();
 	setStore( store, getStateFromCache( currentUser?.ID ) );
 	configureReduxStore( currentUser, store );
@@ -36,9 +37,6 @@ const boot = ( currentUser ) => {
 
 	initLoginSection( ( route, ...handlers ) => page( route, ...handlers, render ) );
 	page.start();
-};
+}
 
-window.AppBoot = async () => {
-	const user = await initializeCurrentUser();
-	boot( user );
-};
+main();

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -83,7 +83,7 @@ const initializeHotJar = ( flowName: string ) => {
 	}
 };
 
-window.AppBoot = async () => {
+async function main() {
 	const { pathname, search } = window.location;
 
 	// Before proceeding we redirect the user if necessary.
@@ -193,4 +193,6 @@ window.AppBoot = async () => {
 			</Provider>
 		</CalypsoI18nProvider>
 	);
-};
+}
+
+main();

--- a/client/landing/subscriptions/index.tsx
+++ b/client/landing/subscriptions/index.tsx
@@ -47,11 +47,7 @@ const setupReduxStore = ( user: CurrentUser ) => {
 	return reduxStore;
 };
 
-declare const window: Window & {
-	AppBoot?: () => void;
-};
-
-window.AppBoot = async () => {
+async function main() {
 	const user = ( await initializeCurrentUser() ) as unknown as CurrentUser;
 	const { queryClient } = await createQueryClient( user.ID );
 	const reduxStore = setupReduxStore( user );
@@ -86,4 +82,6 @@ window.AppBoot = async () => {
 		</CalypsoI18nProvider>,
 		document.getElementById( 'wpcom' )
 	);
-};
+}
+
+main();

--- a/client/server/README.md
+++ b/client/server/README.md
@@ -10,4 +10,3 @@ Output is built on the server side by the following `modules` (corresponding to 
   - render content by passing that to `404.jsx`, `500.jsx`, `browsehappy.jsx`, `support-user.jsx`, `index.jsx` or `desktop.jsx` template files, respectively.
 - `index.jsx`
   - builds an HTML skeleton, including `<script>` tags to load relevant JavaScript files (minified unless in debug mode or in the `development` environment) that contain client-side (React) rendering code
-  - lastly, it runs `window.AppBoot()`, which is defined in `client/boot`.

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -485,10 +485,7 @@ function setUpCSP( req, res, next ) {
 	// and calculating SHA256 hash on it, encoded in base64, example:
 	// `sha256-${ base64( sha256( 'window.AppBoot();' ) ) }` === sha256-3yiQswl88knA3EhjrG5tj5gmV6EUdLYFvn2dygc0xUQ
 	// you can also just run it in Chrome, chrome will give you the hash of the violating scripts
-	const inlineScripts = [
-		'sha256-3yiQswl88knA3EhjrG5tj5gmV6EUdLYFvn2dygc0xUQ=',
-		'sha256-ZKTuGaoyrLu2lwYpcyzib+xE4/2mCN8PKv31uXS3Eg4=',
-	];
+	const inlineScripts = [ 'sha256-ZKTuGaoyrLu2lwYpcyzib+xE4/2mCN8PKv31uXS3Eg4=' ];
 
 	req.context.inlineScriptNonce = crypto.randomBytes( 48 ).toString( 'hex' );
 

--- a/client/types.ts
+++ b/client/types.ts
@@ -130,7 +130,6 @@ export type __TodoAny__ = any; /* eslint-disable-line @typescript-eslint/no-expl
 // Properties added to the `window` object:
 declare global {
 	interface Window {
-		AppBoot: () => void;
 		COMMIT_SHA: string; // Added by an inline script in <head> via SSR context + webpack.
 		app?: {
 			isDebug?: boolean;


### PR DESCRIPTION
I'm often running into the dreadful "`window.AppBoot` is not a function error" so I started looking into it.

This PR is the result: let's remove the `window.AppBoot` function and replace it with a `main`/`boot` function that is called directly in the JS code. That's how webpack apps are supposed to be done. Webpack will make sure that the chunks are loaded in the last one, and that the root module which calls `main()` is run only when all other modules are loaded.

I'm not sure about two things:
1. In addition to loading the entrypoint, we also preload chunks for the current section (e.g., `home` or `reader`). These chunks are loaded _after_ the entrypoint. But the scripts will be executed only after `main()` was already called, because that call is in the entrypoint chunk. Before this PR, we postponed the `main` call until all chunks were loaded.
2. We might need to revisit @arthur791004's #95748 PR that fixed the order of chunks. The code after this PR is more sensitive about the order.
