### PR TITLE
Masterbar: Do not recreate masterbar button element on every render

### DIFF
--- a/client/layout/masterbar/item.tsx
+++ b/client/layout/masterbar/item.tsx
@@ -216,23 +216,14 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 			disabled: this.props.disabled,
 		};
 
-		const MenuItem = ( props: React.HTMLAttributes< HTMLElement > ) =>
-			this.props.url ? (
-				<a
-					href={ this.props.url }
-					ref={ this.props.innerRef as LegacyRef< HTMLAnchorElement > }
-					{ ...props }
-				/>
-			) : (
-				<button ref={ this.props.innerRef as LegacyRef< HTMLButtonElement > } { ...props } />
-			);
-
 		return (
 			<div
 				className={ clsx( 'masterbar__item-wrapper', this.props.wrapperClassName ) }
 				ref={ this.wrapperRef }
 			>
 				<MenuItem
+					url={ this.props.url }
+					innerRef={ this.props.innerRef }
 					{ ...attributes }
 					onKeyDown={ this.props.subItems && this.toggleMenuByKey }
 					onTouchEnd={ this.props.subItems && this.toggleMenuByTouch }
@@ -248,3 +239,16 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 export default forwardRef< HTMLButtonElement | HTMLAnchorElement, MasterbarItemProps >(
 	( props, ref ) => <MasterbarItem innerRef={ ref } { ...props } />
 );
+
+type MenuItemProps< R > = {
+	url?: string;
+	innerRef?: R;
+} & React.HTMLAttributes< HTMLElement >;
+
+function MenuItem< R >( { url, innerRef, ...props }: MenuItemProps< R > ) {
+	return url ? (
+		<a href={ url } ref={ innerRef as LegacyRef< HTMLAnchorElement > } { ...props } />
+	) : (
+		<button ref={ innerRef as LegacyRef< HTMLButtonElement > } { ...props } />
+	);
+}


### PR DESCRIPTION
## Proposed Changes

In this PR we move the `MenuItem` wrapper from `MasterbarItem` to a standalone component so React can recognize it and keep its references stable.

Fixes https://github.com/Automattic/wp-calypso/issues/98893

## Why are these changes being made?

This fixes a bug introduced by https://github.com/Automattic/wp-calypso/pull/98510/. That PR introduced a new React wrapper called `MenuItem` to wrap the button or anchor element rendered by `MasterbarItem`. However, that wrapper was created inline (via `const MenuItem = ...`) inside the render method of its parent. As a result, React re-creates it on every render. This is mostly invisible to the user but it means that the underlying HTML element is being recreated very frequently.

One consequence of this is that any references to the element will quickly go out of date.

The `Popover` component uses one such reference to [determine its position on the page](https://github.com/Automattic/wp-calypso/blob/05bfe819177743a30ec9c9f5731b4d0ca8dc4517/packages/components/src/popover/util.js#L65). When the reference points to a `MasterbarItem`, the reference goes out of date. By the time it calculates the position, it is no longer pointing to an element on the page and gets a position of all 0s.

## Testing Instructions

1. Visit `/plans` and add a product to your cart.
2. Leave checkout and return to another calypso page like `/home`.
3. Click the masterbar shopping-cart icon.
4. Verify that the popup shopping cart appears below the button.