### PR TITLE
Global Styles on Personal AB: Change group assignment for n-treatments on Calypso

### DIFF
--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -80,8 +80,7 @@ const getGlobalStylesInfoForSite = (
 				Promise.resolve( {
 					shouldLimitGlobalStyles: true,
 					globalStylesInUse: false,
-					globalStylesInPersonalPlan:
-						( experimentAssignment?.variationName ?? 'control' ) !== 'control',
+					globalStylesInPersonalPlan: !! experimentAssignment?.variationName,
 				} )
 		);
 	}

--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -80,7 +80,7 @@ const getGlobalStylesInfoForSite = (
 				Promise.resolve( {
 					shouldLimitGlobalStyles: true,
 					globalStylesInUse: false,
-					globalStylesInPersonalPlan: experimentAssignment.variationName === 'treatment',
+					globalStylesInPersonalPlan: experimentAssignment.variationName !== 'control',
 				} )
 		);
 	}

--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -80,7 +80,8 @@ const getGlobalStylesInfoForSite = (
 				Promise.resolve( {
 					shouldLimitGlobalStyles: true,
 					globalStylesInUse: false,
-					globalStylesInPersonalPlan: experimentAssignment.variationName !== 'control',
+					globalStylesInPersonalPlan:
+						( experimentAssignment?.variationName ?? 'control' ) !== 'control',
 				} )
 		);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes
In this PR we change the way we determine if Global Syles is enabled on the Personal plan or not. We have 2 treatment groups, every treatment group has GS enabled. The proposed change is to use the control variant as a discriminator so that only the control group gets Global Styles on the Premium plan.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

These changes are being made to support multiple treatment groups in the Global Styles on Personal experiment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Make sure to apply https://github.com/Automattic/jetpack/pull/41132 to your sandbox
* Sandbox your API
* Change the experiment assignment
* Test all the screens where global style upgrades are shown.
* Make sure all references of plan upgrades reference the correct plan.
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
