### PR TITLE
Revert "Temporarily disable Big Sky on Prod"

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -28,7 +28,7 @@
 		"bulk-plugin-management": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/all-domain-management": false,
-		"calypso/big-sky": false,
+		"calypso/big-sky": true,
 		"bilmur-script": true,
 		"cancellation-offers": true,
 		"catch-js-errors": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#98769

Now that the issue is fixed, let's re-enable big-sky.

