### PR TITLE
A4A > Plugins: Reset selected site on page load

### DIFF
--- a/client/a8c-for-agencies/sections/plugins/controller.tsx
+++ b/client/a8c-for-agencies/sections/plugins/controller.tsx
@@ -1,8 +1,20 @@
-import page from '@automattic/calypso-router';
-import { type Callback } from '@automattic/calypso-router';
+import page, { type Callback, type Context } from '@automattic/calypso-router';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { A4A_PLUGINS_LINK } from '../../components/sidebar-menu/lib/constants';
 import MainSidebar from '../../components/sidebar-menu/main';
+
+// Reset selected site id for multi-site view since it is never reset
+// and the plugins component behaves differently when there
+// is a selected site which is incorrect for multi-site view
+const resetSite = ( context: Context ) => {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	if ( siteId ) {
+		context.store.dispatch( setSelectedSiteId( null ) );
+	}
+};
 
 export const pluginsContext: Callback = ( context ) => {
 	const { slug } = context.params;
@@ -14,6 +26,7 @@ export const pluginsContext: Callback = ( context ) => {
 };
 
 export const pluginManagementContext: Callback = ( context, next ) => {
+	resetSite( context );
 	context.secondary = <MainSidebar path={ context.path } />;
 	context.primary = (
 		<>
@@ -24,6 +37,7 @@ export const pluginManagementContext: Callback = ( context, next ) => {
 };
 
 export const pluginDetailsContext: Callback = ( context, next ) => {
+	resetSite( context );
 	context.secondary = <MainSidebar path={ context.path } />;
 	context.primary = (
 		<>


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1683

## Proposed Changes

This PR resets the selected site, which gets set whenever a site is selected from the Sites dashboard.

## Why are these changes being made?

* This change is being done because the main Plugins page behaves as if the site is selected when loading the page. This is a multi-site view.

## Testing Instructions

* Open the A4A live link
* Go to Plugins in the main sidebar > You should now see all plugins available for all sites.
* In the main menu, go to Sites and select a site.
* Now go back to Plugins > It should now list plugins for all sites instead of listing for a specific site

| Before | After |
|--------|--------|
| <img width="953" alt="Screenshot 2025-01-23 at 8 58 05 AM" src="https://github.com/user-attachments/assets/eefe49ca-ae04-4a81-8e1d-bff43c22fa49" /> | <img width="953" alt="Screenshot 2025-01-23 at 8 55 55 AM" src="https://github.com/user-attachments/assets/0b9e7ca7-a74c-4362-9883-eccb89d40b56" />|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
