### PR TITLE
Domain Transfer: Annotate flow with deprecated version to fix type error

### DIFF
--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -12,14 +12,14 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { USER_STORE } from '../stores';
 import { useLoginUrl } from '../utils/path';
 import {
-	Flow,
 	ProvidedDependencies,
 	AssertConditionResult,
 	AssertConditionState,
+	FlowV1,
 } from './internals/types';
 import type { UserSelect } from '@automattic/data-stores';
 
-const domainTransfer: Flow = {
+const domainTransfer: FlowV1 = {
 	name: DOMAIN_TRANSFER,
 	get title() {
 		return translate( 'Bulk domain transfer' );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/95634 and https://github.com/Automattic/wp-calypso/pull/97999.

## Proposed Changes

We were using a method called `useSteps` in a "v1" flow, however the type annotation indicated that the flow might be v1 or v2, which doesn't include this method. Because of it, we were getting a type error and failing CI.
