### PR TITLE
Help Center: Remove translation handling for waiting buttons

### DIFF
--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -1,5 +1,5 @@
-import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
-import { __, hasTranslation } from '@wordpress/i18n';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { __ } from '@wordpress/i18n';
 import { useNavigate } from 'react-router-dom';
 import { useOdieAssistantContext } from '../../context';
 import { useCreateZendeskConversation } from '../../hooks';
@@ -51,7 +51,6 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 		isUserEligibleForPaidSupport: contextIsUserEligibleForPaidSupport,
 		canConnectToZendesk,
 	} = useOdieAssistantContext();
-	const isEnglishLocale = useIsEnglishLocale();
 
 	// Early return if user is already talking to a human
 	if ( chat.provider !== 'odie' ) {
@@ -69,14 +68,8 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 		if ( isUserEligibleForPaidSupport || contextIsUserEligibleForPaidSupport ) {
 			return [
 				{
-					text:
-						isEnglishLocale || hasTranslation( 'Chat with support' )
-							? __( 'Chat with support', __i18n_text_domain__ )
-							: __( 'Get instant support', __i18n_text_domain__ ),
-					waitTimeText:
-						isEnglishLocale || hasTranslation( 'Average wait time < 5 minutes' )
-							? __( 'Average wait time < 5 minutes', __i18n_text_domain__ )
-							: undefined,
+					text: __( 'Chat with support', __i18n_text_domain__ ),
+					waitTimeText: __( 'Average wait time < 5 minutes', __i18n_text_domain__ ),
 					action: async () => {
 						onClickAdditionalEvent?.( 'chat' );
 						await newConversation();
@@ -84,10 +77,7 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 				},
 				{
 					text: __( 'Email support', __i18n_text_domain__ ),
-					waitTimeText:
-						isEnglishLocale || hasTranslation( 'Average wait time < 8 hours' )
-							? __( 'Average wait time < 8 hours', __i18n_text_domain__ )
-							: undefined,
+					waitTimeText: __( 'Average wait time < 8 hours', __i18n_text_domain__ ),
 					action: async () => {
 						onClickAdditionalEvent?.( 'email' );
 						await newConversation();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/98471/

## Proposed Changes

Removes the code to handle missing translations.