### PR TITLE
Scheduled plugins: Fix radio button style

### DIFF
--- a/client/blocks/plugins-scheduled-updates/schedule-form.scss
+++ b/client/blocks/plugins-scheduled-updates/schedule-form.scss
@@ -168,6 +168,9 @@
 			border: solid 1px var(--wp-admin-theme-color) !important;
 			border-radius: 2px;
 
+			.components-radio-control__input[type="radio"] {
+				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) #fff, 0 0 0 calc(2 * var(--wp-admin-border-width-focus)) var(--wp-admin-theme-color);
+			}
 		}
 
 		&:not(.selected) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fix the radio button style when the radio is selected

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix regression fix

## Testing Instructions

* Go to `/plugins/scheduled-updates/create`
* Check if the selected Frequency radio input has box-shadow

**Before:**
<img width="1025" alt="Screenshot 2025-01-23 at 13 45 21" src="https://github.com/user-attachments/assets/28374a67-3999-4f75-b720-ec70b2e4efc9" />

**After:**
<img width="1012" alt="Screenshot 2025-01-23 at 13 45 30" src="https://github.com/user-attachments/assets/ac8ec922-e3fb-41c9-b090-937fb44b8c71" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
