### PR TITLE
Reader data store: simplify the useIsLoggedIn hook

### DIFF
--- a/packages/data-stores/src/reader/hooks/use-is-logged-in.ts
+++ b/packages/data-stores/src/reader/hooks/use-is-logged-in.ts
@@ -4,19 +4,12 @@ import type { UserSelect } from '../../user';
 
 const USER_STORE = registerUserStore();
 
-const useIsLoggedIn = () => {
-	const currentUser = useSelect(
-		( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
-		[]
-	);
-
-	return {
-		id: currentUser?.ID,
-		isLoggedIn: useSelect(
-			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
-			[]
-		),
-	};
-};
-
-export default useIsLoggedIn;
+export default function useIsLoggedIn() {
+	return useSelect( ( select ) => {
+		const user = select( USER_STORE ) as UserSelect;
+		return {
+			id: user.getCurrentUser()?.ID,
+			isLoggedIn: user.isCurrentUserLoggedIn(),
+		};
+	}, [] );
+}


### PR DESCRIPTION
Simplifies the `useIsLoggedIn` hook to do one `useSelect` instead of two.

Also fixes the following bug:
1. Go to `/read/subscriptions`
2. Look at the browser console. You'll see a "Maximum update depth exceeded" React warning. There is some infinite update loop going on.

Try it with this PR. The warning disappears. There is still something weird going on: the `useIsLoggedIn` hook is called 3000 times during the initial render of the `/read/subscriptions` route. This PR is an incremental step forward.