### PR TITLE
A4A: Implement Product listing based on the new design.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
@@ -80,14 +80,14 @@ const getDisplayableJetpackProducts = ( filteredProductsAndBundles: APIProductFa
 const getDisplayableFeaturedProducts = (
 	filteredProductsAndBundles: APIProductFamilyProduct[]
 ) => {
-	const featured_product_slugs = [
+	const featuredProductSlugs = [
 		'woocommerce-advanced-notifications',
 		'jetpack-boost',
 		'woocommerce-bulk-stock-management',
 	]; // For now, we hardcode this until we understand how we want pick featured products.
 
 	return filteredProductsAndBundles.filter( ( product ) =>
-		featured_product_slugs.includes( product.slug )
+		featuredProductSlugs.includes( product.slug )
 	);
 };
 

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
@@ -77,6 +77,20 @@ const getDisplayableJetpackProducts = ( filteredProductsAndBundles: APIProductFa
 	} ) as APIProductFamilyProduct[];
 };
 
+const getDisplayableFeaturedProducts = (
+	filteredProductsAndBundles: APIProductFamilyProduct[]
+) => {
+	const featured_product_slugs = [
+		'woocommerce-advanced-notifications',
+		'jetpack-boost',
+		'woocommerce-bulk-stock-management',
+	]; // For now, we hardcode this until we understand how we want pick featured products.
+
+	return filteredProductsAndBundles.filter( ( product ) =>
+		featured_product_slugs.includes( product.slug )
+	);
+};
+
 const getDisplayableWoocommerceExtensions = (
 	filteredProductsAndBundles: APIProductFamilyProduct[]
 ) => {
@@ -143,6 +157,7 @@ export default function useProductAndPlans( {
 				PRODUCT_TYPE_JETPACK_BACKUP_ADDON,
 				filteredProductsAndBundles
 			),
+			featuredProducts: getDisplayableFeaturedProducts( filteredProductsAndBundles ),
 			wooExtensions: getDisplayableWoocommerceExtensions( filteredProductsAndBundles ),
 			pressablePlans: filterProductsAndPlansByType(
 				PRODUCT_TYPE_PRESSABLE_PLAN,

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/index.tsx
@@ -12,7 +12,6 @@ import {
 	A4A_MARKETPLACE_CHECKOUT_LINK,
 	A4A_MARKETPLACE_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import LayoutBody from 'calypso/layout/hosting-dashboard/body';
 import LayoutHeader, {
 	LayoutHeaderActions as Actions,
 	LayoutHeaderBreadcrumb as Breadcrumb,
@@ -128,6 +127,7 @@ export function ProductsOverviewV2( {
 								label: translate( 'Products' ),
 							},
 						] }
+						hideOnMobile
 					/>
 
 					<Actions>
@@ -161,22 +161,20 @@ export function ProductsOverviewV2( {
 				setSelectedBundleSize={ setSelectedBundleSize }
 			/>
 
-			<LayoutBody className="products-overview-v2__body">
-				<ShoppingCartContext.Provider value={ { setSelectedCartItems, selectedCartItems } }>
-					{
-						// we will remove this once we have the new product listing component
-						<ProductListing
-							selectedSite={ selectedSite }
-							suggestedProduct={ suggestedProduct }
-							productBrand={ productBrand }
-							productSearchQuery={ productSearchQuery }
-							isReferralMode={ isReferralMode }
-							selectedBundleSize={ selectedBundleSize }
-							selectedFilters={ selectedFilters }
-						/>
-					}
-				</ShoppingCartContext.Provider>
-			</LayoutBody>
+			<ShoppingCartContext.Provider value={ { setSelectedCartItems, selectedCartItems } }>
+				{
+					// we will remove this once we have the new product listing component
+					<ProductListing
+						selectedSite={ selectedSite }
+						suggestedProduct={ suggestedProduct }
+						productBrand={ productBrand }
+						productSearchQuery={ productSearchQuery }
+						isReferralMode={ isReferralMode }
+						selectedBundleSize={ selectedBundleSize }
+						selectedFilters={ selectedFilters }
+					/>
+				}
+			</ShoppingCartContext.Provider>
 		</Layout>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-action-panel/bundle-price-selector.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-action-panel/bundle-price-selector.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@wordpress/components';
-import { Icon, chevronDown } from '@wordpress/icons';
+import { chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
@@ -70,9 +70,12 @@ export function BundlePriceSelector( { options, value, onChange }: Props ) {
 					className="bundle-price-selector__menu-button"
 					variant="secondary"
 					onClick={ () => setIsMenuOpen( ! isMenuOpen ) }
+					icon={ chevronDown }
+					iconPosition="right"
 				>
-					{ value > 1 ? getLabel( value ) : translate( 'Explore bundle discounts to apply' ) }
-					<Icon icon={ chevronDown } />
+					<span>
+						{ value > 1 ? getLabel( value ) : translate( 'Explore bundle discounts to apply' ) }
+					</span>
 				</Button>
 			</div>
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-action-panel/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-action-panel/style.scss
@@ -53,17 +53,17 @@
 
 .bundle-price-selector__menu-button {
 	flex-grow: 1;
-
-	b {
-		margin-inline-start: 4px;
-	}
 }
 
 .bundle-price-selector__popover {
 	margin-inline-start: -135px;
 
-	.popover__menu-item.is-selected {
-		background: var( --color-neutral-5 );
-		color: var( --color-text );
+	.popover__menu .popover__menu-item {
+		display: block;
+
+		&.is-selected {
+			background: var( --color-neutral-5 );
+			color: var( --color-text );
+		}
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-category-menu/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-category-menu/style.scss
@@ -60,7 +60,7 @@
 }
 
 .product-category-menu-title {
-	@include a4a-font-heading-xl;
+	@include a4a-font-heading-lg;
 	color: var(--color-text-inverted);
 	z-index: 10;
 	position: relative;

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/empty.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/empty.tsx
@@ -1,0 +1,19 @@
+import { useTranslate } from 'i18n-calypso';
+
+export default function ProductListingEmpty() {
+	const translate = useTranslate();
+
+	return (
+		<div className="product-listing-empty">
+			<div className="product-listing-empty__message-heading">
+				{ translate( 'Sorry, no results found.' ) }
+			</div>
+
+			<div className="product-listing-empty__message-description">
+				{ translate(
+					"Please try refining your search and filtering to find what you're looking for."
+				) }
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/index.tsx
@@ -60,6 +60,7 @@ export default function ProductListing( {
 		jetpackBackupAddons,
 		jetpackProducts,
 		wooExtensions,
+		featuredProducts,
 		data,
 		suggestedProductSlugs,
 	} = useProductAndPlans( {
@@ -272,10 +273,12 @@ export default function ProductListing( {
 		<>
 			<QueryProductsList currency="USD" />
 
-			{ isEmptyList && (
-				<div className="product-listing">
-					<EmptyResultMessage />
-				</div>
+			{ isEmptyList && <EmptyResultMessage /> }
+
+			{ featuredProducts.length > 0 && (
+				<ProductListingSection id="featured-products" title={ translate( 'Featured products' ) }>
+					{ getProductCards( featuredProducts ) }
+				</ProductListingSection>
 			) }
 
 			{ wooExtensions.length > 0 && (
@@ -284,7 +287,7 @@ export default function ProductListing( {
 					icon={ <WooLogo width={ 45 } height={ 28 } /> }
 					title={ translate( 'WooCommerce Extensions' ) }
 					description={ translate(
-						'You must have WooCommerce installed to utilize these paid extensions.'
+						"Explore the tools and integrations you need to grow your client's Woo store."
 					) }
 				>
 					{ getProductCards( wooExtensions ) }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/index.tsx
@@ -15,9 +15,9 @@ import useProductAndPlans from '../../hooks/use-product-and-plans';
 import { SelectedFilters } from '../../lib/product-filter';
 import MultiProductCard from '../../products-overview/multi-product-card';
 import ProductCard from '../../products-overview/product-card';
-import EmptyResultMessage from '../../products-overview/product-listing/empty-result-message';
 import { getSupportedBundleSizes } from '../../products-overview/product-listing/hooks/use-product-bundle-size';
 import useSubmitForm from '../../products-overview/product-listing/hooks/use-submit-form';
+import ProductListingEmpty from './empty';
 import ProductListingSection from './section';
 import type { ShoppingCartItem } from '../../types';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -273,7 +273,7 @@ export default function ProductListing( {
 		<>
 			<QueryProductsList currency="USD" />
 
-			{ isEmptyList && <EmptyResultMessage /> }
+			{ isEmptyList && <ProductListingEmpty /> }
 
 			{ featuredProducts.length > 0 && (
 				<ProductListingSection id="featured-products" title={ translate( 'Featured products' ) }>

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/index.tsx
@@ -13,15 +13,17 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { ShoppingCartContext } from '../../context';
 import useProductAndPlans from '../../hooks/use-product-and-plans';
 import { SelectedFilters } from '../../lib/product-filter';
-import ListingSection from '../../listing-section';
 import MultiProductCard from '../../products-overview/multi-product-card';
 import ProductCard from '../../products-overview/product-card';
 import EmptyResultMessage from '../../products-overview/product-listing/empty-result-message';
 import { getSupportedBundleSizes } from '../../products-overview/product-listing/hooks/use-product-bundle-size';
 import useSubmitForm from '../../products-overview/product-listing/hooks/use-submit-form';
+import ProductListingSection from './section';
 import type { ShoppingCartItem } from '../../types';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+
+import './style.scss';
 
 interface ProductListingProps {
 	selectedSite?: SiteDetails | null;
@@ -267,7 +269,7 @@ export default function ProductListing( {
 	}
 
 	return (
-		<div className="product-listing">
+		<>
 			<QueryProductsList currency="USD" />
 
 			{ isEmptyList && (
@@ -277,7 +279,7 @@ export default function ProductListing( {
 			) }
 
 			{ wooExtensions.length > 0 && (
-				<ListingSection
+				<ProductListingSection
 					id="woocommerce-extensions"
 					icon={ <WooLogo width={ 45 } height={ 28 } /> }
 					title={ translate( 'WooCommerce Extensions' ) }
@@ -286,11 +288,11 @@ export default function ProductListing( {
 					) }
 				>
 					{ getProductCards( wooExtensions ) }
-				</ListingSection>
+				</ProductListingSection>
 			) }
 
 			{ jetpackPlans.length > 0 && (
-				<ListingSection
+				<ProductListingSection
 					id="jetpack-plans"
 					icon={ <JetpackLogo size={ 26 } /> }
 					title={ translate( 'Jetpack Plans' ) }
@@ -299,11 +301,11 @@ export default function ProductListing( {
 					) } // FIXME: Add proper description for A4A
 				>
 					{ getProductCards( jetpackPlans ) }
-				</ListingSection>
+				</ProductListingSection>
 			) }
 
 			{ jetpackProducts.length > 0 && (
-				<ListingSection
+				<ProductListingSection
 					icon={ <JetpackLogo size={ 26 } /> }
 					title={ translate( 'Jetpack Products' ) }
 					description={ translate(
@@ -311,11 +313,11 @@ export default function ProductListing( {
 					) }
 				>
 					{ getProductCards( jetpackProducts ) }
-				</ListingSection>
+				</ProductListingSection>
 			) }
 
 			{ jetpackBackupAddons.length > 0 && (
-				<ListingSection
+				<ProductListingSection
 					icon={ <JetpackLogo size={ 26 } /> }
 					title={ translate( 'Jetpack VaultPress Backup Add-ons' ) }
 					description={ translate(
@@ -323,8 +325,8 @@ export default function ProductListing( {
 					) }
 				>
 					{ getProductCards( jetpackBackupAddons ) }
-				</ListingSection>
+				</ProductListingSection>
 			) }
-		</div>
+		</>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/index.tsx
@@ -276,14 +276,13 @@ export default function ProductListing( {
 			{ isEmptyList && <ProductListingEmpty /> }
 
 			{ featuredProducts.length > 0 && (
-				<ProductListingSection id="featured-products" title={ translate( 'Featured products' ) }>
+				<ProductListingSection title={ translate( 'Featured products' ) }>
 					{ getProductCards( featuredProducts ) }
 				</ProductListingSection>
 			) }
 
 			{ wooExtensions.length > 0 && (
 				<ProductListingSection
-					id="woocommerce-extensions"
 					icon={ <WooLogo width={ 45 } height={ 28 } /> }
 					title={ translate( 'WooCommerce Extensions' ) }
 					description={ translate(
@@ -296,7 +295,6 @@ export default function ProductListing( {
 
 			{ jetpackPlans.length > 0 && (
 				<ProductListingSection
-					id="jetpack-plans"
 					icon={ <JetpackLogo size={ 26 } /> }
 					title={ translate( 'Jetpack Plans' ) }
 					description={ translate(

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/section.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/section.tsx
@@ -1,7 +1,6 @@
 import { ReactNode } from 'react';
 
 type Props = {
-	id?: string;
 	icon?: ReactNode;
 	title: string;
 	description?: string;
@@ -10,7 +9,6 @@ type Props = {
 };
 
 export default function ProductListingSection( {
-	id,
 	icon,
 	title,
 	description,
@@ -18,13 +16,11 @@ export default function ProductListingSection( {
 	extraContent,
 }: Props ) {
 	return (
-		<div id={ id } className="product-listing-section">
+		<div className="product-listing-section">
 			<div className="product-listing-section__header-wrapper">
 				<div className="product-listing-section__header">
 					{ icon }
-					<h2 className="product-listing-section__header-title">
-						<span>{ title }</span>
-					</h2>
+					<h2 className="product-listing-section__header-title">{ title }</h2>
 					{ description && (
 						<span className="product-listing-section__header-subtitle">{ description }</span>
 					) }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/section.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/section.tsx
@@ -1,0 +1,37 @@
+import { ReactNode } from 'react';
+
+type Props = {
+	id?: string;
+	icon?: ReactNode;
+	title: string;
+	description: string;
+	children: ReactNode;
+	extraContent?: ReactNode;
+};
+
+export default function ProductListingSection( {
+	id,
+	icon,
+	title,
+	description,
+	children,
+	extraContent,
+}: Props ) {
+	return (
+		<div id={ id } className="product-listing-section">
+			<div className="product-listing-section__header-wrapper">
+				<div className="product-listing-section__header">
+					{ icon }
+					<h2 className="product-listing-section__header-title">
+						<span>{ title }</span>
+					</h2>
+					<span className="product-listing-section__header-subtitle">{ description }</span>
+				</div>
+			</div>
+
+			{ extraContent }
+
+			<div className="product-listing-section__content">{ children }</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/section.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/section.tsx
@@ -4,7 +4,7 @@ type Props = {
 	id?: string;
 	icon?: ReactNode;
 	title: string;
-	description: string;
+	description?: string;
 	children: ReactNode;
 	extraContent?: ReactNode;
 };
@@ -25,7 +25,9 @@ export default function ProductListingSection( {
 					<h2 className="product-listing-section__header-title">
 						<span>{ title }</span>
 					</h2>
-					<span className="product-listing-section__header-subtitle">{ description }</span>
+					{ description && (
+						<span className="product-listing-section__header-subtitle">{ description }</span>
+					) }
 				</div>
 			</div>
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/style.scss
@@ -55,3 +55,27 @@
 		grid-template-columns: repeat(3, 1fr);
 	}
 }
+
+.product-listing-empty {
+	margin-inline: auto;
+	text-align: center;
+	padding: 32px;
+}
+
+.product-listing-empty__message {
+	text-align: center;
+	padding: 16px;
+	border-radius: 4px;
+	max-width: 800px;
+	margin: 64px auto 0;
+}
+
+.product-listing-empty__message-heading {
+	font-size: 1rem;
+	font-weight: 600;
+}
+
+.product-listing-empty__message-description {
+	font-size: rem(14px);
+	color: var(--color-neutral-50);
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/style.scss
@@ -1,0 +1,57 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.product-listing-section__content,
+.product-listing-section__header {
+	max-width: 1500px;
+	margin-inline: auto;
+	padding-inline: 16px;
+
+	@include break-medium {
+		padding-inline: 64px;
+	}
+}
+
+.product-listing-section__header-wrapper {
+	background-color: var( --color-surface );
+	padding-block: 32px;
+}
+
+.product-listing-section__header {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 10px;
+
+	@include break-medium {
+		flex-wrap: wrap;
+	}
+}
+
+.product-listing-section__header-title {
+	@include a4a-font-heading-lg;
+}
+
+.product-listing-section__header-subtitle {
+	@include a4a-font-body-md;
+	display: none;
+
+	@include break-medium {
+		display: block;
+	}
+}
+
+.product-listing-section__content {
+	display: grid;
+	gap: 16px;
+	grid-template-columns: 1fr;
+	margin-block-end: 32px;
+
+	@include break-large {
+		grid-template-columns: repeat(2, 1fr);
+	}
+
+	@include break-huge {
+		grid-template-columns: repeat(3, 1fr);
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/style.scss
@@ -71,11 +71,13 @@
 }
 
 .product-listing-empty__message-heading {
-	font-size: 1rem;
-	font-weight: 600;
+	// TODO: Replace with Heading LG
+	font-size: rem(15px);
+	font-weight: 500;
 }
 
 .product-listing-empty__message-description {
-	font-size: rem(14px);
+	// TODO: Replace with Body MD
+	font-size: rem(13px);
 	color: var(--color-neutral-50);
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/style.scss
@@ -6,6 +6,8 @@ $header-height: 300px;
 $header-height-mobile: 350px;
 $header-compact-height: 114px;
 $header-compact-height-mobile: 128px;
+$action-panel-height: 72px;
+$action-panel-height-mobile: 128px;
 
 .products-overview-v2.main.hosting-dashboard-layout {
 	.hosting-dashboard-layout__container {
@@ -69,7 +71,18 @@ $header-compact-height-mobile: 128px;
 		z-index: 2;
 
 		@include break-medium {
-			top: 114px;
+			top: $header-compact-height;
+		}
+	}
+
+	.product-listing-section__header-wrapper {
+		position: sticky;
+		padding-block: 16px;
+
+		top: calc( $header-compact-height-mobile + $action-panel-height-mobile );
+
+		@include break-medium {
+			top: calc( $header-compact-height + $action-panel-height );
 		}
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/style.scss
@@ -75,7 +75,7 @@
 .product-filter-select {
 	display: none;
 
-	@include break-wide {
+	@include break-huge {
 		display: block;
 	}
 }


### PR DESCRIPTION
This PR implements the new product listing based on the latest design.

https://github.com/user-attachments/assets/a65a21c2-2e1a-4d11-b941-65759f89f1d9



Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1640

## Proposed Changes

* The significant change to the product listing is the addition of Featured products. Currently, the list is hardcoded. We will update it once we determine a process for selecting featured products.
* An added UX enhancement for the product listing is a sticky heading. As users scroll down, the section heading remains fixed, helping them stay informed about which section they are currently viewing.

## Why are these changes being made?

* This is part of the UX marketplace improvement project.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace/products?flags=a4a-product-page-redesign` page.
* Confirm the listing is working and following the latest design spec.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
