### PR TITLE
Add option to set Reader as default home page

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -957,7 +957,7 @@ class Account extends Component {
 
 						<FormFieldset className="account__settings-admin-home">
 							<FormLabel id="account__default_landing_page">
-								{ translate( 'Default screen' ) }
+								{ translate( 'Default Landing Page' ) }
 							</FormLabel>
 							<ToggleLandingPageSettings />
 							<FormSettingExplanation>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -52,7 +52,7 @@ import {
 import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
 import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
 import AccountSettingsCloseLink from './close-link';
-import ToggleSitesAsLandingPage from './toggle-sites-as-landing-page';
+import ToggleLandingPageSettings from './toggle-landing-page';
 import ToggleUseCommunityTranslator from './toggle-use-community-translator';
 
 import './style.scss';
@@ -957,9 +957,14 @@ class Account extends Component {
 
 						<FormFieldset className="account__settings-admin-home">
 							<FormLabel id="account__default_landing_page">
-								{ translate( 'Admin home' ) }
+								{ translate( 'Default screen' ) }
 							</FormLabel>
-							<ToggleSitesAsLandingPage />
+							<ToggleLandingPageSettings />
+							<FormSettingExplanation>
+								{ translate(
+									'When you type https://www.wordpress.com in your browser, this is the page you land on.'
+								) }
+							</FormSettingExplanation>
 						</FormFieldset>
 
 						<FormFieldset>

--- a/client/me/account/toggle-landing-page.tsx
+++ b/client/me/account/toggle-landing-page.tsx
@@ -76,8 +76,8 @@ function ToggleLandingPageSettings() {
 				selected={ selectedOption }
 				options={ [
 					{ label: translate( 'My primary site' ), value: 'default' },
-					{ label: translate( 'All sites' ), value: 'my-sites' },
-					{ label: translate( 'The reader' ), value: 'reader' },
+					{ label: translate( 'All my sites' ), value: 'my-sites' },
+					{ label: translate( 'The Reader' ), value: 'reader' },
 				] }
 				onChange={ handlePreferenceChange }
 				disabled={ isSaving }

--- a/client/me/account/toggle-landing-page.tsx
+++ b/client/me/account/toggle-landing-page.tsx
@@ -5,6 +5,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { successNotice } from 'calypso/state/notices/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, isSavingPreference } from 'calypso/state/preferences/selectors';
+import { useState, useEffect } from 'react';
 
 function ToggleLandingPageSettings() {
 	const translate = useTranslate();
@@ -17,40 +18,66 @@ function ToggleLandingPageSettings() {
 	);
 	const isSaving = useSelector( isSavingPreference );
 
-	// Determine the selected option
-	const getSelectedOption = () => {
+	// Local state to handle selected option
+	const [ selectedOption, setSelectedOption ] = useState( 'default' );
+
+	// Sync local state with Redux state when component mounts or Redux state changes
+	useEffect( () => {
 		if ( useSitesAsLandingPage ) {
-			return useReaderAsLandingPage ? 'reader' : 'my-sites';
+			setSelectedOption( useReaderAsLandingPage ? 'reader' : 'my-sites' );
+		} else {
+			setSelectedOption( 'default' );
 		}
-		return 'default';
-	};
+	}, [ useSitesAsLandingPage, useReaderAsLandingPage ] );
 
 	async function handlePreferenceChange( selectedOption: string ) {
-		const preference = { landingPage: selectedOption, updatedAt: Date.now() };
-		const preferenceKey =
-			selectedOption === 'my-sites' ? 'sites-landing-page' : 'reader-landing-page';
+		// Update local state for instant UI feedback
+		setSelectedOption( selectedOption );
 
-		await dispatch( savePreference( preferenceKey, preference ) );
+		console.log( 'selectedOption', selectedOption );
 
-		dispatch(
-			successNotice( translate( 'Settings saved successfully!' ), {
-				id: 'sites-landing-page-save',
-				duration: 10000,
-			} )
-		);
+		let preferenceKey = null;
+		let preference = { landingPage: selectedOption, updatedAt: Date.now() };
 
-		dispatch(
-			recordTracksEvent( 'calypso_settings_sites_dashboard_landing_page_toggle', {
-				sites_as_landing_page: useSitesAsLandingPage,
-				reader_as_landing_page: useReaderAsLandingPage,
-			} )
-		);
+		if ( selectedOption === 'my-sites' ) {
+			preferenceKey = 'sites-landing-page';
+		} else if ( selectedOption === 'reader' ) {
+			preferenceKey = 'reader-landing-page';
+		} else if ( selectedOption === 'default' ) {
+			// Handle default case: reset both preferences to unset state
+			await dispatch( savePreference( 'sites-landing-page', null ) );
+			await dispatch( savePreference( 'reader-landing-page', null ) );
+			dispatch(
+				successNotice( translate( 'Settings reset to default successfully!' ), {
+					id: 'sites-landing-page-reset',
+					duration: 10000,
+				} )
+			);
+			return;
+		}
+
+		if ( preferenceKey ) {
+			await dispatch( savePreference( preferenceKey, preference ) );
+
+			dispatch(
+				successNotice( translate( 'Settings saved successfully!' ), {
+					id: 'sites-landing-page-save',
+					duration: 10000,
+				} )
+			);
+
+			dispatch(
+				recordTracksEvent( 'calypso_settings_sites_dashboard_landing_page_toggle', {
+					landing_page_option: selectedOption,
+				} )
+			);
+		}
 	}
 
 	return (
 		<div>
 			<RadioControl
-				selected={ getSelectedOption() }
+				selected={ selectedOption }
 				options={ [
 					{ label: translate( 'My primary site' ), value: 'default' },
 					{ label: translate( 'All sites' ), value: 'my-sites' },

--- a/client/me/account/toggle-landing-page.tsx
+++ b/client/me/account/toggle-landing-page.tsx
@@ -25,7 +25,7 @@ function ToggleLandingPageSettings() {
 		return 'default';
 	};
 
-	async function handlePreferenceChange( selectedOption ) {
+	async function handlePreferenceChange( selectedOption: string ) {
 		const preference = { landingPage: selectedOption, updatedAt: Date.now() };
 		const preferenceKey =
 			selectedOption === 'my-sites' ? 'sites-landing-page' : 'reader-landing-page';
@@ -50,12 +50,11 @@ function ToggleLandingPageSettings() {
 	return (
 		<div>
 			<RadioControl
-				label={ translate( 'Choose your default landing page:' ) }
 				selected={ getSelectedOption() }
 				options={ [
-					{ label: translate( 'Default site home page' ), value: 'default' },
-					{ label: translate( 'My sites page' ), value: 'my-sites' },
-					{ label: translate( 'Reader page' ), value: 'reader' },
+					{ label: translate( 'My primary site' ), value: 'default' },
+					{ label: translate( 'All sites' ), value: 'my-sites' },
+					{ label: translate( 'The reader' ), value: 'reader' },
 				] }
 				onChange={ handlePreferenceChange }
 				disabled={ isSaving }

--- a/client/me/account/toggle-landing-page.tsx
+++ b/client/me/account/toggle-landing-page.tsx
@@ -1,11 +1,13 @@
 import { RadioControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { successNotice } from 'calypso/state/notices/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, isSavingPreference } from 'calypso/state/preferences/selectors';
-import { useState, useEffect } from 'react';
+import { READER_AS_LANDING_PAGE_PREFERENCE } from 'calypso/state/sites/selectors/has-reader-as-landing-page';
+import { SITES_AS_LANDING_PAGE_PREFERENCE } from 'calypso/state/sites/selectors/has-sites-as-landing-page';
 
 function ToggleLandingPageSettings() {
 	const translate = useTranslate();
@@ -21,43 +23,39 @@ function ToggleLandingPageSettings() {
 	// Local state to handle selected option
 	const [ selectedOption, setSelectedOption ] = useState( 'default' );
 
-	// Sync local state with Redux state when component mounts or Redux state changes
 	useEffect( () => {
 		if ( useSitesAsLandingPage ) {
-			setSelectedOption( useReaderAsLandingPage ? 'reader' : 'my-sites' );
-		} else {
-			setSelectedOption( 'default' );
+			setSelectedOption( 'my-sites' );
+		} else if ( useReaderAsLandingPage ) {
+			setSelectedOption( 'reader' );
 		}
 	}, [ useSitesAsLandingPage, useReaderAsLandingPage ] );
 
 	async function handlePreferenceChange( selectedOption: string ) {
-		// Update local state for instant UI feedback
-		setSelectedOption( selectedOption );
+		try {
+			setSelectedOption( selectedOption );
 
-		console.log( 'selectedOption', selectedOption );
+			const useSitesAsLandingPagePreference = {
+				useSitesAsLandingPage: false,
+				updatedAt: Date.now(),
+			};
+			const useReaderAsLandingPagePreference = {
+				useReaderAsLandingPage: false,
+				updatedAt: Date.now(),
+			};
 
-		let preferenceKey = null;
-		let preference = { landingPage: selectedOption, updatedAt: Date.now() };
+			if ( selectedOption === 'my-sites' ) {
+				useSitesAsLandingPagePreference.useSitesAsLandingPage = true;
+			} else if ( selectedOption === 'reader' ) {
+				useReaderAsLandingPagePreference.useReaderAsLandingPage = true;
+			}
 
-		if ( selectedOption === 'my-sites' ) {
-			preferenceKey = 'sites-landing-page';
-		} else if ( selectedOption === 'reader' ) {
-			preferenceKey = 'reader-landing-page';
-		} else if ( selectedOption === 'default' ) {
-			// Handle default case: reset both preferences to unset state
-			await dispatch( savePreference( 'sites-landing-page', null ) );
-			await dispatch( savePreference( 'reader-landing-page', null ) );
-			dispatch(
-				successNotice( translate( 'Settings reset to default successfully!' ), {
-					id: 'sites-landing-page-reset',
-					duration: 10000,
-				} )
+			await dispatch(
+				savePreference( SITES_AS_LANDING_PAGE_PREFERENCE, useSitesAsLandingPagePreference )
 			);
-			return;
-		}
-
-		if ( preferenceKey ) {
-			await dispatch( savePreference( preferenceKey, preference ) );
+			await dispatch(
+				savePreference( READER_AS_LANDING_PAGE_PREFERENCE, useReaderAsLandingPagePreference )
+			);
 
 			dispatch(
 				successNotice( translate( 'Settings saved successfully!' ), {
@@ -70,6 +68,16 @@ function ToggleLandingPageSettings() {
 				recordTracksEvent( 'calypso_settings_sites_dashboard_landing_page_toggle', {
 					landing_page_option: selectedOption,
 				} )
+			);
+		} catch ( error ) {
+			dispatch(
+				errorNotice(
+					translate( 'An error occurred while saving your preferences. Please try again.' ),
+					{
+						id: 'sites-landing-page-error',
+						duration: 10000,
+					}
+				)
 			);
 		}
 	}

--- a/client/me/account/toggle-landing-page.tsx
+++ b/client/me/account/toggle-landing-page.tsx
@@ -12,12 +12,11 @@ import { SITES_AS_LANDING_PAGE_PREFERENCE } from 'calypso/state/sites/selectors/
 function ToggleLandingPageSettings() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const useSitesAsLandingPage = useSelector(
-		( state ) => getPreference( state, 'sites-landing-page' )?.useSitesAsLandingPage
-	);
-	const useReaderAsLandingPage = useSelector(
-		( state ) => getPreference( state, 'reader-landing-page' )?.useReaderAsLandingPage
-	);
+	const { useSitesAsLandingPage, useReaderAsLandingPage } = useSelector( ( state ) => ( {
+		useSitesAsLandingPage: getPreference( state, 'sites-landing-page' )?.useSitesAsLandingPage,
+		useReaderAsLandingPage: getPreference( state, 'reader-landing-page' )?.useReaderAsLandingPage,
+	} ) );
+
 	const isSaving = useSelector( isSavingPreference );
 
 	// Local state to handle selected option

--- a/client/me/account/toggle-landing-page.tsx
+++ b/client/me/account/toggle-landing-page.tsx
@@ -1,6 +1,6 @@
 import { RadioControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -12,48 +12,37 @@ import { SITES_AS_LANDING_PAGE_PREFERENCE } from 'calypso/state/sites/selectors/
 function ToggleLandingPageSettings() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const { useSitesAsLandingPage, useReaderAsLandingPage } = useSelector( ( state ) => ( {
-		useSitesAsLandingPage: getPreference( state, 'sites-landing-page' )?.useSitesAsLandingPage,
-		useReaderAsLandingPage: getPreference( state, 'reader-landing-page' )?.useReaderAsLandingPage,
+	const { sitesAsLandingPage, readerAsLandingPage } = useSelector( ( state ) => ( {
+		sitesAsLandingPage: getPreference( state, 'sites-landing-page' )?.useSitesAsLandingPage,
+		readerAsLandingPage: getPreference( state, 'reader-landing-page' )?.useReaderAsLandingPage,
 	} ) );
 
-	const isSaving = useSelector( isSavingPreference );
+	let preference = 'default';
+	if ( sitesAsLandingPage ) {
+		preference = 'my-sites';
+	} else if ( readerAsLandingPage ) {
+		preference = 'reader';
+	}
 
 	// Local state to handle selected option
-	const [ selectedOption, setSelectedOption ] = useState( 'default' );
-
-	useEffect( () => {
-		if ( useSitesAsLandingPage ) {
-			setSelectedOption( 'my-sites' );
-		} else if ( useReaderAsLandingPage ) {
-			setSelectedOption( 'reader' );
-		}
-	}, [ useSitesAsLandingPage, useReaderAsLandingPage ] );
+	const [ selectedOption, setSelectedOption ] = useState( preference );
+	const isSaving = useSelector( isSavingPreference );
 
 	async function handlePreferenceChange( selectedOption: string ) {
+		setSelectedOption( selectedOption );
 		try {
-			setSelectedOption( selectedOption );
-
-			const useSitesAsLandingPagePreference = {
-				useSitesAsLandingPage: false,
-				updatedAt: Date.now(),
-			};
-			const useReaderAsLandingPagePreference = {
-				useReaderAsLandingPage: false,
-				updatedAt: Date.now(),
-			};
-
-			if ( selectedOption === 'my-sites' ) {
-				useSitesAsLandingPagePreference.useSitesAsLandingPage = true;
-			} else if ( selectedOption === 'reader' ) {
-				useReaderAsLandingPagePreference.useReaderAsLandingPage = true;
-			}
-
+			const updatedAt = Date.now();
 			await dispatch(
-				savePreference( SITES_AS_LANDING_PAGE_PREFERENCE, useSitesAsLandingPagePreference )
+				savePreference( SITES_AS_LANDING_PAGE_PREFERENCE, {
+					useSitesAsLandingPage: 'my-sites' === selectedOption,
+					updatedAt,
+				} )
 			);
 			await dispatch(
-				savePreference( READER_AS_LANDING_PAGE_PREFERENCE, useReaderAsLandingPagePreference )
+				savePreference( READER_AS_LANDING_PAGE_PREFERENCE, {
+					useReaderAsLandingPage: 'reader' === selectedOption,
+					updatedAt,
+				} )
 			);
 
 			dispatch(

--- a/client/me/account/toggle-landing-page.tsx
+++ b/client/me/account/toggle-landing-page.tsx
@@ -1,0 +1,67 @@
+import { RadioControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { successNotice } from 'calypso/state/notices/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference, isSavingPreference } from 'calypso/state/preferences/selectors';
+
+function ToggleLandingPageSettings() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const useSitesAsLandingPage = useSelector(
+		( state ) => getPreference( state, 'sites-landing-page' )?.useSitesAsLandingPage
+	);
+	const useReaderAsLandingPage = useSelector(
+		( state ) => getPreference( state, 'reader-landing-page' )?.useReaderAsLandingPage
+	);
+	const isSaving = useSelector( isSavingPreference );
+
+	// Determine the selected option
+	const getSelectedOption = () => {
+		if ( useSitesAsLandingPage ) {
+			return useReaderAsLandingPage ? 'reader' : 'my-sites';
+		}
+		return 'default';
+	};
+
+	async function handlePreferenceChange( selectedOption ) {
+		const preference = { landingPage: selectedOption, updatedAt: Date.now() };
+		const preferenceKey =
+			selectedOption === 'my-sites' ? 'sites-landing-page' : 'reader-landing-page';
+
+		await dispatch( savePreference( preferenceKey, preference ) );
+
+		dispatch(
+			successNotice( translate( 'Settings saved successfully!' ), {
+				id: 'sites-landing-page-save',
+				duration: 10000,
+			} )
+		);
+
+		dispatch(
+			recordTracksEvent( 'calypso_settings_sites_dashboard_landing_page_toggle', {
+				sites_as_landing_page: useSitesAsLandingPage,
+				reader_as_landing_page: useReaderAsLandingPage,
+			} )
+		);
+	}
+
+	return (
+		<div>
+			<RadioControl
+				label={ translate( 'Choose your default landing page:' ) }
+				selected={ getSelectedOption() }
+				options={ [
+					{ label: translate( 'Default site home page' ), value: 'default' },
+					{ label: translate( 'My sites page' ), value: 'my-sites' },
+					{ label: translate( 'Reader page' ), value: 'reader' },
+				] }
+				onChange={ handlePreferenceChange }
+				disabled={ isSaving }
+			/>
+		</div>
+	);
+}
+
+export default ToggleLandingPageSettings;

--- a/client/root.js
+++ b/client/root.js
@@ -13,6 +13,7 @@ import {
 	getSiteAdminUrl,
 	isAdminInterfaceWPAdmin,
 } from 'calypso/state/sites/selectors';
+import { hasReadersAsLandingPage } from 'calypso/state/sites/selectors/has-reader-as-landing-page';
 import { hasSitesAsLandingPage } from 'calypso/state/sites/selectors/has-sites-as-landing-page';
 import { getSelectedSiteId } from './state/ui/selectors';
 
@@ -91,6 +92,12 @@ async function getLoggedInLandingPage( { dispatch, getState } ) {
 
 	if ( useSitesAsLandingPage ) {
 		return '/sites';
+	}
+
+	const useReaderAsLandingPage = hasReadersAsLandingPage( getState() );
+
+	if ( useReaderAsLandingPage ) {
+		return '/read';
 	}
 
 	// determine the primary site ID (it's a property of "current user" object) and then

--- a/client/state/sites/selectors/has-reader-as-landing-page.ts
+++ b/client/state/sites/selectors/has-reader-as-landing-page.ts
@@ -1,17 +1,17 @@
 import { getPreference } from 'calypso/state/preferences/selectors';
+import { SITES_AS_LANDING_PAGE_PREFERENCE } from './has-sites-as-landing-page';
 import type { AppState } from 'calypso/types';
 
 export const READER_AS_LANDING_PAGE_PREFERENCE = 'reader-landing-page';
 
-export const READER_AS_LANDING_PAGE_DEFAULT_VALUE = {
-	useReaderAsLandingPage: false,
-	updatedAt: 0,
-};
-
 export const hasReadersAsLandingPage = ( state: AppState ): boolean => {
-	const { useReadersAsLandingPage } =
-		getPreference( state, READER_AS_LANDING_PAGE_PREFERENCE ) ??
-		READER_AS_LANDING_PAGE_DEFAULT_VALUE;
-
-	return useReadersAsLandingPage;
+	const { useSitesAsLandingPage } = getPreference( state, SITES_AS_LANDING_PAGE_PREFERENCE );
+	if ( useSitesAsLandingPage ) {
+		return useSitesAsLandingPage;
+	}
+	const { useReaderAsLandingPage } = getPreference( state, READER_AS_LANDING_PAGE_PREFERENCE );
+	if ( useReaderAsLandingPage ) {
+		return useReaderAsLandingPage;
+	}
+	return false;
 };

--- a/client/state/sites/selectors/has-reader-as-landing-page.ts
+++ b/client/state/sites/selectors/has-reader-as-landing-page.ts
@@ -1,0 +1,17 @@
+import { getPreference } from 'calypso/state/preferences/selectors';
+import type { AppState } from 'calypso/types';
+
+export const READER_AS_LANDING_PAGE_PREFERENCE = 'reader-landing-page';
+
+export const READER_AS_LANDING_PAGE_DEFAULT_VALUE = {
+	useReaderAsLandingPage: false,
+	updatedAt: 0,
+};
+
+export const hasReadersAsLandingPage = ( state: AppState ): boolean => {
+	const { useReadersAsLandingPage } =
+		getPreference( state, READER_AS_LANDING_PAGE_PREFERENCE ) ??
+		READER_AS_LANDING_PAGE_DEFAULT_VALUE;
+
+	return useReadersAsLandingPage;
+};

--- a/client/state/sites/selectors/has-reader-as-landing-page.ts
+++ b/client/state/sites/selectors/has-reader-as-landing-page.ts
@@ -8,8 +8,5 @@ export const hasReadersAsLandingPage = ( state: AppState ): boolean => {
 		state,
 		READER_AS_LANDING_PAGE_PREFERENCE
 	);
-	if ( useReaderAsLandingPage ) {
-		return useReaderAsLandingPage;
-	}
-	return false;
+	return !! useReaderAsLandingPage;
 };

--- a/client/state/sites/selectors/has-reader-as-landing-page.ts
+++ b/client/state/sites/selectors/has-reader-as-landing-page.ts
@@ -1,14 +1,9 @@
 import { getPreference } from 'calypso/state/preferences/selectors';
-import { SITES_AS_LANDING_PAGE_PREFERENCE } from './has-sites-as-landing-page';
 import type { AppState } from 'calypso/types';
 
 export const READER_AS_LANDING_PAGE_PREFERENCE = 'reader-landing-page';
 
 export const hasReadersAsLandingPage = ( state: AppState ): boolean => {
-	const { useSitesAsLandingPage } = getPreference( state, SITES_AS_LANDING_PAGE_PREFERENCE );
-	if ( useSitesAsLandingPage ) {
-		return useSitesAsLandingPage;
-	}
 	const { useReaderAsLandingPage } = getPreference( state, READER_AS_LANDING_PAGE_PREFERENCE );
 	if ( useReaderAsLandingPage ) {
 		return useReaderAsLandingPage;

--- a/client/state/sites/selectors/has-reader-as-landing-page.ts
+++ b/client/state/sites/selectors/has-reader-as-landing-page.ts
@@ -4,7 +4,10 @@ import type { AppState } from 'calypso/types';
 export const READER_AS_LANDING_PAGE_PREFERENCE = 'reader-landing-page';
 
 export const hasReadersAsLandingPage = ( state: AppState ): boolean => {
-	const { useReaderAsLandingPage } = getPreference( state, READER_AS_LANDING_PAGE_PREFERENCE );
+	const { useReaderAsLandingPage = false } = getPreference(
+		state,
+		READER_AS_LANDING_PAGE_PREFERENCE
+	);
 	if ( useReaderAsLandingPage ) {
 		return useReaderAsLandingPage;
 	}

--- a/client/state/sites/selectors/has-reader-as-landing-page.ts
+++ b/client/state/sites/selectors/has-reader-as-landing-page.ts
@@ -4,9 +4,7 @@ import type { AppState } from 'calypso/types';
 export const READER_AS_LANDING_PAGE_PREFERENCE = 'reader-landing-page';
 
 export const hasReadersAsLandingPage = ( state: AppState ): boolean => {
-	const { useReaderAsLandingPage = false } = getPreference(
-		state,
-		READER_AS_LANDING_PAGE_PREFERENCE
-	);
+	const preference = getPreference( state, READER_AS_LANDING_PAGE_PREFERENCE ) || {};
+	const { useReaderAsLandingPage = false } = preference;
 	return !! useReaderAsLandingPage;
 };

--- a/client/state/sites/selectors/has-sites-as-landing-page.ts
+++ b/client/state/sites/selectors/has-sites-as-landing-page.ts
@@ -1,16 +1,17 @@
 import { getPreference } from 'calypso/state/preferences/selectors';
+import { READER_AS_LANDING_PAGE_PREFERENCE } from './has-reader-as-landing-page';
 import type { AppState } from 'calypso/types';
 
 export const SITES_AS_LANDING_PAGE_PREFERENCE = 'sites-landing-page';
 
-export const SITES_AS_LANDING_PAGE_DEFAULT_VALUE = {
-	useSitesAsLandingPage: false,
-	updatedAt: 0,
-};
-
 export const hasSitesAsLandingPage = ( state: AppState ): boolean => {
-	const { useSitesAsLandingPage } =
-		getPreference( state, SITES_AS_LANDING_PAGE_PREFERENCE ) ?? SITES_AS_LANDING_PAGE_DEFAULT_VALUE;
-
-	return useSitesAsLandingPage;
+	const { useReaderAsLandingPage } = getPreference( state, READER_AS_LANDING_PAGE_PREFERENCE );
+	if ( useReaderAsLandingPage ) {
+		return useReaderAsLandingPage;
+	}
+	const { useSitesAsLandingPage } = getPreference( state, SITES_AS_LANDING_PAGE_PREFERENCE );
+	if ( useSitesAsLandingPage ) {
+		return useSitesAsLandingPage;
+	}
+	return false;
 };

--- a/client/state/sites/selectors/has-sites-as-landing-page.ts
+++ b/client/state/sites/selectors/has-sites-as-landing-page.ts
@@ -4,7 +4,10 @@ import type { AppState } from 'calypso/types';
 export const SITES_AS_LANDING_PAGE_PREFERENCE = 'sites-landing-page';
 
 export const hasSitesAsLandingPage = ( state: AppState ): boolean => {
-	const { useSitesAsLandingPage } = getPreference( state, SITES_AS_LANDING_PAGE_PREFERENCE );
+	const { useSitesAsLandingPage = false } = getPreference(
+		state,
+		SITES_AS_LANDING_PAGE_PREFERENCE
+	);
 	if ( useSitesAsLandingPage ) {
 		return useSitesAsLandingPage;
 	}

--- a/client/state/sites/selectors/has-sites-as-landing-page.ts
+++ b/client/state/sites/selectors/has-sites-as-landing-page.ts
@@ -1,14 +1,9 @@
 import { getPreference } from 'calypso/state/preferences/selectors';
-import { READER_AS_LANDING_PAGE_PREFERENCE } from './has-reader-as-landing-page';
 import type { AppState } from 'calypso/types';
 
 export const SITES_AS_LANDING_PAGE_PREFERENCE = 'sites-landing-page';
 
 export const hasSitesAsLandingPage = ( state: AppState ): boolean => {
-	const { useReaderAsLandingPage } = getPreference( state, READER_AS_LANDING_PAGE_PREFERENCE );
-	if ( useReaderAsLandingPage ) {
-		return useReaderAsLandingPage;
-	}
 	const { useSitesAsLandingPage } = getPreference( state, SITES_AS_LANDING_PAGE_PREFERENCE );
 	if ( useSitesAsLandingPage ) {
 		return useSitesAsLandingPage;

--- a/client/state/sites/selectors/has-sites-as-landing-page.ts
+++ b/client/state/sites/selectors/has-sites-as-landing-page.ts
@@ -4,9 +4,7 @@ import type { AppState } from 'calypso/types';
 export const SITES_AS_LANDING_PAGE_PREFERENCE = 'sites-landing-page';
 
 export const hasSitesAsLandingPage = ( state: AppState ): boolean => {
-	const { useSitesAsLandingPage = false } = getPreference(
-		state,
-		SITES_AS_LANDING_PAGE_PREFERENCE
-	);
+	const preference = getPreference( state, SITES_AS_LANDING_PAGE_PREFERENCE ) || {};
+	const { useSitesAsLandingPage = false } = preference;
 	return !! useSitesAsLandingPage;
 };

--- a/client/state/sites/selectors/has-sites-as-landing-page.ts
+++ b/client/state/sites/selectors/has-sites-as-landing-page.ts
@@ -8,8 +8,5 @@ export const hasSitesAsLandingPage = ( state: AppState ): boolean => {
 		state,
 		SITES_AS_LANDING_PAGE_PREFERENCE
 	);
-	if ( useSitesAsLandingPage ) {
-		return useSitesAsLandingPage;
-	}
-	return false;
+	return !! useSitesAsLandingPage;
 };

--- a/client/test/root-section.ts
+++ b/client/test/root-section.ts
@@ -140,6 +140,40 @@ describe( 'Logged In Landing Page', () => {
 		await waitFor( () => expect( page.current ).toBe( '/sites' ) );
 	} );
 
+	test( 'user who opts in goes to reader page', async () => {
+		const state = {
+			currentUser: {
+				id: 1,
+				capabilities: { 1: { edit_posts: true } },
+				user: { primary_blog: 1, site_count: 2 },
+			},
+			preferences: {
+				localValues: {
+					'reader-landing-page': { useReaderAsLandingPage: true, updatedAt: 1111 },
+				},
+			},
+			ui: {},
+			sites: {
+				items: {
+					1: {
+						ID: 1,
+						URL: 'https://test.wordpress.com',
+					},
+					2: {
+						ID: 2,
+						URL: 'https://test.jurassic.ninja',
+						jetpack: true,
+					},
+				},
+			},
+		};
+		const { page } = initRouter( { state } );
+
+		page( '/' );
+
+		await waitFor( () => expect( page.current ).toBe( '/read' ) );
+	} );
+
 	test( 'user with a selected site goes to My Home for Default Style interface', async () => {
 		const state = {
 			currentUser: {

--- a/client/test/root-section.ts
+++ b/client/test/root-section.ts
@@ -116,6 +116,7 @@ describe( 'Logged In Landing Page', () => {
 			preferences: {
 				localValues: {
 					'sites-landing-page': { useSitesAsLandingPage: true, updatedAt: 1111 },
+					'reader-landing-page': { useReaderAsLandingPage: false, updatedAt: 1111 },
 				},
 			},
 			ui: {},
@@ -149,6 +150,7 @@ describe( 'Logged In Landing Page', () => {
 			},
 			preferences: {
 				localValues: {
+					'sites-landing-page': { useSitesAsLandingPage: false, updatedAt: 1111 },
 					'reader-landing-page': { useReaderAsLandingPage: true, updatedAt: 1111 },
 				},
 			},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/loop/issues/340 and https://github.com/Automattic/loop/issues/348

This PR introduces a new component for selecting a default landing page to allow users to set whether they'd like to land on the Reader by default when the go to https://wordpress.com

| Before | After |
|--------|-------|
| <img width="755" alt="Screenshot 2025-01-22 at 10 23 00" src="https://github.com/user-attachments/assets/d876c6cd-1a3e-44f7-87ec-6286255edd0c" />  |  <img width="745" alt="Screenshot 2025-01-22 at 10 26 35" src="https://github.com/user-attachments/assets/7af3c0dd-8737-49c2-95a4-4b18e94c0dbd" /> |

## Proposed Changes

1. **client/me/account/main.jsx**
    - Renamed `ToggleSitesAsLandingPage` to `ToggleLandingPageSettings`.
    - Updated label text to 'Default screen'.
    - Added a description for the default landing page setting.

2. **client/me/account/toggle-landing-page.tsx** (new file)
    - New component `ToggleLandingPageSettings` for selecting the default landing page (primary site, all sites, or reader) and saving preferences.

3. **client/root.js**
    - Import `hasReadersAsLandingPage`.
    - Updated `getLoggedInLandingPage` to check if the reader should be the landing page.

4. **client/state/sites/selectors/has-reader-as-landing-page.ts** (new file)
    - New selector `hasReadersAsLandingPage` to check if the reader should be the landing page.

5. **client/state/sites/selectors/has-sites-as-landing-page.ts**
    - Simplified `hasSitesAsLandingPage` selector to return false if the preference is not set.

6. **client/test/root-section.ts**
    - Added a new test to verify that users who opt-in are directed to the reader page.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Allow users to opt in to landing on the Reader

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/me/account` on calypso.live site
* Click on `The reader` option - confirm when you go to calypso.live root it will redirect to Reader
* Click on `All sites` option - confirm when you go to calypso.live root it will redirect to All sites dashboard


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
