### PR TITLE
Fix TOS for WooCommerce.com auth flow

### DIFF
--- a/client/blocks/authentication/social/social-tos.jsx
+++ b/client/blocks/authentication/social/social-tos.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
 import getIsWooPasswordless from 'calypso/state/selectors/get-is-woo-passwordless';
+import isWooPasswordlessJPCFlow from 'calypso/state/selectors/is-woo-passwordless-jpc-flow';
 
 const toSLinks = {
 	components: {
@@ -31,7 +32,10 @@ function getToSComponent( content ) {
 
 function SocialAuthToS( props ) {
 	if ( props.isWooPasswordless ) {
-		if ( config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) ) {
+		if (
+			config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) &&
+			props.isWooPasswordlessJPC
+		) {
 			const termsOfServiceLink = (
 				<a
 					href={ localizeUrl( 'https://wordpress.com/tos/' ) }
@@ -105,5 +109,6 @@ function SocialAuthToS( props ) {
 export default connect( ( state ) => ( {
 	oauth2Client: getCurrentOAuth2Client( state ),
 	isWooPasswordless: getIsWooPasswordless( state ),
+	isWooPasswordlessJPC: isWooPasswordlessJPCFlow( state ),
 	isBlazePro: getIsBlazePro( state ),
 } ) )( localize( SocialAuthToS ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

We show `By clicking any of the options above, you agree to our Terms of Service and to sync your site’s data with us.` in WooCommerce.com auth screens. This is incorrect because we don't sync site data when signing up/logging in with WooCommerce.com. I believe this was an unintended change when we updated the core profiler flow in https://github.com/Automattic/wp-calypso/pull/95764.

This PR ensures we only show the sync data text when the user uses the Woo JPC flows.

Before:
![Screenshot 2025-01-23 at 12 30 04](https://github.com/user-attachments/assets/53537256-1d27-49b6-b559-844c9cfcc997)

After:
![Screenshot 2025-01-23 at 12 27 51](https://github.com/user-attachments/assets/84bae866-7156-45f3-b9f3-d321c3343cbc)

Core Profiler:
![Screenshot 2025-01-23 at 12 28 58](https://github.com/user-attachments/assets/b8117f23-8c23-4b99-953b-1766c89581a6)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix the incorrect TOS text for WooCommerce.com auth screens.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Go to WooCommerce.com > Login
* Confirm the TOS text shows `By continuing with any of the options above, you agree to our Terms of Service and have read our Privacy Policy.`
* Go to Signup
* Confirm the TOS text shows  `By continuing with any of the options above, you agree to our Terms of Service and have read our Privacy Policy.`
* Go to Core Profiler connect step: `/jetpack/connect/authorize?client_id=240298919&redirect_uri=https%3A%2F%2Ffortunately-surprised-echidna.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fhandler%3Djetpack-connection-webhooks%26action%3Dauthorize%26_wpnonce%3D1a4f7d1826%26redirect%3Dhttps%253A%252F%252Ffortunately-surprised-echidna.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin&state=1&scope=na&user_email=user%40email.com&user_login=ilyasfoo&jp_version=14.2-a.9&secret=na&blogname=Fortunately%20Surprised%20Echidna&site_url=https%3A%2F%2Ffortunately-surprised-echidna.jurassic.ninja&home_url=https%3A%2F%2Ffortunately-surprised-echidna.jurassic.ninja&site_icon=&site_lang=en_US&site_created=2024-12-31%2004%3A30%3A47&allow_site_connection=1&calypso_env=production&source=&_as=wp-cli&locale=en&from=woocommerce-core-profiler&plugin_name=&color_scheme=default&_ui=189375772&_ut=wpcom%3Auser_id&_wp_nonce=c98dc459cb&redirect_after_auth=https%3A%2F%2Ffortunately-surprised-echidna.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-admin&site=https%3A%2F%2Ffortunately-surprised-echidna.jurassic.ninja`
* OBserve that TOS text shows `By clicking any of the options above, you agree to our Terms of Service and to sync your site’s data with us.` 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
