### PR TITLE
Reader onboarding - fix issue with flickering interests modal on /read load.

### DIFF
--- a/client/reader/following/use-site-subscriptions.ts
+++ b/client/reader/following/use-site-subscriptions.ts
@@ -18,7 +18,8 @@ export function useSiteSubscriptions() {
 		refetch: refetchSiteSubscriptions,
 	} = SubscriptionManager.useSiteSubscriptionsQuery();
 
-	const isLoading = isLoadingCount || isLoadingSiteSubscriptions;
+	const isLoadingDependencies = subscriptionsCount === undefined || siteSubscriptions === undefined;
+	const isLoading = isLoadingCount || isLoadingSiteSubscriptions || isLoadingDependencies;
 	const blogCount = subscriptionsCount?.blogs ?? 0;
 
 	const hasNonSelfSubscriptions = useMemo( () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/98916 and https://github.com/Automattic/wp-calypso/pull/96988 / https://github.com/Automattic/wp-calypso/pull/97030

## Proposed Changes

* Updates the `isLoading` logic of the `useSiteSubscriptions` hook to check if `subscriptionsCount` or `siteSubscriptions` are still `undefined`.
    * Note that `isLoading` does not always default to true on the first render, as there may be other dependencies on this request being made.
    * Previously, `isLoading` would be `false` for the first few render cycles until the request from `useQuery` started (delayed due to other dependencies, etc.). This `useSiteSubscriptions` hook would then show the user as having no subscriptions and cause reader onboarding to open before the request had been made. Once the request was actually triggered, this would then disappear and start to behave as expected.

BEFORE
![onboarding-flicker-before](https://github.com/user-attachments/assets/0bb03224-9312-481e-bef1-24073f7a9561)



AFTER
![onboarding-flicker-after](https://github.com/user-attachments/assets/0278aa52-f0dd-4f76-9812-a3e6364ca861)




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Reader onboarding interests modal would sometimes flash open for users loading into the reader, regardless of them having plenty of subscriptions already.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To repro the original issue (on production):
* Using an account with subscriptions, visit /read.
* Clear the indexedDB in application settings. (this is necessary to consistently repro the original issue).
* Reload /read.
* You should see reader onboarding interests modal flicker and disappear.

TESTING:
* Run this branch of calypso.
* Using an account with subscriptions, visit /read.
* Clear the indexedDB in application settings.
* Reload /read.
* Verify the flicker issue is gone.
* Remove your subscriptions, or switch to a test account where you are comfortable removing subscriptions.
* Visit /read, and verify reader onboarding is available.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
