### PR TITLE
Uses TLD to check for subdomain status for Mapping

### DIFF
--- a/client/components/domains/connect-domain-step/connect-domain-step-suggested-start.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-suggested-start.jsx
@@ -26,16 +26,18 @@ export default function ConnectDomainStepSuggestedStart( {
 	onNextStep,
 	progressStepList,
 	setPage,
+	domainSetupInfo,
 } ) {
 	const { __ } = useI18n();
+	const { data } = domainSetupInfo;
 	const selectedSite = useSelector( getSelectedSite );
 	const goToDnsRecordsPage = () => page( domainManagementDns( selectedSite?.slug, domain ) );
-	const firstStep = isSubdomain( domain )
+	const firstStep = isSubdomain( domain, data?.tld )
 		? stepSlug.SUBDOMAIN_ADVANCED_START
 		: stepSlug.ADVANCED_START;
 	const switchToAdvancedSetup = () => setPage( firstStep );
 
-	const message = isSubdomain( domain )
+	const message = isSubdomain( domain, data?.tld )
 		? __(
 				'The easiest way to connect your subdomain is by changing NS records. But if you are unable to do this, then switch to our <a>advanced setup</a>, using A & CNAME records.'
 		  )
@@ -130,4 +132,5 @@ ConnectDomainStepSuggestedStart.propTypes = {
 	onNextStep: PropTypes.func.isRequired,
 	progressStepList: PropTypes.object.isRequired,
 	setPage: PropTypes.func.isRequired,
+	domainSetupInfo: PropTypes.object.isRequired,
 };

--- a/client/components/domains/connect-domain-step/connect-domain-step-suggested-start.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-suggested-start.jsx
@@ -11,7 +11,6 @@ import {
 	stepsHeading,
 	stepSlug,
 } from 'calypso/components/domains/connect-domain-step/constants';
-import { isSubdomain } from 'calypso/lib/domains';
 import { domainManagementDns } from 'calypso/my-sites/domains/paths';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ConnectDomainStepWrapper from './connect-domain-step-wrapper';
@@ -32,12 +31,12 @@ export default function ConnectDomainStepSuggestedStart( {
 	const { data } = domainSetupInfo;
 	const selectedSite = useSelector( getSelectedSite );
 	const goToDnsRecordsPage = () => page( domainManagementDns( selectedSite?.slug, domain ) );
-	const firstStep = isSubdomain( domain, data?.tld )
+	const firstStep = data?.is_subdomain
 		? stepSlug.SUBDOMAIN_ADVANCED_START
 		: stepSlug.ADVANCED_START;
 	const switchToAdvancedSetup = () => setPage( firstStep );
 
-	const message = isSubdomain( domain, data?.tld )
+	const message = data?.is_subdomain
 		? __(
 				'The easiest way to connect your subdomain is by changing NS records. But if you are unable to do this, then switch to our <a>advanced setup</a>, using A & CNAME records.'
 		  )

--- a/client/components/domains/connect-domain-step/constants.ts
+++ b/client/components/domains/connect-domain-step/constants.ts
@@ -58,7 +58,7 @@ export const defaultDomainSetupInfo = {
 	data: {
 		default_ip_addresses: [ '192.0.78.24', '192.0.78.25' ],
 		wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
-		tld: null,
+		is_subdomain: false,
 	},
 } as const;
 

--- a/client/components/domains/connect-domain-step/constants.ts
+++ b/client/components/domains/connect-domain-step/constants.ts
@@ -58,6 +58,7 @@ export const defaultDomainSetupInfo = {
 	data: {
 		default_ip_addresses: [ '192.0.78.24', '192.0.78.25' ],
 		wpcom_name_servers: [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ],
+		tld: null,
 	},
 } as const;
 

--- a/client/lib/domains/is-subdomain.ts
+++ b/client/lib/domains/is-subdomain.ts
@@ -1,69 +1,14 @@
 import { getRootDomain } from 'calypso/lib/domains/utils';
 
-export function isSubdomain( domainName: string, tld?: string ): boolean {
+export function isSubdomain( domainName: string ): boolean {
 	if ( ! domainName || domainName === '' ) {
 		return false;
 	}
-
 	const isValidSubdomain = Boolean(
 		domainName.match(
 			/^([a-z0-9_]([a-z0-9\-_]*[a-z0-9_])?\.)+[a-z0-9]([a-z0-9-]*[a-z0-9])?\.[a-z]{2,63}$/
 		)
 	);
 
-	// If it doesn't even match the subdomain "shape", just return false.
-	if ( ! isValidSubdomain ) {
-		return false;
-	}
-
-	// If the second param isn't a string, treat it as though no TLD was passed
-	// For situations where function is called like: map( domains, 'name' ).every( isSubdomain )
-	let lowerTld: string | undefined;
-	if ( typeof tld === 'string' ) {
-		lowerTld = tld.toLowerCase();
-	}
-
-	if ( ! lowerTld ) {
-		// No TLD provided => original logic based on hard coded list of SLDs
-		return getRootDomain( domainName ) !== domainName;
-	}
-
-	// ----- TLD provided: let’s verify the domain actually ends in that TLD. -----
-
-	const lowerDomain = domainName.toLowerCase();
-	const domainParts = lowerDomain.split( '.' );
-	const tldParts = lowerTld.split( '.' );
-
-	// If domain doesn't have at least as many parts as the TLD, can't match it.
-	if ( domainParts.length < tldParts.length ) {
-		// Fallback to list of SLDs logic
-		return getRootDomain( domainName ) !== domainName;
-	}
-
-	// Compare trailing parts of the domain to see if they match exactly the TLD
-	const domainEnding = domainParts.slice( domainParts.length - tldParts.length );
-
-	if ( ! arraysMatch( domainEnding, tldParts ) ) {
-		// If it doesn't actually end with the TLD, fallback to list of SLDs logic
-		return getRootDomain( domainName ) !== domainName;
-	}
-
-	// At this point, the domain does end with the TLD. Count leftover labels.
-	// Example:
-	//   subdomain.domain.edu.my
-	//   domainParts = [ 'subdomain', 'domain', 'edu', 'my' ]
-	//   tldParts    = [ 'edu', 'my' ]
-	//   leftover    = [ 'subdomain', 'domain' ] => leftover.length = 2 => subdomain
-	const leftover = domainParts.slice( 0, domainParts.length - tldParts.length );
-
-	// If leftover is > 1, that means we have at least "sub.whatever.edu.my", so subdomain = true
-	// If leftover is <= 1, that’s effectively "domain.edu.my" => not a subdomain
-	return leftover.length > 1;
-}
-
-function arraysMatch( a: string[], b: string[] ): boolean {
-	if ( a.length !== b.length ) {
-		return false;
-	}
-	return a.every( ( val, i ) => val === b[ i ] );
+	return isValidSubdomain && getRootDomain( domainName ) !== domainName;
 }

--- a/client/lib/domains/is-subdomain.ts
+++ b/client/lib/domains/is-subdomain.ts
@@ -36,7 +36,7 @@ export function isSubdomain( domainName: string, tld?: string ): boolean {
 
 	// If domain doesn't have at least as many parts as the TLD, can't match it.
 	if ( domainParts.length < tldParts.length ) {
-		// Fallback to your original logic
+		// Fallback to list of SLDs logic
 		return getRootDomain( domainName ) !== domainName;
 	}
 
@@ -44,7 +44,7 @@ export function isSubdomain( domainName: string, tld?: string ): boolean {
 	const domainEnding = domainParts.slice( domainParts.length - tldParts.length );
 
 	if ( ! arraysMatch( domainEnding, tldParts ) ) {
-		// If it doesn't actually end with the TLD, fallback to original logic
+		// If it doesn't actually end with the TLD, fallback to list of SLDs logic
 		return getRootDomain( domainName ) !== domainName;
 	}
 

--- a/client/lib/domains/is-subdomain.ts
+++ b/client/lib/domains/is-subdomain.ts
@@ -1,9 +1,14 @@
 import { getRootDomain } from 'calypso/lib/domains/utils';
 
-export function isSubdomain( domainName: string ): boolean {
+export function isSubdomain( domainName: string, tld?: string ): boolean {
 	if ( ! domainName || domainName === '' ) {
 		return false;
 	}
+
+	if ( tld && domainName.endsWith( tld ) ) {
+		return false;
+	}
+
 	const isValidSubdomain = Boolean(
 		domainName.match(
 			/^([a-z0-9_]([a-z0-9\-_]*[a-z0-9_])?\.)+[a-z0-9]([a-z0-9-]*[a-z0-9])?\.[a-z]{2,63}$/

--- a/client/lib/domains/is-subdomain.ts
+++ b/client/lib/domains/is-subdomain.ts
@@ -5,15 +5,65 @@ export function isSubdomain( domainName: string, tld?: string ): boolean {
 		return false;
 	}
 
-	if ( tld && domainName.endsWith( tld ) ) {
-		return false;
-	}
-
 	const isValidSubdomain = Boolean(
 		domainName.match(
 			/^([a-z0-9_]([a-z0-9\-_]*[a-z0-9_])?\.)+[a-z0-9]([a-z0-9-]*[a-z0-9])?\.[a-z]{2,63}$/
 		)
 	);
 
-	return isValidSubdomain && getRootDomain( domainName ) !== domainName;
+	// If it doesn't even match the subdomain "shape", just return false.
+	if ( ! isValidSubdomain ) {
+		return false;
+	}
+
+	// If the second param isn't a string, treat it as though no TLD was passed
+	// For situations where function is called like: map( domains, 'name' ).every( isSubdomain )
+	let lowerTld: string | undefined;
+	if ( typeof tld === 'string' ) {
+		lowerTld = tld.toLowerCase();
+	}
+
+	if ( ! lowerTld ) {
+		// No TLD provided => original logic based on hard coded list of SLDs
+		return getRootDomain( domainName ) !== domainName;
+	}
+
+	// ----- TLD provided: let’s verify the domain actually ends in that TLD. -----
+
+	const lowerDomain = domainName.toLowerCase();
+	const domainParts = lowerDomain.split( '.' );
+	const tldParts = lowerTld.split( '.' );
+
+	// If domain doesn't have at least as many parts as the TLD, can't match it.
+	if ( domainParts.length < tldParts.length ) {
+		// Fallback to your original logic
+		return getRootDomain( domainName ) !== domainName;
+	}
+
+	// Compare trailing parts of the domain to see if they match exactly the TLD
+	const domainEnding = domainParts.slice( domainParts.length - tldParts.length );
+
+	if ( ! arraysMatch( domainEnding, tldParts ) ) {
+		// If it doesn't actually end with the TLD, fallback to original logic
+		return getRootDomain( domainName ) !== domainName;
+	}
+
+	// At this point, the domain does end with the TLD. Count leftover labels.
+	// Example:
+	//   subdomain.domain.edu.my
+	//   domainParts = [ 'subdomain', 'domain', 'edu', 'my' ]
+	//   tldParts    = [ 'edu', 'my' ]
+	//   leftover    = [ 'subdomain', 'domain' ] => leftover.length = 2 => subdomain
+	const leftover = domainParts.slice( 0, domainParts.length - tldParts.length );
+
+	// If leftover is > 1, that means we have at least "sub.whatever.edu.my", so subdomain = true
+	// If leftover is <= 1, that’s effectively "domain.edu.my" => not a subdomain
+	return leftover.length > 1;
+}
+
+function arraysMatch( a: string[], b: string[] ): boolean {
+	if ( a.length !== b.length ) {
+		return false;
+	}
+	return a.every( ( val, i ) => val === b[ i ] );
 }


### PR DESCRIPTION
rather than a hardcoded list of TLDs on the Front End

relies on wpcom diff: 170938-ghe-Automattic/wpcom

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/nomado-issues/issues/947

## Proposed Changes

* Uses the already called 'domain-mapping-info' API call, and a new key added to that, to get the TLD from the backend (Single Source of Truth), instead of relying purely on a simple check on the front end (incomplete second source of truth).
* Introduces optional parameter, 'tld' to the isSubdomain function
* If 'tld' is provided and validated, uses that TLD or SLD to safely check if the domain is using an SLD or just a subdomain
* Leaves the original functionality to ensure nothing breaks unexpectedly, but it would be good to get the TLD from the backend in all cases where isSubdomain is used, to keep it as Single Source of Truth

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When users connect domains, we suggest some guidance based on whether it's a Subdomain or a full Domain (possibly with multi-level TLD). Users have expressed confusion and reached out to HEs for assistance when provided the wrong guidance
* The current check only looks at a list of hard-coded SLDs in the front-end (which is technically how the backend works, but that should be the source of truth as it's MASSIVELY more complete)
* Instead of adding a few SLDs to that list at a time (won't solve everything), or adding the entire list (too big), Kamen suggested this exact approach on Slack
  * p1736980903062009-slack-C0BNMNMNG

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Load this branch and proxy Sandbox with  170938-ghe-Automattic/wpcom
- Open the network tab, using the filter `mapping-setup-info` to isolate the single API call
- You can skip actually mapping a thing and go straight to the correct Step
- Load up /domains/mapping/YOURSITE.tld/setup/notsubdomain.ca?firstVisit=true Replace YOURISTE.tld with a test site
- Test with a series of domains, subdomains, and two level TLDs, deeply nested subdomains, etc.
  - notsubdomain.ca (ca)
  - subdomain.domain.ca (ca)
  - domain.qc.ca (qc.ca)
  - subdomain.domain.qc.ca (qc.ca)
  - more.
  - I've been testing with a domain provided by an HE as well, a full example I used: http://calypso.localhost:3000/domains/mapping/nomado-test-sp-2025-01-13.blog/setup/assnat.qc.ca?firstVisit=true

With fix ([`assnat.qc.ca` localhost](http://calypso.localhost:3000/domains/mapping/nomado-test-sp-2025-01-13.blog/setup/assnat.qc.ca?firstVisit=true)):
<img width="776" alt="image" src="https://github.com/user-attachments/assets/3ee81520-78d4-46d5-b10c-b55ad373f56c" />


Without fix ([`assnat.qc.ca` on wordpress.com](https://wordpress.com/domains/mapping/nomado-test-sp-2025-01-13.blog/setup/assnat.qc.ca?firstVisit=true)):
<img width="776" alt="image" src="https://github.com/user-attachments/assets/ffb7f55b-bd4b-4a87-80d2-37c7fd9f9078" />