### PR TITLE
i18n: Fix number translations in stats page tooltips

### DIFF
--- a/packages/components/src/highlight-cards/count-card.tsx
+++ b/packages/components/src/highlight-cards/count-card.tsx
@@ -1,9 +1,10 @@
 import { arrowDown, arrowUp, Icon } from '@wordpress/icons';
 import clsx from 'clsx';
+import { numberFormat } from 'i18n-calypso';
 import { useRef, useState } from 'react';
 import { Card } from '../';
 import Popover from '../popover';
-import { formatNumber, subtract } from './lib/numbers';
+import { subtract, formatNumber } from './lib/numbers';
 
 interface CountCardProps {
 	heading?: React.ReactNode;
@@ -25,16 +26,22 @@ export function TooltipContent( { value, label, note, previousValue }: CountCard
 		trendIcon = arrowDown;
 	}
 
+	/**
+	 * TODO clk - We are currently in the process of unifying numberFormat from i18n-calypso with the one from number-formatters.
+	 * Once settled, we should consider where to place the "-" default for null values.
+	 */
+	const tooltipCount = value !== null ? numberFormat( value ) : '—';
+
 	return (
 		<div className="highlight-card-tooltip-content">
 			<span className="highlight-card-tooltip-counts">
-				{ formatNumber( value, false ) }
+				{ tooltipCount }
 				{ label && ` ${ label }` }
 			</span>
 			{ difference !== null && difference !== 0 && (
 				<span className={ trendClass }>
 					<Icon size={ 18 } icon={ trendIcon } />
-					{ formatNumber( Math.abs( difference ), false ) }
+					{ numberFormat( Math.abs( difference ) ) }
 				</span>
 			) }
 			{ note && <div className="highlight-card-tooltip-note">{ note }</div> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/i18n-issues/issues/918

## Proposed Changes

- Fixes missing/wrong translations on stats page tooltips. 
- We make use of the `numberFormat` method from i18n-calypso for the count-card component, which will use the correct locale from settings

## Media

### Before

EL locale from settings

<img width="800" alt="Screenshot 2025-01-28 at 11 57 46 AM" src="https://github.com/user-attachments/assets/3712a4e1-b7f8-495c-9618-511f71231950" />

### After

EL locale from settings

<img width="800" alt="Screenshot 2025-01-28 at 11 57 04 AM" src="https://github.com/user-attachments/assets/5220a45b-4eb4-427b-9526-eb27d52bf3d6" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fix missing translation

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to Greek/EL locale from settings
* Go to `/stats/month/:site` (use FG)
* Confirm the media above (hover to show the tooltip/popup). Thousands should be rendered with a dot in Greek e.g. `1.000`, not `1,000`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
