### PR TITLE
Domain management: Update getEmailManagementPath logic to support checkout context

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/google-workspace-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/google-workspace-product.tsx
@@ -1,7 +1,9 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import ThankYouProduct from 'calypso/components/thank-you-v2/product';
 import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
 export type ThankYouGoogleWorkspaceProductProps = {
 	productFamily: string;
@@ -17,7 +19,8 @@ export function ThankYouGoogleWorkspaceProduct( {
 	siteSlug,
 }: ThankYouGoogleWorkspaceProductProps ) {
 	const translate = useTranslate();
-	const emailManagementPath = getEmailManagementPath( siteSlug, domainName );
+	const currentRoute = useSelector( getCurrentRoute );
+	const emailManagementPath = getEmailManagementPath( siteSlug, domainName, currentRoute );
 
 	let details;
 	if ( numberOfMailboxesPurchased && numberOfMailboxesPurchased > 1 ) {

--- a/client/my-sites/email/paths.ts
+++ b/client/my-sites/email/paths.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { stringify } from 'qs';
 import {
 	isUnderDomainManagementAll,
@@ -23,6 +24,10 @@ export const emailSiteContextPrefix = `${ domainSiteContextRoot() }/email`;
 
 export function isUnderEmailManagementAll( path?: string | null ) {
 	return path?.startsWith( emailManagementAllSitesPrefix + '/' );
+}
+
+export function isUnderCheckoutRoute( path?: string | null ) {
+	return path?.startsWith( '/checkout' );
 }
 
 // Builds a URL query string from an object. Handles null values.
@@ -173,7 +178,11 @@ export const getEmailManagementPath: EmailPathUtilityFunction = (
 	urlParameters = {},
 	inSiteContext = false
 ) => {
-	if ( inSiteContext || isUnderDomainManagementAll( relativeTo ) ) {
+	if (
+		inSiteContext ||
+		isUnderDomainManagementAll( relativeTo ) ||
+		( isUnderCheckoutRoute( relativeTo ) && isEnabled( 'calypso/all-domain-management' ) )
+	) {
 		const prefix =
 			inSiteContext || isUnderDomainSiteContext( relativeTo )
 				? emailSiteContextPrefix


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/97474

## Proposed Changes

* Extend the generate path logic to support the use case when the feature flag is ON and the current route is under `checkout`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Domain Management Revamp project

## Testing Instructions

* Feature flag: `calypso/all-domain-management`
* Create a domain
* Click on the `Email` tab
* Purchase "Google Workspace"
* On the "Congratulations on your purchase!" screen, click on the "Manage email" button
* Check if you stay in the same context

<img width="882" alt="Screenshot 2025-01-20 at 20 10 13" src="https://github.com/user-attachments/assets/6264441b-452e-4719-b5fa-c4dedc940a35" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
