### PR TITLE
Reader: Use wpcom_login instead of login when linking to user profile

### DIFF
--- a/client/blocks/reader-author-link/index.tsx
+++ b/client/blocks/reader-author-link/index.tsx
@@ -23,6 +23,7 @@ export interface ReaderLinkAuthor {
 	URL?: string;
 	name?: string;
 	login?: string;
+	wpcom_login?: string;
 }
 
 /**
@@ -42,8 +43,8 @@ export default function ReaderAuthorLink( props: ReaderAuthorLinkProps ) {
 	};
 
 	const authorLinkUrl =
-		isUserProfileEnabled() && author.login
-			? getUserProfileUrl( author.login )
+		isUserProfileEnabled() && author.wpcom_login
+			? getUserProfileUrl( author.wpcom_login )
 			: props.siteUrl ?? author.URL;
 
 	const authorName = author.name;

--- a/client/blocks/reader-avatar/index.tsx
+++ b/client/blocks/reader-avatar/index.tsx
@@ -19,6 +19,7 @@ export type ReaderAvatarAuthor = {
 	display_name?: string;
 	name?: string;
 	login?: string;
+	wpcom_login?: string;
 };
 
 type ReaderAvatarProps = {
@@ -122,7 +123,7 @@ export default function ReaderAvatar( {
 		<SiteIcon key="site-icon" size={ siteIconSize } site={ fakeSite } />
 	);
 	const avatarUrl =
-		isUserProfileEnabled() && author?.login ? getUserProfileUrl( author.login ) : null;
+		isUserProfileEnabled() && author?.wpcom_login ? getUserProfileUrl( author.wpcom_login ) : null;
 	const authorAvatar = ( hasAvatar || showPlaceholder ) && (
 		<Gravatar key="author-avatar" user={ author } size={ gravatarSize } />
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98868
Requires diff: 171081-ghe-Automattic/wpcom

## Proposed Changes

* This PR uses `wpcom_login` when linking to the user profile page instead of `login`.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* `login` data is inconsistent between Jetpack and wpcom sites. `wpcom_login` is always the wordpress.com `login.`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply 171081-ghe-Automattic/wpcom to your sandbox and sandbox the API.
* Use Calypso Live and observe the author user name on Jetpack sites (and other sites) links correctly to the user profile page.
* For example the author "demo" on these pages should link to the user profile "dreagan": https://wordpress.com/read/feeds/166062205 and https://wordpress.com/read/feeds/166062205/posts/5534312285

<img width="796" alt="Screenshot 2025-01-24 at 4 30 37 PM" src="https://github.com/user-attachments/assets/39b6c482-62f8-425d-bade-6522bfe1bea9" />
<img width="822" alt="Screenshot 2025-01-24 at 4 29 58 PM" src="https://github.com/user-attachments/assets/ad0e54a2-7f99-48f6-a08b-5ca0afba8bc0" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?