### PR TITLE
Implement beforeunload handler in dotcom electron app

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -26,6 +26,7 @@ export DEBUG='*'
 
 For a quicker and more efficient development experience, the application can be run in "development mode", which executes the application code directly (i.e. without building the app). This development mode can be ran against production WordPress.com webapp, or a local instance of Calypso.
 
+- First, create your config file with `yarn run build:config`
 - Use `yarn run dev` to run development mode and load production WordPress.com, _OR_
 - Boot Calpyso from the root of the Calypso repository with `yarn start`. Once Calypso is ready, the desktop app can be booted with `yarn run dev:localhost` to load the local instance of Calypso.
 

--- a/desktop/app/mainWindow/index.js
+++ b/desktop/app/mainWindow/index.js
@@ -166,6 +166,7 @@ function showAppWindow() {
 	require( '../window-handlers/spellcheck' )( appWindow );
 	require( '../window-handlers/navigation' )( appWindow );
 	require( '../window-handlers/clipboard' )( appWindow );
+	require( '../window-handlers/unsaved-changes' )( appWindow );
 
 	platform.setMainWindow( appWindow );
 

--- a/desktop/app/window-handlers/unsaved-changes/index.js
+++ b/desktop/app/window-handlers/unsaved-changes/index.js
@@ -1,0 +1,25 @@
+const { dialog } = require( 'electron' );
+
+/**
+ * Handles client responses to the beforeunload event. Electron doesn't have a default implementation
+ * like browsers do, so we need to provide our own.
+ */
+module.exports = function ( { view, window } ) {
+	view.webContents.on( 'will-prevent-unload', ( event ) => {
+		const choice = dialog.showMessageBoxSync( window, {
+			type: 'question',
+			buttons: [ 'Stay', 'Leave' ],
+			defaultId: 1,
+			cancelId: 0,
+			title: 'WordPress.com',
+			// The beforeunload handler can set a custom message
+			// e.g. https://github.com/WordPress/gutenberg/blob/4b60f9ececa96ba51d9cae4d6d7a9a1311d8b9d8/packages/editor/src/components/unsaved-changes-warning/index.js#L34
+			// Unfortunately Electron doesn't give us access to that value.
+			message: 'You have unsaved changes. If you proceed, they will be lost.',
+		} );
+		if ( choice === 1 ) {
+			// preventDefault() ignores the beforeunload event handler and allow the page to be unloaded.
+			event.preventDefault();
+		}
+	} );
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #85368, the user is unable to leave the editor when there are unsaved changes

https://github.com/Automattic/wp-calypso/assets/13706336/5086d4d1-594e-44b4-95fb-2405d22e8073

## Proposed Changes

* Implements the `beforeunload` handler in the WordPress.com electron app.

I suspect we started relying on the `beforeunload` event when we unwrapped the editor from the iframe. Previously there was some custom iframe logic. So I think that's how this issue will have been introduced.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Unlike browsers, Electron doesn't have a default implementation for `beforeunload` which allows the webpage to cancel the navigation from happening. Gutenberg uses this event to prevent losing changes, but unfortunately it's assuming a choice will be shown to the user. Since it isn't, it's just blocks the user from leaving the editor.

The browser implementations for the confirmation dialog look like this:

Safari
![CleanShot 2025-01-22 at 15 05 32@2x](https://github.com/user-attachments/assets/94a59ba4-7992-4cdf-8f23-d7d55a245001)

Firefox
![CleanShot 2025-01-22 at 15 03 28@2x](https://github.com/user-attachments/assets/8692cc5c-59dd-471d-86ce-32dca496d481)

Chrome
![CleanShot 2025-01-22 at 15 04 56@2x](https://github.com/user-attachments/assets/f8e84e15-59ca-44c6-85fe-9769194ff29a)

This is the dialog I've added in the desktop app. The icon is wrong, but that should be fixed up by a release build of the app. Also note that we're able to do a bit better than the browser and provide better labels for the buttons.

![CleanShot 2025-01-22 at 15 16 14@2x](https://github.com/user-attachments/assets/cfc0f0db-762d-47ae-9297-bb9c7a6eb9bc)

Also note, that as far as I can tell there's no localisation in the desktop app, it's English only.




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Check here for instructions building the app
https://github.com/Automattic/wp-calypso/blob/dd91d6f096144bffafc045437ade3dcf4bf44b58/desktop/README.md#L29-L30

- Test the post/page/site editors warn the user about unsaved changes before leaving
- Test that making changes and saving them means you don't see the dialog when leaving
- Test that pressing Escape dismisses the dialog and Enter continues leaving the editor

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
