### PR TITLE
Bulk Plugin Management: Return a redux action for update plugin

### DIFF
--- a/client/my-sites/plugins/plugins-dashboard/index.tsx
+++ b/client/my-sites/plugins/plugins-dashboard/index.tsx
@@ -22,7 +22,7 @@ import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import UrlSearch from 'calypso/lib/url-search';
-import { handleUpdatePlugins, siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
+import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { useSelector, useDispatch } from 'calypso/state';
 import {
 	activatePlugin,
@@ -259,14 +259,7 @@ const PluginsDashboard = ( {
 			return;
 		}
 
-		doActionOverSelected(
-			'updating',
-			( siteId: number, plugin: Plugin ) => {
-				handleUpdatePlugins( [ plugin ], updatePluginAction, [] );
-				removePluginStatuses();
-			},
-			plugins
-		);
+		doActionOverSelected( 'updating', updatePluginAction, plugins );
 	};
 
 	const setAutoupdateSelected = ( plugins: Plugin[] ) => ( accepted: boolean ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/10335

## Proposed Changes

* Return the redux action for `updatePlugins` instead of executing it as it is [dispatched](https://github.com/Automattic/wp-calypso/blob/de309bb7f7f18189a2f240725ea47d1b557c36ce/client/my-sites/plugins/plugins-dashboard/index.tsx#L187)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix the bug

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/plugins/manage/sites`
* Make sure you have one plugin installed that needs to be updated, you can take a previous version from WordPress.org/plugins
* Click on the `Pending update` filter
* Click on the `Update to version xxx` button
* Ensure the plugin is updated
- For another plugin, select it, to navigate to the sites view
- Update the plugin clicking on the action in the site
- Ensure the plugin is updated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
