### PR TITLE
Remove React lost password screen feature flag

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -18,7 +18,7 @@ import WooCommerceConnectCartHeader from 'calypso/components/woocommerce-connect
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { preventWidows } from 'calypso/lib/formatting';
 import getGravatarOAuth2Flow from 'calypso/lib/get-gravatar-oauth2-flow';
-import { getPluginTitle, getSignupUrl, isReactLostPasswordScreenEnabled } from 'calypso/lib/login';
+import { getPluginTitle, getSignupUrl } from 'calypso/lib/login';
 import {
 	isCrowdsignalOAuth2Client,
 	isJetpackCloudOAuth2Client,
@@ -898,7 +898,7 @@ class Login extends Component {
 			);
 		}
 
-		if ( action === 'lostpassword' && isReactLostPasswordScreenEnabled() ) {
+		if ( action === 'lostpassword' ) {
 			return (
 				<Fragment>
 					<div className="login__lost-password-form-wrapper">

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -27,7 +27,6 @@ import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import {
 	getSignupUrl,
 	pathWithLeadingSlash,
-	isReactLostPasswordScreenEnabled,
 	canDoMagicLogin,
 	getLoginLinkPageUrl,
 } from 'calypso/lib/login';
@@ -37,7 +36,7 @@ import {
 	isGravatarFlowOAuth2Client,
 	isGravatarOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
-import { login, lostPassword } from 'calypso/lib/paths';
+import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { sendEmailLogin } from 'calypso/state/auth/actions';
@@ -622,36 +621,23 @@ export class LoginForm extends Component {
 	}
 
 	renderLostPasswordLink() {
-		if ( isReactLostPasswordScreenEnabled() ) {
-			return (
-				<a
-					className="login__form-forgot-password"
-					href="/"
-					onClick={ ( event ) => {
-						event.preventDefault();
-						this.props.recordTracksEvent( 'calypso_login_reset_password_link_click' );
-						page(
-							login( {
-								redirectTo: this.props.redirectTo,
-								locale: this.props.locale,
-								action: this.props.isWooPasswordlessJPC ? 'jetpack/lostpassword' : 'lostpassword',
-								oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
-								from: get( this.props.currentQuery, 'from' ),
-							} )
-						);
-					} }
-				>
-					{ this.props.translate( 'Forgot password?' ) }
-				</a>
-			);
-		}
-
 		return (
 			<a
 				className="login__form-forgot-password"
-				href={ lostPassword( this.props.locale ) }
-				onClick={ () => this.props.recordTracksEvent( 'calypso_login_reset_password_link_click' ) }
-				rel="external"
+				href="/"
+				onClick={ ( event ) => {
+					event.preventDefault();
+					this.props.recordTracksEvent( 'calypso_login_reset_password_link_click' );
+					page(
+						login( {
+							redirectTo: this.props.redirectTo,
+							locale: this.props.locale,
+							action: this.props.isWooPasswordlessJPC ? 'jetpack/lostpassword' : 'lostpassword',
+							oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
+							from: get( this.props.currentQuery, 'from' ),
+						} )
+					);
+				} }
 			>
 				{ this.props.translate( 'Forgot password?' ) }
 			</a>

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -42,7 +42,6 @@ import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import formState from 'calypso/lib/form-state';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
-import { isReactLostPasswordScreenEnabled } from 'calypso/lib/login';
 import {
 	isCrowdsignalOAuth2Client,
 	isWooOAuth2Client,
@@ -625,7 +624,7 @@ class SignupForm extends Component {
 												onClick={ ( event ) => this.handleLoginClick( event, fieldValue ) }
 											/>
 										),
-										pwdResetLink: isReactLostPasswordScreenEnabled() ? (
+										pwdResetLink: (
 											<a
 												href={ lostPasswordLink }
 												onClick={ ( event ) => {
@@ -644,8 +643,6 @@ class SignupForm extends Component {
 													);
 												} }
 											/>
-										) : (
-											<a href={ lostPasswordLink } />
 										),
 									},
 								}

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { addLocaleToPath, isDefaultLocale } from '@automattic/i18n-utils';
-import cookie from 'cookie';
 import { getLocaleSlug } from 'i18n-calypso';
 import { get, includes, startsWith } from 'lodash';
 import {
@@ -16,10 +15,6 @@ import {
 	isStudioAppOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
-
-function getCookies() {
-	return typeof document === 'undefined' ? {} : cookie.parse( document.cookie );
-}
 
 export function getSocialServiceFromClientId( clientId ) {
 	if ( ! clientId ) {
@@ -192,14 +187,6 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 
 	return signupUrl;
 }
-
-export const isReactLostPasswordScreenEnabled = () => {
-	const cookies = getCookies();
-	return (
-		config.isEnabled( 'login/react-lost-password-screen' ) ||
-		cookies.enable_react_password_screen === 'yes'
-	);
-};
 
 export const canDoMagicLogin = ( twoFactorAuthType, oauth2Client, isJetpackWooCommerceFlow ) => {
 	if ( ! config.isEnabled( `login/magic-login` ) || twoFactorAuthType ) {

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -8,7 +8,6 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import RedirectWhenLoggedIn from 'calypso/components/redirect-when-logged-in';
 import { preventWidows } from 'calypso/lib/formatting/prevent-widows';
-import { isReactLostPasswordScreenEnabled } from 'calypso/lib/login';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import {
@@ -34,7 +33,7 @@ class EmailedLoginLinkSuccessfully extends Component {
 	onLostPasswordClick = ( event ) => {
 		recordTracksEvent( 'calypso_magic_login_lost_password_click' );
 
-		if ( isReactLostPasswordScreenEnabled() && this.props.isWoo ) {
+		if ( this.props.isWoo ) {
 			event.preventDefault();
 
 			page(

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -15,11 +15,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
 import Main from 'calypso/components/main';
-import {
-	getSignupUrl,
-	isReactLostPasswordScreenEnabled,
-	pathWithLeadingSlash,
-} from 'calypso/lib/login';
+import { getSignupUrl, pathWithLeadingSlash } from 'calypso/lib/login';
 import {
 	isJetpackCloudOAuth2Client,
 	isA4AOAuth2Client,
@@ -320,11 +316,10 @@ export class Login extends Component {
 		}
 
 		if (
-			isReactLostPasswordScreenEnabled() &&
-			( this.props.isWoo ||
-				this.props.isBlazePro ||
-				( this.props.isWooPasswordlessJPC &&
-					config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) ) )
+			this.props.isWoo ||
+			this.props.isBlazePro ||
+			( this.props.isWooPasswordlessJPC &&
+				config.isEnabled( 'woocommerce/core-profiler-passwordless-auth' ) )
 		) {
 			return (
 				<a

--- a/config/development.json
+++ b/config/development.json
@@ -116,7 +116,6 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/magic-login": true,
-		"login/react-lost-password-screen": true,
 		"login/social-first": true,
 		"logmein": true,
 		"mailchimp": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -76,7 +76,6 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/social-first": true,
-		"login/react-lost-password-screen": true,
 		"mailchimp": false,
 		"marketplace-domain-bundle": false,
 		"marketplace-fetch-all-dynamic-products": true,

--- a/config/production.json
+++ b/config/production.json
@@ -92,7 +92,6 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/magic-login": true,
-		"login/react-lost-password-screen": true,
 		"login/social-first": true,
 		"mailchimp": true,
 		"marketplace-domain-bundle": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -89,7 +89,6 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/magic-login": true,
-		"login/react-lost-password-screen": true,
 		"login/social-first": true,
 		"mailchimp": true,
 		"marketplace-domain-bundle": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98389


## Proposed Changes

* Remove `login/react-lost-password-screen` feature flag since it's enabled on production for a while to reduce complexity and codebase.

Note: The React Lost password screen is only used for Woo and Blaze Pro.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Test WordPress.com 

* Navigate to /log-in/ on WordPress.com.
* Click "Lost your password?"
* Replace url host to your testing host
* Confirm you're on Classic Lost password screen 

### Test WooCommerce.com 

* Go to woocommerce.com
* Click "Log in" in the header
* Replace url host to your testing host
* Click "Lost your password"
* Confirm React Lost password screen is rendered

![Screenshot 2025-01-23 at 14 36 00](https://github.com/user-attachments/assets/402c8007-1347-4178-9463-e559d4ac3895)


### Test Blaze Pro (Optional)

* Go to https://blazepro.com/
* Click "Get Started"
* Click "Log in to Blaze Pro"
* Replace url host to your testing host
* Click "Lost your password"
* Confirm React Lost password screen is rendered


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
