### PR TITLE
A4A > Referrals: Fix the referral estimated commission

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
@@ -48,8 +48,12 @@ export const getEstimatedCommission = (
 			if ( ! product ) {
 				continue;
 			}
+
 			// Day the license was issued
 			const issuedDate = new Date( purchase.license.issued_at );
+			// Set hours to 0 to compare from start of the day
+			issuedDate.setHours( 0, 0, 0, 0 );
+
 			// Day the license was revoked if present
 			const revokedAt = purchase.license.revoked_at
 				? new Date( purchase.license.revoked_at )
@@ -62,8 +66,11 @@ export const getEstimatedCommission = (
 				revokedAt ? revokedAt.getTime() : Infinity,
 				activityWindow.finish.getTime()
 			);
+
 			// Total days is the difference between finish and start dates in days
-			const totalDays = Math.floor( ( finish - start ) / ( 1000 * 60 * 60 * 24 ) );
+			// We add 1 to include end-to-end days
+			const totalDays = Math.floor( ( finish - start ) / ( 1000 * 60 * 60 * 24 ) ) + 1;
+
 			if ( totalDays < 1 ) {
 				continue;
 			}

--- a/client/a8c-for-agencies/sections/referrals/lib/test/get-estimated-commission.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/test/get-estimated-commission.ts
@@ -104,9 +104,9 @@ describe( 'get-estimated-commission', () => {
 			];
 
 			// Payout window is Jan 1 - Mar 31 for the mock date
-			// License issued on Mar 1, so 30 days * $100 daily price * 50% commission = 1500 cents
+			// License issued on Mar 1, so 31 days (including Mar 1) * $100 daily price * 50% commission = 1550 cents
 			// Convert to dollars by dividing by 100
-			expect( getEstimatedCommission( referrals, [ mockProduct ], mockDate ) ).toBe( 15 );
+			expect( getEstimatedCommission( referrals, [ mockProduct ], mockDate ) ).toBe( 15.5 );
 		} );
 
 		it( 'handles cancelled purchases', () => {
@@ -128,9 +128,9 @@ describe( 'get-estimated-commission', () => {
 				},
 			] as never;
 
-			// 9 days * $100 daily price * 50% commission = 450 cents
+			// 10 days * $100 daily price * 50% commission = 500 cents
 			// Convert to dollars by dividing by 100
-			expect( getEstimatedCommission( referrals, [ mockProduct ], mockDate ) ).toBe( 4.5 );
+			expect( getEstimatedCommission( referrals, [ mockProduct ], mockDate ) ).toBe( 5 );
 		} );
 
 		it( 'skips pending purchases', () => {
@@ -184,9 +184,9 @@ describe( 'get-estimated-commission', () => {
 				},
 			] as never;
 
-			// 30 days * $100 daily price * 50% commission * 2 purchases = 3000 cents
+			// 31 days * $100 daily price * 50% commission * 2 purchases = 3100 cents
 			// Convert to dollars by dividing by 100
-			expect( getEstimatedCommission( referrals, [ mockProduct ], mockDate ) ).toBe( 30 );
+			expect( getEstimatedCommission( referrals, [ mockProduct ], mockDate ) ).toBe( 31 );
 		} );
 
 		it( 'calculates commission for multiple referrals', () => {
@@ -223,9 +223,9 @@ describe( 'get-estimated-commission', () => {
 				},
 			] as never;
 
-			// 30 days * $100 daily price * 50% commission * 2 referrals = 3000 cents
+			// 31 days * $100 daily price * 50% commission * 2 referrals = 3100 cents
 			// Convert to dollars by dividing by 100
-			expect( getEstimatedCommission( referrals, [ mockProduct ], mockDate ) ).toBe( 30 );
+			expect( getEstimatedCommission( referrals, [ mockProduct ], mockDate ) ).toBe( 31 );
 		} );
 
 		it( 'calculates commission with bundle pricing', () => {
@@ -252,9 +252,9 @@ describe( 'get-estimated-commission', () => {
 				},
 			] as never;
 
-			// 30 days * $90 daily price * 50% commission = 1350 cents
+			// 31 days * $90 daily price * 50% commission = 1395 cents
 			// Convert to dollars by dividing by 100
-			expect( getEstimatedCommission( referrals, [ productWithBundle ], mockDate ) ).toBe( 13.5 );
+			expect( getEstimatedCommission( referrals, [ productWithBundle ], mockDate ) ).toBe( 13.95 );
 		} );
 	} );
 } );


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1676

## Proposed Changes

This PR fixes the referral estimated commission by including end-to-end days between the payout days.

## Why are these changes being made?

* To show the accurate estimated commission value for referrals

## Testing Instructions

* Open the A4A live link
* Go to Referrals: Dashboard >Find any existing referral assigned or purchased before 31st December 2024.
* Verify that the calculation for the estimated commission is slightly different from the production version. The value should be slightly more. 

Detailed instructions: 

- Calculate the no of days between the current [payout dates](https://agencieshelp.automattic.com/knowledge-base/automattic-for-agencies-earnings/#payout-calculation-and-schedule): October 1 - December 31
- Get the daily price from the Product Families Public API(https://public-api.wordpress.com/wpcom/v2/jetpack-licensing/partner/product-families?agency_id={id}). Screenshot below.
- Now calculate the commission by using this formula: Daily Price * No of Days * [Commission Percentage](https://github.com/Automattic/wp-calypso/blob/db0ad74cb19d89ab09f7ec8c4b1207b87f9c7023/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts#L5) 
- Verify it now matches the estimated price shown

<img width="686" alt="Screenshot 2025-01-21 at 11 16 36 AM" src="https://github.com/user-attachments/assets/73576333-796d-4e0d-b4fe-e976b117eace" />



| Before | After |
|--------|--------|
| <img width="1051" alt="Screenshot 2025-01-21 at 11 21 48 AM" src="https://github.com/user-attachments/assets/40650233-95d7-44e4-a07d-a2d098c8c6c5" /> | <img width="1051" alt="Screenshot 2025-01-21 at 10 13 28 AM" src="https://github.com/user-attachments/assets/f7d064bb-239d-4d65-8be2-e1f0659f5e33" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
