### PR TITLE
Move admin interface style mutation to common file

### DIFF
--- a/client/my-sites/site-settings/site-admin-interface/index.js
+++ b/client/my-sites/site-settings/site-admin-interface/index.js
@@ -14,18 +14,9 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { useSelector } from 'calypso/state';
 import { recordTracksEvent, recordGoogleEvent } from 'calypso/state/analytics/actions';
-import {
-	errorNotice,
-	infoNotice,
-	removeNotice,
-	successNotice,
-} from 'calypso/state/notices/actions';
 import { getSiteOption, getSiteAdminUrl } from 'calypso/state/sites/selectors';
-import { useSiteInterfaceMutation } from './use-select-interface-mutation';
+import { useSiteInterfaceMutationWithNotices } from './use-select-interface-mutation';
 import './style.scss';
-const changeLoadingNoticeId = 'admin-interface-change-loading';
-const successNoticeId = 'admin-interface-change-success';
-const failureNoticeId = 'admin-interface-change-failure';
 
 const FormRadioStyled = styled( FormRadio )( {
 	'&.form-radio:disabled:checked::before': {
@@ -38,46 +29,13 @@ const SiteAdminInterface = ( { siteId, siteSlug, isHosting = false } ) => {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
 	const dispatch = useDispatch();
-	const removeAllNotices = () => {
-		dispatch( removeNotice( successNoticeId ) );
-		dispatch( removeNotice( failureNoticeId ) );
-		dispatch( removeNotice( changeLoadingNoticeId ) );
-	};
 
 	const adminInterface = useSelector(
 		( state ) => getSiteOption( state, siteId, 'wpcom_admin_interface' ) || 'calypso'
 	);
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 
-	const { setSiteInterface, isLoading: isUpdating } = useSiteInterfaceMutation( siteId, {
-		onMutate: () => {
-			removeAllNotices();
-			dispatch(
-				infoNotice( translate( 'Changing admin interface style…' ), {
-					id: changeLoadingNoticeId,
-					showDismiss: false,
-					isLoading: true,
-					icon: 'sync',
-				} )
-			);
-		},
-		onSuccess() {
-			dispatch( removeNotice( changeLoadingNoticeId ) );
-			dispatch(
-				successNotice( translate( 'Admin interface style changed.' ), {
-					id: successNoticeId,
-				} )
-			);
-		},
-		onError: () => {
-			dispatch( removeNotice( changeLoadingNoticeId ) );
-			dispatch(
-				errorNotice( translate( 'Failed to change admin interface style.' ), {
-					id: failureNoticeId,
-				} )
-			);
-		},
-	} );
+	const { setSiteInterface, isLoading: isUpdating } = useSiteInterfaceMutationWithNotices( siteId );
 
 	const [ selectedAdminInterface, setSelectedAdminInterface ] = useState( adminInterface );
 

--- a/client/my-sites/site-settings/site-admin-interface/use-select-interface-mutation.ts
+++ b/client/my-sites/site-settings/site-admin-interface/use-select-interface-mutation.ts
@@ -1,17 +1,28 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { addQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { navigate } from 'calypso/lib/navigate';
 import wp from 'calypso/lib/wp';
 import { useDispatch, useSelector } from 'calypso/state';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 import { getIsRequestingAdminMenu } from 'calypso/state/admin-menu/selectors';
+import {
+	errorNotice,
+	infoNotice,
+	removeNotice,
+	successNotice,
+} from 'calypso/state/notices/actions';
 import getRawSite from 'calypso/state/selectors/get-raw-site';
 import { receiveSite, requestSite } from 'calypso/state/sites/actions';
 import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 
 const SET_SITE_INTERFACE_MUTATION_KEY = 'set-site-interface-mutation-key';
 const PERSISTENT_DATA_DELAY = 1200;
+
+const changeLoadingNoticeId = 'admin-interface-change-loading';
+const successNoticeId = 'admin-interface-change-success';
+const failureNoticeId = 'admin-interface-change-failure';
 
 interface MutationResponse {
 	interface: 'wp-admin' | 'calypso';
@@ -104,4 +115,44 @@ export const useSiteInterfaceMutation = (
 		setSiteInterface: mutate,
 		isLoading: mutation.isPending || isRequestingMenu,
 	};
+};
+
+export const useSiteInterfaceMutationWithNotices = ( siteId: number ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const removeAllNotices = () => {
+		dispatch( removeNotice( successNoticeId ) );
+		dispatch( removeNotice( failureNoticeId ) );
+		dispatch( removeNotice( changeLoadingNoticeId ) );
+	};
+
+	return useSiteInterfaceMutation( siteId, {
+		onMutate: () => {
+			removeAllNotices();
+			dispatch(
+				infoNotice( translate( 'Changing admin interface style…' ), {
+					id: changeLoadingNoticeId,
+					showDismiss: false,
+					isLoading: true,
+					icon: 'sync',
+				} )
+			);
+		},
+		onSuccess() {
+			dispatch( removeNotice( changeLoadingNoticeId ) );
+			dispatch(
+				successNotice( translate( 'Admin interface style changed.' ), {
+					id: successNoticeId,
+				} )
+			);
+		},
+		onError: () => {
+			dispatch( removeNotice( changeLoadingNoticeId ) );
+			dispatch(
+				errorNotice( translate( 'Failed to change admin interface style.' ), {
+					id: failureNoticeId,
+				} )
+			);
+		},
+	} );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #98193

## Proposed Changes

* This is a refactor attempt, moves the admin interface style change notices to common area so that it can be re-used in all the calypso interfaces to redirect if required.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To re-use the common functionality in other areas.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try switching between classic and default admin views.
* It should continue to work as before after this change, without any issues.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
