### PR TITLE
Revert "i18n: Update `numberFormat` to accept `Intl.NumberFormatOptions` options. Refactor signature, same defaults."

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/billing/billing-summary/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/billing/billing-summary/index.tsx
@@ -70,7 +70,8 @@ export default function BillingSummary() {
 			<div className="billing-summary__stat billing-summary__total-licenses">
 				<span className="billing-summary__label">{ translate( 'Total licenses' ) }</span>
 				<strong className="billing-summary__value">
-					{ billing.isSuccess && numberFormat( billing.data.licenses.total ) }
+					{ billing.isSuccess && numberFormat( billing.data.licenses.total, 0 ) }
+
 					{ billing.isLoading && <TextPlaceholder /> }
 
 					{ billing.isError && <Gridicon icon="minus" /> }
@@ -80,7 +81,7 @@ export default function BillingSummary() {
 			<div className="billing-summary__stat billing-summary__assigned-licenses">
 				<span className="billing-summary__label">{ translate( 'Assigned licenses' ) }</span>
 				<strong className="billing-summary__value">
-					{ billing.isSuccess && numberFormat( billing.data.licenses.assigned ) }
+					{ billing.isSuccess && numberFormat( billing.data.licenses.assigned, 0 ) }
 
 					{ billing.isLoading && <TextPlaceholder /> }
 
@@ -91,7 +92,7 @@ export default function BillingSummary() {
 			<div className="billing-summary__stat billing-summary__unassigned-licenses">
 				<span className="billing-summary__label">{ translate( 'Unassigned licenses' ) }</span>
 				<strong className="billing-summary__value">
-					{ billing.isSuccess && numberFormat( billing.data.licenses.unassigned ) }
+					{ billing.isSuccess && numberFormat( billing.data.licenses.unassigned, 0 ) }
 
 					{ billing.isLoading && <TextPlaceholder /> }
 

--- a/client/blocks/reader-site-subscription/site-subscription-subheader.tsx
+++ b/client/blocks/reader-site-subscription/site-subscription-subheader.tsx
@@ -47,7 +47,7 @@ const SiteSubscriptionSubheader = ( {
 			<div key={ `subscriber-count-${ subscriberCount }` }>
 				{ translate( '%s subscriber', '%s subscribers', {
 					count: subscriberCount,
-					args: [ numberFormat( subscriberCount ) ],
+					args: [ numberFormat( subscriberCount, 0 ) ],
 					comment: '%s is the number of subscribers. For example: "12,000,000"',
 				} ) }
 			</div>

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -154,10 +154,10 @@ function Chart( {
 		<div ref={ yAxisRef } className="chart__y-axis">
 			<div className="chart__y-axis-width-fix">{ numberFormat( 1e5 ) }</div>
 			<div className="chart__y-axis-label is-hundred">
-				{ yMax > 1 ? numberFormat( yMax ) : numberFormat( yMax, { decimals: 2 } ) }
+				{ yMax > 1 ? numberFormat( yMax ) : numberFormat( yMax, 2 ) }
 			</div>
 			<div className="chart__y-axis-label is-fifty">
-				{ yMax > 1 ? numberFormat( yMax / 2 ) : numberFormat( yMax / 2, { decimals: 2 } ) }
+				{ yMax > 1 ? numberFormat( yMax / 2 ) : numberFormat( yMax / 2, 2 ) }
 			</div>
 			<div className="chart__y-axis-label is-zero">{ numberFormat( 0 ) }</div>
 		</div>

--- a/client/components/jetpack/scan-threats/index.tsx
+++ b/client/components/jetpack/scan-threats/index.tsx
@@ -65,7 +65,7 @@ const getThreatCountMessage = (
 		lowThreatsSummary = String(
 			translate( '%(lowCount)s low risk item', '%(lowCount)s low risk items', {
 				args: {
-					lowCount: numberFormat( countLowSeverity ),
+					lowCount: numberFormat( countLowSeverity, 0 ),
 				},
 				comment: '$(lowCount)s is the number of low severity items found.',
 				count: countLowSeverity,
@@ -78,7 +78,7 @@ const getThreatCountMessage = (
 		highThreatsSummary = String(
 			translate( '%(threatCount)s threat', '%(threatCount)s threats', {
 				args: {
-					threatCount: numberFormat( countHighSeverity ),
+					threatCount: numberFormat( countHighSeverity, 0 ),
 				},
 				comment: '%(threatCount)s represents the number of higher severity threats found.',
 				count: countHighSeverity,

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -317,7 +317,6 @@ class CancelPurchaseForm extends Component {
 	getRefundAmount = () => {
 		const { purchase } = this.props;
 		const { refundOptions, currencyCode } = purchase;
-		// TODO clk numberFormat pass through numberFormat if it stays
 		const defaultFormatter = new Intl.NumberFormat( 'en-US', {
 			style: 'currency',
 			currency: currencyCode,

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -111,7 +111,7 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
 	const currencyCode = useSelector( getCurrentUserCurrencyCode ) || 'USD';
-	const numberOfPluginsThemes = numberFormat( 50000 );
+	const numberOfPluginsThemes = numberFormat( 50000, 0 );
 	const discountRate = 25;
 	const couponCode = 'BIZWPC25';
 	const builtByURL = 'https://wordpress.com/website-design-service/?ref=wpcom-cancel-flow';

--- a/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
@@ -69,7 +69,7 @@ export default function BillingSummary() {
 			<div className="billing-summary__stat billing-summary__total-licenses">
 				<span className="billing-summary__label">{ translate( 'Total licenses' ) }</span>
 				<strong className="billing-summary__value">
-					{ billing.isSuccess && numberFormat( billing.data.licenses.total ) }
+					{ billing.isSuccess && numberFormat( billing.data.licenses.total, 0 ) }
 
 					{ billing.isLoading && <TextPlaceholder /> }
 
@@ -80,7 +80,7 @@ export default function BillingSummary() {
 			<div className="billing-summary__stat billing-summary__assigned-licenses">
 				<span className="billing-summary__label">{ translate( 'Assigned licenses' ) }</span>
 				<strong className="billing-summary__value">
-					{ billing.isSuccess && numberFormat( billing.data.licenses.assigned ) }
+					{ billing.isSuccess && numberFormat( billing.data.licenses.assigned, 0 ) }
 
 					{ billing.isLoading && <TextPlaceholder /> }
 
@@ -91,7 +91,7 @@ export default function BillingSummary() {
 			<div className="billing-summary__stat billing-summary__unassigned-licenses">
 				<span className="billing-summary__label">{ translate( 'Unassigned licenses' ) }</span>
 				<strong className="billing-summary__value">
-					{ billing.isSuccess && numberFormat( billing.data.licenses.unassigned ) }
+					{ billing.isSuccess && numberFormat( billing.data.licenses.unassigned, 0 ) }
 
 					{ billing.isLoading && <TextPlaceholder /> }
 

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -261,7 +261,7 @@ export function getDisplayName( purchase: Purchase ): TranslateResult {
 		return i18n.translate( '%(productName)s (%(quantity)s requests per month)', {
 			args: {
 				productName: jetpackProductsDisplayNames[ productSlug ],
-				quantity: numberFormat( purchase.purchaseRenewalQuantity ),
+				quantity: numberFormat( purchase.purchaseRenewalQuantity, 0 ),
 			},
 		} );
 	}
@@ -274,7 +274,7 @@ export function getDisplayName( purchase: Purchase ): TranslateResult {
 		return i18n.translate( '%(productName)s (%(quantity)s views per month)', {
 			args: {
 				productName: jetpackProductsDisplayNames[ productSlug ],
-				quantity: numberFormat( purchase.purchaseRenewalQuantity ),
+				quantity: numberFormat( purchase.purchaseRenewalQuantity, 0 ),
 			},
 		} );
 	}

--- a/client/my-sites/earn/ads/payments.tsx
+++ b/client/my-sites/earn/ads/payments.tsx
@@ -75,9 +75,7 @@ const WordAdsPayments = () => {
 							payment.paymentDate
 						) }
 					</td>
-					<td className="ads__payments-history-value">
-						${ numberFormat( payment.amount, { decimals: 2 } ) }
-					</td>
+					<td className="ads__payments-history-value">${ numberFormat( payment.amount, 2 ) }</td>
 					<td className="ads__payments-history-value">
 						<Badge
 							className="ads__payments-history-badge"

--- a/client/my-sites/plans/jetpack-plans/product-card/product-above-button-text.ts
+++ b/client/my-sites/plans/jetpack-plans/product-card/product-above-button-text.ts
@@ -18,7 +18,7 @@ export default function productAboveButtonText(
 			'*estimated price based on %(records_and_or_requests)s records and/or monthly requests',
 			{
 				args: {
-					records_and_or_requests: numberFormat( siteProduct.tierUsage ),
+					records_and_or_requests: numberFormat( siteProduct.tierUsage, 0 ),
 				},
 				comment:
 					'records_and_or_requests = number of records (posts, pages, etc) in a site or monthly search requests (whichever is greater)',

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -132,9 +132,7 @@ const PluginDetailsHeader = ( {
 							{ translate( 'Active installations' ) }
 						</div>
 						<div className="plugin-details-header__info-value">
-							{ numberFormat( plugin.active_installs, {
-								numberFormatOptions: { notation: 'compact' },
-							} ) }
+							{ numberFormat( plugin.active_installs, { notation: 'compact' } ) }
 						</div>
 					</div>
 				) }

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -160,7 +160,7 @@ const PluginDetailsSidebar = ( {
 						{ translate( 'Active installations' ) }
 					</div>
 					<div className="plugin-details-sidebar__active-installs-value value">
-						{ numberFormat( active_installs, { numberFormatOptions: { notation: 'compact' } } ) }
+						{ numberFormat( active_installs, { notation: 'compact' } ) }
 					</div>
 				</div>
 			) }

--- a/client/my-sites/promote-post-i2/components/promoted-post-filter/index.tsx
+++ b/client/my-sites/promote-post-i2/components/promoted-post-filter/index.tsx
@@ -44,7 +44,7 @@ export default function PromotePostTabBar( { tabs, selectedTab }: Props ) {
 								{ itemCount && itemCount !== 0 ? (
 									<span className="count">
 										{ isCountAmount ? '$' : null }
-										{ numberFormat( itemCount, { decimals: isCountAmount ? 2 : 0 } ) }
+										{ numberFormat( itemCount, isCountAmount ? 2 : 0 ) }
 									</span>
 								) : null }
 							</NavItem>

--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -81,9 +81,8 @@ class AnnualSiteStats extends Component {
 	formatTableValue( key, value ) {
 		const { numberFormat } = this.props;
 		const singleDecimal = [ 'avg_comments', 'avg_likes' ];
-
 		if ( includes( singleDecimal, key ) ) {
-			return numberFormat( value, { decimals: 1 } );
+			return numberFormat( value, 1 );
 		}
 		if ( 'year' === key ) {
 			return value;

--- a/client/my-sites/stats/stats-detail-weeks/index.jsx
+++ b/client/my-sites/stats/stats-detail-weeks/index.jsx
@@ -100,7 +100,8 @@ const StatsPostDetailWeeks = ( props ) => {
 					'is-falling': week.change < 0,
 					'is-same': week.change === 0,
 				} );
-				let displayValue = numberFormat( week.change, { decimals: 2 } ) + '%';
+
+				let displayValue = numberFormat( week.change, 2 ) + '%';
 
 				if ( week.change > 0 ) {
 					iconType = 'arrow-up';

--- a/client/my-sites/stats/stats-views/months.jsx
+++ b/client/my-sites/stats/stats-views/months.jsx
@@ -131,10 +131,7 @@ const StatsViewsMonths = ( props ) => {
 				totals.months[ month ] += value;
 				totals.yearsCount[ year ] += 1;
 				totals.monthsCount[ month ] += 1;
-				displayValue = numberFormat( value, {
-					decimals: 1,
-					numberFormatOptions: { notation: 'compact' },
-				} );
+				displayValue = numberFormat( value, { decimals: 1, notation: 'compact' } );
 			}
 
 			totalValue += value;

--- a/client/my-sites/stats/videopress-stats-module/index.jsx
+++ b/client/my-sites/stats/videopress-stats-module/index.jsx
@@ -225,8 +225,8 @@ class VideoPressStatsModule extends Component {
 										role="button"
 									>
 										{ row.watch_time > 1
-											? numberFormat( row.watch_time, { decimals: 1 } )
-											: `< ${ numberFormat( 1, { decimals: 1 } ) }` }
+											? numberFormat( row.watch_time, 1 )
+											: `< ${ numberFormat( 1, 1 ) }` }
 									</span>
 								</div>
 								<div className="videopress-stats-module__grid-cell videopress-stats-module__grid-metric">

--- a/client/my-sites/stats/wordads/earnings.jsx
+++ b/client/my-sites/stats/wordads/earnings.jsx
@@ -115,7 +115,7 @@ class WordAdsEarnings extends Component {
 		const { earnings, numberFormat, translate } = this.props;
 		const owed =
 			earnings && earnings.total_amount_owed
-				? numberFormat( earnings.total_amount_owed, { decimals: 2 } )
+				? numberFormat( earnings.total_amount_owed, 2 )
 				: '0.00';
 		const notice = translate(
 			'Outstanding amount of $%(amountOwed)s does not exceed the minimum $100 needed to make the payment. ' +
@@ -198,25 +198,19 @@ class WordAdsEarnings extends Component {
 					<span className="ads__earnings-breakdown-label">
 						{ translate( 'Total earnings', { context: 'Sum of earnings' } ) }
 					</span>
-					<span className="ads__earnings-breakdown-value">
-						${ numberFormat( total, { decimals: 2 } ) }
-					</span>
+					<span className="ads__earnings-breakdown-value">${ numberFormat( total, 2 ) }</span>
 				</li>
 				<li className="ads__earnings-breakdown-item">
 					<span className="ads__earnings-breakdown-label">
 						{ translate( 'Total paid', { context: 'Sum of earnings that have been distributed' } ) }
 					</span>
-					<span className="ads__earnings-breakdown-value">
-						${ numberFormat( paid, { decimals: 2 } ) }
-					</span>
+					<span className="ads__earnings-breakdown-value">${ numberFormat( paid, 2 ) }</span>
 				</li>
 				<li className="ads__earnings-breakdown-item">
 					<span className="ads__earnings-breakdown-label">
 						{ translate( 'Outstanding amount', { context: 'Sum earnings left unpaid' } ) }
 					</span>
-					<span className="ads__earnings-breakdown-value">
-						${ numberFormat( owed, { decimals: 2 } ) }
-					</span>
+					<span className="ads__earnings-breakdown-value">${ numberFormat( owed, 2 ) }</span>
 				</li>
 			</ul>
 		);
@@ -236,7 +230,7 @@ class WordAdsEarnings extends Component {
 					<tr key={ type + '-' + period }>
 						<td className="ads__earnings-history-value">{ this.swapYearMonth( period ) }</td>
 						<td className="ads__earnings-history-value">
-							${ numberFormat( earnings[ period ].amount, { decimals: 2 } ) }
+							${ numberFormat( earnings[ period ].amount, 2 ) }
 						</td>
 						<td className="ads__earnings-history-value">
 							{ numberFormat( earnings[ period ].pageviews ) }

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -40,7 +40,7 @@ import './style.scss';
 import 'calypso/my-sites/earn/ads/style.scss';
 
 const formatCurrency = ( value ) => {
-	return '$' + numberFormat( value, { decimals: 2 } );
+	return '$' + numberFormat( value, 2 );
 };
 
 const CHARTS = [

--- a/client/my-sites/store/app/store-stats/utils.js
+++ b/client/my-sites/store/app/store-stats/utils.js
@@ -70,7 +70,7 @@ export function formatValue( value, format, code, decimals ) {
 		case 'currency':
 			return formatCurrency( value, code );
 		case 'number':
-			return numberFormat( value, { ...( typeof decimals === 'number' && { decimals } ) } );
+			return numberFormat( value, decimals );
 		case 'percent':
 			return translate( '%(percentage)s%% ', { args: { percentage: value }, context: 'percent' } );
 		case 'text':

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -85,17 +85,13 @@ const ReaderTagSidebar = ( {
 				<div className="reader-tag-sidebar-stats">
 					<div className="reader-tag-sidebar-stats__item">
 						<span className="reader-tag-sidebar-stats__count">
-							{ numberFormat( tagStats?.data?.total_posts, {
-								numberFormatOptions: { notation: 'compact' },
-							} ) }
+							{ numberFormat( tagStats?.data?.total_posts, { notation: 'compact' } ) }
 						</span>
 						<span className="reader-tag-sidebar-stats__title">{ translate( 'Posts' ) }</span>
 					</div>
 					<div className="reader-tag-sidebar-stats__item">
 						<span className="reader-tag-sidebar-stats__count">
-							{ numberFormat( tagStats?.data?.total_sites, {
-								numberFormatOptions: { notation: 'compact' },
-							} ) }
+							{ numberFormat( tagStats?.data?.total_sites, { notation: 'compact' } ) }
 						</span>
 						<span className="reader-tag-sidebar-stats__title">{ translate( 'Sites' ) }</span>
 					</div>

--- a/client/reader/stream/site-feed-sidebar/index.jsx
+++ b/client/reader/stream/site-feed-sidebar/index.jsx
@@ -46,7 +46,7 @@ const FeedStreamSidebar = ( {
 					{ postCount && (
 						<div className="reader-tag-sidebar-stats__item">
 							<span className="reader-tag-sidebar-stats__count">
-								{ numberFormat( postCount, { numberFormatOptions: { notation: 'compact' } } ) }
+								{ numberFormat( postCount, { notation: 'compact' } ) }
 							</span>
 							<span className="reader-tag-sidebar-stats__title">
 								{ translate( 'Post', 'Posts', { count: postCount } ) }

--- a/client/reader/tags/trending-tags.tsx
+++ b/client/reader/tags/trending-tags.tsx
@@ -28,7 +28,7 @@ const TagRow = ( props: TagRowProps ) => {
 			<a href={ path } onClick={ trackTagClick.bind( null, props.slug ) }>
 				<span className="trending-tags__title">{ titlecase( props.title ) }</span>
 				<span className="trending-tags__count">
-					{ numberFormat( props.count, { numberFormatOptions: { notation: 'compact' } } ) }
+					{ numberFormat( props.count, { notation: 'compact' } ) }
 				</span>
 			</a>
 		</div>

--- a/client/sites/tools/monitoring/components/site-monitoring-line-chart/index.tsx
+++ b/client/sites/tools/monitoring/components/site-monitoring-line-chart/index.tsx
@@ -88,7 +88,7 @@ function createSeries( series: Array< SeriesProp > ) {
 						return '-';
 					}
 
-					return numberFormat( rawValue, { decimals: 0 } );
+					return numberFormat( rawValue, 0 );
 				},
 			},
 		};

--- a/packages/components/src/chart-uplot/index.tsx
+++ b/packages/components/src/chart-uplot/index.tsx
@@ -63,7 +63,7 @@ export default function UplotChart( {
 					return '-';
 				}
 
-				return numberFormat( rawValue, { decimals: 0 } );
+				return numberFormat( rawValue, 0 );
 			},
 		};
 

--- a/packages/components/src/count/index.jsx
+++ b/packages/components/src/count/index.jsx
@@ -18,9 +18,7 @@ export const Count = ( {
 
 	return (
 		<span ref={ forwardRef } className={ clsx( 'count', { 'is-primary': primary } ) } { ...props }>
-			{ compact
-				? numberFormat( count, { numberFormatOptions: { notation: 'compact' } } )
-				: effectiveNumberFormat( count ) }
+			{ compact ? numberFormat( count, { notation: 'compact' } ) : effectiveNumberFormat( count ) }
 		</span>
 	);
 };

--- a/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx
+++ b/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx
@@ -111,8 +111,7 @@ const HorizontalBarListItem = ( {
 		if ( formatValue ) {
 			return formatValue( value, data );
 		}
-
-		return usePlainCard ? value : numberFormat( value, { decimals: 0 } );
+		return usePlainCard ? value : numberFormat( value, 0 );
 	};
 
 	return (

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -168,12 +168,13 @@ I18N.prototype.emit = function ( ...args ) {
 
 /**
  * Formats numbers using locale settings and/or passed options.
- * @returns {string | number}  Formatted number as string, or original number if formatting fails
+ * @param   {string | number}  number to format (required)
+ * @param   {number | Object}  options  Number of decimal places or options object (optional)
+ * @param   {boolean}          forceLatin Whether to use latin numbers by default (optional. default = true)
+ * @returns {string | number}  Formatted number as string, or original number if formatting fails. Null otherwise.
  */
-I18N.prototype.numberFormat = function (
-	number,
-	{ decimals = 0, forceLatin = true, numberFormatOptions = {} } = {}
-) {
+I18N.prototype.numberFormat = function ( number, options = {}, forceLatin = true ) {
+	const decimals = typeof options === 'number' ? options : options.decimals || 0;
 	const browserSafeLocale = this.getBrowserSafeLocale();
 
 	/**
@@ -190,7 +191,7 @@ I18N.prototype.numberFormat = function (
 			minimumFractionDigits: decimals, // default is 0
 			maximumFractionDigits: decimals, // default is the greater between minimumFractionDigits and 3
 			// TODO clk numberFormat this may be the only difference, where some cases use 2 (they can just pass the option to Intl.NumberFormat)
-			...numberFormatOptions,
+			...( options?.notation && { notation: options.notation } ),
 		} ).format( number );
 	} catch ( error ) {
 		warn( 'numberFormat(): Error formatting number with Intl.NumberFormat: ', number, error );

--- a/packages/i18n-calypso/test/index.js
+++ b/packages/i18n-calypso/test/index.js
@@ -258,13 +258,17 @@ describe( 'I18n', function () {
 
 		describe( 'with decimal', function () {
 			it( 'should default to locale decimal separator (, for German in test)', function () {
-				expect( numberFormat( 150, { decimals: 2 } ) ).toBe( '150,00' );
-			} );
-			it( 'should force the specified decimals to a not fractional number/integer', function () {
-				expect( numberFormat( 150, { decimals: 2 } ) ).toBe( '150,00' );
+				expect( numberFormat( 150, 2 ) ).toBe( '150,00' );
 			} );
 			it( 'should truncate to specified decimal', function () {
-				expect( numberFormat( 150.312, { decimals: 2 } ) ).toBe( '150,31' );
+				expect( numberFormat( 150.312, 2 ) ).toBe( '150,31' );
+			} );
+			it( 'should accept decimal as argument or object attribute', function () {
+				expect(
+					numberFormat( 150, {
+						decimals: 2,
+					} )
+				).toBe( '150,00' );
 			} );
 		} );
 
@@ -289,18 +293,12 @@ describe( 'I18n', function () {
 					} );
 				} );
 				test( 'defaults to latin notation and localised unit', () => {
-					expect(
-						numberFormat( 1234, { numberFormatOptions: { notation: 'compact' }, decimals: 1 } )
-					).toEqual( '1.2 ألف' );
+					expect( numberFormat( 1234, { notation: 'compact', decimals: 1 } ) ).toEqual( '1.2 ألف' );
 				} );
 				test( 'non-latin/original notation and localised unit', () => {
-					expect(
-						numberFormat( 1234, {
-							numberFormatOptions: { notation: 'compact' },
-							decimals: 1,
-							forceLatin: false,
-						} )
-					).toEqual( '١٫٢ ألف' );
+					expect( numberFormat( 1234, { notation: 'compact', decimals: 1 }, false ) ).toEqual(
+						'١٫٢ ألف'
+					);
 				} );
 			} );
 		} );

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -63,21 +63,8 @@ export type TranslateOptionsPluralText = TranslateOptionsPlural & { textOnly: tr
 export type TranslateResult = ExistingReactNode;
 
 export interface NumberFormatOptions {
-	/**
-	 * Number of decimal places to use.
-	 * This is just convenience over setting `minimumFractionDigits`, `maximumFractionDigits` to the same value.
-	 * ( default = 0 )
-	 */
 	decimals?: number;
-	/**
-	 * Whether to use latin numbers by default ( default = true )
-	 */
-	forceLatin?: boolean;
-	/**
-	 * `Intl.NumberFormat` options to pass through.
-	 * `minimumFractionDigits` & `maximumFractionDigits` will override `decimals` if set.
-	 */
-	numberFormatOptions?: Intl.NumberFormatOptions;
+	notation: Intl.NumberFormatOptions[ 'notation' ];
 }
 
 export type TranslateHook = (
@@ -106,6 +93,7 @@ export interface I18N {
 	translate( original: string, plural: string, options: TranslateOptionsPlural ): ExistingReactNode;
 	translate( original: string, plural: string, options: TranslateOptionsPluralText ): string;
 
+	numberFormat( number: number, numberOfDecimalPlaces?: number ): string | number;
 	numberFormat( number: number, options?: NumberFormatOptions ): string | number;
 
 	setLocale( localeData: LocaleData ): void;

--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -113,7 +113,7 @@ export function getLabel( product: ResponseCartProduct ): string {
 		return translate( '%(productName)s - %(quantity)s views per month', {
 			args: {
 				productName: product.product_name,
-				quantity: numberFormat( product.quantity, { decimals: 0 } ),
+				quantity: numberFormat( product.quantity, 0 ),
 			},
 			textOnly: true,
 		} );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#98694