### PR TITLE
Update hardcoded blue color values to match Studio counterparts

### DIFF
--- a/client/blocks/reader-join-conversation/style.scss
+++ b/client/blocks/reader-join-conversation/style.scss
@@ -34,20 +34,20 @@
 	}
 
 	button.components-button.is-primary {
-		background-color: #117ac9;
-		border-color: #117ac9;
+		background-color: var(--studio-blue-50);
+		border-color: var(--studio-blue-50);
 
 		&:active:not(:disabled),
 		&:hover:not(:disabled),
 		&:focus:not(:disabled) {
-			background-color: #0e64a5;
-			border-color: #0e64a5;
+			background-color: var(--studio-blue-60);
+			border-color: var(--studio-blue-60);
 		}
 	}
 
 	button.components-button.is-link {
 		padding: 20px 0 6px 0;
-		color: #1d2333;
+		color: var(--studio-blue-90);
 
 		&:hover:not(:disabled) {
 			color: var(--studio-blue-50);

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -238,8 +238,8 @@ button {
 
 .is-section-stepper {
 	.search-filters__popover {
-		--color-accent: #117ac9 !important;
-		--color-accent-60: #0e64a5 !important;
+		--color-accent: var(--studio-blue-50) !important;
+		--color-accent-60: var(--studio-blue-60) !important;
 	}
 }
 

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -73,8 +73,8 @@ const EducationFooterContainer = styled.div`
 `;
 
 const MarketplaceContainer = styled.div< { isloggedIn: boolean } >`
-	--color-accent: #117ac9;
-	--color-accent-60: #0e64a5;
+	--color-accent: var( --studio-blue-50 );
+	--color-accent-60: var( --studio-blue-60 );
 	margin-bottom: -32px;
 
 	.marketplace-cta {

--- a/client/signup/steps/website-content/dialogs.tsx
+++ b/client/signup/steps/website-content/dialogs.tsx
@@ -21,8 +21,8 @@ const DialogButton = styled( Button )`
 	box-shadow: 0px 1px 2px rgba( 0, 0, 0, 0.05 );
 	border-radius: 5px;
 	padding: ${ ( props ) => ( props.primary ? '10px 64px' : '10px 32px' ) };
-	--color-accent: #117ac9;
-	--color-accent-60: #0e64a5;
+	--color-accent: var( --studio-blue-50 );
+	--color-accent-60: var( --studio-blue-60 );
 	.gridicon {
 		margin-left: 10px;
 	}

--- a/client/sites-dashboard/components/sites-site-coming-soon.tsx
+++ b/client/sites-dashboard/components/sites-site-coming-soon.tsx
@@ -13,7 +13,7 @@ const Root = styled.div( {
 	display: 'flex',
 	alignItems: 'center',
 	justifyContent: 'center',
-	backgroundColor: '#117ac9',
+	backgroundColor: 'var(--studio-blue-50)',
 	borderRadius: 4,
 	boxSizing: 'border-box',
 	border: '1px solid rgb(238, 238, 238)',

--- a/packages/onboarding/src/confetti/index.tsx
+++ b/packages/onboarding/src/confetti/index.tsx
@@ -62,7 +62,7 @@ const Index: React.FunctionComponent< { className?: string } > = ( { className }
 			height="15"
 			rx="2.386"
 			transform="rotate(-32 97 2.53)"
-			fill="#117AC9"
+			fill="var(--studio-blue-50)"
 		/>
 		<Rect
 			x="323.638"

--- a/packages/onboarding/styles/variables.scss
+++ b/packages/onboarding/styles/variables.scss
@@ -22,5 +22,5 @@ $onboarding-body-margin-medium: 0 0 80px 0;
 // @TODO: refactor to common variable in onboarding
 // see https://github.com/Automattic/wp-calypso/issues/47181
 // the blue accent this is used as the primary color in focused-launch
-$onboarding-accent-blue: #117ac9;
-$onboarding-accent-blue-background: #fafcfe;
+$onboarding-accent-blue: var(--studio-blue-50);
+$onboarding-accent-blue-background: var(--studio-blue-0);

--- a/packages/privacy-toolset/src/cookie-banner/styles.scss
+++ b/packages/privacy-toolset/src/cookie-banner/styles.scss
@@ -10,7 +10,7 @@ $horizontal-padding: 20px;
 $cookie-banner-bg-color: #fff;
 $cookie-banner-text-color: #000;
 $cookie-banner-text-muted-color: #000;
-$cookie-banner-link-color: #117ac9;
+$cookie-banner-link-color: var(--studio-blue-50);
 
 // Buttons
 $cookie-banner-main-button-color: $cookie-banner-link-color;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/10307#issuecomment-2607061431, alternative to https://github.com/Automattic/wp-calypso/pull/98730

## Proposed Changes

This PR scoured the codebase looking for instances of hard-coded legacy blue colors, and updates them to Blue 50 from [Color Studio](https://color-studio.blog).

This work will later benefit from https://github.com/Automattic/color-studio/pull/764, which updates the values of Blue 50 to match Blueberry.

## Why are these changes being made?

Blueberry is the official WordPress.com accent color, the legacy blue is deprecated.

## Testing Instructions

Test the contexts referenced from the list of changed files. That includes the logged out Reader, available at wordpress.com/read in an incognito window. It also includes the cookie notice, and an onboarding stepper.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
