### PR TITLE
Reader: Fix calling user lists API with undefined as username

### DIFF
--- a/client/state/data-layer/wpcom/read/lists/index.js
+++ b/client/state/data-layer/wpcom/read/lists/index.js
@@ -163,14 +163,14 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/index.js', {
 				http(
 					{
 						method: 'GET',
-						path: `/read/lists/${ action.userSlug }`,
+						path: `/read/lists/${ action.userLogin }`,
 						apiVersion: '1',
 					},
 					action
 				),
 			onSuccess: ( action, apiResponse ) => ( {
 				type: READER_USER_LISTS_RECEIVE,
-				userSlug: action.userSlug,
+				userLogin: action.userLogin,
 				lists: apiResponse?.lists,
 			} ),
 			onError: () => noop,

--- a/client/state/reader/lists/reducer.js
+++ b/client/state/reader/lists/reducer.js
@@ -233,7 +233,7 @@ export const userLists = ( state = {}, action ) => {
 		case READER_USER_LISTS_RECEIVE:
 			return {
 				...state,
-				[ action.userSlug ]: action.lists,
+				[ action.userLogin ]: action.lists,
 			};
 		default:
 			return state;
@@ -245,12 +245,12 @@ export const isRequestingUserLists = ( state = {}, action ) => {
 		case READER_USER_LISTS_REQUEST:
 			return {
 				...state,
-				[ action.userSlug ]: true,
+				[ action.userLogin ]: true,
 			};
 		case READER_USER_LISTS_RECEIVE:
 			return {
 				...state,
-				[ action.userSlug ]: false,
+				[ action.userLogin ]: false,
 			};
 		default:
 			return state;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/324

## Proposed Changes

Change the payload variable name to call the API with correct username.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Regression introduced in https://github.com/Automattic/wp-calypso/pull/98675.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://wordpress.com/read/users/218803706/lists. Verify no lists are appearing.
* Checkout the PR.
* Go to https://wordpress.com/read/users/218803706/lists. Verify lists are appearing.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
