### PR TITLE
Reader: Always show the username in the post even when it matches the site name

### DIFF
--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -6,7 +6,6 @@ import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import ReaderPostEllipsisMenu from 'calypso/blocks/reader-post-options-menu/reader-post-ellipsis-menu';
 import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
 import TimeSince from 'calypso/components/time-since';
-import { areEqualIgnoringWhitespaceAndCase } from 'calypso/lib/string';
 import { getSiteName } from 'calypso/reader/get-helpers';
 import { isAuthorNameBlocked } from 'calypso/reader/lib/author-name-blocklist';
 import { getStreamUrl } from 'calypso/reader/route';
@@ -107,12 +106,7 @@ class PostByline extends Component {
 		const siteUrl = get( site, 'URL' );
 		const siteName = getSiteName( { site, feed, post } );
 		const hasAuthorName = !! get( post, 'author.name', null );
-		const hasMatchingAuthorAndSiteNames =
-			hasAuthorName && areEqualIgnoringWhitespaceAndCase( siteName, post.author.name );
-		const shouldDisplayAuthor =
-			hasAuthorName &&
-			! isAuthorNameBlocked( post.author.name ) &&
-			( ! hasMatchingAuthorAndSiteNames || ! showSiteName );
+		const shouldDisplayAuthor = hasAuthorName && ! isAuthorNameBlocked( post.author.name );
 		const streamUrl = getStreamUrl( feedId, siteId );
 		const siteIcon = get( site, 'icon.img' );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98497

## Proposed Changes

* Display the username in the PostByline even when the username matches the site name.

Before | After
--|--
<img width="1720" alt="Screenshot 2025-01-21 at 5 18 03 PM" src="https://github.com/user-attachments/assets/3b673252-f4b1-4cc9-83da-2a5cb51ff3e5" />  |  <img width="1723" alt="Screenshot 2025-01-21 at 5 17 42 PM" src="https://github.com/user-attachments/assets/3669abd9-a62a-443d-ae6b-ea7703f30082" />




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We link the username to the user profile page. Always displaying the username creates a consistent experience across posts.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In production go to /read/users/21954253?flags=reader/user-profile and view that the username is not included in the posts where the username matches the site name.
* Using Calypso Live, go to /read/users/21954253 and view all posts, including the username and link to the user's profile page.
* 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
