### PR TITLE
Update the shopping cart skeleton.

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -88,7 +88,10 @@ import JetpackAkismetCheckoutSidebarPlanUpsell from './jetpack-akismet-checkout-
 import BeforeSubmitCheckoutHeader from './payment-method-step';
 import SecondaryCartPromotions from './secondary-cart-promotions';
 import WPCheckoutOrderReview, { CouponFieldArea } from './wp-checkout-order-review';
-import { WPCheckoutOrderSummary } from './wp-checkout-order-summary';
+import {
+	LoadingCheckoutSummaryFeaturesList,
+	WPCheckoutOrderSummary,
+} from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
 import WPContactFormSummary from './wp-contact-form-summary';
 import type { OnChangeItemVariant } from './item-variation-picker';
@@ -115,38 +118,42 @@ const LoadingSidebar = styled.div`
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		display: block;
-		padding: 24px;
 		box-sizing: border-box;
-		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-		max-width: 328px;
-		background: ${ ( props ) => props.theme.colors.surface };
+		max-width: 288px;
 		margin-top: 46px;
 	}
 `;
 
 const pulse = keyframes`
-	0% {
-		opacity: 1;
-	}
+	0% { opacity: 1; }
 
-	70% {
-		opacity: 0.5;
-	}
+	70% { opacity: 0.25; }
 
-	100% {
-		opacity: 1;
-	}
+	100% { opacity: 1; }
 `;
 
-const SideBarLoadingCopy = styled.p`
+const LoadingFooter = styled.div`
+	margin-top: 20px;
+	padding-top: 20px;
+	display: flex;
+	justify-content: space-between;
+	border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+`;
+
+interface LoadingContainerProps {
+	width?: string;
+	height?: string;
+}
+
+const SideBarLoadingCopy = styled.div< LoadingContainerProps >`
 	font-size: 14px;
-	height: 16px;
 	content: '';
 	background: ${ ( props ) => props.theme.colors.borderColorLight };
 	color: ${ ( props ) => props.theme.colors.borderColorLight };
-	margin: 8px 0 0 0;
 	padding: 0;
-	animation: ${ pulse } 2s ease-in-out infinite;
+	animation: ${ pulse } 1.5s ease-in-out infinite;
+	width: ${ ( props ) => props.width ?? 'inherit' };
+	height: ${ ( props ) => props.height ?? '16px' };
 `;
 
 const ContactDetailsFormDescription = styled.p`
@@ -174,8 +181,15 @@ function LoadingSidebarContent() {
 	return (
 		<LoadingSidebar>
 			<SideBarLoadingCopy />
-			<SideBarLoadingCopy />
-			<SideBarLoadingCopy />
+			<LoadingCheckoutSummaryFeaturesList />
+			<LoadingFooter>
+				<SideBarLoadingCopy width="50px" />
+				<SideBarLoadingCopy width="75px" />
+			</LoadingFooter>
+			<LoadingFooter>
+				<SideBarLoadingCopy height="30px" width="75px" />
+				<SideBarLoadingCopy height="30px" width="125px" />
+			</LoadingFooter>
 		</LoadingSidebar>
 	);
 }

--- a/packages/composite-checkout/src/components/loading-content.tsx
+++ b/packages/composite-checkout/src/components/loading-content.tsx
@@ -4,7 +4,11 @@ import { useI18n } from '@wordpress/react-i18n';
 
 const LoadingContentWrapper = styled.div`
 	display: flex;
-	padding-top: 50px;
+	padding: 25px 24px 0;
+
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		padding: 25px 0 0;
+	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		align-items: flex-start;
@@ -19,8 +23,6 @@ const LoadingContentInnerWrapper = styled.div`
 	width: 100%;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-		max-width: 556px;
 		margin: 0 auto;
 	}
 
@@ -30,8 +32,7 @@ const LoadingContentInnerWrapper = styled.div`
 `;
 
 const LoadingCard = styled.div`
-	padding: 24px;
-	border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+	padding: 24px 0;
 
 	:first-of-type {
 		border-top: 0;
@@ -52,28 +53,34 @@ const pulse = keyframes`
   }
 `;
 
-const LoadingTitle = styled.h1`
+interface LoadingContainerProps {
+	width?: string;
+	height?: string;
+}
+
+const LoadingTitle = styled.h1< LoadingContainerProps >`
 	font-size: 14px;
 	content: '';
 	font-weight: ${ ( props ) => props.theme.weights.normal };
 	background: ${ ( props ) => props.theme.colors.borderColorLight };
 	color: ${ ( props ) => props.theme.colors.borderColorLight };
-	width: 40%;
-	margin: 3px 0 0 35px;
+	width: ${ ( props ) => props.width ?? '40%' };
+	margin: 3px 0 0 40px;
 	padding: 0;
 	position: relative;
 	animation: ${ pulse } 2s ease-in-out infinite;
 	height: 20px;
+	width: 125px;
 
 	.rtl & {
-		margin: 3px 35px 0 0;
+		margin: 3px 40px 0 0;
 	}
 
 	::before {
 		content: '';
 		display: block;
 		position: absolute;
-		left: -35px;
+		left: -40px;
 		top: -3px;
 		width: 27px;
 		height: 27px;
@@ -81,40 +88,31 @@ const LoadingTitle = styled.h1`
 		border-radius: 100%;
 
 		.rtl & {
-			right: -35px;
+			right: -40px;
 			left: auto;
 		}
 	}
 `;
-const LoadingCopy = styled.p`
+
+const LoadingRow = styled.div`
+	display: flex;
+	justify-content: space-between;
+`;
+
+const LoadingCopy = styled.p< LoadingContainerProps >`
 	font-size: 14px;
-	height: 16px;
+	height: ${ ( props ) => props.height ?? '16px' };
 	content: '';
 	background: ${ ( props ) => props.theme.colors.borderColorLight };
 	color: ${ ( props ) => props.theme.colors.borderColorLight };
-	margin: 8px 0 0 35px;
+	margin: 8px 0 0 40px;
 	padding: 0;
 	animation: ${ pulse } 2s ease-in-out infinite;
+	width: ${ ( props ) => props.width ?? 'inherit' };
+	box-sizing: border-box;
 
 	.rtl & {
-		margin: 8px 35px 0 0;
-	}
-`;
-
-const LoadingFooter = styled.div`
-	background: ${ ( props ) => props.theme.colors.background };
-	content: '';
-	border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-	padding: 24px;
-
-	::before {
-		content: '';
-		display: block;
-		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-		border-radius: 3px;
-		font-size: 14px;
-		width: 100%;
-		height: 40px;
+		margin: 8px 40px 0 0;
 	}
 `;
 
