### PR TITLE
Stats: fix footer link

### DIFF
--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -99,21 +99,21 @@ const StatsCard = ( {
 					>
 						{ isEmpty ? emptyMessage : children }
 					</div>
+					{ footerAction && (
+						<a
+							className={ `${ BASE_CLASS_NAME }--footer` }
+							href={ footerAction?.url }
+							aria-label={
+								translate( 'View all %(title)s', {
+									args: { title: title.toLocaleLowerCase?.() ?? title.toLowerCase() },
+									comment: '"View all posts & pages", "View all referrers", etc.',
+								} ) as string
+							}
+						>
+							{ footerAction.label || translate( 'View all' ) }
+						</a>
+					) }
 				</div>
-				{ footerAction && (
-					<a
-						className={ `${ BASE_CLASS_NAME }--footer` }
-						href={ footerAction?.url }
-						aria-label={
-							translate( 'View all %(title)s', {
-								args: { title: title.toLocaleLowerCase?.() ?? title.toLowerCase() },
-								comment: '"View all posts & pages", "View all referrers", etc.',
-							} ) as string
-						}
-					>
-						{ footerAction.label || translate( 'View all' ) }
-					</a>
-				) }
 			</div>
 			{ overlay && <div className={ `${ BASE_CLASS_NAME }__overlay` }>{ overlay }</div> }
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/jetpack-roadmap#2172.

## Proposed Changes

* Fix the `View all` link position.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* (p1HpG7-rpL-p2)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the Calypso Live preview linked below.
* Scroll down to the Locations section of a site that has meaningful data, like `/stats/day/jetpack.com?flags=stats/locations`
* The `View all` button should appear below the locations list.

### Comparison

| Before | After |
| - | - |
| <img width="1197" alt="image" src="https://github.com/user-attachments/assets/27c7ae1d-e338-46bb-9f1d-156f6c4c73ab" /> | <img width="1199" alt="image" src="https://github.com/user-attachments/assets/9c731ce0-dd71-49f3-981d-b8adef7af55e" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
