### PR TITLE
Stats Locations: Refactor module and styling for improved layout

### DIFF
--- a/apps/odyssey-stats/src/routes.ts
+++ b/apps/odyssey-stats/src/routes.ts
@@ -94,6 +94,7 @@ export default function ( pageBase = '/' ) {
 		'referrers',
 		'clicks',
 		'countryviews',
+		'locations',
 		'authors',
 		'videoplays',
 		'videodetails',

--- a/client/my-sites/stats/features/modules/stats-locations/country-filter.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/country-filter.tsx
@@ -19,7 +19,14 @@ const CountryFilter: React.FC< {
 	];
 
 	return (
-		<SelectControl onChange={ onChange } options={ options } value={ selectedCountry ?? '' } />
+		<SelectControl
+			__next40pxDefaultSize
+			__nextHasNoMarginBottom
+			className="stats-module-locations__country-filter"
+			onChange={ onChange }
+			options={ options }
+			value={ selectedCountry ?? '' }
+		/>
 	);
 };
 

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -145,14 +145,6 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 				// @ts-expect-error TODO: missing TS type
 				onSelect={ changeViewButton }
 			/>
-			{ geoMode !== 'country' && ! summaryUrl && (
-				<CountryFilter
-					countries={ countriesList }
-					defaultLabel={ optionLabels[ selectedOption ].countryFilterLabel }
-					selectedCountry={ countryFilter }
-					onCountryChange={ onCountryChange }
-				/>
-			) }
 		</>
 	);
 
@@ -225,14 +217,29 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 								} ) }
 							</StatsInfoArea>
 						}
-						moduleType="countryviews"
+						moduleType="locations"
 						data={ locationData }
 						emptyMessage={ emptyMessage }
 						metricLabel={ translate( 'Views' ) }
 						loader={ isRequestingData && <StatsModulePlaceholder isLoading={ isRequestingData } /> }
 						splitHeader
 						heroElement={
-							<Geochart data={ locationData } geoMode={ geoMode } skipQuery customHeight={ 480 } />
+							<>
+								<Geochart
+									data={ locationData }
+									geoMode={ geoMode }
+									skipQuery
+									customHeight={ 480 }
+								/>
+								{ geoMode !== 'country' && ! summaryUrl && (
+									<CountryFilter
+										countries={ countriesList }
+										defaultLabel={ optionLabels[ selectedOption ].countryFilterLabel }
+										selectedCountry={ countryFilter }
+										onCountryChange={ onCountryChange }
+									/>
+								) }
+							</>
 						}
 						mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
 						toggleControl={ toggleControlComponent }

--- a/client/my-sites/stats/features/modules/stats-locations/style.scss
+++ b/client/my-sites/stats/features/modules/stats-locations/style.scss
@@ -4,7 +4,17 @@
 $break-large-stats-countries: 1280px;
 $locations-horizontal-bar-width: 380px;
 
