### PR TITLE
Fixed screen size when showing huge URL paths

### DIFF
--- a/client/hosting/performance/style.scss
+++ b/client/hosting/performance/style.scss
@@ -33,6 +33,7 @@ $section-max-width: 1224px;
 
 		.description-area {
 			font-size: $font-body-small;
+			word-break: break-word;
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

We're fixing visual issues when rendering big URLs:

| Before | After |
|--------|--------|
|![image](https://github.com/user-attachments/assets/75ae960d-15be-4c9c-a593-f1fb6a216376) | ![image](https://github.com/user-attachments/assets/b7ee0eb8-4ddc-4479-80a2-7c58084bde77) | 

We checked, and [the logout experience](https://wordpress.com/speed-test-tool) looks good already: 

![image](https://github.com/user-attachments/assets/1cb0e83c-52ec-4440-9cea-a3610c2e3e5d)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://wordpress.com/sites/performance/{siteDomain}
* Check for `Personalized Recommendations` on a site with a big URL and verify that it's not breaking the layout

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
