### PR TITLE
A4A: Enable Jetpack Monitor paid tier by cleaning up feature flag logic

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/test/contact-list.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-list/test/contact-list.tsx
@@ -110,9 +110,6 @@ describe( 'ContactList', () => {
 		const upgradeBadge = screen.getByRole( 'button', { name: 'Upgrade' } );
 		expect( upgradeBadge ).toBeInTheDocument();
 
-		const upgradeLink = screen.getByRole( 'button', { name: 'Upgrade ($1.00/m)' } );
-		expect( upgradeLink ).toBeInTheDocument();
-
 		expect(
 			screen.getByText( /multiple email recipients is part of the basic plan./i )
 		).toBeInTheDocument();

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/email-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/email-notification.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import ContactList from '../../contact-list';
@@ -21,14 +20,11 @@ export default function EmailNotification( {
 	verifiedItem,
 	enableEmailNotification,
 	setEnableEmailNotification,
-	defaultUserEmailAddresses,
 	toggleAddEmailModal,
 	allEmailItems,
 	restriction,
 }: Props ) {
 	const translate = useTranslate();
-
-	const isPaidTierEnabled = isEnabled( 'jetpack/pro-dashboard-monitor-paid-tier' );
 
 	return (
 		<>
@@ -52,23 +48,15 @@ export default function EmailNotification( {
 					<div className="notification-settings__content-heading-with-beta">
 						<div className="notification-settings__content-heading">{ translate( 'Email' ) }</div>
 					</div>
-					{ isPaidTierEnabled ? (
-						<>
-							<div className="notification-settings__content-sub-heading">
-								{ translate( 'Receive email notifications with one or more recipients.' ) }
-							</div>
-						</>
-					) : (
+					<>
 						<div className="notification-settings__content-sub-heading">
-							{ translate( 'Receive email notifications with your account email address %s.', {
-								args: defaultUserEmailAddresses,
-							} ) }
+							{ translate( 'Receive email notifications with one or more recipients.' ) }
 						</div>
-					) }
+					</>
 				</div>
 			</div>
 
-			{ enableEmailNotification && isPaidTierEnabled && (
+			{ enableEmailNotification && (
 				<ContactList
 					type="email"
 					onAction={ toggleAddEmailModal }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/notification-duration.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/notification-duration.tsx
@@ -1,7 +1,5 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { SelectDropdown } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
 import clockIcon from 'calypso/assets/images/jetpack/clock-icon.svg';
 import useNotificationDurations from '../../../sites-overview/hooks/use-notification-durations';
 import FeatureRestrictionBadge from '../../feature-restriction-badge';
@@ -24,13 +22,7 @@ export default function NotificationDuration( {
 }: Props ) {
 	const translate = useTranslate();
 
-	const showPaidDuration = isEnabled( 'jetpack/pro-dashboard-monitor-paid-tier' );
-
 	const durations = useNotificationDurations();
-	const selectableDuration = useMemo(
-		() => ( showPaidDuration ? durations : durations.filter( ( duration ) => ! duration.isPaid ) ),
-		[ durations, showPaidDuration ]
-	);
 
 	return (
 		<div className="notification-settings__content-block">
@@ -52,7 +44,7 @@ export default function NotificationDuration( {
 				}
 				selectedText={ selectedDuration?.label }
 			>
-				{ selectableDuration.map( ( duration ) => (
+				{ durations.map( ( duration ) => (
 					<SelectDropdown.Item
 						key={ duration.time }
 						selected={ duration.time === selectedDuration?.time }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/sms-notification.tsx
@@ -3,7 +3,6 @@ import { useTranslate } from 'i18n-calypso';
 import ContactList from '../../contact-list';
 import FeatureRestrictionBadge from '../../feature-restriction-badge';
 import { RestrictionType } from '../../types';
-import UpgradeLink from '../../upgrade-link';
 import type { MonitorSettings, StateMonitorSettingsSMS } from '../../../sites-overview/types';
 
 interface Props {
@@ -60,11 +59,6 @@ export default function SMSNotification( {
 					<div className="notification-settings__content-sub-heading">
 						{ translate( 'Set up text messages to send to one or more people.' ) }
 					</div>
-					{ restriction === 'upgrade_required' && (
-						<div>
-							<UpgradeLink />
-						</div>
-					) }
 				</div>
 			</div>
 			{ enableSMSNotification && (

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/email-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/email-notification.tsx
@@ -10,12 +10,6 @@ import configureStore from 'redux-mock-store';
 import EmailNotification from '../email-notification';
 import type { RestrictionType } from '../../../types';
 
-jest.mock( '@automattic/calypso-config', () => {
-	const config = () => 'development';
-	config.isEnabled = ( property: string ) => property === 'jetpack/pro-dashboard-monitor-paid-tier';
-	return config;
-} );
-
 describe( 'EmailNotification', () => {
 	const defaultProps = {
 		recordEvent: jest.fn(),

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/notification-duration.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/notification-duration.tsx
@@ -10,12 +10,6 @@ import configureStore from 'redux-mock-store';
 import DashboardDataContext from '../../../../sites-overview/dashboard-data-context';
 import NotificationDuration from '../notification-duration';
 
-jest.mock( '@automattic/calypso-config', () => {
-	const config = () => 'development';
-	config.isEnabled = ( property: string ) => property === 'jetpack/pro-dashboard-monitor-paid-tier';
-	return config;
-} );
-
 describe( 'NotificationDuration', () => {
 	const defaultProps = {
 		selectDuration: jest.fn(),

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/notification-duration.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/notification-duration.tsx
@@ -87,6 +87,5 @@ describe( 'NotificationDuration', () => {
 		expect( dropdownToggle ).toHaveClass( 'is-disabled' );
 		expect( dropdownToggle ).toHaveTextContent( '1 minute' );
 		expect( dropdownToggle ).toHaveTextContent( 'Upgrade' );
-		expect( dropdownToggle ).toHaveTextContent( 'Upgrade ($1.00/m)' );
 	} );
 } );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/sms-notification.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/form-content/test/sms-notification.tsx
@@ -81,7 +81,6 @@ describe( 'SMSNotification', () => {
 
 		expect( screen.getByLabelText( 'Disable SMS notifications' ) ).toBeDisabled();
 		expect( screen.getByRole( 'button', { name: 'Upgrade' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: 'Upgrade ($1.00/m)' } ) ).toBeInTheDocument();
 	} );
 
 	it( 'handles toggle change with SMS notifications enabled', () => {

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -102,8 +102,6 @@ export default function NotificationSettings( {
 		'jetpack/pro-dashboard-monitor-sms-notification'
 	);
 
-	const isPaidTierEnabled = isEnabled( 'jetpack/pro-dashboard-monitor-paid-tier' );
-
 	// Check if current site or all sites selected has a paid license.
 	const hasPaidLicenses = ! sites.find( ( site ) => ! site.has_paid_agency_monitor );
 
@@ -484,18 +482,16 @@ export default function NotificationSettings( {
 					restriction={ restriction }
 				/>
 
-				{ isPaidTierEnabled && (
-					<SMSNotification
-						recordEvent={ recordEvent }
-						enableSMSNotification={ enableSMSNotification }
-						setEnableSMSNotification={ setEnableSMSNotification }
-						toggleModal={ toggleAddSMSModal }
-						allPhoneItems={ allPhoneItems }
-						verifiedItem={ verifiedItem }
-						restriction={ restriction }
-						settings={ settings }
-					/>
-				) }
+				<SMSNotification
+					recordEvent={ recordEvent }
+					enableSMSNotification={ enableSMSNotification }
+					setEnableSMSNotification={ setEnableSMSNotification }
+					toggleModal={ toggleAddSMSModal }
+					allPhoneItems={ allPhoneItems }
+					verifiedItem={ verifiedItem }
+					restriction={ restriction }
+					settings={ settings }
+				/>
 
 				<EmailNotification
 					recordEvent={ recordEvent }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button, Tooltip } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -43,10 +42,8 @@ export default function ToggleActivateMonitoring( {
 	const [ showNotificationSettings, setShowNotificationSettings ] = useState< boolean >( false );
 	const [ showTooltip, setShowTooltip ] = useState( false );
 
-	const isPaidTierEnabled = isEnabled( 'jetpack/pro-dashboard-monitor-paid-tier' );
-
 	const shouldDisplayUpgradePopover =
-		status === 'success' && isPaidTierEnabled && ! site.has_paid_agency_monitor && ! site.is_atomic;
+		status === 'success' && ! site.has_paid_agency_monitor && ! site.is_atomic;
 
 	const handleShowTooltip = () => {
 		setShowTooltip( true );
@@ -131,7 +128,7 @@ export default function ToggleActivateMonitoring( {
 						) as string
 					}
 				>
-					{ isPaidTierEnabled && smsLimitReached ? (
+					{ smsLimitReached ? (
 						<img src={ alertIcon } alt={ translate( 'Alert' ) } />
 					) : (
 						<img src={ clockIcon } alt={ translate( 'Current Schedule' ) } />
@@ -174,7 +171,7 @@ export default function ToggleActivateMonitoring( {
 		}
 
 		let tooltipText = tooltip;
-		if ( isPaidTierEnabled && smsLimitReached && status === 'success' ) {
+		if ( smsLimitReached && status === 'success' ) {
 			tooltipText = translate( 'You have reached the SMS limit' );
 		}
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/test/toggle-activate-monitoring.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/test/toggle-activate-monitoring.tsx
@@ -11,12 +11,6 @@ import configureStore from 'redux-mock-store';
 import { site } from '../../../sites-overview/test/test-utils/constants';
 import ToggleActivateMonitoring from '../index';
 
-jest.mock( '@automattic/calypso-config', () => {
-	const config = () => 'development';
-	config.isEnabled = ( property: string ) => property === 'jetpack/pro-dashboard-monitor-paid-tier';
-	return config;
-} );
-
 describe( 'ToggleActivateMonitoring', () => {
 	const defaultProps = {
 		site,

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-link/test/upgrade-link.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-link/test/upgrade-link.tsx
@@ -3,11 +3,10 @@
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
-import SitesOverviewContext from '../../../sites-overview/context';
 import DashboardDataContext from '../../../sites-overview/dashboard-data-context';
 import UpgradeLink from '../index';
 
@@ -43,37 +42,6 @@ describe( 'UpgradeLink', () => {
 		</Provider>
 	);
 
-	it( 'renders the upgrade link text', () => {
-		render(
-			<DashboardDataContext.Provider value={ dashboardContextValue }>
-				<UpgradeLink />
-			</DashboardDataContext.Provider>,
-			{ wrapper: Wrapper }
-		);
-		const upgradeLink = screen.getByText( 'Upgrade ($1.00/m)' );
-		expect( upgradeLink ).toBeInTheDocument();
-	} );
-
-	it( 'renders the upgrade link text and onclick works', () => {
-		const mockShowLicenseInfo = jest.fn();
-
-		render(
-			// We need only the showLicenseInfo function from the context
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			<SitesOverviewContext.Provider value={ { showLicenseInfo: mockShowLicenseInfo } }>
-				<DashboardDataContext.Provider value={ dashboardContextValue }>
-					<UpgradeLink />
-				</DashboardDataContext.Provider>
-			</SitesOverviewContext.Provider>,
-			{ wrapper: Wrapper }
-		);
-		const upgradeLink = screen.getByText( 'Upgrade ($1.00/m)' );
-		expect( upgradeLink ).toBeInTheDocument();
-		fireEvent.click( upgradeLink );
-		expect( mockShowLicenseInfo ).toHaveBeenCalledWith( 'monitor' );
-	} );
-
 	it( 'renders the upgrade link text inline', () => {
 		render(
 			<DashboardDataContext.Provider value={ dashboardContextValue }>
@@ -84,16 +52,5 @@ describe( 'UpgradeLink', () => {
 
 		const upgradeLink = screen.getByText( 'Upgrade ($1.00/m)' );
 		expect( upgradeLink.parentElement ).toHaveClass( 'is-inline' );
-	} );
-
-	it( 'renders the upgrade link text when the price is undefined', () => {
-		render(
-			<DashboardDataContext.Provider value={ { ...dashboardContextValue, products: [] } }>
-				<UpgradeLink />
-			</DashboardDataContext.Provider>,
-			{ wrapper: Wrapper }
-		);
-		const upgradeLink = screen.getByText( 'Upgrade' );
-		expect( upgradeLink ).toBeInTheDocument();
 	} );
 } );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-link/test/upgrade-link.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-link/test/upgrade-link.tsx
@@ -3,7 +3,7 @@
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
@@ -50,7 +50,6 @@ describe( 'UpgradeLink', () => {
 			{ wrapper: Wrapper }
 		);
 
-		const upgradeLink = screen.getByText( 'Upgrade ($1.00/m)' );
 		expect( upgradeLink.parentElement ).toHaveClass( 'is-inline' );
 	} );
 } );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-banners/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-banners/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import showBanner from 'calypso/jetpack-cloud/sections/utils/show-banner';
 import { useSelector } from 'calypso/state';
 import {
@@ -27,7 +26,6 @@ export default function DashboardBanners() {
 				getPreference( state, downtimeMonitoringUpgradeBannerPreferenceName )
 			),
 			showDays: 7,
-			hideBanner: ! isEnabled( 'jetpack/pro-dashboard-monitor-paid-tier' ),
 		},
 		{
 			component: () => <SiteSurveyBanner isDashboardView />,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-default-site-columns.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-default-site-columns.tsx
@@ -15,7 +15,6 @@ type SiteColumn = {
 const useDefaultSiteColumns = ( isLargeScreen = false ): SiteColumns => {
 	const translate = useTranslate();
 	const isBoostEnabled = isEnabled( 'jetpack/pro-dashboard-jetpack-boost' );
-	const isPaidMonitorEnabled = isEnabled( 'jetpack/pro-dashboard-monitor-paid-tier' );
 	const isWPCOMAtomicSiteCreationEnabled = isEnabled(
 		'jetpack/pro-dashboard-wpcom-atomic-hosting'
 	);
@@ -71,7 +70,7 @@ const useDefaultSiteColumns = ( isLargeScreen = false ): SiteColumns => {
 				title: translate( 'Monitor' ),
 				className: 'min-width-100px jetpack-cloud-site-column__monitor',
 				isExpandable: true,
-				showInfo: isPaidMonitorEnabled,
+				showInfo: true,
 			},
 			{
 				key: 'plugin',
@@ -79,13 +78,7 @@ const useDefaultSiteColumns = ( isLargeScreen = false ): SiteColumns => {
 				className: 'width-fit-content jetpack-cloud-site-column__plugin',
 			},
 		];
-	}, [
-		isBoostEnabled,
-		isPaidMonitorEnabled,
-		isWPCOMAtomicSiteCreationEnabled,
-		translate,
-		isLargeScreen,
-	] );
+	}, [ isBoostEnabled, isWPCOMAtomicSiteCreationEnabled, translate, isLargeScreen ] );
 };
 
 export default useDefaultSiteColumns;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-downtime-monitoring-upgrade-banner/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-downtime-monitoring-upgrade-banner/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useContext, useEffect } from 'react';
 import CelebrationIcon from 'calypso/assets/images/jetpack/celebration-icon.svg';
@@ -35,12 +34,8 @@ export default function SiteDowntimeMonitoringUpgradeBanner() {
 		[ dispatch, preference, preferenceName ]
 	);
 
-	const isDowntimeMonitoringPaidTierEnabled = isEnabled(
-		'jetpack/pro-dashboard-monitor-paid-tier'
-	);
-
 	useEffect( () => {
-		if ( isDowntimeMonitoringPaidTierEnabled && ! isDismissed && ! viewDate ) {
+		if ( ! isDismissed && ! viewDate ) {
 			savePreferenceType( 'view_date', Date.now() );
 			dispatch(
 				recordTracksEvent( 'calypso_jetpack_agency_dashboard_monitor_upgrade_banner_view' )
@@ -50,7 +45,7 @@ export default function SiteDowntimeMonitoringUpgradeBanner() {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	if ( ! isDowntimeMonitoringPaidTierEnabled || isDismissed ) {
+	if ( isDismissed ) {
 		return null;
 	}
 

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -57,7 +57,6 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pro-dashboard-jetpack-boost": true,
 		"jetpack/pro-dashboard-monitor-multiple-email-recipients": true,
-		"jetpack/pro-dashboard-monitor-paid-tier": true,
 		"jetpack/pro-dashboard-monitor-sms-notification": true,
 		"jetpack/pro-dashboard-wpcom-atomic-hosting": true,
 		"jetpack/manage-simple-sites": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -51,7 +51,6 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pro-dashboard-jetpack-boost": true,
 		"jetpack/pro-dashboard-monitor-multiple-email-recipients": true,
-		"jetpack/pro-dashboard-monitor-paid-tier": true,
 		"jetpack/pro-dashboard-monitor-sms-notification": true,
 		"jetpack/pro-dashboard-wpcom-atomic-hosting": true,
 		"jetpack/manage-simple-sites": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -55,7 +55,6 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pro-dashboard-jetpack-boost": true,
 		"jetpack/pro-dashboard-monitor-multiple-email-recipients": true,
-		"jetpack/pro-dashboard-monitor-paid-tier": true,
 		"jetpack/pro-dashboard-monitor-sms-notification": true,
 		"jetpack/pro-dashboard-wpcom-atomic-hosting": true,
 		"jetpack/manage-simple-sites": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -54,7 +54,6 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pro-dashboard-jetpack-boost": true,
 		"jetpack/pro-dashboard-monitor-multiple-email-recipients": true,
-		"jetpack/pro-dashboard-monitor-paid-tier": true,
 		"jetpack/pro-dashboard-monitor-sms-notification": true,
 		"jetpack/manage-sites-v2-menu": false,
 		"jetpack/search-product": true,


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1697

## Proposed Changes

Enable Jetpack Monitor paid tier visibility for Automattic for Agencies by removing legacy feature flag logic. The feature is now fully launched, making the development flag unnecessary.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site and connect Jetpack
* Purchase Jetpack Monitor and assign it to your site
* Enable monitor from the dashboard
* Verify you see the paid features (such as "1-minute monitoring interval" or notifying email addresses) when you configure the notifications
* Verify no regression was introduced by this PR on Jetpack Manage

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
