### PR TITLE
Settings: Fix `useSiteCopy` features requesting selector

### DIFF
--- a/client/landing/stepper/hooks/use-site-copy.tsx
+++ b/client/landing/stepper/hooks/use-site-copy.tsx
@@ -13,7 +13,7 @@ import {
 	isFetchingUserPurchases,
 	getUserPurchases,
 } from 'calypso/state/purchases/selectors';
-import getSiteFeatures from 'calypso/state/selectors/get-site-features';
+import isRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { fetchSiteFeatures } from 'calypso/state/sites/features/actions';
 import type { SiteSelect } from '@automattic/data-stores';
@@ -65,10 +65,9 @@ export const useSiteCopy = (
 		WPCOM_FEATURES_COPY_SITE,
 		options.enabled
 	);
-	const { isRequesting: isRequestingSiteFeatures } = useSelector( ( state ) => {
-		const siteFeatures = getSiteFeatures( state, site?.ID );
-		return siteFeatures ? siteFeatures : { isRequesting: true };
-	} );
+	const requestingSiteFeatures = useSelector( ( state ) =>
+		isRequestingSiteFeatures( state, site?.ID )
+	);
 	const isAtomic = useSelect(
 		( select ) =>
 			site && options.enabled && ( select( SITE_STORE ) as SiteSelect ).isSiteAtomic( site?.ID ),
@@ -128,11 +127,11 @@ export const useSiteCopy = (
 			shouldShowSiteCopyItem,
 			startSiteCopy,
 			resumeSiteCopy,
-			isFetching: isLoadingPurchases || isRequestingSiteFeatures,
+			isFetching: isLoadingPurchases || requestingSiteFeatures,
 		} ),
 		[
 			isLoadingPurchases,
-			isRequestingSiteFeatures,
+			requestingSiteFeatures,
 			resumeSiteCopy,
 			shouldShowSiteCopyItem,
 			startSiteCopy,


### PR DESCRIPTION
## Proposed Changes

Updates `useSiteCopy` hook to use the `isRequestingSiteFeatures` selector instead of building a custom one and returning a new object on every run. 

This also improves the code quality: we already have a dedicated selector for this, so we should be using it.

Introduced previously in #72714.

## Why are these changes being made?
To reduce the number of rerenders on the Settings > General page and resolve this warning:

![Screenshot 2025-01-20 at 10 05 02](https://github.com/user-attachments/assets/b124b2bd-d680-4630-a0f2-4e34c8d771f1)

## Testing Instructions
* Go to `/settings/general/:site` where `:site` is a WP.com simple site.
* Verify the warning doesn't appear in your console.
* Go to `/setup/copy-site/domains?sourceSlug=nonexistingweirdsite.wpcomstaging.com` as per #72714.
* Verify the warning no longer appears in your console. The redirect to `/sites` is expected.