### PR TITLE
Plans: show default storage option in storage drop down

### DIFF
--- a/packages/plans-grid-next/src/components/shared/storage/components/storage-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/storage-dropdown.tsx
@@ -24,7 +24,7 @@ type StorageDropdownOptionProps = {
 	priceOnSeparateLine?: boolean;
 };
 
-const getSelecetedStorageAddOn = (
+const getSelectedStorageAddOn = (
 	storageAddOnsForPlan: ( AddOns.AddOnMeta | null )[] | null,
 	storageOptionSlug: string
 ) => {
@@ -106,23 +106,41 @@ const StorageDropdown = ( {
 					siteId,
 				} );
 		}
-	}, [] );
+	}, [
+		defaultStorageOption,
+		planSlug,
+		selectedStorageOptionForPlan,
+		setSelectedStorageOptionForPlan,
+		siteId,
+	] );
 
-	const selectControlOptions = availableStorageAddOns?.map( ( addOn ) => {
-		const addOnStorage = addOn.quantity ?? 0;
-
-		return {
-			key: addOn.addOnSlug,
+	const defaultStorageItem = useMemo(
+		() => ( {
+			key: defaultStorageOption || '',
 			name: (
-				<StorageDropdownOption
-					price={ addOn?.prices?.formattedMonthlyPrice }
-					totalStorage={ planStorage + addOnStorage }
-				/>
+				<StorageDropdownOption price="" totalStorage={ planStorage } />
 			 ) as unknown as string,
-		};
-	} );
+		} ),
+		[ defaultStorageOption, planStorage ]
+	);
 
-	const selectedStorageAddOn = getSelecetedStorageAddOn(
+	const selectControlOptions = [ defaultStorageItem ].concat(
+		availableStorageAddOns?.map( ( addOn ) => {
+			const addOnStorage = addOn.quantity ?? 0;
+
+			return {
+				key: addOn.addOnSlug,
+				name: (
+					<StorageDropdownOption
+						price={ addOn?.prices?.formattedMonthlyPrice }
+						totalStorage={ planStorage + addOnStorage }
+					/>
+				 ) as unknown as string,
+			};
+		} )
+	);
+
+	const selectedStorageAddOn = getSelectedStorageAddOn(
 		storageAddOns,
 		selectedStorageOptionForPlan
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* In onboarding, the storage drop-down does not allow users to select the default storage if they choose a non-default storage option.
<img width="278" alt="image" src="https://github.com/user-attachments/assets/2659553b-16e6-458f-af12-865516a0413d" />

* This PR adds the default storage option to the storage dropdown.

<img width="236" alt="image" src="https://github.com/user-attachments/assets/7b63cffb-8652-4f61-9e81-0012ee8598b8" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding/plans`.
* Confirm that you see the 50GB option in the storage dropdown for the Business/eCommerce plans.
* Confirm that selecting any of the storage options updates the price correctly.
* Select the 50GB option and proceed to checkout. Confirm that there is no storage add-on added to the cart.
* Test the storage dropdown in `/plans/<site slug>`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
