### PR TITLE
Domains: Include "Do you own it?" link for 100-year flows

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -164,7 +164,7 @@ class DomainSearchResults extends Component {
 									// eslint-disable-next-line jsx-a11y/anchor-is-valid
 									<a
 										href="#"
-										onClick={ this.props.onClickUseYourDomain }
+										onClick={ () => this.props.onClickUseYourDomain( domainArgument ) }
 										data-tracks-button-click-source={ this.props.tracksButtonClickSource }
 									/>
 								),

--- a/client/landing/stepper/declarative-flow/hundred-year-domain.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain.ts
@@ -87,7 +87,11 @@ const HundredYearDomainFlow: Flow = {
 			}
 		}
 
-		return { submit };
+		const exitFlow = ( location = '/sites' ) => {
+			window.location.assign( location );
+		};
+
+		return { exitFlow, submit };
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/hundred-year-plan.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-plan.ts
@@ -156,7 +156,11 @@ const HundredYearPlanFlow: Flow = {
 			}
 		}
 
-		return { submit };
+		const exitFlow = ( location = '/sites' ) => {
+			window.location.assign( location );
+		};
+
+		return { submit, exitFlow };
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -227,6 +227,17 @@ const Domains: React.FC< Props > = ( { onSubmit, variantSlug } ) => {
 			} );
 
 			newDomainsState[ uuid() ] = { ...domainTransferObj };
+
+			// Only keep the latest entry - 100-year domain flows are only
+			// allowed to have one domain at a time, so always keep the latest
+			// one and remove the rest.
+			if ( isHundredYearTransfer ) {
+				Object.entries( newDomainsState ).forEach( ( [ key, domainObject ] ) => {
+					if ( domainObject.domain !== newDomainTransferQueryArg ) {
+						delete newDomainsState[ key ];
+					}
+				} );
+			}
 		}
 
 		if ( ! duplicateDomain ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -37,7 +37,7 @@ interface DomainFormControlProps {
 	onAddMapping: ( domain: string ) => void;
 	onAddTransfer: ( { domain, authCode }: { domain: string; authCode: string } ) => void;
 	onSkip: ( _googleAppsCartItem?: any, shouldHideFreePlan?: boolean ) => void;
-	onUseYourDomainClick: () => void;
+	onUseYourDomainClick: ( domain?: string ) => void;
 	showUseYourDomain: boolean;
 	isCartPendingUpdate: boolean;
 	isCartPendingUpdateDomain: DomainSuggestion | undefined;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -11,7 +11,6 @@ import {
 	isDomainUpsellFlow,
 	isSiteAssemblerFlow,
 	isHundredYearDomainFlow,
-	isHundredYearPlanFlow,
 	HUNDRED_YEAR_DOMAIN_FLOW,
 } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
@@ -266,16 +265,12 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 	};
 
 	const onUseYourDomainClick = ( domain?: string ) => {
-		if ( isHundredYearPlanFlow( flow ) || isHundredYearDomainFlow( flow ) ) {
-			if ( domain ) {
-				const leaveFlowFunction = exitFlow ?? window.location.assign;
-				leaveFlowFunction( `/setup/hundred-year-domain-transfer?new=${ domain }` );
-			} else {
-				setShowUseYourDomain( true );
-			}
-		} else {
-			setShowUseYourDomain( true );
+		if ( domain && isHundredYearDomainFlow( flow ) ) {
+			const leaveFlowFunction = exitFlow ?? window.location.assign;
+			leaveFlowFunction( `/setup/hundred-year-domain-transfer?new=${ domain }` );
 		}
+
+		setShowUseYourDomain( true );
 	};
 
 	const renderContent = () => (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -268,7 +268,8 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 	const onUseYourDomainClick = ( domain?: string ) => {
 		if ( isHundredYearPlanFlow( flow ) || isHundredYearDomainFlow( flow ) ) {
 			if ( domain ) {
-				exitFlow?.( `/setup/hundred-year-domain-transfer?new=${ domain }` );
+				const leaveFlowFunction = exitFlow ?? window.location.assign;
+				leaveFlowFunction( `/setup/hundred-year-domain-transfer?new=${ domain }` );
 			} else {
 				setShowUseYourDomain( true );
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -10,6 +10,8 @@ import {
 	HUNDRED_YEAR_PLAN_FLOW,
 	isDomainUpsellFlow,
 	isSiteAssemblerFlow,
+	isHundredYearDomainFlow,
+	isHundredYearPlanFlow,
 	HUNDRED_YEAR_DOMAIN_FLOW,
 } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
@@ -263,6 +265,18 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 		submitWithDomain( suggestion );
 	};
 
+	const onUseYourDomainClick = ( domain?: string ) => {
+		if ( isHundredYearPlanFlow( flow ) || isHundredYearDomainFlow( flow ) ) {
+			if ( domain ) {
+				exitFlow?.( `/setup/hundred-year-domain-transfer?new=${ domain }` );
+			} else {
+				setShowUseYourDomain( true );
+			}
+		} else {
+			setShowUseYourDomain( true );
+		}
+	};
+
 	const renderContent = () => (
 		<DomainFormControl
 			analyticsSection={ getAnalyticsSection() }
@@ -271,7 +285,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			onAddMapping={ handleAddMapping }
 			onAddTransfer={ handleAddTransfer }
 			onSkip={ handleSkip }
-			onUseYourDomainClick={ () => setShowUseYourDomain( true ) }
+			onUseYourDomainClick={ onUseYourDomainClick }
 			showUseYourDomain={ showUseYourDomain }
 			isCartPendingUpdate={ isCartPendingUpdate }
 			isCartPendingUpdateDomain={ isCartPendingUpdateDomain }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -601,6 +601,11 @@
 			.domain-search-results__domain-available-notice-icon {
 				margin-right: 4px;
 			}
+
+			/* hide transfer link */
+			a {
+				display: none;
+			}
 		}
 
 		// Hide the domain explanation image
@@ -621,6 +626,12 @@
 				align-items: flex-end;
 				align-self: center;
 				margin-right: 16px;
+			}
+		}
+
+		.domain-search-results__domain-available-notice {
+			a {
+				display: unset;
 			}
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -601,11 +601,6 @@
 			.domain-search-results__domain-available-notice-icon {
 				margin-right: 4px;
 			}
-
-			/* hide transfer link */
-			a {
-				display: none;
-			}
 		}
 
 		// Hide the domain explanation image


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #98849 - follow up.

## Proposed Changes
Add the "Do you own it?" link to the 100-year domain specific flow - redirecting it to the 100-year domain transfer with the domain used previously as its input.
The 100-year plan flow is left unchanged, since we don't want to override the cart and remove them from the context or purchase of the 100-year plan itself - bundling is still unsupported and wasn't handled in this PR.

### Preview
#### Within 100-year plan flow
https://github.com/user-attachments/assets/28a14dae-b85e-4ca6-96b7-8fe66b588ef9

#### Within 100-year domain flow
https://github.com/user-attachments/assets/c73b882e-52d3-43cc-8397-44a5537c77f9



## Testing Instructions
- Go to either the 100-year plan or 100-year domain flows;
- Try using a domain that's already registered and that it's transferrable;
- Ensure you get the "Do you own it?" link, clicking it should get you to the 100-year domain transfer flow with the domain as input.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
