### PR TITLE
Stats: Add new tab for real-time stats

### DIFF
--- a/client/blocks/stats-navigation/constants.ts
+++ b/client/blocks/stats-navigation/constants.ts
@@ -104,6 +104,12 @@ const googleMyBusiness = {
 	showIntervals: false,
 } as NavItem;
 
+const realtime = {
+	label: translate( 'Realtime' ),
+	path: '/stats/realtime',
+	showIntervals: false,
+} as NavItem;
+
 export interface NavItems {
 	traffic: NavItem;
 	insights: NavItem;
@@ -111,11 +117,13 @@ export interface NavItems {
 	wordads: NavItem;
 	googleMyBusiness: NavItem;
 	subscribers?: NavItem;
+	realtime?: NavItem;
 }
 
 const assembleNavItems = () => {
 	const navItems = {
 		traffic,
+		realtime,
 		insights,
 		subscribers,
 		store,

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -167,7 +167,7 @@ class StatsNavigation extends Component {
 				if ( 'undefined' === typeof siteId ) {
 					return false;
 				}
-				return false; // config.isEnabled( 'stats/real-time-tab' );
+				return config.isEnabled( 'stats/real-time-tab' );
 
 			default:
 				return true;

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -161,9 +161,13 @@ class StatsNavigation extends Component {
 				return config.isEnabled( 'google-my-business' ) && isGoogleMyBusinessLocationConnected;
 
 			case 'subscribers':
+				return 'undefined' === typeof siteId ? false : true;
+
+			case 'realtime':
 				if ( 'undefined' === typeof siteId ) {
 					return false;
 				}
+				return false; // config.isEnabled( 'stats/real-time-tab' );
 
 			default:
 				return true;

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -515,5 +515,6 @@ export function emailSummary( context, next ) {
 }
 
 export { default as insights } from './pages/insights/controller';
+export { default as realtime } from './pages/realtime/controller';
 export { default as subscribers } from './pages/subscribers/controller';
 export { default as purchase } from './pages/purchase/controller';

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -18,6 +18,7 @@ import {
 	subscribers,
 	purchase,
 	redirectToDaySummary,
+	realtime,
 } from './controller';
 
 import './style.scss';
@@ -51,6 +52,9 @@ export default function () {
 	// Redirect this to default /stats/day view in order to keep
 	// the paths and page view reporting consistent.
 	page( '/stats', '/stats/day' );
+
+	// Realtime stats?!
+	statsPage( '/stats/realtime/:site', realtime );
 
 	// Stat Overview Page
 	statsPage( `/stats/:period(${ validPeriods })`, overview );

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -53,7 +53,9 @@ export default function () {
 	// the paths and page view reporting consistent.
 	page( '/stats', '/stats/day' );
 
-	// Realtime stats?!
+	// Real-time stats?!
+	// ToDo: Clarify usage of real time.
+	// Not really used as one word generally.
 	statsPage( '/stats/realtime/:site', realtime );
 
 	// Stat Overview Page

--- a/client/my-sites/stats/pages/realtime/controller.tsx
+++ b/client/my-sites/stats/pages/realtime/controller.tsx
@@ -6,11 +6,7 @@ setTimeout( () => import( 'calypso/my-sites/stats/pages/realtime' ), 3000 );
 
 function realtime( context: Context, next: () => void ) {
 	context.primary = (
-		<AsyncLoad
-			require="calypso/my-sites/stats/pages/realtime"
-			placeholder={ PageLoading }
-			query={ context.query }
-		/>
+		<AsyncLoad require="calypso/my-sites/stats/pages/realtime" placeholder={ PageLoading } />
 	);
 	next();
 }

--- a/client/my-sites/stats/pages/realtime/controller.tsx
+++ b/client/my-sites/stats/pages/realtime/controller.tsx
@@ -1,0 +1,18 @@
+import AsyncLoad from 'calypso/components/async-load';
+import PageLoading from '../shared/page-loading';
+import type { Context } from '@automattic/calypso-router';
+
+setTimeout( () => import( 'calypso/my-sites/stats/pages/realtime' ), 3000 );
+
+function realtime( context: Context, next: () => void ) {
+	context.primary = (
+		<AsyncLoad
+			require="calypso/my-sites/stats/pages/realtime"
+			placeholder={ PageLoading }
+			query={ context.query }
+		/>
+	);
+	next();
+}
+
+export default realtime;

--- a/client/my-sites/stats/pages/realtime/index.jsx
+++ b/client/my-sites/stats/pages/realtime/index.jsx
@@ -1,0 +1,87 @@
+import config from '@automattic/calypso-config';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import StatsNavigation from 'calypso/blocks/stats-navigation';
+import { navItems } from 'calypso/blocks/stats-navigation/constants';
+import DocumentHead from 'calypso/components/data/document-head';
+import JetpackColophon from 'calypso/components/jetpack-colophon';
+import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
+import StatsModuleTopPosts from 'calypso/my-sites/stats/features/modules/stats-top-posts';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import AnnualHighlightsSection from '../../sections/annual-highlights-section';
+import PageViewTracker from '../../stats-page-view-tracker';
+import statsStrings from '../../stats-strings';
+
+const StatsRealtime = ( props ) => {
+	const { query, siteId, siteSlug, isOdysseyStats, isJetpack } = props;
+	const translate = useTranslate();
+	const moduleStrings = statsStrings();
+
+	const statsModuleListClass = clsx(
+		'stats__module-list--insights',
+		'stats__module--unified',
+		'stats__module-list',
+		'stats__flexible-grid-container',
+		{
+			'is-odyssey-stats': isOdysseyStats,
+			'is-jetpack': isJetpack,
+		}
+	);
+
+	const halfWidthModuleClasses = clsx(
+		'stats__flexible-grid-item--half',
+		'stats__flexible-grid-item--full--large',
+		'stats__flexible-grid-item--full--medium'
+	);
+
+	// Track the last viewed tab.
+	// Necessary to properly configure the fixed navigation headers.
+	sessionStorage.setItem( 'jp-stats-last-tab', 'realtime' );
+
+	// TODO: should be refactored into separate components
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	return (
+		<Main fullWidthLayout>
+			<DocumentHead title={ translate( 'Jetpack Stats' ) } />
+			<PageViewTracker path="/stats/realtime/:site" title="Stats > Realtime" />
+			<div className="stats">
+				<NavigationHeader
+					className="stats__section-header modernized-header"
+					title={ translate( 'Jetpack Stats' ) }
+					subtitle={ translate( "View your site's performance and learn from trends." ) }
+					screenReader={ navItems.realtime?.label }
+					navigationItems={ [] }
+				></NavigationHeader>
+				<StatsNavigation selectedItem="realtime" siteId={ siteId } slug={ siteSlug } />
+				<AnnualHighlightsSection siteId={ siteId } />
+				<div className={ statsModuleListClass }>
+					<StatsModuleTopPosts
+						moduleStrings={ moduleStrings.posts }
+						period={ props.period }
+						query={ query }
+						summaryUrl="https://example.com/" // { getStatHref( 'posts', query ) }
+						className={ halfWidthModuleClasses }
+					/>
+				</div>
+				<JetpackColophon />
+			</div>
+		</Main>
+	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
+};
+
+const connectComponent = connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	return {
+		siteId,
+		siteSlug: getSelectedSiteSlug( state, siteId ),
+		isOdysseyStats,
+		isJetpack: isJetpackSite( state, siteId ),
+	};
+} );
+
+export default connectComponent( StatsRealtime );

--- a/client/my-sites/stats/pages/realtime/index.jsx
+++ b/client/my-sites/stats/pages/realtime/index.jsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { connect, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -33,8 +33,10 @@ function StatsModuleListing( props ) {
 	return <div className={ fullClassName }>{ props.children }</div>;
 }
 
-const StatsRealtime = ( props ) => {
-	const { query, siteId, siteSlug } = props;
+function StatsRealtime( props ) {
+	const { query } = props;
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state, siteId ) );
 	const translate = useTranslate();
 	const moduleStrings = statsStrings();
 
@@ -78,17 +80,6 @@ const StatsRealtime = ( props ) => {
 		</Main>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
-};
+}
 
-const connectComponent = connect( ( state ) => {
-	const siteId = getSelectedSiteId( state );
-	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-	return {
-		siteId,
-		siteSlug: getSelectedSiteSlug( state, siteId ),
-		isOdysseyStats,
-		isJetpack: isJetpackSite( state, siteId ),
-	};
-} );
-
-export default connectComponent( StatsRealtime );
+export default StatsRealtime;

--- a/client/my-sites/stats/pages/realtime/index.jsx
+++ b/client/my-sites/stats/pages/realtime/index.jsx
@@ -14,7 +14,7 @@ import PageViewTracker from '../../stats-page-view-tracker';
 import statsStrings from '../../stats-strings';
 import StatsModuleListing from '../shared/stats-module-listing';
 
-function StatsRealtime( props ) {
+function StatsRealtime() {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state, siteId ) );
 	const translate = useTranslate();
@@ -27,8 +27,9 @@ function StatsRealtime( props ) {
 	);
 
 	// TODO: Determine how query will be set up.
-	// Need a query and a URL to use Top Posts.
-	// See example on Traffic page: getStatHref( 'posts', query )
+	// Need a period, a query, and a URL to use Top Posts.
+	// See getStatHref() example on Traffic page for URL.
+	const period = {};
 	const query = {};
 	const url = '#';
 
@@ -55,7 +56,7 @@ function StatsRealtime( props ) {
 				<StatsModuleListing className="stats__module-list--insights" siteId={ siteId }>
 					<StatsModuleTopPosts
 						moduleStrings={ moduleStrings.posts }
-						period={ props.period }
+						period={ period }
 						query={ query }
 						summaryUrl={ url }
 						className={ halfWidthModuleClasses }

--- a/client/my-sites/stats/pages/realtime/index.jsx
+++ b/client/my-sites/stats/pages/realtime/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
@@ -9,29 +8,11 @@ import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import StatsModuleTopPosts from 'calypso/my-sites/stats/features/modules/stats-top-posts';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import AnnualHighlightsSection from '../../sections/annual-highlights-section';
 import PageViewTracker from '../../stats-page-view-tracker';
 import statsStrings from '../../stats-strings';
-
-function StatsModuleListing( props ) {
-	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-	const isJetpack = useSelector( ( state ) => isJetpackSite( state, props.siteId ) );
-
-	const fullClassName = clsx(
-		props.className ?? '',
-		'stats__module--unified',
-		'stats__module-list',
-		'stats__flexible-grid-container',
-		{
-			'is-odyssey-stats': isOdysseyStats,
-			'is-jetpack': isJetpack,
-		}
-	);
-
-	return <div className={ fullClassName }>{ props.children }</div>;
-}
+import StatsModuleListing from '../shared/stats-module-listing';
 
 function StatsRealtime( props ) {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );

--- a/client/my-sites/stats/pages/realtime/index.jsx
+++ b/client/my-sites/stats/pages/realtime/index.jsx
@@ -34,7 +34,6 @@ function StatsModuleListing( props ) {
 }
 
 function StatsRealtime( props ) {
-	const { query } = props;
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state, siteId ) );
 	const translate = useTranslate();
@@ -45,6 +44,12 @@ function StatsRealtime( props ) {
 		'stats__flexible-grid-item--full--large',
 		'stats__flexible-grid-item--full--medium'
 	);
+
+	// TODO: Determine how query will be set up.
+	// Need a query and a URL to use Top Posts.
+	// See example on Traffic page: getStatHref( 'posts', query )
+	const query = {};
+	const url = '#';
 
 	// Track the last viewed tab.
 	// Necessary to properly configure the fixed navigation headers.
@@ -71,7 +76,7 @@ function StatsRealtime( props ) {
 						moduleStrings={ moduleStrings.posts }
 						period={ props.period }
 						query={ query }
-						summaryUrl="https://example.com/" // { getStatHref( 'posts', query ) }
+						summaryUrl={ url }
 						className={ halfWidthModuleClasses }
 					/>
 				</StatsModuleListing>

--- a/client/my-sites/stats/pages/realtime/index.jsx
+++ b/client/my-sites/stats/pages/realtime/index.jsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -15,13 +15,12 @@ import AnnualHighlightsSection from '../../sections/annual-highlights-section';
 import PageViewTracker from '../../stats-page-view-tracker';
 import statsStrings from '../../stats-strings';
 
-const StatsRealtime = ( props ) => {
-	const { query, siteId, siteSlug, isOdysseyStats, isJetpack } = props;
-	const translate = useTranslate();
-	const moduleStrings = statsStrings();
+function StatsModuleListing( props ) {
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, props.siteId ) );
 
-	const statsModuleListClass = clsx(
-		'stats__module-list--insights',
+	const fullClassName = clsx(
+		props.className ?? '',
 		'stats__module--unified',
 		'stats__module-list',
 		'stats__flexible-grid-container',
@@ -30,6 +29,14 @@ const StatsRealtime = ( props ) => {
 			'is-jetpack': isJetpack,
 		}
 	);
+
+	return <div className={ fullClassName }>{ props.children }</div>;
+}
+
+const StatsRealtime = ( props ) => {
+	const { query, siteId, siteSlug } = props;
+	const translate = useTranslate();
+	const moduleStrings = statsStrings();
 
 	const halfWidthModuleClasses = clsx(
 		'stats__flexible-grid-item--half',
@@ -57,7 +64,7 @@ const StatsRealtime = ( props ) => {
 				></NavigationHeader>
 				<StatsNavigation selectedItem="realtime" siteId={ siteId } slug={ siteSlug } />
 				<AnnualHighlightsSection siteId={ siteId } />
-				<div className={ statsModuleListClass }>
+				<StatsModuleListing className="stats__module-list--insights" siteId={ siteId }>
 					<StatsModuleTopPosts
 						moduleStrings={ moduleStrings.posts }
 						period={ props.period }
@@ -65,7 +72,7 @@ const StatsRealtime = ( props ) => {
 						summaryUrl="https://example.com/" // { getStatHref( 'posts', query ) }
 						className={ halfWidthModuleClasses }
 					/>
-				</div>
+				</StatsModuleListing>
 				<JetpackColophon />
 			</div>
 		</Main>

--- a/client/my-sites/stats/pages/shared/stats-module-listing.tsx
+++ b/client/my-sites/stats/pages/shared/stats-module-listing.tsx
@@ -1,0 +1,31 @@
+import config from '@automattic/calypso-config';
+import clsx from 'clsx';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+
+type StatsModuleListingProps = {
+	children: React.ReactNode;
+	className: string | null;
+	siteId: number;
+};
+
+function StatsModuleListing( props: StatsModuleListingProps ) {
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, props.siteId ) );
+
+	const fullClassName = clsx(
+		props.className ?? '',
+		'stats__module--unified',
+		'stats__module-list',
+		'stats__flexible-grid-container',
+		{
+			'is-odyssey-stats': isOdysseyStats,
+			'is-jetpack': isJetpack,
+		}
+	);
+
+	return <div className={ fullClassName }>{ props.children }</div>;
+}
+
+export default StatsModuleListing;

--- a/client/my-sites/stats/pages/shared/stats-module-listing.tsx
+++ b/client/my-sites/stats/pages/shared/stats-module-listing.tsx
@@ -10,12 +10,12 @@ type StatsModuleListingProps = {
 	siteId: number | null;
 };
 
-function StatsModuleListing( props: StatsModuleListingProps ) {
+function StatsModuleListing( { children, className, siteId }: StatsModuleListingProps ) {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-	const isJetpack = useSelector( ( state ) => isJetpackSite( state, props.siteId ) );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 
 	const fullClassName = clsx(
-		props.className ?? '',
+		className ?? '',
 		'stats__module--unified',
 		'stats__module-list',
 		'stats__flexible-grid-container',
@@ -25,11 +25,11 @@ function StatsModuleListing( props: StatsModuleListingProps ) {
 		}
 	);
 
-	if ( ! props.siteId ) {
+	if ( ! siteId ) {
 		return null;
 	}
 
-	return <div className={ fullClassName }>{ props.children }</div>;
+	return <div className={ fullClassName }>{ children }</div>;
 }
 
 export default StatsModuleListing;

--- a/client/my-sites/stats/pages/shared/stats-module-listing.tsx
+++ b/client/my-sites/stats/pages/shared/stats-module-listing.tsx
@@ -7,7 +7,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 type StatsModuleListingProps = {
 	children: React.ReactNode;
 	className: string | null;
-	siteId: number;
+	siteId: number | null;
 };
 
 function StatsModuleListing( props: StatsModuleListingProps ) {
@@ -24,6 +24,10 @@ function StatsModuleListing( props: StatsModuleListingProps ) {
 			'is-jetpack': isJetpack,
 		}
 	);
+
+	if ( ! props.siteId ) {
+		return null;
+	}
 
 	return <div className={ fullClassName }>{ props.children }</div>;
 }

--- a/config/client.json
+++ b/config/client.json
@@ -23,6 +23,7 @@
 	"signup_url",
 	"stats/empty-module-traffic",
 	"stats/empty-module-v2",
+	"stats/real-time-tab",
 	"wpcom_concierge_schedule_id",
 	"wpcom_signup_id",
 	"wpcom_signup_key",

--- a/config/development.json
+++ b/config/development.json
@@ -194,6 +194,7 @@
 		"stats/locations": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
+		"stats/real-time-tab": true,
 		"subscriber-importer": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -127,6 +127,7 @@
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,
+		"stats/real-time-tab": false,
 		"subscriber-importer": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,

--- a/config/production.json
+++ b/config/production.json
@@ -163,6 +163,7 @@
 		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
+		"stats/real-time-tab": false,
 		"subscriber-importer": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -159,6 +159,7 @@
 		"stats/locations": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
+		"stats/real-time-tab": false,
 		"subscriber-importer": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -165,6 +165,7 @@
 		"stats/locations": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
+		"stats/real-time-tab": false,
 		"subscriber-importer": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Introduces a new "Realtime" tab to the Stats dashboard.

Initially based on the Insights page with some small refactorings to move away from the `connect()` pattern and to extract the module listing "wrapper" component that's repeated across a few of the pages (Insights, Subscribers, and now Realtime).

<img width="732" alt="SCR-20250128-bljx" src="https://github.com/user-attachments/assets/dc46ee59-a90e-4940-a43e-5fd681d19855" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of the real-time stats prototype project.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live environment.
* Visit the Traffic page on one of your test sites.
* Confirm the "Realtime" tab is not visible.
* Manually enable the feature flag: `?flags=stats/real-time-tab`
* Confirm the tab is now visible.
* Confirm the existing modules are laid out correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
