### PR TITLE
Remove loading state from CheckoutSummaryFeaturedList.

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -146,14 +146,10 @@ export function CheckoutSummaryFeaturedList( {
 						? translate( 'WordPress.com Gift Subscription' )
 						: translate( 'Included with your purchase' ) }
 				</CheckoutSummaryFeaturesTitle>
-				{ isCartUpdating ? (
-					<LoadingCheckoutSummaryFeaturesList />
-				) : (
-					<CheckoutSummaryFeaturesWrapper
-						siteId={ siteId }
-						nextDomainIsFree={ responseCart.next_domain_is_free }
-					/>
-				) }
+				<CheckoutSummaryFeaturesWrapper
+					siteId={ siteId }
+					nextDomainIsFree={ responseCart.next_domain_is_free }
+				/>
 			</CheckoutSummaryFeatures>
 			{ ! isCartUpdating && ! hasRenewalInCart && ! isWcMobile && plan && hasMonthlyPlanInCart && (
 				<CheckoutSummaryAnnualUpsell plan={ plan } onChangeSelection={ onChangeSelection } />

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -146,10 +146,14 @@ export function CheckoutSummaryFeaturedList( {
 						? translate( 'WordPress.com Gift Subscription' )
 						: translate( 'Included with your purchase' ) }
 				</CheckoutSummaryFeaturesTitle>
-				<CheckoutSummaryFeaturesWrapper
-					siteId={ siteId }
-					nextDomainIsFree={ responseCart.next_domain_is_free }
-				/>
+				{ isCartUpdating ? (
+					<LoadingCheckoutSummaryFeaturesList />
+				) : (
+					<CheckoutSummaryFeaturesWrapper
+						siteId={ siteId }
+						nextDomainIsFree={ responseCart.next_domain_is_free }
+					/>
+				) }
 			</CheckoutSummaryFeatures>
 			{ ! isCartUpdating && ! hasRenewalInCart && ! isWcMobile && plan && hasMonthlyPlanInCart && (
 				<CheckoutSummaryAnnualUpsell plan={ plan } onChangeSelection={ onChangeSelection } />
@@ -224,6 +228,16 @@ function CheckoutSummaryPriceList() {
 					</span>
 				</CheckoutSummaryTotal>
 			</CheckoutSummaryAmountWrapper>
+		</>
+	);
+}
+
+export function LoadingCheckoutSummaryFeaturesList() {
+	return (
+		<>
+			<LoadingCopy />
+			<LoadingCopy />
+			<LoadingCopy />
 		</>
 	);
 }
@@ -982,6 +996,40 @@ const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )`
 
 	& .wp-checkout-order-summary__total-price {
 		font-size: 40px; line-height: 44px; }
+	}
+`;
+
+const LoadingCopy = styled.p`
+	animation: ${ pulse } 1.5s ease-in-out infinite;
+	background: ${ ( props ) => props.theme.colors.borderColorLight };
+	border-radius: 2px;
+	color: ${ ( props ) => props.theme.colors.borderColorLight };
+	content: '';
+	font-size: 14px;
+	height: 18px;
+	margin: 8px 0 0 26px;
+	padding: 0;
+	position: relative;
+
+	::before {
+		content: '';
+		display: block;
+		position: absolute;
+		left: -26px;
+		top: 0;
+		width: 18px;
+		height: 18px;
+		background: ${ ( props ) => props.theme.colors.borderColorLight };
+		border-radius: 100%;
+	}
+
+	.rtl & {
+		margin: 8px 26px 0 0;
+
+		::before {
+			right: -26px;
+			left: auto;
+		}
 	}
 `;
 

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -146,14 +146,10 @@ export function CheckoutSummaryFeaturedList( {
 						? translate( 'WordPress.com Gift Subscription' )
 						: translate( 'Included with your purchase' ) }
 				</CheckoutSummaryFeaturesTitle>
-				{ isCartUpdating ? (
-					<LoadingCheckoutSummaryFeaturesList />
-				) : (
-					<CheckoutSummaryFeaturesWrapper
-						siteId={ siteId }
-						nextDomainIsFree={ responseCart.next_domain_is_free }
-					/>
-				) }
+				<CheckoutSummaryFeaturesWrapper
+					siteId={ siteId }
+					nextDomainIsFree={ responseCart.next_domain_is_free }
+				/>
 			</CheckoutSummaryFeatures>
 			{ ! isCartUpdating && ! hasRenewalInCart && ! isWcMobile && plan && hasMonthlyPlanInCart && (
 				<CheckoutSummaryAnnualUpsell plan={ plan } onChangeSelection={ onChangeSelection } />
@@ -228,16 +224,6 @@ function CheckoutSummaryPriceList() {
 					</span>
 				</CheckoutSummaryTotal>
 			</CheckoutSummaryAmountWrapper>
-		</>
-	);
-}
-
-export function LoadingCheckoutSummaryFeaturesList() {
-	return (
-		<>
-			<LoadingCopy />
-			<LoadingCopy />
-			<LoadingCopy />
 		</>
 	);
 }
@@ -996,40 +982,6 @@ const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )`
 
 	& .wp-checkout-order-summary__total-price {
 		font-size: 40px; line-height: 44px; }
-	}
-`;
-
-const LoadingCopy = styled.p`
-	animation: ${ pulse } 1.5s ease-in-out infinite;
-	background: ${ ( props ) => props.theme.colors.borderColorLight };
-	border-radius: 2px;
-	color: ${ ( props ) => props.theme.colors.borderColorLight };
-	content: '';
-	font-size: 14px;
-	height: 18px;
-	margin: 8px 0 0 26px;
-	padding: 0;
-	position: relative;
-
-	::before {
-		content: '';
-		display: block;
-		position: absolute;
-		left: -26px;
-		top: 0;
-		width: 18px;
-		height: 18px;
-		background: ${ ( props ) => props.theme.colors.borderColorLight };
-		border-radius: 100%;
-	}
-
-	.rtl & {
-		margin: 8px 26px 0 0;
-
-		::before {
-			right: -26px;
-			left: auto;
-		}
 	}
 `;
 


### PR DESCRIPTION
Fixes #98528.

## Proposed Changes

When anything happens in the cart that triggers [a form validation](https://github.com/Automattic/wp-calypso/blob/8d7385602d51375d0eaa4a3be38bc2ee84d1cb84/packages/composite-checkout/src/lib/form-status.ts#L12), the `CheckoutSummaryFeaturedList` goes back into a loading state. 

This PR removes the loading state for `CheckoutSummaryFeaturedList`

### Before
https://github.com/user-attachments/assets/655ec3e5-faf1-4958-abd3-b4d2954e2bac

### After
https://github.com/user-attachments/assets/37bd9b4d-37c2-4b2c-be2d-00f8c8c89253

## Why are these changes being made?

I don't believe we need the loader for two reasons:
- There aren't any long-running async calls that are made in this component or child components (I think :))
  - Even if there were, I don't think it matters. 
- It's supplementary information and we don't add loading states for any of the products in the cart.
- (and the loader is visually distracting)

## Why not delete `LoadingCheckoutSummaryFeaturesList`?

It's currently being used in the purchase modal:
https://github.com/Automattic/wp-calypso/blob/0894428e114e7772f0e8cb03904c4cbdb64c4a8b/client/my-sites/checkout/purchase-modal/placeholder.jsx#L1

## Why no tests?

I don't think there's anything to test. :)

## Testing Instructions

We want `usePrefillCheckoutContactForm` to auto-select the contact because that adds the most loading lag. 

* So first, create a cart with any item, go to the cart, save the contact, and then navigate away. 
* Add more products to your cart (Domain + Plan)
* Go to your cart.
* Confirm that features are displayed after the initial page load.
* Make some updates to products in the cart. (Billing years)
* Notice the Feature list does not go into a loading state.
* Remove an item from your cart.
* Notice the Feature list does not go into a loading state, but does update appropriately.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
