### PR TITLE
Domain management: Fix badge styling for context-all-domain-management

### DIFF
--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -598,6 +598,10 @@
 		}
 	}
 
+	.email-plan-mailboxes-list__mailbox-list-item > .badge {
+		flex: none;
+	}
+
 	div.email-plan-mailboxes-list__mailbox-list-link span.disabled,
 	.section-header__actions button[disabled] {
 		color: var(--theme-highlight-color-50);


### PR DESCRIPTION
## Proposed Changes

* Fix badge styling for context-all-domain-management

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Domain Management Revamp project

## Testing Instructions

* Go to `/domains/manage?flags=all-domain-management`
* Select a domain with Google Workspace email
* Check the "Admin" badge style

**Before:**
<img width="1361" alt="Screenshot 2025-01-21 at 14 39 56" src="https://github.com/user-attachments/assets/22494264-7053-4b2d-bb3f-720a75ffd74a" />

**After:**
<img width="1358" alt="Screenshot 2025-01-21 at 14 40 18" src="https://github.com/user-attachments/assets/226ee999-1d85-430a-9bbc-8890e1c93e94" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
