### PR TITLE
Subscribers Dataviews: Style subscriber launchpad in empty state

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -92,6 +92,19 @@ body.is-section-subscribers.is-subscribers-dataviews,
                     }
                 }
 
+                .subscriber-launchpad {
+                    width: 100%;
+                    max-width: 569px;
+                    flex-shrink: 0;
+                    overflow: hidden;
+                    box-sizing: border-box;
+
+                    @media ( max-width: 430px ) {
+                        margin: 0;
+                        padding: 16px;
+                    }
+                }
+
                 &-item {
                     display: flex;
                     flex-direction: row;

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -94,7 +94,6 @@ body.is-section-subscribers.is-subscribers-dataviews,
 
                 .subscriber-launchpad {
                     width: 100%;
-                    max-width: 569px;
                     flex-shrink: 0;
                     overflow: hidden;
                     box-sizing: border-box;

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -99,8 +99,8 @@ body.is-section-subscribers.is-subscribers-dataviews,
                     overflow: hidden;
                     box-sizing: border-box;
 
-                    @media ( max-width: 430px ) {
-                        margin: 0;
+                    @media ( max-width: $break-small ) {
+                        margin: 0 auto;
                         padding: 16px;
                     }
                 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/368

## Proposed Changes

* Style the subscriber launchpad in the Subscribers Dataviews empty state.

Before | After
---- | ----
<img width="346" alt="Image" src="https://github.com/user-attachments/assets/48079cf5-663c-4b07-9f1c-f9f45acb2fe7" /> | <img width="1274" alt="Screen Shot 2025-01-28 at 11 53 53 AM" src="https://github.com/user-attachments/assets/9e8233b9-fd43-4165-9af1-cfbebcafeca3" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The launchpad width shrunk because we're now in a flex container.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/subscribers/{ site URL}?flags=subscribers-dataviews` for a site with no subscribers.
* Check the width of the launchpad at different screen sizes. It shouldn't be squished.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
