### PR TITLE
A4A: Update the reference from 'Twitter' to 'X' in the Marketplace.

### DIFF
--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -2002,7 +2002,7 @@ export const getJetpackProductsBenefits = (): Record< string, Array< TranslateRe
 	const woocommerceAutomatewooReferAFriendBenefits = [
 		translate( 'Boost word-of-mouth sales with a customer referral program' ),
 		translate( 'Run coupon-based or link-based referral campaigns' ),
-		translate( 'Allow advocates to share referrals via email, Facebook, Twitter, and WhatsApp' ),
+		translate( 'Allow advocates to share referrals via email, Facebook, X, and WhatsApp' ),
 		translate( 'Reward advocates with store credit for successful referrals' ),
 		translate( 'Include post-purchase share widgets on order confirmation pages and emails' ),
 		translate( 'Implement fraud prevention measures to protect the referral program' ),


### PR DESCRIPTION
Context: p1737901070682989-slack-CEM18K8LT

## Proposed Changes

* Replace 'Twitter' to 'X'.

## Why are these changes being made?

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?