### PR TITLE
Master Bar: Add Launch Button

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -28,7 +28,9 @@ import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteMigrationActiveRoute from 'calypso/state/selectors/is-site-migration-active-route';
 import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
+import getIsUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { updateSiteMigrationMeta } from 'calypso/state/sites/actions';
+import { launchSiteOrRedirectToLaunchSignupFlow } from 'calypso/state/sites/launch/actions';
 import { isTrialExpired } from 'calypso/state/sites/plans/selectors/trials/trials-expiration';
 import {
 	getSiteSlug,
@@ -412,6 +414,23 @@ class MasterbarLoggedIn extends Component {
 		);
 	}
 
+	renderLaunchButton() {
+		const { isUnlaunchedSite, siteId, translate } = this.props;
+
+		if ( ! isUnlaunchedSite ) {
+			return null;
+		}
+
+		return (
+			<Item
+				className="masterbar__item-launch-site"
+				onClick={ () => this.props.launchSiteOrRedirectToLaunchSignupFlow( siteId ) }
+			>
+				{ translate( 'Launch site' ) }
+			</Item>
+		);
+	}
+
 	renderProfileMenu() {
 		const { translate, user } = this.props;
 		const profileActions = [
@@ -600,6 +619,7 @@ class MasterbarLoggedIn extends Component {
 					{ this.renderSiteMenu() }
 					{ this.renderSiteActionMenu() }
 					{ this.renderLanguageSwitcher() }
+					{ this.renderLaunchButton() }
 				</div>
 				<div className="masterbar__section masterbar__section--right">
 					{ this.renderCart() }
@@ -655,6 +675,7 @@ export default connect(
 			isSiteTrialExpired: isTrialExpired( state, siteId ),
 			newPostUrl: getEditorUrl( state, siteId, null, 'post' ),
 			newPageUrl: getEditorUrl( state, siteId, null, 'page' ),
+			isUnlaunchedSite: getIsUnlaunchedSite( state, siteId ),
 		};
 	},
 	{
@@ -664,5 +685,6 @@ export default connect(
 		activateNextLayoutFocus,
 		savePreference,
 		redirectToLogout,
+		launchSiteOrRedirectToLaunchSignupFlow,
 	}
 )( localize( MasterbarLoggedIn ) );

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -652,6 +652,11 @@ body.is-mobile-app-view {
 	}
 }
 
+.masterbar__item-launch-site {
+	cursor: pointer;
+	background-color: var(--wp-admin-theme-color);
+}
+
 .masterbar__item-logo {
 	flex: 0 0 auto;
 	padding: 0 0 0 8px;


### PR DESCRIPTION
closes #98903 

## Proposed Changes

This PR adds a "launch button" to the Calypso master bar. We're adding a similar button to the admin bar (frontend, wp-admin and atomic). For consistency, we're adding it to Calypso's master bar as well.

## Testing Instructions

- Open the admin (default style, not classic style) of an unlaunched site.
- Notice the "launch button" in the master bar.
- Click the button to launch the site.
