### PR TITLE
Reader full post - fix scroll reset on tab change.

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -253,7 +253,6 @@ export class FullPostView extends Component {
 			this.trackReadingTime();
 			this.trackScrollDepth();
 			this.trackExitBeforeCompletion();
-			this.resetScroll();
 		}
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/98745

## Proposed Changes

* Fixes a bug recently introduced that forces the full post page to scroll back to the top when tabbing away/back from another browser tab.
* NOTE - this line was [recently added a month ago](https://github.com/Automattic/wp-calypso/pull/97476) as part of a fix to another bug with dataViews reader feed. This seems to behave well for me but pinging @eoigal for a review/test in case there is some other part of that original bug I am missing (we removed the `resetScroll` you added on visibility change, but left the ones you added to update and mount cycles).


BEFORE
![scroll-reset-full-post](https://github.com/user-attachments/assets/3ee91119-9d85-4673-b23d-5f6ea0b8ebe0)


AFTER
![reader-full-post-scroll-good](https://github.com/user-attachments/assets/7ca77f73-4335-4cd4-81f0-e6cf6f537bd8)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Reader full post should not reset scroll position when the user access another browser tab (like for looking something up, checking an email mid-read, etc.).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit a full post page in the reader.
* Scroll down deeper into the post content.
* Access another browser tab.
* Come back to the reader full post broswer tab.
* Verify the scroll position did not reset.

* Test the dataViews posts view in the Recent feed, verify no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
