### PR TITLE
Domain management: Point "Add Site", "Manage DNS" and "Manage contact information" links to the old screens when feature flag is off

### DIFF
--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -448,7 +448,7 @@ describe( 'site linking ctas', () => {
 			expect( createLink ).toBeInTheDocument();
 			expect( createLink ).toHaveAttribute(
 				'href',
-				'/domains/manage/all/overview/primary-domain.blog/transfer/other-site/primarydomainblog.wordpress.com'
+				'/domains/manage/all/primary-domain.blog/transfer/other-site/primarydomainblog.wordpress.com'
 			);
 		} );
 
@@ -463,7 +463,7 @@ describe( 'site linking ctas', () => {
 			// The link itself is wrapped with a span element.
 			expect( connectAction.closest( '[role=menuitem]' ) ).toHaveAttribute(
 				'href',
-				'/domains/manage/all/overview/primary-domain.blog/transfer/other-site/primarydomainblog.wordpress.com'
+				'/domains/manage/all/primary-domain.blog/transfer/other-site/primarydomainblog.wordpress.com'
 			);
 		} );
 	} );

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -122,14 +122,16 @@ export function domainManagementEditContactInfo(
 	relativeTo: string | null = null,
 	context?: DomainsTableContext
 ) {
-	switch ( context ) {
-		case 'site':
-			return `/overview/site-domain/contact-info/edit/${ domainName }/${ siteName }`;
-		case 'domains':
-			return `${ domainManagementAllRoot() }/contact-info/edit/${ domainName }/${ siteName }`;
-		default:
-			return domainManagementEditBase( siteName, domainName, 'edit-contact-info', relativeTo );
+	if ( config.isEnabled( 'calypso/all-domain-management' ) ) {
+		switch ( context ) {
+			case 'site':
+				return `/overview/site-domain/contact-info/edit/${ domainName }/${ siteName }`;
+			case 'domains':
+				return `${ domainManagementAllRoot() }/contact-info/edit/${ domainName }/${ siteName }`;
+		}
 	}
+
+	return domainManagementEditBase( siteName, domainName, 'edit-contact-info', relativeTo );
 }
 
 export function domainMappingSetup(

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -206,14 +206,16 @@ export function domainManagementDNS(
 	domainName: string,
 	context?: DomainsTableContext
 ) {
-	switch ( context ) {
-		case 'site':
-			return `/overview/site-domain/domain/${ domainName }/dns/${ siteName }`;
-		case 'domains':
-			return `${ domainManagementAllRoot() }/overview/${ domainName }/dns/${ siteName }`;
-		default:
-			return domainManagementEditBase( siteName, domainName, 'dns' );
+	if ( config.isEnabled( 'calypso/all-domain-management' ) ) {
+		switch ( context ) {
+			case 'site':
+				return `/overview/site-domain/domain/${ domainName }/dns/${ siteName }`;
+			case 'domains':
+				return `${ domainManagementAllRoot() }/overview/${ domainName }/dns/${ siteName }`;
+		}
 	}
+
+	return domainManagementEditBase( siteName, domainName, 'dns' );
 }
 
 export function emailManagementEdit(

--- a/packages/domains-table/src/utils/paths.ts
+++ b/packages/domains-table/src/utils/paths.ts
@@ -45,7 +45,9 @@ export function domainManagementLink(
 }
 
 export function domainManagementTransferToOtherSiteLink( siteSlug: string, domainName: string ) {
-	return `${ domainManagementAllRoot() }/overview/${ domainName }/transfer/other-site/${ siteSlug }`;
+	return config.isEnabled( 'calypso/all-domain-management' )
+		? `${ domainManagementAllRoot() }/overview/${ domainName }/transfer/other-site/${ siteSlug }`
+		: `${ domainManagementAllRoot() }/${ domainName }/transfer/other-site/${ siteSlug }`;
 }
 
 function domainManagementViewSlug( type: ResponseDomain[ 'type' ] ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/98733

## Proposed Changes

* Update the "Add Site", "Manage DNS" and "Manage contact information" links to point to the old un-revamped screens when the `calypso/all-domain-management` feature flag is off.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of the domain management revamp project. More context can be found in [this comment](https://github.com/Automattic/wp-calypso/pull/98674#discussion_r1925243633).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the `calypso/all-domain-management` feature flag is off.
* Go to http://calypso.localhost:3000/domains/manage and test the "Add Site", "Manage DNS" and "Manage contact information" links. They should point to the old un-revamped screens.
* If you don't see the "Add Site" link, make sure you have a domain that is not connected to a site. If you don't have one, go through http://calypso.localhost:3000/start/domain/domain-only.
* Turn on the `calypso/all-domain-management` feature flag.
* Go to http://calypso.localhost:3000/domains/manage and test the "Add Site", "Manage DNS" and "Manage contact information" links. They should point to the new revamped screens.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
