### PR TITLE
Clean-up: Remove feature flag desktop-promo

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -54,7 +54,6 @@
 		"current-site/stale-cart-notice": false,
 		"design-picker/goal-centric": true,
 		"design-picker/use-assembler-styles": true,
-		"desktop-promo": true,
 		"dev/auth-helper": true,
 		"dev/account-settings-helper": true,
 		"dev/features-helper": true,

--- a/config/production.json
+++ b/config/production.json
@@ -43,7 +43,6 @@
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
 		"design-picker/goal-centric": true,
-		"desktop-promo": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -41,7 +41,6 @@
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
 		"design-picker/goal-centric": true,
-		"desktop-promo": true,
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
 		"external-media": true,

--- a/config/test.json
+++ b/config/test.json
@@ -40,7 +40,6 @@
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
-		"desktop-promo": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"difm/allow-extra-pages": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -41,7 +41,6 @@
 		"current-site/stale-cart-notice": false,
 		"design-picker/goal-centric": true,
 		"design-picker/use-assembler-styles": true,
-		"desktop-promo": true,
 		"dev/auth-helper": true,
 		"dev/account-settings-helper": true,
 		"dev/preferences-helper": true,

--- a/packages/calypso-config/src/desktop.ts
+++ b/packages/calypso-config/src/desktop.ts
@@ -14,7 +14,6 @@ const config = {
 
 const features = {
 	desktop: true,
-	'desktop-promo': false,
 	'login/last-used-method': false,
 	'login/social-first': false,
 	'sign-in-with-apple': false,


### PR DESCRIPTION
## Proposed Changes

Feature flag desktop-promo is no longer used in code, so it can be removed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

p58i-j6R-p2 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

n/a

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?