### PR TITLE
E2E: Use selector to indicate Tumblr is ready for login

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/marketing-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/marketing-page.ts
@@ -168,9 +168,8 @@ export class MarketingPage {
 	 * @param {string} param1.password Tumblr password.
 	 */
 	async setupTumblr( popup: Page, { username, password }: { username: string; password: string } ) {
-		// Wait for the page load to complete. Otherwise, a `Cannot POST /login` error
-		// is shown.
-		await popup.waitForLoadState( 'networkidle' );
+		// This selector allows us to proceed without waiting for `networkidle`.
+		await popup.waitForSelector( '[data-tumblr-ready="true"]' );
 
 		// Fill in the email and password.
 		await popup.getByRole( 'textbox', { name: 'email' } ).fill( username );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Tumblr tests have been flaky lately because the OAuth popup makes hundreds of requests and it was waiting for `networkidle`, which resulted in the tests timing out.

This PR switches to use the `[data-tumblr-ready="true"]` selector so we can proceed to log in without waiting.

More context (h/t @blowery): p1737658415722589/1737655830.320839-slack-CRF8DGFBR

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Ensure this works:

```
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION="ecomm-plan" TEST_ON_ATOMIC="true" VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/tools/social-connections__tumblr.ts"
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?