### PR TITLE
[Brand Update] Update font styles in Woo for improved design consistency

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -2315,7 +2315,7 @@ $breakpoint-mobile: 660px;
 	}
 
 	.auth-form__social-buttons-tos {
-		color: var(--studio-gray-50);
+		color: var(--studio-gray-50) !important;
 
 		a {
 			text-underline-offset: 2px;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1499,7 +1499,7 @@ $breakpoint-mobile: 660px;
 		label.form-label,
 		.logged-out-form label.form-label,
 		.magic-login__form label.form-label {
-			color: var(--color-gray-100);
+			color: var(--studio-gray-100);
 			font-size: 1rem;
 			font-style: normal;
 			font-weight: 600;
@@ -2251,6 +2251,12 @@ $breakpoint-mobile: 660px;
 	--woo-purple-70: #5007AA;
 	--woo-font-family-header: proxima-vara, 'Proxima Fallback', sans-serif;
 
+	* {
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
+		text-rendering: optimizeLegibility;
+	}
+
 	h1,
 	h2,
 	h3 {
@@ -2261,6 +2267,7 @@ $breakpoint-mobile: 660px;
 		.masterbar__woo-nav {
 			.masterbar__login-back-link {
 				margin-left: 15px;
+				font-weight: 400;
 			}
 		}
 	}
@@ -2295,6 +2302,7 @@ $breakpoint-mobile: 660px;
 
 	.login__header-subtitle a {
 		@include link-woo;
+		font-weight: 500;
 	}
 
 	.continue-as-user__change-user-link {
@@ -2306,8 +2314,12 @@ $breakpoint-mobile: 660px;
 		@include link-woo;
 	}
 
-	.auth-form__social-buttons-tos a {
-		text-underline-offset: 2px;
+	.auth-form__social-buttons-tos {
+		color: var(--studio-gray-50);
+
+		a {
+			text-underline-offset: 2px;
+		}
 	}
 
 	.login__lost-password-no-account a {
@@ -2317,6 +2329,7 @@ $breakpoint-mobile: 660px;
 	.login__lost-password-link {
 		@include link-woo;
 	}
+
 	.security-key-form__help-text,
 	.formatted-header__subtitle {
 		a {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdibGW-3QO-p2#comment-3000

p1737116097678049/1737114693.510319-slack-C080GSRNPA7

## Proposed Changes

Figma render some fonts with smaller font weight than when we use the font in a browser.

Perplexity suggests to disable subpixel rendering, which can make fonts appear thinner.

```css
body {
  -webkit-font-smoothing: antialiased;
  -moz-osx-font-smoothing: grayscale;
  text-rendering: optimizeLegibility;
}
```

This PR applies the same font smoothing properties for Woo when rebranding feature flag is enabled.

Besides, I also updated the font weight and colors to match the Figma design.

Figma: tp2u3Nk9arcpeNMZcylNG4-fi-271_7857


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To make the font weight and colors consistent with Figma.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Go to `/start/wpcc/oauth2-user?oauth2_client_id=50916&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D88ed85523a7c8127cf3deda9c8d4cb6b67d82d97a2f5c8804f338920c8cdad0b%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1%26woo-passwordless%3Dyes&woo-passwordless=yes`
* Make sure the font weight and colors are consistent with Figma.

Known issue:

- ~The color of the subtitle is inconsistent. In Figma, some screens use --Gray-Gray-90, others use --Gray-Gray-60 but we're using --Gray-Gray-60 for all. I left a comment in Figma to confirm the color. tp2u3Nk9arcpeNMZcylNG4-fi-271_8254#1102749706~ Confirmed no change needed


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?