### PR TITLE
Infer zd client id by listening to sent messages

### DIFF
--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -1,7 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { HelpCenterSelect } from '@automattic/data-stores';
-import { type ZendeskMessage } from '@automattic/odie-client';
 import { useGetUnreadConversations } from '@automattic/odie-client/src/data';
 import {
 	useLoadZendeskMessaging,
@@ -17,6 +16,7 @@ import Smooch from 'smooch';
 import { useChatStatus } from '../hooks';
 import { HELP_CENTER_STORE } from '../stores';
 import { getClientId, getZendeskConversations } from './utils';
+import type { ZendeskMessage } from '@automattic/odie-client';
 
 const destroy = () => {
 	Smooch.destroy();

--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { HelpCenterSelect } from '@automattic/data-stores';
+import { type ZendeskMessage } from '@automattic/odie-client';
 import { useGetUnreadConversations } from '@automattic/odie-client/src/data';
 import {
 	useLoadZendeskMessaging,
@@ -64,7 +65,7 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 	const getUnreadNotifications = useGetUnreadConversations();
 
 	const getUnreadListener = useCallback(
-		( message: unknown, data: { conversation: { id: string } } ) => {
+		( message: ZendeskMessage, data: { conversation: { id: string } } ) => {
 			if ( isHelpCenterShown ) {
 				return;
 			}
@@ -72,6 +73,15 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 			Smooch.getConversationById( data?.conversation?.id ).then( () => getUnreadNotifications() );
 		},
 		[ isHelpCenterShown ]
+	);
+
+	const clientIdListener = useCallback(
+		( message: ZendeskMessage ) => {
+			if ( message?.source?.type === 'web' && message.source?.id ) {
+				setZendeskClientId( message.source?.id );
+			}
+		},
+		[ setZendeskClientId ]
 	);
 
 	// Initialize Smooch which communicates with Zendesk
@@ -110,11 +120,14 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 			getUnreadNotifications( allConversations );
 			setZendeskClientId( getClientId( allConversations ) );
 			Smooch.on( 'message:received', getUnreadListener );
+			Smooch.on( 'message:sent', clientIdListener );
 		}
 
 		return () => {
 			// @ts-expect-error -- 'off' is not part of the def.
 			Smooch?.off?.( 'message:received', getUnreadListener );
+			// @ts-expect-error -- 'off' is not part of the def.
+			Smooch?.off?.( 'message:sent', clientIdListener );
 		};
 	}, [ getUnreadListener, isChatLoaded, getUnreadNotifications, setZendeskClientId ] );
 

--- a/packages/help-center/src/components/help-center-smooch.tsx
+++ b/packages/help-center/src/components/help-center-smooch.tsx
@@ -79,6 +79,9 @@ const HelpCenterSmooch: React.FC< { enableAuth: boolean } > = ( { enableAuth } )
 		( message: ZendeskMessage ) => {
 			if ( message?.source?.type === 'web' && message.source?.id ) {
 				setZendeskClientId( message.source?.id );
+				// Unregister the listener after setting the client ID
+				// @ts-expect-error -- 'off' is not part of the def.
+				Smooch?.off?.( 'message:sent', clientIdListener );
 			}
 		},
 		[ setZendeskClientId ]

--- a/packages/help-center/src/components/help-center-support-chat-message.tsx
+++ b/packages/help-center/src/components/help-center-support-chat-message.tsx
@@ -1,7 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Gravatar } from '@automattic/components';
 import { getRelativeTimeString, useLocale } from '@automattic/i18n-utils';
-import { type ZendeskMessage } from '@automattic/odie-client';
 import { HumanAvatar } from '@automattic/odie-client/src/assets';
 import { useGetSupportInteractionById } from '@automattic/odie-client/src/data/use-get-support-interaction-by-id';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
@@ -11,6 +10,7 @@ import clsx from 'clsx';
 import { Link } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { HELP_CENTER_STORE } from '../stores';
+import type { ZendeskMessage } from '@automattic/odie-client';
 
 import './help-center-support-chat-message.scss';
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

In order to allow attachements in zendesk conversations we need to have the zd client id in the store.
We infer this when the user's conversations are fetched.
Because of this new customers opening a chat with support will have attachements disabled/hidden which is really inconvenient.

This PR improves how we infer this id by listening to messages sent. As long as the new customer sends at least one message, the listener will pick up the id from the message. This will enable the attachments after the first message is sent for a new customer.

Fixes https://github.com/Automattic/wp-calypso/issues/97701

## Proposed Changes

* Listen to `message:sent` to get and set the zendesk id

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To enable all users to use the attachment feature

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new user
* Verify their email and give them $50 worth of credits
* Chose the personal plan and choose to pay monthly
* Create the site with the plan
* Open user home via the PR link of via calypso.localhost
* Start a chat with support
* Notice that initially the attachment button is hidden
* Send your first message. The attachement button should appear now.
* Upload an image
* Verify that the image uploaded is added to the ticket

