### PR TITLE
Storage Add On: Allow higher term cart item to be added via query param

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1256,6 +1256,9 @@ export function maybeAddStorageAddonToCart( stepName, defaultDependencies, nextP
 			volume: 1,
 			extra: { feature_slug: AddOns.ADD_ON_50GB_STORAGE },
 		} );
+		recordTracksEvent( 'calypso_signup_storage_add_on_selected', {
+			add_on_slug: selectedAddOn.addOnSlug,
+		} );
 	}
 
 	submitSignupStep( { stepName, cartItem, wasSkipped: true }, { cartItem } );

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -3,7 +3,8 @@ import config from '@automattic/calypso-config';
 import { WPCOM_DIFM_LITE, PRODUCT_1GB_SPACE, isDomainTransfer } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Site, AddOns } from '@automattic/data-stores';
-import { STORAGE_ADD_ON_DEFINITIONS, STORAGE_ADD_ONS } from '@automattic/data-stores/src/add-ons';
+import { STORAGE_ADD_ONS } from '@automattic/data-stores/src/add-ons';
+import { getAddOn } from '@automattic/data-stores/src/add-ons/add-ons-list';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
 import { guessTimezone, getLanguage } from '@automattic/i18n-utils';
 import { isOnboardingGuidedFlow } from '@automattic/onboarding';
