### PR TITLE
Subscribers Dataviews: Style the mobile view

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -35,7 +35,7 @@ body.is-section-subscribers.is-subscribers-dataviews {
             overflow: hidden;
         
             @media ( max-width: $break-small ) {
-                padding: $padding-standard 0;
+                padding: 0;
             }
         
             button {
@@ -162,7 +162,7 @@ body.is-section-subscribers.is-subscribers-dataviews {
             }
         
             .subscriber-profile.subscriber-profile--compact {
-                @media ( max-width: $break-wide ) {
+                @media ( max-width: $break-small ) {
                     max-width: 195px;
                 }
         

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -98,6 +98,11 @@ body.is-section-subscribers.is-subscribers-dataviews {
                             box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
                             border-radius: inherit;
                         }
+
+                        @media ( max-width: $break-wide ) {
+                            height: 40px;
+                            width: 40px;
+                        }
                     }
                 }
             }
@@ -111,6 +116,10 @@ body.is-section-subscribers.is-subscribers-dataviews {
                     .navigation-header {
                         padding: $padding-standard 24px;
                     }
+
+                    @media ( max-width: $break-wide ) {
+                        display: none;
+                    }
                 }
         
                 .subscriber-data-views__details {
@@ -120,6 +129,10 @@ body.is-section-subscribers.is-subscribers-dataviews {
                     /* stylelint-disable-next-line scales/radii */
                     border-radius: 8px;
                     padding: 24px;
+
+                    @media ( max-width: $break-wide ) {
+                        overflow: auto;
+                    }
 
                     .subscriber-details {
                         &__header {
@@ -133,6 +146,12 @@ body.is-section-subscribers.is-subscribers-dataviews {
                             margin-left: auto;
                             border-radius: 4px;
                         }
+
+                        @media ( max-width: $break-large ) {
+                            .highlight-cards-list {
+                                flex-flow: column;
+                            }
+                        }
                     }
                 }
             }
@@ -143,8 +162,8 @@ body.is-section-subscribers.is-subscribers-dataviews {
             }
         
             .subscriber-profile.subscriber-profile--compact {
-                @media ( max-width: $break-xlarge ) {
-                    max-width: 225px;
+                @media ( max-width: $break-wide ) {
+                    max-width: 195px;
                 }
         
                 .subscriber-profile__user-details {

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -162,7 +162,7 @@ body.is-section-subscribers.is-subscribers-dataviews {
             }
         
             .subscriber-profile.subscriber-profile--compact {
-                @media ( max-width: $break-small ) {
+                @media ( max-width: $break-wide ) {
                     max-width: 195px;
                 }
         

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -47,7 +47,7 @@ const SubscriberDataViews = ( {
 	isStagingSite = false,
 }: SubscriberDataViewsProps ) => {
 	const translate = useTranslate();
-	const isMobile = useBreakpoint( '<1040px' );
+	const isMobile = useBreakpoint( '<660px' );
 	const [ selectedSubscriber, setSelectedSubscriber ] = useState< Subscriber | null >( null );
 	const {
 		grandTotal,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/292

## Proposed Changes

* Style the mobile view.

<img width="282" alt="Screen Shot 2025-01-20 at 4 48 52 PM" src="https://github.com/user-attachments/assets/82ecd142-9ae7-48d8-bf71-01977f552538" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pe7F0s-2of-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/subscribers/{site url}?flags=subscribers-dataviews`
* View the table at different screen sizes and check that nothing's overlapping or cut off.
* Click on a subscriber.
* View the subscriber details at different screen sizes and check that nothing's overlapping or cut off. Check that you can scroll vertically.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?