### PR TITLE
Contextual help: log site intent via debug instead of a warning

### DIFF
--- a/packages/data-stores/src/contextual-help/contextual-help.tsx
+++ b/packages/data-stores/src/contextual-help/contextual-help.tsx
@@ -1,5 +1,8 @@
 import { __ } from '@wordpress/i18n';
+import debugFactory from 'debug';
 import { RESULT_TOUR, RESULT_VIDEO } from './constants';
+
+const debug = debugFactory( 'calypso:data-stores:contextual-help' );
 
 export type LinksForSection = {
 	readonly link: string;
@@ -611,8 +614,7 @@ export function getContextResults( section: string, siteIntent: string ) {
 	}
 
 	if ( siteIntent ) {
-		// eslint-disable-next-line no-console
-		console.warn( 'Site intent is', siteIntent );
+		debug( `Site intent: ${ siteIntent }` );
 	}
 
 	// make sure editorially to show at most one tour and one video at once


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/76734#discussion_r1922684752

## Proposed Changes

* Transform a warning into a debug message when logging the site intent in the contextual help widget

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Keep the browser console less clogged, don't use `console.warn` for something that is not a warning

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Open `/overview/{site-slug}`
* Open the help widget by clicking on the "?" icon in the top masterbar
* Notice that no "Site intent is" warning is logged
* Enable debugging by running `localStorage.setItem( 'debug', 'calypso:data-stores:contextual-help' );`
* Reload the page, and open the help widget again
* Notice the debug message about the site intent is now showing

| Before (trunk) | After (this PR) |
|---|---|
| ![Screenshot 2025-01-22 at 15 24 32](https://github.com/user-attachments/assets/db8967d2-774d-4ec5-bf2a-64e77d72a95b) | ![Screenshot 2025-01-22 at 15 13 16](https://github.com/user-attachments/assets/e1480e27-9e81-4624-ace9-1815ae6e25d2) |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
