### PR TITLE
Plans: fix storage add-on selection when site is selected

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -201,6 +201,10 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 				await addPlanToCart( slug, flow, true, theme, planCartItem );
 			}
 
+			if ( productCartItems?.length && slug ) {
+				await addProductsToCart( slug, flow, productCartItems );
+			}
+
 			return {
 				siteSlug: getSignupCompleteSlug(),
 				goToCheckout: shouldGoToCheckout,

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -95,7 +95,7 @@ const usePricingMetaForGridPlans = ( {
 	} );
 	const selectedStorageOptions = useSelect(
 		( select ) => select( WpcomPlansUI.store ).getSelectedStorageOptions( siteId ),
-		[]
+		[ siteId ]
 	);
 
 	const planAvailabilityForPurchase = useCheckPlanAvailabilityForPurchase( {

--- a/packages/plans-grid-next/src/components/shared/action-button/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/action-button/index.tsx
@@ -63,7 +63,7 @@ const ActionButton = ( {
 	const storageAddOns = AddOns.useStorageAddOns( { siteId } );
 	const selectedStorageOptionForPlan = useSelect(
 		( select ) => select( WpcomPlansUI.store ).getSelectedStorageOptionForPlan( planSlug, siteId ),
-		[ planSlug ]
+		[ planSlug, siteId ]
 	);
 	const selectedStorageAddOn = storageAddOns?.find( ( addOn ) => {
 		return selectedStorageOptionForPlan && addOn

--- a/packages/plans-grid-next/src/components/shared/storage/components/storage-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/storage-dropdown.tsx
@@ -91,7 +91,7 @@ const StorageDropdown = ( {
 	} );
 	const selectedStorageOptionForPlan = useSelect(
 		( select ) => select( WpcomPlansUI.store ).getSelectedStorageOptionForPlan( planSlug, siteId ),
-		[ planSlug ]
+		[ planSlug, siteId ]
 	);
 	const defaultStorageOption = useDefaultStorageOption( { planSlug } );
 	const availableStorageAddOns = AddOns.useAvailableStorageAddOns( { siteId } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #98853

## Proposed Changes

* This PR adds the correct dependencies to instances of `useSelect` used for storage add-ons. When a `siteId` is provided, the selector would not listen for changes as the `siteId` would have been `undefined` or `null` initially. By adding the `siteId` dependency, the selector correctly responds to updates in the data store.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to https://wordpress.com/start/
- Select a plan and go to checkout
- Click on the browser back button.
- Confirm that the free plan has the "Your plan" badge.
<img width="319" alt="image" src="https://github.com/user-attachments/assets/871ceb71-9802-44cd-8a42-83faa2884df9" />

- Select any storage add-on and confirm that the price is updated according to the storage selection.
- Click on "Get Business" and confirm that the storage add-on is added to the cart.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
