### PR TITLE
Fix reading `theme_color_admin_color_scheme_override` env config

### DIFF
--- a/client/layout/color-scheme/index.jsx
+++ b/client/layout/color-scheme/index.jsx
@@ -51,7 +51,7 @@ export function refreshColorScheme( prevColorScheme, nextColorScheme ) {
 		classList.add( `is-${ nextColorScheme }` );
 	}
 
-	if ( config.isEnabled( 'theme_color_admin_color_scheme_override' ) ) {
+	if ( config( 'theme_color_admin_color_scheme_override' ) ) {
 		const themeColor = getComputedStyle( document.body )
 			.getPropertyValue( '--color-masterbar-background' )
 			.trim();


### PR DESCRIPTION
## What

This PR fixes how the `theme_color_admin_color_scheme_override ` env config option introduced in https://github.com/Automattic/wp-calypso/pull/98381 is read on the client.

In https://github.com/Automattic/wp-calypso/pull/98381, the option was read via the `config.isEnabled` function — which resulted in the check always returning `false`, since `config.isEnabled` [should be used for feature flags](https://github.com/Automattic/wp-calypso/blob/e566e8f5e0dd8f7561ff877aa9ded54495ba71f2/config/README.md#feature-flags) (and not for general env config options).


## Testing instructions

Follow testing instructions from #98381 