### PR TITLE
Ship drive-migrations feature

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -122,7 +122,7 @@
 		"signup/social-first": true,
 		"site-indicator": true,
 		"site-profiler/metrics": true,
-		"sites/drive-migrations": false,
+		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,

--- a/config/production.json
+++ b/config/production.json
@@ -155,7 +155,7 @@
 		"signup/social-first": true,
 		"site-indicator": true,
 		"site-profiler/metrics": false,
-		"sites/drive-migrations": false,
+		"sites/drive-migrations": true,
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -152,7 +152,7 @@
 		"signup/social-first": true,
 		"site-indicator": true,
 		"site-profiler/metrics": false,
-		"sites/drive-migrations": false,
+		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,

--- a/config/test.json
+++ b/config/test.json
@@ -114,7 +114,7 @@
 		"signup/social": true,
 		"signup/social-first": true,
 		"site-indicator": true,
-		"sites/drive-migrations": false,
+		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -158,7 +158,7 @@
 		"site-indicator": true,
 		"site-profiler/metrics": true,
 		"sites/dashboard-survey": true,
-		"sites/drive-migrations": false,
+		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,


### PR DESCRIPTION
## Proposed Changes

We are updating `sites/drive-migrations` feature flag to true on all environments.
This will ship the feature in production.

## Testing Instructions

Visual inspection is good enough. It will not change localhost behavior.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
