### PR TITLE
[Experiment] Refactor /me/ styles

### DIFF
--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -24,12 +24,12 @@ body.is-section-me {
 			padding-bottom: 0;
 		}
 
-		.layout__primary > .main {
+		.layout__primary {
 			height: calc(100vh - var(--masterbar-height) - var(--content-padding-top));
 		}
 
 		@include break-small {
-			.layout__primary > .main {
+			.layout__primary {
 				height: calc(100vh - var(--masterbar-height) - var(--content-padding-bottom) - var(--content-padding-top));
 			}
 		}

--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -45,22 +45,17 @@ body.is-section-me {
 
 	div.layout.is-global-sidebar-visible {
 		.layout__primary {
+			padding: 24px;
+			margin-inline-start: 1rem;
+			border-block-end: 1px solid var(--studio-gray-0);
+			background: var(--color-surface);
+			border-radius: 8px; /* stylelint-disable-line scales/radii */
+			box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
+			overflow-y: auto;
+			overflow-x: hidden;
+
 			.main {
-				padding: 24px;
-				border-block-end: 1px solid var(--studio-gray-0);
-				background: var(--color-surface);
-				border-radius: 8px; /* stylelint-disable-line scales/radii */
-				box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
-				overflow-y: auto;
-				overflow-x: hidden;
-				max-width: none;
-				& > * {
-					max-width: 1040px;
-					margin: 0 auto;
-				}
-				& > div.section-nav {
-                    margin-bottom: 24px; /* Preserve margin for Purchases mobile nav */
-	            }
+				max-width: 1040px;
 			}
 		}
 	}
@@ -93,6 +88,7 @@ body.is-section-me {
 		div.layout.is-global-sidebar-visible {
 			.layout__primary {
 				overflow-x: hidden;
+				margin-inline-start: 0;
 			}
 		}
 	}


### PR DESCRIPTION
This is an experiment based on [my proposal](https://github.com/Automattic/wp-calypso/issues/98998) to refactor some of the `/me/` stylesheet code.

This is purely subjective work and it doesn't take into account historical reasons for why the `/me/` page is structured the way it is. Maybe @Addison-Stavlo or @candy02058912 can provide some clarity here.

While working through some recent bug fixes, I noticed a lot of the bugs were stemming from changes to the `main` element's styling, [more specifically this wildcard](https://github.com/Automattic/wp-calypso/blob/trunk/client/me/style.scss#L57-L59) to remove margin from all children of `main`.

This appears to have been added to create a compact card look across the `/me/` `Card` components, but it has the knock-on effect of targeting _all_ direct children of `main` which includes other components besides `Card`. This may just be a stylistic choice, which is fine by me, but it does create some odd styling interactions at times - pfOicC-jx-p2 .

Related to #98998 

## Proposed Changes

This PR removes a number of styles from the `main` element and moves them to the parent `layout__primary` element. This is a bit more semantic as the styles generally address layout of the primary content area.

## Why are these changes being made?

* Moves layout styling to the more semantic `layout__primary` element (think interaction between the primary and sidebar, viewport scaling for width and height)
* Allows `main` to focus more specifically on the main content of the "primary" section of `/me/`, i.e. adjusting padding, setting a max-width for the content to maintain readability etc

## Testing Instructions

- Apply PR then go to `calypso.localhost:3000/me/` and click through the various sections and subsections
- Ensure styles and spacing are readable and look correct across device sizes