@@ -126,21 +124,32 @@ export default function LoadingContent() {
 			<LoadingContentInnerWrapper>
 				<LoadingCard>
 					<LoadingTitle>{ __( 'Loading checkout' ) }</LoadingTitle>
-					<LoadingCopy />
-					<LoadingCopy />
+					<LoadingCopy width="225px" />
+				</LoadingCard>
+				<LoadingCard>
+					<LoadingRow>
+						<LoadingCopy width="150px" />
+						<LoadingCopy width="45px" />
+					</LoadingRow>
+					<LoadingCopy height="35px" width="225px" />
+					<LoadingCopy width="100px" />
+				</LoadingCard>
+				<LoadingCard>
+					<LoadingRow>
+						<LoadingCopy width="150px" />
+						<LoadingCopy width="45px" />
+					</LoadingRow>
+					<LoadingCopy height="35px" width="225px" />
+					<LoadingCopy width="100px" />
 				</LoadingCard>
 				<LoadingCard>
 					<LoadingTitle />
-					<LoadingCopy />
-					<LoadingCopy />
+					<LoadingCopy width="300px" />
 				</LoadingCard>
 				<LoadingCard>
 					<LoadingTitle />
+					<LoadingCopy width="300px" />
 				</LoadingCard>
-				<LoadingCard>
-					<LoadingTitle />
-				</LoadingCard>
-				<LoadingFooter />
 			</LoadingContentInnerWrapper>
 		</LoadingContentWrapper>
 	);


### PR DESCRIPTION
Fix: #98526

This PR attempts to align the shopping cart skeleton more closely with the final state to reduce visual shift on load. There isn't a perfect state for the skeleton since the number and type of products change the cart's layout.

I've focused on making the top section of the left side align on load. Specifically the title, the site name, the first product title, and the price. Having those align, in my opinion, significantly reduces shift. 

## Screenshots

### Before

https://github.com/user-attachments/assets/ee29de26-5caa-4217-a115-cdcfdb3302d7

### After

https://github.com/user-attachments/assets/77bd0e32-1129-45d1-9c3c-4de8abe81c70

https://github.com/user-attachments/assets/8a9e9393-38b4-4aa1-b669-3d6f0e66de56




### Stills
| Before | After | Final |
|-------- |--------|--------|
| ![calypso localhost_3000_checkout_abstracting blog (7)](https://github.com/user-attachments/assets/5a938730-1b10-47dd-aeba-e6f566aa6291) | ![calypso localhost_3000_checkout_abstracting blog (2)](https://github.com/user-attachments/assets/441fbfb0-70a6-4c71-9196-86dddb18e4d4)   | ![calypso localhost_3000_checkout_abstracting blog (3)](https://github.com/user-attachments/assets/bc92b856-17ba-46ea-b237-142ff510480d) |
| ![calypso localhost_3000_checkout_abstracting blog (10)](https://github.com/user-attachments/assets/3df3dffc-80b6-4ed4-90c4-c9a679702012) | ![calypso localhost_3000_checkout_abstracting blog (5)](https://github.com/user-attachments/assets/c36764e6-4001-4e0f-9315-6956ace87d2d) | ![calypso localhost_3000_checkout_abstracting blog (4)](https://github.com/user-attachments/assets/5a2ea79c-a2fd-409c-84c4-f71d4849be0d) |


### RTL
| Before | After | Final |
|-------- |--------|--------|
| ![calypso localhost_3000_checkout_abstracting blog (8)](https://github.com/user-attachments/assets/ed804b92-86c6-4dbe-9619-caf8f619e4a7) | ![calypso localhost_3000_checkout_abstracting blog (9)](https://github.com/user-attachments/assets/a7c08cbc-0626-49b7-a7f1-cc7b71e361fd) | ![calypso localhost_3000_checkout_abstracting blog (1)](https://github.com/user-attachments/assets/b7b4f4a1-0e73-4e08-9af0-6112f5572a49) |


## Why are these changes being made?

It's not that the current skeleton is bad, it isn't, but I believe that reducing any extra cognitive load in shopping carts is a worthwhile pursuit. They communicate a lot about a product.

Pinging design for feedback:
@Automattic/dotcom-design 

## Testing Instructions

* Add different types of items to your cart
* Navigate to your cart
* Verify the skeleton matches the cart later.

**Test RTL**

Repeat the same test with your account set to a RTL language like Arabic.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
