### PR TITLE
Cookie notice: Update instance of legacy blue.

### DIFF
--- a/packages/privacy-toolset/src/cookie-banner/styles.scss
+++ b/packages/privacy-toolset/src/cookie-banner/styles.scss
@@ -10,7 +10,7 @@ $horizontal-padding: 20px;
 $cookie-banner-bg-color: #fff;
 $cookie-banner-text-color: #000;
 $cookie-banner-text-muted-color: #000;
-$cookie-banner-link-color: #117ac9;
+$cookie-banner-link-color: #3858e9;
 
 // Buttons
 $cookie-banner-main-button-color: $cookie-banner-link-color;


### PR DESCRIPTION
Related to #10286

## Proposed Changes

Updates the legacy blue color of the cookie notice, to the default WordPress.com blue (blueberry)

Before:

![image](https://github.com/user-attachments/assets/3baa1939-841c-4e80-b701-be8ed8a77727)

After:

![Screenshot 2025-01-22 at 12 24 49](https://github.com/user-attachments/assets/4a213bd9-b6c3-4fd8-8423-92960d80a5ff)

![Screenshot 2025-01-22 at 12 24 57](https://github.com/user-attachments/assets/7251e28e-715e-4500-a5ed-3ca5153d6e39)


## Why are these changes being made?

The old blue is legacy, deprecated.

## Testing Instructions

**Note:** I wasn't actually able to test this locally, as I did not find a way to get the cookie notice to reappear, even in an incognito browser. If you have a way to test, please verify the screenshots match what you see. Though since it's a simple color change, I pushed the PR regardless.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
