### PR TITLE
A4A: Move position of All menu item in Sites

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-sites-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-sites-menu-items.ts
@@ -26,57 +26,35 @@ const useSitesMenuItems = ( path: string ) => {
 	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
 
 	return useMemo( () => {
-		const items = noActiveSite
-			? [
-					// We hide the rest of the options when we do not have sites yet.
-					createItem(
-						{
-							id: 'sites-all-menu-item',
-							icon: category,
-							path: A4A_SITES_LINK,
-							link: A4A_SITES_LINK,
-							title: translate( 'All' ),
-							trackEventProps: {
-								menu_item: 'Automattic for Agencies / Sites / All',
-							},
-						},
-						path
-					),
-			  ]
-			: [
-					{
-						icon: warning,
-						path: A4A_SITES_LINK,
-						link: A4A_SITES_LINK_NEEDS_ATTENTION,
-						title: translate( 'Needs attention' ),
-						trackEventProps: {
-							menu_item: 'Automattic for Agencies / Sites / Needs Attention',
-						},
-					},
-					{
-						icon: starEmpty,
-						path: A4A_SITES_LINK,
-						link: A4A_SITES_LINK_FAVORITE,
-						title: translate( 'Favorites' ),
-						trackEventProps: {
-							menu_item: 'Automattic for Agencies / Sites / Favorites',
-						},
-					},
-					{
-						id: 'sites-all-menu-item',
-						icon: category,
-						path: A4A_SITES_LINK,
-						link: A4A_SITES_LINK,
-						title: translate( 'All' ),
-						trackEventProps: {
-							menu_item: 'Automattic for Agencies / Sites / All',
-						},
-					},
-			  ].map( ( item ) => createItem( item, path ) );
+		const items = [
+			{
+				id: 'sites-all-menu-item',
+				icon: category,
+				path: A4A_SITES_LINK,
+				link: A4A_SITES_LINK,
+				title: translate( 'All' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Sites / All',
+				},
+			},
+		];
 
-		if ( shouldAddNeedsSetup ) {
-			const needsSetupItem = createItem(
-				{
+		// Only add additional menu items if we have an active site.
+		if ( ! noActiveSite ) {
+			items.push( {
+				id: 'sites-needs-attention-menu-item',
+				icon: warning,
+				path: A4A_SITES_LINK,
+				link: A4A_SITES_LINK_NEEDS_ATTENTION,
+				title: translate( 'Needs attention' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Sites / Needs Attention',
+				},
+			} );
+
+			if ( shouldAddNeedsSetup ) {
+				items.push( {
+					id: 'sites-needs-setup-menu-item',
 					icon: tool,
 					path: A4A_SITES_LINK,
 					link: A4A_SITES_LINK_NEEDS_SETUP,
@@ -84,15 +62,12 @@ const useSitesMenuItems = ( path: string ) => {
 					trackEventProps: {
 						menu_item: 'Automattic for Agencies / Sites / Needs Setup',
 					},
-				},
-				path
-			);
-			items.splice( noActiveSite ? 0 : 1, 0, needsSetupItem );
-		}
+				} );
+			}
 
-		if ( devSitesEnabled ) {
-			const needsSetupItem = createItem(
-				{
+			if ( devSitesEnabled ) {
+				items.push( {
+					id: 'sites-development-menu-item',
 					icon: code,
 					path: A4A_SITES_LINK,
 					link: A4A_SITES_LINK_DEVELOPMENT,
@@ -100,13 +75,22 @@ const useSitesMenuItems = ( path: string ) => {
 					trackEventProps: {
 						menu_item: 'Automattic for Agencies / Sites / Development',
 					},
+				} );
+			}
+
+			items.push( {
+				id: 'sites-favorites-menu-item',
+				icon: starEmpty,
+				path: A4A_SITES_LINK,
+				link: A4A_SITES_LINK_FAVORITE,
+				title: translate( 'Favorites' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Sites / Favorites',
 				},
-				path
-			);
-			items.splice( 2, 0, needsSetupItem );
+			} );
 		}
 
-		return items;
-	}, [ noActiveSite, path, translate, shouldAddNeedsSetup ] );
+		return items.map( ( item ) => createItem( item, path ) );
+	}, [ noActiveSite, path, translate, shouldAddNeedsSetup, devSitesEnabled ] );
 };
 export default useSitesMenuItems;


### PR DESCRIPTION
This update moves the "All" item to the top of the list on the Sites page for better usability, following feedback discussed here: p1737466711390019-slack-C047ACYM8UQ

Changes:

* Relocated the "All" item to be the first in the list instead of the last.
* Refactored conditionals to add items directly into the array in the desired order, avoiding splicing them in later.

<img width="266" alt="Screenshot 2025-01-21 at 17 02 56" src="https://github.com/user-attachments/assets/2642fe7b-117d-4c15-ab2d-bbb10c4ad55f" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live link
* Go to Sites
* Confirm that the order of the items matches the screenshot

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?