### PR TITLE
Add block to promote SFTP and SSH

### DIFF
--- a/client/sites/hosting-features/components/hosting-features.tsx
+++ b/client/sites/hosting-features/components/hosting-features.tsx
@@ -115,6 +115,13 @@ const HostingFeatures = ( { showAsTools }: HostingFeaturesProps ) => {
 			),
 			supportContext: 'hosting-configuration',
 		},
+		{
+			title: translate( 'SFTP & SSH Access' ),
+			text: translate(
+				'Securely access and edit your site via SFTP, or use SSH for file management and WP-CLI commands.'
+			),
+			supportContext: 'hosting-sftp',
+		},
 	];
 
 	const canSiteGoAtomic = ! isSiteAtomic && hasSftpFeature;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10338

## Proposed Changes

I propose to add a card that promotes SFTP and SSH access in the Hosting Features tab:

<img width="1041" alt="Screenshot 2025-01-28 at 13 09 35" src="https://github.com/user-attachments/assets/75b78d46-93e2-4c9c-8d07-600a934ddc7d" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*  To promote SFTP and SSH access along with other Hosting Features benefits.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run Calypso locally or use Calypso live
2. Create a new site and choose a Business plan
3. Navigate to the site's Hosting Features tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
