### PR TITLE
E-mandates: Pass SetupIntent ID to save mandate on card update

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -219,6 +219,7 @@ export async function assignNewCardProcessor(
 				city,
 				organization,
 				address,
+				setupKey,
 			} );
 
 			return makeSuccessResponse( result );

--- a/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
@@ -74,6 +74,7 @@ export async function updateCreditCard( {
 	organization,
 	address,
 	countryCode,
+	setupKey,
 }: {
 	purchase: Purchase;
 	token: string;
@@ -86,6 +87,7 @@ export async function updateCreditCard( {
 	organization?: string;
 	address?: string;
 	countryCode: string;
+	setupKey?: string;
 } ): Promise< StoredCardEndpointResponse > {
 	const {
 		purchaseId,
@@ -99,6 +101,7 @@ export async function updateCreditCard( {
 		tax_city,
 		tax_organization,
 		tax_address,
+		setup_key,
 	} = getParamsForApi( {
 		cardToken: token,
 		stripeConfiguration,
@@ -111,6 +114,7 @@ export async function updateCreditCard( {
 		city,
 		organization,
 		address,
+		setupKey,
 	} );
 	const response = await wp.req.post(
 		{
@@ -128,6 +132,7 @@ export async function updateCreditCard( {
 			tax_city,
 			tax_organization,
 			tax_address,
+			setup_key,
 		}
 	);
 	if ( response.error ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # 3373-gh-Automattic/payments-shilling
Dependent on 170870-ghe-Automattic-wpcom

When the decision was made to save the Stripe Mandate ID to Stored Details rather than Ownerships, we forgot to handle saving the Mandate ID when a subscription was having the assigned payment method switched from an existing Stored Detail to a new credit card.

This was caught by @drothstein739:

> The effect is that now, if a customer edits the payment method on their subscription via that "Change payment method" link and adds a card with an India e-mandate, subsequent auto-renewals won't work.

The Mandate is failing to save because the SetupIntent ID is not being passed from Calypso to BD correctly. It is needed to fetch the Mandate ID from Stripe in the `save_payment_method` call in BD.

This PR (in combination with 170870-ghe-Automattic-wpcom) fixes the issue by passing the SetupIntent ID from its creation back to when `save_payment_method` is called.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the testing instructions on 170870-ghe-Automattic-wpcom

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
