### PR TITLE
Fix Social E2E tests for atomic sites

### DIFF
--- a/packages/calypso-e2e/src/lib/utils/social-connections-manager.ts
+++ b/packages/calypso-e2e/src/lib/utils/social-connections-manager.ts
@@ -20,13 +20,13 @@ export class SocialConnectionsManager {
 	 */
 	get patterns() {
 		return {
-			CONNECTION_TESTS_ON_SIMPLE: new RegExp(
+			CONNECTION_TESTS: new RegExp(
 				// The request that deals with connection test results on Simple sites
-				`wpcom/v2/sites/${ this.siteId }/publicize/connections`
+				`wpcom/v2/(?<site_prefix>sites/${ this.siteId }/)?publicize/connections`
 			),
-			CONNECTION_TESTS_ON_ATOMIC: new RegExp(
-				// The request that deals with connection test results on Atomic sites
-				'wpcom/v2/publicize/connections'
+			CONNECTION_TESTS__LEGACY: new RegExp(
+				// The request that deals with legacy connection test results on Simple sites
+				`wpcom/v2/publicize/connection-test-results`
 			),
 			GET_POST: new RegExp(
 				// The request that gets the post data in the editor
@@ -61,21 +61,50 @@ export class SocialConnectionsManager {
 	 * Whether the URL is the one we want to intercept
 	 */
 	isTargetUrl( url: URL ) {
-		const { GET_POST, POST_AUTOSAVES, CONNECTION_TESTS_ON_SIMPLE, CONNECTION_TESTS_ON_ATOMIC } =
-			this.patterns;
+		return (
+			this.isWpGetPostUrl( url ) ||
+			this.isSimpleConnectionTestUrl( url ) ||
+			this.isAtomicConnectionTestUrl( url )
+		);
+	}
 
-		// We don't want to intercept autosave requests.
-		if ( GET_POST.test( url.pathname ) && ! POST_AUTOSAVES.test( url.pathname ) ) {
+	/**
+	 * Check if the URL is a WP get post URL
+	 */
+	isWpGetPostUrl( url: URL ) {
+		return (
+			this.patterns.GET_POST.test( url.pathname ) &&
+			// We don't want to intercept autosave requests.
+			! this.patterns.POST_AUTOSAVES.test( url.pathname )
+		);
+	}
+
+	/**
+	 * Check if the URL is a connection test URL for simple sites
+	 */
+	isSimpleConnectionTestUrl( url: URL ) {
+		return Boolean(
+			url.searchParams.get( 'test_connections' ) === '1' &&
+				this.patterns.CONNECTION_TESTS.exec( url.pathname )?.groups?.site_prefix
+		);
+	}
+
+	/**
+	 * Check if the URL is a connection test URL for atomic sites
+	 */
+	isAtomicConnectionTestUrl( url: URL ) {
+		// TODO - Remove the legacy connection test check
+		if ( this.patterns.CONNECTION_TESTS__LEGACY.test( url.pathname ) ) {
 			return true;
 		}
 
-		if ( url.searchParams.get( 'test_connections' ) !== '1' ) {
-			return false;
-		}
+		const match = this.patterns.CONNECTION_TESTS.exec( url.pathname );
 
-		return (
-			CONNECTION_TESTS_ON_SIMPLE.test( url.pathname ) ||
-			CONNECTION_TESTS_ON_ATOMIC.test( url.toString() )
+		return Boolean(
+			url.searchParams.get( 'test_connections' ) === '1' &&
+				match &&
+				// Atomic sites don't have a site prefix in the URL.
+				! match.groups?.site_prefix
 		);
 	}
 
@@ -89,16 +118,16 @@ export class SocialConnectionsManager {
 
 			const result = await response.json();
 
-			const url = route.request().url();
+			const url = new URL( route.request().url() );
 
-			if ( this.patterns.GET_POST.test( url ) ) {
+			if ( this.isWpGetPostUrl( url ) ) {
 				// For posts, add a test connection to post attributes.
 				result.body.jetpack_publicize_connections.push( ...this.testConnections );
-			} else if ( this.patterns.CONNECTION_TESTS_ON_SIMPLE.test( url ) ) {
-				// For connection tests, add test connections to the body.
+			} else if ( this.isSimpleConnectionTestUrl( url ) ) {
+				// For connection tests on Simple sites, add test connections to the body.
 				// Because the response is an object {"body":[],"status":200,"headers":{}}
 				result.body.push( ...this.testConnections );
-			} else if ( this.patterns.CONNECTION_TESTS_ON_ATOMIC.test( url ) ) {
+			} else if ( this.isAtomicConnectionTestUrl( url ) ) {
 				// For Atomic connection tests, add test connections directly to the result.
 				// because the response is already an array.
 				result.push( ...this.testConnections );
@@ -125,16 +154,7 @@ export class SocialConnectionsManager {
 		await this.page.waitForResponse( ( response ) => {
 			const url = new URL( response.url() );
 
-			const { CONNECTION_TESTS_ON_SIMPLE, CONNECTION_TESTS_ON_ATOMIC } = this.patterns;
-
-			if ( url.searchParams.get( 'test_connections' ) !== '1' ) {
-				return false;
-			}
-
-			return (
-				CONNECTION_TESTS_ON_SIMPLE.test( url.pathname ) ||
-				CONNECTION_TESTS_ON_ATOMIC.test( url.toString() )
-			);
+			return this.isSimpleConnectionTestUrl( url ) || this.isAtomicConnectionTestUrl( url );
 		} );
 	}
 }

--- a/packages/calypso-e2e/src/lib/utils/social-connections-manager.ts
+++ b/packages/calypso-e2e/src/lib/utils/social-connections-manager.ts
@@ -26,7 +26,7 @@ export class SocialConnectionsManager {
 			),
 			CONNECTION_TESTS_ON_ATOMIC: new RegExp(
 				// The request that deals with connection test results on Atomic sites
-				'wpcom/v2/publicize/connection-test-results'
+				'wpcom/v2/publicize/connections'
 			),
 			GET_POST: new RegExp(
 				// The request that gets the post data in the editor
@@ -69,9 +69,12 @@ export class SocialConnectionsManager {
 			return true;
 		}
 
+		if ( url.searchParams.get( 'test_connections' ) !== '1' ) {
+			return false;
+		}
+
 		return (
-			( CONNECTION_TESTS_ON_SIMPLE.test( url.pathname ) &&
-				url.searchParams.get( 'test_connections' ) === '1' ) ||
+			CONNECTION_TESTS_ON_SIMPLE.test( url.pathname ) ||
 			CONNECTION_TESTS_ON_ATOMIC.test( url.toString() )
 		);
 	}
@@ -120,9 +123,17 @@ export class SocialConnectionsManager {
 	 */
 	async waitForConnectionTests() {
 		await this.page.waitForResponse( ( response ) => {
+			const url = new URL( response.url() );
+
+			const { CONNECTION_TESTS_ON_SIMPLE, CONNECTION_TESTS_ON_ATOMIC } = this.patterns;
+
+			if ( url.searchParams.get( 'test_connections' ) !== '1' ) {
+				return false;
+			}
+
 			return (
-				this.patterns.CONNECTION_TESTS_ON_SIMPLE.test( response.url() ) ||
-				this.patterns.CONNECTION_TESTS_ON_ATOMIC.test( response.url() )
+				CONNECTION_TESTS_ON_SIMPLE.test( url.pathname ) ||
+				CONNECTION_TESTS_ON_ATOMIC.test( url.toString() )
 			);
 		} );
 	}


### PR DESCRIPTION
This PR should fix the Social E2E tests following the next Jetpack Atomic deployment

## Proposed Changes

* Fix E2E tests by updating the connection test result endpoint

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* CI should be happy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
