### PR TITLE
Jetpack plugins: consider selection to navigate to a different screen

### DIFF
--- a/client/my-sites/plugins/plugins-dashboard/style.scss
+++ b/client/my-sites/plugins/plugins-dashboard/style.scss
@@ -366,10 +366,6 @@
 				margin-left: 0;
 			}
 		}
-
-		li {
-			cursor: inherit;
-		}
 	}
 }
 

--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -3,7 +3,7 @@ import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
 import { Button } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
 	DATAVIEWS_LIST,
 	DATAVIEWS_TABLE,
@@ -173,6 +173,17 @@ export default function PluginsListDataViews( {
 		};
 	}, [ currentPlugins, dataViewsState, fields ] );
 
+	const updatePluginOnChangeSelection = useCallback(
+		( selection: string[] ) => {
+			if ( dataViewsState.type === 'list' ) {
+				const newPluginSelected = selection[ 0 ].split( '/' )[ 0 ];
+				// @ts-expect-error The openPluginSitesPane function only requires a slug to work and we don't have a way to know the other required props.
+				openPluginSitesPane( { slug: newPluginSelected } );
+			}
+		},
+		[ dataViewsState.type ]
+	);
+
 	return (
 		<>
 			<QueryDotorgPlugins pluginSlugList={ data.map( ( plugin ) => plugin.slug ) } />
@@ -180,6 +191,7 @@ export default function PluginsListDataViews( {
 				data={ data }
 				view={ dataViewsState }
 				onChangeView={ setDataViewsState }
+				onChangeSelection={ updatePluginOnChangeSelection }
 				fields={ fields }
 				search
 				searchLabel={ translate( 'Search' ) }


### PR DESCRIPTION
Dependency of https://github.com/Automattic/wp-calypso/pull/96470

## Proposed Changes

This PR updates the preview pane for Jetpack Cloud Plugins when the user selects a new row in the list view.

## Why are these changes being made?

While testing https://github.com/Automattic/wp-calypso/pull/96470 we realized the selection wasn't working. Instead, the preview pane was updated only via clicking the title. This PR prepares the Jetpack Plugins code so it works when 96470 is merged.

## Testing Instructions

- Update your `/etc/hosts` to have `127.0.0.1 jetpack.cloud.localhost`.
- Start the Jetpack Cloud environment:

```
yarn && yarn start-jetpack-cloud
```
- Visit the Plugins screen (it'll take you to http://jetpack.cloud.localhost:3000/plugins/manage/sites).
- Click on the title of one of the "Installed plugins", so it opens the preview pane.
- Once in the list view, test that both clicking the title or just selecting a row change the preview pane.
