### PR TITLE
Staging Sites: Use `showSitesPage` instead of `navigate` for buttons that switch between staging and production sites

### DIFF
--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -4,8 +4,8 @@ import { Button as WPButton } from '@wordpress/components';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import SiteIcon from 'calypso/blocks/site-icon';
-import { navigate } from 'calypso/lib/navigate';
 import { urlToSlug } from 'calypso/lib/url';
+import { showSitesPage } from 'calypso/sites/components/sites-dashboard';
 import SitesStagingBadge from 'calypso/sites-dashboard/components/sites-staging-badge';
 import { useSelector } from 'calypso/state';
 import getSiteUrl from 'calypso/state/selectors/get-site-url';
@@ -130,13 +130,7 @@ export const ManageStagingSiteCardContent = ( {
 				<Button
 					primary
 					onClick={ () => {
-						navigate(
-							`/overview/${ urlToSlug( stagingSite.url ) }?search=${ urlToSlug(
-								productionSiteUrl as string
-							) }`,
-							false,
-							true
-						);
+						showSitesPage( `/overview/${ urlToSlug( stagingSite.url ) }` );
 					} }
 					disabled={ isButtonDisabled }
 				>

--- a/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
@@ -10,7 +10,7 @@ import { showSitesPage } from 'calypso/sites/components/sites-dashboard';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import getSiteUrl from 'calypso/state/selectors/get-site-url';
+import { getSiteSlug, getSiteUrl } from 'calypso/state/sites/selectors';
 import { getIsSyncingInProgress } from 'calypso/state/sync/selectors/get-is-syncing-in-progress';
 import { IAppState } from 'calypso/state/types';
 import { useProductionSiteDetail, ProductionSite } from '../../hooks/use-production-site-detail';
@@ -50,6 +50,8 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 	} = useProductionSiteDetail( siteId, {
 		enabled: ! disabled,
 	} );
+
+	const productionSiteSlug = useSelector( ( state ) => getSiteSlug( state, productionSite?.id ) );
 
 	useEffect( () => {
 		if ( loadingError ) {
@@ -111,7 +113,7 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 				<ActionButtons>
 					<Button
 						primary
-						onClick={ () => showSitesPage( `/overview/${ productionSite.id }` ) }
+						onClick={ () => showSitesPage( `/overview/${ productionSiteSlug }` ) }
 						disabled={ disabled || isSyncInProgress }
 					>
 						<span>{ __( 'Switch to production site' ) }</span>

--- a/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
@@ -6,8 +6,7 @@ import { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Notice from 'calypso/components/notice';
-import { navigate } from 'calypso/lib/navigate';
-import { urlToSlug } from 'calypso/lib/url';
+import { showSitesPage } from 'calypso/sites/components/sites-dashboard';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
@@ -112,15 +111,7 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 				<ActionButtons>
 					<Button
 						primary
-						onClick={ () => {
-							navigate(
-								`/overview/${ urlToSlug( productionSite.url ) }?search=${ urlToSlug(
-									productionSite.url
-								) }`,
-								false,
-								true
-							);
-						} }
+						onClick={ () => showSitesPage( `/overview/${ productionSite.id }` ) }
 						disabled={ disabled || isSyncInProgress }
 					>
 						<span>{ __( 'Switch to production site' ) }</span>

--- a/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
@@ -6,11 +6,12 @@ import { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Notice from 'calypso/components/notice';
+import { urlToSlug } from 'calypso/lib/url';
 import { showSitesPage } from 'calypso/sites/components/sites-dashboard';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { getSiteSlug, getSiteUrl } from 'calypso/state/sites/selectors';
+import { getSiteUrl } from 'calypso/state/sites/selectors';
 import { getIsSyncingInProgress } from 'calypso/state/sync/selectors/get-is-syncing-in-progress';
 import { IAppState } from 'calypso/state/types';
 import { useProductionSiteDetail, ProductionSite } from '../../hooks/use-production-site-detail';
@@ -50,8 +51,6 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 	} = useProductionSiteDetail( siteId, {
 		enabled: ! disabled,
 	} );
-
-	const productionSiteSlug = useSelector( ( state ) => getSiteSlug( state, productionSite?.id ) );
 
 	useEffect( () => {
 		if ( loadingError ) {
@@ -113,7 +112,7 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 				<ActionButtons>
 					<Button
 						primary
-						onClick={ () => showSitesPage( `/overview/${ productionSiteSlug }` ) }
+						onClick={ () => showSitesPage( `/overview/${ urlToSlug( productionSite.url ) }` ) }
 						disabled={ disabled || isSyncInProgress }
 					>
 						<span>{ __( 'Switch to production site' ) }</span>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/97834.

## Proposed Changes

* use `showSitesPage` instead of `navigate` to get from staging's site `Staging site` tab to production site's `Overview` tab

![Markup on 2025-01-23 at 16:14:55](https://github.com/user-attachments/assets/00780616-fe67-4723-af80-46911e7a2c78)

* use `showSitesPage` instead of `navigate` to get from production's site `Staging site` tab to staging site's `Overview` tab

![Markup on 2025-01-24 at 15:58:06](https://github.com/user-attachments/assets/a418886b-ab1a-494e-be96-56650c826b4d)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/wp-calypso/issues/97834

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start`.
2. Navigate to the `Staging site` tab of a staging site (at `http://calypso.localhost:3000/staging-site/{staging-site-slug}`).
3. Click on the `Switch to production site` button.
4. The button should take you to the `Overview` tab of the related production site without complete page load.
5. Now head over to the `Staging site` tab of a production site (at `http://calypso.localhost:3000/staging-site/{production-site-slug}`).
6. Click on the `Manage staging site` button.
7. The button should take you to the `Overview` tab of the related production site without complete page load.

In other words, it shouldn't be possible to reproduce the issue described in https://github.com/Automattic/wp-calypso/issues/97834.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
