### PR TITLE
FormSettingExplanation: improve style encapsulation

### DIFF
--- a/client/components/forms/form-setting-explanation/style.scss
+++ b/client/components/forms/form-setting-explanation/style.scss
@@ -9,17 +9,4 @@
 	&.is-indented {
 		margin-left: 24px;
 	}
-
-	button.is-borderless {
-		color: var(--color-primary);
-		font-size: inherit;
-		font-style: inherit;
-		font-weight: inherit;
-		line-height: inherit;
-		padding: 0;
-	}
-
-	button.is-borderless:hover {
-		color: var(--color-link-dark);
-	}
 }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -520,6 +520,10 @@
 }
 
 button.site-settings__general-settings-set-guessed-timezone.button.is-borderless.is-compact {
+	padding: 0;
+	line-height: inherit;
+	font-size: inherit;
+
 	text-decoration: underline;
 	color: var(--color-link);
 	font-style: inherit;

--- a/client/sites/settings/site/agency.tsx
+++ b/client/sites/settings/site/agency.tsx
@@ -3,6 +3,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import useFetchAgencyFromBlog from 'calypso/a8c-for-agencies/data/agencies/use-fetch-agency-from-blog';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { isHostingMenuUntangled } from '../utils';
@@ -61,7 +62,7 @@ export function A4AFullyManagedSiteForm( {
 		return (
 			<>
 				{ isDevSite ? (
-					<p className="form-setting-explanation">
+					<FormSettingExplanation>
 						{ translate(
 							"Clients can't access the {{HcLink}}WordPress.com Help Center{{/HcLink}} or {{HfLink}}hosting features{{/HfLink}} on development sites. You may configure access after the site is launched.",
 							{
@@ -81,7 +82,7 @@ export function A4AFullyManagedSiteForm( {
 								),
 							},
 						} ) }
-					</p>
+					</FormSettingExplanation>
 				) : (
 					<ToggleControl
 						disabled={ disabled }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/98702#discussion_r1925001897

## Proposed Changes

Fix a couple of style encapsulation issues regarding the `FormSettingExplanation` component:
- move nested `button` styles from the `FormSettingExplanation` to the consumer of `FormSettingExplanation` where such button is rendered
- replace a vanilla `p.form-setting-explanation` with the actual `FormSettingExplanation`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- Better style encapsulation and architecture
- Removing a hack

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/settings/general/{site-slug}`
* Make sure that the "Select [timezone]" button under the timezone settings looks and behaves as on `trunk`
* Make sure that there were no other usages of `button.is-borderless` inside `FormSettingExplanation`

![Screenshot 2025-01-24 at 13 40 30](https://github.com/user-attachments/assets/a0f257c6-c5a7-4ed5-bf57-84e7c90ac9f6)


A4A testing instructions TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
