### PR TITLE
Newsletter Tasks: Complete 'Start building your audience' upon browsing the page

### DIFF
--- a/client/launchpad/hooks/use-task-completed-notice.ts
+++ b/client/launchpad/hooks/use-task-completed-notice.ts
@@ -1,0 +1,55 @@
+import page from '@automattic/calypso-router';
+import { updateLaunchpadSettings, useLaunchpad } from '@automattic/data-stores';
+import { useI18n } from '@wordpress/react-i18n';
+import { useCallback, useEffect } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
+import { successNotice } from 'calypso/state/notices/actions';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+interface TaskCompleteNoticeOptions {
+	taskSlug: string;
+	enabled?: boolean;
+	noticeId: string;
+	noticeText: string;
+	noticeDuration?: number;
+}
+
+export const useTaskCompletedNotice = ( {
+	taskSlug,
+	noticeId,
+	noticeText,
+	noticeDuration,
+	enabled = false,
+}: TaskCompleteNoticeOptions ) => {
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	const dispatch = useDispatch();
+	const { __ } = useI18n();
+
+	const { data, refetch } = useLaunchpad( siteSlug );
+
+	const isTaskCompleted = data?.checklist?.find( ( task ) => task.id === taskSlug )?.completed;
+
+	const completeTask = useCallback( async () => {
+		await updateLaunchpadSettings( siteSlug, {
+			checklist_statuses: { [ taskSlug ]: true },
+		} );
+
+		const notice = successNotice( noticeText, {
+			id: noticeId,
+			duration: noticeDuration,
+			button: __( 'Next steps' ),
+			onClick: () => page( `/home/${ siteSlug }` ),
+		} );
+
+		dispatch( notice );
+
+		refetch();
+	}, [ noticeText, noticeId, noticeDuration, __, siteSlug, taskSlug, refetch, dispatch ] );
+
+	useEffect( () => {
+		if ( enabled && isTaskCompleted === false ) {
+			completeTask();
+		}
+	}, [ completeTask, enabled, isTaskCompleted ] );
+};

--- a/client/launchpad/hooks/use-task-completed-notice.ts
+++ b/client/launchpad/hooks/use-task-completed-notice.ts
@@ -8,7 +8,7 @@ import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 interface TaskCompleteNoticeOptions {
 	taskSlug: string;
-	enabled?: boolean;
+	enabled: boolean;
 	noticeId: string;
 	noticeText: string;
 	noticeDuration?: number;
@@ -19,7 +19,7 @@ export const useTaskCompletedNotice = ( {
 	noticeId,
 	noticeText,
 	noticeDuration,
-	enabled = false,
+	enabled,
 }: TaskCompleteNoticeOptions ) => {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -4,7 +4,7 @@ import { Button, Gridicon } from '@automattic/components';
 import { HelpCenter, Subscriber as SubscriberDataStore } from '@automattic/data-stores';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { useDispatch as useDataStoreDispatch, useSelect } from '@wordpress/data';
-import { translate } from 'i18n-calypso';
+import { translate, useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { navItems } from 'calypso/blocks/stats-navigation/constants';
@@ -13,6 +13,7 @@ import QueryMembershipsSettings from 'calypso/components/data/query-memberships-
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import SubscriberValidationGate from 'calypso/components/subscribers-validation-gate';
+import { useTaskCompletedNotice } from 'calypso/launchpad/hooks/use-task-completed-notice';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import GiftSubscriptionModal from 'calypso/my-sites/subscribers/components/gift-modal/gift-modal';
 import { SubscriberDataViews } from 'calypso/my-sites/subscribers/components/subscriber-data-views';
@@ -126,12 +127,20 @@ const SubscribersPage = ( {
 	sortTermChanged,
 	reloadData,
 }: SubscribersProps ) => {
+	const translate = useTranslate();
 	const selectedSite = useSelector( getSelectedSite );
 
 	const [ giftUserId, setGiftUserId ] = useState( 0 );
 	const [ giftUsername, setGiftUsername ] = useState( '' );
 
 	const siteId = selectedSite?.ID || null;
+
+	useTaskCompletedNotice( {
+		enabled: isEnabled( 'onboarding/newsletter-goal' ),
+		taskSlug: 'start_building_your_audience',
+		noticeId: 'subscribers-page-visited',
+		noticeText: translate( 'Subscribers page visited' ),
+	} );
 
 	const pageArgs = {
 		currentPage: pageNumber,

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -139,7 +139,7 @@ const SubscribersPage = ( {
 		enabled: isEnabled( 'onboarding/newsletter-goal' ),
 		taskSlug: 'start_building_your_audience',
 		noticeId: 'subscribers-page-visited',
-		noticeText: translate( 'Subscribers page visited' ),
+		noticeText: translate( 'Explored subscriber settings' ),
 	} );
 
 	const pageArgs = {

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -5,7 +5,7 @@ import { HelpCenter, Subscriber as SubscriberDataStore } from '@automattic/data-
 import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { useDispatch as useDataStoreDispatch, useSelect } from '@wordpress/data';
 import { translate, useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -135,8 +135,12 @@ const SubscribersPage = ( {
 
 	const siteId = selectedSite?.ID || null;
 
+	const initiallyLoadedWithTaskCompletionHash = useRef(
+		window.location.hash === '#building-your-audience-task'
+	);
+
 	useTaskCompletedNotice( {
-		enabled: isEnabled( 'onboarding/newsletter-goal' ),
+		enabled: initiallyLoadedWithTaskCompletionHash.current,
 		taskSlug: 'start_building_your_audience',
 		noticeId: 'subscribers-page-visited',
 		noticeText: translate( 'Explored subscriber settings' ),


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/98775.


https://github.com/user-attachments/assets/efb34e4c-5692-4d50-a5f5-076109b85ce9

![CleanShot 2025-01-27 at 09 29 29@2x](https://github.com/user-attachments/assets/1c53adf9-1e47-43bb-805c-5fbfaf3157bb)



## Testing Instructions

1. Apply https://github.com/Automattic/jetpack/pull/41299 to your sandbox (it's merged, but might not have been deployed)
1. Turn the feature flag on and create a Newsletter through `/setup/onboarding` flow.
2. Click the "Start building your audience" task in Launchpad.
3. Observe the notice at the top-right corner and click "Next steps".

You'll end up in `/home/%s` and the checklist task should be ticked.