### PR TITLE
Make custom domain callout in "Change your site address" modal appear more link-like.

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -462,9 +462,11 @@ export class SiteAddressChanger extends Component {
 					) }
 					{ ! hasNonWpcomDomains && (
 						<div className="site-address-changer__info-custom-domain">
-							<a href={ addDomainPath } onClick={ this.handleAddDomainClick }>
-								{ translate( 'Did you want to add a custom domain instead?' ) }
-							</a>
+							{ translate( 'Did you want to {{a}}add a custom domain{{/a}} instead?', {
+								components: {
+									a: <a href={ addDomainPath } onClick={ this.handleAddDomainClick } />,
+								},
+							} ) }
 						</div>
 					) }
 				</div>

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -84,7 +84,7 @@
 		}
 	}
 
-	.site-address-changer__info-custom-domain a {
+	.site-address-changer__info-custom-domain {
 		margin-top: 10px;
 		font-size: 0.875rem;
 		color: $gray-60;


### PR DESCRIPTION
Fixes #98717

## Proposed Changes

This PR updates `Did you want to add a custom domain?` in the "Change your site address" modal to appear visually as a link and to only link the action specific to the outcome of clicking the link. When a user clicks on the link, it goes into the domain search.


## Screenshots

| Before | After |
|--------|--------|
| <img width="782" alt="Screenshot 2025-01-22 at 10 09 58 AM" src="https://github.com/user-attachments/assets/2acab7f0-3e37-40aa-a42a-54174504a73b" /> | <img width="763" alt="Screenshot 2025-01-22 at 11 04 14 AM" src="https://github.com/user-attachments/assets/3c693a01-8e5f-46a8-b446-5aacb76a8826" /> | 




## Why are these changes being made?

* It doesn't appear like a link.
* Linked questions typically navigate to documentation but this goes to the domain search.

## Testing Instructions

With an account that doesn't have a domain.

* Go to `domains/manage/{site}`
* Click three dots in "Action" column
* Verify that the link matches the Screenshots above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
