### PR TITLE
Preserve Username/Email When Switching to Password Login from Magic Link Flow

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -230,7 +230,7 @@ class MagicLogin extends Component {
 		const loginParameters = {
 			isJetpack: this.props.isJetpackLogin,
 			locale: this.props.locale,
-			emailAddress: this.props.query?.email_address,
+			emailAddress: this.props.userEmail,
 			signupUrl: this.props.query?.signup_url,
 			usernameOnly: true,
 		};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR fixes an issue where users must re-enter their username or email when switching from the "Email me a login link" view to the "Enter a password instead" view. Now, the previously entered username/email is retained in the input field, improving the user experience.

This fixes the partial of https://github.com/Automattic/wp-calypso/issues/53495. See https://github.com/Automattic/wp-calypso/issues/53495#issuecomment-2601649468 for further improvement. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://github.com/Automattic/wp-calypso/issues/53495

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to /log-in.
- Enter an email address or username and click "Continue."
	- <img width="1397" alt="Screenshot 2025-01-20 at 16 47 27" src="https://github.com/user-attachments/assets/f0c9a03b-8226-4cc6-b746-2e2078870405" />
- Click on "Email me a login link."
	- <img width="1396" alt="Screenshot 2025-01-20 at 16 48 06" src="https://github.com/user-attachments/assets/7095e408-7b59-497b-b219-55e4adefb8ae" />
- Click on "Enter a password instead."
	- <img width="1395" alt="Screenshot 2025-01-20 at 16 48 36" src="https://github.com/user-attachments/assets/dbe5dff1-53e7-4bee-9d05-02e3eb605558" />
- The username/email field should now be pre-filled.
	- <img width="1399" alt="Screenshot 2025-01-20 at 16 49 11" src="https://github.com/user-attachments/assets/fde9c70b-8d60-489f-ad1f-6a2424782de5" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
