### PR TITLE
i18n: `useFixMe` hook for similar use to `useTranslate`

### DIFF
--- a/packages/i18n-calypso/CHANGELOG.md
+++ b/packages/i18n-calypso/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 7.2.0
+
+- Add new `ueFixMe` method
+- Update default parameters to `fixMe`
+
 ## 7.1.0
 
 - Add new `fixMe` method for conditionally loading a copy given a respective translation exists

--- a/packages/i18n-calypso/README.md
+++ b/packages/i18n-calypso/README.md
@@ -225,6 +225,8 @@ Using the method `fixMe` you can apply a translation (`newCopy` parameter) only 
 
 Important: Due to the way our string extraction mechanism works, always pass `i18n.translate( '...' )` for `newCopy` parameter as otherwise the new string will not be picked up for translation.
 
+For React context, refer to `useFixMe` hook below, which is reactive to locale and other i18n state changes.
+
 ### Usage
 
 ```js
@@ -323,6 +325,25 @@ export default Greeting;
 
 Unlike the `localize` HOC, the component doesn't need to be wrapped and receives the `translate`
 function from the hook call rather than a prop.
+
+## `useFixMe` React Hook
+
+Similar to `useTranslate`, this is an alternative to the `i18n.fixMe` that will cause the consuming component to
+rerender when the `i18n` locale or other state changes.
+
+### Usage
+
+```jsx
+import { useFixMe, useTranslate } from 'i18n-calypso';
+
+function Greeting( { className } ) {
+	const fixMe = useFixMe();
+	const translate = useTranslate();
+	return <h1>{ fixMe( { text: 'hello', newCopy: translate( 'Hello!' ), oldCopy: translate( 'hello' ) } ) }</h1>;
+}
+
+export default Greeting;
+```
 
 ## React Localization Helpers for RTL
 

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "i18n-calypso",
-	"version": "7.1.0",
+	"version": "7.2.0",
 	"description": "I18n JavaScript library on top of Tannin originally used in Calypso.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -33,7 +33,8 @@
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"react-test-renderer": "^18.3.1"
+		"react-test-renderer": "^18.3.1",
+		"@testing-library/react": "^15.0.7"
 	},
 	"peerDependencies": {
 		"react": "^18.3.1"

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -347,24 +347,16 @@ I18N.prototype.hasTranslation = function () {
 
 /**
  * Returns `newCopy` if given `text` is translated or locale is English, otherwise returns the `oldCopy`.
- * ------------------
  * Important - Usage:
- * ------------------
- * `newCopy` prop should be an actual `i18n.translate()` call from the consuming end.
- * This is the only way currently to ensure that it is picked up by our string extraction mechanism
+ * - `newCopy` prop should be an actual `i18n.translate()` call from the consuming end.
+ * - This is the only way currently to ensure that it is picked up by our string extraction mechanism
  * and propagate into GlotPress for translation.
- * ------------------
  * @param {Object} options
  * @param {string} options.text - The text to check for translation.
  * @param {string | Object} options.newCopy - The translation to return if the text is translated.
  * @param {string | Object | undefined } options.oldCopy - The fallback to return if the text is not translated.
  */
-I18N.prototype.fixMe = function ( { text, newCopy, oldCopy } ) {
-	if ( typeof text !== 'string' ) {
-		warn( 'fixMe() requires an object with a proper text property (string)' );
-		return null;
-	}
-
+I18N.prototype.fixMe = function ( { text, newCopy, oldCopy } = { text: '' } ) {
 	if ( [ 'en', 'en-gb' ].includes( this.getLocaleSlug() ) || this.hasTranslation( text ) ) {
 		return newCopy;
 	}

--- a/packages/i18n-calypso/src/index.js
+++ b/packages/i18n-calypso/src/index.js
@@ -3,9 +3,10 @@ import i18n from './default-i18n';
 import I18N from './i18n';
 import localize from './localize';
 import { useRtl, withRtl } from './rtl';
+import useFixMe from './use-fix-me';
 import useTranslate from './use-translate';
 
-export { I18N, I18NContext, localize, useRtl, withRtl, useTranslate };
+export { I18N, I18NContext, localize, useRtl, withRtl, useTranslate, useFixMe };
 export default i18n;
 
 // Export the default instance's properties and bound methods for convenience

--- a/packages/i18n-calypso/src/use-fix-me.js
+++ b/packages/i18n-calypso/src/use-fix-me.js
@@ -1,0 +1,22 @@
+import { useContext, useEffect, useState, useMemo } from 'react';
+import I18NContext from './context';
+
+function bindFixMe( i18n ) {
+	return i18n.fixMe.bind( i18n );
+}
+
+/**
+ * Returns a new binding to fixMe whenever internal i18n state/context changes
+ */
+export default function useFixMe() {
+	const i18n = useContext( I18NContext );
+	const [ counter, setCounter ] = useState( 0 );
+
+	useEffect( () => {
+		const onChange = () => setCounter( ( c ) => c + 1 );
+		i18n.on( 'change', onChange );
+		return () => i18n.off( 'change', onChange );
+	}, [ i18n ] );
+
+	return useMemo( () => bindFixMe( i18n, counter ), [ i18n, counter ] );
+}

--- a/packages/i18n-calypso/test/index.js
+++ b/packages/i18n-calypso/test/index.js
@@ -285,11 +285,6 @@ describe( 'I18n', function () {
 	} );
 
 	describe( 'fixMe', () => {
-		it( 'should return null if text is missing or wrong type', () => {
-			const result = i18n.fixMe( {} );
-			expect( result ).toBe( null );
-		} );
-
 		it( 'should return newCopy if locale is en', () => {
 			i18n.getLocaleSlug = jest.fn().mockReturnValue( 'en' );
 			const result = i18n.fixMe( {

--- a/packages/i18n-calypso/test/use-fix-me.js
+++ b/packages/i18n-calypso/test/use-fix-me.js
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+import defaultCalypsoI18n from '../src';
+import I18NContext from '../src/context';
+import useFixMe from '../src/use-fix-me';
+
+describe( 'useFixMe', () => {
+	beforeEach( () => {
+		defaultCalypsoI18n.setLocale( {
+			'': {
+				localeSlug: 'en',
+			},
+		} );
+		jest.clearAllMocks();
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+		defaultCalypsoI18n.configure(); // ensure everything is reset
+	} );
+
+	test( 'returns a new method bound whenever i18n locale changes', () => {
+		const wrapper = ( { children } ) => (
+			<I18NContext.Provider value={ defaultCalypsoI18n }>{ children }</I18NContext.Provider>
+		);
+		const { result } = renderHook( () => useFixMe(), { wrapper } );
+		const initialFixMe = result.current;
+
+		act( () =>
+			defaultCalypsoI18n.setLocale( {
+				'': {
+					localeSlug: 'fr',
+				},
+			} )
+		);
+
+		expect( result.current ).not.toBe( initialFixMe );
+	} );
+
+	test( 'cleans up event listeners on unmount', () => {
+		const wrapper = ( { children } ) => (
+			<I18NContext.Provider value={ defaultCalypsoI18n }>{ children }</I18NContext.Provider>
+		);
+		const { unmount } = renderHook( () => useFixMe(), { wrapper } );
+
+		// Spy on the off method to ensure it's called
+		const offSpy = jest.spyOn( defaultCalypsoI18n, 'off' );
+
+		unmount();
+		expect( offSpy ).toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/654
Related to https://github.com/Automattic/wp-calypso/pull/97690

## Proposed Changes

This PR introduces `useFixMe` hook that behaves similarly to `useTranslate`, effectively rebinding the `fixMe` method and returning a new function when i18n-calypso state/locale changes.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Follow-up to https://github.com/Automattic/wp-calypso/pull/97690

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Unit tests

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
