### PR TITLE
Stats: Refactoring Jetpack upsells

### DIFF
--- a/client/my-sites/stats/jetpack-upsell-section/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/index.tsx
@@ -45,6 +45,33 @@ function bundledProductsFromPurchases( purchases: Purchase[] ) {
 	return [];
 }
 
+function getCheckoutConfig() {
+	return {
+		backup: PRODUCT_JETPACK_BACKUP_T1_YEARLY,
+		boost: PRODUCT_JETPACK_BOOST,
+		search: PRODUCT_JETPACK_SEARCH,
+		security: PLAN_JETPACK_SECURITY_T1_YEARLY,
+		social: PRODUCT_JETPACK_SOCIAL_BASIC,
+		video: PRODUCT_JETPACK_VIDEOPRESS,
+	};
+}
+
+function getCheckoutUrls( siteSlug: string | null ) {
+	if ( ! siteSlug ) {
+		return {};
+	}
+	// TODO: Change URL to point at plugin installation within wp-admin.
+	// ie: /wp-admin/update.php?action=install-plugin&plugin=plugin-name&_wpnonce=valid-nonce).
+	const checkoutConfig = getCheckoutConfig();
+	const checkoutURLs = Object.fromEntries(
+		Object.entries( checkoutConfig ).map( ( [ key, value ] ) => [
+			key,
+			`${ CHECKOUT_URL_PREFIX }${ buildCheckoutURL( siteSlug, value, QUERY_VALUES ) }`,
+		] )
+	);
+	return checkoutURLs;
+}
+
 export default function JetpackUpsellSection() {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 
@@ -68,28 +95,7 @@ export default function JetpackUpsellSection() {
 	const finalProducts = [ ...purchasedProducts, ...bundledProducts ];
 
 	// Build checkout URL prefixed with WordPress.com.
-	// TODO: Change URL to point at plugin installation within wp-admin.
-	//       (e.g., /wp-admin/update.php?action=install-plugin&plugin=plugin-name&_wpnonce=valid-nonce).
-	const upgradeUrls: Record< string, string > = ! siteSlug
-		? {}
-		: {
-				backup:
-					CHECKOUT_URL_PREFIX +
-					buildCheckoutURL( siteSlug, PRODUCT_JETPACK_BACKUP_T1_YEARLY, QUERY_VALUES ),
-				boost:
-					CHECKOUT_URL_PREFIX + buildCheckoutURL( siteSlug, PRODUCT_JETPACK_BOOST, QUERY_VALUES ),
-				search:
-					CHECKOUT_URL_PREFIX + buildCheckoutURL( siteSlug, PRODUCT_JETPACK_SEARCH, QUERY_VALUES ),
-				security:
-					CHECKOUT_URL_PREFIX +
-					buildCheckoutURL( siteSlug, PLAN_JETPACK_SECURITY_T1_YEARLY, QUERY_VALUES ),
-				social:
-					CHECKOUT_URL_PREFIX +
-					buildCheckoutURL( siteSlug, PRODUCT_JETPACK_SOCIAL_BASIC, QUERY_VALUES ),
-				video:
-					CHECKOUT_URL_PREFIX +
-					buildCheckoutURL( siteSlug, PRODUCT_JETPACK_VIDEOPRESS, QUERY_VALUES ),
-		  };
+	const upgradeUrls = getCheckoutUrls( siteSlug );
 
 	return (
 		<div className="jetpack-upsell-section">

--- a/client/my-sites/stats/jetpack-upsell-section/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/index.tsx
@@ -96,12 +96,14 @@ export default function JetpackUpsellSection() {
 
 	// Build checkout URL prefixed with WordPress.com.
 	const upgradeUrls = getCheckoutUrls( siteSlug );
+	const siteFeatures = [ 'videopress', 'videopress-1tb-storage', 'search' ];
 
 	return (
 		<div className="jetpack-upsell-section">
 			<JetpackUpsellCard
 				purchasedProducts={ finalProducts }
 				siteSlug={ siteSlug }
+				siteFeatures={ siteFeatures }
 				upgradeUrls={ upgradeUrls }
 			/>
 		</div>

--- a/client/my-sites/stats/jetpack-upsell-section/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/index.tsx
@@ -96,14 +96,12 @@ export default function JetpackUpsellSection() {
 
 	// Build checkout URL prefixed with WordPress.com.
 	const upgradeUrls = getCheckoutUrls( siteSlug );
-	const siteFeatures = [ 'videopress', 'videopress-1tb-storage', 'search' ];
 
 	return (
 		<div className="jetpack-upsell-section">
 			<JetpackUpsellCard
 				purchasedProducts={ finalProducts }
 				siteSlug={ siteSlug }
-				siteFeatures={ siteFeatures }
 				upgradeUrls={ upgradeUrls }
 			/>
 		</div>

--- a/packages/components/src/jetpack-upsell-card/index.tsx
+++ b/packages/components/src/jetpack-upsell-card/index.tsx
@@ -12,7 +12,6 @@ import './style.scss';
 type JetpackUpsellCardProps = {
 	purchasedProducts: string[];
 	siteSlug?: string | null;
-	siteFeatures: string[];
 	upgradeUrls: Record< string, string >;
 };
 
@@ -28,7 +27,6 @@ type Product = {
 export function JetpackUpsellCard( {
 	purchasedProducts,
 	siteSlug,
-	siteFeatures,
 	upgradeUrls = {},
 }: JetpackUpsellCardProps ) {
 	// TODO: Make card collapsible
@@ -105,9 +103,7 @@ export function JetpackUpsellCard( {
 		( { slug } ) => ! purchasedProducts?.includes( slug ) && slug in upgradeUrls
 	);
 
-	// Do someething with siteFeatures for the sake of test builds.
-	const hasSiteFeatures = siteFeatures.length > 0;
-	const hasProductsToUpsell = visibleProducts.length > 0 && hasSiteFeatures;
+	const hasProductsToUpsell = visibleProducts.length > 0;
 
 	return ! hasProductsToUpsell ? null : (
 		<Card className="jetpack-upsell-card">

--- a/packages/components/src/jetpack-upsell-card/index.tsx
+++ b/packages/components/src/jetpack-upsell-card/index.tsx
@@ -102,7 +102,6 @@ export function JetpackUpsellCard( {
 	const visibleProducts = PRODUCTS.filter(
 		( { slug } ) => ! purchasedProducts?.includes( slug ) && slug in upgradeUrls
 	);
-
 	const hasProductsToUpsell = visibleProducts.length > 0;
 
 	return ! hasProductsToUpsell ? null : (

--- a/packages/components/src/jetpack-upsell-card/index.tsx
+++ b/packages/components/src/jetpack-upsell-card/index.tsx
@@ -12,6 +12,7 @@ import './style.scss';
 type JetpackUpsellCardProps = {
 	purchasedProducts: string[];
 	siteSlug?: string | null;
+	siteFeatures: string[];
 	upgradeUrls: Record< string, string >;
 };
 
@@ -27,6 +28,7 @@ type Product = {
 export function JetpackUpsellCard( {
 	purchasedProducts,
 	siteSlug,
+	siteFeatures,
 	upgradeUrls = {},
 }: JetpackUpsellCardProps ) {
 	// TODO: Make card collapsible
@@ -102,7 +104,10 @@ export function JetpackUpsellCard( {
 	const visibleProducts = PRODUCTS.filter(
 		( { slug } ) => ! purchasedProducts?.includes( slug ) && slug in upgradeUrls
 	);
-	const hasProductsToUpsell = visibleProducts.length > 0;
+
+	// Do someething with siteFeatures for the sake of test builds.
+	const hasSiteFeatures = siteFeatures.length > 0;
+	const hasProductsToUpsell = visibleProducts.length > 0 && hasSiteFeatures;
 
 	return ! hasProductsToUpsell ? null : (
 		<Card className="jetpack-upsell-card">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
