### PR TITLE
Stats: Filter Odyssey upsells by site features

### DIFF
--- a/client/my-sites/stats/jetpack-upsell-section/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/index.tsx
@@ -51,12 +51,28 @@ function useSiteFeatures( siteId: number | null ) {
 	// This should come from somewhere. Maybe from a query.
 	// Matches security, backup, search, video, boost, social.
 	const upsellFeatures = [
-		'scan', // Security plan
-		'backup', // Backup plan
+		// Backup
+		'backups',
+		'restore',
+		// Boost
+		'cloud-critical-css',
+		'cornerstone-10-pages',
+		'image-cdn-liar',
+		'image-cdn-quality',
+		'image-size-analysis',
+		'performance-history',
+		// Security
+		'scan',
+		// Search
 		'search',
+		'instant-search',
+		// Social
+		'social-enhanced-publishing',
+		'social-image-generator',
+		'subscriber-unlimited-imports',
+		// Video
 		'videopress',
-		'cloud-critical-css', // Boost plan
-		'social-enhanced-publishing', // Social plan
+		'videopress-1tb-storage',
 	];
 	// Ideally we'd make a single call to get the full array of features but this will work for now.
 	const activeFeatures = useSelector( ( state ) =>

--- a/client/my-sites/stats/jetpack-upsell-section/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/index.tsx
@@ -11,6 +11,7 @@ import { JetpackUpsellCard } from '@automattic/components';
 import { buildCheckoutURL } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import { useSelector } from 'calypso/state';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { hasBusinessPlan, hasCompletePlan, hasSecurityPlan } from '../hooks/use-stats-purchases';
 import usePurchasedProducts from './use-purchased-products';
@@ -45,6 +46,25 @@ function bundledProductsFromPurchases( purchases: Purchase[] ) {
 	return [];
 }
 
+function useSiteFeatures( siteId: number | null ) {
+	// Hard-coded list of features that correspond to upsells.
+	// This should come from somewhere. Maybe from a query.
+	// Matches security, backup, search, video, boost, social.
+	const upsellFeatures = [
+		'scan', // Security plan
+		'backup', // Backup plan
+		'search',
+		'videopress',
+		'cloud-critical-css', // Boost plan
+		'social-enhanced-publishing', // Social plan
+	];
+	// Ideally we'd make a single call to get the full array of features but this will work for now.
+	const activeFeatures = useSelector( ( state ) =>
+		upsellFeatures.filter( ( feature ) => siteHasFeature( state, siteId, feature ) )
+	);
+	return activeFeatures;
+}
+
 export default function JetpackUpsellSection() {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 
@@ -58,7 +78,7 @@ export default function JetpackUpsellSection() {
 	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
 	const shouldHideUpsells = shouldHideUpsellSection( sitePurchases );
 
-	const siteFeatures = [ 'videopress', 'search' ];
+	const siteFeatures = useSiteFeatures( siteId );
 
 	// Exit early if we don't have and can't get the site purchase data.
 	// Also exit early if we're not in the Odyssey Stats environment.

--- a/client/my-sites/stats/jetpack-upsell-section/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/index.tsx
@@ -104,6 +104,8 @@ export default function JetpackUpsellSection() {
 
 	const bundledProducts = bundledProductsFromPurchases( sitePurchases );
 	const finalProducts = [ ...purchasedProducts, ...bundledProducts ];
+	// eslint-disable-next-line no-console
+	console.log( 'finalProducts', finalProducts );
 
 	// Build checkout URL prefixed with WordPress.com.
 	// TODO: Change URL to point at plugin installation within wp-admin.
@@ -132,7 +134,6 @@ export default function JetpackUpsellSection() {
 	return (
 		<div className="jetpack-upsell-section">
 			<JetpackUpsellCard
-				purchasedProducts={ finalProducts }
 				siteSlug={ siteSlug }
 				siteFeatures={ siteFeatures }
 				upgradeUrls={ upgradeUrls }

--- a/client/my-sites/stats/jetpack-upsell-section/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/index.tsx
@@ -58,6 +58,33 @@ function useSiteFeatures( siteId: number | null ) {
 	return activeFeatures;
 }
 
+function getCheckoutConfig() {
+	return {
+		backup: PRODUCT_JETPACK_BACKUP_T1_YEARLY,
+		boost: PRODUCT_JETPACK_BOOST,
+		search: PRODUCT_JETPACK_SEARCH,
+		security: PLAN_JETPACK_SECURITY_T1_YEARLY,
+		social: PRODUCT_JETPACK_SOCIAL_BASIC,
+		video: PRODUCT_JETPACK_VIDEOPRESS,
+	};
+}
+
+function getCheckoutUrls( siteSlug: string | null ) {
+	if ( ! siteSlug ) {
+		return {};
+	}
+	// TODO: Change URL to point at plugin installation within wp-admin.
+	// ie: /wp-admin/update.php?action=install-plugin&plugin=plugin-name&_wpnonce=valid-nonce).
+	const checkoutConfig = getCheckoutConfig();
+	const checkoutURLs = Object.fromEntries(
+		Object.entries( checkoutConfig ).map( ( [ key, value ] ) => [
+			key,
+			`${ CHECKOUT_URL_PREFIX }${ buildCheckoutURL( siteSlug, value, QUERY_VALUES ) }`,
+		] )
+	);
+	return checkoutURLs;
+}
+
 // TODO: Remove local use-purchased-products.tsx file.
 
 export default function JetpackUpsellSection() {
@@ -70,28 +97,7 @@ export default function JetpackUpsellSection() {
 	}
 
 	// Build checkout URL prefixed with WordPress.com.
-	// TODO: Change URL to point at plugin installation within wp-admin.
-	//       (e.g., /wp-admin/update.php?action=install-plugin&plugin=plugin-name&_wpnonce=valid-nonce).
-	const upgradeUrls: Record< string, string > = ! siteSlug
-		? {}
-		: {
-				backup:
-					CHECKOUT_URL_PREFIX +
-					buildCheckoutURL( siteSlug, PRODUCT_JETPACK_BACKUP_T1_YEARLY, QUERY_VALUES ),
-				boost:
-					CHECKOUT_URL_PREFIX + buildCheckoutURL( siteSlug, PRODUCT_JETPACK_BOOST, QUERY_VALUES ),
-				search:
-					CHECKOUT_URL_PREFIX + buildCheckoutURL( siteSlug, PRODUCT_JETPACK_SEARCH, QUERY_VALUES ),
-				security:
-					CHECKOUT_URL_PREFIX +
-					buildCheckoutURL( siteSlug, PLAN_JETPACK_SECURITY_T1_YEARLY, QUERY_VALUES ),
-				social:
-					CHECKOUT_URL_PREFIX +
-					buildCheckoutURL( siteSlug, PRODUCT_JETPACK_SOCIAL_BASIC, QUERY_VALUES ),
-				video:
-					CHECKOUT_URL_PREFIX +
-					buildCheckoutURL( siteSlug, PRODUCT_JETPACK_VIDEOPRESS, QUERY_VALUES ),
-		  };
+	const upgradeUrls = getCheckoutUrls( siteSlug );
 
 	return (
 		<div className="jetpack-upsell-section">

--- a/client/my-sites/stats/jetpack-upsell-section/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/index.tsx
@@ -8,6 +8,7 @@ import {
 	PRODUCT_JETPACK_VIDEOPRESS,
 } from '@automattic/calypso-products';
 import { JetpackUpsellCard } from '@automattic/components';
+import { useMemo } from 'react';
 import { buildCheckoutURL } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import { useSelector } from 'calypso/state';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -92,12 +93,12 @@ export default function JetpackUpsellSection() {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const siteFeatures = useSiteFeatures( siteId );
 
+	// Build checkout URLs with siteSlug and prefixed with WordPress.com.
+	const upgradeUrls = useMemo( () => getCheckoutUrls( siteSlug ), [ siteSlug ] );
+
 	if ( ! isOdysseyStats ) {
 		return null;
 	}
-
-	// Build checkout URL prefixed with WordPress.com.
-	const upgradeUrls = getCheckoutUrls( siteSlug );
 
 	return (
 		<div className="jetpack-upsell-section">

--- a/client/my-sites/stats/jetpack-upsell-section/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/index.tsx
@@ -58,6 +58,8 @@ export default function JetpackUpsellSection() {
 	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
 	const shouldHideUpsells = shouldHideUpsellSection( sitePurchases );
 
+	const siteFeatures = [ 'videopress', 'search' ];
+
 	// Exit early if we don't have and can't get the site purchase data.
 	// Also exit early if we're not in the Odyssey Stats environment.
 	if ( ! isOdysseyStats || shouldHideUpsells ) {
@@ -96,6 +98,7 @@ export default function JetpackUpsellSection() {
 			<JetpackUpsellCard
 				purchasedProducts={ finalProducts }
 				siteSlug={ siteSlug }
+				siteFeatures={ siteFeatures }
 				upgradeUrls={ upgradeUrls }
 			/>
 		</div>

--- a/client/my-sites/stats/jetpack-upsell-section/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/index.tsx
@@ -10,12 +10,8 @@ import {
 import { JetpackUpsellCard } from '@automattic/components';
 import { buildCheckoutURL } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import { useSelector } from 'calypso/state';
-import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { hasBusinessPlan, hasCompletePlan, hasSecurityPlan } from '../hooks/use-stats-purchases';
-import usePurchasedProducts from './use-purchased-products';
-import type { Purchase } from 'calypso/lib/purchases/types';
 
 const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
@@ -26,25 +22,6 @@ const QUERY_VALUES = {
 	// Redirects to Odyssey Stats after after removing all products from the shopping cart.
 	checkoutBackUrl: window.location.href,
 };
-
-function shouldHideUpsellSection( purchases: Purchase[] ) {
-	if ( purchases.length === 0 ) {
-		return false;
-	}
-
-	const hasBusiness = hasBusinessPlan( purchases );
-	const hasComplete = hasCompletePlan( purchases );
-
-	return hasBusiness || hasComplete;
-}
-
-function bundledProductsFromPurchases( purchases: Purchase[] ) {
-	if ( hasSecurityPlan( purchases ) ) {
-		return [ 'backup', 'security' ];
-	}
-
-	return [];
-}
 
 function useSiteFeatures( siteId: number | null ) {
 	// Hard-coded list of features that correspond to upsells.
@@ -81,31 +58,16 @@ function useSiteFeatures( siteId: number | null ) {
 	return activeFeatures;
 }
 
+// TODO: Remove local use-purchased-products.tsx file.
+
 export default function JetpackUpsellSection() {
-	const siteSlug = useSelector( getSelectedSiteSlug );
-
-	// NOTE: This will only work within Odyssey Stats.
-	// Doesn't recogize Commercial plan bundles.
-	const { purchasedProducts } = usePurchasedProducts();
-
-	// Check for bundled products.
-	// We don't want to show the upsell section if we find a Business or Complete plan.
 	const siteId = useSelector( getSelectedSiteId );
-	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
-	const shouldHideUpsells = shouldHideUpsellSection( sitePurchases );
-
+	const siteSlug = useSelector( getSelectedSiteSlug );
 	const siteFeatures = useSiteFeatures( siteId );
 
-	// Exit early if we don't have and can't get the site purchase data.
-	// Also exit early if we're not in the Odyssey Stats environment.
-	if ( ! isOdysseyStats || shouldHideUpsells ) {
+	if ( ! isOdysseyStats ) {
 		return null;
 	}
-
-	const bundledProducts = bundledProductsFromPurchases( sitePurchases );
-	const finalProducts = [ ...purchasedProducts, ...bundledProducts ];
-	// eslint-disable-next-line no-console
-	console.log( 'finalProducts', finalProducts );
 
 	// Build checkout URL prefixed with WordPress.com.
 	// TODO: Change URL to point at plugin installation within wp-admin.

--- a/packages/components/src/jetpack-upsell-card/index.tsx
+++ b/packages/components/src/jetpack-upsell-card/index.tsx
@@ -127,8 +127,9 @@ export function JetpackUpsellCard( {
 	// console.log( 'visibleProducts 1: ', visibleProducts );
 
 	// New product visibility testing based on siteFeatures.
+	// If any of the product features are not in siteFeatures, it's a potential upsell.
 	visibleProducts = PRODUCTS.filter( ( product ) =>
-		product.features.every( ( feature ) => ! siteFeatures.includes( feature ) )
+		product.features.some( ( feature ) => ! siteFeatures.includes( feature ) )
 	);
 	// eslint-disable-next-line no-console
 	// console.log( 'visibleProducts 2: ', visibleProducts );

--- a/packages/components/src/jetpack-upsell-card/index.tsx
+++ b/packages/components/src/jetpack-upsell-card/index.tsx
@@ -46,7 +46,7 @@ export function JetpackUpsellCard( {
 				isFree: false,
 				slug: 'security',
 				title: translate( 'Security', { context: 'Jetpack product name' } ),
-				features: [],
+				features: [ 'scan' ],
 			},
 			{
 				description: translate(
@@ -57,7 +57,7 @@ export function JetpackUpsellCard( {
 				isFree: false,
 				slug: 'backup',
 				title: translate( 'Backup' ),
-				features: [],
+				features: [ 'backups', 'restore' ],
 			},
 			{
 				description: translate(
@@ -68,7 +68,7 @@ export function JetpackUpsellCard( {
 				isFree: false,
 				slug: 'search',
 				title: translate( 'Search' ),
-				features: [ 'search' ],
+				features: [ 'search', 'instant-search' ],
 			},
 			{
 				description: translate(
@@ -79,7 +79,7 @@ export function JetpackUpsellCard( {
 				isFree: false,
 				slug: 'video',
 				title: translate( 'VideoPress' ),
-				features: [ 'videopress' ],
+				features: [ 'videopress', 'videopress-1tb-storage' ],
 			},
 			{
 				description: translate(
@@ -90,7 +90,14 @@ export function JetpackUpsellCard( {
 				isFree: true,
 				slug: 'boost',
 				title: translate( 'Boost' ),
-				features: [],
+				features: [
+					'cloud-critical-css',
+					'cornerstone-10-pages',
+					'image-cdn-liar',
+					'image-cdn-quality',
+					'image-size-analysis',
+					'performance-history',
+				],
 			},
 			{
 				description: translate(
@@ -101,7 +108,11 @@ export function JetpackUpsellCard( {
 				isFree: true,
 				slug: 'social',
 				title: translate( 'Social' ),
-				features: [],
+				features: [
+					'social-enhanced-publishing',
+					'social-image-generator',
+					'subscriber-unlimited-imports',
+				],
 			},
 			// TODO: Add Jetpack CRM upsell.
 		],

--- a/packages/components/src/jetpack-upsell-card/index.tsx
+++ b/packages/components/src/jetpack-upsell-card/index.tsx
@@ -20,14 +20,12 @@ type Product = {
 };
 
 type JetpackUpsellCardProps = {
-	purchasedProducts: string[];
 	siteSlug?: string | null;
 	siteFeatures: string[];
 	upgradeUrls: Record< string, string >;
 };
 
 export function JetpackUpsellCard( {
-	purchasedProducts,
 	siteSlug,
 	siteFeatures,
 	upgradeUrls = {},
@@ -117,16 +115,12 @@ export function JetpackUpsellCard( {
 		[ translate ]
 	) as Product[];
 
-	let visibleProducts = PRODUCTS.filter(
-		( { slug } ) => ! purchasedProducts?.includes( slug ) && slug in upgradeUrls
-	);
-	const hasProductsToUpsell = visibleProducts.length > 0;
-
 	// New product visibility testing based on siteFeatures.
 	// If any of the product features are not in siteFeatures, it's a potential upsell.
-	visibleProducts = PRODUCTS.filter( ( product ) =>
+	const visibleProducts = PRODUCTS.filter( ( product ) =>
 		product.features.some( ( feature ) => ! siteFeatures.includes( feature ) )
 	);
+	const hasProductsToUpsell = visibleProducts.length > 0;
 
 	return ! hasProductsToUpsell ? null : (
 		<Card className="jetpack-upsell-card">

--- a/packages/components/src/jetpack-upsell-card/index.tsx
+++ b/packages/components/src/jetpack-upsell-card/index.tsx
@@ -106,10 +106,20 @@ export function JetpackUpsellCard( {
 		[ translate ]
 	) as Product[];
 
-	const visibleProducts = PRODUCTS.filter(
+	let visibleProducts = PRODUCTS.filter(
 		( { slug } ) => ! purchasedProducts?.includes( slug ) && slug in upgradeUrls
 	);
 	const hasProductsToUpsell = visibleProducts.length > 0;
+	// eslint-disable-next-line no-console
+	// console.log( 'visibleProducts 1: ', visibleProducts );
+
+	// New product visibility testing based on siteFeatures.
+	const siteFeatures = [ 'videopress', 'search' ];
+	visibleProducts = PRODUCTS.filter( ( product ) =>
+		product.features.every( ( feature ) => ! siteFeatures.includes( feature ) )
+	);
+	// eslint-disable-next-line no-console
+	// console.log( 'visibleProducts 2: ', visibleProducts );
 
 	return ! hasProductsToUpsell ? null : (
 		<Card className="jetpack-upsell-card">

--- a/packages/components/src/jetpack-upsell-card/index.tsx
+++ b/packages/components/src/jetpack-upsell-card/index.tsx
@@ -22,6 +22,7 @@ type Product = {
 	isFree: boolean;
 	slug: string;
 	title: string;
+	features: string[];
 };
 
 export function JetpackUpsellCard( {
@@ -43,6 +44,7 @@ export function JetpackUpsellCard( {
 				isFree: false,
 				slug: 'security',
 				title: translate( 'Security', { context: 'Jetpack product name' } ),
+				features: [],
 			},
 			{
 				description: translate(
@@ -53,6 +55,7 @@ export function JetpackUpsellCard( {
 				isFree: false,
 				slug: 'backup',
 				title: translate( 'Backup' ),
+				features: [],
 			},
 			{
 				description: translate(
@@ -63,6 +66,7 @@ export function JetpackUpsellCard( {
 				isFree: false,
 				slug: 'search',
 				title: translate( 'Search' ),
+				features: [ 'search' ],
 			},
 			{
 				description: translate(
@@ -73,6 +77,7 @@ export function JetpackUpsellCard( {
 				isFree: false,
 				slug: 'video',
 				title: translate( 'VideoPress' ),
+				features: [ 'videopress' ],
 			},
 			{
 				description: translate(
@@ -83,6 +88,7 @@ export function JetpackUpsellCard( {
 				isFree: true,
 				slug: 'boost',
 				title: translate( 'Boost' ),
+				features: [],
 			},
 			{
 				description: translate(
@@ -93,6 +99,7 @@ export function JetpackUpsellCard( {
 				isFree: true,
 				slug: 'social',
 				title: translate( 'Social' ),
+				features: [],
 			},
 			// TODO: Add Jetpack CRM upsell.
 		],

--- a/packages/components/src/jetpack-upsell-card/index.tsx
+++ b/packages/components/src/jetpack-upsell-card/index.tsx
@@ -32,8 +32,6 @@ export function JetpackUpsellCard( {
 	siteFeatures,
 	upgradeUrls = {},
 }: JetpackUpsellCardProps ) {
-	// TODO: Make card collapsible
-
 	const translate = useTranslate();
 	const PRODUCTS = useMemo(
 		() => [
@@ -123,16 +121,12 @@ export function JetpackUpsellCard( {
 		( { slug } ) => ! purchasedProducts?.includes( slug ) && slug in upgradeUrls
 	);
 	const hasProductsToUpsell = visibleProducts.length > 0;
-	// eslint-disable-next-line no-console
-	// console.log( 'visibleProducts 1: ', visibleProducts );
 
 	// New product visibility testing based on siteFeatures.
 	// If any of the product features are not in siteFeatures, it's a potential upsell.
 	visibleProducts = PRODUCTS.filter( ( product ) =>
 		product.features.some( ( feature ) => ! siteFeatures.includes( feature ) )
 	);
-	// eslint-disable-next-line no-console
-	// console.log( 'visibleProducts 2: ', visibleProducts );
 
 	return ! hasProductsToUpsell ? null : (
 		<Card className="jetpack-upsell-card">

--- a/packages/components/src/jetpack-upsell-card/index.tsx
+++ b/packages/components/src/jetpack-upsell-card/index.tsx
@@ -9,12 +9,6 @@ import SocialIcon from '../assets/jetpack-product-icon-social.svg';
 import VideoPressIcon from '../assets/jetpack-product-icon-videopress.svg';
 import './style.scss';
 
-type JetpackUpsellCardProps = {
-	purchasedProducts: string[];
-	siteSlug?: string | null;
-	upgradeUrls: Record< string, string >;
-};
-
 type Product = {
 	description: string;
 	href: string;
@@ -23,6 +17,12 @@ type Product = {
 	slug: string;
 	title: string;
 	features: string[];
+};
+
+type JetpackUpsellCardProps = {
+	purchasedProducts: string[];
+	siteSlug?: string | null;
+	upgradeUrls: Record< string, string >;
 };
 
 export function JetpackUpsellCard( {

--- a/packages/components/src/jetpack-upsell-card/index.tsx
+++ b/packages/components/src/jetpack-upsell-card/index.tsx
@@ -22,12 +22,14 @@ type Product = {
 type JetpackUpsellCardProps = {
 	purchasedProducts: string[];
 	siteSlug?: string | null;
+	siteFeatures: string[];
 	upgradeUrls: Record< string, string >;
 };
 
 export function JetpackUpsellCard( {
 	purchasedProducts,
 	siteSlug,
+	siteFeatures,
 	upgradeUrls = {},
 }: JetpackUpsellCardProps ) {
 	// TODO: Make card collapsible
@@ -114,7 +116,6 @@ export function JetpackUpsellCard( {
 	// console.log( 'visibleProducts 1: ', visibleProducts );
 
 	// New product visibility testing based on siteFeatures.
-	const siteFeatures = [ 'videopress', 'search' ];
 	visibleProducts = PRODUCTS.filter( ( product ) =>
 		product.features.every( ( feature ) => ! siteFeatures.includes( feature ) )
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: https://github.com/Automattic/wp-calypso/issues/80536

## Proposed Changes

Updates the `JetpackUpsellCard` to take a list of features instead of a list of purchases. These are compared to the features included in the upsells to determine if a given upsell should be presented or not. For example, a VideoPress plan enables both the `videopress` and `videopress-1tb-storage` features. If the current site has both of these features, the upsell for VideoPress will not be shown.

Also updates the `JetpackUpsellSection` to do the various feature checks and pass them to the `JetpackUpsellCard`. Removes the previous plan-based setup.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Previous logic wasn't aware of all the necessary plans and would need to be updated whenever new plans/products/bundles are introduced or it would potentially recommend upsells that were not appropriate for the site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up Odyssey per FG: PCYsg-Pp7-p2
* Check out this branch.
* Test that the upsells section is shown correctly on your self-hosted site.
* If the site has no paid features enabled, all 6 upsells should be visible.
* Test adding a Boost plan to your site and then revisit the Traffic page to Confirm the Boost upsell is no longer visible.
* Test adding and removing other plans/bundles to confirm the upsell section is updated properly.

Note: You can also test via the React Dev tools as shown below. Manually `siteFeatures` prop to see how the card updates. For example, adding `'scan'` to the array will cause the Security plan to disappear from the upsells.

<img width="710" alt="SCR-20250124-bqwk" src="https://github.com/user-attachments/assets/8eb8a5f7-4c4b-45aa-a4b3-4120d395f21f" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?