### PR TITLE
Reader: Limit Recent "Scrolling feed" to posts newer than 60 days to match the "Full post" feed

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -735,7 +735,25 @@ class ReaderStream extends Component {
 				{ this.props.children }
 				{ showingStream && items.length ? this.props.intro?.() : null }
 				{ body }
-				{ showingStream && items.length && ! isRequesting ? <ListEnd /> : null }
+				{ showingStream && items.length && ! isRequesting && (
+					<>
+						<ListEnd />
+						{ streamKey.startsWith( 'following' ) && (
+							<div className="stream__caught-up">
+								<p>{ translate( "You've seen all new posts from the past 60 days." ) }</p>
+								<p>
+									{ this.props.selectedFeedId
+										? translate( "Visit {{link}}this site's feed{{/link}} to view older posts.", {
+												components: {
+													link: <a href={ `/read/feeds/${ this.props.selectedFeedId }` } />,
+												},
+										  } )
+										: translate( 'Visit the individual site to view older posts.' ) }
+								</p>
+							</div>
+						) }
+					</>
+				) }
 			</TopLevel>
 		);
 	}

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -48,6 +48,16 @@
 
 .following {
 
+	.stream__caught-up {
+		text-align: center;
+		color: var( --color-text-subtle );
+		font-size: $font-body-small;
+
+		p {
+			margin: 0 0 0.5em;
+		}
+	}
+
 	@include breakpoint-deprecated( "<660px" ) {
 		-webkit-perspective: none;
 		perspective: none;
@@ -1025,4 +1035,3 @@
 		}
 	}
 }
-

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -194,12 +194,19 @@ const streamApis = {
 		path: () => '/read/following',
 		dateProperty: 'date',
 		query: ( extras ) => {
-			const sixtyDaysAgo = new Date();
-			sixtyDaysAgo.setDate( sixtyDaysAgo.getDate() - 60 );
-			return getQueryString( {
-				...extras,
-				after: sixtyDaysAgo.toISOString().split( '.' )[ 0 ] + 'Z',
-			} );
+			// Filter out undefined values from extras
+			const filteredExtras = Object.fromEntries(
+				Object.entries( extras ).filter( ( [ , value ] ) => value !== undefined )
+			);
+
+			// If no after param is provided, default to 60 days ago
+			if ( ! filteredExtras.after && ! filteredExtras.pageHandle?.after ) {
+				const sixtyDaysAgo = new Date();
+				sixtyDaysAgo.setDate( sixtyDaysAgo.getDate() - 60 );
+				filteredExtras.after = sixtyDaysAgo.toISOString().split( '.' )[ 0 ] + 'Z';
+			}
+
+			return getQueryString( filteredExtras );
 		},
 	},
 	recent: {

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -193,6 +193,14 @@ const streamApis = {
 	following: {
 		path: () => '/read/following',
 		dateProperty: 'date',
+		query: ( extras ) => {
+			const sixtyDaysAgo = new Date();
+			sixtyDaysAgo.setDate( sixtyDaysAgo.getDate() - 60 );
+			return getQueryString( {
+				...extras,
+				after: sixtyDaysAgo.toISOString().split( '.' )[ 0 ] + 'Z',
+			} );
+		},
 	},
 	recent: {
 		path: () => '/read/streams/following',

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -17,6 +17,7 @@ jest.mock( '@wordpress/warning', () => () => {} );
 
 describe( 'streams', () => {
 	const action = deepfreeze( requestPageAction( { streamKey: 'following', page: 2 } ) );
+	const ISO_DATE_MATCHER = expect.stringMatching( /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/ );
 
 	describe( 'requestPage', () => {
 		const query = {
@@ -33,7 +34,10 @@ describe( 'streams', () => {
 					method: 'GET',
 					path: '/read/following',
 					apiVersion: '1.2',
-					query,
+					query: {
+						...query,
+						after: ISO_DATE_MATCHER,
+					},
 					onSuccess: action,
 					onFailure: action,
 				} )
@@ -68,7 +72,10 @@ describe( 'streams', () => {
 						method: 'GET',
 						path: '/read/following',
 						apiVersion: '1.2',
-						query,
+						query: {
+							...query,
+							after: ISO_DATE_MATCHER,
+						},
 					},
 				},
 				{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98883

## Proposed Changes

The "Full post" view uses the /read/streams/following endpoint and has a 60 day limit defined here: fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Syvo%2Sfgernz%2Qohvyqre%2Qpbasvt%2SFgernzf%2SSbyybjvatFgernz.cuc%3Se%3Qs1pq9827%2323-og

The "Scrolling feed" view uses the /read/following endpoint and has no date limit, but it can take an optional `after` query parameter to limit the date range.

This PR achieves parity between these two views by adding the `after` parameter to the "Scrolling feed" so that it also only shows posts that are less than 60 days old. 

* Limits the /read "Scrolling feed" to posts newer than 60 days to match the "Full post" feed
* Adds `after` query parameter to the /read/following endpoint (aka the "Scrolling feed" view on /read) so it only returns posts newer than 60 days.
* Updates unit tests to expect the new `after` parameter
* Adds a "You're all caught up" message to the bottom of the /read "Scrolling feed" that explains the 60 day limit. (see screenshots below)

When an individual site is selected, we link to the full site feed at the bottom.
Before | After
--|--
<img width="1275" alt="Screenshot 2025-01-29 at 5 15 27 PM" src="https://github.com/user-attachments/assets/a5970948-75c2-4cf5-a09c-d81bec9aaa49" /> |  <img width="1277" alt="Screenshot 2025-01-29 at 5 15 41 PM" src="https://github.com/user-attachments/assets/fcaaaa3a-145e-4256-a99c-7f09d7d1f577" />

When the "All" feed is selected, we present a generic message with no link.
<img width="1278" alt="Screenshot 2025-01-29 at 5 16 11 PM" src="https://github.com/user-attachments/assets/e4a3a713-bfbb-4c97-a5b5-d2d9d7a631b9" />




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve UX by matching the "Scrolling feed" and "Full post" feed experiences.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /read and scroll down. You should not see posts older than 60 days.
* You should see a message explaining the 60-day limit at the bottom of the feed (this message should only appear on the /read feed)
* Select a specific site under "Recent" and scroll to the bottom of that site's feed. You should not see posts older than 60 days.
* You should see a message explaining the 60-day limit at the bottom of the feed with a link for the user to find older posts.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?