### PR TITLE
Implement Core Typography

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-category-menu/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-category-menu/style.scss
@@ -3,7 +3,7 @@
 }
 
 .product-category-menu-title {
-	@include a4a-font-heading-xl;
+	@include heading-x-large;
 	color: var(--color-text-inverted);
 }
 

--- a/client/assets/stylesheets/shared/mixins/_core-typography.scss
+++ b/client/assets/stylesheets/shared/mixins/_core-typography.scss
@@ -1,0 +1,101 @@
+// ==========================================================================
+// Core Typography definitions
+//
+// Based on: https://wordpress.github.io/gutenberg/?path=/docs/tokens-typography--page
+// ==========================================================================
+
+$font-family-headings: -apple-system, "system-ui", "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+$font-family-body: -apple-system, "system-ui", "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+$font-family-mono: Menlo, Consolas, monaco, monospace;
+
+$font-weight-regular: 400;
+$font-weight-medium: 500;
+
+$font-line-height-x-small: 16px;
+$font-line-height-small: 20px;
+$font-line-height-medium: 24px;
+$font-line-height-large: 28px;
+$font-line-height-x-large: 32px;
+$font-line-height-2x-large: 40px;
+
+$font-size-x-small: 11px;
+$font-size-small: 12px;
+$font-size-medium: 13px;
+$font-size-large: 15px;
+$font-size-x-large: 20px;
+$font-size-2x-large: 32px;
+
+/* Internal mixin for heading */
+@mixin _text-heading() {
+	font-family: $font-family-headings;
+	font-weight: $font-weight-medium;
+}
+
+/* Internal mixin for body */
+@mixin _text-body() {
+	font-family: $font-family-body;
+	font-weight: $font-weight-regular;
+}
+
+/* Heading 2X Large */
+@mixin heading-2x-large() {
+	@include _text-heading();
+	font-size: $font-size-2x-large;
+	line-height: $font-line-height-2x-large;
+}
+
+/* Heading X Large */
+@mixin heading-x-large() {
+	@include _text-heading();
+	font-size: $font-size-x-large;
+	line-height: $font-line-height-large;
+}
+
+/* Heading Large */
+@mixin heading-large() {
+	@include _text-heading();
+	font-size: $font-size-large;
+	line-height: $font-line-height-large;
+}
+
+/* Heading Medium */
+@mixin heading-medium() {
+	@include _text-heading();
+	font-size: $font-size-medium;
+	line-height: $font-line-height-small;
+}
+
+/* Heading Small */
+@mixin heading-small() {
+	@include _text-heading();
+	font-size: $font-size-small;
+	line-height: $font-line-height-small;
+}
+
+/* Body X Large */
+@mixin body-x-large() {
+	@include _text-body();
+	font-size: $font-size-x-large;
+	line-height: $font-line-height-x-large;
+}
+
+/* Body Large */
+@mixin body-large() {
+	@include _text-body();
+	font-size: $font-size-large;
+	line-height: $font-line-height-medium;
+}
+
+/* Body Medium */
+@mixin body-medium() {
+	@include _text-body();
+	font-size: $font-size-medium;
+	line-height: $font-line-height-small;
+}
+
+/* Body Small */
+@mixin body-small() {
+	@include _text-body();
+	font-size: $font-size-small;
+	line-height: $font-line-height-x-small;
+}

--- a/client/assets/stylesheets/shared/mixins/_mixins.scss
+++ b/client/assets/stylesheets/shared/mixins/_mixins.scss
@@ -13,6 +13,7 @@
 @import "placeholder";
 @import "stats-fade-text";
 @import "a4a-typography";
+@import "core-typography";
 
 //======================================================
 // Copied _extends rules that are used in @media


### PR DESCRIPTION
## Proposed Changes

This PR creates heading and body text mixins on Calypso that match with [Core Typography](https://wordpress.github.io/gutenberg/?path=/docs/tokens-typography--page).

_Edit_

We are using the core [mixins](https://github.com/WordPress/gutenberg/blob/a900e036b33cab143bef3aee883a568394620023/packages/base-styles/_mixins.scss#L18-L70) and [variables](https://github.com/WordPress/gutenberg/blob/a900e036b33cab143bef3aee883a568394620023/packages/base-styles/_variables.scss#L18-L45) here


## Why are these changes being made?

To align the user experience more closely with Core, we are implementing Core typography within Calypso. This would allow A4A and Dotcom to adopt consistent typography moving forward. 

## Testing Instructions

* Open the A4A live link
* Go to Marketplace: Products(marketplace/products) > We have updated one text from this page to use the newly created mixin as this is behind a feature flag and we have designed this page as per Core Typography. Verify everything looks good.

<img width="1728" alt="Screenshot 2025-01-20 at 4 35 49 PM" src="https://github.com/user-attachments/assets/506cded8-5f5b-4646-8d9b-df2e0c947483" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
