### PR TITLE
RDV: Override the redirect for Calypso screens

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -406,7 +406,7 @@ export const redirectIfDuplicatedView = ( wpAdminPath ) => async ( context, next
 		'remove_duplicate_views_experiment_assignment'
 	);
 
-	if ( ! isE2ETest() && 'treatment' !== overrideAssignment ) {
+	if ( 'control' === overrideAssignment ) {
 		next();
 		return;
 	}

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -31,6 +31,7 @@ import {
 	getImmediateLoginEmail,
 	getImmediateLoginLocale,
 } from 'calypso/state/immediate-login/selectors';
+import { getPreference } from 'calypso/state/preferences/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSiteAdminUrl, getSiteHomeUrl, getSiteOption } from 'calypso/state/sites/selectors';
 import { setSelectedSiteId } from 'calypso/state/ui/actions/set-sites.js';
@@ -399,6 +400,17 @@ export const redirectIfDuplicatedView = ( wpAdminPath ) => async ( context, next
 
 	loadExperimentAssignment( aaTestName );
 	const duplicateViewsExperimentAssignment = await loadExperimentAssignment( experimentName );
+
+	const overrideAssignment = getPreference(
+		context.store.getState(),
+		'remove_duplicate_views_experiment_assignment'
+	);
+
+	if ( ! isE2ETest() && 'treatment' !== overrideAssignment ) {
+		next();
+		return;
+	}
+
 	if ( isE2ETest() || duplicateViewsExperimentAssignment.variationName === 'treatment' ) {
 		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );


### PR DESCRIPTION
This overrides the redirect for Calypso screens to WP-Admin when the user has the experiment variation override

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98647

## Proposed Changes

* Override the redirect when there's a preference set

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This prevents the users being redirected to WP-Admin when the experiment assignment is overriden

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the live link
* Test the implementation from https://github.com/Automattic/jetpack/pull/41179/files with a **non-a11n** account
* Set control variation with the Jetpack implementation
* Go to /posts/your-site
* Make sure you're not redirected to WP-Admin

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
