### PR TITLE
[Brand Update] Fix Woo two-factor authentication footer links style

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -2330,6 +2330,7 @@ $breakpoint-mobile: 660px;
 		@include link-woo;
 	}
 
+	.login__two-factor-footer,
 	.security-key-form__help-text,
 	.formatted-header__subtitle {
 		a {


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdibGW-3QO-p2#comment-3003



## Proposed Changes

Update links to the new link styles (new purple and underline) to align with the rest of the links in the flow.


Before:

<img src="https://github.com/user-attachments/assets/b3f497a9-c067-43f0-b691-c1e136fbba28" width="300px" />

After:

![Screenshot 2025-01-24 at 10 57 15](https://github.com/user-attachments/assets/022f7559-7e74-4c73-9634-db24d9f8ca9c)
![Screenshot 2025-01-24 at 10 57 28](https://github.com/user-attachments/assets/957796ff-32a8-4427-93d5-4d30f793cd5c)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Align with the rest of the links in the flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Set up Woo Start environment
* Go to WooCommerce.com > Login
* Login with an account has two-factor authentication enabled
* Observe the links in the footer match the new styles

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?