### PR TITLE
Domain management: Update domainManagementEdit logic to support checkout context

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
@@ -2,12 +2,14 @@ import { isDomainMapping, isDomainTransfer } from '@automattic/calypso-products'
 import formatCurrency from '@automattic/format-currency';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import ThankYouProduct from 'calypso/components/thank-you-v2/product';
 import {
 	createSiteFromDomainOnly,
 	domainManagementEdit,
 	domainManagementRoot,
 } from 'calypso/my-sites/domains/paths';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import type { ReceiptPurchase } from 'calypso/state/receipts/types';
 
 type DomainTransferSectionProps = {
@@ -52,6 +54,7 @@ export default function ThankYouDomainProduct( {
 	isGravatarDomain,
 }: ThankYouDomainProductProps ) {
 	const translate = useTranslate();
+	const currentRoute = useSelector( getCurrentRoute );
 
 	domainName ??= purchase?.meta;
 
@@ -74,7 +77,7 @@ export default function ThankYouDomainProduct( {
 		const createSiteHref = siteSlug && createSiteFromDomainOnly( siteSlug, purchase.blogId );
 		const createSiteProps = createSiteHref ? { href: createSiteHref } : { disabled: true };
 
-		const manageDomainHref = siteSlug && domainManagementEdit( siteSlug, domainName );
+		const manageDomainHref = siteSlug && domainManagementEdit( siteSlug, domainName, currentRoute );
 		const manageDomainProps = manageDomainHref ? { href: manageDomainHref } : { disabled: true };
 
 		actions = (

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -1,7 +1,8 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { filter } from 'lodash';
 import { stringify } from 'qs';
 import { addQueryArgs } from 'calypso/lib/url';
-import { isUnderEmailManagementAll } from 'calypso/my-sites/email/paths';
+import { isUnderEmailManagementAll, isUnderCheckoutRoute } from 'calypso/my-sites/email/paths';
 
 function resolveRootPath( relativeTo = null ) {
 	if ( relativeTo ) {
@@ -140,6 +141,10 @@ export function domainManagementEdit(
 	relativeTo = null,
 	expandSections = null
 ) {
+	if ( isUnderCheckoutRoute( relativeTo ) && isEnabled( 'calypso/all-domain-management' ) ) {
+		return `${ domainManagementAllRoot() }/overview/${ domainName }/${ siteName }`;
+	}
+
 	return domainManagementEditBase( siteName, domainName, 'edit', relativeTo, expandSections );
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/98615

## Proposed Changes

* Extend the generate path logic to support the use case when the feature flag is ON, and the current route is under checkout.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Domain Management Revamp project

## Testing Instructions

* Feature flag: `calypso/all-domain-management`
* Go to `/domains/manage`
* Click on "Add new domain"
* Purchase a domain (example: `.blog` domain; use credits)
* On the "Thank you" page, click on "Manage domain" button
* Check if you stay in the same context

<img width="789" alt="Screenshot 2025-01-21 at 14 35 42" src="https://github.com/user-attachments/assets/6effb7d6-beed-4c28-841f-da7d00d48d38" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
