### PR TITLE
Revert "Masterbar: Update colors so they match Modern (default) color scheme."

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -59,10 +59,10 @@ $brand-text: "SF Pro Text", $sans;
 		--color-sidebar-gridicon-selected-fill: var(--color-sidebar-menu-selected-text);
 		--color-sidebar-tooltip-background: var(--color-sidebar-menu-hover-background);
 		--color-sidebar-tooltip-text: var(--color-sidebar-menu-hover-text);
-		--color-masterbar-unread-dot-background: var(--studio-wordpress-blue-20);
-		--color-masterbar-background: #1e1e1e; // From "Modern" color scheme.
-		--color-masterbar-text: #fff; // From "Modern" color scheme.
-		--color-masterbar-icon: #fff; // From "Modern" color scheme.
+		--color-masterbar-unread-dot-background: #e65054;
+		--color-masterbar-background: var(--studio-gray-90);
+		--color-masterbar-text: var(--studio-gray-10);
+		--color-masterbar-icon: var(--studio-gray-10);
 		--color-masterbar-submenu-text: var(--color-sidebar-text);
 		--color-masterbar-submenu-hover-text: var(--color-accent);
 		--color-global-masterbar-submenu-background: var(--studio-white);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_global.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_global.scss
@@ -13,7 +13,7 @@ WPCom Global theme, Modern theme adjusted for use in calypso non site contexts
 	--theme-icon-color: #ece6f6; /* Direct from wp-admin */
 	--theme-highlight-color: #3858e9; /* Direct from wp-admin */
 	--theme-highlight-color-rgb: 56, 88, 233; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
-	--theme-notification-color: var(--studio-wordpress-blue-20);
+	--theme-notification-color: #3858e9; /* Direct from wp-admin */
 
 	/* Theme highlight monochromatic palette */
 	--theme-highlight-color-0: #d5dffa;

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
@@ -31,7 +31,7 @@ Uses custom theme highlight monochromatic palette for primary + accent
 	--theme-icon-color: #f3f1f1; /* $icon-color */
 	--theme-highlight-color: #3858e9; /* $highlight-color */
 	--theme-highlight-color-rgb: 56, 88, 233; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
-	--theme-notification-color: var(--studio-wordpress-blue-20);
+	--theme-notification-color: #3858e9; /* Direct from wp-admin */
 
 	/* Theme highlight monochromatic palette */
 	--theme-highlight-color-0: #d5dffa;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#98542

Tests were failing. 