### PR TITLE
Stepper: Goals first add flow flow prop to event

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -22,6 +22,7 @@ type KebabToSnakeCase< S extends string > = S extends `${ infer T }${ infer U }`
 	: S;
 
 type TracksGoalsSelectEventProperties = {
+	flow: string;
 	goals: string;
 	combo: string;
 	total: number;
@@ -43,7 +44,7 @@ const refGoals: Record< string, Onboard.SiteGoal[] > = {
 /**
  * The goals capture step
  */
-const GoalsStep: Step = ( { navigation } ) => {
+const GoalsStep: Step = ( { navigation, flow } ) => {
 	const translate = useTranslate();
 	const whatAreYourGoalsText = translate( 'What would you like to do?' );
 	const subHeaderText = translate(
@@ -82,6 +83,7 @@ const GoalsStep: Step = ( { navigation } ) => {
 			combo: goals.slice().sort().join( ',' ),
 			total: goals.length,
 			is_goals_big_sky_eligible: isGoalsBigSkyEligible( goals ),
+			flow,
 		};
 
 		goals.forEach( ( goal, i ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pfYzsZ-1xh-p2

## Proposed Changes

Add a `flow` property to the `calypso_signup_goals_select` event.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through `/setup/onboarding`.
* After goals step, check the event triggered.