### PR TITLE
Change warning message on restore

### DIFF
--- a/client/my-sites/backup/rewind-flow/granular-restore.tsx
+++ b/client/my-sites/backup/rewind-flow/granular-restore.tsx
@@ -434,6 +434,16 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 				item.path === '//'
 		);
 
+		let restoreWarning = translate(
+			'Important: This action will replace the selected content from the selected restore point.'
+		);
+
+		if ( hasSelectedTables ) {
+			restoreWarning = translate(
+				'Important: This action will replace all settings, posts, pages and other site content with the information from the selected restore point.'
+			);
+		}
+
 		return (
 			<>
 				{ ! isAtomic && <QueryJetpackCredentialsStatus siteId={ siteId } role="main" /> }
@@ -455,23 +465,11 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 				{ renderSection( 'plugin' ) }
 				{ renderSection( 'table' ) }
 				{ renderSection( 'file' ) }
-				{ hasSelectedTables ? (
-					<RewindFlowNotice
-						gridicon="notice"
-						title={ translate(
-							'Important: this action will replace all settings, posts, pages and other site content with the information from the selected restore point.'
-						) }
-						type={ RewindFlowNoticeLevel.WARNING }
-					/>
-				) : (
-					<RewindFlowNotice
-						gridicon="notice"
-						title={ translate(
-							'Important: This action will replace the selected content from the selected restore point.'
-						) }
-						type={ RewindFlowNoticeLevel.WARNING }
-					/>
-				) }
+				<RewindFlowNotice
+					gridicon="notice"
+					title={ restoreWarning }
+					type={ RewindFlowNoticeLevel.WARNING }
+				/>
 				<>
 					{ backupCurrentlyInProgress && (
 						<RewindFlowNotice

--- a/client/my-sites/backup/rewind-flow/granular-restore.tsx
+++ b/client/my-sites/backup/rewind-flow/granular-restore.tsx
@@ -455,11 +455,19 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 				{ renderSection( 'plugin' ) }
 				{ renderSection( 'table' ) }
 				{ renderSection( 'file' ) }
-				{ hasSelectedTables && (
+				{ hasSelectedTables ? (
 					<RewindFlowNotice
 						gridicon="notice"
 						title={ translate(
 							'Important: this action will replace all settings, posts, pages and other site content with the information from the selected restore point.'
+						) }
+						type={ RewindFlowNoticeLevel.WARNING }
+					/>
+				) : (
+					<RewindFlowNotice
+						gridicon="notice"
+						title={ translate(
+							'Important: This action will replace the selected content from the selected restore point.'
 						) }
 						type={ RewindFlowNoticeLevel.WARNING }
 					/>

--- a/client/my-sites/backup/rewind-flow/granular-restore.tsx
+++ b/client/my-sites/backup/rewind-flow/granular-restore.tsx
@@ -425,61 +425,73 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 		);
 	};
 
-	const renderConfirm = () => (
-		<>
-			{ ! isAtomic && <QueryJetpackCredentialsStatus siteId={ siteId } role="main" /> }
-			<div className="rewind-flow__header">
-				<Icon icon={ backup } size={ 48 } />
-			</div>
-			<h3 className="rewind-flow__title">{ translate( 'Restore your files' ) }</h3>
-			<p className="rewind-flow__info">
-				{ translate( 'Selected restore point: {{strong}}%(backupDisplayDate)s{{/strong}}', {
-					args: {
-						backupDisplayDate,
-					},
-					components: {
-						strong: <strong />,
-					},
-				} ) }
-			</p>
-			{ renderSection( 'theme' ) }
-			{ renderSection( 'plugin' ) }
-			{ renderSection( 'table' ) }
-			{ renderSection( 'file' ) }
-			<RewindFlowNotice
-				gridicon="notice"
-				title={ translate(
-					'Important: this action will replace all settings, posts, pages and other site content with the information from the selected restore point.'
-				) }
-				type={ RewindFlowNoticeLevel.WARNING }
-			/>
+	const renderConfirm = () => {
+		const hasSelectedTables = browserSelectedList.some(
+			( item ) =>
+				item.type === 'table' ||
+				// Also check if root path or /sql is selected as this includes all tables
+				item.path === '/sql' ||
+				item.path === '//'
+		);
+
+		return (
 			<>
-				{ backupCurrentlyInProgress && (
+				{ ! isAtomic && <QueryJetpackCredentialsStatus siteId={ siteId } role="main" /> }
+				<div className="rewind-flow__header">
+					<Icon icon={ backup } size={ 48 } />
+				</div>
+				<h3 className="rewind-flow__title">{ translate( 'Restore your files' ) }</h3>
+				<p className="rewind-flow__info">
+					{ translate( 'Selected restore point: {{strong}}%(backupDisplayDate)s{{/strong}}', {
+						args: {
+							backupDisplayDate,
+						},
+						components: {
+							strong: <strong />,
+						},
+					} ) }
+				</p>
+				{ renderSection( 'theme' ) }
+				{ renderSection( 'plugin' ) }
+				{ renderSection( 'table' ) }
+				{ renderSection( 'file' ) }
+				{ hasSelectedTables && (
 					<RewindFlowNotice
 						gridicon="notice"
 						title={ translate(
-							'A backup is currently in progress; restoring now will stop the backup.'
+							'Important: this action will replace all settings, posts, pages and other site content with the information from the selected restore point.'
 						) }
 						type={ RewindFlowNoticeLevel.WARNING }
 					/>
 				) }
+				<>
+					{ backupCurrentlyInProgress && (
+						<RewindFlowNotice
+							gridicon="notice"
+							title={ translate(
+								'A backup is currently in progress; restoring now will stop the backup.'
+							) }
+							type={ RewindFlowNoticeLevel.WARNING }
+						/>
+					) }
+				</>
+				<div className="rewind-flow__btn-group">
+					<Button className="rewind-flow__back-button" href={ goBackUrl } onClick={ onCancel }>
+						{ translate( 'Cancel' ) }
+					</Button>
+					<Button
+						className="rewind-flow__primary-button"
+						primary
+						onClick={ onConfirm }
+						disabled={ disableRestore }
+					>
+						{ translate( 'Restore now' ) }
+					</Button>
+				</div>
+				<Interval onTick={ refreshBackups } period={ EVERY_FIVE_SECONDS } />
 			</>
-			<div className="rewind-flow__btn-group">
-				<Button className="rewind-flow__back-button" href={ goBackUrl } onClick={ onCancel }>
-					{ translate( 'Cancel' ) }
-				</Button>
-				<Button
-					className="rewind-flow__primary-button"
-					primary
-					onClick={ onConfirm }
-					disabled={ disableRestore }
-				>
-					{ translate( 'Restore now' ) }
-				</Button>
-			</div>
-			<Interval onTick={ refreshBackups } period={ EVERY_FIVE_SECONDS } />
-		</>
-	);
+		);
+	};
 
 	const renderInProgress = () => (
 		<>

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -274,13 +274,15 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			) }
 			<h4 className="rewind-flow__cta">{ translate( 'Choose the items you wish to restore:' ) }</h4>
 			<RewindConfigEditor currentConfig={ rewindConfig } onConfigChange={ setRewindConfig } />
-			<RewindFlowNotice
-				gridicon="notice"
-				title={ translate(
-					'Important: this action will replace all settings, posts, pages and other site content with the information from the selected restore point.'
-				) }
-				type={ RewindFlowNoticeLevel.WARNING }
-			/>
+			{ rewindConfig.sqls && (
+				<RewindFlowNotice
+					gridicon="notice"
+					title={ translate(
+						'Important: this action will replace all settings, posts, pages and other site content with the information from the selected restore point.'
+					) }
+					type={ RewindFlowNoticeLevel.WARNING }
+				/>
+			) }
 			<>
 				{ backupCurrentlyInProgress && (
 					<RewindFlowNotice

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -274,11 +274,19 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			) }
 			<h4 className="rewind-flow__cta">{ translate( 'Choose the items you wish to restore:' ) }</h4>
 			<RewindConfigEditor currentConfig={ rewindConfig } onConfigChange={ setRewindConfig } />
-			{ rewindConfig.sqls && (
+			{ rewindConfig.sqls ? (
 				<RewindFlowNotice
 					gridicon="notice"
 					title={ translate(
 						'Important: this action will replace all settings, posts, pages and other site content with the information from the selected restore point.'
+					) }
+					type={ RewindFlowNoticeLevel.WARNING }
+				/>
+			) : (
+				<RewindFlowNotice
+					gridicon="notice"
+					title={ translate(
+						'Important: This action will replace the selected content from the selected restore point.'
 					) }
 					type={ RewindFlowNoticeLevel.WARNING }
 				/>

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -240,88 +240,90 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 		);
 	}, [ dispatch, hasCredentials ] );
 
-	const renderConfirm = () => (
-		<>
-			{ ! isAtomic && <QueryJetpackCredentialsStatus siteId={ siteId } role="main" /> }
-			<div className="rewind-flow__header">
-				<Gridicon icon="history" size={ 48 } />
-				<div className="rewind-flow__learn-about">
-					<ExternalLink
-						href="https://jetpack.com/support/backup/restoring-with-jetpack-backup/"
-						onClick={ onLearnAboutClick }
-					>
-						{ translate( 'Learn about restores' ) }
-					</ExternalLink>
-				</div>
-			</div>
-			<h3 className="rewind-flow__title">{ translate( 'Restore your site' ) }</h3>
-			<p className="rewind-flow__info">
-				{ translate( 'Selected restore point: {{strong}}%(backupDisplayDate)s{{/strong}}', {
-					args: {
-						backupDisplayDate,
-					},
-					components: {
-						strong: <strong />,
-					},
-				} ) }
-			</p>
-			{ showRealTimeMessage && (
-				<BackupRealtimeMessage
-					baseBackupDate={ baseBackupDate }
-					eventsCount={ backup.rewindStepCount }
-					selectedBackupDate={ selectedDate }
-				/>
-			) }
-			<h4 className="rewind-flow__cta">{ translate( 'Choose the items you wish to restore:' ) }</h4>
-			<RewindConfigEditor currentConfig={ rewindConfig } onConfigChange={ setRewindConfig } />
-			{ rewindConfig.sqls ? (
-				<RewindFlowNotice
-					gridicon="notice"
-					title={ translate(
-						'Important: this action will replace all settings, posts, pages and other site content with the information from the selected restore point.'
-					) }
-					type={ RewindFlowNoticeLevel.WARNING }
-				/>
-			) : (
-				<RewindFlowNotice
-					gridicon="notice"
-					title={ translate(
-						'Important: This action will replace the selected content from the selected restore point.'
-					) }
-					type={ RewindFlowNoticeLevel.WARNING }
-				/>
-			) }
+	const renderConfirm = () => {
+		let restoreWarning = translate(
+			'Important: This action will replace the selected content from the selected restore point.'
+		);
+
+		if ( rewindConfig.sqls ) {
+			restoreWarning = translate(
+				'Important: This action will replace all settings, posts, pages and other site content with the information from the selected restore point.'
+			);
+		}
+
+		return (
 			<>
-				{ backupCurrentlyInProgress && (
-					<RewindFlowNotice
-						gridicon="notice"
-						title={ translate(
-							'A backup is currently in progress; restoring now will stop the backup.'
-						) }
-						type={ RewindFlowNoticeLevel.WARNING }
+				{ ! isAtomic && <QueryJetpackCredentialsStatus siteId={ siteId } role="main" /> }
+				<div className="rewind-flow__header">
+					<Gridicon icon="history" size={ 48 } />
+					<div className="rewind-flow__learn-about">
+						<ExternalLink
+							href="https://jetpack.com/support/backup/restoring-with-jetpack-backup/"
+							onClick={ onLearnAboutClick }
+						>
+							{ translate( 'Learn about restores' ) }
+						</ExternalLink>
+					</div>
+				</div>
+				<h3 className="rewind-flow__title">{ translate( 'Restore your site' ) }</h3>
+				<p className="rewind-flow__info">
+					{ translate( 'Selected restore point: {{strong}}%(backupDisplayDate)s{{/strong}}', {
+						args: {
+							backupDisplayDate,
+						},
+						components: {
+							strong: <strong />,
+						},
+					} ) }
+				</p>
+				{ showRealTimeMessage && (
+					<BackupRealtimeMessage
+						baseBackupDate={ baseBackupDate }
+						eventsCount={ backup.rewindStepCount }
+						selectedBackupDate={ selectedDate }
 					/>
 				) }
+				<h4 className="rewind-flow__cta">
+					{ translate( 'Choose the items you wish to restore:' ) }
+				</h4>
+				<RewindConfigEditor currentConfig={ rewindConfig } onConfigChange={ setRewindConfig } />
+				<RewindFlowNotice
+					gridicon="notice"
+					title={ restoreWarning }
+					type={ RewindFlowNoticeLevel.WARNING }
+				/>
+				<>
+					{ backupCurrentlyInProgress && (
+						<RewindFlowNotice
+							gridicon="notice"
+							title={ translate(
+								'A backup is currently in progress; restoring now will stop the backup.'
+							) }
+							type={ RewindFlowNoticeLevel.WARNING }
+						/>
+					) }
+				</>
+				<div className="rewind-flow__btn-group">
+					<Button
+						className="rewind-flow__back-button"
+						href={ backupMainPath( siteSlug ) }
+						onClick={ onGoBack }
+					>
+						{ translate( 'Go back' ) }
+					</Button>
+					<Button
+						className="rewind-flow__primary-button"
+						primary
+						onClick={ onConfirm }
+						disabled={ disableRestore }
+					>
+						{ translate( 'Restore now' ) }
+					</Button>
+				</div>
+				<Interval onTick={ refreshBackups } period={ EVERY_FIVE_SECONDS } />
 			</>
-			<div className="rewind-flow__btn-group">
-				<Button
-					className="rewind-flow__back-button"
-					href={ backupMainPath( siteSlug ) }
-					onClick={ onGoBack }
-				>
-					{ translate( 'Go back' ) }
-				</Button>
-				<Button
-					className="rewind-flow__primary-button"
-					primary
-					onClick={ onConfirm }
-					disabled={ disableRestore }
-				>
-					{ translate( 'Restore now' ) }
-				</Button>
-			</div>
-			<Interval onTick={ refreshBackups } period={ EVERY_FIVE_SECONDS } />
-		</>
-	);
+		);
+	};
 
 	const renderInProgress = () => (
 		<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/97401

## Proposed Changes

* Show a different message if no SQL is selected for a restore. Example:

**--> No SQL in restore**
<img width="663" alt="Screenshot 2025-01-28 at 5 21 17 PM" src="https://github.com/user-attachments/assets/29ac5abf-d468-41b1-ad75-14380316089f" />

**--> Some SQL in the restore**
<img width="666" alt="Screenshot 2025-01-28 at 5 21 48 PM" src="https://github.com/user-attachments/assets/fbbb05f1-978c-42e0-b72a-071587c5adb2" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The message `Important: this action will replace all settings, posts, pages and other site content with the information from the selected restore point.` is not accurate if  we are not restoring all the elements (in particular, making any change in the database)

<img width="578" alt="Screenshot 2025-01-28 at 5 23 12 PM" src="https://github.com/user-attachments/assets/f17dd1aa-d0ea-4498-8d05-0da9716186fe" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using Calypso live and Jetpack Cloud live, go to Backup restore and verify the message when a SQL is selected in the restore and when it is not, for a normal restore and for a granuar restore (view files)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
