### PR TITLE
Improve tracking on new Multi-site 'Add new site' button.

### DIFF
--- a/client/components/sites-add-new-site/content/index.tsx
+++ b/client/components/sites-add-new-site/content/index.tsx
@@ -11,9 +11,50 @@ import { TRACK_SOURCE_NAME } from 'calypso/sites-dashboard/utils';
 import { Column } from './layout/column';
 import { MenuItem } from './layout/menu-item';
 
+const wordpressClick = () => {
+	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_add' );
+	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
+		action: 'wordpress',
+	} );
+	page( '/start?source=sites-dashboard&ref=topbar' );
+};
+
+const jetpackClick = () => {
+	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_jetpack' );
+	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
+		action: 'jetpack',
+	} );
+	page( `/jetpack/connect?cta_from=${ TRACK_SOURCE_NAME }&cta_id=add-site` );
+};
+
+const migrateClick = () => {
+	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
+		action: 'migrate',
+	} );
+	page(
+		'/setup/hosted-site-migration/site-migration-identify?source=sites-dashboard&ref=topbar&action=migrate'
+	);
+};
+
+const importClick = () => {
+	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_import' );
+	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
+		action: 'import',
+	} );
+	page(
+		'/setup/hosted-site-migration/site-migration-identify?source=sites-dashboard&ref=topbar&action=import'
+	);
+};
+
+const offerClick = () => {
+	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
+		action: 'offer',
+	} );
+	window.location.href = 'https://wordpress.com/pricing/';
+};
+
 export const Content = () => {
 	const translate = useTranslate();
-
 	return (
 		<>
 			<Column heading={ translate( 'Add a new site' ) }>
@@ -24,10 +65,7 @@ export const Content = () => {
 						translate( 'Build and grow your site, all in one powerful platform.' )
 					) }
 					buttonProps={ {
-						onClick: () => {
-							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_wordpress' );
-							page( '/start?source=sites-dashboard&ref=topbar' );
-						},
+						onClick: wordpressClick,
 					} }
 				/>
 				<MenuItem
@@ -37,10 +75,7 @@ export const Content = () => {
 						translate( 'Install the Jetpack plugin on an existing site' )
 					) }
 					buttonProps={ {
-						onClick: () => {
-							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_jetpack' );
-							page( `/jetpack/connect?cta_from=${ TRACK_SOURCE_NAME }&cta_id=add-site` );
-						},
+						onClick: jetpackClick,
 					} }
 				/>
 			</Column>
@@ -52,12 +87,7 @@ export const Content = () => {
 						translate( 'Bring your theme, plugins, and content to WordPress.com.' )
 					) }
 					buttonProps={ {
-						onClick: () => {
-							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_migrate' );
-							page(
-								'/setup/hosted-site-migration/site-migration-identify?source=sites-dashboard&ref=topbar&action=migrate'
-							);
-						},
+						onClick: migrateClick,
 					} }
 				/>
 				<MenuItem
@@ -67,12 +97,7 @@ export const Content = () => {
 						translate( 'Use a backup file to import your content into a new site.' )
 					) }
 					buttonProps={ {
-						onClick: () => {
-							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_import' );
-							page(
-								'/setup/hosted-site-migration/site-migration-identify?source=sites-dashboard&ref=topbar&action=import'
-							);
-						},
+						onClick: importClick,
 					} }
 				/>
 			</Column>
@@ -87,10 +112,7 @@ export const Content = () => {
 						)
 					) }
 					buttonProps={ {
-						onClick: () => {
-							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_offer' );
-							window.location.href = 'https://wordpress.com/pricing/';
-						},
+						onClick: offerClick,
 					} }
 				>
 					<div>

--- a/client/components/sites-add-new-site/content/index.tsx
+++ b/client/components/sites-add-new-site/content/index.tsx
@@ -50,7 +50,7 @@ const offerClick = () => {
 	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
 		action: 'offer',
 	} );
