### PR TITLE
Banner: fix callToAction and secondaryCallToAction types to accept JSX elements

### DIFF
--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -32,8 +32,8 @@ const noop = () => {};
 
 export class Banner extends Component {
 	static propTypes = {
-		callToAction: PropTypes.string,
-		secondaryCallToAction: PropTypes.string,
+		callToAction: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
+		secondaryCallToAction: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
 		className: PropTypes.string,
 		compactButton: PropTypes.bool,
 		description: PropTypes.oneOfType( [ PropTypes.node, PropTypes.symbol ] ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Allow the `callToAction` and `secondaryCallToAction` props of the `Banner` component to also be a JSX element

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The component [already supports that usecase in the code ](https://github.com/Automattic/wp-calypso/blob/75624cf5b4b6eb4d19ebf6c47241e0558542fbce/client/components/banner/index.jsx#L295-L338) and [this a4a banner](https://github.com/Automattic/wp-calypso/blob/c2d41bff91c68f37ae00cb2d98fc28d1734182b2/client/sites/components/sites-dashboard-banners/use-a8c-for-agencies-sites-banner.tsx#L24-L28) already renders a react element successfully

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load `/overview/{site-slug}` on your machine
* On trunk, notice the "Failed prop type: Invalid prop `callToAction` of type `object` supplied to `Banner`, expected `string`." error
* On this PR, the error should be gone
* Bonus: follow testing instructions from https://github.com/Automattic/wp-calypso/pull/97868 to see the banner


![Screenshot 2025-01-20 at 18 38 50](https://github.com/user-attachments/assets/8d418f78-57f0-4910-97e7-22c0f35cf10a)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
