### PR TITLE
Fix Social E2E tests

### DIFF
--- a/packages/calypso-e2e/src/lib/utils/social-connections-manager.ts
+++ b/packages/calypso-e2e/src/lib/utils/social-connections-manager.ts
@@ -22,11 +22,11 @@ export class SocialConnectionsManager {
 		return {
 			CONNECTION_TESTS_ON_SIMPLE: new RegExp(
 				// The request that deals with connection test results on Simple sites
-				`wpcom/v2/sites/${ this.siteId }/publicize/connection-test-results`
+				`wpcom/v2/sites/${ this.siteId }/publicize/connections`
 			),
 			CONNECTION_TESTS_ON_ATOMIC: new RegExp(
 				// The request that deals with connection test results on Atomic sites
-				'wpcom/v2/publicize/connection-test-results'
+				'wpcom/v2/publicize/connections'
 			),
 			GET_POST: new RegExp(
 				// The request that gets the post data in the editor
@@ -70,8 +70,9 @@ export class SocialConnectionsManager {
 		}
 
 		return (
-			CONNECTION_TESTS_ON_SIMPLE.test( url.pathname ) ||
-			CONNECTION_TESTS_ON_ATOMIC.test( url.toString() )
+			( CONNECTION_TESTS_ON_SIMPLE.test( url.pathname ) ||
+				CONNECTION_TESTS_ON_ATOMIC.test( url.toString() ) ) &&
+			url.searchParams.get( 'test_connections' ) === '1'
 		);
 	}
 

--- a/packages/calypso-e2e/src/lib/utils/social-connections-manager.ts
+++ b/packages/calypso-e2e/src/lib/utils/social-connections-manager.ts
@@ -26,7 +26,7 @@ export class SocialConnectionsManager {
 			),
 			CONNECTION_TESTS_ON_ATOMIC: new RegExp(
 				// The request that deals with connection test results on Atomic sites
-				'wpcom/v2/publicize/connections'
+				'wpcom/v2/publicize/connection-test-results'
 			),
 			GET_POST: new RegExp(
 				// The request that gets the post data in the editor
@@ -70,9 +70,9 @@ export class SocialConnectionsManager {
 		}
 
 		return (
-			( CONNECTION_TESTS_ON_SIMPLE.test( url.pathname ) ||
-				CONNECTION_TESTS_ON_ATOMIC.test( url.toString() ) ) &&
-			url.searchParams.get( 'test_connections' ) === '1'
+			( CONNECTION_TESTS_ON_SIMPLE.test( url.pathname ) &&
+				url.searchParams.get( 'test_connections' ) === '1' ) ||
+			CONNECTION_TESTS_ON_ATOMIC.test( url.toString() )
 		);
 	}
 


### PR DESCRIPTION
Social E2E tests have been failing following https://github.com/Automattic/jetpack/pull/40679

## Proposed Changes

* Update the connection test results path for publicize E2E tests

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* CI should be happy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
