### PR TITLE
i18n: Fix compact-number translations on /stats page

### DIFF
--- a/client/my-sites/stats/stats-tabs/tab.jsx
+++ b/client/my-sites/stats/stats-tabs/tab.jsx
@@ -1,6 +1,5 @@
 import { TooltipContent } from '@automattic/components/src/highlight-cards/count-card';
 import { TrendComparison } from '@automattic/components/src/highlight-cards/count-comparison-card';
-import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import Popover from '@automattic/components/src/popover';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
@@ -38,7 +37,7 @@ class StatsTabsTab extends Component {
 	};
 
 	ensureValue = ( value ) => {
-		const { loading, numberFormat, format } = this.props;
+		const { loading, format, numberFormat } = this.props;
 
 		if ( ! loading && ( value || value === 0 ) ) {
 			return format ? format( value ) : numberFormat( value );
@@ -67,6 +66,7 @@ class StatsTabsTab extends Component {
 			previousValue,
 			value,
 			hasPreviousData,
+			numberFormat,
 		} = this.props;
 
 		const tabClass = clsx( 'stats-tab', className, {
@@ -100,7 +100,12 @@ class StatsTabsTab extends Component {
 					{ hasPreviousData && (
 						<div className="stats-tabs__highlight">
 							<span className="stats-tabs__highlight-value" ref={ this.tooltipRef }>
-								{ formatNumber( value ) }
+								{ numberFormat( value, {
+									numberFormatOptions: {
+										notation: 'compact',
+										maximumFractionDigits: 1,
+									},
+								} ) }
 							</span>
 							<TrendComparison count={ value } previousCount={ previousValue } />
 							<Popover


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/i18n-issues/issues/917

## Proposed Changes

On `/stats` page, in the main chart/view, the numbers in compact form aren't being translated correctly. They are always in the default/EN locale. This looks to be due to using the number-format from [@automattc/components:number-formatter](https://github.com/Automattic/wp-calypso/blob/trunk/packages/components/src/number-formatters/lib/format-number.ts). I am not sure though if this was intentional - apparently the locales are set differently across that and i18n-calypso's `numberFormat` method.

## Media

### Before

<img width="800" alt="Screenshot 2025-01-27 at 12 31 12 PM" src="https://github.com/user-attachments/assets/8565bab8-066b-4fcb-8103-1ec55ef4204b" />


### After

<img width="800" alt="Screenshot 2025-01-27 at 12 31 29 PM" src="https://github.com/user-attachments/assets/5655d1b2-6878-4482-afee-79fa4b5c6772" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix https://github.com/Automattic/i18n-issues/issues/917

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/stats/day/:site` (use FG for site). The compact number is displayed with English characters e.g. `44.3K`. 
- Switch locale from settings e.g. to Greek. It should show a translated unit instead e.g. `44.3 χιλ.`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
