### PR TITLE
E2E Tests: Skip flaky Tumblr tests

### DIFF
--- a/test/e2e/specs/tools/social-connections__tumblr.ts
+++ b/test/e2e/specs/tools/social-connections__tumblr.ts
@@ -66,15 +66,16 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 			await marketingPage.visitTab( testAccount.getSiteURL( { protocol: false } ), 'connections' );
 		} );
 
-		it( 'Click on the "Connect" button for Tumblr', async function () {
+		// Skipping the bulk of the spec, as it's flaky. We're working on better E2E tests.
+		it.skip( 'Click on the "Connect" button for Tumblr', async function () {
 			popup = await marketingPage.clickSocialConnectButton( 'Tumblr' );
 		} );
 
-		it( 'Set up Tumblr', async function () {
+		it.skip( 'Set up Tumblr', async function () {
 			await marketingPage.setupTumblr( popup, SecretsManager.secrets.socialAccounts.tumblr );
 		} );
 
-		it( 'Tumblr is connected', async function () {
+		it.skip( 'Tumblr is connected', async function () {
 			await marketingPage.validateSocialConnected( 'Tumblr' );
 		} );
 	}


### PR DESCRIPTION
## Proposed Changes
We shouldn't rely on external APIs for E2E tests, so this change skips the flaky ones for now.
*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The test that checks we can connect to Tumblr has been quite flaky. We're working on better E2E tests for social, that don't rely on 3rd party APIs.

## Testing Instructions

* Check the E2E tests run and these tests have been skipped

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?