### PR TITLE
Domains Management: Fix popover overflow for longer domains

### DIFF
--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -390,7 +390,7 @@ main.domains-overview main.domains-overview__list .hosting-dashboard-layout-colu
 	}
 }
 
-.is-bulk-all-domains-page .popover .popover__inner {
+.is-bulk-all-domains-page .popover.status-popover__tooltip .popover__inner {
 	word-break: break-word;
 	overflow-wrap: break-word;
 	white-space: normal;

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -389,3 +389,9 @@ main.domains-overview main.domains-overview__list .hosting-dashboard-layout-colu
 		}
 	}
 }
+
+.is-bulk-all-domains-page .popover .popover__inner {
+	word-break: break-word;
+	overflow-wrap: break-word;
+	white-space: normal;
+}


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/98617

## Proposed Changes

* Fix popover overflow for longer domains.

<img width="300" src="https://github.com/user-attachments/assets/f53a6a71-61b6-4aa2-ba6c-6bd07c83a55b" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of the Domain Management Revamp project: pfuQfP-13x-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR to your local.
* Buy a new domain with a longer name.
* Go to http://calypso.localhost:3000/domains/manage?flags=calypso/all-domain-management.
* Check the tooltip under the Status column.
* Check if it breaks only the domain, but not the other words.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?