### PR TITLE
Help Center: Add a Pattern query

### DIFF
--- a/packages/help-center/src/route-to-query-mapping.ts
+++ b/packages/help-center/src/route-to-query-mapping.ts
@@ -43,6 +43,7 @@ export const useQueryForRoute = ( currentRoute: string ) => {
 		'/wp-admin/options-general.php?page=debug-bar-extender': __( 'debug bar extender' ),
 		'/wp-admin/options-media.php': __( 'media settings' ),
 		'/wp-admin/post-new.php?post_type=jetpack-testimonial': __( 'new testimonial' ),
+		'/wp-admin/site-editor.php?p=%2Fpattern': __( 'patterns' ),
 	};
 
 	// Find exact URL matches


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to paYJgx-5Ku-p2#comment-5698

## Proposed Changes

Let's add a default query param when we are in `/wp-admin/site-editor.php?p=%2Fpattern`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To provide contextual help in patterns.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- in `apps/help-center` run `yarn dev --sync`.
- Sandbox `widgets.wordpress.com`
- Go to `simple-site/wp-admin/site-editor.php?p=%2Fpattern`
- Open the Help Center.
- Check the recommended resources