@@ -1248,9 +1249,10 @@ export function maybeAddStorageAddonToCart( stepName, defaultDependencies, nextP
 	const selectedStorage = get( getSignupDependencyStore( state ), 'storage', null );
 
 	if ( STORAGE_ADD_ONS.includes( selectedStorage ) ) {
+		const selectedAddOn = getAddOn( selectedStorage );
 		cartItem.push( {
 			product_slug: PRODUCT_1GB_SPACE,
-			quantity: STORAGE_ADD_ON_DEFINITIONS[ selectedStorage ].quantity,
+			quantity: selectedAddOn.quantity,
 			volume: 1,
 			extra: { feature_slug: AddOns.ADD_ON_50GB_STORAGE },
 		} );

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -3,6 +3,7 @@ import config from '@automattic/calypso-config';
 import { WPCOM_DIFM_LITE, PRODUCT_1GB_SPACE, isDomainTransfer } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Site, AddOns } from '@automattic/data-stores';
+import { STORAGE_ADD_ON_DEFINITIONS, STORAGE_ADD_ONS } from '@automattic/data-stores/src/add-ons';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
 import { guessTimezone, getLanguage } from '@automattic/i18n-utils';
 import { isOnboardingGuidedFlow } from '@automattic/onboarding';
@@ -1246,29 +1247,13 @@ export function maybeAddStorageAddonToCart( stepName, defaultDependencies, nextP
 	const state = store.getState();
 	const selectedStorage = get( getSignupDependencyStore( state ), 'storage', null );
 
-	switch ( selectedStorage ) {
-		case AddOns.ADD_ON_50GB_STORAGE:
-			cartItem.push( {
-				product_slug: PRODUCT_1GB_SPACE,
-				quantity: 50,
-				volume: 1,
-				extra: { feature_slug: AddOns.ADD_ON_50GB_STORAGE },
-			} );
-			recordTracksEvent( 'calypso_signup_storage_add_on_selected', {
-				add_on_slug: AddOns.ADD_ON_50GB_STORAGE,
-			} );
-			break;
-		case AddOns.ADD_ON_100GB_STORAGE:
-			cartItem.push( {
-				product_slug: PRODUCT_1GB_SPACE,
-				quantity: 100,
-				volume: 1,
-				extra: { feature_slug: AddOns.ADD_ON_100GB_STORAGE },
-			} );
-			recordTracksEvent( 'calypso_signup_storage_add_on_selected', {
-				add_on_slug: AddOns.ADD_ON_100GB_STORAGE,
-			} );
-			break;
+	if ( STORAGE_ADD_ONS.includes( selectedStorage ) ) {
+		cartItem.push( {
+			product_slug: PRODUCT_1GB_SPACE,
+			quantity: STORAGE_ADD_ON_DEFINITIONS[ selectedStorage ].quantity,
+			volume: 1,
+			extra: { feature_slug: AddOns.ADD_ON_50GB_STORAGE },
+		} );
 	}
 
 	submitSignupStep( { stepName, cartItem, wasSkipped: true }, { cartItem } );

--- a/packages/data-stores/src/add-ons/add-ons-list.ts
+++ b/packages/data-stores/src/add-ons/add-ons-list.ts
@@ -21,7 +21,7 @@ import {
 import customDesignIcon from './icons/custom-design';
 import spaceUpgradeIcon from './icons/space-upgrade';
 import unlimitedThemesIcon from './icons/unlimited-themes';
-import type { AddOnMeta } from './types';
+import type { AddOnMeta, AddOnSlug } from './types';
 
 export const getAddOnsList = (): AddOnMeta[] => {
 	const defaultAddOns: AddOnMeta[] = [
@@ -109,4 +109,8 @@ export const getAddOnsList = (): AddOnMeta[] => {
 	}
 
 	return defaultAddOns;
+};
+
+export const getAddOn = ( addOnSlug: AddOnSlug ): AddOnMeta | undefined => {
+	return getAddOnsList().find( ( addOn ) => addOn.addOnSlug === addOnSlug );
 };

--- a/packages/data-stores/src/add-ons/constants.ts
+++ b/packages/data-stores/src/add-ons/constants.ts
@@ -33,27 +33,3 @@ export const STORAGE_ADD_ONS = < const >[
 	ADD_ON_300GB_STORAGE,
 	ADD_ON_350GB_STORAGE,
 ];
-
-export const STORAGE_ADD_ON_DEFINITIONS = {
-	[ ADD_ON_50GB_STORAGE ]: {
-		quantity: 50,
-	},
-	[ ADD_ON_100GB_STORAGE ]: {
-		quantity: 100,
-	},
-	[ ADD_ON_150GB_STORAGE ]: {
-		quantity: 150,
-	},
-	[ ADD_ON_200GB_STORAGE ]: {
-		quantity: 200,
-	},
-	[ ADD_ON_250GB_STORAGE ]: {
-		quantity: 250,
-	},
-	[ ADD_ON_300GB_STORAGE ]: {
-		quantity: 300,
-	},
-	[ ADD_ON_350GB_STORAGE ]: {
-		quantity: 350,
-	},
-};

--- a/packages/data-stores/src/add-ons/constants.ts
+++ b/packages/data-stores/src/add-ons/constants.ts
@@ -10,6 +10,7 @@ export const ADD_ON_200GB_STORAGE = '200gb-storage-add-on';
 export const ADD_ON_250GB_STORAGE = '250gb-storage-add-on';
 export const ADD_ON_300GB_STORAGE = '300gb-storage-add-on';
 export const ADD_ON_350GB_STORAGE = '350gb-storage-add-on';
+export const ADD_ON_400GB_STORAGE = '400gb-storage-add-on';
 
 export const ADD_ONS = < const >[
 	ADD_ON_JETPACK_AI_MONTHLY,
@@ -33,3 +34,27 @@ export const STORAGE_ADD_ONS = < const >[
 	ADD_ON_300GB_STORAGE,
 	ADD_ON_350GB_STORAGE,
 ];
+
+export const STORAGE_ADD_ON_DEFINITIONS = {
+	[ ADD_ON_50GB_STORAGE ]: {
+		quantity: 50,
+	},
+	[ ADD_ON_100GB_STORAGE ]: {
+		quantity: 100,
+	},
+	[ ADD_ON_150GB_STORAGE ]: {
+		quantity: 150,
+	},
+	[ ADD_ON_200GB_STORAGE ]: {
+		quantity: 200,
+	},
+	[ ADD_ON_250GB_STORAGE ]: {
+		quantity: 250,
+	},
+	[ ADD_ON_300GB_STORAGE ]: {
+		quantity: 300,
+	},
+	[ ADD_ON_350GB_STORAGE ]: {
+		quantity: 350,
+	},
+};

--- a/packages/data-stores/src/add-ons/constants.ts
+++ b/packages/data-stores/src/add-ons/constants.ts
@@ -10,7 +10,6 @@ export const ADD_ON_200GB_STORAGE = '200gb-storage-add-on';
 export const ADD_ON_250GB_STORAGE = '250gb-storage-add-on';
 export const ADD_ON_300GB_STORAGE = '300gb-storage-add-on';
 export const ADD_ON_350GB_STORAGE = '350gb-storage-add-on';
-export const ADD_ON_400GB_STORAGE = '400gb-storage-add-on';
 
 export const ADD_ONS = < const >[
 	ADD_ON_JETPACK_AI_MONTHLY,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Issue: https://github.com/Automattic/wp-calypso/issues/97221

## Proposed Changes

* Allow addition of storage of higher tiers via query param from landing pages

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Allow landing pages to directly add storage addons to the cart

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start/business/?ref=pricing-lp&storage=400gb-storage-add-on 
* Select domain
* Make sure the 400gb add on is added to the card
* Also should work with any of these variations
    * 400gb-storage-add-on 
    * 350gb-storage-add-on
    * 300gb-storage-add-on
    * 250gb-storage-add-on
    * 200gb-storage-add-on
    * 150gb-storage-add-on
    * 100gb-storage-add-on

<img width="470" alt="image" src="https://github.com/user-attachments/assets/eb14b8f3-5797-4146-b814-94b749d4479c" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
