### PR TITLE
Reader: remove width constraint on discover header

### DIFF
--- a/client/components/scrollable-horizontal-navigation/styles.scss
+++ b/client/components/scrollable-horizontal-navigation/styles.scss
@@ -1,11 +1,3 @@
-.is-section-reader .navigation-header.discover-stream-header {
-	margin: 0 auto;
-	
-	&.reader-dual-column {
-		max-width: 968px; // Max width of dual column reader stream.
-	}
-}
-
 .scrollable-horizontal-navigation {
 	position: relative;
 	margin: auto;

--- a/client/components/scrollable-horizontal-navigation/styles.scss
+++ b/client/components/scrollable-horizontal-navigation/styles.scss
@@ -1,6 +1,6 @@
 .is-section-reader .navigation-header.discover-stream-header {
 	margin: 0 auto;
-	max-width: 600px;
+	
 	&.reader-dual-column {
 		max-width: 968px; // Max width of dual column reader stream.
 	}
@@ -10,7 +10,6 @@
 	position: relative;
 	margin: auto;
 	margin-bottom: -20px;
-	max-width: 600px; // Max width of single column reader stream.
 	overflow: hidden;
 	@media only screen and (max-width: 600px) {
 		padding: 0 24px;

--- a/client/reader/discover/discover-navigation.scss
+++ b/client/reader/discover/discover-navigation.scss
@@ -1,7 +1,18 @@
-.is-section-reader .navigation-header.discover-stream-header {
-	margin: 0 auto;
+.is-section-reader {
+	.navigation-header.discover-stream-header {
+		margin: 0 auto;
+		padding: 0 16px 24px;
 
-	&.reader-dual-column {
-		max-width: 968px; // Max width of dual column reader stream.
+		@media only screen and ( min-width: 660px ) {
+			padding: 0 0 24px 0;
+		}
+
+		&.reader-dual-column {
+			max-width: 968px; // Max width of dual column reader stream.
+		}
+	}
+	.discover-stream-navigation {
+		padding: 0;
+		margin-bottom: 0;
 	}
 }

--- a/client/reader/discover/discover-navigation.scss
+++ b/client/reader/discover/discover-navigation.scss
@@ -1,10 +1,10 @@
 .is-section-reader {
 	.navigation-header.discover-stream-header {
 		margin: 0 auto;
-		padding: 0 16px 24px;
+		padding: 0 0 24px 0;
 
-		@media only screen and ( min-width: 660px ) {
-			padding: 0 0 24px 0;
+		@media only screen and ( max-width: 660px ) {
+			padding: 0 16px 24px;
 		}
 
 		&.reader-dual-column {

--- a/client/reader/discover/discover-navigation.scss
+++ b/client/reader/discover/discover-navigation.scss
@@ -1,6 +1,6 @@
 .is-section-reader .navigation-header.discover-stream-header {
 	margin: 0 auto;
-	max-width: 600px;
+
 	&.reader-dual-column {
 		max-width: 968px; // Max width of dual column reader stream.
 	}

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -117,21 +117,6 @@ body.is-section-reader {
 			height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
 		}
 	}
-
-	.is-discover-stream {
-		header.navigation-header.discover-stream-header {
-			padding: 0;
-			@media only screen and (max-width: 600px) {
-				padding: 0 24px;
-			}
-		}
-		@media only screen and (max-width: 660px) {
-			.discover-stream-navigation {
-				margin-left: 0;
-				margin-right: 0;
-			}
-		}
-	}
 }
 
 .is-section-reader {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #98432

## Proposed Changes

* Remove unnecessary max-width on discover feed header components

| Before | After |
|-|-|
| <img width="1133" alt="image" src="https://github.com/user-attachments/assets/7d453c6a-b12e-41c0-b595-13eb9015d335" /> | <img width="1133" alt="image" src="https://github.com/user-attachments/assets/5f40d916-28ad-44d1-a6d5-4eeeb62a5677" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The discover feed had some old styles that no longer apply and were causing an inconsistent header width

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/discover` (authenticated and unauthenticated)
* Check for any regressions for the header of the tag selection
* Check various breakpoints
* Compare discover header to other feed headers (recent, likes, conversations, etc.)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
