### PR TITLE
Billing History: increase margin between amount and tax string

### DIFF
--- a/client/me/purchases/billing-history/style.scss
+++ b/client/me/purchases/billing-history/style.scss
@@ -83,6 +83,7 @@
 	color: var(--color-text-subtle);
 	font-size: $font-body-extra-small;
 	white-space: nowrap;
+	margin-left: 0.3rem;
 }
 
 .billing-history__transaction-tax-amount {


### PR DESCRIPTION
In the new `DataViews` Billing History view (enabled in `dev`), the receipt amount and tax string are rendered on the same line. In `currency-on-right` locales (e.g. Greek or Polish), there's often a non-breaking space included between the amount and currency symbol. Since this space is bigger than the default element spacing between the the receipt amount and tax string, it makes the currency symbol look like it's attached to the tax string.

This PR adds some margin to the tax string to correct the issue.

Fixes: #98881

| Before | After |
| ----------- | ----------- |
| <img width="406" alt="Screenshot 2025-01-26 at 11 21 43 AM" src="https://github.com/user-attachments/assets/642b5c66-cbda-491c-a6fe-7e867c1dca44" /> | <img width="391" alt="Screenshot 2025-01-26 at 11 21 35 AM" src="https://github.com/user-attachments/assets/ebdc641d-1b65-4279-af27-527d6e790071" /> |

**To test:**
- switch your user locale to a language like Greek or Polish
- visit your billing history and view a receipt with tax collected
- verify that the spacing looks correct