### PR TITLE
Social previews | Remove learn more for link previews

### DIFF
--- a/packages/social-previews/CHANGELOG.md
+++ b/packages/social-previews/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added Threads and Bluesky preview
 - Fixed media image URL for Tumblr and Instagram previews
+- Removed the learn more link for link previews
 
 ## v2.0.1 (2024-06-10)
 

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "2.1.0-beta.8",
+	"version": "2.1.0-beta.9",
 	"description": "A suite of components to generate previews for a post for both social and search engines.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/social-previews/src/bluesky-preview/previews.tsx
+++ b/packages/social-previews/src/bluesky-preview/previews.tsx
@@ -1,4 +1,3 @@
-import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { SectionHeading } from '../shared/section-heading';
 import { SocialPreviewsBaseProps } from '../types';
@@ -43,10 +42,6 @@ export const BlueskyPreviews: React.FC< BlueskyPreviewsProps > = ( {
 							'This is what it will look like when someone shares the link to your WordPress post on Bluesky.',
 							'social-previews'
 						) }
-						&nbsp;
-						<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
-							{ __( 'Learn more about links', 'social-previews' ) }
-						</ExternalLink>
 					</p>
 					<BlueskyLinkPreview { ...props } />
 				</section>

--- a/packages/social-previews/src/facebook-preview/previews.tsx
+++ b/packages/social-previews/src/facebook-preview/previews.tsx
@@ -1,4 +1,3 @@
-import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import SectionHeading from '../shared/section-heading';
 import { SocialPreviewsBaseProps } from '../types';
@@ -47,10 +46,6 @@ export const FacebookPreviews: React.FC< FacebookPreviewsProps > = ( {
 							'This is what it will look like when someone shares the link to your WordPress post on Facebook.',
 							'social-previews'
 						) }
-						&nbsp;
-						<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
-							{ __( 'Learn more about links', 'social-previews' ) }
-						</ExternalLink>
 					</p>
 					{ hasCustomImage ? (
 						<LinkPreviewDetails { ...props } />

--- a/packages/social-previews/src/linkedin-preview/previews.tsx
+++ b/packages/social-previews/src/linkedin-preview/previews.tsx
@@ -1,4 +1,3 @@
-import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import SectionHeading from '../shared/section-heading';
 import { LinkedInLinkPreview } from './link-preview';
@@ -40,10 +39,6 @@ export const LinkedInPreviews: React.FC< LinkedInPreviewsProps > = ( {
 							'This is what it will look like when someone shares the link to your WordPress post on LinkedIn.',
 							'social-previews'
 						) }
-						&nbsp;
-						<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
-							{ __( 'Learn more about links', 'social-previews' ) }
-						</ExternalLink>
 					</p>
 					<LinkedInLinkPreview { ...props } name="" profileImage="" />
 				</section>

--- a/packages/social-previews/src/mastodon-preview/previews.tsx
+++ b/packages/social-previews/src/mastodon-preview/previews.tsx
@@ -1,4 +1,3 @@
-import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { SectionHeading } from '../shared/section-heading';
 import { SocialPreviewsBaseProps } from '../types';
@@ -43,10 +42,6 @@ export const MastodonPreviews: React.FC< MastodonPreviewsProps > = ( {
 							'This is what it will look like when someone shares the link to your WordPress post on Mastodon.',
 							'social-previews'
 						) }
-						&nbsp;
-						<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
-							{ __( 'Learn more about links', 'social-previews' ) }
-						</ExternalLink>
 					</p>
 					<MastodonLinkPreview { ...props } user={ undefined } />
 				</section>

--- a/packages/social-previews/src/nextdoor-preview/previews.tsx
+++ b/packages/social-previews/src/nextdoor-preview/previews.tsx
@@ -1,4 +1,3 @@
-import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import SectionHeading from '../shared/section-heading';
 import { NextdoorLinkPreview } from './link-preview';
@@ -40,10 +39,6 @@ export const NextdoorPreviews: React.FC< NextdoorPreviewsProps > = ( {
 							'This is what it will look like when someone shares the link to your WordPress post on Nextdoor.',
 							'social-previews'
 						) }
-						&nbsp;
-						<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
-							{ __( 'Learn more about links', 'social-previews' ) }
-						</ExternalLink>
 					</p>
 					<NextdoorLinkPreview { ...props } name="" profileImage="" />
 				</section>

--- a/packages/social-previews/src/threads-preview/previews.tsx
+++ b/packages/social-previews/src/threads-preview/previews.tsx
@@ -1,4 +1,3 @@
-import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import SectionHeading from '../shared/section-heading';
 import { ThreadsLinkPreview } from './link-preview';
@@ -55,10 +54,6 @@ export const ThreadsPreviews: React.FC< ThreadsPreviewsProps > = ( {
 									'This is what it will look like when someone shares the link to your WordPress post on Threads.',
 									'social-previews'
 								) }
-								&nbsp;
-								<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
-									{ __( 'Learn more about links', 'social-previews' ) }
-								</ExternalLink>
 							</p>
 							<ThreadsLinkPreview { ...posts[ 0 ] } name="" profileImage="" />
 						</>

--- a/packages/social-previews/src/tumblr-preview/previews.tsx
+++ b/packages/social-previews/src/tumblr-preview/previews.tsx
@@ -1,4 +1,3 @@
-import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { SectionHeading } from '../shared/section-heading';
 import { SocialPreviewsBaseProps } from '../types';
@@ -45,10 +44,6 @@ export const TumblrPreviews: React.FC< TumblrPreviewsProps > = ( {
 							'This is what it will look like when someone shares the link to your WordPress post on Tumblr.',
 							'social-previews'
 						) }
-						&nbsp;
-						<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
-							{ __( 'Learn more about links', 'social-previews' ) }
-						</ExternalLink>
 					</p>
 					<TumblrLinkPreview { ...props } user={ undefined } />
 				</section>

--- a/packages/social-previews/src/twitter-preview/previews.tsx
+++ b/packages/social-previews/src/twitter-preview/previews.tsx
@@ -1,4 +1,3 @@
-import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import SectionHeading from '../shared/section-heading';
 import { TwitterLinkPreview } from './link-preview';
@@ -53,10 +52,6 @@ export const TwitterPreviews: React.FC< TwitterPreviewsProps > = ( {
 							'This is what it will look like when someone shares the link to your WordPress post on X.',
 							'social-previews'
 						) }
-						&nbsp;
-						<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
-							{ __( 'Learn more about links', 'social-previews' ) }
-						</ExternalLink>
 					</p>
 					<TwitterLinkPreview { ...tweets[ 0 ] } name="" profileImage="" screenName="" />
 				</section>


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/41063

## Proposed Changes

* Remove the needless learn more link in Social Previews components which anyway points to the wrong documentation.
<img width="947" alt="Screenshot 2025-01-27 at 4 59 22 PM" src="https://github.com/user-attachments/assets/0ba58897-1c91-4e59-8ebc-164dde490c94" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This can be tested via https://github.com/Automattic/jetpack/pull/41329

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
