### PR TITLE
A4A: Remove 'browse plugins' button from Plugins section

### DIFF
--- a/client/my-sites/plugins/plugins-dashboard/index.tsx
+++ b/client/my-sites/plugins/plugins-dashboard/index.tsx
@@ -18,6 +18,7 @@ import LayoutHeader, {
 	LayoutHeaderSubtitle as Subtitle,
 } from 'calypso/layout/hosting-dashboard/header';
 import LayoutTop from 'calypso/layout/hosting-dashboard/top';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import UrlSearch from 'calypso/lib/url-search';
@@ -151,7 +152,10 @@ const PluginsDashboard = ( {
 	const sitesWithoutPluginAvailable = sitesToShow.filter(
 		( site ) =>
 			! sitesWithPlugin.find( ( siteWithPlugin ) => siteWithPlugin?.ID === site?.ID ) &&
-			! ( isJetpackCloud() && hasMarketplaceProduct( productsList, pluginSlug ) )
+			! (
+				( isJetpackCloud() || isA8CForAgencies() ) &&
+				hasMarketplaceProduct( productsList, pluginSlug )
+			)
 	);
 
 	const doActionOverSelected = (
@@ -335,7 +339,9 @@ const PluginsDashboard = ( {
 			wide
 			title={ dashboardTitle }
 			sidebarNavigation={
-				isJetpackCloud() && <SidebarNavigation sectionTitle={ translate( 'Manage Plugins' ) } />
+				( isJetpackCloud() || isA8CForAgencies() ) && (
+					<SidebarNavigation sectionTitle={ translate( 'Manage Plugins' ) } />
+				)
 			}
 		>
 			<PageViewTracker
@@ -352,7 +358,7 @@ const PluginsDashboard = ( {
 						{ ! pluginSlug && (
 							<Subtitle>{ translate( 'Manage all your plugins in one place' ) }</Subtitle>
 						) }
-						{ ! pluginSlug && ! isJetpackCloud() && (
+						{ ! pluginSlug && ! ( isJetpackCloud() || isA8CForAgencies() ) && (
 							<Actions>
 								<Button href="/plugins">{ translate( 'Browse plugins' ) }</Button>
 							</Actions>

--- a/client/my-sites/plugins/plugins-dashboard/index.tsx
+++ b/client/my-sites/plugins/plugins-dashboard/index.tsx
@@ -107,6 +107,7 @@ const PluginsDashboard = ( {
 }: PluginsDashboardProps ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const isJetpackCloudOrA8CForAgencies = isJetpackCloud() || isA8CForAgencies();
 	const allSites = useSelector( ( state ) => getSelectedOrAllSites( state ) );
 	const sites = useSelector( ( state ) => getSelectedOrAllSitesWithPlugins( state ) );
 	const siteIds = siteObjectsToSiteIds( sites ) ?? [];
@@ -152,10 +153,7 @@ const PluginsDashboard = ( {
 	const sitesWithoutPluginAvailable = sitesToShow.filter(
 		( site ) =>
 			! sitesWithPlugin.find( ( siteWithPlugin ) => siteWithPlugin?.ID === site?.ID ) &&
-			! (
-				( isJetpackCloud() || isA8CForAgencies() ) &&
-				hasMarketplaceProduct( productsList, pluginSlug )
-			)
+			! ( isJetpackCloudOrA8CForAgencies && hasMarketplaceProduct( productsList, pluginSlug ) )
 	);
 
 	const doActionOverSelected = (
@@ -339,7 +337,7 @@ const PluginsDashboard = ( {
 			wide
 			title={ dashboardTitle }
 			sidebarNavigation={
-				( isJetpackCloud() || isA8CForAgencies() ) && (
+				isJetpackCloudOrA8CForAgencies && (
 					<SidebarNavigation sectionTitle={ translate( 'Manage Plugins' ) } />
 				)
 			}
@@ -358,7 +356,7 @@ const PluginsDashboard = ( {
 						{ ! pluginSlug && (
 							<Subtitle>{ translate( 'Manage all your plugins in one place' ) }</Subtitle>
 						) }
-						{ ! pluginSlug && ! ( isJetpackCloud() || isA8CForAgencies() ) && (
+						{ ! pluginSlug && ! isJetpackCloudOrA8CForAgencies && (
 							<Actions>
 								<Button href="/plugins">{ translate( 'Browse plugins' ) }</Button>
 							</Actions>


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1684

## Proposed Changes

* Remove the "Browse Plugins" button at the top of the Plugins Management page. This button is intended to redirect to the plugins directory, which is not applicable to the A4A dashboard.

## Testing Instructions

* Open the live link
* Go to Plugins in the main navigation button.
* Confirm that you don't see the "Browse Plugins" button in the header

![image](https://github.com/user-attachments/assets/706af30c-602a-4ecc-a885-866a6e388260)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
