### PR TITLE
Avoid black bar blinking on migrations

### DIFF
--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -35,7 +35,7 @@ function isInRoute( state: AppState, routes: string[] ) {
 }
 
 function shouldShowSitesDashboard( state: AppState ) {
-	return isInRoute( state, [ '/sites', '/p2s', ...SITE_DASHBOARD_ROUTES ] );
+	return isInRoute( state, [ '/sites', '/p2s', '/setup', ...SITE_DASHBOARD_ROUTES ] );
 }
 
 export function shouldShowSiteDashboard( state: AppState, siteId: number | null ) {

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -35,11 +35,11 @@ function isInRoute( state: AppState, routes: string[] ) {
 }
 
 function shouldShowSitesDashboard( state: AppState ) {
-	return isInRoute( state, [ '/sites', '/p2s', '/setup', ...SITE_DASHBOARD_ROUTES ] );
+	return isInRoute( state, [ '/sites', '/p2s', '/setup', '/start', ...SITE_DASHBOARD_ROUTES ] );
 }
 
 export function shouldShowSiteDashboard( state: AppState, siteId: number | null ) {
-	return !! siteId && isInRoute( state, [ '/setup', ...SITE_DASHBOARD_ROUTES ] );
+	return !! siteId && isInRoute( state, [ '/setup', '/start', ...SITE_DASHBOARD_ROUTES ] );
 }
 
 export const getShouldShowGlobalSidebar = (

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -39,7 +39,7 @@ function shouldShowSitesDashboard( state: AppState ) {
 }
 
 export function shouldShowSiteDashboard( state: AppState, siteId: number | null ) {
-	return !! siteId && isInRoute( state, SITE_DASHBOARD_ROUTES );
+	return !! siteId && isInRoute( state, [ '/setup', ...SITE_DASHBOARD_ROUTES ] );
 }
 
 export const getShouldShowGlobalSidebar = (


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/10340

## Proposed Changes

When starting a migration from `/sites` dashboard.
The sidebar blinks on black color for a second.

This happens due the global style of the layout being controlled by a redux state that watches for url changes.
Between the time user clicks on migration to the next page being loaded, `/sites` is not part of the url anymore. So the layout behaves like the user is on "My Home".

By adding `/setup` as part of the urls that uses the global sidebar, fixes the bug for now.
A more robust approach will require more thinking and architectural changes, maybe decoupling the global layout from the url address bar.
I will write a P2 post about that.

## Testing Instructions
- Open `/sites` page. Live preview is good enough for that.
- Throttle your connection to slow 3G, on chrome dev tools. It will give you more time between clicking on linking and loading next page.
- Click on `Add new site` button on top right side.
- Click on `Import an existing site`.
- Keep an eye on the left site menu. It should not blink black at any moment.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
