### PR TITLE
Launchpad My Home: Show next steps snackbar on tasks related to hosting flow

### DIFF
--- a/client/hosting/constants.ts
+++ b/client/hosting/constants.ts
@@ -1,5 +1,4 @@
 //hosting flow task hashes
 export const HOSTING_THEME_SELCETED_HASH = '#theme-selected';
 export const HOSTING_INSTALL_PLUGIN_HASH = '#install-plugin';
-export const HOSTING_SET_UP_SSH_HASH = '#sftp-credentials';
 export const HOSTING_SITE_MONITORING_HASH = '#site-monitoring';

--- a/client/hosting/constants.ts
+++ b/client/hosting/constants.ts
@@ -1,0 +1,5 @@
+//hosting flow task hashes
+export const HOSTING_THEME_SELCETED_HASH = '#theme-selected';
+export const HOSTING_INSTALL_PLUGIN_HASH = '#install-plugin';
+export const HOSTING_SET_UP_SSH_HASH = '#sftp-credentials';
+export const HOSTING_SITE_MONITORING_HASH = '#site-monitoring';

--- a/client/hosting/server-settings/components/sftp-card/test/index.js
+++ b/client/hosting/server-settings/components/sftp-card/test/index.js
@@ -13,6 +13,10 @@ jest.mock( '@automattic/components/src/spinner', () => ( {
 	Spinner: () => <div data-testid="spinner" />,
 } ) );
 
+jest.mock( 'calypso/launchpad/hooks/use-complete-launchpad-tasks-with-notice', () => ( {
+	useCompleteLaunchpadTasksWithNotice: () => jest.fn(),
+} ) );
+
 const INITIAL_STATE = {
 	ui: { selectedSiteId: 1 },
 	currentUser: { id: 1 },

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -282,7 +282,7 @@ export const getTask = (
 				),
 				actionText: translate( 'Choose a theme' ),
 				isSkippable: false,
-				actionUrl: `/themes/${ siteSlug }`,
+				actionUrl: `/themes/${ siteSlug }#theme-selected`,
 			};
 			break;
 		case CHECKLIST_KNOWN_TASKS.PROFESSIONAL_EMAIL_MAILBOX_CREATED:
@@ -365,7 +365,7 @@ export const getTask = (
 					'Add new features to your site with plugins. Choose from thousands of free and premium plugins or upload your own to make your site stand out.'
 				),
 				actionText: translate( 'Install' ),
