### PR TITLE
A4A: Add Marketplace walkthrough guided tour.

### DIFF
--- a/client/a8c-for-agencies/data/guided-tours/tours/use-marketplace-walkthrough-tour.tsx
+++ b/client/a8c-for-agencies/data/guided-tours/tours/use-marketplace-walkthrough-tour.tsx
@@ -1,4 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
+import { preventWidows } from 'calypso/lib/formatting/prevent-widows';
 
 export default function useMarketplaceWalkthroughTour() {
 	const translate = useTranslate();
@@ -14,8 +15,21 @@ export default function useMarketplaceWalkthroughTour() {
 			id: 'marketplace-walkthrough-referral-toggle',
 			popoverPosition: 'bottom',
 			title: translate( 'Earn money when you refer our hosting and products to clients' ),
-			description: translate(
-				'Assemble a cart, send a request for payment to your clients, and earn commissions.'
+			description: preventWidows(
+				translate(
+					'Assemble a cart, send a request for payment to your clients, and earn commissions. {{a}}Learn more ↗{{/a}}',
+					{
+						components: {
+							a: (
+								<a
+									href="https://agencieshelp.automattic.com/knowledge-base/referring-products-to-clients"
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+					}
+				)
 			),
 		},
 	];

--- a/client/a8c-for-agencies/data/guided-tours/tours/use-marketplace-walkthrough-tour.tsx
+++ b/client/a8c-for-agencies/data/guided-tours/tours/use-marketplace-walkthrough-tour.tsx
@@ -1,0 +1,22 @@
+import { useTranslate } from 'i18n-calypso';
+
+export default function useMarketplaceWalkthroughTour() {
+	const translate = useTranslate();
+
+	return [
+		// {
+		// 	id: 'hosting-overview-v3-navigation',
+		// 	popoverPosition: 'right',
+		// 	title: translate( 'Browse hosting and products' ),
+		// 	description: translate( 'Save on hosting and product bundles via Automattic from Agencies.' ),
+		// },
+		{
+			id: 'hosting-overview-v3-referral-toggle',
+			popoverPosition: 'bottom',
+			title: translate( 'Earn money when you refer our hosting and products to clients' ),
+			description: translate(
+				'Assemble a cart, send a request for payment to your clients, and earn commissions.'
+			),
+		},
+	];
+}

--- a/client/a8c-for-agencies/data/guided-tours/tours/use-marketplace-walkthrough-tour.tsx
+++ b/client/a8c-for-agencies/data/guided-tours/tours/use-marketplace-walkthrough-tour.tsx
@@ -4,14 +4,14 @@ export default function useMarketplaceWalkthroughTour() {
 	const translate = useTranslate();
 
 	return [
-		// {
-		// 	id: 'hosting-overview-v3-navigation',
-		// 	popoverPosition: 'right',
-		// 	title: translate( 'Browse hosting and products' ),
-		// 	description: translate( 'Save on hosting and product bundles via Automattic from Agencies.' ),
-		// },
 		{
-			id: 'hosting-overview-v3-referral-toggle',
+			id: 'marketplace-walkthrough-navigation',
+			popoverPosition: 'right',
+			title: translate( 'Browse hosting and products' ),
+			description: translate( 'Save on hosting and product bundles via Automattic from Agencies.' ),
+		},
+		{
+			id: 'marketplace-walkthrough-referral-toggle',
 			popoverPosition: 'bottom',
 			title: translate( 'Earn money when you refer our hosting and products to clients' ),
 			description: translate(

--- a/client/a8c-for-agencies/data/guided-tours/use-guided-tours.tsx
+++ b/client/a8c-for-agencies/data/guided-tours/use-guided-tours.tsx
@@ -1,16 +1,20 @@
 import { useMemo } from 'react';
 import useAddNewSiteTour from './tours/use-add-new-site-tour';
+import useMarketplaceWalkthroughTour from './tours/use-marketplace-walkthrough-tour';
 import useSitesWalkthroughTour from './tours/use-sites-walkthrough-tour';
 
 export default function useGuidedTours() {
 	const sitesWalkthrough = useSitesWalkthroughTour();
+	const marketplaceWalkthrough = useMarketplaceWalkthroughTour();
+
 	const addNewSite = useAddNewSiteTour();
 	const tours = useMemo(
 		() => ( {
 			sitesWalkthrough: sitesWalkthrough,
+			marketplaceWalkthrough,
 			addSiteStep1: addNewSite,
 		} ),
-		[]
+		[ addNewSite, marketplaceWalkthrough, sitesWalkthrough ]
 	);
 
 	return tours;

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/index.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
@@ -13,6 +13,8 @@ import {
 	A4A_MARKETPLACE_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import QueryProductsList from 'calypso/components/data/query-products-list';
+import GuidedTour from 'calypso/components/guided-tour';
+import { GuidedTourStep } from 'calypso/components/guided-tour/step';
 import LayoutBody from 'calypso/layout/hosting-dashboard/body';
 import LayoutHeader, {
 	LayoutHeaderActions as Actions,
@@ -40,6 +42,8 @@ function HostingOverviewV3( { section }: SectionProps ) {
 	const dispatch = useDispatch();
 
 	const isNarrowView = useBreakpoint( '<660px' );
+
+	const [ referralToggleRef, setReferralToggleRef ] = useState< HTMLElement | null >();
 
 	const {
 		selectedCartItems,
@@ -88,6 +92,8 @@ function HostingOverviewV3( { section }: SectionProps ) {
 			onScroll={ onScroll }
 			wide
 		>
+			<GuidedTour defaultTourId="marketplaceWalkthrough" />
+
 			<LayoutTop>
 				<PressableUsageLimitNotice />
 				<A4AAgencyApprovalNotice />
@@ -104,10 +110,11 @@ function HostingOverviewV3( { section }: SectionProps ) {
 						] }
 						hideOnMobile
 					/>
-
 					<Actions className="a4a-marketplace__header-actions">
 						<MobileSidebarNavigation />
-						<ReferralToggle />
+						<div ref={ ( ref ) => setReferralToggleRef( ref as HTMLElement | null ) }>
+							<ReferralToggle />
+						</div>
 						<ShoppingCart
 							showCart={ showCart }
 							setShowCart={ setShowCart }
@@ -118,9 +125,15 @@ function HostingOverviewV3( { section }: SectionProps ) {
 								page( A4A_MARKETPLACE_CHECKOUT_LINK );
 							} }
 						/>
+
+						<GuidedTourStep
+							className="a4a-marketplace__guided-tour-referral-toggle"
+							id="hosting-overview-v3-referral-toggle"
+							tourId="marketplaceWalkthrough"
+							context={ referralToggleRef }
+						/>
 					</Actions>
 				</LayoutHeader>
-
 				<HeroSection
 					section={ section }
 					onSectionChange={ handleSectionChange }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/index.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState } from 'react';
+import { useCallback, useLayoutEffect, useState } from 'react';
 import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
@@ -85,6 +85,20 @@ function HostingOverviewV3( { section }: SectionProps ) {
 
 	const { onScroll, isCompact, ref: heroSectionRef } = useCompactOnScroll();
 
+	const [ sidebarRef, setSidebarRef ] = useState< HTMLElement | null >( null );
+
+	/* Currently, there is no way for us to have a shared context between the Sidebar and Toggle component which both uses the same guided tour context.
+	 * And both components need to reside on the same Node Tree where the guided tour context is available. However, this is impossible with how we have
+	 * structured the page layout in Calypso.
+	 *
+	 * To solve this issue, we are querying the DOM to get the sidebar element for us to anchor our guided tour popover.
+	 */
+	useLayoutEffect( () => {
+		setTimeout( () => {
+			setSidebarRef( document.querySelector( '.sidebar-v2__navigator-sub-menu' ) as HTMLElement );
+		}, 300 );
+	}, [ sidebarRef ] );
+
 	return (
 		<Layout
 			className="hosting-overview-v3"
@@ -127,8 +141,15 @@ function HostingOverviewV3( { section }: SectionProps ) {
 						/>
 
 						<GuidedTourStep
-							className="a4a-marketplace__guided-tour-referral-toggle"
-							id="hosting-overview-v3-referral-toggle"
+							className="a4a-marketplace__guided-tour"
+							id="marketplace-walkthrough-navigation"
+							tourId="marketplaceWalkthrough"
+							context={ sidebarRef }
+						/>
+
+						<GuidedTourStep
+							className="a4a-marketplace__guided-tour"
+							id="marketplace-walkthrough-referral-toggle"
 							tourId="marketplaceWalkthrough"
 							context={ referralToggleRef }
 						/>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/style.scss
@@ -1,4 +1,5 @@
 @import "../variables";
+@import "../shared";
 
 .hosting-overview-v3.main.hosting-dashboard-layout {
 	.hosting-dashboard-layout__body {

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/index.tsx
@@ -3,7 +3,7 @@ import { SiteDetails } from '@automattic/data-stores';
 import { useBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useLayoutEffect, useState } from 'react';
 import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
@@ -93,6 +93,20 @@ export function ProductsOverviewV2( {
 		setSelectedSize: setSelectedBundleSize,
 	} = useProductBundleSize();
 
+	const [ sidebarRef, setSidebarRef ] = useState< HTMLElement | null >( null );
+
+	/* Currently, there is no way for us to have a shared context between the Sidebar and Toggle component which both uses the same guided tour context.
+	 * And both components need to reside on the same Node Tree where the guided tour context is available. However, this is impossible with how we have
+	 * structured the page layout in Calypso.
+	 *
+	 * To solve this issue, we are querying the DOM to get the sidebar element for us to anchor our guided tour popover.
+	 */
+	useLayoutEffect( () => {
+		setTimeout( () => {
+			setSidebarRef( document.querySelector( '.sidebar-v2__navigator-sub-menu' ) as HTMLElement );
+		}, 300 );
+	}, [ sidebarRef ] );
+
 	const onCategorySelected = useCallback(
 		( category: string ) => {
 			setSelectedFilters( ( prevFilters ) => ( {
@@ -152,8 +166,15 @@ export function ProductsOverviewV2( {
 						/>
 
 						<GuidedTourStep
-							className="a4a-marketplace__guided-tour-referral-toggle"
-							id="hosting-overview-v3-referral-toggle"
+							className="a4a-marketplace__guided-tour"
+							id="marketplace-walkthrough-navigation"
+							tourId="marketplaceWalkthrough"
+							context={ sidebarRef }
+						/>
+
+						<GuidedTourStep
+							className="a4a-marketplace__guided-tour"
+							id="marketplace-walkthrough-referral-toggle"
 							tourId="marketplaceWalkthrough"
 							context={ referralToggleRef }
 						/>

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/index.tsx
@@ -12,6 +12,8 @@ import {
 	A4A_MARKETPLACE_CHECKOUT_LINK,
 	A4A_MARKETPLACE_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import GuidedTour from 'calypso/components/guided-tour';
+import { GuidedTourStep } from 'calypso/components/guided-tour/step';
 import LayoutHeader, {
 	LayoutHeaderActions as Actions,
 	LayoutHeaderBreadcrumb as Breadcrumb,
@@ -48,6 +50,7 @@ export function ProductsOverviewV2( {
 	searchQuery,
 }: Props ) {
 	const [ selectedSite, setSelectedSite ] = useState< SiteDetails | null | undefined >( null );
+	const [ referralToggleRef, setReferralToggleRef ] = useState< HTMLElement | null >( null );
 
 	const translate = useTranslate();
 
@@ -114,6 +117,8 @@ export function ProductsOverviewV2( {
 			onScroll={ onScroll }
 			wide
 		>
+			<GuidedTour defaultTourId="marketplaceWalkthrough" />
+
 			<LayoutTop>
 				<A4AAgencyApprovalNotice />
 				<LayoutHeader>
@@ -130,9 +135,11 @@ export function ProductsOverviewV2( {
 						hideOnMobile
 					/>
 
-					<Actions>
+					<Actions className="a4a-marketplace__header-actions">
 						<MobileSidebarNavigation />
-						<ReferralToggle />
+						<div ref={ ( ref ) => setReferralToggleRef( ref as HTMLElement | null ) }>
+							<ReferralToggle />
+						</div>
 						<ShoppingCart
 							showCart={ showCart }
 							setShowCart={ setShowCart }
@@ -142,6 +149,13 @@ export function ProductsOverviewV2( {
 							onCheckout={ () => {
 								page( A4A_MARKETPLACE_CHECKOUT_LINK );
 							} }
+						/>
+
+						<GuidedTourStep
+							className="a4a-marketplace__guided-tour-referral-toggle"
+							id="hosting-overview-v3-referral-toggle"
+							tourId="marketplaceWalkthrough"
+							context={ referralToggleRef }
 						/>
 					</Actions>
 				</LayoutHeader>

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/style.scss
@@ -1,6 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 @import "../variables";
+@import "../shared";
 
 $header-height: 300px;
 $header-height-mobile: 350px;

--- a/client/a8c-for-agencies/sections/marketplace/shared.scss
+++ b/client/a8c-for-agencies/sections/marketplace/shared.scss
@@ -1,5 +1,5 @@
 
-.popover.a4a-marketplace__guided-tour-referral-toggle {
+.popover.a4a-marketplace__guided-tour {
 	margin-block-start: 32px;
 	max-width: 300px;
 

--- a/client/a8c-for-agencies/sections/marketplace/shared.scss
+++ b/client/a8c-for-agencies/sections/marketplace/shared.scss
@@ -1,0 +1,18 @@
+
+.popover.a4a-marketplace__guided-tour-referral-toggle {
+	margin-block-start: 32px;
+	max-width: 300px;
+
+	.popover__arrow {
+		display: block;
+	}
+
+	.guided-tour__popover-heading {
+		text-wrap: wrap;
+		text-align: left;
+	}
+
+	.guided-tour__popover-description {
+		max-width: 300px;
+	}
+}

--- a/client/a8c-for-agencies/sections/onboarding-tours/constants.ts
+++ b/client/a8c-for-agencies/sections/onboarding-tours/constants.ts
@@ -5,6 +5,7 @@ export const A4A_ONBOARDING_TOURS_PREFERENCE_NAME: Record< string, string > = {
 	addSiteStep1: 'a4a-sites-add-new-site-tour-step-1',
 	addSiteStep2: 'a4a-sites-add-new-site-tour-step-2',
 	sitesWalkthrough: 'a4a-sites-tour',
+	marketplaceWalkthrough: 'a4a-marketplace-tour-v2',
 	exploreMarketplace: 'a4a-marketplace-tour',
 	boostAgencyVisibility: 'a4a-boost-agency-visibility-tour',
 	startReferrals: 'a4a-start-referrals',


### PR DESCRIPTION
This PR implements the Guided tour for the redesigned Marketplace. Note that the Popover does not follow the design, as we are reusing the same component from Calypso.

<img width="570" alt="Screenshot 2025-01-24 at 11 05 41 PM" src="https://github.com/user-attachments/assets/1c1ddb14-6463-4f24-95f4-4b0e9c004c73" />
<img width="377" alt="Screenshot 2025-01-24 at 11 05 48 PM" src="https://github.com/user-attachments/assets/0e365255-c928-4d89-a03f-4c1cd46f11cf" />


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1638

## Proposed Changes

* Include the `GuidedTour` component and context on both the Hosting and Product marketplace pages. We are reusing the Calypso component, and while the design is slightly different, it still functions the same way.

## Why are these changes being made?

* This is part of the UX Marketplace improvement project.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace` page.
* Confirm you see the Guided tour.
* If you do not see it, try to reset the `a4a-marketplace-tour-v2` preference.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
