### PR TITLE
Fix: Error that could occur when loading compiled CSS.

### DIFF
--- a/packages/verbum-block-editor/src/editor/editor-style.scss
+++ b/packages/verbum-block-editor/src/editor/editor-style.scss
@@ -4,10 +4,10 @@
 	width: 100%;
 	box-sizing: border-box;
 
-	@import "@wordpress/components/build-style/style";
-	@import "@wordpress/edit-post/build-style/style";
-	@import "@wordpress/block-editor/build-style/style";
-	@import "@wordpress/block-editor/build-style/content";
+	@import "@wordpress/components/build-style/style.css";
+	@import "@wordpress/edit-post/build-style/style.css";
+	@import "@wordpress/block-editor/build-style/style.css";
+	@import "@wordpress/block-editor/build-style/content.css";
 
 	.editor__header {
 		top: 0;


### PR DESCRIPTION
During the package upgrade https://github.com/Automattic/wp-calypso/pull/96470 after rebasing the PR we start getting the following error:
```
[@automattic/verbum-block-editor]: [build:app] ERROR in ./src/editor/editor-style.scss
[@automattic/verbum-block-editor]: [build:app] Module build failed (from ../../node_modules/mini-css-extract-plugin/dist/loader.js):
[@automattic/verbum-block-editor]: [build:app] ModuleBuildError: Module build failed (from ../../node_modules/sass-loader/dist/cjs.js):
[@automattic/verbum-block-editor]: [build:app] SassError: expected "{".
[@automattic/verbum-block-editor]: [build:app]     ╷
[@automattic/verbum-block-editor]: [build:app] 117 │ @media not (prefers-reduced-motion) {
[@automattic/verbum-block-editor]: [build:app]     │            ^
[@automattic/verbum-block-editor]: [build:app]     ╵
[@automattic/verbum-block-editor]: [build:app]   
```


This is similar to the error in Gutenberg that affected the storybook and was fixed at https://github.com/WordPress/gutenberg/pull/68526.

We were importing some built styles without the CSS prefix, these caused the files to be interpreted as scss which causes the built error.

## Proposed Changes
We apply the same change done at https://github.com/WordPress/gutenberg/pull/68526 and added the CSS prefix to the imports causing the error.



## Testing Instructions
Verify yarn and yarn start work as expected.
More testing instructions will be included.
