### PR TITLE
Fix E2E failing test

### DIFF
--- a/test/e2e/specs/tracks/tracks__lohp-to-signup-events.ts
+++ b/test/e2e/specs/tracks/tracks__lohp-to-signup-events.ts
@@ -41,7 +41,7 @@ describe( DataHelper.createSuiteTitle( 'Verify Tracks events starting at LOHP' )
 		const didEventFirePromise = tracksEventManager.didEventFire( 'wpcom_link_click' );
 
 		// Click first signup link to go to signup page
-		await page.locator( 'a[href^="https://wordpress.com/start"]' ).first().click();
+		await page.locator( 'a[href^="https://wordpress.com/setup/onboarding"]' ).first().click();
 
 		// Expect the event to fire
 		expect( await didEventFirePromise ).toBe( true );
@@ -62,7 +62,7 @@ describe( DataHelper.createSuiteTitle( 'Verify Tracks events starting at LOHP' )
 		requestUrlPromise = tracksEventManager.getRequestUrlForEvent( 'calypso_page_view' );
 
 		// Click first signup link to go to signup page
-		await page.locator( 'a[href^="https://wordpress.com/start"]' ).first().click();
+		await page.locator( 'a[href^="https://wordpress.com/setup/onboarding"]' ).first().click();
 		requestUrl = await requestUrlPromise;
 
 		// Expect anon ids in wpcom and calypso page view events to match


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes
This PR fixes the failing test due to the LOHP CTA link changing from `/start` to `setup/onboarding`
*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
