### PR TITLE
Remove duplicate views: Fix Page Basic Flow E2E test

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/pages-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/pages-page.ts
@@ -1,6 +1,11 @@
 import { Page, Response } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
 
+const selectors = {
+	// General
+	addNewPageButton: 'a.page-title-action, span.split-page-title-action>a',
+};
+
 /**
  * Represents the Pages page
  */
@@ -30,12 +35,10 @@ export class PagesPage {
 	 * Start a new page using the 'Add new page' button.
 	 */
 	async addNewPage(): Promise< void > {
+		const locator = this.page.locator( selectors.addNewPageButton );
 		await Promise.all( [
-			this.page.waitForNavigation(),
-			this.page
-				.getByRole( 'link', { name: /Add New Page/ } )
-				.first()
-				.click(),
+			this.page.waitForNavigation( { url: /post-new.php\?post_type=page/, timeout: 20 * 1000 } ),
+			locator.click( { timeout: 20 * 1000 } ),
 		] );
 	}
 }


### PR DESCRIPTION
See p1737384275008899-slack-C034JEXD1RD

## Proposed Changes

Updates the logic to click on the "Add New Page" button for the Page Basic Flow E2E test since apparently it was broken when we started the "Remove duplicate views" experiment

## Why are these changes being made?

Because there is a broken e2e test

## Testing Instructions

Run this locally:
```
export TEST_ON_ATOMIC='true'        
export ATOMIC_VARIATION='ecomm-plan'  
export JETPACK_TARGET='wpcom-deployment'          
yarn workspace wp-e2e-tests build  
yarn workspace wp-e2e-tests test -- specs/editor/editor__page-basic-flow.ts
```

Make sure the E2E test passes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?