### PR TITLE
Staging sites: Remove full stop at the end of the Learn more staging tagline

### DIFF
--- a/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
@@ -160,7 +160,7 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 	return (
 		<CardContentWrapper
 			subtitle={ translate(
-				'This staging site lets you preview and troubleshoot changes before updating the production site. {{a}}Learn more{{/a}}.',
+				'This staging site lets you preview and troubleshoot changes before updating the production site. {{a}}Learn more{{/a}}',
 				{
 					components: {
 						a: <InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/10331

## Proposed Changes

This PR removes the full step at the end of the `Learn more` for the staging site tagline:

<img width="797" alt="Screenshot 2025-01-24 at 11 23 57 AM" src="https://github.com/user-attachments/assets/d7297b69-887c-4f60-8878-ad15f0023a4b" />

This makes it consistent with the production site tagline [as well as other patterns in Calypso. ](https://github.com/Automattic/dotcom-forge/issues/9962)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the Calypso Live link below or pull the changes from this branch
* Ensure that you have a staging site
* Navigate to `staging-site/{yourStagingSite}?search=staging`
* Confirm that you do not see the full stop at the end of learn more `This staging site lets you preview and troubleshoot changes before updating the production site. Learn more`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
