### PR TITLE
Overview: Fix quick actions warning

### DIFF
--- a/client/sites/overview/components/quick-actions-card.tsx
+++ b/client/sites/overview/components/quick-actions-card.tsx
@@ -64,22 +64,21 @@ const QuickActionsCard: FC = () => {
 	const hasEnTranslation = useHasEnTranslation();
 	const site = useSelector( getSelectedSite );
 	const { data: activeThemeData } = useActiveThemeQuery( site?.ID || -1, !! site );
-	const { editorUrl, themeInstallUrl, pluginInstallUrl, statsUrl, siteEditorUrl } = useSelector(
-		( state ) => ( {
-			editorUrl: site?.ID ? getEditorUrl( state, site.ID ) : '#',
-			themeInstallUrl: getThemeInstallUrl( state, site?.ID ) ?? '',
-			pluginInstallUrl: getPluginInstallUrl( state, site?.ID ) ?? '',
-			statsUrl: getStatsUrl( state, site?.ID ) ?? '',
-			siteEditorUrl:
-				site?.ID && activeThemeData
-					? getCustomizeUrl(
-							state as object,
-							activeThemeData[ 0 ]?.stylesheet,
-							site?.ID,
-							activeThemeData[ 0 ]?.is_block_theme
-					  )
-					: '',
-		} )
+	const editorUrl = useSelector( ( state ) =>
+		site?.ID ? getEditorUrl( state, site?.ID ) : '#'
+	);
+	const themeInstallUrl = useSelector( ( state ) => getThemeInstallUrl( state, site?.ID ) ?? '' );
+	const pluginInstallUrl = useSelector( ( state ) => getPluginInstallUrl( state, site?.ID ) ?? '' );
+	const statsUrl = useSelector( ( state ) => getStatsUrl( state, site?.ID ) ?? '' );
+	const siteEditorUrl = useSelector( ( state ) =>
+		site?.ID && activeThemeData
+			? getCustomizeUrl(
+					state as object,
+					activeThemeData[ 0 ]?.stylesheet,
+					site?.ID,
+					activeThemeData[ 0 ]?.is_block_theme
+			  )
+			: ''
 	);
 
 	const { adminLabel, adminUrl } = useSiteAdminInterfaceData( site?.ID );


### PR DESCRIPTION
## Proposed Changes

Fixes an unnecessary, incorrect usage of `useSelector` that will cause unnecessary rerenders of the `QuickActionsCard` in the site overview.

## Why are these changes being made?

Because `useSelector` doesn't handle returning new objects well, unlike `useSelect` (see p4TIVU-aST-p2)

We're essentially fixing this warning:

![Screenshot 2025-01-20 at 10 55 57](https://github.com/user-attachments/assets/08752653-70cb-43e8-984e-ad1692c99b5b)


## Testing Instructions

* Go to `/overview/:site` where `:site` is an Atomic site.
* Verify the warning doesn't appear anymore.
