### PR TITLE
Reader onboarding - expose to unverified users and prompt verification at the appropriate point.

### DIFF
--- a/client/components/email-verification/email-verification-dialog/index.jsx
+++ b/client/components/email-verification/email-verification-dialog/index.jsx
@@ -70,9 +70,18 @@ class VerifyEmailDialog extends Component {
 	};
 
 	getDialogButtons() {
+		const { closeButtonAction, closeLabel, translate } = this.props;
+
+		const onClickClose = () => {
+			if ( typeof closeButtonAction === 'function' ) {
+				closeButtonAction();
+			}
+			this.handleClose();
+		};
+
 		return [
-			<Button key="close" onClick={ this.handleClose }>
-				{ this.props.translate( 'Cancel' ) }
+			<Button key="close" onClick={ onClickClose }>
+				{ closeLabel || translate( 'Cancel' ) }
 			</Button>,
 			<Button
 				key="resend"

--- a/client/me/email-verification-banner/index.tsx
+++ b/client/me/email-verification-banner/index.tsx
@@ -8,9 +8,11 @@ import isPendingEmailChange from 'calypso/state/selectors/is-pending-email-chang
 
 import './style.scss';
 
-const EmailVerificationBanner: React.FC< { customDescription?: string | React.ReactNode } > = ( {
-	customDescription,
-} ) => {
+const EmailVerificationBanner: React.FC< {
+	customDescription?: string | React.ReactNode;
+	dialogCloseLabel?: string | React.ReactNode;
+	dialogCloseAction?: () => void;
+} > = ( { customDescription, dialogCloseLabel, dialogCloseAction = () => {} } ) => {
 	const isVerified = useSelector( isCurrentUserEmailVerified );
 	const isEmailChangePending = useSelector( isPendingEmailChange );
 	const translate = useTranslate();
@@ -22,7 +24,15 @@ const EmailVerificationBanner: React.FC< { customDescription?: string | React.Re
 
 	return (
 		<>
-			{ isDialogOpen && <EmailVerificationDialog onClose={ () => setIsDialogOpen( false ) } /> }
+			{ isDialogOpen && (
+				<EmailVerificationDialog
+					onClose={ () => setIsDialogOpen( false ) }
+					closeLabel={ dialogCloseLabel }
+					// We only want this triggered from the close button, but not from clicking
+					// outside to close the modal (so not adding to onClose prop).
+					closeButtonAction={ dialogCloseAction }
+				/>
+			) }
 			<Banner
 				className="email-verification-banner"
 				title={ translate( 'Please, verify your email address.' ) }

--- a/client/me/email-verification-banner/index.tsx
+++ b/client/me/email-verification-banner/index.tsx
@@ -6,7 +6,9 @@ import { useSelector } from 'calypso/state';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import isPendingEmailChange from 'calypso/state/selectors/is-pending-email-change';
 
-const EmailVerificationBanner: React.FC = () => {
+const EmailVerificationBanner: React.FC< { customDescription?: string | React.ReactNode } > = ( {
+	customDescription,
+} ) => {
 	const isVerified = useSelector( isCurrentUserEmailVerified );
 	const isEmailChangePending = useSelector( isPendingEmailChange );
 	const translate = useTranslate();
@@ -22,9 +24,13 @@ const EmailVerificationBanner: React.FC = () => {
 			<Banner
 				className="email-verification-banner"
 				title={ translate( 'Please, verify your email address.' ) }
-				description={ translate(
-					'Verifying your email helps you secure your WordPress.com account and enables key features.'
-				) }
+				description={
+					customDescription
+						? customDescription
+						: translate(
+								'Verifying your email helps you secure your WordPress.com account and enables key features.'
+						  )
+				}
 				callToAction={ translate( 'Verify email' ) }
 				onClick={ () => {
 					setIsDialogOpen( true );

--- a/client/me/email-verification-banner/index.tsx
+++ b/client/me/email-verification-banner/index.tsx
@@ -6,6 +6,8 @@ import { useSelector } from 'calypso/state';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import isPendingEmailChange from 'calypso/state/selectors/is-pending-email-change';
 
+import './style.scss';
+
 const EmailVerificationBanner: React.FC< { customDescription?: string | React.ReactNode } > = ( {
 	customDescription,
 } ) => {

--- a/client/me/email-verification-banner/style.scss
+++ b/client/me/email-verification-banner/style.scss
@@ -1,0 +1,4 @@
+.email-verification-banner {
+	--color-accent: var(--studio-red);
+	--color-accent-60: var(--studio-red-60);
+}

--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -96,7 +96,5 @@ body.is-section-me {
 
 	.email-verification-banner {
 		max-width: 1040px;
-		--color-accent: var(--studio-red);
-		--color-accent-60: var(--studio-red-60);
 	}
 }

--- a/client/reader/onboarding/index.tsx
+++ b/client/reader/onboarding/index.tsx
@@ -12,10 +12,7 @@ import {
 import InterestsModal from 'calypso/reader/onboarding/interests-modal';
 import SubscribeModal from 'calypso/reader/onboarding/subscribe-modal';
 import { useDispatch, useSelector } from 'calypso/state';
-import {
-	getCurrentUserDate,
-	isCurrentUserEmailVerified,
-} from 'calypso/state/current-user/selectors';
+import { getCurrentUserDate } from 'calypso/state/current-user/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
@@ -40,7 +37,6 @@ const ReaderOnboarding = ( {
 	);
 	const preferencesLoaded = useSelector( hasReceivedRemotePreferences );
 	const userRegistrationDate = useSelector( getCurrentUserDate );
-	const isEmailVerified = useSelector( isCurrentUserEmailVerified );
 
 	const dispatch = useDispatch();
 
@@ -50,7 +46,6 @@ const ReaderOnboarding = ( {
 		( preferencesLoaded &&
 			! hasCompletedOnboarding &&
 			userRegistrationDate &&
-			isEmailVerified &&
 			new Date( userRegistrationDate ) >= new Date( '2024-10-01T00:00:00Z' ) );
 
 	// Modal state handlers with tracking.

--- a/client/reader/onboarding/index.tsx
+++ b/client/reader/onboarding/index.tsx
@@ -99,6 +99,21 @@ const ReaderOnboarding = ( {
 		}
 	}, [ shouldShowOnboarding, hasSeenOnboarding, dispatch ] );
 
+	// Reopen subscription onboarding page if prompted by query param.
+	useEffect( () => {
+		const params = new URLSearchParams( window.location.search );
+		const loadSubsStep = params.get( 'reloadSubscriptionOnboarding' );
+		if ( loadSubsStep ) {
+			openDiscoverModal();
+		}
+		params.delete( 'reloadSubscriptionOnboarding' );
+		window.history.replaceState(
+			{},
+			'',
+			`${ window.location.pathname }${ params.toString() ? '?' + params.toString() : '' }`
+		);
+	}, [] );
+
 	// Notify the parent component if onboarding will render.
 	onRender?.( shouldShowOnboarding );
 

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -28,6 +28,7 @@ import {
 	requestPaginatedStream,
 } from 'calypso/state/reader/streams/actions';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
+import SubscribeVerificationNudge from './verificationNudge';
 
 import './style.scss';
 
@@ -316,6 +317,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 				headerActions={ headerActions }
 				isDismissible={ false }
 			>
+				{ promptVerification && <SubscribeVerificationNudge /> }
 				<div
 					className={ clsx( 'subscribe-modal__content', {
 						'subscribe-modal__disabled-for-verification': promptVerification,

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -3,6 +3,7 @@ import { LoadingPlaceholder } from '@automattic/components';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Modal, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
 import { getLocaleSlug } from 'i18n-calypso';
 import React, { useMemo, useState, ComponentType, useEffect, useCallback } from 'react';
 import { useSelector } from 'react-redux';
@@ -17,6 +18,7 @@ import {
 import { curatedBlogs } from 'calypso/reader/onboarding/curated-blogs';
 import Stream from 'calypso/reader/stream';
 import { useDispatch } from 'calypso/state';
+import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { requestFollows } from 'calypso/state/reader/follows/actions';
 import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
@@ -68,6 +70,8 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 	const followedTagSlugs = useMemo( () => {
 		return ( followedTags || [] ).map( ( tag ) => tag.slug );
 	}, [ followedTags ] );
+
+	const promptVerification = ! useSelector( isCurrentUserEmailVerified );
 
 	const [ currentPage, setCurrentPage ] = useState( 0 );
 	const [ selectedSite, setSelectedSite ] = useState< CardData | null >( null );
@@ -297,7 +301,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 			<Button onClick={ handleClose } variant="link">
 				{ __( 'Cancel' ) }
 			</Button>
-			<Button onClick={ handleContinue } variant="primary">
+			<Button onClick={ handleContinue } variant="primary" disabled={ promptVerification }>
 				{ __( 'Continue' ) }
 			</Button>
 		</>
@@ -312,7 +316,11 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 				headerActions={ headerActions }
 				isDismissible={ false }
 			>
-				<div className="subscribe-modal__content">
+				<div
+					className={ clsx( 'subscribe-modal__content', {
+						'subscribe-modal__disabled-for-verification': promptVerification,
+					} ) }
+				>
 					<div className="subscribe-modal__site-list-column">
 						<h2 className="subscribe-modal__title">{ __( "Discover sites that you'll love" ) }</h2>
 						<p className="subscribe-modal__description">

--- a/client/reader/onboarding/subscribe-modal/style.scss
+++ b/client/reader/onboarding/subscribe-modal/style.scss
@@ -41,6 +41,11 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 		}
 	}
 
+	&__disabled-for-verification {
+		opacity: 0.5;
+		pointer-events: none;
+	}
+
 	&__site-list-column {
 		flex: 1;
 		padding: 20px 20px 0;

--- a/client/reader/onboarding/subscribe-modal/verificationNudge.tsx
+++ b/client/reader/onboarding/subscribe-modal/verificationNudge.tsx
@@ -8,26 +8,24 @@ const SubscribeVerificationNudge: React.FC = () => {
 	const reloadLink = addQueryArgs( '/read', { reloadSubscriptionOnboarding: 'true' } );
 
 	return (
-		<>
-			<EmailVerificationBanner
-				customDescription={ translate(
-					'Verifying your email helps you secure your WordPress.com account and enables key features such as subscribing to sites. If necessary, please {{link}}click here{{/link}} to reload when complete.',
-					{
-						components: {
-							link: (
-								<a
-									href={ reloadLink }
-									onClick={ ( e ) => {
-										e.preventDefault();
-										window.location.replace( reloadLink );
-									} }
-								/>
-							),
-						},
-					}
-				) }
-			/>
-		</>
+		<EmailVerificationBanner
+			customDescription={ translate(
+				'Verifying your email helps you secure your WordPress.com account and enables key features such as subscribing to sites. If necessary, please {{link}}click here{{/link}} to reload when complete.',
+				{
+					components: {
+						link: (
+							<a
+								href={ reloadLink }
+								onClick={ ( e ) => {
+									e.preventDefault();
+									window.location.replace( reloadLink );
+								} }
+							/>
+						),
+					},
+				}
+			) }
+		/>
 	);
 };
 

--- a/client/reader/onboarding/subscribe-modal/verificationNudge.tsx
+++ b/client/reader/onboarding/subscribe-modal/verificationNudge.tsx
@@ -9,6 +9,8 @@ const SubscribeVerificationNudge: React.FC = () => {
 
 	return (
 		<EmailVerificationBanner
+			dialogCloseLabel={ translate( 'I just verified my email' ) }
+			dialogCloseAction={ () => window.location.replace( reloadLink ) }
 			customDescription={ translate(
 				'Verifying your email helps you secure your WordPress.com account and enables key features such as subscribing to sites. If necessary, please {{link}}click here{{/link}} to reload when complete.',
 				{

--- a/client/reader/onboarding/subscribe-modal/verificationNudge.tsx
+++ b/client/reader/onboarding/subscribe-modal/verificationNudge.tsx
@@ -1,0 +1,34 @@
+import { addQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import EmailVerificationBanner from 'calypso/me/email-verification-banner';
+
+const SubscribeVerificationNudge: React.FC = () => {
+	const translate = useTranslate();
+
+	const reloadLink = addQueryArgs( '/read', { reloadSubscriptionOnboarding: 'true' } );
+
+	return (
+		<>
+			<EmailVerificationBanner
+				customDescription={ translate(
+					'Verifying your email helps you secure your WordPress.com account and enables key features such as subscribing to sites. If necessary, please {{link}}click here{{/link}} to reload when complete.',
+					{
+						components: {
+							link: (
+								<a
+									href={ reloadLink }
+									onClick={ ( e ) => {
+										e.preventDefault();
+										window.location.replace( reloadLink );
+									} }
+								/>
+							),
+						},
+					}
+				) }
+			/>
+		</>
+	);
+};
+
+export default SubscribeVerificationNudge;


### PR DESCRIPTION
ON HOLD: Awaiting translations before shipping.
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98423 / Automattic/loop#318

## Proposed Changes

* Enables reader onboarding for users with unverified email addresses.
* Adds the email verification banner and dialogue to the second page of reader onboarding if the user has not verified their email address.
    * Restricts use of this onboarding page until email is verified. Subscriptions require verified email for spam prevention reasons, so we must ensure the email is verified before moving forward.
    * Updates the verification banner to take a custom description, so we can be more contextual to the situation.
    * Adds an optional 'click here' reload button to the custom description used here. Allowing users who have verified their email to reload the page if necessary. 
        * NOTE - regardless of where any specific email verification email will land users, this reload button seems necessary for user simplicity. Old email verification emails may exist in the user's inbox leading elsewhere in the app, so it is important to give (and prompt) users an easy way to reload when complete in the current tab of interaction.
    * Updates the verification dialog to have a custom secondary action label and callback prop to fire when this is clicked. We update the label to "I just verified my email" and trigger the same reload action as the 'click here' mentioned above in the banner (reload with this onboarding page open).
* Adds handling to open the subscription onboarding page if a specific query param is present (used for reloading after verification). 

BEFORE (no onboarding shown for unverified email users)
<img width="600" alt="Screenshot 2025-01-21 at 11 45 04 AM" src="https://github.com/user-attachments/assets/a3dee7ab-9ed3-4607-8cd4-cd6d8212e10a" />

AFTER (onboarding appears for unverified email users)
<img width="600" alt="Screenshot 2025-01-21 at 11 45 24 AM" src="https://github.com/user-attachments/assets/bd00085d-3be5-4ff5-b9f0-12f832f12b95" />

<img width="600" alt="Screenshot 2025-01-21 at 11 45 11 AM" src="https://github.com/user-attachments/assets/d04434ae-88a4-4348-925d-af1d8d4e53de" />

AFTER (subscriptions page uses pre-existing email verification banner/dialog)

<img width="600" alt="Screenshot 2025-01-21 at 11 57 41 AM" src="https://github.com/user-attachments/assets/dd6622f6-1886-4d47-99d0-a9797588ed17" />

New/proposed contextual copy for banner above: "Verifying your email helps you secure your WordPress.com account and enables key features such as subscribing to sites. If necessary, please {{link}}click here{{/link}} to reload when complete."  This was extended from the base version "'Verifying your email helps you secure your WordPress.com account and enables key features." used in /me pages.

<img width="600" alt="Screenshot 2025-01-22 at 2 45 17 PM" src="https://github.com/user-attachments/assets/88a24f0f-4e2d-48a5-8aed-99e0ce95ba5b" />

New copy for the dialog's secondary action (only in this context): "I just verified my email"

AFTER (videos of flow)

Unverified user starts reader onboarding, finds verification prompt at second page, clicks original verification email:
![onboarding-1](https://github.com/user-attachments/assets/12b560e1-2f8e-4724-ab45-693528d07d96)

User returns to current tab and clicks the reload prompt, continues with subscriptions step as normal.
![onboarding-2](https://github.com/user-attachments/assets/3ec12ae9-d1a4-4b9f-bf7c-e932a470b966)

Note ^^ this gives the user a simple way to continue in the tab they were working. However, the user could alternatively navigate back to /read in another tab or through the verification link (depending on which verification email they open and click).


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Reader onboarding has a large impact on the relevance of content shown to new users in the reader. Currently, users may not have the benefit of reader onboarding if their email is not verified. Lets expose this to them so they have a better chance at getting use out of the Reader.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a test email for a new unverified account.
* Run this calypso branch in an incognito window.
* Sign up for wordpress.com with the new email.
* Visit /me and verify the existing banner shows up with no changes. Verify the dialog that appears when clicking the CTA has no changes.
* Continue to /read.
* Verify onboarding is available and the interest page appears. Select some interests and continue.
* Verify the subscriptions page appears and has the email verification notice at the top. 
    * Verify clicking the CTA in the notice opens the email verification dialog modal as expected.
        * Verify this dialog has a secondary action with a custom label "I just verified my email".
        * Verify clicking outside the dialog closes the dialog.
        * Verify clicking "I just verified my email" reloads the page but remains on the subscription step.
    * Verify the page content below the banner is greyed out and not clickable.
    * Verify clicking "click here" in the banner description reloads the page but remains on the subscription step.
* Visit your email and accept the original verification email from signup.
* Go back to the tab with onboarding and select either the "click here" to reload (in banner) or "I just verified my email" (in dialog modal).
* Verify subscriptions page of reader onboarding reloads without the banner and functionality resumes as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
