### PR TITLE
Stats Locations: improve locations module skeleton to match the current layout

### DIFF
--- a/client/my-sites/stats/features/modules/shared/stats-card-skeleton.scss
+++ b/client/my-sites/stats/features/modules/shared/stats-card-skeleton.scss
@@ -13,12 +13,12 @@
 		border-radius: 4px;
 	}
 
-	ul {
+	.stats-card--body ul {
 		padding: 0 24px; // match horizontal bar spacing
 		margin: 0;
 	}
 
-	li {
+	.stats-card--body ul li {
 		list-style: none;
 
 		& + li {

--- a/client/my-sites/stats/features/modules/shared/stats-card-skeleton.tsx
+++ b/client/my-sites/stats/features/modules/shared/stats-card-skeleton.tsx
@@ -13,6 +13,11 @@ type StatsCardSkeletonProps = {
 	 */
 	type?: 1 | 2 | 3;
 	withHero?: boolean;
+	withSplitHeader?: boolean;
+	toggleControl?: React.ReactNode;
+	metricLabel?: string;
+	mainItemLabel?: string;
+	titleNodes?: React.ReactNode;
 };
 
 const StatsCardSkeleton: React.FC< StatsCardSkeletonProps > = ( {
@@ -21,6 +26,11 @@ const StatsCardSkeleton: React.FC< StatsCardSkeletonProps > = ( {
 	title,
 	type = 1,
 	withHero,
+	withSplitHeader,
+	toggleControl,
+	metricLabel,
+	mainItemLabel,
+	titleNodes,
 } ) => {
 	// Horizontal Bar placeholders
 	const dataTypes = [
@@ -42,7 +52,8 @@ const StatsCardSkeleton: React.FC< StatsCardSkeletonProps > = ( {
 			{ /* TODO: Empty title - use another LoadingPlaceholder */ }
 			<StatsCard
 				title={ title || '' }
-				metricLabel=""
+				metricLabel={ metricLabel }
+				mainItemLabel={ mainItemLabel }
 				heroElement={
 					withHero ? (
 						<LoadingPlaceholder
@@ -52,6 +63,9 @@ const StatsCardSkeleton: React.FC< StatsCardSkeletonProps > = ( {
 						/>
 					) : null
 				}
+				splitHeader={ withSplitHeader }
+				toggleControl={ toggleControl }
+				titleNodes={ titleNodes }
 			>
 				<ul>
 					{ data?.map( ( value, index ) => {

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -170,6 +170,24 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 		/>
 	);
 
+	const titleTooltip = (
+		<StatsInfoArea>
+			{ translate( 'Stats on visitors and their {{link}}viewing location{{/link}}.', {
+				comment: '{{link}} links to support documentation.',
+				components: {
+					link: (
+						<a
+							target="_blank"
+							rel="noreferrer"
+							href={ localizeUrl( `${ supportUrl }#countries` ) }
+						/>
+					),
+				},
+				context: 'Stats: Link in a popover for Countries module when the module has data',
+			} ) }
+		</StatsInfoArea>
+	);
+
 	const fakeData = [
 		{ label: 'United States', countryCode: 'US', value: 2000, region: '021' },
 		{ label: 'India', countryCode: 'IN', value: 1500, region: '034' },
@@ -192,7 +210,18 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 				<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
 			) }
 			{ isRequestingData && ! shouldGate && (
-				<StatsCardSkeleton isLoading={ isRequestingData } title={ title } type={ 3 } withHero />
+				<StatsCardSkeleton
+					className="locations-skeleton"
+					isLoading={ isRequestingData }
+					title={ title }
+					type={ 3 }
+					withHero
+					withSplitHeader
+					toggleControl={ toggleControlComponent }
+					mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
+					metricLabel={ translate( 'Views' ) }
+					titleNodes={ titleTooltip }
+				/>
 			) }
 			{ ( ( ! isRequestingData && ! isError && hasLocationData ) || shouldGate ) && (
 				// show data or an overlay
@@ -200,23 +229,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 					{ /* @ts-expect-error TODO: Refactor StatsListCard with TypeScript. */ }
 					<StatsListCard
 						title={ title }
-						titleNodes={
-							<StatsInfoArea>
-								{ translate( 'Stats on visitors and their {{link}}viewing location{{/link}}.', {
-									comment: '{{link}} links to support documentation.',
-									components: {
-										link: (
-											<a
-												target="_blank"
-												rel="noreferrer"
-												href={ localizeUrl( `${ supportUrl }#countries` ) }
-											/>
-										),
-									},
-									context: 'Stats: Link in a popover for Countries module when the module has data',
-								} ) }
-							</StatsInfoArea>
-						}
+						titleNodes={ titleTooltip }
 						moduleType="locations"
 						data={ locationData }
 						emptyMessage={ emptyMessage }

--- a/client/my-sites/stats/features/modules/stats-locations/style.scss
+++ b/client/my-sites/stats/features/modules/stats-locations/style.scss
@@ -4,7 +4,8 @@
 $break-large-stats-countries: 1280px;
 $locations-horizontal-bar-width: 380px;
 
-.stats-card.list-locations {
+.stats-card.list-locations,
+.stats-card-skeleton.locations-skeleton {
 	@include segmented-controls;
 
 	.stats-card-header {
@@ -53,13 +54,23 @@ $locations-horizontal-bar-width: 380px;
 	}
 }
 
-.stats-summary-view .stats-card.list-locations {
-	.stats-card--hero .stats-card-header {
-		padding: 0 24px 12px 0;
+.stats-summary-view {
+	.stats-card.list-locations,
+	.stats-card-skeleton.locations-skeleton {
+		.stats-card--hero .stats-card-header {
+			padding: 0 24px 12px 0;
+		}
+	}
+
+	.stats-card-skeleton.locations-skeleton {
+		&.stats-card-skeleton--with-hero .stats-card__content {
+			flex-direction: column;
+		}
 	}
 }
 
-.stats__module-list--traffic .stats-card.list-locations {
+.stats__module-list--traffic .stats-card.list-locations,
+.stats__module-list--traffic .stats-card-skeleton.locations-skeleton {
 	.stats-card-header {
 		padding: 0 24px;
 	}
@@ -87,8 +98,21 @@ $locations-horizontal-bar-width: 380px;
 	}
 }
 
+.stats__module-list--traffic .stats-card-skeleton.locations-skeleton .stats-card--hero {
+	width: auto;
+}
+
+.stats-card-skeleton.locations-skeleton .stats-card--hero,
+.stats-card.list-locations .stats-card--hero {
+	.stats-card-skeleton__placeholder,
+	.stats-geochart.stats-module__placeholder {
+		height: 480px;
+	}
+}
+
 @include break-large {
-	.stats-card.list-locations .stats-card-header {
+	.stats-card.list-locations .stats-card-header,
+	.stats-card-skeleton.locations-skeleton .stats-card-header {
 		.segmented-control.stats-module-locations__tabs {
 			flex: none;
 		}
@@ -100,13 +124,15 @@ $locations-horizontal-bar-width: 380px;
 }
 
 @include break-wide {
-	.stats__module-list--traffic .stats-card.list-locations .stats-card__content {
+	.stats__module-list--traffic .stats-card.list-locations .stats-card__content,
+	.stats__module-list--traffic .stats-card-skeleton.locations-skeleton .stats-card__content {
 		display: flex;
 		flex-direction: row;
 		flex-wrap: wrap;
 	}
 
-	.stats-card.list-locations {
+	.stats-card.list-locations,
+	.stats-card-skeleton.locations-skeleton {
 		.stats-card__content .stats-card--hero {
 			flex: 2;
 			margin: 0 24px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-roadmap/issues/2207

## Proposed Changes

* Improve the Locations' module skeleton (loading placeholder) to match the current layout (including responsive layouts).
* Ensure the title and tabs remain visible while fetching content by adding new optional props to StatsCardSkeleton.

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/715d0644-3a03-4023-a5ed-9d9a4e3aaf30" /> | <video src="https://github.com/user-attachments/assets/b3fadf4d-7b44-4701-9ece-2fb3a11c7b41" /> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Calypso live branch.
* Navigate to the Stats page.
* Ensure the skeleton/loading placeholder displayed while fetching locations data looks good, as shown in the video shared above (in the ‘After’ column).
* Validate that it also looks good on the Summary page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
