### PR TITLE
Created a custom style for the new full screen launchpad

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -12,13 +12,11 @@ import './style.scss';
 interface CustomerHomeLaunchpadProps {
 	checklistSlug: string;
 	onSiteLaunched?: () => void;
-	highlightNextAction?: boolean;
 }
 
 const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( {
 	checklistSlug,
 	onSiteLaunched,
-	highlightNextAction,
 }: CustomerHomeLaunchpadProps ) => {
 	const launchpadContext = 'customer-home';
 	const translate = useTranslate();
@@ -90,7 +88,6 @@ const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( {
 				checklistSlug={ checklistSlug }
 				launchpadContext={ launchpadContext }
 				onSiteLaunched={ onSiteLaunched }
-				highlightNextAction={ highlightNextAction }
 			/>
 		</div>
 	);

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -19,11 +19,13 @@ import './style.scss';
 interface CustomerHomeLaunchpadProps {
 	checklistSlug: string;
 	onSiteLaunched?: () => void;
+	highlightNextAction?: boolean;
 }
 
 const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( {
 	checklistSlug,
 	onSiteLaunched,
+	highlightNextAction,
 }: CustomerHomeLaunchpadProps ) => {
 	const launchpadContext = 'customer-home';
 	const siteId = useSelector( getSelectedSiteId );
@@ -104,6 +106,7 @@ const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( {
 				checklistSlug={ checklistSlug }
 				launchpadContext={ launchpadContext }
 				onSiteLaunched={ onSiteLaunched }
+				highlightNextAction={ highlightNextAction }
 			/>
 		</div>
 	);

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -1,21 +1,14 @@
 import { Button, CircularProgressBar, Gridicon } from '@automattic/components';
-import {
-	TemporaryDismiss,
-	useLaunchpadDismisser,
-	useSortedLaunchpadTasks,
-} from '@automattic/data-stores';
-import { Launchpad, type Task } from '@automattic/launchpad';
+import { Launchpad } from '@automattic/launchpad';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { type FC } from 'react';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import { useSelector } from 'calypso/state';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import type { AppState } from 'calypso/types';
+import { useLaunchpad } from './use-launchpad';
 
 import './style.scss';
+
 interface CustomerHomeLaunchpadProps {
 	checklistSlug: string;
 	onSiteLaunched?: () => void;
@@ -28,37 +21,28 @@ const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( {
 	highlightNextAction,
 }: CustomerHomeLaunchpadProps ) => {
 	const launchpadContext = 'customer-home';
-	const siteId = useSelector( getSelectedSiteId );
 	const translate = useTranslate();
-	const siteSlug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) || '' );
-
-	const { mutate: dismiss } = useLaunchpadDismisser( siteSlug, checklistSlug );
 
 	const {
-		data: { checklist, is_dismissed: isDismissed, is_dismissible: isDismissible, title },
-	} = useSortedLaunchpadTasks( siteSlug, checklistSlug, launchpadContext );
-
-	const numberOfSteps = checklist?.length || 0;
-	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
+		siteSlug,
+		isDismissed,
+		isDismissible,
+		numberOfSteps,
+		completedSteps,
+		hasChecklist,
+		launchpadTitle,
+		temporaryDismiss,
+		permanentDismiss,
+	} = useLaunchpad( { checklistSlug, launchpadContext } );
 
 	// return nothing if the launchpad is dismissed
 	if ( isDismissed ) {
 		return null;
 	}
 
-	const hasChecklist = checklist !== undefined && checklist !== null;
-	const launchpadTitle = hasChecklist ? title ?? translate( 'Next steps for your site' ) : ' ';
 	const headerClasses = clsx( 'customer-home-launchpad__header', {
 		'is-placeholder': ! hasChecklist,
 	} );
-
-	const temporaryDismiss = ( { dismissBy }: Pick< TemporaryDismiss, 'dismissBy' > ) => {
-		dismiss( {
-			dismissBy,
-		} );
-	};
-
-	const permanentDismiss = () => dismiss( { isDismissed: true } );
 
 	return (
 		<div className="customer-home-launchpad customer-home__card is-small-hero">
@@ -94,7 +78,7 @@ const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( {
 								borderless
 								onClick={ permanentDismiss }
 							>
-								<div> { translate( 'Dismiss guide' ) } </div>
+								<div>{ translate( 'Dismiss guide' ) }</div>
 								<Gridicon icon="cross" size={ 12 } />
 							</Button>
 						</div>

--- a/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
@@ -1,12 +1,10 @@
-import { updateLaunchpadSettings } from '@automattic/data-stores';
-import { useState } from 'react';
 import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
-import { useSelector, useDispatch } from 'calypso/state';
-import { requestSite } from 'calypso/state/sites/actions';
+import { useSelector } from 'calypso/state';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CelebrateLaunchModal from '../../components/celebrate-launch-modal';
+import { useCelebrateLaunchModal } from './use-celebrate-launch-modal';
 import CustomerHomeLaunchpad from '.';
 import type { AppState } from 'calypso/types';
 
@@ -16,51 +14,26 @@ type LaunchpadPreLaunchProps = {
 };
 
 const LaunchpadPreLaunch = ( props: LaunchpadPreLaunchProps ): JSX.Element => {
-	const siteId = useSelector( getSelectedSiteId ) || '';
+	const siteId = useSelector( getSelectedSiteId ) || 0;
 	const site = useSelector( ( state: AppState ) => getSite( state, siteId ) );
 	const checklistSlug = site?.options?.site_intent ?? '';
-	const [ celebrateLaunchModalIsOpen, setCelebrateLaunchModalIsOpen ] = useState( false );
 	const { data: allDomains = [] } = useGetDomainsQuery( site?.ID ?? null, {
 		retry: false,
 	} );
 
-	const dispatch = useDispatch();
 	const layout = useHomeLayoutQuery( siteId || null );
-
-	const setCelebrateLaunchModalIsOpenWrapper = ( isOpen: boolean ) => {
-		// Triggered when the site is launched (true) and when the modal is closed (false)
-		setCelebrateLaunchModalIsOpen( isOpen );
-
-		if ( isOpen ) {
-			// Site launched, update site data
-			dispatch( requestSite( siteId ) );
-		} else {
-			// Modal closed, update the launchpad data/checklist
-			layout?.refetch();
-		}
-	};
-
-	const onSiteLaunched = () => {
-		setCelebrateLaunchModalIsOpenWrapper( true );
-		// currently the action to update site_launch status on atomic doesn't fire
-		// this is a workaround until that is fixed
-		if ( site?.is_wpcom_atomic ) {
-			updateLaunchpadSettings( siteId, {
-				checklist_statuses: { site_launched: true },
-			} );
-		}
-	};
+	const { isOpen, setModalIsOpen, handleSiteLaunched } = useCelebrateLaunchModal( siteId, layout );
 
 	return (
 		<>
 			<CustomerHomeLaunchpad
 				checklistSlug={ props.checklistSlug ?? checklistSlug }
-				onSiteLaunched={ onSiteLaunched }
+				onSiteLaunched={ () => handleSiteLaunched( !! site?.is_wpcom_atomic ) }
 				highlightNextAction={ props.highlightNextAction }
 			/>
-			{ celebrateLaunchModalIsOpen && (
+			{ isOpen && (
 				<CelebrateLaunchModal
-					setModalIsOpen={ setCelebrateLaunchModalIsOpenWrapper }
+					setModalIsOpen={ setModalIsOpen }
 					site={ site }
 					allDomains={ allDomains }
 				/>

--- a/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
@@ -12,6 +12,7 @@ import type { AppState } from 'calypso/types';
 
 type LaunchpadPreLaunchProps = {
 	checklistSlug?: string;
+	highlightNextAction?: boolean;
 };
 
 const LaunchpadPreLaunch = ( props: LaunchpadPreLaunchProps ): JSX.Element => {
@@ -55,6 +56,7 @@ const LaunchpadPreLaunch = ( props: LaunchpadPreLaunchProps ): JSX.Element => {
 			<CustomerHomeLaunchpad
 				checklistSlug={ props.checklistSlug ?? checklistSlug }
 				onSiteLaunched={ onSiteLaunched }
+				highlightNextAction={ props.highlightNextAction }
 			/>
 			{ celebrateLaunchModalIsOpen && (
 				<CelebrateLaunchModal

--- a/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
@@ -10,7 +10,6 @@ import type { AppState } from 'calypso/types';
 
 type LaunchpadPreLaunchProps = {
 	checklistSlug?: string;
-	highlightNextAction?: boolean;
 };
 
 const LaunchpadPreLaunch = ( props: LaunchpadPreLaunchProps ): JSX.Element => {
@@ -29,7 +28,6 @@ const LaunchpadPreLaunch = ( props: LaunchpadPreLaunchProps ): JSX.Element => {
 			<CustomerHomeLaunchpad
 				checklistSlug={ props.checklistSlug ?? checklistSlug }
 				onSiteLaunched={ () => handleSiteLaunched( !! site?.is_wpcom_atomic ) }
-				highlightNextAction={ props.highlightNextAction }
 			/>
 			{ isOpen && (
 				<CelebrateLaunchModal

--- a/client/my-sites/customer-home/cards/launchpad/use-celebrate-launch-modal.ts
+++ b/client/my-sites/customer-home/cards/launchpad/use-celebrate-launch-modal.ts
@@ -1,0 +1,38 @@
+import { updateLaunchpadSettings } from '@automattic/data-stores';
+import { useState } from 'react';
+import { useDispatch } from 'calypso/state';
+import { requestSite } from 'calypso/state/sites/actions';
+
+export function useCelebrateLaunchModal( siteId: number, layout: { refetch: () => void } | null ) {
+	const [ isOpen, setIsOpen ] = useState( false );
+	const dispatch = useDispatch();
+
+	const setModalIsOpen = ( isOpen: boolean ) => {
+		setIsOpen( isOpen );
+
+		if ( isOpen ) {
+			// Site launched, update site data
+			dispatch( requestSite( siteId ) );
+		} else {
+			// Modal closed, update the launchpad data/checklist
+			layout?.refetch();
+		}
+	};
+
+	const handleSiteLaunched = ( isWpcomAtomic: boolean ) => {
+		setModalIsOpen( true );
+		// currently the action to update site_launch status on atomic doesn't fire
+		// this is a workaround until that is fixed
+		if ( isWpcomAtomic ) {
+			updateLaunchpadSettings( siteId, {
+				checklist_statuses: { site_launched: true },
+			} );
+		}
+	};
+
+	return {
+		isOpen,
+		setModalIsOpen,
+		handleSiteLaunched,
+	};
+}

--- a/client/my-sites/customer-home/cards/launchpad/use-launchpad.ts
+++ b/client/my-sites/customer-home/cards/launchpad/use-launchpad.ts
@@ -1,0 +1,53 @@
+import {
+	TemporaryDismiss,
+	useLaunchpadDismisser,
+	useSortedLaunchpadTasks,
+} from '@automattic/data-stores';
+import { type Task } from '@automattic/launchpad';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import type { AppState } from 'calypso/types';
+
+interface UseLaunchpadProps {
+	checklistSlug: string;
+	launchpadContext: string;
+}
+
+export function useLaunchpad( { checklistSlug, launchpadContext }: UseLaunchpadProps ) {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) || '' );
+
+	const { mutate: dismiss } = useLaunchpadDismisser( siteSlug, checklistSlug );
+
+	const {
+		data: { checklist, is_dismissed: isDismissed, is_dismissible: isDismissible, title },
+	} = useSortedLaunchpadTasks( siteSlug, checklistSlug, launchpadContext );
+
+	const numberOfSteps = checklist?.length || 0;
+	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
+	const hasChecklist = checklist !== undefined && checklist !== null;
+	const launchpadTitle = hasChecklist ? title ?? translate( 'Next steps for your site' ) : ' ';
+
+	const temporaryDismiss = ( { dismissBy }: Pick< TemporaryDismiss, 'dismissBy' > ) => {
+		dismiss( {
+			dismissBy,
+		} );
+	};
+
+	const permanentDismiss = () => dismiss( { isDismissed: true } );
+
+	return {
+		siteSlug,
+		isDismissed,
+		isDismissible,
+		numberOfSteps,
+		completedSteps,
+		hasChecklist,
+		launchpadTitle,
+		temporaryDismiss,
+		permanentDismiss,
+	};
+}

--- a/client/my-sites/customer-home/components/full-screen-launchpad.scss
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.scss
@@ -1,0 +1,49 @@
+
+.is-launchpad-first .customer-home-launchpad {
+	max-width: 536px;
+	margin: auto;
+	box-shadow: none;
+
+	.checklist-item__task {
+		a, button {
+			padding: 20px 24px;
+			margin: 0;
+			border: 1px solid var(--studio-gray-5);
+			border-bottom: none;
+
+			&:hover {
+				border-bottom: none;
+			}
+		}
+
+		&:first-child a,
+		&:first-child button {
+			border-radius: 4px 4px 0 0;
+		}
+
+		&:last-child a, &:last-child button {
+			border-radius: 0 0 4px 4px;
+			border-bottom: 1px solid var(--studio-gray-5);
+		}
+
+		&.completed .gridicons-checkmark {
+			fill: var(--studio-green-50);
+		}
+
+		&.highlighted {
+			margin: 0 -12px;
+
+			a,
+			button {
+				border-bottom: 1px solid var(--studio-gray-5);
+				margin: 0 0 -1px 0;
+				padding: 28px 24px;
+			}
+		}
+
+		.checklist-item__text {
+			font-weight: 400;
+			font-size: 1rem;
+		}
+	}
+}

--- a/client/my-sites/customer-home/components/full-screen-launchpad.scss
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.scss
@@ -4,6 +4,21 @@
 	margin: auto;
 	box-shadow: none;
 
+	.customer-home__launchpad-header{
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+
+		h2 {
+			margin-top: 24px;
+			font-size: 2rem;
+		}
+
+		span {
+			margin: 4px 0 24px 0;
+		}
+	}
+
 	.checklist-item__task {
 		a, button {
 			padding: 20px 24px;

--- a/client/my-sites/customer-home/components/full-screen-launchpad.scss
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.scss
@@ -72,11 +72,21 @@
 
 		&:first-child {
             border-radius: 4px 4px 0 0;
+
+            a,
+            button {
+                border-radius: 2px 2px 0 0;
+            }
         }
 
 		&:last-child {
 			border-radius: 0 0 4px 4px;
-			border-bottom: 1px solid var(--studio-gray-5);
+            border-bottom: 1px solid var(--studio-gray-5);
+            
+            a,
+            button {
+                border-radius: 0 0 2px 2px;
+            }
 		}
 	}
 }

--- a/client/my-sites/customer-home/components/full-screen-launchpad.scss
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.scss
@@ -20,25 +20,28 @@
 	}
 
 	.checklist-item__task {
+        padding: 2px;
+        border: 1px solid var(--studio-gray-5);
+        border-bottom: none;
+
+        &:hover,
+        &:focus {
+            border-bottom: none;
+        }
+
 		a, button {
 			padding: 20px 24px;
 			margin: 0;
-			border: 1px solid var(--studio-gray-5);
 			border-bottom: none;
+			border-radius: 0;
 
-			&:hover {
-				border-bottom: none;
-			}
-		}
-
-		&:first-child a,
-		&:first-child button {
-			border-radius: 4px 4px 0 0;
-		}
-
-		&:last-child a, &:last-child button {
-			border-radius: 0 0 4px 4px;
-			border-bottom: 1px solid var(--studio-gray-5);
+            &:hover,
+            &:focus {
+                border-bottom: none;
+				span {
+					color: var(--color-accent);
+				}
+            }
 		}
 
 		&.completed .gridicons-checkmark {
@@ -47,18 +50,33 @@
 
 		&.highlighted {
 			margin: 0 -12px;
+            border-bottom: 1px solid var(--studio-gray-5);
+			border-radius: 4px;
 
 			a,
 			button {
-				border-bottom: 1px solid var(--studio-gray-5);
 				margin: 0 0 -1px 0;
 				padding: 28px 24px;
+				border-radius: 2px;
 			}
+		}
+
+		&.highlighted + .checklist-item__task {
+			border-top: none;
 		}
 
 		.checklist-item__text {
 			font-weight: 400;
 			font-size: 1rem;
+		}
+
+		&:first-child {
+            border-radius: 4px 4px 0 0;
+        }
+
+		&:last-child {
+			border-radius: 0 0 4px 4px;
+			border-bottom: 1px solid var(--studio-gray-5);
 		}
 	}
 }

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -1,16 +1,71 @@
+import { CircularProgressBar } from '@automattic/components';
+import { Launchpad } from '@automattic/launchpad';
 import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import LaunchpadPreLaunch from '../cards/launchpad/pre-launch';
+import { useSelector } from 'react-redux';
+import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
+import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
+import { getSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { AppState } from 'calypso/types';
+import { useCelebrateLaunchModal } from '../cards/launchpad/use-celebrate-launch-modal';
+import { useLaunchpad } from '../cards/launchpad/use-launchpad';
+import CelebrateLaunchModal from './celebrate-launch-modal';
 
 import './full-screen-launchpad.scss';
 
 export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ) => {
 	const { __ } = useI18n();
+	const siteId = useSelector( getSelectedSiteId ) || 0;
+	const site = useSelector( ( state: AppState ) => getSite( state, siteId ) );
+	const checklistSlug = site?.options?.site_intent ?? '';
+
+	const launchpadContext = 'customer-home';
+
+	const { siteSlug, isDismissed, numberOfSteps, completedSteps } = useLaunchpad( {
+		checklistSlug,
+		launchpadContext,
+	} );
+
+	const layout = useHomeLayoutQuery( siteId || null );
+	const { isOpen, setModalIsOpen, handleSiteLaunched } = useCelebrateLaunchModal( siteId, layout );
+	const { data: allDomains = [] } = useGetDomainsQuery( site?.ID ?? null, {
+		retry: false,
+	} );
+
+	const onSiteLaunched = () => {
+		handleSiteLaunched( !! site?.is_wpcom_atomic );
+	};
+
+	if ( isDismissed ) {
+		return null;
+	}
 
 	return (
 		<div css={ { display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '24px' } }>
 			<div className="is-launchpad-first" css={ { width: '100%' } }>
-				<LaunchpadPreLaunch highlightNextAction />
+				<div className="customer-home-launchpad customer-home__card is-small-hero">
+					<CircularProgressBar
+						size={ 40 }
+						enableDesktopScaling
+						numberOfSteps={ numberOfSteps }
+						currentStep={ completedSteps }
+					/>
+					<Launchpad
+						siteSlug={ siteSlug }
+						checklistSlug={ checklistSlug }
+						launchpadContext={ launchpadContext }
+						onSiteLaunched={ onSiteLaunched }
+						highlightNextAction
+					/>
+					{ isOpen && (
+						<CelebrateLaunchModal
+							setModalIsOpen={ setModalIsOpen }
+							site={ site }
+							allDomains={ allDomains }
+						/>
+					) }
+				</div>
 			</div>
 			<Button onClick={ onClose }>{ __( 'Hide onboarding setup' ) }</Button>
 		</div>

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -22,7 +22,7 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ) => {
 
 	const launchpadContext = 'customer-home';
 
-	const { siteSlug, isDismissed, numberOfSteps, completedSteps } = useLaunchpad( {
+	const { siteSlug, isDismissed, numberOfSteps, completedSteps, launchpadTitle } = useLaunchpad( {
 		checklistSlug,
 		launchpadContext,
 	} );
@@ -53,7 +53,7 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ) => {
 							currentStep={ completedSteps }
 						/>
 						<h2>{ __( 'Let’s get started!' ) }</h2>
-						<span>{ __( 'Welcome! It’s time to set up your Newsletter.' ) }</span>
+						<span>{ launchpadTitle }</span>
 					</div>
 					<Launchpad
 						siteSlug={ siteSlug }

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -2,13 +2,15 @@ import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import LaunchpadPreLaunch from '../cards/launchpad/pre-launch';
 
+import './full-screen-launchpad.scss';
+
 export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ) => {
 	const { __ } = useI18n();
 
 	return (
 		<div css={ { display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '24px' } }>
-			<div css={ { width: '100%' } }>
-				<LaunchpadPreLaunch />
+			<div className="is-launchpad-first" css={ { width: '100%' } }>
+				<LaunchpadPreLaunch highlightNextAction />
 			</div>
 			<Button onClick={ onClose }>{ __( 'Hide onboarding setup' ) }</Button>
 		</div>

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -42,15 +42,19 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ) => {
 	}
 
 	return (
-		<div css={ { display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '24px' } }>
+		<div css={ { display: 'flex', flexDirection: 'column', alignItems: 'center' } }>
 			<div className="is-launchpad-first" css={ { width: '100%' } }>
 				<div className="customer-home-launchpad customer-home__card is-small-hero">
-					<CircularProgressBar
-						size={ 40 }
-						enableDesktopScaling
-						numberOfSteps={ numberOfSteps }
-						currentStep={ completedSteps }
-					/>
+					<div className="customer-home__launchpad-header">
+						<CircularProgressBar
+							size={ 40 }
+							enableDesktopScaling
+							numberOfSteps={ numberOfSteps }
+							currentStep={ completedSteps }
+						/>
+						<h2>{ __( 'Let’s get started!' ) }</h2>
+						<span>{ __( 'Welcome! It’s time to set up your Newsletter.' ) }</span>
+					</div>
 					<Launchpad
 						siteSlug={ siteSlug }
 						checklistSlug={ checklistSlug }
@@ -67,7 +71,7 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ) => {
 					) }
 				</div>
 			</div>
-			<Button onClick={ onClose }>{ __( 'Hide onboarding setup' ) }</Button>
+			<Button onClick={ onClose }>{ __( 'Skip onboarding setup' ) }</Button>
 		</div>
 	);
 };

--- a/packages/launchpad/src/checklist-item/index.tsx
+++ b/packages/launchpad/src/checklist-item/index.tsx
@@ -11,11 +11,18 @@ interface Props {
 	key?: Key;
 	task: Task;
 	isPrimaryAction?: boolean;
+	isHighlighted?: boolean;
 	expandable?: Expandable;
 	onClick?: () => void;
 }
 
-const ChecklistItem: FC< Props > = ( { task, isPrimaryAction, expandable, onClick } ) => {
+const ChecklistItem: FC< Props > = ( {
+	task,
+	isPrimaryAction,
+	isHighlighted,
+	expandable,
+	onClick,
+} ) => {
 	const { id, completed, disabled = false, title, subtitle, actionDispatch } = task;
 
 	// If the task says we should use the Calypso path, ensure we use that link for the button's href.
@@ -56,6 +63,7 @@ const ChecklistItem: FC< Props > = ( { task, isPrimaryAction, expandable, onClic
 				enabled: ! disabled,
 				disabled: disabled,
 				expanded: expandable && expandable.isOpen,
+				highlighted: isHighlighted,
 			} ) }
 		>
 			{ isPrimaryAction ? (

--- a/packages/launchpad/src/checklist/index.tsx
+++ b/packages/launchpad/src/checklist/index.tsx
@@ -5,13 +5,15 @@ import './style.scss';
 
 interface Props {
 	makeLastTaskPrimaryAction?: boolean;
+	highlightNextAction?: boolean;
 	children?:
 		| ReactElement< ComponentProps< typeof ChecklistItem > >
 		| ReactElement< ComponentProps< typeof ChecklistItem > >[];
 }
 
-const Checklist: FC< Props > = ( { children, makeLastTaskPrimaryAction } ) => {
+const Checklist: FC< Props > = ( { children, makeLastTaskPrimaryAction, highlightNextAction } ) => {
 	const lastChildIndex = Children.count( children ) - 1;
+	let hasHighlightedItem = false;
 
 	return (
 		<ul
@@ -21,8 +23,18 @@ const Checklist: FC< Props > = ( { children, makeLastTaskPrimaryAction } ) => {
 			aria-label="Launchpad Checklist"
 		>
 			{ Children.map( children || [], ( child, index ) => {
-				if ( index === lastChildIndex ) {
-					return cloneElement( child, { isPrimaryAction: makeLastTaskPrimaryAction } );
+				const shouldHighlightItem =
+					highlightNextAction && ! hasHighlightedItem && child.props.task.completed === false;
+
+				if ( shouldHighlightItem ) {
+					hasHighlightedItem = true;
+				}
+
+				if ( index === lastChildIndex || shouldHighlightItem ) {
+					return cloneElement( child, {
+						isPrimaryAction: makeLastTaskPrimaryAction,
+						isHighlighted: shouldHighlightItem,
+					} );
 				}
 				return child;
 			} ) }

--- a/packages/launchpad/src/checklist/test/test-checklist.tsx
+++ b/packages/launchpad/src/checklist/test/test-checklist.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import Checklist from '..';
+import ChecklistItem from '../../checklist-item';
+
+describe( 'Checklist', () => {
+	const createTask = ( id: string, completed = false ) => ( {
+		id,
+		title: `Task ${ id }`,
+		completed,
+		onClick: jest.fn(),
+		disabled: false,
+	} );
+
+	it( 'highlights the first incomplete task when highlightNextAction is true', () => {
+		const tasks = [
+			createTask( '1', true ), // completed
+			createTask( '2', false ), // should be highlighted
+			createTask( '3', false ), // should not be highlighted
+		];
+
+		render(
+			<Checklist highlightNextAction>
+				{ tasks.map( ( task ) => (
+					<ChecklistItem key={ task.id } task={ task } />
+				) ) }
+			</Checklist>
+		);
+
+		// Get all checklist items
+		const items = screen.getAllByRole( 'listitem' );
+
+		// Second task should have the highlighted class
+		expect( items[ 1 ] ).toHaveClass( 'highlighted' );
+		// Third task should not be highlighted
+		expect( items[ 2 ] ).not.toHaveClass( 'highlighted' );
+	} );
+} );

--- a/packages/launchpad/src/launchpad-internal.tsx
+++ b/packages/launchpad/src/launchpad-internal.tsx
@@ -11,6 +11,7 @@ interface Props {
 	siteSlug: string | null;
 	checklistSlug: string | null;
 	makeLastTaskPrimaryAction?: boolean;
+	highlightNextAction?: boolean;
 	taskFilter?: ( tasks: Task[] ) => Task[];
 	useLaunchpadOptions?: UseLaunchpadOptions;
 	launchpadContext: string;
@@ -28,6 +29,7 @@ const LaunchpadInternal: FC< Props > = ( {
 	checklistSlug,
 	taskFilter,
 	makeLastTaskPrimaryAction,
+	highlightNextAction,
 	useLaunchpadOptions = {},
 	launchpadContext,
 } ) => {
@@ -66,7 +68,10 @@ const LaunchpadInternal: FC< Props > = ( {
 	return (
 		<div className="launchpad__checklist-wrapper">
 			{ isFetchedAfterMount ? (
-				<Checklist makeLastTaskPrimaryAction={ makeLastTaskPrimaryAction }>
+				<Checklist
+					makeLastTaskPrimaryAction={ makeLastTaskPrimaryAction }
+					highlightNextAction={ highlightNextAction }
+				>
 					{ tasks.map( ( task ) => (
 						<ChecklistItem
 							task={ task }

--- a/packages/launchpad/src/launchpad.tsx
+++ b/packages/launchpad/src/launchpad.tsx
@@ -21,6 +21,7 @@ type LaunchpadProps = {
 	onSiteLaunched?: () => void;
 	onTaskClick?: EventHandlers[ 'onTaskClick' ];
 	onPostFilterTasks?: ( tasks: Task[] ) => Task[];
+	highlightNextAction?: boolean;
 };
 
 const Launchpad = ( {
@@ -30,6 +31,7 @@ const Launchpad = ( {
 	onSiteLaunched,
 	onTaskClick,
 	onPostFilterTasks,
+	highlightNextAction,
 }: LaunchpadProps ) => {
 	const {
 		data: { checklist },
@@ -84,6 +86,7 @@ const Launchpad = ( {
 				taskFilter={ taskFilter }
 				useLaunchpadOptions={ launchpadOptions }
 				launchpadContext={ launchpadContext }
+				highlightNextAction={ highlightNextAction }
 			/>
 		</>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98358

## Proposed Changes

* We're improving the style for the new full-screen launchpad
* Adding a new highlight feature to it
* Creating a custom header and footer


![image](https://github.com/user-attachments/assets/7d979cc3-ad9f-42a7-813f-b8ebf804f77b)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is part of Launchpad In My Home project: pet6gk-1T7-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open your site home with the feature flag: http://calypso.localhost:3000/home/{siteSlug}?flags=home/launchpad-first
2. Make sure it's working as expected, and its styles follows Figma (see [gxnoWeSoVeLpFOtk3XODsU-fi-6202_11633](https://href.li/?https://www.figma.com/file/gxnoWeSoVeLpFOtk3XODsU/?node-id=6202-11633) )
3. Open the home page without the feature flag and make sure the old launchpad still works as expected:

	![image](https://github.com/user-attachments/assets/3cf181e1-0f08-4443-ad52-c3a7bf12ad69)

4. Review launchpad launch actions to ensure the refactor on `useLaunchpad` and `useCelebrateLaunchModal` works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?