### PR TITLE
PoC Transitioning Plugin Management to /wp/v2 endpoints

### DIFF
--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -77,8 +77,40 @@ const pluginHasTruthySiteProp = ( prop, plugin, siteId ) => {
  * @returns {any} SitePlugin instance
  */
 const getPluginHandler = ( siteId, pluginId ) => {
-	const siteHandler = wpcom.site( siteId );
-	return siteHandler.plugin( pluginId );
+	const pluginHandler = wpcom.site( siteId ).plugin( pluginId );
+
+	// For wp/v2 we need to override the encoded pluginId otherwise the plugin will not be found.
+	pluginHandler.pluginPath = pluginHandler.pluginPath.replace(
+		encodeURIComponent( pluginId ),
+		pluginId
+	);
+	pluginHandler._slug = pluginId;
+
+	// Create handlers for all plugin methods with wp/v2 namespace.
+	const methods = [
+		'get',
+		'update',
+		'updateVersion',
+		'install',
+		'delete',
+		'enableAutoupdate',
+		'disableAutoupdate',
+	];
+
+	const handlers = methods.reduce( ( acc, method ) => {
+		acc[ method ] = ( query, ...args ) =>
+			pluginHandler[ method ]( { ...query, apiNamespace: 'wp/v2' }, ...args );
+		return acc;
+	}, {} );
+
+	// Custom methods for wp/v2 requiring different payloads.
+	handlers.activate = ( query, ...args ) =>
+		pluginHandler.update( { ...query, apiNamespace: 'wp/v2' }, { status: 'active' }, ...args );
+
+	handlers.deactivate = ( query, ...args ) =>
+		pluginHandler.update( { ...query, apiNamespace: 'wp/v2' }, { status: 'inactive' }, ...args );
+
+	return handlers;
 };
 
 /**
@@ -159,7 +191,7 @@ export function activatePlugin( siteId, plugin ) {
 			// Activation error is ok, because it means the plugin is already active
 			if (
 				( error && error.error !== 'activation_error' ) ||
-				( ! ( data && data.active ) && ! error )
+				( ! ( data && data.status === 'active' ) && ! error )
 			) {
 				dispatch( bumpStat( 'calypso_plugin_activated', 'failed' ) );
 				dispatch(
@@ -616,7 +648,7 @@ export function fetchSitePlugins( siteId ) {
 
 		return wpcom
 			.site( siteId )
-			.pluginsList()
+			.pluginsList( { apiNamespace: 'wp/v2' } )
 			.then( receivePluginsDispatchSuccess )
 			.catch( receivePluginsDispatchFail );
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
