### PR TITLE
Staging sites: Update translations of error messages

### DIFF
--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
@@ -377,25 +377,24 @@ const SyncCardContainer = ( {
 		siteToSync: 'production' | 'staging',
 		siteUrls: { production: string | null; staging: string | null }
 	): React.ReactNode => {
-		const messages = {
-			production: translate( 'We couldn’t connect to the production site: {{br/}} %(siteUrl)s', {
+		if ( siteToSync === 'production' ) {
+			return translate( 'We couldn’t connect to the production site: {{br/}} %(siteUrl)s', {
 				args: {
 					siteUrl: siteUrls.production ? urlToSlug( siteUrls.production ) : '',
 				},
 				components: {
 					br: <br />,
 				},
-			} ),
-			staging: translate( 'We couldn’t connect to the staging site: {{br/}} %(siteUrl)s', {
-				args: {
-					siteUrl: siteUrls.staging ? urlToSlug( siteUrls.staging ) : '',
-				},
-				components: {
-					br: <br />,
-				},
-			} ),
-		};
-		return messages[ siteToSync ];
+			} );
+		}
+		return translate( 'We couldn’t connect to the staging site: {{br/}} %(siteUrl)s', {
+			args: {
+				siteUrl: siteUrls.staging ? urlToSlug( siteUrls.staging ) : '',
+			},
+			components: {
+				br: <br />,
+			},
+		} );
 	};
 
 	const getOldConnectionErrorText = (

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
@@ -13,7 +13,6 @@ import { useSelector } from 'calypso/state';
 import { removeNotice, successNotice } from 'calypso/state/notices/actions';
 import isSiteStore from 'calypso/state/selectors/is-site-store';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
-import { SiteSyncStatus } from 'calypso/state/sync/constants';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { useCheckSyncStatus } from '../../../hooks/use-site-sync-status';
 import { ConfirmationModal } from '../confirmation-modal';
@@ -361,6 +360,49 @@ const SyncCardContainer = ( {
 	const isJetpackConnectionError = useIsJetpackConnectionSyncError( error );
 	const isFailedSyncError = useIsFailedSyncError( error );
 
+	const getConnectionErrorText = (
+		siteToSync: 'production' | 'staging',
+		siteUrls: { production: string | null; staging: string | null }
+	): React.ReactNode => {
+		const messages = {
+			production: translate( "We couldn't connect to the production site: {{br/}} %(siteUrl)s", {
+				args: {
+					siteUrl: siteUrls.production ? urlToSlug( siteUrls.production ) : '',
+				},
+				components: {
+					br: <br />,
+				},
+			} ),
+			staging: translate( "We couldn't connect to the staging site: {{br/}} %(siteUrl)s", {
+				args: {
+					siteUrl: siteUrls.staging ? urlToSlug( siteUrls.staging ) : '',
+				},
+				components: {
+					br: <br />,
+				},
+			} ),
+		};
+		return messages[ siteToSync ];
+	};
+
+	const getSyncErrorText = (
+		error: string | null | undefined,
+		siteToSync: 'production' | 'staging'
+	): string => {
+		if ( error === 'studio_import_in_progress' ) {
+			return siteToSync === 'production'
+				? translate(
+						'We couldn’t synchronize the production environment. Studio push operation is currently in progress.'
+				  )
+				: translate(
+						'We couldn’t synchronize the staging environment. Studio push operation is currently in progress.'
+				  );
+		}
+		return siteToSync === 'production'
+			? translate( 'We couldn’t synchronize the production environment.' )
+			: translate( 'We couldn’t synchronize the staging environment.' );
+	};
+
 	return (
 		<StagingSyncCardBody>
 			<SyncContainerTitle>{ translate( 'Database and file synchronization' ) }</SyncContainerTitle>
@@ -381,20 +423,7 @@ const SyncCardContainer = ( {
 							status="is-error"
 							icon="mention"
 							showDismiss={ false }
-							text={ translate(
-								'We couldn’t connect to the %(siteType)s site: {{br/}} %(siteUrl)s',
-								{
-									args: {
-										siteType: siteToSync,
-										siteUrl: siteUrls[ siteToSync ]
-											? urlToSlug( siteUrls[ siteToSync ] as string )
-											: '',
-									},
-									components: {
-										br: <br />,
-									},
-								}
-							) }
+							text={ getConnectionErrorText( siteToSync, siteUrls ) }
 						>
 							<NoticeAction href="/help">{ translate( 'Contact support' ) }</NoticeAction>
 						</Notice>
@@ -421,18 +450,7 @@ const SyncCardContainer = ( {
 							status="is-error"
 							icon="mention"
 							showDismiss={ false }
-							text={
-								error === 'studio_import_in_progress'
-									? translate(
-											'We couldn’t synchronize the %s environment. Studio push operation is currently in progress.',
-											{
-												args: [ siteToSync ],
-											}
-									  )
-									: translate( 'We couldn’t synchronize the %s environment.', {
-											args: [ siteToSync ],
-									  } )
-							}
+							text={ getSyncErrorText( error, siteToSync ) }
 						>
 							<NoticeAction onClick={ () => onRetry?.() }>
 								{ translate( 'Try Again' ) }

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
@@ -372,7 +372,13 @@ const SyncCardContainer = ( {
 		hasEnTranslation( 'We couldn’t synchronize the production environment.' ) &&
 		hasEnTranslation( 'We couldn’t synchronize the staging environment.' ) &&
 		hasEnTranslation( "We couldn't connect to the production site: {{br/}} %(siteUrl)s" ) &&
-		hasEnTranslation( "We couldn't connect to the staging site: {{br/}} %(siteUrl)s" );
+		hasEnTranslation( "We couldn't connect to the staging site: {{br/}} %(siteUrl)s" ) &&
+		hasEnTranslation(
+			'We couldn’t synchronize changes to the production site. Please contact support.'
+		) &&
+		hasEnTranslation(
+			'We couldn’t synchronize changes to the staging site. Please contact support.'
+		);
 
 	const getConnectionErrorText = (
 		siteToSync: 'production' | 'staging',
@@ -448,6 +454,25 @@ const SyncCardContainer = ( {
 			  } );
 	};
 
+	const getFailedSyncErrorText = ( siteToSync: 'production' | 'staging' ) => {
+		return siteToSync === 'production'
+			? translate(
+					'We couldn’t synchronize changes to the production site. Please contact support.'
+			  )
+			: translate( 'We couldn’t synchronize changes to the staging site. Please contact support.' );
+	};
+
+	const getOldFailedSyncErrorText = ( siteToSync: 'production' | 'staging' ) => {
+		return translate(
+			'We couldn’t synchronize changes to the %(siteType)s site. Please contact support.',
+			{
+				args: {
+					siteType: siteToSync,
+				},
+			}
+		);
+	};
+
 	return (
 		<StagingSyncCardBody>
 			<SyncContainerTitle>{ translate( 'Database and file synchronization' ) }</SyncContainerTitle>
@@ -482,14 +507,11 @@ const SyncCardContainer = ( {
 							status="is-error"
 							icon="mention"
 							showDismiss={ false }
-							text={ translate(
-								'We couldn’t synchronize changes to the %(siteType)s site. Please contact support.',
-								{
-									args: {
-										siteType: siteToSync,
-									},
-								}
-							) }
+							text={
+								hasNewTranslations
+									? getFailedSyncErrorText( siteToSync )
+									: getOldFailedSyncErrorText( siteToSync )
+							}
 						>
 							<NoticeAction href="/help">{ translate( 'Contact support' ) }</NoticeAction>
 						</Notice>

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
@@ -362,30 +362,23 @@ const SyncCardContainer = ( {
 	const isJetpackConnectionError = useIsJetpackConnectionSyncError( error );
 	const isFailedSyncError = useIsFailedSyncError( error );
 	const hasEnTranslation = useHasEnTranslation();
-	const hasNewTranslations =
-		hasEnTranslation(
-			'We couldn’t synchronize the production environment. Studio push operation is currently in progress.'
-		) &&
-		hasEnTranslation(
-			'We couldn’t synchronize the staging environment. Studio push operation is currently in progress.'
-		) &&
-		hasEnTranslation( 'We couldn’t synchronize the production environment.' ) &&
-		hasEnTranslation( 'We couldn’t synchronize the staging environment.' ) &&
-		hasEnTranslation( "We couldn't connect to the production site: {{br/}} %(siteUrl)s" ) &&
-		hasEnTranslation( "We couldn't connect to the staging site: {{br/}} %(siteUrl)s" ) &&
-		hasEnTranslation(
-			'We couldn’t synchronize changes to the production site. Please contact support.'
-		) &&
-		hasEnTranslation(
-			'We couldn’t synchronize changes to the staging site. Please contact support.'
-		);
+	const hasNewTranslations = [
+		'We couldn’t synchronize the production environment. Studio push operation is currently in progress.',
+		'We couldn’t synchronize the staging environment. Studio push operation is currently in progress.',
+		'We couldn’t synchronize the production environment.',
+		'We couldn’t synchronize the staging environment.',
+		'We couldn’t connect to the production site: {{br/}} %(siteUrl)s',
+		'We couldn’t connect to the staging site: {{br/}} %(siteUrl)s',
+		'We couldn’t synchronize changes to the production site. Please contact support.',
+		'We couldn’t synchronize changes to the staging site. Please contact support.',
+	].every( ( value ) => hasEnTranslation( value ) );
 
 	const getConnectionErrorText = (
 		siteToSync: 'production' | 'staging',
 		siteUrls: { production: string | null; staging: string | null }
 	): React.ReactNode => {
 		const messages = {
-			production: translate( "We couldn't connect to the production site: {{br/}} %(siteUrl)s", {
+			production: translate( 'We couldn’t connect to the production site: {{br/}} %(siteUrl)s', {
 				args: {
 					siteUrl: siteUrls.production ? urlToSlug( siteUrls.production ) : '',
 				},
@@ -393,7 +386,7 @@ const SyncCardContainer = ( {
 					br: <br />,
 				},
 			} ),
-			staging: translate( "We couldn't connect to the staging site: {{br/}} %(siteUrl)s", {
+			staging: translate( 'We couldn’t connect to the staging site: {{br/}} %(siteUrl)s', {
 				args: {
 					siteUrl: siteUrls.staging ? urlToSlug( siteUrls.staging ) : '',
 				},

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
@@ -1,5 +1,4 @@
 import { FormLabel } from '@automattic/components';
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { translate, useTranslate } from 'i18n-calypso';
 import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
@@ -361,17 +360,6 @@ const SyncCardContainer = ( {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const isJetpackConnectionError = useIsJetpackConnectionSyncError( error );
 	const isFailedSyncError = useIsFailedSyncError( error );
-	const hasEnTranslation = useHasEnTranslation();
-	const hasNewTranslations = [
-		'We couldn’t synchronize the production environment. Studio push operation is currently in progress.',
-		'We couldn’t synchronize the staging environment. Studio push operation is currently in progress.',
-		'We couldn’t synchronize the production environment.',
-		'We couldn’t synchronize the staging environment.',
-		'We couldn’t synchronize changes to the production site. Please contact support.',
-		'We couldn’t synchronize changes to the staging site. Please contact support.',
-		'We couldn’t connect to the production site: {{br/}} %(siteUrl)s',
-		'We couldn’t connect to the staging site: {{br/}} %(siteUrl)s',
-	].every( ( value ) => hasEnTranslation( value ) );
 
 	const getConnectionErrorText = (
 		siteToSync: 'production' | 'staging',
@@ -397,21 +385,6 @@ const SyncCardContainer = ( {
 		} );
 	};
 
-	const getOldConnectionErrorText = (
-		siteToSync: 'production' | 'staging',
-		siteUrls: { production: string | null; staging: string | null }
-	): React.ReactNode => {
-		return translate( 'We couldn’t connect to the %(siteType)s site: {{br/}} %(siteUrl)s', {
-			args: {
-				siteType: siteToSync,
-				siteUrl: siteUrls[ siteToSync ] ? urlToSlug( siteUrls[ siteToSync ] as string ) : '',
-			},
-			components: {
-				br: <br />,
-			},
-		} );
-	};
-
 	const getSyncErrorText = (
 		error: string | null | undefined,
 		siteToSync: 'production' | 'staging'
@@ -430,39 +403,12 @@ const SyncCardContainer = ( {
 			: translate( 'We couldn’t synchronize the staging environment.' );
 	};
 
-	const getOldSyncErrorText = (
-		error: string | null | undefined,
-		siteToSync: 'production' | 'staging'
-	): React.ReactNode => {
-		return error === 'studio_import_in_progress'
-			? translate(
-					'We couldn’t synchronize the %s environment. Studio push operation is currently in progress.',
-					{
-						args: [ siteToSync ],
-					}
-			  )
-			: translate( 'We couldn’t synchronize the %s environment.', {
-					args: [ siteToSync ],
-			  } );
-	};
-
 	const getFailedSyncErrorText = ( siteToSync: 'production' | 'staging' ) => {
 		return siteToSync === 'production'
 			? translate(
 					'We couldn’t synchronize changes to the production site. Please contact support.'
 			  )
 			: translate( 'We couldn’t synchronize changes to the staging site. Please contact support.' );
-	};
-
-	const getOldFailedSyncErrorText = ( siteToSync: 'production' | 'staging' ) => {
-		return translate(
-			'We couldn’t synchronize changes to the %(siteType)s site. Please contact support.',
-			{
-				args: {
-					siteType: siteToSync,
-				},
-			}
-		);
 	};
 
 	return (
@@ -485,11 +431,7 @@ const SyncCardContainer = ( {
 							status="is-error"
 							icon="mention"
 							showDismiss={ false }
-							text={
-								hasNewTranslations
-									? getConnectionErrorText( siteToSync, siteUrls )
-									: getOldConnectionErrorText( siteToSync, siteUrls )
-							}
+							text={ getConnectionErrorText( siteToSync, siteUrls ) }
 						>
 							<NoticeAction href="/help">{ translate( 'Contact support' ) }</NoticeAction>
 						</Notice>
@@ -499,11 +441,7 @@ const SyncCardContainer = ( {
 							status="is-error"
 							icon="mention"
 							showDismiss={ false }
-							text={
-								hasNewTranslations
-									? getFailedSyncErrorText( siteToSync )
-									: getOldFailedSyncErrorText( siteToSync )
-							}
+							text={ getFailedSyncErrorText( siteToSync ) }
 						>
 							<NoticeAction href="/help">{ translate( 'Contact support' ) }</NoticeAction>
 						</Notice>
@@ -513,11 +451,7 @@ const SyncCardContainer = ( {
 							status="is-error"
 							icon="mention"
 							showDismiss={ false }
-							text={
-								hasNewTranslations
-									? getSyncErrorText( error, siteToSync )
-									: getOldSyncErrorText( error, siteToSync )
-							}
+							text={ getSyncErrorText( error, siteToSync ) }
 						>
 							<NoticeAction onClick={ () => onRetry?.() }>
 								{ translate( 'Try Again' ) }

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
@@ -367,10 +367,10 @@ const SyncCardContainer = ( {
 		'We couldn’t synchronize the staging environment. Studio push operation is currently in progress.',
 		'We couldn’t synchronize the production environment.',
 		'We couldn’t synchronize the staging environment.',
-		'We couldn’t connect to the production site: {{br/}} %(siteUrl)s',
-		'We couldn’t connect to the staging site: {{br/}} %(siteUrl)s',
 		'We couldn’t synchronize changes to the production site. Please contact support.',
 		'We couldn’t synchronize changes to the staging site. Please contact support.',
+		'We couldn’t connect to the production site: {{br/}} %(siteUrl)s',
+		'We couldn’t connect to the staging site: {{br/}} %(siteUrl)s',
 	].every( ( value ) => hasEnTranslation( value ) );
 
 	const getConnectionErrorText = (

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
@@ -370,7 +370,9 @@ const SyncCardContainer = ( {
 			'We couldn’t synchronize the staging environment. Studio push operation is currently in progress.'
 		) &&
 		hasEnTranslation( 'We couldn’t synchronize the production environment.' ) &&
-		hasEnTranslation( 'We couldn’t synchronize the staging environment.' );
+		hasEnTranslation( 'We couldn’t synchronize the staging environment.' ) &&
+		hasEnTranslation( "We couldn't connect to the production site: {{br/}} %(siteUrl)s" ) &&
+		hasEnTranslation( "We couldn't connect to the staging site: {{br/}} %(siteUrl)s" );
 
 	const getConnectionErrorText = (
 		siteToSync: 'production' | 'staging',
@@ -395,6 +397,21 @@ const SyncCardContainer = ( {
 			} ),
 		};
 		return messages[ siteToSync ];
+	};
+
+	const getOldConnectionErrorText = (
+		siteToSync: 'production' | 'staging',
+		siteUrls: { production: string | null; staging: string | null }
+	): React.ReactNode => {
+		return translate( 'We couldn’t connect to the %(siteType)s site: {{br/}} %(siteUrl)s', {
+			args: {
+				siteType: siteToSync,
+				siteUrl: siteUrls[ siteToSync ] ? urlToSlug( siteUrls[ siteToSync ] as string ) : '',
+			},
+			components: {
+				br: <br />,
+			},
+		} );
 	};
 
 	const getSyncErrorText = (
@@ -451,7 +468,11 @@ const SyncCardContainer = ( {
 							status="is-error"
 							icon="mention"
 							showDismiss={ false }
-							text={ getConnectionErrorText( siteToSync, siteUrls ) }
+							text={
+								hasNewTranslations
+									? getConnectionErrorText( siteToSync, siteUrls )
+									: getOldConnectionErrorText( siteToSync, siteUrls )
+							}
 						>
 							<NoticeAction href="/help">{ translate( 'Contact support' ) }</NoticeAction>
 						</Notice>

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
@@ -1,4 +1,5 @@
 import { FormLabel } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { translate, useTranslate } from 'i18n-calypso';
 import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
@@ -360,6 +361,16 @@ const SyncCardContainer = ( {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const isJetpackConnectionError = useIsJetpackConnectionSyncError( error );
 	const isFailedSyncError = useIsFailedSyncError( error );
+	const hasEnTranslation = useHasEnTranslation();
+	const hasNewTranslations =
+		hasEnTranslation(
+			'We couldn’t synchronize the production environment. Studio push operation is currently in progress.'
+		) &&
+		hasEnTranslation(
+			'We couldn’t synchronize the staging environment. Studio push operation is currently in progress.'
+		) &&
+		hasEnTranslation( 'We couldn’t synchronize the production environment.' ) &&
+		hasEnTranslation( 'We couldn’t synchronize the staging environment.' );
 
 	const getConnectionErrorText = (
 		siteToSync: 'production' | 'staging',
@@ -402,6 +413,22 @@ const SyncCardContainer = ( {
 		return siteToSync === 'production'
 			? translate( 'We couldn’t synchronize the production environment.' )
 			: translate( 'We couldn’t synchronize the staging environment.' );
+	};
+
+	const getOldSyncErrorText = (
+		error: string | null | undefined,
+		siteToSync: 'production' | 'staging'
+	): React.ReactNode => {
+		return error === 'studio_import_in_progress'
+			? translate(
+					'We couldn’t synchronize the %s environment. Studio push operation is currently in progress.',
+					{
+						args: [ siteToSync ],
+					}
+			  )
+			: translate( 'We couldn’t synchronize the %s environment.', {
+					args: [ siteToSync ],
+			  } );
 	};
 
 	return (
@@ -451,7 +478,11 @@ const SyncCardContainer = ( {
 							status="is-error"
 							icon="mention"
 							showDismiss={ false }
-							text={ getSyncErrorText( error, siteToSync ) }
+							text={
+								hasNewTranslations
+									? getSyncErrorText( error, siteToSync )
+									: getOldSyncErrorText( error, siteToSync )
+							}
 						>
 							<NoticeAction onClick={ () => onRetry?.() }>
 								{ translate( 'Try Again' ) }

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
@@ -13,6 +13,7 @@ import { useSelector } from 'calypso/state';
 import { removeNotice, successNotice } from 'calypso/state/notices/actions';
 import isSiteStore from 'calypso/state/selectors/is-site-store';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { SiteSyncStatus } from 'calypso/state/sync/constants';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { useCheckSyncStatus } from '../../../hooks/use-site-sync-status';
 import { ConfirmationModal } from '../confirmation-modal';


### PR DESCRIPTION
Resolves https://github.com/Automattic/dotcom-forge/issues/10290.

## Proposed Changes

* update text of error messages to allow proper translations

![Markup on 2025-01-21 at 16:56:53](https://github.com/user-attachments/assets/e9086730-8a33-4377-9439-68d5cd343231)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/dotcom-forge/issues/10290

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the branch and apply the changes from the diff below. These changes will make sure the error messages will get displayed without any cumbersome manual steps.
2. Build the app with `yarn start`.
3. Navigate to the `Staging Site` tab of an Atomic site that has a staging site attached.
4. Review the error messages.

```diff
diff --git a/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx b/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
index 35517b6b0d9..13e46c8e8e5 100644
--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
@@ -357,6 +357,7 @@ const SyncCardContainer = ( {
 	error?: string | null;
 	onRetry?: () => void;
 } ) => {
+	const displayErrors = true;
 	const translate = useTranslate();
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const isJetpackConnectionError = useIsJetpackConnectionSyncError( error );
@@ -481,50 +482,45 @@ const SyncCardContainer = ( {
 									'Refresh your staging site with the latest from production, or push changes in your staging site to production.'
 							  ) }
 					</SyncContainerContent>
-					{ error && isJetpackConnectionError && (
-						<Notice
-							status="is-error"
-							icon="mention"
-							showDismiss={ false }
-							text={
-								hasNewTranslations
-									? getConnectionErrorText( siteToSync, siteUrls )
-									: getOldConnectionErrorText( siteToSync, siteUrls )
-							}
-						>
-							<NoticeAction href="/help">{ translate( 'Contact support' ) }</NoticeAction>
-						</Notice>
-					) }
-					{ error && isFailedSyncError && (
-						<Notice
-							status="is-error"
-							icon="mention"
-							showDismiss={ false }
-							text={
-								hasNewTranslations
-									? getFailedSyncErrorText( siteToSync )
-									: getOldFailedSyncErrorText( siteToSync )
-							}
-						>
-							<NoticeAction href="/help">{ translate( 'Contact support' ) }</NoticeAction>
-						</Notice>
-					) }
-					{ error && ! isJetpackConnectionError && ! isFailedSyncError && (
-						<Notice
-							status="is-error"
-							icon="mention"
-							showDismiss={ false }
-							text={
-								hasNewTranslations
-									? getSyncErrorText( error, siteToSync )
-									: getOldSyncErrorText( error, siteToSync )
-							}
-						>
-							<NoticeAction onClick={ () => onRetry?.() }>
-								{ translate( 'Try Again' ) }
-							</NoticeAction>
-						</Notice>
-					) }
+
+					<Notice
+						status="is-error"
+						icon="mention"
+						showDismiss={ false }
+						text={
+							hasNewTranslations
+								? getConnectionErrorText( siteToSync, siteUrls )
+								: getOldConnectionErrorText( siteToSync, siteUrls )
+						}
+					>
+						<NoticeAction href="/help">{ translate( 'Contact support' ) }</NoticeAction>
+					</Notice>
+
+					<Notice
+						status="is-error"
+						icon="mention"
+						showDismiss={ false }
+						text={
+							hasNewTranslations
+								? getFailedSyncErrorText( siteToSync )
+								: getOldFailedSyncErrorText( siteToSync )
+						}
+					>
+						<NoticeAction href="/help">{ translate( 'Contact support' ) }</NoticeAction>
+					</Notice>
+					<Notice
+						status="is-error"
+						icon="mention"
+						showDismiss={ false }
+						text={
+							hasNewTranslations
+								? getSyncErrorText( error, siteToSync )
+								: getOldSyncErrorText( error, siteToSync )
+						}
+					>
+						<NoticeAction onClick={ () => onRetry?.() }>{ translate( 'Try Again' ) }</NoticeAction>
+					</Notice>
+
 					{ ! error && (
 						<>
 							<SyncContainerTitle>

```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
