### PR TITLE
Stats: Restore UTM and Devices modules title

### DIFF
--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -56,7 +56,10 @@ const StatsCard = ( {
 		<div
 			className={ `${ BASE_CLASS_NAME }-header ${ headerClassName } ${ BASE_CLASS_NAME }-header--split` }
 		>
-			<div className={ `${ BASE_CLASS_NAME }-header--main` }> { toggleControl } </div>
+			<div className={ `${ BASE_CLASS_NAME }-header--main` }>
+				{ ! heroElement && titleNode }
+				{ toggleControl }
+			</div>
 			{ ! isEmpty && (
 				<div className={ `${ BASE_CLASS_NAME }--column-header` }>
 					<div className={ `${ BASE_CLASS_NAME }--column-header__left` } key="left">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/98242, p1737611838668739-slack-C82FZ5T4G

## Proposed Changes

* Restore `titleNode` back to `StatsCard` for checks with props `splitHeader` on UTM and Devices modules.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The title passed from the UTM and Devices modules to `StatsCard` is accidentally missing because of [the change](https://github.com/Automattic/wp-calypso/pull/98242/files#diff-f6a64784aac89af90236feaf4cc4be65d44f53307afd4cfc6c855d62bbe4d447L60).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Ensure the title of UTM and Devices modules is shown.

<img width="650" alt="截圖 2025-01-23 晚上9 59 45" src="https://github.com/user-attachments/assets/4f3bb6c6-f6f6-4f37-b0b4-f6bb562db785" />

<img width="636" alt="截圖 2025-01-23 晚上9 59 58" src="https://github.com/user-attachments/assets/4a832fb9-710c-4a62-bce7-7631c9a232ae" />

* Append the feature flag `?flags=stats/locations` to the URL.
* Ensure the title of the original Countries module works as the testing instructions of https://github.com/Automattic/wp-calypso/pull/98242.

<img width="1270" alt="截圖 2025-01-23 晚上9 59 29" src="https://github.com/user-attachments/assets/e2c1bdc4-3e92-4ccb-8b78-a9e0f181f483" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?