### PR TITLE
Use the domain name for site title when creating a new site.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -211,13 +211,19 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 		const siteIntent = isMigrationSignupFlow( flow ) ? 'migration' : '';
 
 		const sourceSlug = hasSourceSlug( data ) ? data.sourceSlug : undefined;
+
+		let siteTitle = urlData?.meta.title || selectedSiteTitle;
+		if ( ! siteTitle.length ) {
+			siteTitle = domainItem.domain_name.split( '.' )[ 0 ];
+		}
+
 		const site = await createSiteWithCart(
 			flow,
 			true,
 			isPaidDomainItem,
 			theme,
 			siteVisibility,
-			urlData?.meta.title ?? selectedSiteTitle,
+			siteTitle,
 			// We removed the color option during newsletter onboarding.
 			// But backend still expects/needs a value, so supplying the default.
 			// Ideally should remove this and update code downstream to handle this.

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -213,7 +213,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 		const sourceSlug = hasSourceSlug( data ) ? data.sourceSlug : undefined;
 
 		let siteTitle = urlData?.meta.title || selectedSiteTitle;
-		if ( ! siteTitle.length ) {
+		if ( 0 === siteTitle?.length && domainItem?.domain_name ) {
 			siteTitle = domainItem.domain_name.split( '.' )[ 0 ];
 		}
 


### PR DESCRIPTION
Related to: #98521

> [!CAUTION]
> This PR is early and very naive. The actual change may make more sense on the server. I've opened this up to initiate that discussion.

## Proposed Changes
If we don't have a designated site title, use the domain name or subdomain name.

## Site Title references

### Main Dashboard + Site Preview
<img width="1042" alt="Screenshot 2025-01-24 at 1 51 59 PM" src="https://github.com/user-attachments/assets/e61cf1f1-4da3-47b8-ac4e-3e8c1dd7f1fd" />

### My Home
<img width="1350" alt="Screenshot 2025-01-24 at 1 54 33 PM" src="https://github.com/user-attachments/assets/b58514ba-e0f4-43b1-aabe-b789f9dfd390" />

### My Sites

<img width="901" alt="Screenshot 2025-01-24 at 1 53 39 PM" src="https://github.com/user-attachments/assets/d5ba00a3-cf6b-4ecd-8bed-4437567a2627" />


## Why are these changes being made?

As mentioned #98521, it's currently being set to "Site Title" which in many context is confusing.

## Testing Instructions

TODO

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
