### PR TITLE
Prioritise `NewsletterGoal` intent over `Write` (when feature flag is enabled)

### DIFF
--- a/packages/data-stores/src/onboard/test/utils.ts
+++ b/packages/data-stores/src/onboard/test/utils.ts
@@ -2,10 +2,17 @@
  * @jest-environment jsdom
  */
 
+import config from '@automattic/calypso-config';
 import { SiteGoal, SiteIntent } from '../constants';
 import { goalsToIntent } from '../utils';
 
+jest.mock( '@automattic/calypso-config' );
+
 describe( 'Test onboard utils', () => {
+	beforeEach( () => {
+		config.isEnabled.mockReset();
+	} );
+
 	it.each( [
 		{
 			goals: [],
@@ -27,7 +34,39 @@ describe( 'Test onboard utils', () => {
 			goals: [ SiteGoal.Promote, SiteGoal.Sell, SiteGoal.Write ],
 			expectedIntent: SiteIntent.Sell,
 		},
-	] )( 'Should map the $goals to $expectedIntent intent', ( { goals, expectedIntent } ) => {
-		expect( goalsToIntent( goals ) ).toBe( expectedIntent );
-	} );
+		{
+			goals: [ SiteGoal.Write, SiteGoal.Engagement ],
+			expectedIntent: SiteIntent.Write,
+		},
+		{
+			goals: [ SiteGoal.Write, SiteGoal.Engagement ],
+			expectedIntent: SiteIntent.Write,
+		},
+		{
+			goals: [ SiteGoal.Write, SiteGoal.Newsletter ],
+			expectedIntent: SiteIntent.Write,
+			featureFlags: { 'onboarding/newsletter-goal': false },
+		},
+		{
+			goals: [ SiteGoal.Write, SiteGoal.Newsletter ],
+			expectedIntent: SiteIntent.NewsletterGoal,
+			featureFlags: { 'onboarding/newsletter-goal': true },
+		},
+		{
+			goals: [ SiteGoal.Sell, SiteGoal.Newsletter ],
+			expectedIntent: SiteIntent.Sell,
+			featureFlags: { 'onboarding/newsletter-goal': false },
+		},
+		{
+			goals: [ SiteGoal.Sell, SiteGoal.Newsletter ],
+			expectedIntent: SiteIntent.NewsletterGoal,
+			featureFlags: { 'onboarding/newsletter-goal': true },
+		},
+	] )(
+		'Should map the $goals to $expectedIntent intent ($featureFlags)',
+		( { goals, expectedIntent, featureFlags = {} } ) => {
+			config.isEnabled.mockImplementation( ( flag ) => Boolean( featureFlags[ flag ] ) );
+			expect( goalsToIntent( goals ) ).toBe( expectedIntent );
+		}
+	);
 } );

--- a/packages/data-stores/src/onboard/test/utils.ts
+++ b/packages/data-stores/src/onboard/test/utils.ts
@@ -10,7 +10,7 @@ jest.mock( '@automattic/calypso-config' );
 
 describe( 'Test onboard utils', () => {
 	beforeEach( () => {
-		config.isEnabled.mockReset();
+		( config.isEnabled as jest.Mock ).mockReset();
 	} );
 
 	it.each( [
@@ -65,7 +65,9 @@ describe( 'Test onboard utils', () => {
 	] )(
 		'Should map the $goals to $expectedIntent intent ($featureFlags)',
 		( { goals, expectedIntent, featureFlags = {} } ) => {
-			config.isEnabled.mockImplementation( ( flag ) => Boolean( featureFlags[ flag ] ) );
+			( config.isEnabled as jest.Mock ).mockImplementation( ( flag ) =>
+				Boolean( featureFlags[ flag ] )
+			);
 			expect( goalsToIntent( goals ) ).toBe( expectedIntent );
 		}
 	);

--- a/packages/data-stores/src/onboard/utils.ts
+++ b/packages/data-stores/src/onboard/utils.ts
@@ -11,6 +11,11 @@ export const goalsToIntent = ( goals: SiteGoal[] ): SiteIntent => {
 		return SiteIntent.Import;
 	}
 
+	// Newsletter flow
+	if ( config.isEnabled( 'onboarding/newsletter-goal' ) && goals.includes( SiteGoal.Newsletter ) ) {
+		return SiteIntent.NewsletterGoal;
+	}
+
 	// Prioritize Sell over Build and Write
 	if (
 		goals.some( ( goal ) =>
@@ -27,11 +32,6 @@ export const goalsToIntent = ( goals: SiteGoal[] ): SiteIntent => {
 
 	if ( goals.includes( SiteGoal.Write ) ) {
 		return SiteIntent.Write;
-	}
-
-	// Newsletter flow
-	if ( config.isEnabled( 'onboarding/newsletter-goal' ) && goals.includes( SiteGoal.Newsletter ) ) {
-		return SiteIntent.NewsletterGoal;
 	}
 
 	return SiteIntent.Build;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #98385

## Proposed Changes

* Rearrange intent precedence during on boarding
* Add tests to try a few goal combinations

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See #98385. The newsletter task list has higher value tasks than the write task list. So we want to prioritise it if the user chooses both the blog and newsletter goals.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply 170645-ghe-Automattic/wpcom to your sandbox if it hasn't been deployed yet
* Create a site at `/setup/onboarding?flags=onboarding/newsletter-goal`
* Add a newsletter goal
* You should land in My Home with the newsletter goal task list
* Test again without the feature again
* You should land on the fullscreen launchpad, regardless of whether you select the newsletter goal

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?