### PR TITLE
Domains Management Revamp: Fix the last domain item in the left pane partially hidden

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain-dashboard-layout.tsx
+++ b/client/my-sites/domains/domain-management/components/domain-dashboard-layout.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from 'i18n-calypso';
 import Layout from 'calypso/layout/hosting-dashboard';
 import LayoutColumn from 'calypso/layout/hosting-dashboard/column';
 import DomainManagement from 'calypso/my-sites/domains/domain-management';
@@ -13,9 +14,11 @@ type DomainDashboardLayoutProps = {
 };
 
 function DomainDashboardLayout( props: DomainDashboardLayoutProps ) {
+	const translate = useTranslate();
+
 	return (
 		<Layout
-			title="Domain Management"
+			title={ translate( 'Domain Management' ) }
 			wide
 			className={ `domains-overview${ props.selectedDomainName ? ' is-domain-selected' : '' }` }
 		>

--- a/client/my-sites/domains/domain-management/components/domain-dashboard-layout.tsx
+++ b/client/my-sites/domains/domain-management/components/domain-dashboard-layout.tsx
@@ -14,7 +14,11 @@ type DomainDashboardLayoutProps = {
 
 function DomainDashboardLayout( props: DomainDashboardLayoutProps ) {
 	return (
-		<Layout title="Domain Management" wide className="domains-overview">
+		<Layout
+			title="Domain Management"
+			wide
+			className={ `domains-overview${ props.selectedDomainName ? ' is-domain-selected' : '' }` }
+		>
 			<LayoutColumn className="domains-overview__list">
 				<DomainManagement.BulkAllDomains
 					analyticsPath={ domainManagementRoot() }

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -335,6 +335,10 @@
 	}
 }
 
+.domains-overview.is-domain-selected .main.domains-overview__list {
+	height: calc(100vh - 32px - var(--masterbar-height));
+}
+
 main.domains-overview main.domains-overview__list .hosting-dashboard-layout-column__container {
 	// Header navigation styles
 	.navigation-header {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/98610

## Proposed Changes

* Fix the last domain item in the left pane that was partially hidden.

<img width="439" alt="Screenshot 2025-01-20 at 19 06 43" src="https://github.com/user-attachments/assets/8d71a3c4-be79-44ae-a84f-14a7f9abd4e8" />

* Fix missing translation.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of the Domain Management Revamp project: pfuQfP-13x-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR to your local.
* Go to http://calypso.localhost:3000/domains/manage?flags=calypso/all-domain-management.
* Select a domain in the list.
* It should display the domain overview on the right side and the domain list on the left side.
* Scroll down to the bottom of the domain list (left pane).
* It should display the last item without cropping.
* Go back to the full domains list.
* Verify if the design looks consistent. No changes should apply to the full domains list.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?