-	window.location.href = 'https://wordpress.com/pricing/';
+	window.location.assign( 'https://wordpress.com/pricing/' );
 };
 
 export const Content = () => {

--- a/client/components/sites-add-new-site/content/index.tsx
+++ b/client/components/sites-add-new-site/content/index.tsx
@@ -16,7 +16,7 @@ const wordpressClick = () => {
 	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
 		action: 'wordpress',
 	} );
-	page( '/start?source=sites-dashboard&ref=topbar' );
+	page( '/start?source=sites-dashboard&ref=new-site-popover' );
 };
 
 const jetpackClick = () => {
@@ -32,7 +32,7 @@ const migrateClick = () => {
 		action: 'migrate',
 	} );
 	page(
-		'/setup/hosted-site-migration/site-migration-identify?source=sites-dashboard&ref=topbar&action=migrate'
+		'/setup/hosted-site-migration/site-migration-identify?source=sites-dashboard&ref=new-site-popover&action=migrate'
 	);
 };
 
@@ -42,7 +42,7 @@ const importClick = () => {
 		action: 'import',
 	} );
 	page(
-		'/setup/hosted-site-migration/site-migration-identify?source=sites-dashboard&ref=topbar&action=import'
+		'/setup/hosted-site-migration/site-migration-identify?source=sites-dashboard&ref=new-site-popover&action=import'
 	);
 };
 

--- a/client/components/sites-add-new-site/index.tsx
+++ b/client/components/sites-add-new-site/index.tsx
@@ -15,9 +15,11 @@ export const SitesAddNewSitePopover = ( { showCompact }: Props ) => {
 	const translate = useTranslate();
 
 	const toggleMenu = useCallback( () => {
-		recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_add' );
+		if ( ! isOpen ) {
+			recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_open' );
+		}
 		setIsOpen( ( open ) => ! open );
-	}, [] );
+	}, [ isOpen ] );
 
 	return (
 		<AddNewSiteButton


### PR DESCRIPTION
## Proposed Changes
![image](https://github.com/user-attachments/assets/cda69bc6-fb7b-45e0-ae0a-4b701952394d)

To improving tracking on our **Drive migrations from multi-site dashboard** project, we are adding some changes.
- When opening the Multi-site popover, triggering `calypso_sites_dashboard_new_site_action_click_open`.
- Do not trigger `calypso_sites_dashboard_new_site_action_click_add` just from opening the popover.


- ![image](https://github.com/user-attachments/assets/42496891-629a-4c72-834e-6b4542f7261c) triggers:
  - `calypso_sites_dashboard_new_site_action_click_add` 
  - `calypso_sites_dashboard_new_site_action_click_item` with `action: 'wordpress'`
  
  
- ![image](https://github.com/user-attachments/assets/a929b70c-7ef9-4d62-8015-025118ee5b29) triggers:
  - `calypso_sites_dashboard_new_site_action_click_jetpack` 
  - `calypso_sites_dashboard_new_site_action_click_item` with `action: 'jetpack'`
  
  
- ![image](https://github.com/user-attachments/assets/0765329c-57ca-4251-b9f2-88206ef4a6e8) triggers:
  - `calypso_sites_dashboard_new_site_action_click_item` with `action: 'migrate'`
  
  
- ![image](https://github.com/user-attachments/assets/785aa7ca-eff6-4231-bded-f2a5c7ec8400) triggers:
  - `calypso_sites_dashboard_new_site_action_click_import` 
  - `calypso_sites_dashboard_new_site_action_click_item` with `action: 'import'`
  
  
- ![image](https://github.com/user-attachments/assets/153495bb-4552-4837-aa15-6bae767a24ed) triggers:
  - `calypso_sites_dashboard_new_site_action_click_item` with `action: 'offer'`


## Testing Instructions

Access the dashboard with the feature flag `/sites?flags=-sites%2Fdrive-migrations`.
Start to listen to events. Click on each options from the new `Add new site` button.
Check that the events work as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
