### PR TITLE
Purchases: Add margin back to purchases mobile navigation

### DIFF
--- a/client/me/purchases/style.scss
+++ b/client/me/purchases/style.scss
@@ -1,5 +1,21 @@
 /* Layout
 ================================================== */
+.layout__primary .main {
+	& div.section-nav {
+		@media ( max-width: 480px ) {
+			&.is-open {
+				& > .section-nav__panel {
+					padding: 0;
+
+					& > .section-nav-group {
+						margin-top: 0;
+					}
+				}
+			}
+		}
+	}
+}
+
 .purchases-layout__wrapper {
 	display: flex;
 	align-items: center;

--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -58,6 +58,9 @@ body.is-section-me {
 					max-width: 1040px;
 					margin: 0 auto;
 				}
+				& > div.section-nav {
+                    margin-bottom: 24px; /* Preserve margin for Purchases mobile nav */
+	            }
 			}
 		}
 	}

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -32,6 +32,8 @@ import {
 import Subscriptions from './subscriptions';
 import { getChangeOrAddPaymentMethodUrlFor } from './utils';
 
+import './styles.scss';
+
 function useLogPurchasesError( message: string ) {
 	return useCallback(
 		( error: Error ) => {

--- a/client/my-sites/purchases/styles.scss
+++ b/client/my-sites/purchases/styles.scss
@@ -1,0 +1,15 @@
+.layout__primary .main {
+	& div.section-nav {
+		@media ( max-width: 480px ) {
+			&.is-open {
+				& > .section-nav__panel {
+					padding: 0;
+
+					& > .section-nav-group {
+						margin-top: 0;
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
While troubleshooting https://github.com/Automattic/wp-calypso/pull/98606, I came across some styling errors in the mobile navigation section for both "my-sites" and "me" version of the Purchases section.

#### The `/me` Purchases section - note the overlap with the next section

| Closed | Open |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/40f2266d-eaeb-4ad4-960e-1aecc4cac44c) | ![image](https://github.com/user-attachments/assets/f8503227-eb71-49fa-a7ef-ca6fb618cd2f) |

Extra padding at the bottom of the navigation section - made more apparent by the unexplained bottom border of the Billing History section (possibly related to https://github.com/Automattic/wp-calypso/pull/98606)

| Active Upgrades | Billing History |
| ![image](https://github.com/user-attachments/assets/cf2d1eba-2389-4088-b212-bc28622fd08d) | ![image](https://github.com/user-attachments/assets/3f369992-e313-4866-99eb-752329454d7a) |

#### The "my-sites" Purchases section
Before, the Billing History section had the same issue where extra padding was added to the bottom of the nav list, After the padding is removed and the box shadow is applied correctly.

| Before | After |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/fdf622b0-b745-49cc-98ba-b7cb7776fa7e) | ![image](https://github.com/user-attachments/assets/cbfeb68c-5618-458c-a41f-5416a3faa29f) |


## Proposed Changes

The CSS changes are essentially the same, but the implementation varies since we handle styling a bit differently depending on whether we are in "my-sites" or "me". 

#### For "my-sites" 
I have added a separately style.scss file to `my-sites > purchases`. This was done because it appears we largely followed a component based system when constructing these sections originally, so all of the styling logic is tucked away within `client > components > ...`

If there is a better way to override these styles, then let me know! Otherwise, importing a stylesheet here does the trick but runs the risk of more custom styling being added in the future (which may or may not benefit whatever design system is running that section then).

#### For "me"
At some point the top and bottom margins for all components within the `.main` section were set to `0`, I suspect this was to create a more 'compact' view. Unfortunately, its a bit too compact when it comes to the Purchases section, so this PR add bottom margin specifically for `div.section-nav`. Then further styling changes are added to the existing stylesheet under `me > purchases`, similar to `my-sites > purchases`.

## Testing Instructions
- Observe the issue in production at both the site level Purchases screen and the /me/ account level
- Load this PR and check that the mobile navigation does not obstruct any components 'below' it, nor does it have any unintended side-effects
