### PR TITLE
Fix 100-year domain search width

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -471,6 +471,10 @@
 		}
 	}
 
+	.hundred-year-plan-step-wrapper__step-container {
+		width: 100%;
+	}
+
 	.register-domain-step__search-card {
 		background: none;
 	}
@@ -488,12 +492,14 @@
 
 		@include break-small {
 			max-width: 780px;
+			margin: 0 auto;
 		}
 
 		.domains__step-content {
 			padding: 0 16px;
+
 			@include break-small {
-				padding: 0 48px 0 32px;
+				padding: 0 32px;	
 			}
 		}
 


### PR DESCRIPTION
## Proposed Changes

This PR fixes a regression on the 100-year domain search.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The domain search field width fluctuates as you search for different terms.

**Before**

https://github.com/user-attachments/assets/f86c8d9f-36c0-4681-88ec-564d5bb74f1b

**After**

https://github.com/user-attachments/assets/394996cf-ff6e-496e-b0d2-774d75bfe95d

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/setup/hundred-year-domain/domains` and test at different widths.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
