### PR TITLE
Server Settings: Fix warning in SFTP users

### DIFF
--- a/client/sites/tools/sftp-ssh/sftp-form.tsx
+++ b/client/sites/tools/sftp-ssh/sftp-form.tsx
@@ -119,26 +119,21 @@ export const SftpForm = ( {
 	const isLoadingSftpUsers = useSelector( ( state ) =>
 		getAtomicHostingIsLoadingSftpUsers( state, siteId )
 	);
-	const { username, password } = useSelector( ( state ) => {
-		let username;
-		let password;
 
-		const users = getAtomicHostingSftpUsers( state, siteId );
-
-		if ( ! disabled && users !== null ) {
-			if ( users.length ) {
-				// Pick first user. Rest of users will be handled in next phases.
-				username = users[ 0 ].username;
-				password = users[ 0 ].password;
-			} else {
-				// No SFTP user created yet.
-				username = null;
-				password = null;
-			}
+	let username: string | null | undefined = undefined;
+	let password: string | null | undefined = undefined;
+	const atomicSftpUsers = useSelector( ( state ) => getAtomicHostingSftpUsers( state, siteId ) );
+	if ( ! disabled && atomicSftpUsers !== null ) {
+		if ( atomicSftpUsers.length ) {
+			// Pick first user. Rest of users will be handled in next phases.
+			username = atomicSftpUsers[ 0 ].username;
+			password = atomicSftpUsers[ 0 ].password;
+		} else {
+			// No SFTP user created yet.
+			username = null;
+			password = null;
 		}
-
-		return { username, password };
-	} );
+	}
 
 	// State for clipboard copy button for both username and password data
 	const [ isLoading, setIsLoading ] = useState( false );
@@ -152,7 +147,7 @@ export const SftpForm = ( {
 
 	const handleResetPassword = () => {
 		setPasswordLoading( true );
-		dispatch( resetSftpPassword( siteId, username ) );
+		dispatch( resetSftpPassword( siteId, username as string ) );
 	};
 
 	const handleCreateUser = () => {


### PR DESCRIPTION
## Proposed Changes

Simplify the code to retrieve SFTP users. Currently, it creates a new object inside a `useSelector(),` triggering a bunch of additional rerenders. Instead, we can derive the state and avoid those rerenders.

## Why are these changes being made?

To reduce rerenders and remove this warning:

![Screenshot 2025-01-20 at 10 24 52](https://github.com/user-attachments/assets/79efe54e-52ee-4731-a83d-5213309cc0ef)

## Testing Instructions

* Go to `/hosting-config/:site` where `:site` is one of your Atomic sites.
* Verify the warning doesn't appear anymore.