### PR TITLE
i18n: Fix missing/wrong number translations on subscribers page

### DIFF
--- a/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
@@ -3,7 +3,7 @@ import { StatsCard } from '@automattic/components';
 import { mail } from '@automattic/components/src/icons';
 import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
+import { numberFormat, useTranslate } from 'i18n-calypso';
 import React from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import StatsInfoArea from 'calypso/my-sites/stats/features/modules/shared/stats-info-area';
@@ -87,7 +87,15 @@ const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
 							const hasUniques = hasUniqueMetrics( opensUnique, opens );
 							return (
 								<TooltipWrapper
-									value={ hasUniques ? `${ item.opens_rate }%` : '—' }
+									value={
+										hasUniques
+											? `${ numberFormat( item.opens_rate, {
+													numberFormatOptions: {
+														maximumFractionDigits: 2,
+													},
+											  } ) }%`
+											: '—'
+									}
 									item={ item }
 									TooltipContent={ OpensTooltipContent }
 								/>
@@ -110,7 +118,15 @@ const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
 						const hasUniques = hasUniqueMetrics( clicksUnique, clicks );
 						return (
 							<TooltipWrapper
-								value={ hasUniques ? `${ item.clicks_rate }%` : '—' }
+								value={
+									hasUniques
+										? `${ numberFormat( item.clicks_rate, {
+												numberFormatOptions: {
+													maximumFractionDigits: 2,
+												},
+										  } ) }%`
+										: '—'
+								}
 								item={ item }
 								TooltipContent={ ClicksTooltipContent }
 							/>

--- a/client/my-sites/stats/features/modules/stats-emails/tooltips.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/tooltips.tsx
@@ -1,5 +1,5 @@
 import { Tooltip } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import React, { useRef, useState } from 'react';
 
 export interface EmailStatsItem {
@@ -49,28 +49,32 @@ export const hasUniqueMetrics = ( uniqueValue: number, totalValue: number ) => {
 
 export const OpensTooltipContent: React.FC< { item: EmailStatsItem } > = ( { item } ) => {
 	const translate = useTranslate();
-	const opensUnique = parseInt( String( item.unique_opens ), 10 );
-	const opens = parseInt( String( item.opens ), 10 );
-	const opensRate = parseFloat( String( item.opens_rate ) );
-	const totalSends = parseInt( String( item.total_sends ), 10 );
-	const hasUniques = hasUniqueMetrics( opensUnique, opens );
+	const hasUniques = hasUniqueMetrics(
+		parseInt( String( item.unique_opens ), 10 ),
+		parseInt( String( item.opens ), 10 )
+	);
 
 	return (
 		<div className="stats-email__tooltip">
 			<div>
-				{ translate( 'Recipients: %(sends)d', {
-					args: { sends: totalSends },
+				{ translate( 'Recipients: %(sends)s', {
+					args: { sends: numberFormat( item.total_sends ) },
 				} ) }
 			</div>
 			<div>
-				{ translate( 'Total opens: %(opens)d', {
-					args: { opens },
+				{ translate( 'Total opens: %(opens)s', {
+					args: { opens: numberFormat( item.opens ) },
 				} ) }
 			</div>
 			<div>
 				{ hasUniques
-					? translate( 'Unique opens: %(uniqueOpens)d (%(openRate).2f%%)', {
-							args: { uniqueOpens: opensUnique, openRate: opensRate },
+					? translate( 'Unique opens: %(uniqueOpens)s (%(openRate)s%)', {
+							args: {
+								uniqueOpens: numberFormat( item.unique_opens ),
+								openRate: numberFormat( item.opens_rate, {
+									numberFormatOptions: { maximumFractionDigits: 2 },
+								} ),
+							},
 					  } )
 					: translate( 'Unique opens: —' ) }
 			</div>
@@ -80,28 +84,32 @@ export const OpensTooltipContent: React.FC< { item: EmailStatsItem } > = ( { ite
 
 export const ClicksTooltipContent: React.FC< { item: EmailStatsItem } > = ( { item } ) => {
 	const translate = useTranslate();
-	const clicksUnique = parseInt( String( item.unique_clicks ), 10 );
-	const clicks = parseInt( String( item.clicks ), 10 );
-	const clicksRate = parseFloat( String( item.clicks_rate ) );
-	const totalSends = parseInt( String( item.total_sends ), 10 );
-	const hasUniques = hasUniqueMetrics( clicksUnique, clicks );
+	const hasUniques = hasUniqueMetrics(
+		parseInt( String( item.unique_clicks ), 10 ),
+		parseInt( String( item.clicks ), 10 )
+	);
 
 	return (
 		<div className="stats-email__tooltip">
 			<div>
-				{ translate( 'Recipients: %(sends)d', {
-					args: { sends: totalSends },
+				{ translate( 'Recipients: %(sends)s', {
+					args: { sends: numberFormat( item.total_sends ) },
 				} ) }
 			</div>
 			<div>
-				{ translate( 'Total clicks: %(clicks)d', {
-					args: { clicks },
+				{ translate( 'Total clicks: %(clicks)s', {
+					args: { clicks: numberFormat( item.clicks ) },
 				} ) }
 			</div>
 			<div>
 				{ hasUniques
-					? translate( 'Unique clicks: %(uniqueClicks)d (%(clickRate).2f%%)', {
-							args: { uniqueClicks: clicksUnique, clickRate: clicksRate },
+					? translate( 'Unique clicks: %(uniqueClicks)s (%(clickRate)s%)', {
+							args: {
+								uniqueClicks: numberFormat( item.unique_clicks ),
+								clickRate: numberFormat( item.clicks_rate, {
+									numberFormatOptions: { maximumFractionDigits: 2 },
+								} ),
+							},
 					  } )
 					: translate( 'Unique clicks: —' ) }
 			</div>

--- a/client/my-sites/stats/features/modules/stats-emails/tooltips.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/tooltips.tsx
@@ -57,21 +57,21 @@ export const OpensTooltipContent: React.FC< { item: EmailStatsItem } > = ( { ite
 	return (
 		<div className="stats-email__tooltip">
 			<div>
-				{ translate( 'Recipients: %(sends)s', {
-					args: { sends: numberFormat( item.total_sends ) },
+				{ translate( 'Recipients: %(sendsCount)s', {
+					args: { sendsCount: numberFormat( item.total_sends ) },
 				} ) }
 			</div>
 			<div>
-				{ translate( 'Total opens: %(opens)s', {
-					args: { opens: numberFormat( item.opens ) },
+				{ translate( 'Total opens: %(opensCount)s', {
+					args: { opensCount: numberFormat( item.opens ) },
 				} ) }
 			</div>
 			<div>
 				{ hasUniques
-					? translate( 'Unique opens: %(uniqueOpens)s (%(openRate)s%)', {
+					? translate( 'Unique opens: %(uniqueOpensCount)s (%(opensRate)s%)', {
 							args: {
-								uniqueOpens: numberFormat( item.unique_opens ),
-								openRate: numberFormat( item.opens_rate, {
+								uniqueOpensCount: numberFormat( item.unique_opens ),
+								opensRate: numberFormat( item.opens_rate, {
 									numberFormatOptions: { maximumFractionDigits: 2 },
 								} ),
 							},
@@ -92,21 +92,21 @@ export const ClicksTooltipContent: React.FC< { item: EmailStatsItem } > = ( { it
 	return (
 		<div className="stats-email__tooltip">
 			<div>
-				{ translate( 'Recipients: %(sends)s', {
-					args: { sends: numberFormat( item.total_sends ) },
+				{ translate( 'Recipients: %(sendsCount)s', {
+					args: { sendsCount: numberFormat( item.total_sends ) },
 				} ) }
 			</div>
 			<div>
-				{ translate( 'Total clicks: %(clicks)s', {
-					args: { clicks: numberFormat( item.clicks ) },
+				{ translate( 'Total clicks: %(clicksCount)s', {
+					args: { clicksCount: numberFormat( item.clicks ) },
 				} ) }
 			</div>
 			<div>
 				{ hasUniques
-					? translate( 'Unique clicks: %(uniqueClicks)s (%(clickRate)s%)', {
+					? translate( 'Unique clicks: %(uniqueClicksCount)s (%(clicksRate)s%)', {
 							args: {
-								uniqueClicks: numberFormat( item.unique_clicks ),
-								clickRate: numberFormat( item.clicks_rate, {
+								uniqueClicksCount: numberFormat( item.unique_clicks ),
+								clicksRate: numberFormat( item.clicks_rate, {
 									numberFormatOptions: { maximumFractionDigits: 2 },
 								} ),
 							},

--- a/client/my-sites/stats/features/modules/stats-emails/tooltips.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/tooltips.tsx
@@ -57,20 +57,20 @@ export const OpensTooltipContent: React.FC< { item: EmailStatsItem } > = ( { ite
 	return (
 		<div className="stats-email__tooltip">
 			<div>
-				{ translate( 'Recipients: %(sendsCount)s', {
-					args: { sendsCount: numberFormat( item.total_sends ) },
+				{ translate( 'Recipients: %(sendsCountFormatted)s', {
+					args: { sendsCountFormatted: numberFormat( item.total_sends ) },
 				} ) }
 			</div>
 			<div>
-				{ translate( 'Total opens: %(opensCount)s', {
-					args: { opensCount: numberFormat( item.opens ) },
+				{ translate( 'Total opens: %(opensCountFormatted)s', {
+					args: { opensCountFormatted: numberFormat( item.opens ) },
 				} ) }
 			</div>
 			<div>
 				{ hasUniques
-					? translate( 'Unique opens: %(uniqueOpensCount)s (%(opensRate)s%)', {
+					? translate( 'Unique opens: %(uniqueOpensCountFormatted)s (%(opensRate)s%)', {
 							args: {
-								uniqueOpensCount: numberFormat( item.unique_opens ),
+								uniqueOpensCountFormatted: numberFormat( item.unique_opens ),
 								opensRate: numberFormat( item.opens_rate, {
 									numberFormatOptions: { maximumFractionDigits: 2 },
 								} ),
@@ -92,20 +92,20 @@ export const ClicksTooltipContent: React.FC< { item: EmailStatsItem } > = ( { it
 	return (
 		<div className="stats-email__tooltip">
 			<div>
-				{ translate( 'Recipients: %(sendsCount)s', {
-					args: { sendsCount: numberFormat( item.total_sends ) },
+				{ translate( 'Recipients: %(sendsCountFormatted)s', {
+					args: { sendsCountFormatted: numberFormat( item.total_sends ) },
 				} ) }
 			</div>
 			<div>
-				{ translate( 'Total clicks: %(clicksCount)s', {
-					args: { clicksCount: numberFormat( item.clicks ) },
+				{ translate( 'Total clicks: %(clicksCountFormatted)s', {
+					args: { clicksCountFormatted: numberFormat( item.clicks ) },
 				} ) }
 			</div>
 			<div>
 				{ hasUniques
-					? translate( 'Unique clicks: %(uniqueClicksCount)s (%(clicksRate)s%)', {
+					? translate( 'Unique clicks: %(uniqueClicksCountFormatted)s (%(clicksRate)s%)', {
 							args: {
-								uniqueClicksCount: numberFormat( item.unique_clicks ),
+								uniqueClicksCountFormatted: numberFormat( item.unique_clicks ),
 								clicksRate: numberFormat( item.clicks_rate, {
 									numberFormatOptions: { maximumFractionDigits: 2 },
 								} ),

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -1,4 +1,4 @@
-import { localize } from 'i18n-calypso';
+import { localize, numberFormat } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
@@ -74,7 +74,15 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 							const hasUniquesData = opensUnique > 0 || opens === 0;
 							return (
 								<TooltipWrapper
-									value={ hasUniquesData ? `${ item.opens_rate }%` : '—' }
+									value={
+										hasUniquesData
+											? `${ numberFormat( item.opens_rate, {
+													numberFormatOptions: {
+														maximumFractionDigits: 2,
+													},
+											  } ) }%`
+											: '—'
+									}
 									item={ item }
 									TooltipContent={ OpensTooltipContent }
 								/>
@@ -97,7 +105,15 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 							const hasUniquesData = clicksUnique > 0 || clicks === 0;
 							return (
 								<TooltipWrapper
-									value={ hasUniquesData ? `${ item.clicks_rate }%` : '—' }
+									value={
+										hasUniquesData
+											? `${ numberFormat( item.clicks_rate, {
+													numberFormatOptions: {
+														maximumFractionDigits: 2,
+													},
+											  } ) }%`
+											: '—'
+									}
 									item={ item }
 									TooltipContent={ ClicksTooltipContent }
 								/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/i18n-issues/issues/922
Related to https://github.com/Automattic/wp-calypso/pull/97729

## Proposed Changes

The email stats on `/stats/subscribers` contain untranslated numbers, resulting in wrong or missing notation depending on locale e.g. `10.000` as `10000`, or `33,33` as `33.33` (about half the world uses comma `,` for decimal mark).

We pass these numbers through `numberFormat` and return the correct strings. As a result, the enclosing sentences are also changed - hence new translations are needed.

## Media

| Before (EL/DE) | After (EL/DE) |
|--------|--------|
| <img width="642" alt="Screenshot 2025-01-28 at 7 22 34 PM" src="https://github.com/user-attachments/assets/83465fc7-108b-420d-a1b7-2a799fb13e7f" /> | <img width="647" alt="Screenshot 2025-01-28 at 7 21 59 PM" src="https://github.com/user-attachments/assets/7a2d24fd-d32f-45b8-ba0c-adb9df952b4e" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fix missing/wrong number translations.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/stats/subscribers/:site` (use FG)
* Switch different locales and confirm the numbers shown in the "Emails" block and the tooltips on hovering are formatted correctly. 
  * Check EL/DE locale that a comma `,` is used for decimal mark in percentages
  * Check that 1K+ numbers are rendered with separators, either comma `,` (EN), or dot `.` (EL/DE/etc.)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
