### PR TITLE
A4A: Add missing track events in the new Product marketplace.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/section.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/section.tsx
@@ -1,4 +1,6 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 type Props = {
 	icon?: ReactNode;
@@ -15,8 +17,42 @@ export default function ProductListingSection( {
 	children,
 	extraContent,
 }: Props ) {
+	const sectionRef = useRef< HTMLDivElement >( null );
+	const [ isVisibleOnce, setIsVisibleOnce ] = useState( false );
+	const dispatch = useDispatch();
+	useEffect( () => {
+		const observer = new IntersectionObserver(
+			( [ entry ] ) => {
+				if ( ! isVisibleOnce ) {
+					setIsVisibleOnce( entry.isIntersecting );
+				}
+			},
+			{
+				threshold: 0.1, // Trigger when at least 10% of the element is visible
+			}
+		);
+
+		if ( sectionRef.current ) {
+			observer.observe( sectionRef.current );
+		}
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [ isVisibleOnce ] );
+
+	useEffect( () => {
+		if ( isVisibleOnce ) {
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_marketplace_products_overview_section_visible', {
+					section: title,
+				} )
+			);
+		}
+	}, [ dispatch, isVisibleOnce, title ] );
+
 	return (
-		<div className="product-listing-section">
+		<div className="product-listing-section" ref={ sectionRef }>
 			<div className="product-listing-section__header-wrapper">
 				<div className="product-listing-section__header">
 					{ icon }


### PR DESCRIPTION
This PR adds missing track events in the new Product marketplace.

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1643

## Proposed Changes
This PR adds the following track events
* **calypso_a4a_marketplace_products_overview_input_search** - When inputting value in the search field.
   <img width="232" alt="Screenshot 2025-01-28 at 6 25 03 PM" src="https://github.com/user-attachments/assets/9c7d2c45-18cb-4f6c-9dfb-d90b519783fc" />
* **calypso_a4a_marketplace_products_overview_select_filter** - When selecting a filter.
   <img width="559" alt="Screenshot 2025-01-28 at 6 25 11 PM" src="https://github.com/user-attachments/assets/caf4f768-afe1-4146-ab0c-50177c9770e0" />

* **calypso_a4a_marketplace_products_overview_reset_filter** - When resetting the filter.
   <img width="222" alt="Screenshot 2025-01-28 at 6 25 16 PM" src="https://github.com/user-attachments/assets/3a5d8bc9-c397-4362-baca-a773626dd49d" />

* **calypso_a4a_marketplace_products_overview_section_visible** - When a product section is visible on the screen (During scroll).

## Why are these changes being made?

* This is part of the UX Marketplace project.

## Testing Instructions


* Use the A4A live link and go to the `/marketplace/products?flags=a4a-product-page-redesign`
* Verify that when inputting value in the search field, a record action is dispatched with **calypso_a4a_marketplace_products_overview_input_search** track event.
* Verify that when selecting a filter, a record action is dispatched with **calypso_a4a_marketplace_products_overview_select_filter** track event.
* Verify that when resetting the filter, a record action is dispatched with **calypso_a4a_marketplace_products_overview_reset_filter** track event.
* Verify that when a product section is visible during scroll, a record action is dispatched with **calypso_a4a_marketplace_products_overview_section_visible** track event.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
