### PR TITLE
Stats: fix upsell prompt position

### DIFF
--- a/packages/components/src/horizontal-bar-list/stats-card.scss
+++ b/packages/components/src/horizontal-bar-list/stats-card.scss
@@ -116,6 +116,11 @@
 			grid-row: 1;
 		}
 
+		.stats-card__content--hero {
+			grid-column: auto;
+			grid-row: auto;
+		}
+
 		.stats-card__content .stats-card--header-and-body .stats-card--body,
 		.stats-card__content .stats-card-header--split .stats-card--column-header,
 		.stats-card__content .stats-card--hero,
@@ -128,6 +133,14 @@
 		.stats-card__overlay {
 			z-index: 1;
 		}
+
+		.stats-card__overlay--hero {
+			position: absolute;
+			bottom: 0;
+			left: 0;
+			right: 0;
+			top: 0;
+		}
 	}
 
 	.stats-card__content {
@@ -136,6 +149,7 @@
 		flex-direction: column;
 		justify-content: space-between;
 		height: 100%;
+		position: relative;
 	}
 }
 

--- a/packages/components/src/horizontal-bar-list/stats-hero-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-hero-card.tsx
@@ -75,7 +75,7 @@ const StatsHeroCard = ( {
 					{ toggleControl }
 				</div>
 			</div>
-			<div className={ `${ BASE_CLASS_NAME }__content` }>
+			<div className={ `${ BASE_CLASS_NAME }__content ${ BASE_CLASS_NAME }__content--hero` }>
 				<div className={ `${ BASE_CLASS_NAME }--hero` }>{ heroElement }</div>
 				<div className={ `${ BASE_CLASS_NAME }--header-and-body` }>
 					<div
@@ -101,8 +101,12 @@ const StatsHeroCard = ( {
 						</a>
 					) }
 				</div>
+				{ overlay && (
+					<div className={ `${ BASE_CLASS_NAME }__overlay ${ BASE_CLASS_NAME }__overlay--hero` }>
+						{ overlay }
+					</div>
+				) }
 			</div>
-			{ overlay && <div className={ `${ BASE_CLASS_NAME }__overlay` }>{ overlay }</div> }
 		</div>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/jetpack-roadmap#2206.

## Proposed Changes

* Fix the title and location selectors, as they were appearing below the upsell prompt.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* (p1HpG7-rpL-p2)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Access the Calypso Live preview linked below.
- In the Stats Traffic tab, scroll down to the Locations section of a site that has a free plan.
  - In my case, I used my local Jetpack development site.
- Check the positioning of the title and `Countries`/`Regions`/`Cities` selector, they both should remain above the upsell prompt.
  - The same behavior should be observed in the Summary page, accessible via the `View details` link.

### Traffic Page

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/d9387f21-74ea-4b63-80de-3cbc7a83abf6) | <img alt="image" src="https://github.com/user-attachments/assets/ac704583-08d2-4a85-89cd-63093e4c858b" /> |

### Summary Page

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/852280f5-59b2-490d-bd3c-61be21afc2b1) | <img alt="image" src="https://github.com/user-attachments/assets/38632a54-927d-417b-8c2c-b303ad954bf6" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
