### PR TITLE
Reader User Profile: Remove the flag gate check

### DIFF
--- a/client/reader/index.ts
+++ b/client/reader/index.ts
@@ -8,10 +8,7 @@ import {
 	render as clientRender,
 	setSelectedSiteIdByOrigin,
 } from 'calypso/controller';
-import {
-	getUserProfileBasePath,
-	isUserProfileEnabled,
-} from 'calypso/reader/user-profile/user-profile.utils';
+import { getUserProfileBasePath } from 'calypso/reader/user-profile/user-profile.utils';
 import {
 	blogListing,
 	feedDiscovery,
@@ -101,28 +98,26 @@ export default async function (): Promise< void > {
 		);
 
 		// User profile
-		if ( isUserProfileEnabled() ) {
-			page(
-				getUserProfileBasePath(),
-				blogDiscoveryByFeedId,
-				redirectLoggedOutToSignup,
-				updateLastRoute,
-				sidebar,
-				userPosts,
-				makeLayout,
-				clientRender
-			);
-			page(
-				getUserProfileBasePath( 'lists' ),
-				blogDiscoveryByFeedId,
-				redirectLoggedOutToSignup,
-				updateLastRoute,
-				sidebar,
-				userLists,
-				makeLayout,
-				clientRender
-			);
-		}
+		page(
+			getUserProfileBasePath(),
+			blogDiscoveryByFeedId,
+			redirectLoggedOutToSignup,
+			updateLastRoute,
+			sidebar,
+			userPosts,
+			makeLayout,
+			clientRender
+		);
+		page(
+			getUserProfileBasePath( 'lists' ),
+			blogDiscoveryByFeedId,
+			redirectLoggedOutToSignup,
+			updateLastRoute,
+			sidebar,
+			userLists,
+			makeLayout,
+			clientRender
+		);
 
 		// Old full post view
 		page( '/read/post/feed/:feed_id/:post_id', legacyRedirects );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pe7F0s-2nU-p2

## Proposed Changes

* This PR removes the feature flag gate check for access to the user profile page.

> [!NOTE]  
> This PR leaves the feature flag checks in place for links to the user profile page. So, while the page is accessible publicly, there are currently no links to it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Make the user profile page sharable in production.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Review the code to make sure it is correct.
* Use Calypso Live to visit the /read/users/:username endpoint for a basic regression test.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?