### PR TITLE
Launchpad in My Home: Only display it if site was created through the onboarding flow

### DIFF
--- a/client/my-sites/customer-home/main.tsx
+++ b/client/my-sites/customer-home/main.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -7,10 +6,8 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { FullScreenLaunchpad } from './components/full-screen-launchpad';
 import HomeContent from './components/home-content';
 
-export default function CustomerHome() {
-	const [ isShowingLaunchpad, setIsShowingLaunchpad ] = useState(
-		config.isEnabled( 'home/launchpad-first' )
-	);
+export default function CustomerHome( { showLaunchpadFirst = false } ) {
+	const [ isShowingLaunchpad, setIsShowingLaunchpad ] = useState( showLaunchpadFirst );
 
 	const translate = useTranslate();
 

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -278,6 +278,7 @@ export interface SiteDetailsOptions {
 	site_goals?: SiteGoal[];
 	site_segment?: string | null;
 	site_vertical_id?: string | null;
+	site_creation_flow?: string;
 	software_version?: string;
 	theme_slug?: string;
 	timezone?: string;


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/98761.

## Proposed Changes

The eligibility criteria for Launchpad in My Home is the feature flag AND the site being created through the onboarding flow. We were not checking for the latter.

## Testing Instructions

1. Apply the back-end PR to your sandbox and proxy yourself.
2. Create a site through `/setup/onboarding` and enable the feature flag. You should see the big Launchpad in `/home/%s`
3. Disable the flag and the big Launchpad should be gone
4. Enable the flag again and create another site through a different flow
5. You should not see the big Launchpad