### PR TITLE
Stats: add filter by country on regions and cities views

### DIFF
--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -62,6 +62,10 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 	const supportUrl = isOdysseyStats ? JETPACK_SUPPORT_URL_TRAFFIC : SUPPORT_URL;
 
 	const [ selectedOption, setSelectedOption ] = useState( OPTION_KEYS.COUNTRIES );
+
+	// TODO: we should get it from a dropdown in the UI and manage it as a state.
+	const countryFilter = new URLSearchParams( window.location.search ).get( 'country' ) ?? null;
+
 	const optionLabels = {
 		[ OPTION_KEYS.COUNTRIES ]: {
 			selectLabel: translate( 'Countries' ),
@@ -94,7 +98,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 		data = [],
 		isLoading: isRequestingData,
 		isError,
-	} = useLocationViewsQuery< StatsLocationViewsData >( siteId, geoMode, query, {
+	} = useLocationViewsQuery< StatsLocationViewsData >( siteId, geoMode, query, countryFilter, {
 		enabled: ! shouldGate,
 	} );
 

--- a/client/my-sites/stats/hooks/use-location-views-query.ts
+++ b/client/my-sites/stats/hooks/use-location-views-query.ts
@@ -30,8 +30,13 @@ const useLocationViewsQuery = < T = StatsLocationViewsData >(
 	siteId: number,
 	geoMode: 'country' | 'region' | 'city',
 	query: QueryStatsParams,
+	countryFilter: string | null,
 	options?: CustomQueryOptions< T, Error >
 ) => {
+	if ( ( geoMode === 'region' || geoMode === 'city' ) && countryFilter ) {
+		query.filter_by_country = countryFilter;
+	}
+
 	return useQuery( {
 		...getDefaultQueryParams(),
 		...options,

--- a/client/my-sites/stats/hooks/utils.ts
+++ b/client/my-sites/stats/hooks/utils.ts
@@ -6,6 +6,7 @@ export interface QueryStatsParams {
 	num?: number;
 	period?: string;
 	summarize?: number;
+	filter_by_country?: string;
 }
 
 const getDaysOfMonthFromDate = ( date: string ): number => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-roadmap/issues/2096

## Proposed Changes

* Add option to filter regions and cities by country in the summary page

This PR is just about to make it work using a URL param, but we will iterate to use a dropdown in another PR.

![CleanShot 2025-01-21 at 10 09 12@2x](https://github.com/user-attachments/assets/7aa57c41-0154-4aa1-b924-1cc0a5f82350)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://github.com/Automattic/jetpack-roadmap/issues/2096

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Calypso Live Branch
* And pick a site with WordPress.com Premium or higher plan
* Navigate to `/stats/day/locations/site_slug?flags=stats/locations&country=US`
* Click on `Regions` or `Cities` tabs, and it should show you only the locations related to US country.
* You can pass other countries, like IN, PA, etc.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
