### PR TITLE
Fix: garbled icon in dashicons.css

### DIFF
--- a/client/components/jetpack/sidebar/style.scss
+++ b/client/components/jetpack/sidebar/style.scss
@@ -1,4 +1,4 @@
-@import url( //s0.wp.com/wp-includes/css/dashicons.min.css ); // Used for switch-sites icon.
+@import url( //s0.wp.com/wp-includes/css/dashicons.min.css?v=20250127 ); // Used for switch-sites icon.
 
 // Menu links
 .sidebar__jetpack-cloud {

--- a/client/components/jetpack/sidebar/style.scss
+++ b/client/components/jetpack/sidebar/style.scss
@@ -1,4 +1,4 @@
-@import url( //s1.wp.com/wp-includes/css/dashicons.css?v=20150727 ); // Used for switch-sites icon.
+@import url( //s0.wp.com/wp-includes/css/dashicons.min.css ); // Used for switch-sites icon.
 
 // Menu links
 .sidebar__jetpack-cloud {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -8,7 +8,7 @@ $masterbar-color-secondary: #101517;
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 @import "calypso/assets/stylesheets/shared/animation";
-@import url( //s1.wp.com/wp-includes/css/dashicons.css?v=20150727 );
+@import url( //s0.wp.com/wp-includes/css/dashicons.min.css );
 @import "@automattic/typography/styles/variables";
 
 // Hide the masterbar on WP Mobile App views.

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -8,7 +8,7 @@ $masterbar-color-secondary: #101517;
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 @import "calypso/assets/stylesheets/shared/animation";
-@import url( //s0.wp.com/wp-includes/css/dashicons.min.css );
+@import url( //s0.wp.com/wp-includes/css/dashicons.min.css?v=20250127 );
 @import "@automattic/typography/styles/variables";
 
 // Hide the masterbar on WP Mobile App views.

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 // The following changes should be merged in their respective files before nav unification goes to production
-@import url( //s0.wp.com/wp-includes/css/dashicons.min.css );
+@import url( //s0.wp.com/wp-includes/css/dashicons.min.css?v=20250127 );
 @import "@automattic/typography/styles/variables";
 
 $brand-text: "SF Pro Text", $sans;

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 // The following changes should be merged in their respective files before nav unification goes to production
-@import url( //s1.wp.com/wp-includes/css/dashicons.css?v=20150727 );
+@import url( //s0.wp.com/wp-includes/css/dashicons.min.css );
 @import "@automattic/typography/styles/variables";
 
 $brand-text: "SF Pro Text", $sans;

--- a/client/performance-profiler/components/message-display/test.json
+++ b/client/performance-profiler/components/message-display/test.json
@@ -509,7 +509,7 @@
 								"children": {
 									"61119.509": {
 										"request": {
-											"url": "https://s0.wp.com/wp-includes/css/dashicons.min.css",
+											"url": "https://s0.wp.com/wp-includes/css/dashicons.min.css?v=20250127",
 											"startTime": 358903.512026,
 											"endTime": 358903.780287,
 											"responseReceivedTime": 358903.72527000005,
@@ -2083,7 +2083,7 @@
 						"entity": "WordPress"
 					},
 					{
-						"url": "https://s0.wp.com/wp-includes/css/dashicons.min.css",
+						"url": "https://s0.wp.com/wp-includes/css/dashicons.min.css?v=20250127",
 						"sessionTargetType": "page",
 						"protocol": "h2",
 						"rendererStartTime": 720.944000005722,
@@ -10411,7 +10411,7 @@
 						"wastedMs": 150
 					},
 					{
-						"url": "https://s0.wp.com/wp-includes/css/dashicons.min.css",
+						"url": "https://s0.wp.com/wp-includes/css/dashicons.min.css?v=20250127",
 						"totalBytes": 35528,
 						"wastedMs": 1185
 					},
@@ -10871,7 +10871,7 @@
 						"totalBytes": 41374
 					},
 					{
-						"url": "https://s0.wp.com/wp-includes/css/dashicons.min.css",
+						"url": "https://s0.wp.com/wp-includes/css/dashicons.min.css?v=20250127",
 						"wastedBytes": 33936,
 						"wastedPercent": 99.34692743252162,
 						"totalBytes": 34159

--- a/client/performance-profiler/components/message-display/test.json
+++ b/client/performance-profiler/components/message-display/test.json
@@ -509,7 +509,7 @@
 								"children": {
 									"61119.509": {
 										"request": {
-											"url": "https://s1.wp.com/wp-includes/css/dashicons.css?v=20150727",
+											"url": "https://s0.wp.com/wp-includes/css/dashicons.min.css",
 											"startTime": 358903.512026,
 											"endTime": 358903.780287,
 											"responseReceivedTime": 358903.72527000005,
@@ -2083,7 +2083,7 @@
 						"entity": "WordPress"
 					},
 					{
-						"url": "https://s1.wp.com/wp-includes/css/dashicons.css?v=20150727",
+						"url": "https://s0.wp.com/wp-includes/css/dashicons.min.css",
 						"sessionTargetType": "page",
 						"protocol": "h2",
 						"rendererStartTime": 720.944000005722,
@@ -10411,7 +10411,7 @@
 						"wastedMs": 150
 					},
 					{
-						"url": "https://s1.wp.com/wp-includes/css/dashicons.css?v=20150727",
+						"url": "https://s0.wp.com/wp-includes/css/dashicons.min.css",
 						"totalBytes": 35528,
 						"wastedMs": 1185
 					},
@@ -10871,7 +10871,7 @@
 						"totalBytes": 41374
 					},
 					{
-						"url": "https://s1.wp.com/wp-includes/css/dashicons.css?v=20150727",
+						"url": "https://s0.wp.com/wp-includes/css/dashicons.min.css",
 						"wastedBytes": 33936,
 						"wastedPercent": 99.34692743252162,
 						"totalBytes": 34159


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8405
See: pMz3w-lpD-p2#comment-124426 for explanation

## Proposed Changes

* Replace `dashicons.css` with the core minified font CSS

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See P2 discussion for details.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

It's difficult to reproduce the source issue. But open multiple Calypso pages like `/me`, `/posts`, etc., and be sure all the icons seen are the same found on production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?