### PR TITLE
Focused Launchpad: Persist skip onboarding and prevent it from showing again

### DIFF
--- a/client/landing/stepper/utils/skip-launchpad.ts
+++ b/client/landing/stepper/utils/skip-launchpad.ts
@@ -3,13 +3,20 @@ import { updateLaunchpadSettings } from '@automattic/data-stores';
 type SkipLaunchpadProps = {
 	siteId: string | number | null;
 	siteSlug: string | null;
+	redirectToHome?: boolean;
 };
 
-export const skipLaunchpad = async ( { siteId, siteSlug }: SkipLaunchpadProps ) => {
+export const skipLaunchpad = async ( {
+	siteId,
+	siteSlug,
+	redirectToHome = true,
+}: SkipLaunchpadProps ) => {
 	const siteIdOrSlug = siteId || siteSlug;
 	if ( siteIdOrSlug ) {
 		await updateLaunchpadSettings( siteIdOrSlug, { launchpad_screen: 'skipped' } );
 	}
 
-	return window.location.assign( `/home/${ siteIdOrSlug }` );
+	if ( redirectToHome ) {
+		return window.location.assign( `/home/${ siteIdOrSlug }` );
+	}
 };

--- a/client/landing/stepper/utils/test/skip-launchpad.ts
+++ b/client/landing/stepper/utils/test/skip-launchpad.ts
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+import { updateLaunchpadSettings } from '@automattic/data-stores';
+import { skipLaunchpad } from '../skip-launchpad';
+
+// Mock the data-stores module
+jest.mock( '@automattic/data-stores', () => ( {
+	updateLaunchpadSettings: jest.fn(),
+} ) );
+
+describe( 'skipLaunchpad', () => {
+	beforeEach( () => {
+		// Clear all mocks before each test
+		jest.clearAllMocks();
+		// Properly mock window.location
+		delete window.location;
+		window.location = { assign: jest.fn() } as unknown as Location;
+	} );
+
+	it( 'should update launchpad settings and redirect to siteId by default', async () => {
+		await skipLaunchpad( { siteId: '123', siteSlug: null } );
+
+		expect( updateLaunchpadSettings ).toHaveBeenCalledWith( '123', {
+			launchpad_screen: 'skipped',
+		} );
+		expect( window.location.assign ).toHaveBeenCalledWith( '/home/123' );
+	} );
+
+	it( 'should update launchpad settings and redirect to siteSlug by default', async () => {
+		await skipLaunchpad( { siteId: null, siteSlug: 'test-site' } );
+
+		expect( updateLaunchpadSettings ).toHaveBeenCalledWith( 'test-site', {
+			launchpad_screen: 'skipped',
+		} );
+		expect( window.location.assign ).toHaveBeenCalledWith( '/home/test-site' );
+	} );
+
+	it( 'should not redirect when redirectToHome is false', async () => {
+		await skipLaunchpad( { siteId: '123', siteSlug: null, redirectToHome: false } );
+
+		expect( updateLaunchpadSettings ).toHaveBeenCalledWith( '123', {
+			launchpad_screen: 'skipped',
+		} );
+		expect( window.location.assign ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/my-sites/customer-home/cards/launchpad/test/focused-launchpad.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/test/focused-launchpad.tsx
@@ -3,9 +3,9 @@
  */
 import { render, screen, act } from '@testing-library/react';
 import React from 'react';
-import CustomerHome from '../main';
+import CustomerHome from '../../../main';
 
-jest.mock( '../components/full-screen-launchpad', () => ( {
+jest.mock( '../../../components/full-screen-launchpad', () => ( {
 	FullScreenLaunchpad: ( { onClose }: { onClose: () => void } ) => (
 		<div data-testid="launchpad">
 			<button onClick={ onClose } data-testid="close-launchpad">
@@ -15,7 +15,7 @@ jest.mock( '../components/full-screen-launchpad', () => ( {
 	),
 } ) );
 
-jest.mock( '../components/home-content', () => () => (
+jest.mock( '../../../components/home-content', () => () => (
 	<div data-testid="home-content">Home Content</div>
 ) );
 

--- a/client/my-sites/customer-home/cards/launchpad/test/focused-launchpad.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/test/focused-launchpad.tsx
@@ -4,6 +4,11 @@
 import { render, screen, act } from '@testing-library/react';
 import React from 'react';
 import CustomerHome from '../../../main';
+import type { SiteDetails } from '@automattic/data-stores';
+
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: jest.fn( ( flag ) => flag === 'home/launchpad-first' ),
+} ) );
 
 jest.mock( '../../../components/full-screen-launchpad', () => ( {
 	FullScreenLaunchpad: ( { onClose }: { onClose: () => void } ) => (
@@ -30,16 +35,46 @@ jest.mock( 'calypso/components/main', () => ( { children }: { children: React.Re
 jest.mock( 'calypso/components/data/document-head', () => () => null );
 jest.mock( 'calypso/lib/analytics/page-view-tracker', () => () => null );
 
+function makeTestSite( site: Partial< SiteDetails > = {} ): SiteDetails {
+	return {
+		ID: 1,
+		title: 'Test Site',
+		slug: 'https://example.com',
+		URL: 'https://example.com',
+		domain: 'example.com',
+		launch_status: 'launched',
+		options: { site_creation_flow: 'onboarding', launchpad_screen: false, ...site.options },
+		...site,
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	} as any; // This partial site object should be good enough for testing purposes
+}
+
 describe( 'Make sure CustomerHome render traditional home or Focused Launchpad', () => {
-	it( 'should show HomeContent by default when showLaunchpadFirst is false', () => {
-		render( <CustomerHome /> );
+	it( 'should show HomeContent for launched site', () => {
+		const testSite = makeTestSite( { launch_status: 'launched' } );
+		render( <CustomerHome site={ testSite } /> );
 
 		expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument();
 		expect( screen.queryByTestId( 'launchpad' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'should show Launchpad when showLaunchpadFirst is true', async () => {
-		render( <CustomerHome showLaunchpadFirst /> );
+	it( 'should show HomeContent for unlaunched site when launchpad is skipped', () => {
+		const testSite = makeTestSite( {
+			launch_status: 'unlaunched',
+			options: { launchpad_screen: 'skipped' },
+		} );
+		render( <CustomerHome site={ testSite } /> );
+
+		expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument();
+		expect( screen.queryByTestId( 'launchpad' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should show Launchpad when site is unlaunched, created by onboarding flow, and launchpad is unskipped', async () => {
+		const testSite = makeTestSite( {
+			launch_status: 'unlaunched',
+			options: { site_creation_flow: 'onboarding', launchpad_screen: false },
+		} );
+		render( <CustomerHome site={ testSite } /> );
 
 		expect( screen.getByTestId( 'launchpad' ) ).toBeInTheDocument();
 		expect( screen.queryByTestId( 'home-content' ) ).not.toBeInTheDocument();

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -6,6 +6,8 @@ import { useSelector } from 'react-redux';
 import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
+import { useDispatch } from 'calypso/state';
+import { requestSite } from 'calypso/state/sites/actions';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
@@ -16,6 +18,7 @@ import CelebrateLaunchModal from './celebrate-launch-modal';
 import './full-screen-launchpad.scss';
 
 export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ) => {
+	const dispatch = useDispatch();
 	const { __ } = useI18n();
 	const siteId = useSelector( getSelectedSiteId ) || 0;
 	const site = useSelector( ( state: AppState ) => getSite( state, siteId ) );
@@ -38,14 +41,16 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ) => {
 		handleSiteLaunched( !! site?.is_wpcom_atomic );
 	};
 
-	const onSkipLaunchpad = () => {
-		skipLaunchpad( {
+	const onSkipLaunchpad = async () => {
+		onClose();
+
+		await skipLaunchpad( {
 			siteId,
 			siteSlug,
 			redirectToHome: false,
 		} );
 
-		onClose();
+		dispatch( requestSite( siteId ) );
 	};
 
 	if ( isDismissed ) {

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
 import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
+import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
@@ -35,6 +36,16 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ) => {
 
 	const onSiteLaunched = () => {
 		handleSiteLaunched( !! site?.is_wpcom_atomic );
+	};
+
+	const onSkipLaunchpad = () => {
+		skipLaunchpad( {
+			siteId,
+			siteSlug,
+			redirectToHome: false,
+		} );
+
+		onClose();
 	};
 
 	if ( isDismissed ) {
@@ -71,7 +82,7 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ) => {
 					) }
 				</div>
 			</div>
-			<Button onClick={ onClose }>{ __( 'Skip onboarding setup' ) }</Button>
+			<Button onClick={ onSkipLaunchpad }>{ __( 'Skip onboarding setup' ) }</Button>
 		</div>
 	);
 };

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -87,7 +87,7 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ) => {
 					) }
 				</div>
 			</div>
-			<Button onClick={ onSkipLaunchpad }>{ __( 'Skip onboarding setup' ) }</Button>
+			<Button onClick={ onSkipLaunchpad }>{ __( 'Skip to dashboard' ) }</Button>
 		</div>
 	);
 };

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -28,7 +28,7 @@ export default async function renderHome( context, next ) {
 		window.scrollTo( 0, 0 );
 	}
 
-	context.primary = <CustomerHome site={ site } />;
+	context.primary = <CustomerHome key={ site.ID } site={ site } />;
 
 	next();
 }

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -28,9 +28,7 @@ export default async function renderHome( context, next ) {
 		window.scrollTo( 0, 0 );
 	}
 
-	context.primary = (
-		<CustomerHome key={ site.ID } showLaunchpadFirst={ shouldShowLaunchpadFirst( site ) } />
-	);
+	context.primary = <CustomerHome site={ site } />;
 
 	next();
 }

--- a/client/my-sites/customer-home/main.tsx
+++ b/client/my-sites/customer-home/main.tsx
@@ -3,11 +3,22 @@ import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import shouldShowLaunchpadFirst from 'calypso/state/selectors/should-show-launchpad-first';
 import { FullScreenLaunchpad } from './components/full-screen-launchpad';
 import HomeContent from './components/home-content';
+import type { SiteDetails } from '@automattic/data-stores';
 
-export default function CustomerHome( { showLaunchpadFirst = false } ) {
-	const [ isShowingLaunchpad, setIsShowingLaunchpad ] = useState( showLaunchpadFirst );
+export default function CustomerHome( { site }: { site: SiteDetails } ) {
+	const showLaunchpadFirst = shouldShowLaunchpadFirst( site );
+
+	const isSiteLaunched = site?.launch_status === 'launched' || false;
+
+	const [ isShowingLaunchpad, setIsShowingLaunchpad ] = useState(
+		showLaunchpadFirst &&
+			site.options?.launchpad_screen !== undefined &&
+			site.options?.launchpad_screen !== 'skipped' &&
+			! isSiteLaunched
+	);
 
 	const translate = useTranslate();
 

--- a/client/my-sites/customer-home/test/my-home.tsx
+++ b/client/my-sites/customer-home/test/my-home.tsx
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, act } from '@testing-library/react';
+import React from 'react';
+import CustomerHome from '../main';
+
+jest.mock( '../components/full-screen-launchpad', () => ( {
+	FullScreenLaunchpad: ( { onClose }: { onClose: () => void } ) => (
+		<div data-testid="launchpad">
+			<button onClick={ onClose } data-testid="close-launchpad">
+				Close Launchpad
+			</button>
+		</div>
+	),
+} ) );
+
+jest.mock( '../components/home-content', () => () => (
+	<div data-testid="home-content">Home Content</div>
+) );
+
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: () => ( str: string ) => str,
+} ) );
+
+jest.mock( 'calypso/components/main', () => ( { children }: { children: React.ReactNode } ) => (
+	<div data-testid="main">{ children }</div>
+) );
+
+jest.mock( 'calypso/components/data/document-head', () => () => null );
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => () => null );
+
+describe( 'Make sure CustomerHome render traditional home or Focused Launchpad', () => {
+	it( 'should show HomeContent by default when showLaunchpadFirst is false', () => {
+		render( <CustomerHome /> );
+
+		expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument();
+		expect( screen.queryByTestId( 'launchpad' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should show Launchpad when showLaunchpadFirst is true', async () => {
+		render( <CustomerHome showLaunchpadFirst /> );
+
+		expect( screen.getByTestId( 'launchpad' ) ).toBeInTheDocument();
+		expect( screen.queryByTestId( 'home-content' ) ).not.toBeInTheDocument();
+
+		// Click the close button
+		await act( async () => {
+			screen.getByTestId( 'close-launchpad' ).click();
+		} );
+
+		// Verify HomeContent is now shown
+		expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument();
+		expect( screen.queryByTestId( 'launchpad' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -291,7 +291,7 @@ export interface SiteDetailsOptions {
 	was_created_with_blank_canvas_design?: boolean;
 	woocommerce_is_active?: boolean;
 	wordads?: boolean;
-	launchpad_screen?: false | 'off' | 'full' | 'minimized';
+	launchpad_screen?: false | 'off' | 'full' | 'minimized' | 'skipped';
 	launchpad_checklist_tasks_statuses?: LaunchPadCheckListTasksStatuses;
 	migration_source_site_domain?: string;
 	wpcom_production_blog_id?: number;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98904

This work is fundamental to allow us to move this code to the staging environment and release it internally. We're now allowing users to skip Focused Launchpad and persisting that data.

## Proposed Changes

* Persist skip onboarding in the Focused launchpad
* If the user skipped it, don't show it again while navigating back to /home (even with the feature flag enabled)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is part of Launchpad In My Home project: pet6gk-1T7-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Configure your `development.json` to have `"home/launchpad-first": true`
* Restart your yarn server
* Create a new site with [the /setup/onboarding flow](http://calypso.localhost:3000/setup/onboarding)
* Make sure when you arrive at the homepage, you'll see the Focused Launchpad
* Dismiss it by clicking at `Skip onboarding setup` and navigate to any other Calypso page
* Get back to the home page and make sure you shouldn't see it again for that site


https://github.com/user-attachments/assets/04800043-84fa-4c4e-a07c-139c2309e025


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?