### PR TITLE
Help Center: Wire initial message, siteId, and siteUrl from url

### DIFF
--- a/packages/help-center/src/hooks/use-action-hooks.ts
+++ b/packages/help-center/src/hooks/use-action-hooks.ts
@@ -60,7 +60,13 @@ export const useActionHooks = () => {
 				return queryParams.get( 'help-center' ) === 'happiness-engineer';
 			},
 			action() {
-				setNavigateToRoute( '/odie?provider=zendesk' );
+				const message = queryParams.get( 'user-message' ) ?? '';
+				const siteUrl = queryParams.get( 'site-url' ) ?? '';
+				const siteId = queryParams.get( 'site-id' ) ?? '';
+
+				setNavigateToRoute(
+					`/odie?provider=zendesk&userFieldMessage=${ message }&siteUrl=${ siteUrl }&siteId=${ siteId }`
+				);
 				setShowHelpCenter( true );
 			},
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9733

## Proposed Changes

* wire initial message, site id and site url when opening direct chat from url

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We have use cases where we need to open the hc and open a direct chat with zendesk with customizable message via the URL

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the PR link or build the branch locally
* Visit `http://calypso.localhost:3000/help?help-center=happiness-engineer&user-message=SOME_TEXT&site-id=SITE_ID&site-url=SITE_URL`
* Ensure that by visiting this URL a chat is opened with zd directly
* Ensure that the correct user message, site id and site url are used

