### PR TITLE
Site Migration: Remove `automated-migration/pending-status` feature flag

### DIFF
--- a/client/data/site-migration/landing/use-migration-cancellation/index.ts
+++ b/client/data/site-migration/landing/use-migration-cancellation/index.ts
@@ -1,14 +1,9 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useMutation } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 import { SiteId } from 'calypso/types';
 import { log } from '../logger';
 
 const request = async ( { siteId }: { siteId: SiteId } ): Promise< Response > => {
-	if ( ! isEnabled( 'automated-migration/pending-status' ) ) {
-		return { status: 'skipped' };
-	}
-
 	await wp.req.post( {
 		path: `/sites/${ siteId }/site-migration-status-sticker`,
 		apiNamespace: 'wpcom/v2',

--- a/client/data/site-migration/landing/use-migration-cancellation/test/index.tsx
+++ b/client/data/site-migration/landing/use-migration-cancellation/test/index.tsx
@@ -2,9 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { isEnabled } from '@automattic/calypso-config';
 import { waitFor } from '@testing-library/react';
-import { when } from 'jest-when';
 import nock from 'nock';
 import { useMigrationCancellation } from 'calypso/data/site-migration/landing/use-migration-cancellation';
 import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
@@ -13,7 +11,6 @@ jest.mock( '@automattic/calypso-config' );
 
 describe( 'useMigrationCancellation', () => {
 	beforeEach( () => {
-		when( isEnabled ).calledWith( 'automated-migration/pending-status' ).mockReturnValue( true );
 		nock.disableNetConnect();
 	} );
 
@@ -31,18 +28,6 @@ describe( 'useMigrationCancellation', () => {
 		await waitFor( () => {
 			expect( nock.isDone() ).toBe( true );
 			expect( result.current.data ).toEqual( { status: 'success' } );
-		} );
-	} );
-
-	it( 'skips the migration cancellation when the feature is off', async () => {
-		when( isEnabled ).calledWith( 'automated-migration/pending-status' ).mockReturnValue( false );
-
-		const { result } = renderHookWithProvider( () => useMigrationCancellation( 123 ) );
-
-		result.current.mutate();
-
-		await waitFor( () => {
-			expect( result.current.data ).toEqual( { status: 'skipped' } );
 		} );
 	} );
 } );

--- a/client/data/site-migration/landing/use-update-migration-status/index.ts
+++ b/client/data/site-migration/landing/use-update-migration-status/index.ts
@@ -1,16 +1,8 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useMutation } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 import { SiteId } from 'calypso/types';
 import { log } from '../logger';
 import { MigrationStatus } from '../types';
-
-const shouldSkipStatus = ( status: MigrationStatus ) => {
-	const isPendingStatusEnabled = isEnabled( 'automated-migration/pending-status' );
-	const isPendingStatus = status.includes( 'pending' );
-
-	return isPendingStatus && ! isPendingStatusEnabled;
-};
 
 const request = async ( {
 	siteId,
@@ -19,10 +11,6 @@ const request = async ( {
 	siteId: SiteId;
 	status: MigrationStatus;
 } ): Promise< Response > => {
-	if ( shouldSkipStatus( status ) ) {
-		return { status: 'skipped' };
-	}
-
 	await wp.req.post( {
 		path: `/sites/${ siteId }/site-migration-status-sticker`,
 		apiNamespace: 'wpcom/v2',

--- a/client/data/site-migration/landing/use-update-migration-status/test/index.tsx
+++ b/client/data/site-migration/landing/use-update-migration-status/test/index.tsx
@@ -2,9 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { isEnabled } from '@automattic/calypso-config';
 import { waitFor } from '@testing-library/react';
-import { when } from 'jest-when';
 import nock from 'nock';
 import { MigrationStatus } from 'calypso/data/site-migration/landing/types';
 import { useUpdateMigrationStatus } from 'calypso/data/site-migration/landing/use-update-migration-status';
@@ -14,7 +12,6 @@ jest.mock( '@automattic/calypso-config' );
 
 describe( 'useUpdateMigrationStatus', () => {
 	beforeEach( () => {
-		when( isEnabled ).calledWith( 'automated-migration/pending-status' ).mockReturnValue( true );
 		nock.disableNetConnect();
 	} );
 
@@ -32,18 +29,6 @@ describe( 'useUpdateMigrationStatus', () => {
 		await waitFor( () => {
 			expect( nock.isDone() ).toBe( true );
 			expect( result.current.data ).toEqual( { status: 'success' } );
-		} );
-	} );
-
-	it( 'skips the status update when the status contains migration-pending- and the feature is off', async () => {
-		when( isEnabled ).calledWith( 'automated-migration/pending-status' ).mockReturnValue( false );
-
-		const { result } = renderHookWithProvider( () => useUpdateMigrationStatus( 123 ) );
-
-		result.current.mutate( { status: MigrationStatus.PENDING_DIFM } );
-
-		await waitFor( () => {
-			expect( result.current.data ).toEqual( { status: 'skipped' } );
 		} );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { captureException } from '@automattic/calypso-sentry';
 import { CircularProgressBar } from '@automattic/components';
 import { LaunchpadContainer } from '@automattic/launchpad';
@@ -88,12 +87,7 @@ const SiteMigrationInstructions: Step = function ( { navigation, flow } ) {
 
 	useEffect( () => {
 		if ( siteId ) {
-			//TODO: We can stop to set the status to STARTED_DIY when the feature is enabled.
-			const status = isEnabled( 'automated-migration/pending-status' )
-				? MigrationStatus.PENDING_DIY
-				: MigrationStatus.STARTED_DIY;
-
-			updateMigrationStatus( { status } );
+			updateMigrationStatus( { status: MigrationStatus.PENDING_DIY } );
 		}
 	}, [ siteId, updateMigrationStatus ] );
 

--- a/config/development.json
+++ b/config/development.json
@@ -36,7 +36,6 @@
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/application-password": true,
-		"automated-migration/pending-status": true,
 		"bulk-plugin-management": true,
 		"calypso/ai-blogging-prompts": true,
 		"calypso/all-domain-management": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -14,7 +14,6 @@
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
 		"automated-migration/application-password": true,
-		"automated-migration/pending-status": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/all-domain-management": false,
 		"calypso/big-sky": true,

--- a/config/production.json
+++ b/config/production.json
@@ -25,7 +25,6 @@
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/application-password": true,
-		"automated-migration/pending-status": true,
 		"bulk-plugin-management": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/all-domain-management": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -24,7 +24,6 @@
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/application-password": true,
-		"automated-migration/pending-status": true,
 		"bulk-plugin-management": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/all-domain-management": false,

--- a/config/test.json
+++ b/config/test.json
@@ -27,7 +27,6 @@
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/application-password": true,
-		"automated-migration/pending-status": true,
 		"calypso/all-domain-management": false,
 		"cancellation-offers": true,
 		"catch-js-errors": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -23,7 +23,6 @@
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/application-password": true,
-		"automated-migration/pending-status": true,
 		"bulk-plugin-management": true,
 		"calypso/ai-blogging-prompts": true,
 		"calypso/all-domain-management": true,


### PR DESCRIPTION
## Proposed Changes
* Remove the `automated-migration/pending-status` 

## Testing Instructions 
* Visual inspection should be enough because there are automated tests covering the expected behaviors. 

## Extra context
This feature flag was managing when we should set a migration status as pending. 
It happens when the user lands on the credential step for the `DIFM` migration and the instruction step for the `DIY` migrations. 

The feature flag was introduced via the PR https://github.com/Automattic/wp-calypso/pull/96102

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
