### PR TITLE
Domains Management Revamp: Fix breadcrumb on Email tab and Add Mailbox page

### DIFF
--- a/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
@@ -144,22 +144,43 @@ const DomainOverviewPane = ( {
 		} );
 	}, [ selectedFeature, selectedDomainPreview, inSiteContext, selectedDomain, siteSlug ] );
 
+	const navigationItems = useMemo( () => {
+		if ( ! inSiteContext ) {
+			return [];
+		}
+
+		const items = [
+			{
+				label: site.name || selectedDomain,
+				href: `/overview/${ siteSlug }`,
+				icon: <SiteIcon site={ site } viewType="breadcrumb" disableClick />,
+			},
+			{
+				label: selectedDomain,
+			},
+		];
+
+		if ( selectedFeature === EMAIL_MANAGEMENT ) {
+			items[ 1 ].href = paths.domainManagementAllOverview(
+				siteSlug,
+				selectedDomain,
+				undefined,
+				inSiteContext
+			);
+
+			items.push( {
+				label: translate( 'Email' ),
+			} );
+		}
+
+		return items;
+	}, [ inSiteContext, site, selectedDomain, siteSlug, selectedFeature, translate ] );
+
 	return (
 		<>
 			{ inSiteContext && (
 				<div className="domain-overview__breadcrumb">
-					<NavigationHeader
-						navigationItems={ [
-							{
-								label: site.name || selectedDomain,
-								href: `/overview/${ siteSlug }`,
-								icon: <SiteIcon site={ site } viewType="breadcrumb" disableClick />,
-							},
-							{
-								label: selectedDomain,
-							},
-						] }
-					/>
+					<NavigationHeader navigationItems={ navigationItems } />
 				</div>
 			) }
 

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/add-mailbox-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/add-mailbox-header.tsx
@@ -2,7 +2,7 @@ import { SiteExcerptData } from '@automattic/sites';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import NavigationHeader from 'calypso/components/navigation-header';
-import { domainManagementOverviewRoot } from 'calypso/my-sites/domains/paths';
+import { domainManagementAllOverview } from 'calypso/my-sites/domains/paths';
 import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
 import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';
 import { useSelector } from 'calypso/state';
@@ -23,7 +23,12 @@ const AddMailboxHeader: CustomHeaderComponentType = ( {
 		const baseNavigationItems = [
 			{
 				label: selectedDomainName,
-				href: `${ domainManagementOverviewRoot() }/${ selectedDomainName }/${ selectedSiteSlug }`,
+				href: domainManagementAllOverview(
+					selectedSiteSlug,
+					selectedDomainName,
+					currentRoute,
+					inSiteContext
+				),
 				className: 'navigation-header__domain-name',
 			},
 			{

--- a/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/style.scss
@@ -234,7 +234,7 @@
         }
 
         &__breadcrumb {
-            padding-top: 24px;
+            padding-top: 22px;
 
             @media ( max-width: $break-medium ) {
                 padding-top: 16px;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/98695

## Proposed Changes

* Show "Email" item on the Email tab breadcrumb when displayed under site context.
* Fix breadcrumb navigation on the Add Mailbox page.

## Why are these changes being made?

* This is part of the Domain Management Revamp project: pfuQfP-13x-p2

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/sites?flags=calypso/all-domain-management.
* Click on a site with a domain previously configured.
* Scroll down to the domains table and click on the domain.
* You should see the domain overview page within the site context.
* Click on the Email tab.
* You should see the Email item rendered on the breadcrumb.
* Navigate using the breadcrumb, it should stay under the site context.
* Testing a site with previously configured Mailboxes, click "Add New Mailboxes" on the Email tab.
* You should see the "Add New Mailboxes" page.
* Navigate using the breadcrumb, it should stay under the site context.
* Perform regression tests on the Domains context, make sure the breadcrumb isn't displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?