-				actionUrl: `/plugins/${ siteSlug }`,
+				actionUrl: `/plugins/${ siteSlug }#install-plugin`,
 				isSkippable: true,
 			};
 			break;

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -183,13 +183,16 @@ class ThemeSheet extends Component {
 
 	// This is a plain instance property because we only want to know the state of the
 	// hash at the time of the component mounting.
-	isThemeSelectedTask = window.location.hash === HOSTING_THEME_SELCETED_HASH;
+	// Checking hash in `componentDidMount` to preserve SSR behavior.
+	isThemeSelectedTask = false;
 
 	scrollToTop = () => {
 		window.scroll( 0, 0 );
 	};
 
 	componentDidMount() {
+		this.isThemeSelectedTask = window.location.hash === HOSTING_THEME_SELCETED_HASH;
+
 		this.scrollToTop();
 
 		const { syncActiveTheme, themeStartActivationSync, siteId, themeId } = this.props;

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -45,6 +45,8 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
 import ThemeSiteSelectorModal from 'calypso/components/theme-site-selector-modal';
 import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
+import { HOSTING_THEME_SELCETED_HASH } from 'calypso/hosting/constants';
+import { withCompleteLaunchpadTasksWithNotice } from 'calypso/launchpad/hooks/with-complete-launchpad-tasks-with-notice';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
@@ -100,6 +102,7 @@ import {
 	isThemeWooCommerce,
 	isActivatingTheme as getIsActivatingTheme,
 	isInstallingTheme as getIsInstallingTheme,
+	hasActivatedTheme as getHasActivatedTheme,
 } from 'calypso/state/themes/selectors';
 import { getIsLoadingCart } from 'calypso/state/themes/selectors/get-is-loading-cart';
 import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
@@ -206,6 +209,24 @@ class ThemeSheet extends Component {
 
 		if ( defaultOption?.key !== prevProps.defaultOption?.key ) {
 			this.maybeAutoActivate();
+		}
+
+		if (
+			this.props.hasActivatedTheme &&
+			! prevProps.hasActivatedTheme &&
+			this.props.isActive &&
+			! prevProps.isActive &&
+			( this.props.isThemeSelectedTask || this.props.defaultOption?.key === 'activate' )
+		) {
+			const noticeSettings = {
+				id: 'site-theme-activated',
+				duration: 10000,
+			};
+			this.props.completeLaunchpadTask(
+				'site_theme_selected',
+				this.props.translate( 'Congratulations! You’ve activated your theme!' ),
+				noticeSettings
+			);
 		}
 	}
 
@@ -1429,9 +1450,12 @@ export default connect(
 
 		const queryArgs = getCurrentQueryArguments( state );
 
+		const isThemeSelectedTask = window.location.hash === HOSTING_THEME_SELCETED_HASH;
+
 		return {
 			...theme,
 			themeId,
+			isThemeSelectedTask,
 			error,
 			siteId,
 			siteSlug,
@@ -1480,6 +1504,7 @@ export default connect(
 			themeType: getThemeType( state, themeId ),
 			isActivatingTheme: getIsActivatingTheme( state, siteId ),
 			isInstallingTheme: getIsInstallingTheme( state, themeId, siteId ),
+			hasActivatedTheme: getHasActivatedTheme( state, siteId ),
 		};
 	},
 	{
@@ -1490,5 +1515,9 @@ export default connect(
 		errorNotice,
 	}
 )(
-	withSiteGlobalStylesStatus( withSiteGlobalStylesOnPersonal( localize( ThemeSheetWithOptions ) ) )
+	withCompleteLaunchpadTasksWithNotice(
+		withSiteGlobalStylesStatus(
+			withSiteGlobalStylesOnPersonal( localize( ThemeSheetWithOptions ) )
+		)
+	)
 );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -181,6 +181,10 @@ class ThemeSheet extends Component {
 		isWide: isWithinBreakpoint( '>960px' ),
 	};
 
+	// This is a plain instance property because we only want to know the state of the
+	// hash at the time of the component mounting.
+	isThemeSelectedTask = window.location.hash === HOSTING_THEME_SELCETED_HASH;
+
 	scrollToTop = () => {
 		window.scroll( 0, 0 );
 	};
@@ -216,7 +220,7 @@ class ThemeSheet extends Component {
 			! prevProps.hasActivatedTheme &&
 			this.props.isActive &&
 			! prevProps.isActive &&
-			( this.props.isThemeSelectedTask || this.props.defaultOption?.key === 'activate' )
+			( this.isThemeSelectedTask || this.props.defaultOption?.key === 'activate' )
 		) {
 			const noticeSettings = {
 				id: 'site-theme-activated',
@@ -1273,7 +1277,7 @@ class ThemeSheet extends Component {
 				<ActivationModal
 					source="details"
 					siteIntent={ this.props.siteIntent }
-					showSuccessNotice={ ! this.props.isThemeSelectedTask }
+					showSuccessNotice={ ! this.isThemeSelectedTask }
 				/>
 				<NavigationHeader
 					navigationItems={ navigationItems }
@@ -1454,12 +1458,9 @@ export default connect(
 
 		const queryArgs = getCurrentQueryArguments( state );
 
-		const isThemeSelectedTask = window.location.hash === HOSTING_THEME_SELCETED_HASH;
-
 		return {
 			...theme,
 			themeId,
-			isThemeSelectedTask,
 			error,
 			siteId,
 			siteSlug,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -224,7 +224,7 @@ class ThemeSheet extends Component {
 			};
 			this.props.completeLaunchpadTasks(
 				[ 'site_theme_selected' ],
-				this.props.translate( "Congratulations! You've activated your theme!" ),
+				this.props.translate( 'Congratulations! You’ve activated your theme!' ),
 				noticeSettings
 			);
 		}
@@ -1146,7 +1146,7 @@ class ThemeSheet extends Component {
 		const { defaultOption, isActive, isWpcomTheme, themeId, shouldLimitGlobalStyles, translate } =
 			this.props;
 		if ( isActive && defaultOption.getUrl ) {
-			return translate( "Open the {{a}}site editor{{/a}} to change your site's style.", {
+			return translate( 'Open the {{a}}site editor{{/a}} to change your site’s style.', {
 				components: {
 					a: (
 						<a href={ defaultOption.getUrl( themeId ) } target="_blank" rel="noopener noreferrer" />

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -222,9 +222,9 @@ class ThemeSheet extends Component {
 				id: 'site-theme-activated',
 				duration: 10000,
 			};
-			this.props.completeLaunchpadTask(
-				'site_theme_selected',
-				this.props.translate( 'Congratulations! You’ve activated your theme!' ),
+			this.props.completeLaunchpadTasks(
+				[ 'site_theme_selected' ],
+				this.props.translate( "Congratulations! You've activated your theme!" ),
 				noticeSettings
 			);
 		}
@@ -1146,7 +1146,7 @@ class ThemeSheet extends Component {
 		const { defaultOption, isActive, isWpcomTheme, themeId, shouldLimitGlobalStyles, translate } =
 			this.props;
 		if ( isActive && defaultOption.getUrl ) {
-			return translate( 'Open the {{a}}site editor{{/a}} to change your site’s style.', {
+			return translate( "Open the {{a}}site editor{{/a}} to change your site's style.", {
 				components: {
 					a: (
 						<a href={ defaultOption.getUrl( themeId ) } target="_blank" rel="noopener noreferrer" />
@@ -1270,7 +1270,11 @@ class ThemeSheet extends Component {
 						}
 					} }
 				/>
-				<ActivationModal source="details" siteIntent={ this.props.siteIntent } />
+				<ActivationModal
+					source="details"
+					siteIntent={ this.props.siteIntent }
+					showSuccessNotice={ ! this.props.isThemeSelectedTask }
+				/>
 				<NavigationHeader
 					navigationItems={ navigationItems }
 					compactBreadcrumb={ ! this.state.isWide }

--- a/client/my-sites/theme/test/main.jsx
+++ b/client/my-sites/theme/test/main.jsx
@@ -14,6 +14,27 @@ jest.mock( 'dompurify', () => ( {
 	sanitize: jest.fn().mockImplementation( ( text ) => text ),
 } ) );
 
+const mockWindow = {
+	location: {
+		hash: '',
+		href: 'http://example.com',
+		origin: 'http://example.com',
+		pathname: '/',
+		search: '',
+	},
+	matchMedia: () => ( {
+		matches: false,
+		addListener: () => {},
+		removeListener: () => {},
+	} ),
+	scroll: () => {},
+};
+
+global.window = mockWindow;
+global.document = {
+	readyState: 'complete',
+};
+
 const themeData = {
 	name: 'Twenty Sixteen',
 	author: 'the WordPress team',
@@ -43,6 +64,8 @@ const TestComponent = ( { themeId, store } ) => {
 describe( 'main', () => {
 	afterEach( () => {
 		queryClient.clear();
+		// Reset window hash after each test
+		window.location.hash = '';
 	} );
 
 	test( "doesn't throw an exception without theme data", () => {

--- a/client/my-sites/themes/activation-modal.jsx
+++ b/client/my-sites/themes/activation-modal.jsx
@@ -48,6 +48,7 @@ export class ActivationModal extends Component {
 		isVisible: PropTypes.bool,
 		onClose: PropTypes.func,
 		newThemeId: PropTypes.string,
+		showSuccessNotice: PropTypes.bool,
 	};
 
 	constructor( props ) {
@@ -66,7 +67,14 @@ export class ActivationModal extends Component {
 	closeModalHandler =
 		( action = 'dismiss' ) =>
 		() => {
-			const { newThemeId, activeTheme, siteId, source, isCurrentThemeAllowedOnSite } = this.props;
+			const {
+				newThemeId,
+				activeTheme,
+				siteId,
+				source,
+				isCurrentThemeAllowedOnSite,
+				showSuccessNotice,
+			} = this.props;
 			if ( 'activeTheme' === action ) {
 				this.props.acceptActivationModal( newThemeId );
 				const eventName = ! isCurrentThemeAllowedOnSite
@@ -77,7 +85,7 @@ export class ActivationModal extends Component {
 					theme: newThemeId,
 					activeTheme: activeTheme.id,
 				} );
-				return this.props.activateTheme( newThemeId, siteId, { source } );
+				return this.props.activateTheme( newThemeId, siteId, { source, showSuccessNotice } );
 			} else if ( 'dismiss' === action ) {
 				const eventName = ! isCurrentThemeAllowedOnSite
 					? 'calypso_theme_switch_plan_warning_declined'

--- a/client/sites/tools/monitoring/components/site-monitoring.tsx
+++ b/client/sites/tools/monitoring/components/site-monitoring.tsx
@@ -2,11 +2,13 @@ import colorStudio from '@automattic/color-studio';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import NavigationHeader from 'calypso/components/navigation-header';
+import { HOSTING_SITE_MONITORING_HASH } from 'calypso/hosting/constants';
+import { useCompleteLaunchpadTaskWithNoticeOnLoad } from 'calypso/launchpad/hooks/use-complete-launchpad-task-with-notice-on-load';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import {
 	MetricsType,
@@ -513,6 +515,10 @@ const useErrorHttpCodeSeries = () => {
 };
 
 export const SiteMonitoring = ( { className }: { className?: string } ) => {
+	const initiallyLoadedWithTaskCompletionHash = useRef(
+		window.location.hash === HOSTING_SITE_MONITORING_HASH
+	);
+
 	const { __, _x } = useI18n();
 	const moment = useLocalizedMoment();
 	const timeRange = useTimeRange();
@@ -538,6 +544,13 @@ export const SiteMonitoring = ( { className }: { className?: string } ) => {
 		timeRange,
 		errorHttpCodes.statusCodes
 	);
+
+	useCompleteLaunchpadTaskWithNoticeOnLoad( {
+		taskSlug: 'site_monitoring_page',
+		enabled: initiallyLoadedWithTaskCompletionHash.current && ! isLoadingLineChart,
+		noticeId: 'site-monitoring-page-visited',
+		noticeText: 'You’ve explored the site monitoring page!',
+	} );
 
 	const startDate = moment( timeRange.start * 1000 );
 	const endDate = moment( timeRange.end * 1000 );

--- a/client/sites/tools/sftp-ssh/sftp-form.tsx
+++ b/client/sites/tools/sftp-ssh/sftp-form.tsx
@@ -1,6 +1,5 @@
 import { FEATURE_SFTP, FEATURE_SSH } from '@automattic/calypso-products';
 import { Button, FormLabel, Spinner } from '@automattic/components';
-import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
@@ -9,6 +8,7 @@ import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { useCompleteLaunchpadTasksWithNotice } from 'calypso/launchpad/hooks/use-complete-launchpad-tasks-with-notice';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import ReauthRequired from 'calypso/me/reauth-required';
 import { useSelector } from 'calypso/state';
@@ -38,7 +38,6 @@ import { useSiteOption } from 'calypso/state/sites/hooks';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { SftpCardLoadingPlaceholder } from './sftp-card-loading-placeholder';
 import SshKeys from './ssh-keys';
-
 import './sftp-form.scss';
 
 const FILEZILLA_URL = 'https://filezilla-project.org/';
@@ -142,6 +141,7 @@ export const SftpForm = ( {
 	const hasSftpFeatureAndIsLoading = siteHasSftpFeature && isLoadingSftpUsers;
 	const hasSshFeatureAndIsLoading = siteHasSshFeature && isLoadingSshAccess;
 	const siteIntent = useSiteOption( 'site_intent' );
+	const completeTasks = useCompleteLaunchpadTasksWithNotice();
 
 	const sshConnectString = `ssh ${ username }@sftp.wp.com`;
 
@@ -154,8 +154,9 @@ export const SftpForm = ( {
 		setIsLoading( true );
 		dispatch( createSftpUser( siteId, currentUserId ) );
 		if ( 'host-site' === siteIntent ) {
-			updateLaunchpadSettings( siteId, {
-				checklist_statuses: { setup_ssh: true },
+			completeTasks( [ 'setup_ssh' ], translate( 'You’ve set up SSH access!' ), {
+				id: 'site-setup-ssh',
+				duration: 10000,
 			} );
 		}
 	};

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -34,6 +34,7 @@ export function activate( themeId, siteId, options ) {
 			purchased,
 			isOnboardingFlow = typeof window !== 'undefined' &&
 				hasQueryArg( window.location.href, 'onboarding' ),
+			showSuccessNotice = true,
 		} = options || {};
 		const isDotComTheme = !! getTheme( getState(), 'wpcom', themeId );
 		const isDotOrgTheme = !! getTheme( getState(), 'wporg', themeId );
@@ -83,7 +84,7 @@ export function activate( themeId, siteId, options ) {
 		return activateOrInstallThenActivate( themeId, siteId, {
 			source,
 			purchased,
-			showSuccessNotice: true,
+			showSuccessNotice,
 		} )( dispatch, getState );
 	};
 }

--- a/client/state/themes/selectors/get-theme-details-url.js
+++ b/client/state/themes/selectors/get-theme-details-url.js
@@ -31,5 +31,7 @@ export function getThemeDetailsUrl( state, themeId, siteId, options = {} ) {
 		searchParams.style_variation = styleVariationSlug;
 	}
 
-	return addQueryArgs( `/theme/${ themeId }${ sitePart }`, searchParams );
+	const hash = typeof window !== 'undefined' ? window.location.hash : '';
+	const url = addQueryArgs( `/theme/${ themeId }${ sitePart }`, searchParams );
+	return hash ? `${ url }${ hash }` : url;
 }

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -14,7 +14,6 @@ const TASKS_TO_COMPLETE_ON_CLICK = [
 	'manage_subscribers',
 	'connect_social_media',
 	'drive_traffic',
-	'site_monitoring_page',
 	'front_page_updated',
 	'post_sharing_enabled',
 	'mobile_app_installed',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98839

## Proposed Changes
This PR adds `Next steps` modal to task related to `host-site` intent. We only show these if the users switches to the default admin style as these sites are setup to `wp-admin` experience.

Note. The snackbar is not added for the `install plugin` task as it redirects to `wp-admin` when a plugin is installed

* Add `Next steps` snackbar to sites created in the `/setup/new-hosted-site` flow

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Test with this Jetpack PR https://github.com/Automattic/jetpack/pull/41377

* Create a site through `/setup/new-hosted-site` flow
* Change admin interface to default style in `/settings`, you should see launchpad tasks in my home
* Use jetpack beta tester plugin to install [the](https://github.com/Automattic/jetpack/pull/41377) on the site (you may need to `define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true ); ` in sites `wp-config.php` file for it to use the changes from the branch). You need ssh, so in setting up you will complete the `setup_ssh` task
* Complete the tasks `choose theme, view site monitoring` and you should see the `Next step` snackbar



https://github.com/user-attachments/assets/0c23fa43-b9b7-4f56-8338-f4168249d06a



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
