### PR TITLE
@automattic/request-external-access: Bump version to 1.0.1

### DIFF
--- a/packages/request-external-access/package.json
+++ b/packages/request-external-access/package.json
@@ -30,7 +30,7 @@
 	],
 	"scripts": {
 		"clean": "rm -rf dist",
-		"build": "transpile",
+		"build": "run -T transpile",
 		"prepack": "yarn run clean && yarn run build"
 	},
 	"dependencies": {

--- a/packages/request-external-access/package.json
+++ b/packages/request-external-access/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/request-external-access",
-	"version": "1.0.0",
+	"version": "1.0.1-rc.1",
 	"description": "Utility for requesting authorization of sharing services.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/request-external-access/package.json
+++ b/packages/request-external-access/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/request-external-access",
-	"version": "1.0.1-rc.2",
+	"version": "1.0.1",
 	"description": "Utility for requesting authorization of sharing services.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/request-external-access/package.json
+++ b/packages/request-external-access/package.json
@@ -34,7 +34,8 @@
 		"prepack": "yarn run clean && yarn run build"
 	},
 	"dependencies": {
-		"@automattic/popup-monitor": "workspace:^"
+		"@automattic/popup-monitor": "workspace:^",
+		"@babel/runtime": "^7.26.0"
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^"

--- a/packages/request-external-access/package.json
+++ b/packages/request-external-access/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/request-external-access",
-	"version": "1.0.1-rc.1",
+	"version": "1.0.1-rc.2",
 	"description": "Utility for requesting authorization of sharing services.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1802,6 +1802,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/popup-monitor": "workspace:^"
+    "@babel/runtime": "npm:^7.26.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/41078

## Proposed Changes

* Add missing dependencies, `@babel/runtime`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