-.list-locations {
+.stats-card.list-locations {
+	.stats-card-header {
+		.segmented-control {
+			flex: 1;
+		}
+
+		.stats-card-header__title {
+			display: none;
+		}
+	}
+
 	.stats-module-locations__country-filter {
 		width: fit-content;
 	}
@@ -79,6 +89,20 @@ $locations-horizontal-bar-width: 380px;
 	.stats-module-locations__tabs {
 		position: relative;
 		z-index: 2;
+	}
+}
+
+@include break-large {
+	.stats-card.list-locations {
+		.stats-card-header {
+			.segmented-control {
+				flex: none;
+			}
+
+			.stats-card-header__title {
+				display: flex;
+			}
+		}
 	}
 }
 

--- a/client/my-sites/stats/features/modules/stats-locations/style.scss
+++ b/client/my-sites/stats/features/modules/stats-locations/style.scss
@@ -5,9 +5,17 @@ $break-large-stats-countries: 1280px;
 $locations-horizontal-bar-width: 380px;
 
 .stats-card.list-locations {
+	@include segmented-controls;
+
 	.stats-card-header {
-		.segmented-control {
+		.segmented-control.stats-module-locations__tabs {
 			flex: 1;
+			max-width: 100%;
+			width: calc( $locations-horizontal-bar-width - 24px - 24px);
+		}
+
+		.segmented-control.stats-module-locations__tabs .segmented-control__item {
+			flex: 1 1 0;
 		}
 
 		.stats-card-header__title {
@@ -16,6 +24,7 @@ $locations-horizontal-bar-width: 380px;
 	}
 
 	.stats-module-locations__country-filter {
+		margin: 12px 24px 0;
 		width: fit-content;
 	}
 
@@ -23,66 +32,52 @@ $locations-horizontal-bar-width: 380px;
 		height: auto;
 	}
 
+	.stats-card__content .stats-card--hero {
+		padding: 0;
+	}
+
 	.stats-card--column-header {
 		display: flex;
 		justify-content: space-between;
 		padding: 12px 24px;
 	}
+
 	.stats-card--column-header__left {
 		display: flex;
-		width: calc(100% - 75px);
 		justify-content: space-between;
+		width: calc(100% - 75px);
 	}
 	.stats-card--column-header__right {
 		width: 75px;
 		text-align: right;
 	}
+}
 
-	.stats-module-locations__tabs {
-		width: calc( $locations-horizontal-bar-width - 24px - 24px);
-		max-width: 100%;
-
-		.segmented-control__item {
-			flex: 1 1 0;
-		}
+.stats-summary-view .stats-card.list-locations {
+	.stats-card--hero .stats-card-header {
+		padding: 0 24px 12px 0;
 	}
 }
 
-.stats-summary-view {
-	.list-locations {
-		.stats-card--hero {
-			padding: 0 24px;
-
-			.stats-card-header {
-				padding: 0 24px 12px 0;
-			}
-		}
+.stats__module-list--traffic .stats-card.list-locations {
+	.stats-card-header {
+		padding: 0 24px;
 	}
-}
 
-.stats__module-list--traffic {
-	@include segmented-controls;
-	.list-locations {
-		.stats-card-header {
-			padding: 0 24px;
-		}
+	.stats-card--hero {
+		width: 100%;
+	}
 
-		.stats-card--hero {
-			padding: 0 24px;
-			width: 100%;
+	.stats-card--hero .stats-geochart {
+		height: auto;
+		margin-bottom: 0;
+	}
 
-			.stats-geochart {
-				height: auto;
-				margin-bottom: 0;
-			}
-
-			.stats-geochart.stats-module__placeholder {
-				margin: 0;
-				min-width: 100%;
-				padding: 0;
-				width: 100%;
-			}
-		}
+	.stats-card--hero .stats-geochart.stats-module__placeholder {
+		margin: 0;
+		min-width: 100%;
+		padding: 0;
+		width: 100%;
 	}
 
 	// Ensure the tabs are above the overlay
@@ -93,37 +88,38 @@ $locations-horizontal-bar-width: 380px;
 }
 
 @include break-large {
-	.stats-card.list-locations {
-		.stats-card-header {
-			.segmented-control {
-				flex: none;
-			}
+	.stats-card.list-locations .stats-card-header {
+		.segmented-control.stats-module-locations__tabs {
+			flex: none;
+		}
 
-			.stats-card-header__title {
-				display: flex;
-			}
+		.stats-card-header__title {
+			display: flex;
 		}
 	}
 }
 
 @include break-wide {
-	.stats__module-list--traffic .list-locations .stats-card__content {
+	.stats__module-list--traffic .stats-card.list-locations .stats-card__content {
 		display: flex;
 		flex-direction: row;
 		flex-wrap: wrap;
 	}
 
-	.list-locations {
-		.stats-card--hero {
+	.stats-card.list-locations {
+		.stats-card__content .stats-card--hero {
 			flex: 2;
+			margin: 0 24px;
+
 			.stats-geochart {
 				margin: 0 auto;
 				overflow: hidden;
 				width: 100%;
-				div > div {
-					display: block;
-					margin: 0 auto;
-				}
+			}
+
+			.stats-geochart div > div {
+				display: block;
+				margin: 0 auto;
 			}
 		}
 
@@ -133,6 +129,10 @@ $locations-horizontal-bar-width: 380px;
 
 		.stats-card--footer {
 			flex-basis: 100%;
+		}
+
+		.stats-module-locations__country-filter {
+			margin: 12px 0 0;
 		}
 	}
 }

--- a/client/my-sites/stats/features/modules/stats-locations/style.scss
+++ b/client/my-sites/stats/features/modules/stats-locations/style.scss
@@ -2,11 +2,46 @@
 @import "../../../modernized-mixins";
 
 $break-large-stats-countries: 1280px;
+$locations-horizontal-bar-width: 380px;
+
+.list-locations {
+	.stats-module-locations__country-filter {
+		width: fit-content;
+	}
+
+	.stats-card__content {
+		height: auto;
+	}
+
+	.stats-card--column-header {
+		display: flex;
+		justify-content: space-between;
+		padding: 12px 24px;
+	}
+	.stats-card--column-header__left {
+		display: flex;
+		width: calc(100% - 75px);
+		justify-content: space-between;
+	}
+	.stats-card--column-header__right {
+		width: 75px;
+		text-align: right;
+	}
+
+	.stats-module-locations__tabs {
+		width: calc( $locations-horizontal-bar-width - 24px - 24px);
+		max-width: 100%;
+
+		.segmented-control__item {
+			flex: 1 1 0;
+		}
+	}
+}
 
 .stats-summary-view {
-	.list-countryviews {
+	.list-locations {
 		.stats-card--hero {
-			padding: 0 24px 32px;
+			padding: 0 24px;
 
 			.stats-card-header {
 				padding: 0 24px 12px 0;
@@ -17,7 +52,11 @@ $break-large-stats-countries: 1280px;
 
 .stats__module-list--traffic {
 	@include segmented-controls;
-	.list-countryviews {
+	.list-locations {
+		.stats-card-header {
+			padding: 0 24px;
+		}
+
 		.stats-card--hero {
 			padding: 0 24px;
 			width: 100%;
@@ -33,10 +72,6 @@ $break-large-stats-countries: 1280px;
 				padding: 0;
 				width: 100%;
 			}
-
-			.stats-card-header {
-				padding: 0 24px 12px 0;
-			}
 		}
 	}
 
@@ -48,13 +83,13 @@ $break-large-stats-countries: 1280px;
 }
 
 @include break-wide {
-	.stats__module-list--traffic .list-countryviews .stats-card__content {
+	.stats__module-list--traffic .list-locations .stats-card__content {
 		display: flex;
 		flex-direction: row;
 		flex-wrap: wrap;
 	}
 
-	.list-countryviews {
+	.list-locations {
 		.stats-card--hero {
 			flex: 2;
 			.stats-geochart {
@@ -70,19 +105,10 @@ $break-large-stats-countries: 1280px;
 
 		.stats-card--header-and-body {
 			flex: 0 0 380px;
-			min-width: 380px;
 		}
 
 		.stats-card--footer {
 			flex-basis: 100%;
-		}
-
-		.stats-module-locations__tabs {
-			width: 100%;
-
-			.segmented-control__item {
-				flex: 1 1 0;
-			}
 		}
 	}
 }

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -871,7 +871,8 @@ ul.module-content-list-legend {
 }
 
 .list-countryviews,
-.list-countries {
+.list-countries,
+.list-locations {
 	.stats-list__flag-icon {
 		position: relative;
 		display: inline-block;

--- a/client/my-sites/stats/summary/style.scss
+++ b/client/my-sites/stats/summary/style.scss
@@ -46,7 +46,3 @@
 		}
 	}
 }
-
-.stats-module-locations__tabs {
-	width: 100%;
-}

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -26,6 +26,7 @@ const StatsCard = ( {
 	overlay,
 }: StatsCardProps ) => {
 	const translate = useTranslate();
+	const hasHeroElement = !! heroElement;
 
 	const titleNode = titleURL ? (
 		<a href={ `${ titleURL }` } className={ `${ BASE_CLASS_NAME }-header__title` }>
@@ -39,6 +40,25 @@ const StatsCard = ( {
 		>
 			<div>{ title }</div>
 			<div className={ `${ BASE_CLASS_NAME }-header__title-nodes` }>{ titleNodes }</div>
+		</div>
+	);
+
+	// Column header node for split header
+	const columnHeaderNode = (
+		<div className={ `${ BASE_CLASS_NAME }--column-header` }>
+			<div className={ `${ BASE_CLASS_NAME }--column-header__left` } key="left">
+				{ splitHeader && mainItemLabel }
+				{ additionalHeaderColumns && (
+					<div className={ `${ BASE_CLASS_NAME }-header__additional` }>
+						{ additionalHeaderColumns }
+					</div>
+				) }
+			</div>
+			{ ! isEmpty && (
+				<div className={ `${ BASE_CLASS_NAME }--column-header__right` } key="right">
+					{ metricLabel ?? translate( 'Views' ) }
+				</div>
+			) }
 		</div>
 	);
 
@@ -57,49 +77,31 @@ const StatsCard = ( {
 			className={ `${ BASE_CLASS_NAME }-header ${ headerClassName } ${ BASE_CLASS_NAME }-header--split` }
 		>
 			<div className={ `${ BASE_CLASS_NAME }-header--main` }>
-				{ ! heroElement && titleNode }
+				{ titleNode }
 				{ toggleControl }
 			</div>
-			{ ! isEmpty && (
-				<div className={ `${ BASE_CLASS_NAME }--column-header` }>
-					<div className={ `${ BASE_CLASS_NAME }--column-header__left` } key="left">
-						{ splitHeader && mainItemLabel }
-						{ additionalHeaderColumns && (
-							<div className={ `${ BASE_CLASS_NAME }-header__additional` }>
-								{ additionalHeaderColumns }
-							</div>
-						) }
-					</div>
-					{ ! isEmpty && (
-						<div className={ `${ BASE_CLASS_NAME }--column-header__right` } key="right">
-							{ metricLabel ?? translate( 'Views' ) }
-						</div>
-					) }
-				</div>
-			) }
+			{ ! isEmpty && ! hasHeroElement ? columnHeaderNode : null }
 		</div>
 	);
 
+	const headerNode = splitHeader ? splitHeaderNode : simpleHeaderNode;
 	return (
 		<div
 			className={ clsx( className, BASE_CLASS_NAME, {
 				[ `${ BASE_CLASS_NAME }__hasoverlay` ]: !! overlay,
 			} ) }
 		>
+			{ hasHeroElement && splitHeaderNode }
 			<div className={ `${ BASE_CLASS_NAME }__content` }>
-				{ !! heroElement && (
-					<div className={ `${ BASE_CLASS_NAME }--hero` }>
-						{ splitHeader && <div className={ `${ BASE_CLASS_NAME }-header` }>{ titleNode }</div> }
-						{ heroElement }
-					</div>
-				) }
+				{ hasHeroElement && <div className={ `${ BASE_CLASS_NAME }--hero` }>{ heroElement }</div> }
 				<div className={ `${ BASE_CLASS_NAME }--header-and-body` }>
-					{ splitHeader ? splitHeaderNode : simpleHeaderNode }
+					{ ! hasHeroElement ? headerNode : null }
 					<div
 						className={ clsx( `${ BASE_CLASS_NAME }--body`, {
 							[ `${ BASE_CLASS_NAME }--body-empty` ]: isEmpty,
 						} ) }
 					>
+						{ hasHeroElement ? columnHeaderNode : null }
 						{ isEmpty ? emptyMessage : children }
 					</div>
 					{ footerAction && (

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -91,17 +91,17 @@ const StatsCard = ( {
 				[ `${ BASE_CLASS_NAME }__hasoverlay` ]: !! overlay,
 			} ) }
 		>
-			{ hasHeroElement && splitHeaderNode }
+			{ hasHeroElement && splitHeader ? splitHeaderNode : null }
 			<div className={ `${ BASE_CLASS_NAME }__content` }>
 				{ hasHeroElement && <div className={ `${ BASE_CLASS_NAME }--hero` }>{ heroElement }</div> }
 				<div className={ `${ BASE_CLASS_NAME }--header-and-body` }>
-					{ ! hasHeroElement ? headerNode : null }
+					{ ! hasHeroElement || ( hasHeroElement && ! splitHeader ) ? headerNode : null }
 					<div
 						className={ clsx( `${ BASE_CLASS_NAME }--body`, {
 							[ `${ BASE_CLASS_NAME }--body-empty` ]: isEmpty,
 						} ) }
 					>
-						{ hasHeroElement ? columnHeaderNode : null }
+						{ hasHeroElement && splitHeader ? columnHeaderNode : null }
 						{ isEmpty ? emptyMessage : children }
 					</div>
 					{ footerAction && (

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -11,6 +11,8 @@ const StatsCard = ( props: StatsCardProps ) => {
 	const translate = useTranslate();
 	const { heroElement, splitHeader, toggleControl } = props;
 
+	// Isolate the rendering logic for the Locations module into a new component.
+	// This ensures the existing StatsCard component remains unchanged, allowing us to safely iterate on it.
 	if ( heroElement && splitHeader && toggleControl ) {
 		return <StatsHeroCard { ...props } />;
 	}

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -1,32 +1,36 @@
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import StatsHeroCard from './stats-hero-card';
 import type { StatsCardProps } from './types';
 
 import './stats-card.scss';
 
 const BASE_CLASS_NAME = 'stats-card';
 
-const StatsCard = ( {
-	children,
-	className,
-	title,
-	titleURL,
-	titleAriaLevel = 4,
-	titleNodes,
-	footerAction,
-	isEmpty,
-	emptyMessage,
-	heroElement,
-	splitHeader,
-	metricLabel,
-	mainItemLabel,
-	additionalHeaderColumns,
-	toggleControl,
-	headerClassName,
-	overlay,
-}: StatsCardProps ) => {
+const StatsCard = ( props: StatsCardProps ) => {
 	const translate = useTranslate();
-	const hasHeroElement = !! heroElement;
+	const { heroElement, splitHeader, toggleControl } = props;
+
+	if ( heroElement && splitHeader && toggleControl ) {
+		return <StatsHeroCard { ...props } />;
+	}
+
+	const {
+		children,
+		className,
+		title,
+		titleURL,
+		titleAriaLevel = 4,
+		titleNodes,
+		footerAction,
+		isEmpty,
+		emptyMessage,
+		metricLabel,
+		mainItemLabel,
+		additionalHeaderColumns,
+		headerClassName,
+		overlay,
+	} = props;
 
 	const titleNode = titleURL ? (
 		<a href={ `${ titleURL }` } className={ `${ BASE_CLASS_NAME }-header__title` }>
@@ -40,25 +44,6 @@ const StatsCard = ( {
 		>
 			<div>{ title }</div>
 			<div className={ `${ BASE_CLASS_NAME }-header__title-nodes` }>{ titleNodes }</div>
-		</div>
-	);
-
-	// Column header node for split header
-	const columnHeaderNode = (
-		<div className={ `${ BASE_CLASS_NAME }--column-header` }>
-			<div className={ `${ BASE_CLASS_NAME }--column-header__left` } key="left">
-				{ splitHeader && mainItemLabel }
-				{ additionalHeaderColumns && (
-					<div className={ `${ BASE_CLASS_NAME }-header__additional` }>
-						{ additionalHeaderColumns }
-					</div>
-				) }
-			</div>
-			{ ! isEmpty && (
-				<div className={ `${ BASE_CLASS_NAME }--column-header__right` } key="right">
-					{ metricLabel ?? translate( 'Views' ) }
-				</div>
-			) }
 		</div>
 	);
 
@@ -77,31 +62,49 @@ const StatsCard = ( {
 			className={ `${ BASE_CLASS_NAME }-header ${ headerClassName } ${ BASE_CLASS_NAME }-header--split` }
 		>
 			<div className={ `${ BASE_CLASS_NAME }-header--main` }>
-				{ titleNode }
+				{ ! heroElement && titleNode }
 				{ toggleControl }
 			</div>
-			{ ! isEmpty && ! hasHeroElement ? columnHeaderNode : null }
+			{ ! isEmpty && (
+				<div className={ `${ BASE_CLASS_NAME }--column-header` }>
+					<div className={ `${ BASE_CLASS_NAME }--column-header__left` } key="left">
+						{ splitHeader && mainItemLabel }
+						{ additionalHeaderColumns && (
+							<div className={ `${ BASE_CLASS_NAME }-header__additional` }>
+								{ additionalHeaderColumns }
+							</div>
+						) }
+					</div>
+					{ ! isEmpty && (
+						<div className={ `${ BASE_CLASS_NAME }--column-header__right` } key="right">
+							{ metricLabel ?? translate( 'Views' ) }
+						</div>
+					) }
+				</div>
+			) }
 		</div>
 	);
 
-	const headerNode = splitHeader ? splitHeaderNode : simpleHeaderNode;
 	return (
 		<div
 			className={ clsx( className, BASE_CLASS_NAME, {
 				[ `${ BASE_CLASS_NAME }__hasoverlay` ]: !! overlay,
 			} ) }
 		>
-			{ hasHeroElement && splitHeader ? splitHeaderNode : null }
 			<div className={ `${ BASE_CLASS_NAME }__content` }>
-				{ hasHeroElement && <div className={ `${ BASE_CLASS_NAME }--hero` }>{ heroElement }</div> }
+				{ !! heroElement && (
+					<div className={ `${ BASE_CLASS_NAME }--hero` }>
+						{ splitHeader && <div className={ `${ BASE_CLASS_NAME }-header` }>{ titleNode }</div> }
+						{ heroElement }
+					</div>
+				) }
 				<div className={ `${ BASE_CLASS_NAME }--header-and-body` }>
-					{ ! hasHeroElement || ( hasHeroElement && ! splitHeader ) ? headerNode : null }
+					{ splitHeader ? splitHeaderNode : simpleHeaderNode }
 					<div
 						className={ clsx( `${ BASE_CLASS_NAME }--body`, {
 							[ `${ BASE_CLASS_NAME }--body-empty` ]: isEmpty,
 						} ) }
 					>
-						{ hasHeroElement && splitHeader ? columnHeaderNode : null }
 						{ isEmpty ? emptyMessage : children }
 					</div>
 					{ footerAction && (

--- a/packages/components/src/horizontal-bar-list/stats-hero-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-hero-card.tsx
@@ -1,0 +1,109 @@
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import type { StatsCardProps } from './types';
+
+import './stats-card.scss';
+
+const BASE_CLASS_NAME = 'stats-card';
+
+const StatsHeroCard = ( {
+	children,
+	className,
+	title,
+	titleURL,
+	titleAriaLevel = 4,
+	titleNodes,
+	footerAction,
+	isEmpty,
+	emptyMessage,
+	heroElement,
+	metricLabel,
+	mainItemLabel,
+	additionalHeaderColumns,
+	toggleControl,
+	headerClassName,
+	overlay,
+}: StatsCardProps ) => {
+	const translate = useTranslate();
+
+	const titleNode = titleURL ? (
+		<a href={ `${ titleURL }` } className={ `${ BASE_CLASS_NAME }-header__title` }>
+			{ title }
+		</a>
+	) : (
+		<div
+			className={ `${ BASE_CLASS_NAME }-header__title` }
+			role="heading"
+			aria-level={ titleAriaLevel }
+		>
+			<div>{ title }</div>
+			<div className={ `${ BASE_CLASS_NAME }-header__title-nodes` }>{ titleNodes }</div>
+		</div>
+	);
+
+	// Column header node for split header
+	const columnHeaderNode = (
+		<div className={ `${ BASE_CLASS_NAME }--column-header` }>
+			<div className={ `${ BASE_CLASS_NAME }--column-header__left` } key="left">
+				{ mainItemLabel }
+				{ additionalHeaderColumns && (
+					<div className={ `${ BASE_CLASS_NAME }-header__additional` }>
+						{ additionalHeaderColumns }
+					</div>
+				) }
+			</div>
+			{ ! isEmpty && (
+				<div className={ `${ BASE_CLASS_NAME }--column-header__right` } key="right">
+					{ metricLabel ?? translate( 'Views' ) }
+				</div>
+			) }
+		</div>
+	);
+
+	return (
+		<div
+			className={ clsx( className, BASE_CLASS_NAME, {
+				[ `${ BASE_CLASS_NAME }__hasoverlay` ]: !! overlay,
+			} ) }
+		>
+			<div
+				className={ `${ BASE_CLASS_NAME }-header ${ headerClassName } ${ BASE_CLASS_NAME }-header--split` }
+			>
+				<div className={ `${ BASE_CLASS_NAME }-header--main` }>
+					{ titleNode }
+					{ toggleControl }
+				</div>
+			</div>
+			<div className={ `${ BASE_CLASS_NAME }__content` }>
+				<div className={ `${ BASE_CLASS_NAME }--hero` }>{ heroElement }</div>
+				<div className={ `${ BASE_CLASS_NAME }--header-and-body` }>
+					<div
+						className={ clsx( `${ BASE_CLASS_NAME }--body`, {
+							[ `${ BASE_CLASS_NAME }--body-empty` ]: isEmpty,
+						} ) }
+					>
+						{ columnHeaderNode }
+						{ isEmpty ? emptyMessage : children }
+					</div>
+					{ footerAction && (
+						<a
+							className={ `${ BASE_CLASS_NAME }--footer` }
+							href={ footerAction?.url }
+							aria-label={
+								translate( 'View all %(title)s', {
+									args: { title: title.toLocaleLowerCase?.() ?? title.toLowerCase() },
+									comment: '"View all posts & pages", "View all referrers", etc.',
+								} ) as string
+							}
+						>
+							{ footerAction.label || translate( 'View all' ) }
+						</a>
+					) }
+				</div>
+			</div>
+			{ overlay && <div className={ `${ BASE_CLASS_NAME }__overlay` }>{ overlay }</div> }
+		</div>
+	);
+};
+
+export default StatsHeroCard;

--- a/packages/components/src/horizontal-bar-list/stats-hero-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-hero-card.tsx
@@ -6,6 +6,7 @@ import './stats-card.scss';
 
 const BASE_CLASS_NAME = 'stats-card';
 
+// This component is mainly used for the Locations module, which uses heroElement, splitHeader and toggleControl
 const StatsHeroCard = ( {
 	children,
 	className,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-roadmap/issues/2173 and p1737784281954529-slack-C087GMDHE5P

## Proposed Changes
* Add a new `StatsHeroCard` component to the `horizontal-bar-list` package to isolate the rendering logic for the Locations module. This ensures the existing `StatsCard` component remains unchanged, allowing us to safely iterate on it.
* Position the location tabs above the map, aligning them with the module title. These changes apply to `StatsCard` when `heroElement` is passed, and `splitHeader` is set to `true`. Note that in the legacy Countries module, `splitHeader` is `false`.
* On screens smaller than 1280px:
  * Move the locations list below the map.
* On screens smaller than 960px:
  * Hide the module title.
  * Stretch the tabs to 100% width.
* Fix various margin and padding issues.

### Screenshots

#### Traffic page
| Scenario | Before | After |
|---|---|---|
| >= 1280px | <p align="center"><img src="https://github.com/user-attachments/assets/1fb5cd8c-a723-444a-85ea-c2e3214f0c53" height="180" /></p> | <p align="center"><img src="https://github.com/user-attachments/assets/f8ab7b71-0e64-4388-baa6-b15cfeac9641" height="180" /></p> |
| < 1280px | <p align="center"><img src="https://github.com/user-attachments/assets/4169b1bb-09fc-4086-892a-8eb51dae4f29" height="180" /></p> | <p align="center"><img src="https://github.com/user-attachments/assets/6850de85-a1f0-4750-a271-654996e4b62e" height="180" /></p> |
| < 960px | <p align="center"><img src="https://github.com/user-attachments/assets/c4d6a695-9354-4505-8326-1112a8b7f503" height="180" /></p> | <p align="center"><img src="https://github.com/user-attachments/assets/416812f8-2fbd-4025-ac62-8077ae90b719" height="180" /></p> |

#### Summary page
| Scenario | Before | After |
|---|---|---|
| >= 1280px | <p align="center"><img src="https://github.com/user-attachments/assets/0375688d-2ff9-48b0-a0ca-87c769e16e3a" height="180" /></p> | <p align="center"><img src="https://github.com/user-attachments/assets/4425ab6c-9d8c-4a64-96a2-b3548a4385c5" height="180" /></p> |
| < 1280px | <p align="center"><img src="https://github.com/user-attachments/assets/32a7e50d-ad94-4d7e-a306-e1c0938965dc" height="180" /></p> | <p align="center"><img src="https://github.com/user-attachments/assets/478c68f8-8b9b-4cea-af93-de8eb29f840e" height="180" /></p> |
| < 960px | <p align="center"><img src="https://github.com/user-attachments/assets/5d37455e-bd9b-40ab-b11c-3cac008329b5" height="180" /></p> | <p align="center"><img src="https://github.com/user-attachments/assets/b8615407-73cd-40fe-a936-d09462e24fda" height="180" /></p> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is a follow-up of https://github.com/Automattic/wp-calypso/pull/98767 and we are also aiming to address https://github.com/Automattic/jetpack-roadmap/issues/2173.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Calypso Live Branch.
* Navigate to the Stats page.
* Validate the Locations module on the Traffic page and the Summary page across the screen sizes mentioned above.
* Ensure the Countries module looks the same as the production version.
* Confirm that the titles and column headers of other modules also match the production version.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?