### PR TITLE
Onboarding: Add subheading text when entering the account step from DIFM and Import flows

### DIFF
--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -171,8 +171,8 @@ body.is-section-accept-invite {
 				font-style: normal;
 				font-weight: 400;
 				line-height: 18px;
-				margin-top: 24px;
-				margin-bottom: 12px;
+				margin-top: 3rem;
+				margin-bottom: 0;
 
 				a {
 					color: var(--studio-gray-50, #646970);
@@ -181,7 +181,6 @@ body.is-section-accept-invite {
 			}
 
 			.signup-form-social-first__tos-link {
-				margin-top: 32px;
 				text-align: center;
 			}
 		}

--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -113,7 +113,6 @@
 	@include breakpoint-deprecated( ">660px" ) {
 		font-size: $font-title-medium;
 		padding: 0;
-		margin: 0 0 5px;
 	}
 
 	.is-left-align &,
@@ -127,6 +126,7 @@
 	color: var(--color-neutral-50);
 	font-size: $font-body-small;
 	padding: 0 20px 24px;
+	margin-top: 8px;
 
 	@include breakpoint-deprecated( ">480px" ) {
 		padding: 0;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -36,35 +36,9 @@
 		transform-origin: 0 0;
 	}
 
-	.step-container__content {
-		.formatted-header {
-			margin: 24px 20px;
-			.formatted-header__title {
-				/* this is to match with start */
-				/* stylelint-disable-next-line scales/font-sizes */
-				font-size: 1.875rem;
-				line-height: 40px;
-				@include break-small {
-					font-size: 2rem;
-					line-height: 3.25;
-				}
-			}
-			.formatted-header__title:has(+ p) {
-				@include break-small {
-					line-height: 1.9;
-				}
-			}
-			.formatted-header__subtitle {
-				@include break-small {
-					padding-bottom: 1em;
-				}
-			}
-		}
-	}
-
 	.signup-form-social-first {
 		width: 327px;
-		margin: 0 auto;
+		margin: 3rem auto 0 auto;
 
 		.signup-form__notice {
 			width: 327px;
@@ -88,8 +62,8 @@
 			font-style: normal;
 			font-weight: 400;
 			line-height: 18px;
-			margin-top: 24px;
-			margin-bottom: 12px;
+			margin-top: 3rem;
+			margin-bottom: 0;
 
 			a {
 				color: var(--studio-gray-50, #646970);
@@ -98,7 +72,6 @@
 		}
 
 		.signup-form-social-first__tos-link {
-			margin-top: 32px;
 			text-align: center;
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -374,7 +374,7 @@ function UnifiedPlansStep( {
 		return translate( 'Choose your flavor of WordPress' );
 	};
 
-	const SubHeaderText = () => {
+	const getSubheaderText = () => {
 		const { segmentationSurveyAnswers } = signupDependencies;
 		const { segmentSlug } = getSegmentedIntent( segmentationSurveyAnswers );
 
@@ -436,7 +436,7 @@ function UnifiedPlansStep( {
 	} );
 
 	const fallbackHeaderText = fallbackHeaderTextFromProps || <HeaderText />;
-	const fallbackSubHeaderText = fallbackSubHeaderTextFromProps || <SubHeaderText />;
+	const fallbackSubHeaderText = fallbackSubHeaderTextFromProps || getSubheaderText();
 
 	let backUrl;
 	let backLabelText;
@@ -640,7 +640,7 @@ function UnifiedPlansStep( {
 						headerText={ <HeaderText /> }
 						shouldHideNavButtons={ shouldHideNavButtons }
 						fallbackHeaderText={ fallbackHeaderText }
-						subHeaderText={ <SubHeaderText /> }
+						subHeaderText={ getSubheaderText() }
 						fallbackSubHeaderText={ fallbackSubHeaderText }
 						allowBackFirstStep={ !! initializedSitesBackUrl }
 						queryParams={ queryParams }

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -235,6 +235,7 @@ class StepWrapper extends Component {
 								subHeaderText={ this.subHeaderText() }
 								align={ align }
 								disablePreventWidows
+								brandFont
 							/>
 							{ headerImageUrl && (
 								<div className="step-wrapper__header-image">

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -311,6 +311,16 @@ export class UserStep extends Component {
 			);
 		}
 
+		const redirectToAfterLoginUrl = getRedirectToAfterLoginUrl( this.props );
+
+		if ( redirectToAfterLoginUrl?.startsWith( '/setup/hosted-site-migration' ) ) {
+			subHeaderText = translate(
+				'Pick an option to start moving your site to the world’s best WordPress host.'
+			);
+		} else if ( redirectToAfterLoginUrl?.startsWith( '/start/do-it-for-me' ) ) {
+			subHeaderText = translate( 'Pick an option to start shaping your dream website with us.' );
+		}
+
 		if ( this.props.userLoggedIn ) {
 			subHeaderText = '';
 		}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -226,32 +226,6 @@ body.is-section-signup .layout:not(.dops) {
 	}
 }
 
-// Signup headings
-body.is-section-signup .layout:not(.dops):not(.is-wccom-oauth-flow) .formatted-header {
-	margin: 0 0 16px;
-
-	.formatted-header__title {
-		margin: 0;
-		font-weight: 400;
-		color: var(--color-text-inverted);
-	}
-
-	.formatted-header__subtitle {
-		margin: 8px 0 0;
-		font-size: $font-body;
-		color: var(--color-text-inverted);
-	}
-
-	.signup:not(.is-wpcc):not(.is-crowdsignal) a {
-		color: var(--color-neutral-0);
-		text-decoration: underline;
-
-		&:hover {
-			color: var(--color-text-inverted);
-		}
-	}
-}
-
 .is-section-signup .layout__content,
 .is-section-signup .layout__primary {
 	overflow: visible;
@@ -427,7 +401,7 @@ body.is-section-signup.is-white-signup:not(.is-videopress-signup) .layout:not(.d
 			margin: 24px 20px;
 
 			@include break-large {
-				margin: 48px 0 40px;
+				margin: 48px 0 36px;
 			}
 		}
 	}
@@ -445,7 +419,7 @@ body.is-section-signup.is-white-signup:not(.is-videopress-signup) .layout:not(.d
 		.formatted-header__title {
 			@include onboarding-font-recoleta;
 			color: $gray-100;
-			letter-spacing: 0.2px;
+			margin-top: 0;
 			font-size: 2.25rem;
 
 			@include break-xlarge {
@@ -456,70 +430,21 @@ body.is-section-signup.is-white-signup:not(.is-videopress-signup) .layout:not(.d
 		.formatted-header__subtitle {
 			color: $gray-60;
 			font-size: 1rem;
-
-			@include breakpoint-deprecated("<660px") {
-				margin-top: 16px;
-			}
+			margin-bottom: 0;
 		}
 
 		.formatted-header__title,
 		.formatted-header__subtitle {
-			padding: 0 20px;
 			text-align: center;
 
 			@include break-xlarge {
 				padding: 0;
 			}
 		}
-
-		&.is-left-align {
-
-			.formatted-header__title,
-			.formatted-header__subtitle {
-				padding: 0;
-				text-align: start;
-			}
-		}
-
-		&.is-right-align {
-
-			.formatted-header__title,
-			.formatted-header__subtitle {
-				padding: 0;
-				text-align: end;
-			}
-		}
 	}
 
 	.signup__step.is-user,
 	.signup__step.is-user-social {
-		.formatted-header {
-			.formatted-header__title {
-				text-align: center;
-
-				@include break-small {
-					max-width: inherit;
-				}
-			}
-
-			.formatted-header__subtitle {
-				text-align: center;
-				color: #646970;
-				a {
-					color: var(--studio-gray-90);
-					text-decoration: underline;
-					cursor: pointer;
-				}
-
-				@include break-small {
-					max-width: inherit;
-					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-					line-height: 1.625rem;
-					letter-spacing: 0.24px;
-				}
-			}
-		}
-
 		button.signup-form__submit[disabled],
 		button.signup-form__submit:disabled,
 		button.signup-form__submit.disabled {
@@ -699,25 +624,7 @@ body.is-section-signup.is-white-signup:not(.is-videopress-signup) .layout:not(.d
 		}
 
 		.step-wrapper__header {
-			margin-bottom: 24px !important;
-		}
-
-		.formatted-header {
-			.formatted-header__title {
-				font-size: rem(30px);
-				line-height: 40px;
-
-				@include break-small {
-					font-size: 2rem;
-					line-height: 3.25;
-				}
-			}
-
-			.formatted-header__subtitle {
-				@include break-small {
-					font-size: rem(18px);
-				}
-			}
+			margin-bottom: 3rem !important;
 		}
 
 		a.step-wrapper__navigation-link {
@@ -739,27 +646,6 @@ body.is-section-signup.is-white-signup:not(.is-videopress-signup) .layout:not(.d
 				box-shadow: none;
 				border-radius: 0;
 			}
-		}
-	}
-
-	.signup__step.is-user {
-		.formatted-header {
-			.formatted-header__title {
-				@include break-small {
-					font-size: 3.25rem; /* stylelint-disable-line scales/font-sizes */
-					line-height: 56px;
-				}
-			}
-
-			.formatted-header__subtitle {
-				@include break-small {
-					font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
-				}
-			}
-		}
-
-		.social-buttons__button {
-			border: 0;
 		}
 	}
 
@@ -879,10 +765,4 @@ body.is-section-signup .is-gravatar {
 	:root {
 		--signup-form-column-max-width: 408px;
 	}
-}
-
-body.is-section-signup
-.signup:not(.is-wpcc2)
-.layout:not(.dops):not(.is-wccom-oauth-flow) .formatted-header {
-	margin: 0 0 16px;
 }

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -435,8 +435,6 @@ body.is-section-signup.is-white-signup:not(.is-videopress-signup) .layout:not(.d
 
 		.formatted-header__title,
 		.formatted-header__subtitle {
-			text-align: center;
-
 			@include break-xlarge {
 				padding: 0;
 			}
@@ -660,29 +658,6 @@ body.is-section-signup.is-white-signup:not(.is-videopress-signup) .layout:not(.d
 				padding: 0;
 				border-radius: 0;
 
-			}
-		}
-	}
-
-	/* TODO: Remove the following when the 2023 pricig grid is live to all users */
-	.signup .signup__step .plans.plans-step {
-		.formatted-header {
-			.formatted-header__title {
-				font-size: 2.25rem;
-				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-				line-height: 2.5rem;
-				font-weight: 500;
-
-				@include break-mobile {
-					font-size: 2.75rem;
-					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-					line-height: 3rem;
-				}
-			}
-
-			.formatted-header__subtitle button.is-borderless {
-				font-weight: 500;
-				color: var(--studio-gray-90);
 			}
 		}
 	}


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/97454. Part of https://github.com/Automattic/wp-calypso/issues/98641. (Copy updates)

Part of https://github.com/Automattic/wp-calypso/issues/98648. (Design updates to Signup/User in Stepper)

## Proposed Changes

Uses the copy defined in p58i-jeX-p2#comment-65796 when entering the account step after clicking in the DIFM and Import links at the bottom of the goals screen.

This PR is also starts to polish the step headers and subtitles as proposed in https://github.com/Automattic/wp-calypso/issues/98648. It removes a big chunk of `formatted-header` customizations in Signup and the user step in Stepper. I'll come up with modifications/refactors for other screens in future PRs.

### Import or migrate an existing site

<img width="665" alt="image" src="https://github.com/user-attachments/assets/2cc0930b-11ac-4ad0-890f-3e861ac1aad2" />

### Let us build a custom site for you

<img width="583" alt="image" src="https://github.com/user-attachments/assets/c47159e1-1048-489d-b930-5e5a12ec43da" />


## Why are these changes being made?

For user clarification. There's gotta be a reason for the sign up, and the subheading copy reinforces the intention.

## Testing Instructions

Make sure you're assigned to the `treatment` group in the `calypso_signup_onboarding_goals_first_flow_holdout_20241220` experiment so you can see the goals step as a guest.

Click each link and verify that the corresponding copy shows up.

Check that all formatted header instances in Start framework and Stepper's user are showing up as they were before.