### PR TITLE
Support the launch celebration modal to newsletter goals launchpad

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/intent-newsletter.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-newsletter.tsx
@@ -1,9 +1,39 @@
+import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
+import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
+import { useSelector } from 'calypso/state';
+import { getSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import CelebrateLaunchModal from '../../components/celebrate-launch-modal';
+import { useCelebrateLaunchModal } from './use-celebrate-launch-modal';
 import CustomerHomeLaunchpad from '.';
+import type { AppState } from 'calypso/types';
 
 const LaunchpadIntentNewsletter = ( { checklistSlug }: { checklistSlug: string } ): JSX.Element => {
+	const siteId = useSelector( getSelectedSiteId ) || 0;
+	const site = useSelector( ( state: AppState ) => getSite( state, siteId ) );
+	const { data: allDomains = [] } = useGetDomainsQuery( site?.ID ?? null, {
+		retry: false,
+	} );
+
+	const layoutQuery = useHomeLayoutQuery( siteId || null );
+	const { isOpen, setModalIsOpen, handleSiteLaunched } = useCelebrateLaunchModal(
+		siteId,
+		layoutQuery
+	);
+
 	return (
 		<>
-			<CustomerHomeLaunchpad checklistSlug={ checklistSlug }></CustomerHomeLaunchpad>
+			<CustomerHomeLaunchpad
+				checklistSlug={ checklistSlug }
+				onSiteLaunched={ () => handleSiteLaunched( !! site?.is_wpcom_atomic ) }
+			></CustomerHomeLaunchpad>
+			{ isOpen && (
+				<CelebrateLaunchModal
+					setModalIsOpen={ setModalIsOpen }
+					site={ site }
+					allDomains={ allDomains }
+				/>
+			) }
 		</>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #98773

## Proposed Changes

In https://github.com/Automattic/jetpack/pull/41344 the newsletter goal
can return a launch site task. The client needs to be updated to support
showing the modal for this intent.

![CleanShot 2025-01-28 at 11 12 23](https://github.com/user-attachments/assets/afdb8381-1fe4-4b73-a3da-aa45e19ce952)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The launch bar no longer appears on the front of the site. The preview site task is no longer the viable path to launching the site that it once was. See #98773

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply https://github.com/Automattic/jetpack/pull/41344 to your sandbox
* Create a site with `/setup/onboarding?flags=onboarding/newsletter-goal`
* Choose "newsletter" on the goals screen
* Once on My Home, observe the "launch site" task
* Clicking the task and the site is launched and the celebration modal appears

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
