### PR TITLE
Fix UI alignment and spacing issue with "OR" separator between buttons for Woo 2FA screen

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1918,7 +1918,7 @@ $breakpoint-mobile: 660px;
 			.two-factor-authentication__actions.card {
 				padding: 0;
 				border: 0;
-				margin-bottom: 32px;
+				margin: 32px auto;
 				clip-path: none;
 				display: flex;
 				flex-direction: column;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR addresses the spacing issues related to the "OR" separator between the 2FA action buttons. 

This happens in both Production and Staging (brand update).

Before:
![Screenshot 2025-01-20 at 11 44 03](https://github.com/user-attachments/assets/a5d50cfc-63f5-4af5-ad2d-78870a91816d)


After:

![Screenshot 2025-01-20 at 11 51 29](https://github.com/user-attachments/assets/58cb7a2e-212d-43ec-8f50-f0e3afe8580c)



## Proposed Changes

* Add 32px margin to the top of the 2FA action buttons

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To match the design.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Go to WooCommerce.com
* Click on `Login`
* Enter an "email/password" account (not passwordless). If you don't have one, you can create a passwordless account and then add a password in the account settings.
* Click on `Continue`
* Observe the spacing between the 2FA action buttons is 32px

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
