### PR TITLE
Enable site specific purchases billing with DataViews

### DIFF
--- a/client/me/purchases/billing-history/billing-history-list-data-view.tsx
+++ b/client/me/purchases/billing-history/billing-history-list-data-view.tsx
@@ -19,10 +19,12 @@ const DEFAULT_LAYOUT = { table: {} };
 
 export interface BillingHistoryListProps {
 	getReceiptUrlFor: ( receiptId: string ) => string;
+	siteId?: number | null;
 }
 
 export default function BillingHistoryListDataView( {
 	getReceiptUrlFor,
+	siteId,
 }: BillingHistoryListProps ) {
 	const transactions = useSelector( getPastBillingTransactions );
 	const isLoading = useSelector( isRequestingBillingTransactions );
@@ -34,7 +36,15 @@ export default function BillingHistoryListDataView( {
 		icon: <Gridicon icon={ action.iconName } />,
 	} ) );
 
-	const filteredTransactions = useTransactionsFiltering( transactions, viewState.view );
+	const siteFilteredTransactions =
+		transactions && siteId
+			? transactions.filter( ( transaction ) =>
+					transaction.items.some( ( item ) => String( item.site_id ) === String( siteId ) )
+			  )
+			: transactions || [];
+
+	const filteredTransactions = useTransactionsFiltering( siteFilteredTransactions, viewState.view );
+
 	const sortedTransactions = useTransactionsSorting( filteredTransactions, viewState.view );
 	const { paginatedItems, totalPages, totalItems } = usePagination(
 		sortedTransactions,

--- a/client/me/purchases/billing-history/billing-history-list-data-view.tsx
+++ b/client/me/purchases/billing-history/billing-history-list-data-view.tsx
@@ -19,7 +19,7 @@ const DEFAULT_LAYOUT = { table: {} };
 
 export interface BillingHistoryListProps {
 	getReceiptUrlFor: ( receiptId: string ) => string;
-	siteId?: number | null;
+	siteId: number | null;
 }
 
 export default function BillingHistoryListDataView( {
@@ -36,14 +36,7 @@ export default function BillingHistoryListDataView( {
 		icon: <Gridicon icon={ action.iconName } />,
 	} ) );
 
-	const siteFilteredTransactions =
-		transactions && siteId
-			? transactions.filter( ( transaction ) =>
-					transaction.items.some( ( item ) => String( item.site_id ) === String( siteId ) )
-			  )
-			: transactions || [];
-
-	const filteredTransactions = useTransactionsFiltering( siteFilteredTransactions, viewState.view );
+	const filteredTransactions = useTransactionsFiltering( transactions, viewState.view, siteId );
 
 	const sortedTransactions = useTransactionsSorting( filteredTransactions, viewState.view );
 	const { paginatedItems, totalPages, totalItems } = usePagination(

--- a/client/me/purchases/billing-history/hooks/use-transactions-filtering.ts
+++ b/client/me/purchases/billing-history/hooks/use-transactions-filtering.ts
@@ -44,14 +44,26 @@ function matchesFilter(
 	return true;
 }
 
+function matchesSiteId( transaction: BillingTransaction, siteId: number | null | undefined ) {
+	if ( ! siteId ) {
+		return true;
+	}
+	return transaction.items.some( ( item ) => String( item.site_id ) === String( siteId ) );
+}
+
 export function useTransactionsFiltering(
 	transactions: BillingTransaction[] | null,
-	view: ViewState
+	view: ViewState,
+	siteId: number | null
 ) {
 	const translate = useTranslate();
 
 	return useMemo( () => {
 		return ( transactions ?? [] ).filter( ( transaction ) => {
+			if ( ! matchesSiteId( transaction, siteId ) ) {
+				return false;
+			}
+
 			if ( view.search && ! matchesSearch( transaction, view.search, translate ) ) {
 				return false;
 			}
@@ -62,5 +74,5 @@ export function useTransactionsFiltering(
 
 			return view.filters.every( ( filter ) => matchesFilter( transaction, filter, translate ) );
 		} );
-	}, [ transactions, view.search, view.filters, translate ] );
+	}, [ transactions, view.search, view.filters, translate, siteId ] );
 }

--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -30,7 +30,7 @@ export function BillingHistoryContent( {
 	return (
 		<Card id="billing-history" className="section-content" tagName="section">
 			{ useDataViewBillingHistoryList ? (
-				<BillingHistoryListDataView getReceiptUrlFor={ getReceiptUrlFor } />
+				<BillingHistoryListDataView siteId={ siteId } getReceiptUrlFor={ getReceiptUrlFor } />
 			) : (
 				<BillingHistoryList header siteId={ siteId } getReceiptUrlFor={ getReceiptUrlFor } />
 			) }

--- a/client/me/purchases/billing-history/test/use-transactions-filtering.test.ts
+++ b/client/me/purchases/billing-history/test/use-transactions-filtering.test.ts
@@ -9,19 +9,23 @@ import { mockTransactions } from '../test-fixtures/billing-transactions';
 describe( 'useTransactionsFiltering', () => {
 	test( 'returns all transactions when no filters are applied', () => {
 		const { result } = renderHook( () =>
-			useTransactionsFiltering( mockTransactions, {
-				search: '',
-				filters: [],
-				type: 'table',
-				page: 0,
-				perPage: 0,
-				sort: {
-					field: 'service',
-					direction: 'asc',
+			useTransactionsFiltering(
+				mockTransactions,
+				{
+					search: '',
+					filters: [],
+					type: 'table',
+					page: 0,
+					perPage: 0,
+					sort: {
+						field: 'service',
+						direction: 'asc',
+					},
+					fields: [],
+					hiddenFields: [],
 				},
-				fields: [],
-				hiddenFields: [],
-			} )
+				null
+			)
 		);
 
 		expect( result.current ).toEqual( mockTransactions );
@@ -29,19 +33,23 @@ describe( 'useTransactionsFiltering', () => {
 
 	test( 'filters transactions by search term matching service', () => {
 		const { result } = renderHook( () =>
-			useTransactionsFiltering( mockTransactions, {
-				search: 'Jetpack',
-				filters: [],
-				type: 'table',
-				page: 0,
-				perPage: 0,
-				sort: {
-					field: 'service',
-					direction: 'asc',
+			useTransactionsFiltering(
+				mockTransactions,
+				{
+					search: 'Jetpack',
+					filters: [],
+					type: 'table',
+					page: 0,
+					perPage: 0,
+					sort: {
+						field: 'service',
+						direction: 'asc',
+					},
+					fields: [],
+					hiddenFields: [],
 				},
-				fields: [],
-				hiddenFields: [],
-			} )
+				null
+			)
 		);
 
 		expect( result.current.length ).toBe( 1 );
@@ -50,25 +58,29 @@ describe( 'useTransactionsFiltering', () => {
 
 	test( 'filters transactions by service type', () => {
 		const { result } = renderHook( () =>
-			useTransactionsFiltering( mockTransactions, {
-				search: '',
-				filters: [
-					{
+			useTransactionsFiltering(
+				mockTransactions,
+				{
+					search: '',
+					filters: [
+						{
+							field: 'service',
+							value: 'Store Services',
+							operator: 'is',
+						},
+					],
+					type: 'table',
+					page: 0,
+					perPage: 0,
+					sort: {
 						field: 'service',
-						value: 'Store Services',
-						operator: 'is',
+						direction: 'asc',
 					},
-				],
-				type: 'table',
-				page: 0,
-				perPage: 0,
-				sort: {
-					field: 'service',
-					direction: 'asc',
+					fields: [],
+					hiddenFields: [],
 				},
-				fields: [],
-				hiddenFields: [],
-			} )
+				null
+			)
 		);
 
 		expect( result.current.length ).toBe( 1 );
@@ -77,25 +89,29 @@ describe( 'useTransactionsFiltering', () => {
 
 	test( 'filters transactions by purchase type', () => {
 		const { result } = renderHook( () =>
-			useTransactionsFiltering( mockTransactions, {
-				search: '',
-				filters: [
-					{
-						field: 'type',
-						value: 'renewal',
-						operator: 'is',
+			useTransactionsFiltering(
+				mockTransactions,
+				{
+					search: '',
+					filters: [
+						{
+							field: 'type',
+							value: 'renewal',
+							operator: 'is',
+						},
+					],
+					type: 'table',
+					page: 0,
+					perPage: 0,
+					sort: {
+						field: 'service',
+						direction: 'asc',
 					},
-				],
-				type: 'table',
-				page: 0,
-				perPage: 0,
-				sort: {
-					field: 'service',
-					direction: 'asc',
+					fields: [],
+					hiddenFields: [],
 				},
-				fields: [],
-				hiddenFields: [],
-			} )
+				null
+			)
 		);
 
 		expect( result.current.length ).toBe( 1 );
@@ -104,25 +120,29 @@ describe( 'useTransactionsFiltering', () => {
 
 	test( 'filters transactions by date', () => {
 		const { result } = renderHook( () =>
-			useTransactionsFiltering( mockTransactions, {
-				search: '',
-				filters: [
-					{
-						field: 'date',
-						value: '2023-02',
-						operator: 'is',
+			useTransactionsFiltering(
+				mockTransactions,
+				{
+					search: '',
+					filters: [
+						{
+							field: 'date',
+							value: '2023-02',
+							operator: 'is',
+						},
+					],
+					type: 'table',
+					page: 0,
+					perPage: 0,
+					sort: {
+						field: 'service',
+						direction: 'asc',
 					},
-				],
-				type: 'table',
-				page: 0,
-				perPage: 0,
-				sort: {
-					field: 'service',
-					direction: 'asc',
+					fields: [],
+					hiddenFields: [],
 				},
-				fields: [],
-				hiddenFields: [],
-			} )
+				null
+			)
 		);
 
 		expect( result.current.length ).toBe( 1 );
@@ -131,35 +151,39 @@ describe( 'useTransactionsFiltering', () => {
 
 	test( 'combines multiple filters', () => {
 		const { result } = renderHook( () =>
-			useTransactionsFiltering( mockTransactions, {
-				search: '',
-				filters: [
-					{
+			useTransactionsFiltering(
+				mockTransactions,
+				{
+					search: '',
+					filters: [
+						{
+							field: 'service',
+							value: 'WordPress.com',
+							operator: 'is',
+						},
+						{
+							field: 'type',
+							value: 'new purchase',
+							operator: 'is',
+						},
+						{
+							field: 'date',
+							value: '2023-01',
+							operator: 'is',
+						},
+					],
+					type: 'table',
+					page: 0,
+					perPage: 0,
+					sort: {
 						field: 'service',
-						value: 'WordPress.com',
-						operator: 'is',
+						direction: 'asc',
 					},
-					{
-						field: 'type',
-						value: 'new purchase',
-						operator: 'is',
-					},
-					{
-						field: 'date',
-						value: '2023-01',
-						operator: 'is',
-					},
-				],
-				type: 'table',
-				page: 0,
-				perPage: 0,
-				sort: {
-					field: 'service',
-					direction: 'asc',
+					fields: [],
+					hiddenFields: [],
 				},
-				fields: [],
-				hiddenFields: [],
-			} )
+				null
+			)
 		);
 
 		expect( result.current.length ).toBe( 1 );
@@ -170,19 +194,23 @@ describe( 'useTransactionsFiltering', () => {
 
 	test( 'handles null transactions array', () => {
 		const { result } = renderHook( () =>
-			useTransactionsFiltering( null, {
-				search: 'test',
-				filters: [],
-				type: 'table',
-				page: 0,
-				perPage: 0,
-				sort: {
-					field: 'service',
-					direction: 'asc',
+			useTransactionsFiltering(
+				null,
+				{
+					search: 'test',
+					filters: [],
+					type: 'table',
+					page: 0,
+					perPage: 0,
+					sort: {
+						field: 'service',
+						direction: 'asc',
+					},
+					fields: [],
+					hiddenFields: [],
 				},
-				fields: [],
-				hiddenFields: [],
-			} )
+				null
+			)
 		);
 
 		expect( result.current ).toEqual( [] );
@@ -190,19 +218,23 @@ describe( 'useTransactionsFiltering', () => {
 
 	test( 'search is case insensitive', () => {
 		const { result } = renderHook( () =>
-			useTransactionsFiltering( mockTransactions, {
-				search: 'jetpack',
-				filters: [],
-				type: 'table',
-				page: 0,
-				perPage: 0,
-				sort: {
-					field: 'service',
-					direction: 'asc',
+			useTransactionsFiltering(
+				mockTransactions,
+				{
+					search: 'jetpack',
+					filters: [],
+					type: 'table',
+					page: 0,
+					perPage: 0,
+					sort: {
+						field: 'service',
+						direction: 'asc',
+					},
+					fields: [],
+					hiddenFields: [],
 				},
-				fields: [],
-				hiddenFields: [],
-			} )
+				null
+			)
 		);
 
 		expect( result.current.length ).toBe( 1 );
@@ -211,22 +243,74 @@ describe( 'useTransactionsFiltering', () => {
 
 	test( 'search matches partial strings', () => {
 		const { result } = renderHook( () =>
-			useTransactionsFiltering( mockTransactions, {
-				search: 'jet',
-				filters: [],
-				type: 'table',
-				page: 0,
-				perPage: 0,
-				sort: {
-					field: 'service',
-					direction: 'asc',
+			useTransactionsFiltering(
+				mockTransactions,
+				{
+					search: 'jet',
+					filters: [],
+					type: 'table',
+					page: 0,
+					perPage: 0,
+					sort: {
+						field: 'service',
+						direction: 'asc',
+					},
+					fields: [],
+					hiddenFields: [],
 				},
-				fields: [],
-				hiddenFields: [],
-			} )
+				null
+			)
 		);
 
 		expect( result.current.length ).toBe( 1 );
 		expect( result.current[ 0 ].service ).toBe( 'Jetpack' );
+	} );
+
+	describe( 'site filtering', () => {
+		test( 'filters transactions by siteId', () => {
+			const { result } = renderHook( () =>
+				useTransactionsFiltering(
+					mockTransactions,
+					{
+						search: '',
+						filters: [],
+						type: 'table',
+						page: 0,
+						perPage: 0,
+						sort: { field: 'service', direction: 'asc' },
+						fields: [],
+						hiddenFields: [],
+					},
+					123 // assuming this siteId exists in mockTransactions
+				)
+			);
+
+			result.current.forEach( ( transaction ) => {
+				expect( transaction.items.some( ( item ) => String( item.site_id ) === '123' ) ).toBe(
+					true
+				);
+			} );
+		} );
+
+		test( 'returns all transactions when siteId is null', () => {
+			const { result } = renderHook( () =>
+				useTransactionsFiltering(
+					mockTransactions,
+					{
+						search: '',
+						filters: [],
+						type: 'table',
+						page: 0,
+						perPage: 0,
+						sort: { field: 'service', direction: 'asc' },
+						fields: [],
+						hiddenFields: [],
+					},
+					null
+				)
+			);
+
+			expect( result.current ).toEqual( mockTransactions );
+		} );
 	} );
 } );


### PR DESCRIPTION
Related to https://github.com/Automattic/payments-florin/issues/752

## Proposed Changes

This PR will pass the `siteId` param to `BillingHistoryListDataView` so that it can be used to filter transactions by the site ID.  It adds a new function, `matchesSiteId`, to the filtering hook which is used to first filter the list by site ID if it's provided.  This allows additional searching/filtering to be applied to the already filtered list.  It also includes some additional automated tests.

## Why are these changes being made?
While working on https://github.com/Automattic/wp-calypso/pull/98606, I discovered that site specific filtering used in `wordpress.com/purchases/<site>` was no longer working.  That's because the siteId was not passed into `BillingHistoryListDataView` and used to filter the transactions as it is with `BillingHistoryList`.  When I viewed the site-specific purchases, all transactions were shown which doesn't make sense given its context.  


## Testing Instructions

1. Visit `https://wpcalypso.wordpress.com/purchases/billing-history/<site>` and observe how all transactions are returned and not just the ones related to the site being viewed.
2. Checkout this branch and then visit `http://calypso.localhost:3000/purchases/billing-history/<site>`. This should show a list of transactions related to this site and not all transactions.
3. Try sorting, filtering, searching the site-specific list to ensure it works as expected.
4. Also open `http://calypso.localhost:3000/me/purchases/billing-history` and ensure that all transactions are visible here.
5. Try filtering, sorting, searching this list and make sure it works too.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
