### PR TITLE
Subscription Delete: fix bug in logic

### DIFF
--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -65,9 +65,6 @@ const useSubscriberRemoveMutation = (
 					// Only throw if subscription_id is empty
 					if ( ( e as ApiResponseError )?.error === 'not_found' && ! subscriber.subscription_id ) {
 						throw new Error( ( e as ApiResponseError )?.message );
-					} else {
-						// Throw for any other error
-						throw new Error( ( e as ApiResponseError )?.message );
 					}
 				}
 			}


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack/issues/40850

## Proposed Changes

* Remove the `else`, this should error gracefully

## Why are these changes being made?

Previously fixed the logic that catches when deleting a subscriber fails to be able to retry deleting the email follows. Accidentally added an `else` that should not be there.

## Testing Instructions

1. Go to `/subscribers` and attempt to delete a subscriber
2. If you happen to know of a stuck user that is not able to be deleted. Try it on that one too.
