### PR TITLE
Bulk Plugin Management: Use list view for small viewports

### DIFF
--- a/client/my-sites/plugins/plugin-activate-toggle/style.scss
+++ b/client/my-sites/plugins/plugin-activate-toggle/style.scss
@@ -49,13 +49,18 @@
 }
 
 .plugin-row-formatter__toggle {
-	.plugin-autoupdate-toggle {
+	.components-flex.components-h-stack {
+		flex-direction: row-reverse;
 		.plugin-action__label {
-			@include break-xlarge() {
+			@include break-large() {
 				// We don't want to use display: none here, because it will hide the popover icon
 				// that might contain useful details about why the action is disabled.
 				font-size: 0;
 			}
+		}
+	}
+	.plugin-autoupdate-toggle {
+		.plugin-action__label {
 			.plugin-action__disabled-info {
 				color: var(--studio-gray-40);
 			}

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
@@ -171,7 +171,9 @@ export default function SitesWithInstalledPluginsList( { sites, plugin, isWpCom 
 		...initialDataViewsState,
 		type: shouldUseListView ? DATAVIEWS_LIST : DATAVIEWS_TABLE,
 		fields: [ 'domain', 'activate', 'autoupdate', 'update', 'actions' ],
-		items: sites,
+		layout: {
+			primaryField: 'domain',
+		},
 	} ) );
 
 	const sitesWithSecondarySites = useSelector( ( state ) =>

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
@@ -1,7 +1,7 @@
-import { isDesktop } from '@automattic/viewport';
+import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useState, useCallback } from 'react';
+import { useMemo, useState, useCallback, useEffect } from 'react';
 import {
 	DATAVIEWS_LIST,
 	DATAVIEWS_TABLE,
@@ -177,6 +177,25 @@ export default function SitesWithInstalledPluginsList( { sites, plugin, isWpCom 
 	const sitesWithSecondarySites = useSelector( ( state ) =>
 		getSitesWithSecondarySites( state, sites )
 	);
+
+	useEffect( () => {
+		// Sets the correct fields when route changes or viewport changes
+		setDataViewsState( ( dVwState ) => ( {
+			...dVwState,
+			type: shouldUseListView ? DATAVIEWS_LIST : DATAVIEWS_TABLE,
+		} ) );
+
+		// Subscribe to viewport changes
+		const unsubscribe = subscribeIsDesktop( ( matches ) => {
+			const shouldUseListView = ! matches;
+			setDataViewsState( ( dVwState ) => ( {
+				...dVwState,
+				type: shouldUseListView ? DATAVIEWS_LIST : DATAVIEWS_TABLE,
+			} ) );
+		} );
+
+		return () => unsubscribe();
+	}, [ plugin.slug, shouldUseListView ] );
 
 	if ( ! sitesWithSecondarySites?.length ) {
 		return null;

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
@@ -1,7 +1,12 @@
+import { isDesktop } from '@automattic/viewport';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState, useCallback } from 'react';
-import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import {
+	DATAVIEWS_LIST,
+	DATAVIEWS_TABLE,
+	initialDataViewsState,
+} from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import { DataViews } from 'calypso/components/dataviews';
@@ -31,8 +36,10 @@ interface Props {
 export default function SitesWithInstalledPluginsList( { sites, plugin, isWpCom }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const isDesktopView = isDesktop();
+	const shouldUseListView = ! isDesktopView;
 
-	const compareBooleans =
+	const compareBooleans = useCallback(
 		( fieldName: keyof PluginSite ) => ( a: SiteDetails, b: SiteDetails, direction: string ) => {
 			const aValue = plugin.sites[ a.ID ][ fieldName ];
 			const bValue = plugin.sites[ b.ID ][ fieldName ];
@@ -43,7 +50,9 @@ export default function SitesWithInstalledPluginsList( { sites, plugin, isWpCom 
 				return aValue ? 1 : -1;
 			}
 			return aValue ? -1 : 1;
-		};
+		},
+		[ plugin ]
+	);
 
 	const renderActions = useCallback(
 		( site: SiteDetails ) => {
@@ -155,11 +164,12 @@ export default function SitesWithInstalledPluginsList( { sites, plugin, isWpCom 
 				enableSorting: false,
 			},
 		],
-		[ translate, plugin, sites.length, dispatch, renderActions ]
+		[ translate, compareBooleans, plugin, sites.length, dispatch, renderActions ]
 	);
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( () => ( {
 		...initialDataViewsState,
+		type: shouldUseListView ? DATAVIEWS_LIST : DATAVIEWS_TABLE,
 		fields: [ 'domain', 'activate', 'autoupdate', 'update', 'actions' ],
 		items: sites,
 	} ) );

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/style.scss
@@ -162,4 +162,13 @@
 			justify-content: flex-end;
 		}
 	}
+// Hiding this here because in this version the mediaField is not hiddable
+// https://github.com/WordPress/gutenberg/tree/d59faffa3d270dbc7716f653b4cdab6020812658/packages/dataviews#properties-of-layout
+// In future versions, a showMedia property can be used
+	.dataviews-view-list {
+		.dataviews-view-list__media-wrapper {
+			background-color: transparent;
+			display: none;
+		}
+	}
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/style.scss
@@ -153,22 +153,31 @@
 		td:first-child .dataviews-view-table__cell-content-wrapper > span {
 			flex-grow: 1;
 
-			.plugin-row-formatter__overlay {
-				display: none;
-			}
 		}
 
 		td:last-child .dataviews-view-table__cell-content-wrapper {
 			justify-content: flex-end;
 		}
 	}
-// Hiding this here because in this version the mediaField is not hiddable
-// https://github.com/WordPress/gutenberg/tree/d59faffa3d270dbc7716f653b4cdab6020812658/packages/dataviews#properties-of-layout
-// In future versions, a showMedia property can be used
+
+	.plugin-row-formatter__overlay {
+		display: none;
+	}
+
 	.dataviews-view-list {
+		// Hiding this here because in this version the mediaField is not hiddable
+		// https://github.com/WordPress/gutenberg/tree/d59faffa3d270dbc7716f653b4cdab6020812658/packages/dataviews#properties-of-layout
+		// In future versions, a showMedia property can be used
 		.dataviews-view-list__media-wrapper {
 			background-color: transparent;
 			display: none;
+		}
+		.dataviews-view-list__field-wrapper {
+			width: 100%;
+			.dataviews-view-list__field:last-child {
+				margin-left: auto;
+				order: 0;
+			}
 		}
 	}
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -213,7 +213,6 @@ export default function PluginRowFormatter( {
 				<div className="plugin-row-formatter__toggle">
 					<PluginActivateToggle
 						isJetpackCloud
-						hideLabel={ ! isSmallScreen }
 						plugin={ pluginOnSite }
 						site={ selectedSite }
 						disabled={ !! item?.isSelectable }
@@ -225,7 +224,6 @@ export default function PluginRowFormatter( {
 				<div className="plugin-row-formatter__toggle">
 					<PluginAutoupdateToggle
 						plugin={ pluginOnSite }
-						hideLabel
 						site={ selectedSite }
 						wporg={ !! item.wporg }
 						isMarketplaceProduct={ isFromMarketplace }

--- a/client/my-sites/plugins/plugins-dashboard/index.tsx
+++ b/client/my-sites/plugins/plugins-dashboard/index.tsx
@@ -47,6 +47,7 @@ import { PluginActionName, PluginActions, Site } from '../hooks/types';
 import { withShowPluginActionDialog } from '../hooks/use-show-plugin-action-dialog';
 import PluginAvailableOnSitesList from '../plugin-management-v2/plugin-details-v2/plugin-available-on-sites-list';
 import SitesWithInstalledPluginsList from '../plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list';
+import { PluginComponentProps } from '../plugin-management-v2/types';
 import PluginsListDataViews from '../plugins-list/plugins-list-dataviews';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { Plugin } from 'calypso/state/plugins/installed/types';
@@ -115,8 +116,8 @@ const PluginsDashboard = ( {
 	const productsList = useSelector( ( state ) => getProductsList( state ) );
 	const { data: dotComPlugins }: { data: Plugin[] | undefined } = useWPCOMPluginsList( 'all' );
 	const allPlugins = useSelector( ( state ) =>
-		getPlugins( state, siteIds, 'all' ).map( ( plugin: Plugin ) => {
-			let dotComPluginData: Plugin | undefined;
+		getPlugins( state, siteIds, 'all' ).map( ( plugin: PluginComponentProps ) => {
+			let dotComPluginData: PluginComponentProps | undefined;
 			if ( dotComPlugins ) {
 				dotComPluginData = dotComPlugins.find(
 					( dotComPlugin ) => dotComPlugin.slug === plugin.slug

--- a/client/state/plugins/installed/types.ts
+++ b/client/state/plugins/installed/types.ts
@@ -33,7 +33,6 @@ export type Plugin = {
 	wporg?: boolean;
 	status?: Array< number >;
 	allStatuses?: Array< CurrentSiteStatus >;
-	isMarketplaceProduct?: boolean;
 };
 
 export type PluginSite = {


### PR DESCRIPTION
This also removes one property for a type

This is the initial implementation to be updated

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/10216

## Proposed Changes

* Uses the `list` layout for screens smaller than Desktop view (i.e. `960px`)
* Displays the labels in the list view for the toggle controls

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve the UI for small viewports

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this changes and navigate to `/plugins/manage/sites`
* Select a plugin
* Reduce the screen and check that the top table displays nicely in small viewports
- Check that there are no regressions in Jetpack cloud. To test this use  [links generated below](https://github.com/Automattic/wp-calypso/pull/98551#issuecomment-2598707402)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
