### PR TITLE
Stale bot: trigger stale issues a bit earlier

### DIFF
--- a/.github/workflows/mark-issue-stale.yml
+++ b/.github/workflows/mark-issue-stale.yml
@@ -15,9 +15,9 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # Message to be added to stale issues.
-          stale-issue-message: 'This issue is stale because 720 days have passed with no activity. A member of the Dotcom Product Ambassadors Guild will review and if required close this issue within 7 days. If you disagree and would like this issue to remain open, please provide additional context, updated reproduction steps and/or screenshots.'
+          stale-issue-message: 'This issue is stale because 540 days have passed with no activity. A member of the Dotcom Product Ambassadors Guild will review and if required close this issue within 7 days. If you disagree and would like this issue to remain open, please provide additional context, updated reproduction steps and/or screenshots.'
           # Days before issue is considered stale.
-          days-before-issue-stale: 720
+          days-before-issue-stale: 540
           # Override stale setting for PRs.
           days-before-pr-stale: -1
           # Exempted issue labels.


### PR DESCRIPTION
## Proposed Changes

We'll gradually try to address stale issues faster. Let's move from 720 days to 540 days for now, and then we'll reduce it again until we can get to 180.

## Why are these changes being made?

In #78455, we had bumped the number of days before a stale label is applied to issues to 720 days.

Internal reference: pdqkMK-14B-p2

Now that we're working on improving our triaging methods, we'll aim to triage those issues faster. Let's start by bringing that number down to 540 days. We'll work on the issues that are flagged that way, and then bring the numbers down a bit more. 

## Testing Instructions

Not much to test here, the change will be applied when this PR gets merged.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
