### PR TITLE
Stepper Onboarding: Unify progress loader

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -115,7 +115,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 
 	const username = useSelector( getCurrentUserName );
 
-	const { setPendingAction, setProgress } = useDispatch( ONBOARD_STORE );
+	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 
 	// when it's empty, the default WordPress theme will be used.
 	let theme = '';
@@ -275,9 +275,6 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 	}
 
 	useEffect( () => {
-		if ( ! isFreeFlow( flow ) ) {
-			setProgress( 0.1 );
-		}
 		if ( submit ) {
 			setPendingAction( createSite );
 			submit();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -12,12 +12,12 @@ import {
 	HUNDRED_YEAR_DOMAIN_TRANSFER,
 	isAnyHostingFlow,
 } from '@automattic/onboarding';
+import { ProgressBar } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState, useRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { LoadingBar } from 'calypso/components/loading-bar';
-import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import availableFlows from 'calypso/landing/stepper/declarative-flow/registered-flows';
 import { useRecordSignupComplete } from 'calypso/landing/stepper/hooks/use-record-signup-complete';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
@@ -197,6 +197,24 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 
 	const subtitle = getSubtitle();
 
+	const renderProgressComponent = () => {
+		if ( isWooExpressFlow( flow ) || isTransferringHostedSiteCreationFlow( flow ) ) {
+			return (
+				<LoadingBar
+					progress={ progress }
+					className="processing-step__content woocommerce-install__content"
+				/>
+			);
+		}
+
+		return (
+			<ProgressBar
+				value={ progress >= 0 ? progress * 100 : undefined }
+				className="processing-step__progress-bar"
+			/>
+		);
+	};
+
 	return (
 		<>
 			<DocumentHead title={ __( 'Processing' ) } />
@@ -208,16 +226,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 					<>
 						<div className="processing-step">
 							<h1 className="processing-step__progress-step">{ getCurrentMessage() }</h1>
-							{ progress >= 0 ||
-							isWooExpressFlow( flow ) ||
-							isTransferringHostedSiteCreationFlow( flow ) ? (
-								<LoadingBar
-									progress={ progress }
-									className="processing-step__content woocommerce-install__content"
-								/>
-							) : (
-								<LoadingEllipsis />
-							) }
+							{ renderProgressComponent() }
 							{ subtitle && <p className="processing-step__subtitle">{ subtitle }</p> }
 						</div>
 					</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -17,6 +17,10 @@
 		vertical-align: middle;
 		margin: 0;
 	}
+
+	.processing-step__progress-bar {
+		margin: 46px auto 0 auto;
+	}
 }
 
 .processing-step__step-wrapper {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -3,6 +3,8 @@
 @import "@automattic/onboarding/styles/mixins";
 
 .processing-step {
+	--wp-components-color-foreground: #3858E9;
+
 	padding: 1em;
 	max-width: 540px;
 	text-align: center;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98162

## Proposed Changes

Let's use `ProgressBar` component from Core instead of the Loading Ellipsis or the Calypso bar.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Live Link.
* Go to `/setup/onboarding`.
* Go through the flow and check the loading before and after checkout.
* At the moment, if you choose free site and plan, you will not see checkout but two distinct loadings. This is a different issue that we can look at in a second moment.