### PR TITLE
Restore width of Billing History in Purchases

### DIFF
--- a/client/me/purchases/billing-history/billing-history-list-data-view.tsx
+++ b/client/me/purchases/billing-history/billing-history-list-data-view.tsx
@@ -47,7 +47,7 @@ export default function BillingHistoryListDataView( {
 	const handleViewChange = ( view: View ) => viewState.updateView( view as ViewStateUpdate );
 
 	return (
-		<div className="billing-history">
+		<div className="billing-history with-dataviews">
 			<div className="dataviews-wrapper">
 				<DataViews
 					data={ paginatedItems }

--- a/client/me/purchases/billing-history/billing-history-list-data-view.tsx
+++ b/client/me/purchases/billing-history/billing-history-list-data-view.tsx
@@ -47,24 +47,20 @@ export default function BillingHistoryListDataView( {
 	const handleViewChange = ( view: View ) => viewState.updateView( view as ViewStateUpdate );
 
 	return (
-		<div className="billing-history with-dataviews">
-			<div className="dataviews-wrapper">
-				<DataViews
-					data={ paginatedItems }
-					paginationInfo={ {
-						totalItems,
-						totalPages,
-					} }
-					fields={ fields }
-					view={ viewState.view }
-					search
-					searchLabel={ translate( 'Search receipts' ) }
-					onChangeView={ handleViewChange }
-					defaultLayouts={ DEFAULT_LAYOUT }
-					actions={ actions }
-					isLoading={ isLoading }
-				/>
-			</div>
-		</div>
+		<DataViews
+			data={ paginatedItems }
+			paginationInfo={ {
+				totalItems,
+				totalPages,
+			} }
+			fields={ fields }
+			view={ viewState.view }
+			search
+			searchLabel={ translate( 'Search receipts' ) }
+			onChangeView={ handleViewChange }
+			defaultLayouts={ DEFAULT_LAYOUT }
+			actions={ actions }
+			isLoading={ isLoading }
+		/>
 	);
 }

--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -28,7 +28,7 @@ export function BillingHistoryContent( {
 	const useDataViewBillingHistoryList = config.isEnabled( 'purchases/billing-history-data-view' );
 
 	return (
-		<Card className="billing-history__receipts">
+		<Card id="billing-history" className="section-content" tagName="section">
 			{ useDataViewBillingHistoryList ? (
 				<BillingHistoryListDataView getReceiptUrlFor={ getReceiptUrlFor } />
 			) : (
@@ -61,7 +61,7 @@ function BillingHistory() {
 	const vatText = vatDetails.id ? editVatText : addVatText;
 
 	return (
-		<Main wideLayout className="billing-history">
+		<Main id="purchases" wideLayout>
 			<DocumentHead title={ titles.billingHistory } />
 			<PageViewTracker path="/me/purchases/billing" title="Me > Billing History" />
 			<NavigationHeader

--- a/client/me/purchases/billing-history/style-data-view.scss
+++ b/client/me/purchases/billing-history/style-data-view.scss
@@ -1,4 +1,4 @@
-.billing-history {
+.billing-history.with-dataviews {
     .navigation-header::after {
         display: none;
     }
@@ -6,6 +6,7 @@
     .dataviews-wrapper {
         width: 100%;
         margin-bottom: 1rem;
+        padding: 0 1rem;
 
         .dataviews-view-table {
             width: 100%;

--- a/client/me/purchases/billing-history/style-data-view.scss
+++ b/client/me/purchases/billing-history/style-data-view.scss
@@ -202,14 +202,18 @@
     }
 }
 
-@media screen and (min-width: 782px) {
-    body.is-section-me .navigation-header::after {
-        display: none;
+// Sets max-width of all payment sections
+body.is-section-me div.layout.is-global-sidebar-visible .layout__primary {
+    .billing-history.main,
+    .purchases-list.main,
+    .payment-methods__main.main,
+    .add-new-payment-method.main,
+    .receipt.main,
+    .vat-details.main {
+        > * {
+            max-width: 100%;
+        }
     }
-}
-
-body.is-section-me div.layout.is-global-sidebar-visible .layout__primary .billing-history.main > * {
-    max-width: 100%;
 }
 
 @media screen and (min-width: 782px) {

--- a/client/me/purchases/billing-history/style-data-view.scss
+++ b/client/me/purchases/billing-history/style-data-view.scss
@@ -1,7 +1,4 @@
-.billing-history.with-dataviews {
-    .navigation-header::after {
-        display: none;
-    }
+#billing-history {
 
     .dataviews-wrapper {
         width: 100%;

--- a/client/me/purchases/billing-history/style-data-view.scss
+++ b/client/me/purchases/billing-history/style-data-view.scss
@@ -201,23 +201,3 @@
         gap: 1em;
     }
 }
-
-// Sets max-width of all payment sections
-body.is-section-me div.layout.is-global-sidebar-visible .layout__primary {
-    .billing-history.main,
-    .purchases-list.main,
-    .payment-methods__main.main,
-    .add-new-payment-method.main,
-    .receipt.main,
-    .vat-details.main {
-        > * {
-            max-width: 100%;
-        }
-    }
-}
-
-@media screen and (min-width: 782px) {
-    body.is-section-me .navigation-header::after {
-       display: none !important;
-    }
-}


### PR DESCRIPTION
Related to #98568

## Proposed Changes

Streamlines the HTML structure of the Billing History List DataViews component and sets its maximum width to match the original Billing History List component.  It adds a `#billing-history` ID that can be used as a styling hook for all changes.  That way we can prevent styles from seeping outside of what's intended. 

## Why are these changes being made?

We're updating the `me/purchases` screens to utilize the DataViews component which will allow for easier searching/filtering/sorting as well as give a more modern appearance.  The first part of this, the Billing History (receipts) was deployed in https://github.com/Automattic/wp-calypso/pull/97625 but hidden by a feature flag.  There was an unintentional side effect of changing the existing Billing History list's max-width which made it inconsistent with the other `me/purchases` screens.

This PR limits the styling of the new`BillingHistoryListDataView` to the `#billing-history` scope so our customers will remain unaffected by these changes.

## Testing Instructions

Open the following URLs in your browser to ensure they are all the same width:

 * http://calypso.localhost:3000/me/purchases
 * http://calypso.localhost:3000/me/purchases/billing
 * Click on the "view receipt" link for one of the receipts in the billing history list to verify its layout.
 * http://calypso.localhost:3000/me/purchases/vat-details
 * http://calypso.localhost:3000/me/purchases/payment-methods
 * http://calypso.localhost:3000/me/purchases/add-payment-method

Make sure to extend the width of your browser window as these changes will only be noticeable at slightly larger sizes.

<img width="1688" alt="Screenshot 2025-01-20 at 8 50 01 AM" src="https://github.com/user-attachments/assets/97e15c51-ed77-4f43-84d9-c954e74b712a" />
<img width="1688" alt="Screenshot 2025-01-20 at 8 50 11 AM" src="https://github.com/user-attachments/assets/c5f9a2f5-47c1-46e7-9989-702746e982d5" />
<img width="1688" alt="Screenshot 2025-01-20 at 8 50 19 AM" src="https://github.com/user-attachments/assets/15adc0c6-c4b7-44ab-a4a7-b77327988268" />
<img width="1688" alt="Screenshot 2025-01-20 at 8 50 27 AM" src="https://github.com/user-attachments/assets/bdf7c54c-d779-4ad7-a294-d96ff3d7e345" />
<img width="1688" alt="Screenshot 2025-01-20 at 8 50 38 AM" src="https://github.com/user-attachments/assets/5ef0c126-fd27-483f-acb4-89a916e2053d" />



---


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
