### PR TITLE
Checkout: Add business use label to checkout tax line items

### DIFF
--- a/client/my-sites/checkout/src/components/is-for-business-checkbox.tsx
+++ b/client/my-sites/checkout/src/components/is-for-business-checkbox.tsx
@@ -1,10 +1,15 @@
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
-import { useShoppingCart, convertTaxLocationToLocationUpdate } from '@automattic/shopping-cart';
+import {
+	useShoppingCart,
+	convertTaxLocationToLocationUpdate,
+	ResponseCart,
+} from '@automattic/shopping-cart';
 import { hasCheckoutVersion, styled } from '@automattic/wpcom-checkout';
 import { CheckboxControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import useCartKey from '../../use-cart-key';
+
 const CheckboxWrapper = styled.div`
 	margin-top: 16px;
 
@@ -17,6 +22,30 @@ const CheckboxWrapper = styled.div`
 		color: ${ ( props ) => props.theme.colors.primary };
 	}
 `;
+
+export const BusinessUseLabelByState = ( {
+	responseCart,
+	classNames,
+}: {
+	responseCart: ResponseCart;
+	classNames?: string;
+} ): JSX.Element | null => {
+	const translate = useTranslate();
+	let label: string | undefined;
+
+	const zipCode = parseInt( responseCart.tax.location.postal_code ?? '0', 10 );
+
+	if ( zipCode >= 43000 && zipCode <= 45999 ) {
+		// Ohio; OH
+		label = translate( 'OH business use' );
+	} else if ( ( zipCode >= 6000 && zipCode <= 6389 ) || ( zipCode >= 6391 && zipCode <= 6999 ) ) {
+		// Connecticut; CT
+		label = translate( 'CT business use' );
+	}
+
+	return label ? <span className={ classNames }>({ label })</span> : null;
+};
+
 export function IsForBusinessCheckbox() {
 	const translate = useTranslate();
 	const { formStatus } = useFormStatus();

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -53,6 +53,7 @@ import getJetpackProductFeatures from '../lib/get-jetpack-product-features';
 import getPlanFeatures from '../lib/get-plan-features';
 import { CheckIcon } from './check-icon';
 import { ProductsAndCostOverridesList } from './cost-overrides-list';
+import { BusinessUseLabelByState } from './is-for-business-checkbox';
 import { getRefundPolicies, getRefundWindows, RefundPolicy } from './refund-policies';
 import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
 import type { TranslateResult } from 'i18n-calypso';
@@ -199,7 +200,15 @@ function CheckoutSummaryPriceList() {
 					</CheckoutSummaryLineItem>
 					{ taxLineItems.map( ( taxLineItem ) => (
 						<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + taxLineItem.id }>
-							<span>{ taxLineItem.label }</span>
+							<span>
+								{ taxLineItem.label }
+								{ responseCart.tax.location.is_for_business && (
+									<BusinessUseLabelByState
+										responseCart={ responseCart }
+										classNames="checkout-summary-line-item__tax-reason"
+									/>
+								) }
+							</span>
 							<span>{ taxLineItem.formattedAmount }</span>
 						</CheckoutSummaryLineItem>
 					) ) }
@@ -971,6 +980,10 @@ const CheckoutSummaryLineItem = styled.div< { isDiscount?: boolean } >`
 
 	.is-loading & {
 		animation: ${ pulse } 1.5s ease-in-out infinite;
+	}
+
+	.checkout-summary-line-item__tax-reason {
+		margin-inline-start: 0.25rem;
 	}
 `;
 


### PR DESCRIPTION
As a follow up to the Business Use Tax project, this PR conditionally adds labels to tax line items in Checkout to provide clarity as to why the tax rate changed - i.e. they are declaring their purchase is for business use in OH or CT.

![image](https://github.com/user-attachments/assets/6dbaa029-d112-4d81-854b-5499c6be3f14)


Related to https://github.com/Automattic/payments-shilling/issues/3239

## Proposed Changes

* Add a BusinessUseLabelByState component that can be used anywhere that a responseCart is available (may need some error handling here if outside of the ShoppingCart context?)
* This component uses similar logic to the `isUnitedStateWithBusinessOption` function that the 'is for business use' checkbox uses in Checkout

## Testing Instructions

* Go to checkout and apply this PR, make sure you add the query parameter `?checkoutVersion=business-use-tax` to see the 'is for business use' checkbox
* Click on the checkbox to toggle the business use state
* You should see a label appear next to both tax line items with the appropriate US state
* Tax line items appear at the bottom of checkout and in the sidebar
