### PR TITLE
A4A > Referrals: Use the updated commission calculation on referrals table

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/referrals-list/commissions-column.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/commissions-column.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useRef } from 'react';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
+import useGetConsolidatedPayoutData from '../hooks/use-get-consolidated-payout-data';
 import { getConsolidatedData } from '../lib/commissions';
 import type { Referral, ReferralInvoice } from '../types';
 
@@ -27,6 +28,8 @@ export default function CommissionsColumn( {
 		pendingCommission: 0,
 	} );
 
+	const { expectedCommission } = useGetConsolidatedPayoutData( [ referral ], data );
+
 	useEffect( () => {
 		if ( data?.length ) {
 			const consolidatedData = getConsolidatedData( [ referral ], data || [], referralInvoices );
@@ -35,7 +38,7 @@ export default function CommissionsColumn( {
 	}, [ data, referral, referralInvoices ] );
 
 	const allTimeCommissions = formatCurrency( consolidatedData.allTimeCommissions, 'USD' );
-	const pendingCommission = formatCurrency( consolidatedData.pendingCommission, 'USD' );
+	const pendingCommission = formatCurrency( expectedCommission, 'USD' );
 
 	return isFetching ? (
 		<TextPlaceholder />


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1676

## Proposed Changes

This PR
- Fixes an issue with the Referrals page where the columns on the Referral table use the old commission calculation to show the "All time" and "Expected" commissions. 
- Removes the unused code.

## Why are these changes being made?

- To show the correct commission calculation, use a single source of truth.

Note: we need to figure out how to show the "All time" value from the updated calculation. Also, we need to fix the calculation to include the last date of the payout date which will be done in another PR. 

## Testing Instructions

* Open the A4A live link
* Go to Referrals: Dashboard > Hover over the `COMMISSIONS` column and verify the "Expected" commissions value matches the value on the detailed view. You can reproduce this comparing it with production.

<img width="258" alt="Screenshot 2025-01-20 at 4 07 18 PM" src="https://github.com/user-attachments/assets/ca2d18ca-7bd0-40d1-83f2-da19ad5955fd" />

<img width="963" alt="Screenshot 2025-01-20 at 4 21 21 PM" src="https://github.com/user-attachments/assets/628a7956-f929-4342-911e-e62e9a78c87c" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
