### PR TITLE
Stats: Refactor applied date range shortcut and redirections for feature gates

### DIFF
--- a/client/components/date-control/types.d.ts
+++ b/client/components/date-control/types.d.ts
@@ -30,12 +30,6 @@ interface DateControlPickerProps {
 	) => void;
 }
 
-interface DateControlPickerShortcutsProps {
-	shortcutList: DateRangePickerShortcut[];
-	currentShortcut: string | undefined;
-	onClick: ( shortcut: DateRangePickerShortcut ) => void;
-}
-
 interface DateControlPickerDateProps {
 	startDate?: string;
 	endDate?: string;
@@ -46,9 +40,4 @@ interface DateControlPickerDateProps {
 	overlay?: JSX.Element;
 }
 
-export {
-	DateControlProps,
-	DateControlPickerProps,
-	DateControlPickerShortcutsProps,
-	DateControlPickerDateProps,
-};
+export { DateControlProps, DateControlPickerProps, DateControlPickerDateProps };

--- a/client/components/date-range/shortcuts.tsx
+++ b/client/components/date-range/shortcuts.tsx
@@ -18,15 +18,7 @@ export interface DateRangePickerShortcut {
 	isGated?: boolean;
 }
 
-const DateRangePickerShortcuts = ( {
-	selectedShortcutId,
-	onClick,
-	onShortcutClick, // Optional callback function for tracking shortcut clicks
-	locked = false,
-	startDate,
-	endDate,
-	shortcutList,
-}: {
+interface DateRangePickerShortcutsProps {
 	selectedShortcutId?: string;
 	onClick: (
 		newFromDate: moment.Moment,
@@ -38,7 +30,17 @@ const DateRangePickerShortcuts = ( {
 	startDate?: MomentOrNull;
 	endDate?: MomentOrNull;
 	shortcutList?: DateRangePickerShortcut[];
-} ) => {
+}
+
+const DateRangePickerShortcuts = ( {
+	selectedShortcutId,
+	onClick,
+	onShortcutClick, // Optional callback function for tracking shortcut clicks
+	locked = false,
+	startDate,
+	endDate,
+	shortcutList,
+}: DateRangePickerShortcutsProps ) => {
 	const normalizeDate = ( date: MomentOrNull ) => {
 		return date ? date.startOf( 'day' ) : date;
 	};

--- a/client/components/stats-interval-dropdown/index.jsx
+++ b/client/components/stats-interval-dropdown/index.jsx
@@ -105,9 +105,9 @@ const IntervalDropdown = ( { slug, period, queryParams, intervals, onGatedHandle
 			return;
 		}
 
-		localStorage.setItem( `jetpack_stats_stored_period_${ siteId }`, interval );
-		// Remove legacy item key.
+		// Deprecate the stored period and removing legacy localStorage keys.
 		localStorage.removeItem( 'jetpack_stats_stored_period' );
+		localStorage.removeItem( `jetpack_stats_stored_period_${ siteId }` );
 
 		page( generateNewLink( interval ) );
 	}

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -175,22 +175,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	);
 	const queryDate = date.format( DATE_FORMAT );
 
-	// Find the applied shortcut with shortcut ID from the URL.
-	const { selectedShortcut: appliedShortcut, supportedShortcutList } = useShortcuts( {
-		chartStart: context.query?.chartStart,
-		chartEnd: context.query?.chartEnd,
-		shortcutId: context.query?.shortcut,
-	} );
-
-	const storedShortcut = useMemo( () => {
-		const storedShortcutId =
-			localStorage.getItem( `jetpack_stats_stored_date_range_shortcut_id_${ siteId }` ) ||
-			// Fallback for the compatibility.
-			localStorage.getItem( 'jetpack_stats_stored_date_range_shortcut_id' );
-
-		return supportedShortcutList.find( ( shortcut ) => shortcut.id === storedShortcutId ) || null;
-	}, [ siteId, supportedShortcutList ] );
-
 	const moduleStrings = statsStrings();
 
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
@@ -221,17 +205,41 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		supportUserFeedback,
 	} = useSelector( ( state ) => getEnvStatsFeatureSupportChecks( state, siteId ) );
 
+	// Find the applied shortcut with shortcut ID from the URL.
+	const shortcuts = useShortcuts( {
+		chartStart: context.query?.chartStart,
+		chartEnd: context.query?.chartEnd,
+		shortcutId: context.query?.shortcut,
+	} );
+	const { supportedShortcutList } = shortcuts;
+	let storedShortcut = useMemo( () => {
+		const storedShortcutId =
+			localStorage.getItem( `jetpack_stats_stored_date_range_shortcut_id_${ siteId }` ) ||
+			// Fallback for the compatibility.
+			localStorage.getItem( 'jetpack_stats_stored_date_range_shortcut_id' );
+
+		return supportedShortcutList.find( ( shortcut ) => shortcut.id === storedShortcutId ) || null;
+	}, [ siteId, supportedShortcutList ] );
+	let { selectedShortcut: appliedShortcut } = shortcuts;
+
 	const hasSiteLoadedFeatures = useSelector(
 		( state ) => isWPAdmin || hasLoadedSiteFeatures( state, siteId )
 	);
+	const shouldForceDefaultDateRange =
+		useSelector( ( state ) =>
+			shouldGateStats( state, siteId, STATS_FEATURE_DATE_CONTROL_LAST_30_DAYS )
+		) && hasSiteLoadedFeatures;
 
-	const shouldForceDefaultDateRange = useSelector( ( state ) =>
-		shouldGateStats( state, siteId, STATS_FEATURE_DATE_CONTROL_LAST_30_DAYS )
-	);
+	const shouldForceDefaultPeriod =
+		useSelector( ( state ) =>
+			shouldGateStats( state, siteId, STATS_FEATURE_INTERVAL_DROPDOWN_WEEK )
+		) && hasSiteLoadedFeatures;
 
-	const shouldForceDefaultPeriod = useSelector( ( state ) =>
-		shouldGateStats( state, siteId, STATS_FEATURE_INTERVAL_DROPDOWN_WEEK )
-	);
+	// Remove appliedShortcut and storedShortcut if the date range or chart perod is locked.
+	if ( shouldForceDefaultDateRange || shouldForceDefaultPeriod ) {
+		appliedShortcut = null;
+		storedShortcut = null;
+	}
 
 	const wpcomShowUpsell = useSelector(
 		( state ) =>
@@ -329,9 +337,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 					const storedValue = storedShortcut[ inputKey ];
 					const isStoredValueValid = moment( storedValue ).isValid();
 
-					return hasSiteLoadedFeatures && ! shouldForceDefaultDateRange && isStoredValueValid
-						? storedValue
-						: null;
+					return isStoredValueValid ? storedValue : null;
 				}
 			}
 
@@ -339,7 +345,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 
 			return isValid ? inputDate : null;
 		},
-		[ storedShortcut, hasSiteLoadedFeatures, shouldForceDefaultDateRange ]
+		[ storedShortcut ]
 	);
 
 	// Note: This is only used in the empty version of the module.

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -370,23 +370,28 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 
 	// Set up a custom range for the chart.
 	// Dependant on new date range picker controls.
-	let customChartRange = null;
+	const customChartRange = {};
 
 	// Sort out end date for chart.
-	const chartEnd = useMemo( () => {
+	let chartEnd = useMemo( () => {
 		return getValidDateOrNullFromInput( context.query?.chartEnd, 'endDate' );
 	}, [ context.query?.chartEnd, getValidDateOrNullFromInput ] );
 
-	const chartStart = useMemo( () => {
+	let chartStart = useMemo( () => {
 		return getValidDateOrNullFromInput( context.query?.chartStart, 'startDate' );
 	}, [ context.query?.chartStart, getValidDateOrNullFromInput ] );
 
+	// Respect the shortcut ID from the URL if it's valid.
+	if ( appliedShortcut ) {
+		customChartRange.shortcutId = appliedShortcut.id;
+		chartEnd = appliedShortcut.endDate;
+		chartStart = appliedShortcut.startDate;
+	}
+
 	if ( chartEnd ) {
-		customChartRange = { chartEnd };
+		customChartRange.chartEnd = chartEnd;
 	} else {
-		customChartRange = {
-			chartEnd: momentSiteZone.format( DATE_FORMAT ),
-		};
+		customChartRange.chartEnd = momentSiteZone.format( DATE_FORMAT );
 	}
 
 	const isSameOrBefore = moment( chartStart ).isSameOrBefore( moment( chartEnd ) );
@@ -439,13 +444,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		customChartRange.chartStart = moment( customChartRange.chartEnd )
 			.subtract( customChartRange.daysInRange - 1, 'days' )
 			.format( DATE_FORMAT );
-	}
-
-	// Respect the shortcut ID from the URL if it's valid.
-	if ( appliedShortcut ) {
-		customChartRange.shortcutId = appliedShortcut.id;
-		customChartRange.chartEnd = appliedShortcut.endDate;
-		customChartRange.chartStart = appliedShortcut.startDate;
 	}
 
 	// Redirect with the shortcut period of appliedShortcut or storedShortcut.

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -402,7 +402,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	// Apply the stored shortcut ID if the date range is not set.
 	if ( ! context.query?.chartStart && ! context.query?.chartEnd && storedShortcut ) {
 		customChartRange.shortcutId = storedShortcut.id;
-		// TODO: Handle the redirection when the applied shortcut period differs from the current period.
 	}
 
 	// Calculate diff between requested start and end in `priod` units.
@@ -441,6 +440,45 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		customChartRange.chartEnd = appliedShortcut.endDate;
 		customChartRange.chartStart = appliedShortcut.startDate;
 	}
+
+	// Redirect with the shortcut period of appliedShortcut or storedShortcut.
+	useEffect(
+		() => {
+			if ( appliedShortcut?.period ) {
+				if ( appliedShortcut?.period !== period ) {
+					page.redirect(
+						appendQueryStringForRedirection(
+							`/stats/${ appliedShortcut?.period }/${ slug }`,
+							context.query
+						)
+					);
+					return;
+				}
+			} else if (
+				! context.query?.chartStart &&
+				! context.query?.chartEnd &&
+				storedShortcut?.period &&
+				storedShortcut?.period !== period
+			) {
+				page.redirect(
+					appendQueryStringForRedirection(
+						`/stats/${ storedShortcut?.period }/${ slug }`,
+						context.query
+					)
+				);
+				return;
+			}
+		},
+		/* eslint-disable-next-line react-hooks/exhaustive-deps */
+		[
+			period,
+			slug,
+			appliedShortcut?.period,
+			context.query?.chartStart,
+			context.query?.chartEnd,
+			storedShortcut?.period,
+		]
+	);
 
 	// Redirect to the corresponding period by gates and date range.
 	useEffect( () => {

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -361,33 +361,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		return url;
 	};
 
-	useEffect( () => {
-		const newActiveTab = getActiveTab( chartTab );
-		setActiveTabState( newActiveTab );
-		setActiveLegend( period !== 'hour' ? newActiveTab.legendOptions || [] : [] );
-	}, [ chartTab, period, activeTabState, context.query ] );
-
-	useEffect( () => {
-		// Use the stored period if it's different from the current period.
-		const storedPeriod =
-			localStorage.getItem( `jetpack_stats_stored_period_${ siteId }` ) ||
-			localStorage.getItem( 'jetpack_stats_stored_period' );
-		if (
-			hasSiteLoadedFeatures &&
-			! shouldForceDefaultPeriod &&
-			// Avoid the infinite redirect loop between single day period and hourly views.
-			period !== 'hour' &&
-			storedPeriod &&
-			storedPeriod !== period
-		) {
-			// TODO: Determine if we need to save the period as it might be a conflict with the drilling down.
-			page.redirect(
-				appendQueryStringForRedirection( `/stats/${ storedPeriod }/${ slug }`, context.query )
-			);
-			return;
-		}
-	}, [ hasSiteLoadedFeatures, shouldForceDefaultPeriod, slug ] ); // eslint-disable-line react-hooks/exhaustive-deps
-
 	// Set up a custom range for the chart.
 	// Dependant on new date range picker controls.
 	let customChartRange = null;
@@ -432,19 +405,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		// TODO: Handle the redirection when the applied shortcut period differs from the current period.
 	}
 
-	// Redirect to the daily views if the period dropdown is locked.
-	if ( shouldForceDefaultPeriod && period !== 'day' ) {
-		page.redirect( appendQueryStringForRedirection( `/stats/day/${ slug }`, context.query ) );
-		return;
-	}
-
-	// TODO: all the date logic should be done in controllers, otherwise it affects the performance.
-	// If it's single day period, redirect to hourly stats.
-	if ( ! shouldForceDefaultPeriod && period === 'day' && daysInRange === 1 ) {
-		page.redirect( appendQueryStringForRedirection( `/stats/hour/${ slug }`, context.query ) );
-		return;
-	}
-
 	// Calculate diff between requested start and end in `priod` units.
 	// Move end point (most recent) to the end of period to account for partial periods
 	// (e.g. requesting period between June 2020 and Feb 2021 would require 2 `yearly` units but would return 1 unit without the shift to the end of period)
@@ -481,6 +441,51 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		customChartRange.chartEnd = appliedShortcut.endDate;
 		customChartRange.chartStart = appliedShortcut.startDate;
 	}
+
+	// Redirect to the corresponding period by gates and date range.
+	useEffect( () => {
+		// Redirect to the daily views if the period dropdown is locked.
+		if ( shouldForceDefaultPeriod && period !== 'day' ) {
+			page.redirect( appendQueryStringForRedirection( `/stats/day/${ slug }`, context.query ) );
+			return;
+		}
+
+		// TODO: all the date logic should be done in controllers, otherwise it affects the performance.
+		// If it's single day period, redirect to hourly stats.
+		if ( ! shouldForceDefaultPeriod && period === 'day' && daysInRange === 1 ) {
+			page.redirect( appendQueryStringForRedirection( `/stats/hour/${ slug }`, context.query ) );
+			return;
+		}
+	}, [ shouldForceDefaultPeriod, period, daysInRange, slug, context.query ] );
+
+	// setActiveTabState and setActiveLegend
+	useEffect( () => {
+		const newActiveTab = getActiveTab( chartTab );
+		setActiveTabState( newActiveTab );
+		setActiveLegend( period !== 'hour' ? newActiveTab.legendOptions || [] : [] );
+	}, [ chartTab, period, activeTabState, context.query ] );
+
+	// Redirect to the stored period
+	useEffect( () => {
+		// Use the stored period if it's different from the current period.
+		const storedPeriod =
+			localStorage.getItem( `jetpack_stats_stored_period_${ siteId }` ) ||
+			localStorage.getItem( 'jetpack_stats_stored_period' );
+		if (
+			hasSiteLoadedFeatures &&
+			! shouldForceDefaultPeriod &&
+			// Avoid the infinite redirect loop between single day period and hourly views.
+			period !== 'hour' &&
+			storedPeriod &&
+			storedPeriod !== period
+		) {
+			// TODO: Determine if we need to save the period as it might be a conflict with the drilling down.
+			page.redirect(
+				appendQueryStringForRedirection( `/stats/${ storedPeriod }/${ slug }`, context.query )
+			);
+			return;
+		}
+	}, [ hasSiteLoadedFeatures, shouldForceDefaultPeriod, slug ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	const query = chartRangeToQuery( customChartRange );
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -225,6 +225,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	const hasSiteLoadedFeatures = useSelector(
 		( state ) => isWPAdmin || hasLoadedSiteFeatures( state, siteId )
 	);
+	// TODO: We may need a detailed hierarchy of the shortcut gates.
 	const shouldForceDefaultDateRange =
 		useSelector( ( state ) =>
 			shouldGateStats( state, siteId, STATS_FEATURE_DATE_CONTROL_LAST_30_DAYS )

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -476,7 +476,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		},
 		/* eslint-disable-next-line react-hooks/exhaustive-deps */
 		[
-			period,
+			// Do not include the period from URL segments in the dependency array to prevent period selection invalidation.
 			slug,
 			appliedShortcut?.period,
 			context.query?.chartStart,

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -503,28 +503,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		setActiveLegend( period !== 'hour' ? newActiveTab.legendOptions || [] : [] );
 	}, [ chartTab, period, activeTabState, context.query ] );
 
-	// Redirect to the stored period
-	useEffect( () => {
-		// Use the stored period if it's different from the current period.
-		const storedPeriod =
-			localStorage.getItem( `jetpack_stats_stored_period_${ siteId }` ) ||
-			localStorage.getItem( 'jetpack_stats_stored_period' );
-		if (
-			hasSiteLoadedFeatures &&
-			! shouldForceDefaultPeriod &&
-			// Avoid the infinite redirect loop between single day period and hourly views.
-			period !== 'hour' &&
-			storedPeriod &&
-			storedPeriod !== period
-		) {
-			// TODO: Determine if we need to save the period as it might be a conflict with the drilling down.
-			page.redirect(
-				appendQueryStringForRedirection( `/stats/${ storedPeriod }/${ slug }`, context.query )
-			);
-			return;
-		}
-	}, [ hasSiteLoadedFeatures, shouldForceDefaultPeriod, slug ] ); // eslint-disable-line react-hooks/exhaustive-deps
-
 	const query = chartRangeToQuery( customChartRange );
 
 	// For period option links


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Refactor redirections on the Traffic page due to gated features with `useEffects`.
* Refactor the `shouldForceDefaultDateRange` and `shouldForceDefaultPeriod` checks directly with `hasSiteLoadedFeatures`.
* Deprecate the stored period in localStorage because each shortcut has a corresponding period, which would cause conflicts and unexpected redirections.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Refactors for the complex Stats Traffic page redirection.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Open the date range picker.
* Select the `Year to date` shortcut.
* Ensure the date range and chart period `Months` are set correctly.
* Click on the Stats item on the left sidebar or directly visit `/stats/day/{site-slug}`.
* Ensure the date range and chart period are still set as `Year to date`.
* Append the `Month to date` shortcut ID to the URL: `/stats/day/{site-slug}?shortcut=month_to_date`.
* Ensure the date range and chart period `Days` are set as `Month to date`.
* Ensure all the date range shortcuts and chart period preset are ineffective for sites without access to date control and period dropdown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
