### PR TITLE
Multi-year Plans Default Experiment: Ensure only the `onboarding` flow is eligible

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -224,7 +224,7 @@ function UnifiedPlansStep( {
 }: UnifiedPlansStepProps ) {
 	const [ isDesktop, setIsDesktop ] = useState< boolean | undefined >( isDesktopViewport() );
 	const dispatch = reduxUseDispatch();
-	const longerPlanTermDefaultExperiment = useLongerPlanTermDefaultExperiment();
+	const longerPlanTermDefaultExperiment = useLongerPlanTermDefaultExperiment( flowName );
 	const translate = useTranslate();
 	const initializedSitesBackUrl = useSelector( ( state ) =>
 		getCurrentUserSiteCount( state ) ? '/sites/' : null

--- a/client/my-sites/plans-features-main/hooks/experiments/use-longer-plan-term-default-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/experiments/use-longer-plan-term-default-experiment.ts
@@ -1,3 +1,4 @@
+import { ONBOARDING_FLOW } from '@automattic/onboarding';
 import { useExperiment } from 'calypso/lib/explat';
 
 const useTermFromExperimentVariant = (
@@ -23,7 +24,9 @@ const useTermFromExperimentVariant = (
  * define the default term in the grid/plans page.
  *
  */
-const useLongerPlanTermDefaultExperiment = (): {
+const useLongerPlanTermDefaultExperiment = (
+	flowName?: string | null
+): {
 	isLoadingExperiment: boolean;
 	term?: string | null;
 	// TODO: Consider removing this and always return concrete term values (where undefined/null would mean no term savings)
@@ -33,7 +36,10 @@ const useLongerPlanTermDefaultExperiment = (): {
 	// variation names 'default_to_three_year_plans', 'default_to_two_year_plans'
 	// and 'emphasize_savings_only'.
 	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
-		'calypso_plans_page_emphasize_longer_plan_savings'
+		'calypso_plans_page_emphasize_longer_plan_savings',
+		{
+			isEligible: flowName === ONBOARDING_FLOW,
+		}
 	);
 	const term = useTermFromExperimentVariant( experimentAssignment?.variationName );
 

--- a/client/my-sites/plans-features-main/hooks/use-eligibility-for-term-savings-price-display.ts
+++ b/client/my-sites/plans-features-main/hooks/use-eligibility-for-term-savings-price-display.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	getPlanSlugForTermVariant,
 	PlanSlug,
@@ -80,11 +79,7 @@ const useEligibilityForTermSavingsPriceDisplay = ( {
 		return false;
 	}
 
-	return (
-		( isEnabled( 'plans/term-savings-price-display' ) ||
-			longerPlanTermDefaultExperiment.isEligibleForTermSavings ) &&
-		isInSignup
-	);
+	return longerPlanTermDefaultExperiment.isEligibleForTermSavings && isInSignup;
 };
 
 export default useEligibilityForTermSavingsPriceDisplay;

--- a/client/my-sites/plans-features-main/hooks/use-eligibility-for-term-savings-price-display.ts
+++ b/client/my-sites/plans-features-main/hooks/use-eligibility-for-term-savings-price-display.ts
@@ -17,6 +17,7 @@ import useLongerPlanTermDefaultExperiment from './experiments/use-longer-plan-te
 import useCheckPlanAvailabilityForPurchase from './use-check-plan-availability-for-purchase';
 
 const useEligibilityForTermSavingsPriceDisplay = ( {
+	flowName,
 	hiddenPlans,
 	intent,
 	isSubdomainNotGenerated,
@@ -27,6 +28,7 @@ const useEligibilityForTermSavingsPriceDisplay = ( {
 	siteId,
 	isInSignup,
 }: {
+	flowName?: string | null;
 	hiddenPlans?: HiddenPlans;
 	intent?: PlansIntent;
 	isSubdomainNotGenerated?: boolean;
@@ -37,7 +39,7 @@ const useEligibilityForTermSavingsPriceDisplay = ( {
 	siteId?: number | null;
 	isInSignup?: boolean;
 } ) => {
-	const longerPlanTermDefaultExperiment = useLongerPlanTermDefaultExperiment();
+	const longerPlanTermDefaultExperiment = useLongerPlanTermDefaultExperiment( flowName );
 	const availablePlanSlugs = usePlansFromTypes( {
 		planTypes: usePlanTypesWithIntent( {
 			intent,

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -246,7 +246,7 @@ const PlansFeaturesMain = ( {
 	const showUpgradeableStorage = config.isEnabled( 'plans/upgradeable-storage' );
 	const getPlanTypeDestination = usePlanTypeDestinationCallback();
 
-	const longerPlanTermDefaultExperiment = useLongerPlanTermDefaultExperiment();
+	const longerPlanTermDefaultExperiment = useLongerPlanTermDefaultExperiment( flowName );
 
 	const resolveModal = useModalResolutionCallback( {
 		isCustomDomainAllowedOnFreePlan,
@@ -415,6 +415,7 @@ const PlansFeaturesMain = ( {
 	};
 
 	const enableTermSavingsPriceDisplay = useEligibilityForTermSavingsPriceDisplay( {
+		flowName: flowName,
 		selectedPlan,
 		hiddenPlans,
 		isSubdomainNotGenerated: ! resolvedSubdomainName.result,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

- Introduces changes to the `useLongerPlanTermDefaultExperiment` hook and adds an optional `flowName` parameter.
- This parameter is used to ensure only the `onboarding` flow displays the multi-year plans by default experiment changes.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We only want to target `/setup/onboarding/plans` and `/start/plans`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Manually assign self to an experiment variant `default_to_three_year_plans`, `default_to_two_year_plans`, `emphasize_savings_only` 22092-explat-experiment
* Visit `/setup/onboarding/plans` and verify that the savings emphasis badges and multi-year plan term defaults behave as expected
* Visit a different flow, like `/setup/newsletter/plans` or `/start/onboarding-pm/plans` and verify that the savings emphasis badges and multi-year defaults aren't displayed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
