### PR TITLE
Subscribers Dataviews: Add Jetpack Cloud style selectors

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -21,7 +21,8 @@ body.is-section-subscribers.is-subscribers-dataviews,
 
             // This is a Jetpack Cloud breakpoint.
             @media( max-width: 660px ) {
-                padding-left: $padding-standard;
+                padding-left: 0;
+                padding-right: 0;
             }
         }
     }

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -11,13 +11,18 @@ body.is-section-subscribers.is-subscribers-dataviews,
     overflow: hidden;
     
     .layout:not(.has-no-sidebar),
-    .layout.focus-content.is-group-jetpack-cloud.is-section-jetpack-subscribers.has-no-masterbar {
+    .has-no-masterbar {
         .layout__content {
             background: var(--studio-gray-0);
             padding: calc(var(--masterbar-height) + #{$padding-standard})
                  $padding-standard
                  $padding-standard
                  calc(var(--sidebar-width-max) + #{$padding-standard});
+
+            // This is a Jetpack Cloud breakpoint.
+            @media( max-width: 660px ) {
+                padding-left: $padding-standard;
+            }
         }
     }
 
@@ -48,6 +53,7 @@ body.is-section-subscribers.is-subscribers-dataviews,
             button {
                 cursor: pointer;
                 max-width: 100%;
+                border: none;
             }
         
             .subscriber-data-views__square-avatar {

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -55,6 +55,10 @@ body.is-section-subscribers.is-subscribers-dataviews,
                 cursor: pointer;
                 max-width: 100%;
                 border: none;
+
+                &.components-button.dataviews-all-actions-button {
+                    background: none;
+                }
             }
         
             .subscriber-data-views__square-avatar {

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -5,10 +5,13 @@
 
 $padding-standard: 16px;
 
-body.is-section-subscribers.is-subscribers-dataviews {
+body.is-section-subscribers.is-subscribers-dataviews,
+.theme-jetpack-cloud.is-subscribers-dataviews.is-group-jetpack-cloud.is-section-jetpack-subscribers
+ {
     overflow: hidden;
     
-    .layout:not(.has-no-sidebar) {
+    .layout:not(.has-no-sidebar),
+    .layout.focus-content.is-group-jetpack-cloud.is-section-jetpack-subscribers.has-no-masterbar {
         .layout__content {
             background: var(--studio-gray-0);
             padding: calc(var(--masterbar-height) + #{$padding-standard})
@@ -18,7 +21,11 @@ body.is-section-subscribers.is-subscribers-dataviews {
         }
     }
 
-    .subscribers.main {
+    .layout.focus-content.has-no-masterbar {
+        padding-top: 0;
+    }
+
+    .subscribers.main, .main.is-wide-layout {
         max-width: none;
         padding: 0;
         margin: 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/298

## Proposed Changes

* Add Jetpack Cloud selectors to apply the Subscribers Dataviews styles to the UI.
* Style the mobile view.
* Remove button borders to improve alignment.

<img width="1045" alt="Screen Shot 2025-01-27 at 1 39 32 PM" src="https://github.com/user-attachments/assets/a7ad84de-ca51-49c7-9d8a-c6312f22bcae" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pe7F0s-2of-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/subscribers/{site url}?flags=subscribers-dataviews` on Calypso Live and check that there are no regressions.
* Go to `/subscribers/{site url}` on Jetpack Cloud Live and check that there are no regressions.
* Go to `/subscribers/{site url}?flags=subscribers-dataviews` on Jetpack Cloud Live and check that the subscribers table is full-width.
* Check that when you click a subscriber, the preview pane slides in on the right.
* Check that the mobile view isn't cut off.

Noting that at 960px wide there's a "minimal sidebar" on Jetpack Cloud and we have some extra padding.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?