### PR TITLE
E2E Test: Handle undefined user details in WooCommerce signup test

### DIFF
--- a/test/e2e/specs/onboarding/signup__woo-email.ts
+++ b/test/e2e/specs/onboarding/signup__woo-email.ts
@@ -24,7 +24,7 @@ describe(
 		const emailClient = new EmailClient();
 
 		let page: Page;
-		let newUserDetails: NewUserResponse;
+		let newUserDetails: NewUserResponse | undefined;
 
 		beforeAll( async () => {
 			page = await browser.newPage();
@@ -60,6 +60,11 @@ describe(
 		} );
 
 		afterAll( async function () {
+			if ( ! newUserDetails ) {
+				// Test fails before signup is complete so we don't need to close account.
+				return;
+			}
+
 			const restAPIClient = new RestAPIClient(
 				{
 					username: testUser.username,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


When tests fail before the signup completes, the afterAll hook throws another error. This hides the actual error message and leads to confusion.

![Screenshot 2025-01-28 at 10 28 32](https://github.com/user-attachments/assets/260c1ef0-67b6-4cf4-ac91-25796b1cd92b)
https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release/14140079?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildDeploymentsSection=false&expandBuildChangesSection=true&expandBuildTestsSection=true&showLog=14140079_469_287.429.430.431.434.446&logFilter=debug&logView=flowAware

## Proposed Changes

* Skip the afterAll hook if `newUserDetails` is undefined. This is the same approach used in `specs/onboarding/signup__with-*` tests.

https://github.com/Automattic/wp-calypso/blob/a80308764f3ac56c8de333dd50369b7e63f75603/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts#L189-L191

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The afterAll hook is not necessary for the tests that fail before the signup completes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

[Pre-Release E2E Tests](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release?branch=improve%2Fwoo-signup-e2e-tests&buildTypeTab=overview&mode=builds) should pass

To test locally:

* Checkout this branch
* Set up local e2e test env https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e
* Run the following tests

- `yarn workspace wp-e2e-tests test test/e2e/specs/onboarding/signup__woo-email.ts`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?


