### PR TITLE
Domains: Tweaks to the 100-year domain transfer flow

### DIFF
--- a/client/landing/stepper/declarative-flow/hundred-year-domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain-transfer.ts
@@ -53,13 +53,13 @@ const hundredYearDomainTransfer: Flow = {
 					await new Promise( ( resolve ) => setTimeout( resolve, 2000 ) );
 
 					const checkoutBackURL = new URL(
-						'/setup/hundred-year-domain-transfer',
+						'/setup/hundred-year-domain-transfer/domains',
 						window.location.href
 					);
 
 					// use replace instead of assign to remove the processing URL from history
 					return window.location.replace(
-						`/checkout/no-site?signup=0&isDomainOnly=1&checkoutBackUrl=${ encodeURIComponent(
+						`/checkout/no-site?signup=1&isDomainOnly=1&checkoutBackUrl=${ encodeURIComponent(
 							checkoutBackURL.href
 						) }`
 					);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -261,9 +261,11 @@ const Domains: React.FC< Props > = ( { onSubmit, variantSlug } ) => {
 					variantSlug={ variantSlug }
 				/>
 			) ) }
-			<Button className="bulk-domain-transfer__add-domain" icon={ plus } onClick={ addDomain }>
-				{ isHundredYearTransfer ? __( 'Add another domain' ) : __( 'Add more' ) }
-			</Button>
+			{ ! isHundredYearTransfer && (
+				<Button className="bulk-domain-transfer__add-domain" icon={ plus } onClick={ addDomain }>
+					{ __( 'Add more' ) }
+				</Button>
+			) }
 			<div className="bulk-domain-transfer__cta-container">
 				<Button
 					disabled={ numberOfValidDomains === 0 || ! allGood }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -18,6 +18,10 @@
 			width: 100%;
 			margin: 0;
 			max-width: none;
+
+			&.processing {
+				padding: 0;
+			}
 		}
 
 		.domains {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
@@ -22,6 +22,7 @@ import HundredYearPlanLogo from './hundred-year-plan-logo';
 import InfoModal from './info-modal';
 
 import './style.scss';
+
 type Props = {
 	stepName: string;
 	flowName: string;

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -34,4 +34,5 @@ export { getRegisteredDomains, isFreeUrlDomain, isRegisteredDomain } from './reg
 export { resendIcannVerification } from './resend-icann-verification';
 export { resolveDomainStatus } from './resolve-domain-status';
 export { startInboundTransfer } from './start-inbound-transfer';
+export { getTransferredInDomains, isTransferredInDomain } from './transferred-domains';
 export { extractDomainFromInput } from './get-domain-from-input';

--- a/client/lib/domains/transferred-domains.ts
+++ b/client/lib/domains/transferred-domains.ts
@@ -1,0 +1,10 @@
+import { ResponseDomain } from 'calypso/lib/domains/types';
+import { type as domainTypes } from './constants';
+
+export function getTransferredInDomains( domains: ResponseDomain[] ) {
+	return domains.filter( isTransferredInDomain );
+}
+
+export function isTransferredInDomain( domain: ResponseDomain ) {
+	return domain.type === domainTypes.TRANSFER;
+}

--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -9,13 +9,14 @@ import { useEffect } from 'react';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import HundredYearLoaderView from 'calypso/components/hundred-year-loader-view';
 import WordPressLogo from 'calypso/components/wordpress-logo';
-import { getRegisteredDomains } from 'calypso/lib/domains';
+import { getRegisteredDomains, getTransferredInDomains } from 'calypso/lib/domains';
 import { useDispatch, useSelector } from 'calypso/state';
 import { fetchReceipt } from 'calypso/state/receipts/actions';
 import { getReceiptById } from 'calypso/state/receipts/selectors';
 import { getDomainsBySiteId, isRequestingSiteDomains } from 'calypso/state/sites/domains/selectors';
-import { getSiteId, getSiteOptions } from 'calypso/state/sites/selectors';
+import { getSiteId, getSiteOptions, isRequestingSite } from 'calypso/state/sites/selectors';
 import { hideMasterbar } from 'calypso/state/ui/actions';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
 
 const HOUR_IN_MS = 1000 * 60;
 const VideoContainer = styled.div< { isMobile: boolean } >`
@@ -38,6 +39,7 @@ const VideoContainer = styled.div< { isMobile: boolean } >`
 const hundredYearProducts = [
 	PLAN_100_YEARS,
 	domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION,
+	domainProductSlugs.TRANSFER_IN,
 ] as const;
 
 interface Props {
@@ -155,10 +157,21 @@ export default function HundredYearThankYou( {
 		siteId ? getDomainsBySiteId( state, siteId ) : []
 	);
 	const isLoadingDomains = useSelector( ( state ) =>
-		siteId ? isRequestingSiteDomains( state, siteId ) : false
+		siteId && productSlug !== PLAN_100_YEARS
+			? isRequestingSite( state, siteId ) || isRequestingSiteDomains( state, siteId )
+			: false
 	);
-	const registeredDomains = getRegisteredDomains( siteDomains );
-	const registeredDomain = registeredDomains.length ? registeredDomains[ 0 ] : null;
+	let targetDomain: ResponseDomain | null = null;
+	switch ( productSlug ) {
+		case domainProductSlugs.TRANSFER_IN:
+			targetDomain = getTransferredInDomains( siteDomains )[ 0 ] ?? null;
+			break;
+		case domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION:
+			targetDomain = getRegisteredDomains( siteDomains )[ 0 ] ?? null;
+			break;
+		default:
+			targetDomain = null;
+	}
 
 	useEffect( () => {
 		dispatch( hideMasterbar() );
@@ -169,13 +182,17 @@ export default function HundredYearThankYou( {
 
 	if (
 		! isReceiptLoading &&
-		( ! receipt.data?.purchases?.length || receipt.data?.purchases[ 0 ].blogId !== siteId )
+		( ! receipt.data?.purchases?.length || receipt.data?.purchases[ 0 ].blogId !== siteId ) &&
+		// For transfers, the current siteId might be different - purchase performed with no site (siteId = null)
+		// and blog created after the purchase (siteId != null).
+		productSlug !== domainProductSlugs.TRANSFER_IN
 	) {
 		page( '/' );
 	}
 
 	const isMobile = useMobileBreakpoint();
-	const isPageLoading = isReceiptLoading || isLoadingDomains;
+	const isDomainDataLoaded = ! isLoadingDomains && targetDomain !== null;
+	const isPageLoading = isReceiptLoading || isLoadingDomains || ! isDomainDataLoaded;
 	const hundredYearPlanCta =
 		siteCreatedTimeStamp && isSiteCreatedWithinLastHour( siteCreatedTimeStamp ) ? (
 			<StyledLightButton onClick={ () => page( `/setup/site-setup/goals?siteSlug=${ siteSlug }` ) }>
@@ -189,7 +206,7 @@ export default function HundredYearThankYou( {
 	const hundredYearDomainCta = (
 		<StyledLightButton
 			onClick={ () =>
-				page( ` /domains/manage/all/${ registeredDomain.name }/edit/${ registeredDomain.name }` )
+				page( ` /domains/manage/all/${ targetDomain?.name }/edit/${ targetDomain?.name }` )
 			}
 		>
 			{ translate( 'Manage your domain' ) }
@@ -203,23 +220,27 @@ export default function HundredYearThankYou( {
 					'The %(planTitle)s for %(domain)s is active. Our Premier Support team will be in touch by email shortly to schedule a welcome session and walk you through your exclusive benefits. We’re looking forward to supporting you every step of the way.',
 					{
 						args: {
-							domain: registeredDomain?.domain || siteSlug,
+							domain: targetDomain?.domain || siteSlug,
 							planTitle: getPlan( PLAN_100_YEARS )?.getTitle() || '',
 						},
 					}
 			  )
 			: translate(
-					'Your 100-Year Domain %(domain)s has been registered. Our Premier Support team will be in touch by email shortly to schedule a welcome session and walk you through your exclusive benefits. We’re looking forward to supporting you every step of the way.',
+					'Your 100-Year Domain %(domain)s has been %(action)s. Our Premier Support team will be in touch by email shortly to schedule a welcome session and walk you through your exclusive benefits. We’re looking forward to supporting you every step of the way.',
 					{
 						args: {
-							domain: registeredDomain?.domain || siteSlug,
+							domain: targetDomain?.domain || siteSlug,
+							action:
+								productSlug === domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION
+									? translate( 'registered' )
+									: translate( 'transferred' ),
 						},
 					}
 			  );
 
 	return (
 		<>
-			{ siteId && <QuerySiteDomains siteId={ siteId } /> }
+			{ siteId && ! siteDomains.length && <QuerySiteDomains siteId={ siteId } /> }
 			<Global
 				styles={ css`
 					body.is-section-checkout,

--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -227,7 +227,7 @@ export default function HundredYearThankYou( {
 			  } )
 			: translate( 'Your 100-Year Domain %(domain)s is being transferred.', {
 					args: {
-						domain: targetDomain?.domain, || siteSlug,
+						domain: targetDomain?.domain || siteSlug,
 					},
 			  } );
 	const hundredYearPlanDescription = translate(

--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -217,29 +217,36 @@ export default function HundredYearThankYou( {
 	);
 	const cta = productSlug === PLAN_100_YEARS ? hundredYearPlanCta : hundredYearDomainCta;
 
+	const messageTarget = targetDomain?.domain || siteSlug;
+	const domainSpecificDescription =
+		productSlug === domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION
+			? translate( 'Your 100-Year Domain %(messageTarget)s has been registered.', {
+					args: {
+						messageTarget,
+					},
+			  } )
+			: translate( 'Your 100-Year Domain %(messageTarget)s is being transferred.', {
+					args: {
+						messageTarget,
+					},
+			  } );
+	const hundredYearPlanDescription = translate(
+		'The %(planTitle)s for %(messageTarget)s is active.',
+		{
+			args: {
+				messageTarget,
+				planTitle: getPlan( PLAN_100_YEARS )?.getTitle() || '',
+			},
+		}
+	);
+	const helpAndSupportDescription = translate(
+		'Our Premier Support team will be in touch by email shortly to schedule a welcome session and walk you through your exclusive benefits. We’re looking forward to supporting you every step of the way.'
+	);
+
 	const description =
 		productSlug === PLAN_100_YEARS
-			? translate(
-					'The %(planTitle)s for %(domain)s is active. Our Premier Support team will be in touch by email shortly to schedule a welcome session and walk you through your exclusive benefits. We’re looking forward to supporting you every step of the way.',
-					{
-						args: {
-							domain: targetDomain?.domain || siteSlug,
-							planTitle: getPlan( PLAN_100_YEARS )?.getTitle() || '',
-						},
-					}
-			  )
-			: translate(
-					'Your 100-Year Domain %(domain)s has been %(action)s. Our Premier Support team will be in touch by email shortly to schedule a welcome session and walk you through your exclusive benefits. We’re looking forward to supporting you every step of the way.',
-					{
-						args: {
-							domain: targetDomain?.domain || siteSlug,
-							action:
-								productSlug === domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION
-									? translate( 'registered' )
-									: translate( 'transferred' ),
-						},
-					}
-			  );
+			? `${ hundredYearPlanDescription } ${ helpAndSupportDescription }`
+			: `${ domainSpecificDescription } ${ helpAndSupportDescription }`;
 
 	return (
 		<>

--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -220,14 +220,14 @@ export default function HundredYearThankYou( {
 	const messageTarget = targetDomain?.domain || siteSlug;
 	const domainSpecificDescription =
 		productSlug === domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION
-			? translate( 'Your 100-Year Domain %(messageTarget)s has been registered.', {
+			? translate( 'Your 100-Year Domain %(domain)s has been registered.', {
 					args: {
-						messageTarget,
+						domain: targetDomain?.domain || siteSlug, // though targetDomain?.domain should be defined here, right?
 					},
 			  } )
-			: translate( 'Your 100-Year Domain %(messageTarget)s is being transferred.', {
+			: translate( 'Your 100-Year Domain %(domain)s is being transferred.', {
 					args: {
-						messageTarget,
+						domain: targetDomain?.domain, || siteSlug,
 					},
 			  } );
 	const hundredYearPlanDescription = translate(

--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -192,7 +192,10 @@ export default function HundredYearThankYou( {
 
 	const isMobile = useMobileBreakpoint();
 	const isDomainDataLoaded = ! isLoadingDomains && targetDomain !== null;
-	const isPageLoading = isReceiptLoading || isLoadingDomains || ! isDomainDataLoaded;
+	const isPageLoading =
+		isReceiptLoading ||
+		isLoadingDomains ||
+		( productSlug !== PLAN_100_YEARS && ! isDomainDataLoaded );
 	const hundredYearPlanCta =
 		siteCreatedTimeStamp && isSiteCreatedWithinLastHour( siteCreatedTimeStamp ) ? (
 			<StyledLightButton onClick={ () => page( `/setup/site-setup/goals?siteSlug=${ siteSlug }` ) }>

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -58,6 +58,7 @@ import getAtomicTransfer from 'calypso/state/selectors/get-atomic-transfer';
 import getCheckoutUpgradeIntent from 'calypso/state/selectors/get-checkout-upgrade-intent';
 import getCustomizeOrEditFrontPageUrl from 'calypso/state/selectors/get-customize-or-edit-front-page-url';
 import { requestSite } from 'calypso/state/sites/actions';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { fetchSitePlans, refreshSitePlans } from 'calypso/state/sites/plans/actions';
 import { getPlansBySite } from 'calypso/state/sites/plans/selectors';
 import { getSiteHomeUrl, getSiteSlug, getSite } from 'calypso/state/sites/selectors';
@@ -86,6 +87,7 @@ import {
 import type { FindPredicate } from './utils';
 import type { SitesPlansResult } from '../src/hooks/product-variants';
 import type { OnboardActions, SiteDetails } from '@automattic/data-stores';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { UserData } from 'calypso/lib/user/user';
 import type { ReceiptState, ReceiptPurchase } from 'calypso/state/receipts/types';
 import type { LocalizeProps } from 'i18n-calypso';
@@ -126,6 +128,7 @@ export interface CheckoutThankYouConnectedProps {
 	siteHomeUrl: string;
 	customizeUrl: string | null | undefined;
 	site: SiteDetails | null | undefined;
+	siteDomains: ResponseDomain[] | null | undefined;
 	fetchAtomicTransfer: ( siteId: number ) => void;
 	fetchSitePlugins: ( siteId: number ) => void;
 	fetchReceipt: ( receiptId: number ) => void;
@@ -541,10 +544,11 @@ export class CheckoutThankYou extends Component<
 				isGSuiteOrExtraLicenseOrGoogleWorkspace
 			);
 
-			if ( isOnlyDomainTransfers( purchases ) ) {
+			if ( this.props.receipt.data && isOnlyDomainTransfers( purchases ) ) {
 				pageContent = (
 					<DomainBulkTransferThankYou
 						purchases={ purchases }
+						receipt={ this.props.receipt.data }
 						currency={ this.props.receipt.data?.currency ?? 'USD' }
 					/>
 				);
@@ -718,6 +722,7 @@ export default connect(
 					? getCustomizeOrEditFrontPageUrl( state, activeTheme, siteId )
 					: undefined,
 			site: siteId ? getSite( state, siteId ) : null,
+			siteDomains: siteId ? getDomainsBySiteId( state, siteId ) : null,
 		};
 	},
 	{

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-bulk-transfer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-bulk-transfer.tsx
@@ -1,24 +1,82 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { domainProductSlugs } from '@automattic/calypso-products';
+import { Global, css } from '@emotion/react';
 import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { translate } from 'i18n-calypso';
+import QuerySiteDomains from 'calypso/components/data/query-site-domains';
+import QuerySites from 'calypso/components/data/query-sites';
 import ThankYouV2 from 'calypso/components/thank-you-v2';
 import { preventWidows } from 'calypso/lib/formatting';
 import { usePresalesChat } from 'calypso/lib/presales-chat';
+import HundredYearThankYou from 'calypso/my-sites/checkout/checkout-thank-you/hundred-year-thank-you';
 import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
+import { useSelector } from 'calypso/state';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import { getSite } from 'calypso/state/sites/selectors';
 import ThankYouDomainProduct from '../products/domain-product';
-import type { ReceiptPurchase } from 'calypso/state/receipts/types';
+import type { ReceiptData, ReceiptPurchase } from 'calypso/state/receipts/types';
 
 interface DomainBulkTransferThankYouProps {
+	receipt: ReceiptData;
 	purchases: ReceiptPurchase[];
 	currency: string;
 }
 
 export default function DomainBulkTransferThankYou( {
 	purchases,
+	receipt,
 	currency,
 }: DomainBulkTransferThankYouProps ) {
 	const { __, _n } = useI18n();
+	const blogIds = purchases.map( ( purchase ) => purchase.blogId );
+	const isSingleProductPurchase = purchases.length === 1;
+	const isHundredYearDomain = isSingleProductPurchase && purchases[ 0 ].isHundredYearDomain;
+
+	const transferSite = useSelector( ( state ) =>
+		isHundredYearDomain ? getSite( state, blogIds[ 0 ] ) : null
+	);
+	const transferredDomain = useSelector( ( state ) =>
+		transferSite
+			? getDomainsBySiteId( state, blogIds[ 0 ] ).find(
+					( domainObject ) => domainObject.domain === purchases[ 0 ].meta
+			  )
+			: null
+	);
+
+	usePresalesChat( 'wpcom' );
+
+	if ( isHundredYearDomain ) {
+		return (
+			<>
+				{ ! transferSite && <QuerySites siteId={ blogIds[ 0 ] } /> }
+				{ ! transferredDomain && <QuerySiteDomains siteId={ blogIds[ 0 ] } /> }
+				<Global
+					styles={ css`
+						main.checkout-thank-you {
+							&.is-redesign-v2 {
+								&.main {
+									max-width: unset;
+								}
+							}
+						}
+
+						body.is-section-checkout,
+						body.is-section-checkout .layout__content,
+						body.is-section-checkout-thank-you,
+						body.is-section-checkout-thank-you .layout__content {
+							background: linear-gradient( 233deg, #06101c 2.17%, #050c16 41.26%, #02080f 88.44% );
+						}
+					` }
+				/>
+				<HundredYearThankYou
+					siteSlug={ String( blogIds[ 0 ] ) }
+					receiptId={ Number( receipt.receiptId ) }
+					productSlug={ domainProductSlugs.TRANSFER_IN }
+				/>
+			</>
+		);
+	}
 
 	const handleUserClick = ( destination: string ) => {
 		recordTracksEvent( 'calypso_domain_transfer_complete_click', {
@@ -67,8 +125,6 @@ export default function DomainBulkTransferThankYou( {
 			),
 		},
 	];
-
-	usePresalesChat( 'wpcom' );
 
 	return (
 		<ThankYouV2

--- a/client/state/receipts/assembler.ts
+++ b/client/state/receipts/assembler.ts
@@ -44,6 +44,7 @@ export function createReceiptObject(
 		purchases: purchases.map( ( purchase ) => {
 			return {
 				delayedProvisioning: Boolean( purchase.delayed_provisioning ),
+				isHundredYearDomain: Boolean( purchase.is_hundred_year_domain ),
 				freeTrial: false,
 				isDomainRegistration: Boolean( purchase.is_domain_registration ),
 				meta: purchase.meta || '',

--- a/client/state/receipts/test/assembler.ts
+++ b/client/state/receipts/test/assembler.ts
@@ -82,6 +82,7 @@ const standardAssembledReceipt: ReceiptData = {
 			isEmailVerified: true,
 			isRenewal: false,
 			isRootDomainWithUs: false,
+			isHundredYearDomain: false,
 			meta: 'example.com',
 			newQuantity: 1,
 			productId: '54321',

--- a/client/state/receipts/types.ts
+++ b/client/state/receipts/types.ts
@@ -13,6 +13,7 @@ export interface ReceiptPurchase {
 	registrarSupportUrl: string;
 	isEmailVerified: boolean;
 	isRootDomainWithUs: boolean;
+	isHundredYearDomain: boolean;
 	isRenewal: boolean;
 	willAutoRenew: boolean;
 	saasRedirectUrl: string;

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -761,7 +761,10 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 	const isDomainMapping = productSlug === 'domain_map';
 	const isDomainTransfer = productSlug === 'domain_transfer';
 
-	if ( ( isDomainRegistration || isDomainMapping ) && product.months_per_bill_period === 12 ) {
+	if (
+		( ( isDomainRegistration || isDomainMapping ) && product.months_per_bill_period === 12 ) ||
+		( isDomainTransfer && product.volume === 100 )
+	) {
 		const premiumLabel = product.extra?.premium ? translate( 'Premium' ) : '';
 		return (
 			<>

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -102,6 +102,7 @@ export interface Purchase {
 	is_email_verified?: boolean;
 	is_renewal: boolean;
 	is_root_domain_with_us?: boolean;
+	is_hundred_year_domain?: boolean;
 	meta: string | null;
 	new_quantity?: number;
 	product_id: string | number;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #95634 - follow up.

## Proposed Changes
Adds the specific "Thank-you" page for the 100-year domain transfer flow and some more changes/tweaks: UI-related changes, checkout, etc.

**Please notice that adding the domain transfer along with the 100-year plan is still unsupported - this will be handled in the future, not in this PR.**

### Comments from the previous PR handled here

- [x] Gray section at the top of the "Setting up your legacy" step
- [x] The checkout page says the transfer will be billed annually for $2000
- [x] The thank you page says it's $2000 for one year
- [x] If you click on "Remove from cart" to remove the domain, you get redirected to the site picker


## Why are these changes being made?
Follow up to #95634 so the review gets easier - plus the specific thank you page was accounted for in the original design file.

## Testing Instructions
Follow all the same steps from the previous PR, but this time make sure all the comments addressed are fixed - also try completing the checkout and ensure the "thank-you" page looks good now.
Also ensure other 100-year related flows are left unchanged.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
