### PR TITLE
Hide the top bar “Sign Up” button for OAuth flow

### DIFF
--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -133,6 +133,13 @@ class MasterbarLoggedOut extends Component {
 		}
 
 		/**
+		 * Hide signup for OAuth flow (it doesn't correctly route the arugments)
+		 */
+		if ( currentQuery?.client_id !== null && currentQuery?.redirect_to != null ) {
+			return null;
+		}
+
+		/**
 		 * Hide signup from the screen when we have been sent to the login page from a redirect
 		 * by a service provider to authorize a Domain Connect template application.
 		 */


### PR DESCRIPTION
## Proposed Changes

* Removes the "Sign Up" button from the top bar during the OAuth flow. It launches into the site creator and doesn't properly pass through the OAuth parameters, so it results in a dead end.

## Why are these changes being made?
WP.com OAuth login is being used for iOS and Android users, and already rolled out to beta users. @tiagomar found this issue in a last-minute test session.

## Testing Instructions
- Go to http://calypso.localhost:3000/log-in?client_id=2697&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fredirect_uri%3Dwordpress%253A%252F%252Fwpcom-authorize%26client_id%3D2697%26response_type%3Dtoken%26from-calypso%3D1 (it'll take a really long time to load) and note that the "Sign Up" button is hidden.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
