### PR TITLE
Server: preload section chunks

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -146,6 +146,9 @@ class Document extends Component {
 					) ) }
 					{ chunkCssLinks( entrypoint, isRTL ) }
 					{ chunkCssLinks( chunkFiles, isRTL ) }
+					{ chunkFiles.js.map( ( chunk ) => (
+						<link key={ chunk } rel="preload" as="script" href={ chunk } />
+					) ) }
 				</Head>
 				<body
 					className={ clsx( {
@@ -242,10 +245,6 @@ class Document extends Component {
 
 					{ entrypoint.js.map( ( asset ) => (
 						<script key={ asset } src={ asset } />
-					) ) }
-
-					{ chunkFiles.js.map( ( chunk ) => (
-						<script key={ chunk } src={ chunk } />
 					) ) }
 					<script nonce={ inlineScriptNonce } type="text/javascript">
 						window.AppBoot();


### PR DESCRIPTION
As discussed in #98543, this PR moves section chunks, i.e., chunks that are not part of the entrypoint but are part of the section async chunk handling the initial route (like `/read`), into `<link rel="preload">` links in the document head.

After this patch, we synchronously load only the entrypoint chunks, where the "root" entrypoint chunk is loaded and executed as the last one. Further loads are merely preloaded.

Then, when you load a `wordpress.com/read` URL, the app in the entrypoint calls `await import( 'reader' )` when handling the initial `/read` route, and all `reader` chunks are already preloaded.

This is a more correct approach that prevents possible race condition when the webpack app is already executing and some scripts are still loading in parallel.

I'm only preloading the JS chunks. CSS chunks are fully loaded as before. The reason is SSR: the server might have already rendered markup for Reader UI, so we need the styles.

**How to test:**
Verify that various routes and entrypoints still work the same. The last `<script>` loaded at the bottom of the document should be the entrypoint. All the section chunks should be `<link>` elements in the `<head>`.

When webpack actually wants to load the chunk, it will create a `<script>` element for it, insert it into `<head>`, and after the `load` event fires it will remove the `<script>` element again. That's why you'll never see it in the DOM inspector.