### PR TITLE
A4A > Plugins: Implement plugin handler to use wp/v2

### DIFF
--- a/client/my-sites/plugins/hooks/types.ts
+++ b/client/my-sites/plugins/hooks/types.ts
@@ -16,6 +16,11 @@ export type Site = {
 	ID: number;
 	title: string;
 	canUpdateFiles?: boolean;
+	is_a4a_client?: boolean;
+	capabilities?: {
+		activate_plugins: boolean;
+		update_plugins: boolean;
+	};
 };
 
 export type Plugin = {

--- a/client/my-sites/plugins/hooks/types.ts
+++ b/client/my-sites/plugins/hooks/types.ts
@@ -11,20 +11,3 @@ export const PluginActions = {
 } as const;
 
 export type PluginActionName = ( typeof PluginActions )[ keyof typeof PluginActions ];
-
-export type Site = {
-	ID: number;
-	title: string;
-	canUpdateFiles?: boolean;
-	is_a4a_client?: boolean;
-	capabilities?: {
-		activate_plugins: boolean;
-		update_plugins: boolean;
-	};
-};
-
-export type Plugin = {
-	slug: string;
-	sites: Record< string, unknown >;
-	name?: string;
-};

--- a/client/my-sites/plugins/hooks/use-get-dialog-text/index.ts
+++ b/client/my-sites/plugins/hooks/use-get-dialog-text/index.ts
@@ -47,12 +47,13 @@ const getAffectedSites = ( plugins: Plugin[], sites: Site[] ) => {
 			.map( ( id ) => parseInt( id ) )
 	);
 
-	return (
-		sites
-			// We can't affect any sites that don't allow updating files
-			.filter( ( { canUpdateFiles } ) => canUpdateFiles )
-			.filter( ( s ) => pluginsInstalledOnSiteIds.has( s.ID ) )
-	);
+	return sites
+		.filter(
+			( s ) =>
+				s.canUpdateFiles ||
+				( s.is_a4a_client && s.capabilities?.activate_plugins && s.capabilities?.update_plugins )
+		)
+		.filter( ( s ) => pluginsInstalledOnSiteIds.has( s.ID ) );
 };
 
 const getTranslatableHeading = ( { headings }: ActionTexts, plugins: Plugin[] ) => {

--- a/client/my-sites/plugins/hooks/use-get-dialog-text/index.ts
+++ b/client/my-sites/plugins/hooks/use-get-dialog-text/index.ts
@@ -47,13 +47,14 @@ const getAffectedSites = ( plugins: Plugin[], sites: Site[] ) => {
 			.map( ( id ) => parseInt( id ) )
 	);
 
-	return sites
-		.filter(
-			( s ) =>
-				s.canUpdateFiles ||
-				( s.is_a4a_client && s.capabilities?.activate_plugins && s.capabilities?.update_plugins )
-		)
-		.filter( ( s ) => pluginsInstalledOnSiteIds.has( s.ID ) );
+	return sites.filter(
+		( s ) =>
+			( s.canUpdateFiles ||
+				( s.is_a4a_client &&
+					s.capabilities?.activate_plugins &&
+					s.capabilities?.update_plugins ) ) &&
+			pluginsInstalledOnSiteIds.has( s.ID )
+	);
 };
 
 const getTranslatableHeading = ( { headings }: ActionTexts, plugins: Plugin[] ) => {

--- a/client/my-sites/plugins/hooks/use-get-dialog-text/index.ts
+++ b/client/my-sites/plugins/hooks/use-get-dialog-text/index.ts
@@ -1,8 +1,9 @@
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
-import { Site, Plugin } from '../types';
 import { getActionTexts } from './actions';
-import { ActionTexts } from './types';
+import type { ActionTexts } from './types';
+import type { SiteDetails } from '@automattic/data-stores';
+import type { Plugin } from 'calypso/state/plugins/installed/types';
 
 /****************************
  * NOTE BEFORE READING:
@@ -35,7 +36,7 @@ import { ActionTexts } from './types';
  * will be affected.
  ****************************/
 
-const getAffectedSites = ( plugins: Plugin[], sites: Site[] ) => {
+const getAffectedSites = ( plugins: Plugin[], sites: SiteDetails[] ) => {
 	// NOTE: We expect the `sites` parameter not to have any duplicate IDs;
 	// if duplicate IDs are present, the returned list of sites will include all
 	// duplicates.
@@ -65,7 +66,11 @@ const getTranslatableHeading = ( { headings }: ActionTexts, plugins: Plugin[] ) 
 	return headings.manyPlugins( plugins );
 };
 
-const getTranslatableMessage = ( { messages }: ActionTexts, plugins: Plugin[], sites: Site[] ) => {
+const getTranslatableMessage = (
+	{ messages }: ActionTexts,
+	plugins: Plugin[],
+	sites: SiteDetails[]
+) => {
 	if ( plugins.length > 1 && sites.length > 1 ) {
 		return messages.manyPluginsManySites( plugins, sites );
 	}
@@ -85,7 +90,7 @@ const useGetDialogText = () => {
 	const translate = useTranslate();
 
 	return useCallback(
-		( action: string, plugins: Plugin[], sites: Site[] ) => {
+		( action: string, plugins: Plugin[], sites: SiteDetails[] ) => {
 			const actionTexts = getActionTexts( action );
 			const affectedSites = getAffectedSites( plugins, sites );
 

--- a/client/my-sites/plugins/hooks/use-get-dialog-text/index.ts
+++ b/client/my-sites/plugins/hooks/use-get-dialog-text/index.ts
@@ -49,12 +49,12 @@ const getAffectedSites = ( plugins: Plugin[], sites: SiteDetails[] ) => {
 	);
 
 	return sites.filter(
-		( s ) =>
-			( s.canUpdateFiles ||
-				( s.is_a4a_client &&
-					s.capabilities?.activate_plugins &&
-					s.capabilities?.update_plugins ) ) &&
-			pluginsInstalledOnSiteIds.has( s.ID )
+		( site ) =>
+			( site.canUpdateFiles ||
+				( site.is_a4a_client &&
+					site.capabilities?.activate_plugins &&
+					site.capabilities?.update_plugins ) ) &&
+			pluginsInstalledOnSiteIds.has( site.ID )
 	);
 };
 

--- a/client/my-sites/plugins/hooks/use-show-plugin-action-dialog.tsx
+++ b/client/my-sites/plugins/hooks/use-show-plugin-action-dialog.tsx
@@ -2,7 +2,8 @@ import React, { useCallback } from 'react';
 import acceptDialog from 'calypso/lib/accept';
 import { PluginActions } from './types';
 import useGetDialogText from './use-get-dialog-text';
-import type { Site, Plugin } from './types';
+import type { SiteDetails } from '@automattic/data-stores';
+import type { Plugin } from 'calypso/state/plugins/installed/types';
 import type { TranslateResult } from 'i18n-calypso';
 
 type DialogMessageProps = {
@@ -15,7 +16,7 @@ const useShowPluginActionDialog = () => {
 	const getDialogText = useGetDialogText();
 
 	return useCallback(
-		( action: string, plugins: Plugin[], sites: Site[], callback: DialogCallback ) => {
+		( action: string, plugins: Plugin[], sites: SiteDetails[], callback: DialogCallback ) => {
 			const { heading, message, cta } = getDialogText( action, plugins, sites );
 
 			const dialogOptions = {

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -29,6 +29,8 @@ import { getProductsList } from 'calypso/state/products-list/selectors';
 import getSiteConnectionStatus from 'calypso/state/selectors/get-site-connection-status';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import hasPluginCapabilities from 'calypso/state/sites/selectors/has-plugin-capabilities';
+import isA4AClientSite from 'calypso/state/sites/selectors/is-a4a-client-site';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { isCompatiblePlugin } from '../plugin-compatibility';
 import { getPeriodVariationValue } from '../plugin-price';
@@ -73,6 +75,8 @@ export class PluginInstallButton extends Component {
 			plugin,
 			canInstallPlugins,
 			siteIsWpcomAtomic,
+			siteIsA4AClient,
+			siteHasPluginCapabilities,
 			recordGoogleEvent: recordGAEvent,
 			recordTracksEvent: recordEvent,
 		} = this.props;
@@ -81,7 +85,11 @@ export class PluginInstallButton extends Component {
 			return;
 		}
 
-		if ( canInstallPlugins && siteIsWpcomAtomic ) {
+		const isA4AWithPluginCapabilities = siteIsA4AClient && siteHasPluginCapabilities;
+		const isAtomicAndCanInstallPlugins = siteIsWpcomAtomic && canInstallPlugins;
+		const siteCanInstallPlugins = isAtomicAndCanInstallPlugins || isA4AWithPluginCapabilities;
+
+		if ( siteCanInstallPlugins ) {
 			this.props.removePluginStatuses( 'completed', 'error', 'up-to-date' );
 			this.props.installPlugin( siteId, plugin );
 		} else {
@@ -235,8 +243,13 @@ export class PluginInstallButton extends Component {
 			isJetpackCloud,
 			canInstallPlugins,
 			siteIsWpcomAtomic,
+			siteHasPluginCapabilities,
+			siteIsA4AClient,
 		} = this.props;
 		const label = isInstalling ? translate( 'Installing…' ) : translate( 'Install' );
+		const isA4AWithPluginCapabilities = siteIsA4AClient && siteHasPluginCapabilities;
+		const isAtomicAndCanInstallPlugins = siteIsWpcomAtomic && canInstallPlugins;
+		const siteCanInstallPlugins = isAtomicAndCanInstallPlugins || isA4AWithPluginCapabilities;
 
 		if ( isEmbed ) {
 			return (
@@ -251,9 +264,7 @@ export class PluginInstallButton extends Component {
 									<Gridicon icon="plugins" size={ 18 } />
 								</>
 							) }
-							{ canInstallPlugins && siteIsWpcomAtomic
-								? translate( 'Install' )
-								: translate( 'Go to plugin page' ) }
+							{ siteCanInstallPlugins ? translate( 'Install' ) : translate( 'Go to plugin page' ) }
 						</Button>
 					) }
 				</span>
@@ -279,6 +290,8 @@ export class PluginInstallButton extends Component {
 			siteIsWpcomAtomic,
 			translate,
 			canInstallPurchasedPlugins,
+			siteHasPluginCapabilities,
+			siteIsA4AClient,
 		} = this.props;
 
 		if ( siteIsConnected === false ) {
@@ -317,7 +330,10 @@ export class PluginInstallButton extends Component {
 		}
 
 		const disabledInfo = this.getDisabledInfo();
-		if ( ! selectedSite.canUpdateFiles && disabledInfo ) {
+		const isA4AWithPluginCapabilities = siteIsA4AClient && siteHasPluginCapabilities;
+		const siteCanInstallPlugins = selectedSite.canUpdateFiles || isA4AWithPluginCapabilities;
+
+		if ( ! siteCanInstallPlugins && disabledInfo ) {
 			return disabledInfo ? (
 				<PluginInstallNotice warningText={ translate( 'Install Disabled' ) } isEmbed={ isEmbed }>
 					{ disabledInfo }
@@ -378,6 +394,8 @@ export default connect(
 				WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS
 			),
 			canInstallPlugins: siteHasFeature( state, siteId, WPCOM_FEATURES_INSTALL_PLUGINS ),
+			siteHasPluginCapabilities: hasPluginCapabilities( state, siteId ),
+			siteIsA4AClient: isA4AClientSite( state, siteId ),
 			productsList: getProductsList( state ),
 		};
 	},

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -66,6 +66,14 @@ const PluginInstallNotice = ( { isEmbed, warningText, children } ) => {
 };
 
 export class PluginInstallButton extends Component {
+	siteCanInstallPlugins = () => {
+		const { siteIsWpcomAtomic, canInstallPlugins, siteIsA4AClient, siteHasPluginCapabilities } =
+			this.props;
+		const isA4AWithPluginCapabilities = siteIsA4AClient && siteHasPluginCapabilities;
+		const isAtomicAndCanInstallPlugins = siteIsWpcomAtomic && canInstallPlugins;
+		return isAtomicAndCanInstallPlugins || isA4AWithPluginCapabilities;
+	};
+
 	installAction = () => {
 		const {
 			isEmbed,
@@ -73,10 +81,6 @@ export class PluginInstallButton extends Component {
 			selectedSite,
 			isInstalling,
 			plugin,
-			canInstallPlugins,
-			siteIsWpcomAtomic,
-			siteIsA4AClient,
-			siteHasPluginCapabilities,
 			recordGoogleEvent: recordGAEvent,
 			recordTracksEvent: recordEvent,
 		} = this.props;
@@ -85,11 +89,7 @@ export class PluginInstallButton extends Component {
 			return;
 		}
 
-		const isA4AWithPluginCapabilities = siteIsA4AClient && siteHasPluginCapabilities;
-		const isAtomicAndCanInstallPlugins = siteIsWpcomAtomic && canInstallPlugins;
-		const siteCanInstallPlugins = isAtomicAndCanInstallPlugins || isA4AWithPluginCapabilities;
-
-		if ( siteCanInstallPlugins ) {
+		if ( this.siteCanInstallPlugins() ) {
 			this.props.removePluginStatuses( 'completed', 'error', 'up-to-date' );
 			this.props.installPlugin( siteId, plugin );
 		} else {
@@ -235,21 +235,8 @@ export class PluginInstallButton extends Component {
 	}
 
 	renderButton() {
-		const {
-			translate,
-			isInstalling,
-			isEmbed,
-			disabled,
-			isJetpackCloud,
-			canInstallPlugins,
-			siteIsWpcomAtomic,
-			siteHasPluginCapabilities,
-			siteIsA4AClient,
-		} = this.props;
+		const { translate, isInstalling, isEmbed, disabled, isJetpackCloud } = this.props;
 		const label = isInstalling ? translate( 'Installing…' ) : translate( 'Install' );
-		const isA4AWithPluginCapabilities = siteIsA4AClient && siteHasPluginCapabilities;
-		const isAtomicAndCanInstallPlugins = siteIsWpcomAtomic && canInstallPlugins;
-		const siteCanInstallPlugins = isAtomicAndCanInstallPlugins || isA4AWithPluginCapabilities;
 
 		if ( isEmbed ) {
 			return (
@@ -264,7 +251,9 @@ export class PluginInstallButton extends Component {
 									<Gridicon icon="plugins" size={ 18 } />
 								</>
 							) }
-							{ siteCanInstallPlugins ? translate( 'Install' ) : translate( 'Go to plugin page' ) }
+							{ this.siteCanInstallPlugins()
+								? translate( 'Install' )
+								: translate( 'Go to plugin page' ) }
 						</Button>
 					) }
 				</span>

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -100,11 +100,8 @@ export default function UpdatePlugin( { plugin, selectedSite, className, updateP
 					className="update-plugin__new-version"
 					compact
 				>
-					{ translate( '{{span}}Update to {{/span}}%s', {
-						components: {
-							span: <span />,
-						},
-						args: updatedVersions[ 0 ],
+					{ translate( 'Update to %(version)s', {
+						args: { version: updatedVersions[ 0 ] },
 					} ) }
 				</Button>
 			</div>

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -18,8 +18,9 @@ import PluginAction from 'calypso/my-sites/plugins/plugin-action/plugin-action';
 import { removePlugin } from 'calypso/state/plugins/installed/actions';
 import { isPluginActionInProgress } from 'calypso/state/plugins/installed/selectors';
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
+import hasPluginCapabilities from 'calypso/state/sites/selectors/has-plugin-capabilities';
+import isA4AClientSite from 'calypso/state/sites/selectors/is-a4a-client-site';
 import { withShowPluginActionDialog } from '../hooks/use-show-plugin-action-dialog';
-
 import './style.scss';
 
 class PluginRemoveButton extends Component {
@@ -88,7 +89,11 @@ class PluginRemoveButton extends Component {
 			);
 		}
 
-		if ( ! this.props.site.canUpdateFiles && this.props.site.options.file_mod_disabled ) {
+		const canRemovePlugin =
+			( this.props.site.canUpdateFiles && this.props.site.options.file_mod_disabled ) ||
+			( this.props.siteIsA4AClient && this.props.siteHasPluginCapabilities );
+
+		if ( ! canRemovePlugin ) {
 			const reasons = getSiteFileModDisableReason( this.props.site, 'modifyFiles' );
 			const html = [];
 
@@ -191,7 +196,12 @@ class PluginRemoveButton extends Component {
 	};
 
 	render() {
-		if ( ! this.props.site.jetpack ) {
+		const { siteIsA4AClient, siteHasPluginCapabilities } = this.props;
+
+		const canRemovePlugin =
+			this.props.site.jetpack || ( siteIsA4AClient && siteHasPluginCapabilities );
+
+		if ( ! canRemovePlugin ) {
 			return null;
 		}
 
@@ -211,6 +221,8 @@ class PluginRemoveButton extends Component {
 export default connect(
 	( state, { site, plugin } ) => ( {
 		inProgress: isPluginActionInProgress( state, site.ID, plugin.id, REMOVE_PLUGIN ),
+		siteHasPluginCapabilities: hasPluginCapabilities( state, site.ID ),
+		siteIsA4AClient: isA4AClientSite( state, site.ID ),
 	} ),
 	{ removePlugin, removePluginStatuses }
 )( withShowPluginActionDialog( localize( PluginRemoveButton ) ) );

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -90,7 +90,7 @@ class PluginRemoveButton extends Component {
 		}
 
 		const canRemovePlugin =
-			( this.props.site.canUpdateFiles && this.props.site.options.file_mod_disabled ) ||
+			( this.props.site.canUpdateFiles && ! this.props.site.options.file_mod_disabled ) ||
 			( this.props.siteIsA4AClient && this.props.siteHasPluginCapabilities );
 
 		if ( ! canRemovePlugin ) {

--- a/client/my-sites/plugins/plugins-dashboard/index.tsx
+++ b/client/my-sites/plugins/plugins-dashboard/index.tsx
@@ -44,7 +44,7 @@ import { getProductsList } from 'calypso/state/products-list/selectors';
 import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
-import { PluginActionName, PluginActions, Site } from '../hooks/types';
+import { PluginActionName, PluginActions } from '../hooks/types';
 import { withShowPluginActionDialog } from '../hooks/use-show-plugin-action-dialog';
 import PluginAvailableOnSitesList from '../plugin-management-v2/plugin-details-v2/plugin-available-on-sites-list';
 import SitesWithInstalledPluginsList from '../plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list';
@@ -68,7 +68,7 @@ interface PluginsDashboardProps {
 	showPluginActionDialog: (
 		actionName: PluginActionName,
 		selectedPlugins: Plugin[],
-		sites: Site[],
+		sites: SiteDetails[],
 		selectedActionCallback: ( accepted: boolean ) => void
 	) => void;
 	fullPlugin: object;
@@ -308,7 +308,7 @@ const PluginsDashboard = ( {
 		showPluginActionDialog(
 			actionName as PluginActionName,
 			pluginsToProcess,
-			sites as Site[],
+			sites as SiteDetails[],
 			selectedActionCallback( pluginsToProcess )
 		);
 	};

--- a/client/state/plugins/handler.ts
+++ b/client/state/plugins/handler.ts
@@ -5,15 +5,7 @@ const useWPV2APIEndpoint = isA8CForAgencies();
 const wpV2APINamespace = 'wp/v2';
 
 // Create handlers for all plugin methods with wp/v2 namespace.
-const methods = [
-	'get',
-	'update',
-	'updateVersion',
-	'install',
-	'delete',
-	'enableAutoupdate',
-	'disableAutoupdate',
-];
+const methods = [ 'get', 'update', 'updateVersion', 'enableAutoupdate', 'disableAutoupdate' ];
 
 type PluginHandlers = {
 	[ key in ( typeof methods )[ number ] ]?: (
@@ -21,6 +13,8 @@ type PluginHandlers = {
 		...args: unknown[]
 	) => unknown;
 } & {
+	install?: ( query: Record< string, unknown >, ...args: unknown[] ) => unknown;
+	delete?: ( query: Record< string, unknown >, ...args: unknown[] ) => unknown;
 	activate?: ( query: Record< string, unknown >, ...args: unknown[] ) => unknown;
 	deactivate?: ( query: Record< string, unknown >, ...args: unknown[] ) => unknown;
 };
@@ -54,7 +48,26 @@ export const getPluginHandler = ( siteId: number, pluginId: number ) => {
 	handlers.deactivate = ( query, ...args ) =>
 		pluginHandler.update(
 			{ ...query, apiNamespace: wpV2APINamespace },
-			{ status: 'inactive' },
+			{
+				slug: pluginHandler._slug,
+				status: 'inactive',
+			},
+			...args
+		);
+
+	handlers.install = ( query, ...args ) =>
+		pluginHandler.wpcom.req.post(
+			`/sites/${ siteId }/plugins`,
+			{ ...query, apiNamespace: wpV2APINamespace },
+			{ slug: pluginHandler._slug },
+			...args
+		);
+
+	handlers.delete = ( query, ...args ) =>
+		pluginHandler.wpcom.req.post(
+			{ path: pluginHandler.pluginPath, method: 'delete' },
+			{ ...query, apiNamespace: wpV2APINamespace },
+			null,
 			...args
 		);
 

--- a/client/state/plugins/handler.ts
+++ b/client/state/plugins/handler.ts
@@ -30,26 +30,29 @@ export const getPluginHandler = ( siteId: number, pluginId: string ) => {
 	if ( ! useWPV2APIEndpoint ) {
 		return pluginHandler;
 	}
-	// For wp/v2 we need to override the encoded pluginId otherwise the plugin will not be found.
-	pluginHandler.pluginPath = pluginHandler.pluginPath.replace(
-		encodeURIComponent( pluginId ),
-		pluginId
-	);
-	pluginHandler._slug = pluginId;
 
-	const handlers: PluginHandlers = methods.reduce< PluginHandlers >( ( acc, method ) => {
-		acc[ method ] = ( query, ...args ) =>
-			pluginHandler[ method ]( { ...query, apiNamespace: wpV2APINamespace }, ...args );
-		return acc;
-	}, {} );
+	const handlers: PluginHandlers = methods.reduce< PluginHandlers >(
+		( acc, method ) => ( {
+			...acc,
+			[ method ]: ( query, ...args ) => pluginHandler[ method ]( { ...query }, ...args ),
+		} ),
+		{}
+	);
+
+	// For wp/v2 we need to override the encoded pluginId otherwise the plugin will not be found.
+	const pluginPath = pluginHandler.pluginPath.replace( encodeURIComponent( pluginId ), pluginId );
 
 	// Custom methods for wp/v2 requiring different payloads.
 	handlers.get = ( query, ...args ) =>
-		pluginHandler.get( { ...query, apiNamespace: wpV2APINamespace }, ...args );
+		pluginHandler.wpcom.req.get(
+			pluginPath,
+			{ ...query, apiNamespace: wpV2APINamespace },
+			...args
+		);
 
 	handlers.update = ( query, body, ...args ) =>
 		pluginHandler.wpcom.req.post(
-			pluginHandler.pluginPath,
+			pluginPath,
 			{ ...query, apiNamespace: wpV2APINamespace },
 			body,
 			...args
@@ -91,7 +94,7 @@ export const getPluginHandler = ( siteId: number, pluginId: string ) => {
 
 	handlers.delete = ( query, ...args ) =>
 		pluginHandler.wpcom.req.post(
-			{ path: pluginHandler.pluginPath, method: 'delete' },
+			{ path: pluginPath, method: 'delete' },
 			{ ...query, apiNamespace: wpV2APINamespace },
 			null,
 			...args

--- a/client/state/plugins/handler.ts
+++ b/client/state/plugins/handler.ts
@@ -1,0 +1,25 @@
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
+import wpcom from 'calypso/lib/wp';
+
+const useWPV2APIEndpoint = isA8CForAgencies();
+
+export const getPluginHandler = ( siteId: number, pluginId: number ) => {
+	const pluginHandler = wpcom.site( siteId ).plugin( pluginId );
+	if ( ! useWPV2APIEndpoint ) {
+		return pluginHandler;
+	}
+	// For wp/v2 we need to override the encoded pluginId otherwise the plugin will not be found.
+	pluginHandler.pluginPath = pluginHandler.pluginPath.replace(
+		encodeURIComponent( pluginId ),
+		pluginId
+	);
+	pluginHandler._slug = pluginId;
+	// Other logic as per your POC
+};
+
+export const getSitePluginsHandler = ( siteId: number ) => {
+	const siteHandler = wpcom.site( siteId );
+	return siteHandler.pluginsList( {
+		...( useWPV2APIEndpoint && { apiNamespace: 'wp/v2' } ),
+	} );
+};

--- a/client/state/plugins/handler.ts
+++ b/client/state/plugins/handler.ts
@@ -5,7 +5,7 @@ const useWPV2APIEndpoint = isA8CForAgencies();
 const wpV2APINamespace = 'wp/v2';
 
 // Create handlers for all plugin methods with wp/v2 namespace.
-const methods = [ 'get', 'update', 'updateVersion', 'enableAutoupdate', 'disableAutoupdate' ];
+const methods = [ 'updateVersion', 'enableAutoupdate', 'disableAutoupdate' ];
 
 type PluginHandlers = {
 	[ key in ( typeof methods )[ number ] ]?: (
@@ -13,13 +13,19 @@ type PluginHandlers = {
 		...args: unknown[]
 	) => unknown;
 } & {
+	get?: ( query: Record< string, unknown >, ...args: unknown[] ) => unknown;
+	update?: (
+		query: Record< string, unknown >,
+		body: Record< string, unknown >,
+		...args: unknown[]
+	) => unknown;
 	install?: ( query: Record< string, unknown >, ...args: unknown[] ) => unknown;
 	delete?: ( query: Record< string, unknown >, ...args: unknown[] ) => unknown;
 	activate?: ( query: Record< string, unknown >, ...args: unknown[] ) => unknown;
 	deactivate?: ( query: Record< string, unknown >, ...args: unknown[] ) => unknown;
 };
 
-export const getPluginHandler = ( siteId: number, pluginId: number ) => {
+export const getPluginHandler = ( siteId: number, pluginId: string ) => {
 	const pluginHandler = wpcom.site( siteId ).plugin( pluginId );
 	if ( ! useWPV2APIEndpoint ) {
 		return pluginHandler;
@@ -38,30 +44,50 @@ export const getPluginHandler = ( siteId: number, pluginId: number ) => {
 	}, {} );
 
 	// Custom methods for wp/v2 requiring different payloads.
-	handlers.activate = ( query, ...args ) =>
-		pluginHandler.update(
+	handlers.get = ( query, ...args ) =>
+		pluginHandler.get( { ...query, apiNamespace: wpV2APINamespace }, ...args );
+
+	handlers.update = ( query, body, ...args ) =>
+		pluginHandler.wpcom.req.post(
+			pluginHandler.pluginPath,
 			{ ...query, apiNamespace: wpV2APINamespace },
-			{ status: 'active' },
+			body,
+			...args
+		);
+
+	handlers.activate = ( query, ...args ) =>
+		handlers.update?.(
+			query,
+			{
+				status: 'active',
+			},
 			...args
 		);
 
 	handlers.deactivate = ( query, ...args ) =>
-		pluginHandler.update(
-			{ ...query, apiNamespace: wpV2APINamespace },
+		handlers.update?.(
+			query,
 			{
-				slug: pluginHandler._slug,
 				status: 'inactive',
 			},
 			...args
 		);
 
-	handlers.install = ( query, ...args ) =>
-		pluginHandler.wpcom.req.post(
+	handlers.install = ( query, ...args ) => {
+		// The pluginId can be a plugin's basename (e.g., woocommerce/woocommerce).
+		// WordPress core expects the plugin's WordPress.org slug for installations.
+		let pluginSlug = pluginId;
+		if ( pluginId.includes( '/' ) ) {
+			pluginSlug = pluginId.split( '/' )[ 0 ];
+		}
+
+		return pluginHandler.wpcom.req.post(
 			`/sites/${ siteId }/plugins`,
 			{ ...query, apiNamespace: wpV2APINamespace },
-			{ slug: pluginHandler._slug },
+			{ slug: pluginSlug },
 			...args
 		);
+	};
 
 	handlers.delete = ( query, ...args ) =>
 		pluginHandler.wpcom.req.post(

--- a/client/state/plugins/handler.ts
+++ b/client/state/plugins/handler.ts
@@ -2,6 +2,7 @@ import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import wpcom from 'calypso/lib/wp';
 
 const useWPV2APIEndpoint = isA8CForAgencies();
+const wpV2APINamespace = 'wp/v2';
 
 export const getPluginHandler = ( siteId: number, pluginId: number ) => {
 	const pluginHandler = wpcom.site( siteId ).plugin( pluginId );
@@ -14,12 +15,55 @@ export const getPluginHandler = ( siteId: number, pluginId: number ) => {
 		pluginId
 	);
 	pluginHandler._slug = pluginId;
-	// Other logic as per your POC
+
+	// Create handlers for all plugin methods with wp/v2 namespace.
+	const methods = [
+		'get',
+		'update',
+		'updateVersion',
+		'install',
+		'delete',
+		'enableAutoupdate',
+		'disableAutoupdate',
+	];
+
+	type PluginHandlers = {
+		[ key in ( typeof methods )[ number ] ]?: (
+			query: Record< string, unknown >,
+			...args: unknown[]
+		) => unknown;
+	} & {
+		activate?: ( query: Record< string, unknown >, ...args: unknown[] ) => unknown;
+		deactivate?: ( query: Record< string, unknown >, ...args: unknown[] ) => unknown;
+	};
+
+	const handlers: PluginHandlers = methods.reduce< PluginHandlers >( ( acc, method ) => {
+		acc[ method ] = ( query, ...args ) =>
+			pluginHandler[ method ]( { ...query, apiNamespace: wpV2APINamespace }, ...args );
+		return acc;
+	}, {} );
+
+	// Custom methods for wp/v2 requiring different payloads.
+	handlers.activate = ( query, ...args ) =>
+		pluginHandler.update(
+			{ ...query, apiNamespace: wpV2APINamespace },
+			{ status: 'active' },
+			...args
+		);
+
+	handlers.deactivate = ( query, ...args ) =>
+		pluginHandler.update(
+			{ ...query, apiNamespace: wpV2APINamespace },
+			{ status: 'inactive' },
+			...args
+		);
+
+	return handlers;
 };
 
 export const getSitePluginsHandler = ( siteId: number ) => {
 	const siteHandler = wpcom.site( siteId );
 	return siteHandler.pluginsList( {
-		...( useWPV2APIEndpoint && { apiNamespace: 'wp/v2' } ),
+		...( useWPV2APIEndpoint && { apiNamespace: wpV2APINamespace } ),
 	} );
 };

--- a/client/state/plugins/handler.ts
+++ b/client/state/plugins/handler.ts
@@ -4,6 +4,27 @@ import wpcom from 'calypso/lib/wp';
 const useWPV2APIEndpoint = isA8CForAgencies();
 const wpV2APINamespace = 'wp/v2';
 
+// Create handlers for all plugin methods with wp/v2 namespace.
+const methods = [
+	'get',
+	'update',
+	'updateVersion',
+	'install',
+	'delete',
+	'enableAutoupdate',
+	'disableAutoupdate',
+];
+
+type PluginHandlers = {
+	[ key in ( typeof methods )[ number ] ]?: (
+		query: Record< string, unknown >,
+		...args: unknown[]
+	) => unknown;
+} & {
+	activate?: ( query: Record< string, unknown >, ...args: unknown[] ) => unknown;
+	deactivate?: ( query: Record< string, unknown >, ...args: unknown[] ) => unknown;
+};
+
 export const getPluginHandler = ( siteId: number, pluginId: number ) => {
 	const pluginHandler = wpcom.site( siteId ).plugin( pluginId );
 	if ( ! useWPV2APIEndpoint ) {
@@ -15,27 +36,6 @@ export const getPluginHandler = ( siteId: number, pluginId: number ) => {
 		pluginId
 	);
 	pluginHandler._slug = pluginId;
-
-	// Create handlers for all plugin methods with wp/v2 namespace.
-	const methods = [
-		'get',
-		'update',
-		'updateVersion',
-		'install',
-		'delete',
-		'enableAutoupdate',
-		'disableAutoupdate',
-	];
-
-	type PluginHandlers = {
-		[ key in ( typeof methods )[ number ] ]?: (
-			query: Record< string, unknown >,
-			...args: unknown[]
-		) => unknown;
-	} & {
-		activate?: ( query: Record< string, unknown >, ...args: unknown[] ) => unknown;
-		deactivate?: ( query: Record< string, unknown >, ...args: unknown[] ) => unknown;
-	};
 
 	const handlers: PluginHandlers = methods.reduce< PluginHandlers >( ( acc, method ) => {
 		acc[ method ] = ( query, ...args ) =>

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -173,9 +173,16 @@ export function activatePlugin( siteId, plugin ) {
 		};
 
 		const successCallback = ( data ) => {
-			dispatch( { ...defaultAction, type: PLUGIN_ACTIVATE_REQUEST_SUCCESS, data } );
-			dispatch( handleDispatchSuccessCallback( defaultAction, data ) );
-			afterActivationCallback( undefined, data );
+			// Add shim for wp/v2 API response format
+			const normalizedData = {
+				...data,
+				id: data.plugin,
+				active: data.status === 'active' || data.active,
+			};
+
+			dispatch( { ...defaultAction, type: PLUGIN_ACTIVATE_REQUEST_SUCCESS, data: normalizedData } );
+			dispatch( handleDispatchSuccessCallback( defaultAction, normalizedData ) );
+			afterActivationCallback( undefined, normalizedData );
 		};
 
 		const errorCallback = ( error ) => {
@@ -240,8 +247,19 @@ export function deactivatePlugin( siteId, plugin ) {
 		};
 
 		const successCallback = ( data ) => {
-			dispatch( { ...defaultAction, type: PLUGIN_DEACTIVATE_REQUEST_SUCCESS, data } );
-			dispatch( handleDispatchSuccessCallback( defaultAction, data ) );
+			// Add shim for wp/v2 API response format
+			const normalizedData = {
+				...data,
+				id: data.plugin,
+				active: data.status === 'active' || data.active,
+			};
+
+			dispatch( {
+				...defaultAction,
+				type: PLUGIN_DEACTIVATE_REQUEST_SUCCESS,
+				data: normalizedData,
+			} );
+			dispatch( handleDispatchSuccessCallback( defaultAction, normalizedData ) );
 			afterDeactivationCallback( undefined );
 		};
 

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -555,20 +555,20 @@ export function removePlugin( siteId, plugin ) {
 
 		const doDeactivate = function ( pluginData ) {
 			if ( pluginData.active ) {
-				return getPluginHandler( siteId, pluginData.id ).deactivate();
+				return getPluginHandler( siteId, pluginId ).deactivate();
 			}
 			return Promise.resolve( pluginData );
 		};
 
 		const doDisableAutoupdate = function ( pluginData ) {
 			if ( pluginData.autoupdate ) {
-				return getPluginHandler( siteId, pluginData.id ).disableAutoupdate();
+				return getPluginHandler( siteId, pluginId ).disableAutoupdate();
 			}
 			return Promise.resolve( pluginData );
 		};
 
-		const doRemove = function ( pluginData ) {
-			return getPluginHandler( siteId, pluginData.id ).delete();
+		const doRemove = function () {
+			return getPluginHandler( siteId, pluginId ).delete();
 		};
 
 		const successCallback = () => {

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -483,7 +483,7 @@ function installPluginHelper(
 		const successCallback = ( data ) => {
 			const normalizedData = {
 				...data,
-				slug: data.slug ?? pluginId,
+				slug: data.slug ?? plugin.slug,
 			};
 
 			dispatch( { ...defaultAction, type: PLUGIN_INSTALL_REQUEST_SUCCESS, data: normalizedData } );

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -458,19 +458,19 @@ function installPluginHelper(
 			return getPluginHandler( siteId, pluginData.slug ).install();
 		};
 
-		const doActivate = function ( pluginData ) {
+		const doActivate = function () {
 			lastStep = 'doActivate';
-			return getPluginHandler( siteId, pluginData.id ).activate();
+			return getPluginHandler( siteId, pluginId ).activate();
 		};
 
-		const doUpdate = function ( pluginData ) {
+		const doUpdate = function () {
 			lastStep = 'doUpdate';
-			return getPluginHandler( siteId, pluginData.id ).updateVersion();
+			return getPluginHandler( siteId, pluginId ).updateVersion();
 		};
 
-		const doAutoupdates = function ( pluginData ) {
+		const doAutoupdates = function () {
 			lastStep = 'doAutoupdates';
-			return getPluginHandler( siteId, pluginData.id ).enableAutoupdate();
+			return getPluginHandler( siteId, pluginId ).enableAutoupdate();
 		};
 
 		const recordInstallPluginEvent = ( type, error ) => {
@@ -481,8 +481,13 @@ function installPluginHelper(
 		};
 
 		const successCallback = ( data ) => {
-			dispatch( { ...defaultAction, type: PLUGIN_INSTALL_REQUEST_SUCCESS, data } );
-			dispatch( handleDispatchSuccessCallback( defaultAction, data ) );
+			const normalizedData = {
+				...data,
+				slug: data.slug ?? pluginId,
+			};
+
+			dispatch( { ...defaultAction, type: PLUGIN_INSTALL_REQUEST_SUCCESS, data: normalizedData } );
+			dispatch( handleDispatchSuccessCallback( defaultAction, normalizedData ) );
 			recordInstallPluginEvent( 'RECEIVE_INSTALLED_PLUGIN' );
 			refreshNetworkSites( siteId );
 		};

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -49,6 +49,7 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getNetworkSites from 'calypso/state/selectors/get-network-sites';
 import { sitePluginUpdated } from 'calypso/state/sites/actions';
 import { getSite } from 'calypso/state/sites/selectors';
+import { getPluginHandler, getSitePluginsHandler } from '../handler';
 
 import 'calypso/state/plugins/init';
 
@@ -68,17 +69,6 @@ const pluginHasTruthySiteProp = ( prop, plugin, siteId ) => {
 	return !! ( plugin.hasOwnProperty( prop )
 		? plugin[ prop ]
 		: siteId && plugin.sites?.[ siteId ]?.[ prop ] );
-};
-
-/**
- * Return a SitePlugin instance used to handle the plugin
- * @param {Object} siteId - site ID
- * @param {string} pluginId - plugin identifier
- * @returns {any} SitePlugin instance
- */
-const getPluginHandler = ( siteId, pluginId ) => {
-	const siteHandler = wpcom.site( siteId );
-	return siteHandler.plugin( pluginId );
 };
 
 /**
@@ -614,9 +604,7 @@ export function fetchSitePlugins( siteId ) {
 			dispatch( { ...defaultAction, type: PLUGINS_REQUEST_FAILURE, error } );
 		};
 
-		return wpcom
-			.site( siteId )
-			.pluginsList()
+		return getSitePluginsHandler( siteId )
 			.then( receivePluginsDispatchSuccess )
 			.catch( receivePluginsDispatchFail );
 	};

--- a/client/state/sites/selectors/has-plugin-capabilities.ts
+++ b/client/state/sites/selectors/has-plugin-capabilities.ts
@@ -1,0 +1,17 @@
+import getRawSite from 'calypso/state/selectors/get-raw-site';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Returns true if the site has capabilities to manage plugins
+ */
+export default function hasPluginCapabilities(
+	state: AppState,
+	siteId: number | undefined | null
+): boolean {
+	if ( ! siteId ) {
+		return false;
+	}
+
+	const site = getRawSite( state, siteId );
+	return !! ( site?.capabilities?.activate_plugins && site?.capabilities?.update_plugins );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/7
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1719

## Proposed Changes

Simplify plugin API interactions and ensure compatibility with the `wp/v2` namespace, aligning with requirements for agency accounts. 

This PR refactors plugin handler methods to introduce support for the `wp/v2` API namespace when the `isA8CForAgencies` condition is met. Key changes:

* A new `handler.ts` file that centralizes plugin method handlers, including custom handling for activation and deactivation payloads specific to the `wp/v2` API.
* Replacement of `getPluginHandler` and `pluginsList` implementations with `getPluginHandler` and  `getSitePluginsHandler` to improve consistency and maintainability.
* Removal of redundant code in `installed/actions.js` by replacing direct calls to `wpcom` with the newly refactored handlers.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure plugin operations (get, update, install, activate, deactivate, etc.) function correctly for both legacy and `wp/v2` API paths.
* Verify activation and deactivation payloads are sent correctly to the API.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
