### PR TITLE
Subscribers Dataviews: Fix sort order and add column widths

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -1,12 +1,8 @@
 import { Gravatar } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
-import { DataViews } from '@wordpress/dataviews';
+import { DataViews, type View, type Action } from '@wordpress/dataviews';
 import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import {
-	DATAVIEWS_LIST,
-	DATAVIEWS_TABLE,
-} from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import TimeSince from 'calypso/components/time-since';
 import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
 import { SubscriberLaunchpad } from 'calypso/my-sites/subscribers/components/subscriber-launchpad';
@@ -19,7 +15,6 @@ import { isSimpleSite } from 'calypso/state/sites/selectors';
 import { SubscribersSortBy } from '../../constants';
 import { SubscriberDetails } from '../subscriber-details';
 import { SubscribersHeader } from '../subscribers-header';
-import type { View, Action } from '@wordpress/dataviews';
 import './style.scss';
 
 type SubscriberDataViewsProps = {
@@ -293,7 +288,7 @@ const SubscriberDataViews = ( {
 			if ( selectedSubscriber ) {
 				return {
 					...baseView,
-					type: DATAVIEWS_LIST,
+					type: 'list',
 					layout: {
 						primaryField: 'name',
 						mediaField: 'media',
@@ -303,7 +298,7 @@ const SubscriberDataViews = ( {
 
 			return {
 				...baseView,
-				type: DATAVIEWS_TABLE,
+				type: 'table',
 				layout: {
 					styles: {
 						media: { width: '60px' },

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -280,15 +280,13 @@ const SubscriberDataViews = ( {
 			const baseView = {
 				...oldCurrentView,
 				...commonViewProps,
-				fields: selectedSubscriber
-					? [ 'media', 'name' ]
-					: [ 'name', ...( ! isMobile ? [ 'subscription_type', 'date_subscribed' ] : [] ) ],
 			};
 
 			if ( selectedSubscriber ) {
 				return {
 					...baseView,
 					type: 'list',
+					fields: [ 'media', 'name' ],
 					layout: {
 						primaryField: 'name',
 						mediaField: 'media',
@@ -299,6 +297,7 @@ const SubscriberDataViews = ( {
 			return {
 				...baseView,
 				type: 'table',
+				fields: [ 'name', ...( ! isMobile ? [ 'subscription_type', 'date_subscribed' ] : [] ) ],
 				layout: {
 					styles: {
 						media: { width: '60px' },

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -3,6 +3,10 @@ import { useBreakpoint } from '@automattic/viewport-react';
 import { DataViews } from '@wordpress/dataviews';
 import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
+import {
+	DATAVIEWS_LIST,
+	DATAVIEWS_TABLE,
+} from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import TimeSince from 'calypso/components/time-since';
 import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
 import { SubscriberLaunchpad } from 'calypso/my-sites/subscribers/components/subscriber-launchpad';
@@ -74,7 +78,7 @@ const SubscriberDataViews = ( {
 		page,
 		perPage,
 		sort: {
-			field: SubscribersSortBy.DateSubscribed,
+			field: sortTerm,
 			direction: 'desc',
 		},
 	} );
@@ -268,27 +272,48 @@ const SubscriberDataViews = ( {
 
 	// Update the view when a subscriber is selected
 	useEffect( () => {
-		setCurrentView( ( oldCurrentView ) => ( {
-			...oldCurrentView,
-			type: selectedSubscriber ? 'list' : 'table',
-			layout: selectedSubscriber
-				? {
-						showMedia: true,
-						mediaSize: 40,
-						mediaField: 'media',
-						primaryField: 'name',
-				  }
-				: {},
-			fields: selectedSubscriber
-				? [ 'media', 'name' ]
-				: [ 'name', ...( ! isMobile ? [ 'subscription_type', 'date_subscribed' ] : [] ) ],
-			sort: {
-				field: sortTerm,
-				direction: sortOrder ?? sortTerm === SubscribersSortBy.DateSubscribed ? 'desc' : 'asc',
-			},
+		const commonViewProps = {
 			page,
 			perPage,
-		} ) );
+			sort: {
+				field: sortTerm,
+				direction: sortOrder,
+			},
+		};
+
+		setCurrentView( ( oldCurrentView ) => {
+			const baseView = {
+				...oldCurrentView,
+				...commonViewProps,
+				fields: selectedSubscriber
+					? [ 'media', 'name' ]
+					: [ 'name', ...( ! isMobile ? [ 'subscription_type', 'date_subscribed' ] : [] ) ],
+			};
+
+			if ( selectedSubscriber ) {
+				return {
+					...baseView,
+					type: DATAVIEWS_LIST,
+					layout: {
+						primaryField: 'name',
+						mediaField: 'media',
+					},
+				} as View;
+			}
+
+			return {
+				...baseView,
+				type: DATAVIEWS_TABLE,
+				layout: {
+					styles: {
+						media: { width: '60px' },
+						name: { width: '55%', minWidth: '195px' },
+						subscription_type: { width: '25%' },
+						date_subscribed: { width: '25%' },
+					},
+				},
+			} as View;
+		} );
 	}, [ isMobile, selectedSubscriber, page, perPage, sortTerm, sortOrder ] );
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/98498

## Proposed Changes

* Fix sort order issue.
* Add column widths to prevent jumping around on sort.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pe7F0s-2of-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/subscribers/{site url}?flags=subscribers-dataviews`
* Sort by Name ascending and descending
* Sort by Since ascending and descending
* Check that you can move the columns around
* Check that you don't see the column widths change
* Regression test without the flag. Check that the Name and Date Subscribed sorts in the correct order.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?