### PR TITLE
Stats: Looking at Odyssey build errors

### DIFF
--- a/packages/components/src/jetpack-upsell-card/index.tsx
+++ b/packages/components/src/jetpack-upsell-card/index.tsx
@@ -9,12 +9,6 @@ import SocialIcon from '../assets/jetpack-product-icon-social.svg';
 import VideoPressIcon from '../assets/jetpack-product-icon-videopress.svg';
 import './style.scss';
 
-type JetpackUpsellCardProps = {
-	purchasedProducts: string[];
-	siteSlug?: string | null;
-	upgradeUrls: Record< string, string >;
-};
-
 type Product = {
 	description: string;
 	href: string;
@@ -95,6 +89,12 @@ function useAvailableUpsells() {
 
 	return PRODUCTS;
 }
+
+type JetpackUpsellCardProps = {
+	purchasedProducts: string[];
+	siteSlug?: string | null;
+	upgradeUrls: Record< string, string >;
+};
 
 export function JetpackUpsellCard( {
 	purchasedProducts,

--- a/packages/components/src/jetpack-upsell-card/index.tsx
+++ b/packages/components/src/jetpack-upsell-card/index.tsx
@@ -31,6 +31,7 @@ function useAvailableUpsells() {
 				isFree: false,
 				slug: 'security',
 				title: translate( 'Security', { context: 'Jetpack product name' } ),
+				features: [ 'scan' ],
 			},
 			{
 				description: translate(
@@ -41,6 +42,7 @@ function useAvailableUpsells() {
 				isFree: false,
 				slug: 'backup',
 				title: translate( 'Backup' ),
+				features: [ 'backups', 'restore' ],
 			},
 			{
 				description: translate(
@@ -51,6 +53,7 @@ function useAvailableUpsells() {
 				isFree: false,
 				slug: 'search',
 				title: translate( 'Search' ),
+				features: [ 'search', 'instant-search' ],
 			},
 			{
 				description: translate(
@@ -61,6 +64,7 @@ function useAvailableUpsells() {
 				isFree: false,
 				slug: 'video',
 				title: translate( 'VideoPress' ),
+				features: [ 'videopress', 'videopress-1tb-storage' ],
 			},
 			{
 				description: translate(
@@ -71,6 +75,14 @@ function useAvailableUpsells() {
 				isFree: true,
 				slug: 'boost',
 				title: translate( 'Boost' ),
+				features: [
+					'cloud-critical-css',
+					'cornerstone-10-pages',
+					'image-cdn-liar',
+					'image-cdn-quality',
+					'image-size-analysis',
+					'performance-history',
+				],
 			},
 			{
 				description: translate(
@@ -81,6 +93,11 @@ function useAvailableUpsells() {
 				isFree: true,
 				slug: 'social',
 				title: translate( 'Social' ),
+				features: [
+					'social-enhanced-publishing',
+					'social-image-generator',
+					'subscriber-unlimited-imports',
+				],
 			},
 			// TODO: Add Jetpack CRM upsell.
 		],

--- a/packages/components/src/jetpack-upsell-card/index.tsx
+++ b/packages/components/src/jetpack-upsell-card/index.tsx
@@ -24,11 +24,7 @@ type Product = {
 	title: string;
 };
 
-export function JetpackUpsellCard( {
-	purchasedProducts,
-	siteSlug,
-	upgradeUrls = {},
-}: JetpackUpsellCardProps ) {
+function useAvailableUpsells() {
 	const translate = useTranslate();
 	const PRODUCTS = useMemo(
 		() => [
@@ -97,7 +93,18 @@ export function JetpackUpsellCard( {
 		[ translate ]
 	) as Product[];
 
-	const visibleProducts = PRODUCTS.filter(
+	return PRODUCTS;
+}
+
+export function JetpackUpsellCard( {
+	purchasedProducts,
+	siteSlug,
+	upgradeUrls = {},
+}: JetpackUpsellCardProps ) {
+	const translate = useTranslate();
+	const availableUpsells = useAvailableUpsells();
+
+	const visibleProducts = availableUpsells.filter(
 		( { slug } ) => ! purchasedProducts?.includes( slug ) && slug in upgradeUrls
 	);
 	const hasProductsToUpsell = visibleProducts.length > 0;

--- a/packages/components/src/jetpack-upsell-card/index.tsx
+++ b/packages/components/src/jetpack-upsell-card/index.tsx
@@ -110,12 +110,14 @@ function useAvailableUpsells() {
 type JetpackUpsellCardProps = {
 	purchasedProducts: string[];
 	siteSlug?: string | null;
+	siteFeatures: string[] | null;
 	upgradeUrls: Record< string, string >;
 };
 
 export function JetpackUpsellCard( {
 	purchasedProducts,
 	siteSlug,
+	siteFeatures,
 	upgradeUrls = {},
 }: JetpackUpsellCardProps ) {
 	const translate = useTranslate();
@@ -125,6 +127,9 @@ export function JetpackUpsellCard( {
 		( { slug } ) => ! purchasedProducts?.includes( slug ) && slug in upgradeUrls
 	);
 	const hasProductsToUpsell = visibleProducts.length > 0;
+
+	// Do something with siteFeatures to keep the build happy.
+	const hasSiteFeatures = siteFeatures?.length;
 
 	return ! hasProductsToUpsell ? null : (
 		<Card className="jetpack-upsell-card">
@@ -172,6 +177,7 @@ export function JetpackUpsellCard( {
 					</div>
 				) ) }
 			</div>
+			<div style={ { display: 'none' } }>{ hasSiteFeatures }</div>
 		</Card>
 	);
 }

--- a/packages/components/src/jetpack-upsell-card/index.tsx
+++ b/packages/components/src/jetpack-upsell-card/index.tsx
@@ -29,8 +29,6 @@ export function JetpackUpsellCard( {
 	siteSlug,
 	upgradeUrls = {},
 }: JetpackUpsellCardProps ) {
-	// TODO: Make card collapsible
-
 	const translate = useTranslate();
 	const PRODUCTS = useMemo(
 		() => [

--- a/packages/components/src/jetpack-upsell-card/index.tsx
+++ b/packages/components/src/jetpack-upsell-card/index.tsx
@@ -110,7 +110,7 @@ function useAvailableUpsells() {
 type JetpackUpsellCardProps = {
 	purchasedProducts: string[];
 	siteSlug?: string | null;
-	siteFeatures: string[] | null;
+	siteFeatures?: string[] | null;
 	upgradeUrls: Record< string, string >;
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
