### PR TITLE
Use flexbox gap to position currency symbol with the tax information string

### DIFF
--- a/client/me/purchases/billing-history/style-data-view.scss
+++ b/client/me/purchases/billing-history/style-data-view.scss
@@ -112,6 +112,10 @@
                 font-size: 0.875rem;
                 color: var(--color-text-subtle);
             }
+
+            &-wrapper {
+                gap: 4px;
+            }
         }
 
         .dataviews-view-table__cell-actions {
@@ -143,10 +147,6 @@
                 }
             }
         }
-    }
-
-    .dataviews-no-results, .dataviews-loading {
-        min-height: 500px;
     }
 
     .dataviews__view-actions {

--- a/client/me/purchases/billing-history/style-data-view.scss
+++ b/client/me/purchases/billing-history/style-data-view.scss
@@ -5,6 +5,18 @@
         margin-bottom: 1rem;
         padding: 0 1rem;
 
+        .dataviews-loading {
+            display: flex;
+            align-items: end;
+            justify-content: center;
+            padding-top: 48px;
+
+            .components-spinner {
+                width: 32px;
+                height: 32px;
+            }
+        }
+
         .dataviews-view-table {
             width: 100%;
             border-collapse: collapse;

--- a/client/me/purchases/billing-history/style.scss
+++ b/client/me/purchases/billing-history/style.scss
@@ -83,7 +83,6 @@
 	color: var(--color-text-subtle);
 	font-size: $font-body-extra-small;
 	white-space: nowrap;
-	margin-left: 0.3rem;
 }
 
 .billing-history__transaction-tax-amount {


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/98920

## Proposed Changes

The new Billing History component based on DataViews (currently enabled in `DEV`) had a bug where the currency symbol would appear next to the tax string in `currency-on-right` locales.  The lack of space made it look like the currency symbol was part of the string instead of being separated by a space. 

This PR adjusts the fix from [98920](https://github.com/Automattic/wp-calypso/pull/98920) to use the flexbox gap property instead of a left-hand margin.  It also moves the changes to `client/me/purchases/billing-history/style-data-view.scss` so they'll be scoped specifically for the new Billing History component.

It also replaces a `min-height` property for the loading state of the list with a bit of styling to center the spinner without using such an artificially large loading area.

## Why are these changes being made?

By utilizing the `gap` property, we should be able to avoid any unexpected alignment issues if this line were to end up broken up in the future.  

**Symbol on the left of amount**
<img width="517" alt="Screenshot 2025-01-27 at 9 30 09 AM" src="https://github.com/user-attachments/assets/a123ad15-2d31-4de5-8b11-9b329559071c" />


**Symbol on the right of amount**
<img width="517" alt="Screenshot 2025-01-27 at 9 20 43 AM" src="https://github.com/user-attachments/assets/a4ae59fd-07bd-4739-9e19-997b7d90aa85" />


**RTL language**
<img width="517" alt="Screenshot 2025-01-27 at 9 29 02 AM" src="https://github.com/user-attachments/assets/bc0ecc7d-00be-4987-abc6-66ffdf68468c" />

## Testing Instructions

* Open http://calypso.localhost:3000/me/purchases/billing and locate a receipt that includes tax.
* Make sure the currency symbol and tax information are properly aligned.
* Switch your locale to Greek or Polish and refresh the Billing History.  Make sure the alignment includes a space between the currency symbol and the tax string.
* Switch your locale to a RTL language (such as Hebrew) and check again to make sure the spacing is consistent.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
