### PR TITLE
Show domains when additional data is loaded

### DIFF
--- a/client/my-sites/domains/domain-management/dataviews/domains-dataviews.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/domains-dataviews.tsx
@@ -32,7 +32,7 @@ export const DomainsDataViews = ( {
 	selectedDomainName,
 }: Props ) => {
 	const translate = useTranslate();
-	const { isDesktop } = useDomainsDataViewsContext();
+	const { isDesktop, isLoadingAdditionalData } = useDomainsDataViewsContext();
 	const queryParams = useQueryParams();
 
 	const [ view, setView ] = useState( () =>
@@ -83,7 +83,7 @@ export const DomainsDataViews = ( {
 			{ ! sidebarMode && <BulkUpdateNotice /> }
 			<div className={ clsx( 'domains-dataviews', { 'domains-dataviews-list': sidebarMode } ) }>
 				<DataViews
-					data={ domainsToDisplay }
+					data={ isLoadingAdditionalData ? [] : domainsToDisplay }
 					fields={ fields }
 					onChangeView={ ( newView ) => setView( () => newView ) }
 					view={ view }
@@ -94,7 +94,7 @@ export const DomainsDataViews = ( {
 					getItemId={ getDomainId }
 					selection={ selectedDomain ? [ getDomainId( selectedDomain ) ] : selectedIds }
 					onChangeSelection={ setSelectedIds }
-					isLoading={ isLoading }
+					isLoading={ isLoading || isLoadingAdditionalData }
 					defaultLayouts={ layout }
 				/>
 			</div>

--- a/client/my-sites/domains/domain-management/dataviews/types.ts
+++ b/client/my-sites/domains/domain-management/dataviews/types.ts
@@ -105,4 +105,5 @@ export interface Context {
 	selectedFeature?: string;
 	hasConnectableSites: boolean;
 	context?: DomainsDataViewUsage;
+	isLoadingAdditionalData: boolean;
 }

--- a/client/my-sites/domains/domain-management/dataviews/use-context.ts
+++ b/client/my-sites/domains/domain-management/dataviews/use-context.ts
@@ -87,6 +87,8 @@ export const useGenerateDomainsDataViewsState = ( props: DomainsDataViewsProps )
 		return fetchedSiteDomains;
 	}, [ allSiteDomains ] );
 
+	const isLoadingSiteDomains = allSiteDomains.some( ( { isLoading } ) => isLoading );
+
 	const getFullDomain = ( domain: PartialDomainData ) => {
 		const domains = siteDomains[ domain.blog_id ] ?? [];
 		return domains.find( ( d ) => d.name === domain.domain );
@@ -206,6 +208,7 @@ export const useGenerateDomainsDataViewsState = ( props: DomainsDataViewsProps )
 		selectedFeature,
 		hasConnectableSites: hasConnectableSites ?? false,
 		context: dataViewsUsage,
+		isLoadingAdditionalData: isLoadingSiteDomains || isLoadingSites,
 	};
 
 	return context;


### PR DESCRIPTION
This PR is an experimental one and addresses one particular [comment](https://github.com/Automattic/wp-calypso/pull/97677#discussion_r1928506120) and suggestion in Slack: p1737717086233169/1737614237.091909-slack-C082KU0C0MR

For an average user it should work fine, however will be a serious problem in edge cases when users have many domains.

## Proposed Changes

* Show domains when additional data is loaded

## Why are these changes being made?

* We try to improve DataViews usage, considering other challenges we have now.

## Testing Instructions

* Turn on feature flags in your browser's console: `window.sessionStorage.setItem('flags', ['calypso/all-domain-management', 'calypso/domains-dataviews'])`
- Go to http://calypso.localhost:3000/plugins/manage
- Check filtering, sorting, actions, bulk actions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?