### PR TITLE
Stats Locations: add compatibility check for Odyssey

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -201,6 +201,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		supportsPlanUsage,
 		supportsUTMStats: supportsUTMStatsFeature,
 		supportsDevicesStats: supportsDevicesStatsFeature,
+		supportsLocationsStats: supportsLocationsStatsFeature,
 		isOldJetpack,
 		supportUserFeedback,
 	} = useSelector( ( state ) => getEnvStatsFeatureSupportChecks( state, siteId ) );
@@ -251,7 +252,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	const shouldShowUpsells = isOdysseyStats && ! isAtomic;
 	const supportsUTMStats = supportsUTMStatsFeature || isInternal;
 	const supportsDevicesStats = supportsDevicesStatsFeature || isInternal;
-
+	const supportsLocationsStats = supportsLocationsStatsFeature || isInternal;
 	const getAvailableLegend = () => {
 		const activeTab = getActiveTab( chartTab );
 		// TODO: remove this when we support hourly visitors.
@@ -639,7 +640,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 								className={ halfWidthModuleClasses }
 							/>
 
-							{ config.isEnabled( 'stats/locations' ) ? (
+							{ config.isEnabled( 'stats/locations' ) && supportsLocationsStats ? (
 								<>
 									<StatsModuleLocations
 										moduleStrings={ moduleStrings.locations }

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -57,6 +57,11 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 			'0.22.0',
 			isOdysseyStats
 		),
+		supportsLocationsStats: version_greater_than_or_equal(
+			statsAdminVersion,
+			'0.24.0',
+			isOdysseyStats
+		),
 		shouldUseStatsBuiltInPurchasesApi: version_greater_than_or_equal(
 			statsAdminVersion,
 			'0.21.0-alpha',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-roadmap/issues/2213

## Proposed Changes

* Add locations module compatibility check for jetpack-stats-admin package >= 0.24.0

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Locations API support for Odyssey is available on stats-admin package since v0.24.0:
https://github.com/Automattic/jetpack-stats-admin/commits/v0.24.0

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> jetpack-stats-admin v0.24.0 is available in Jetpack plugin since v14.2.

* Prepare a self-hosted site with Jetpack v14.1 or lower (preferable using Jetpack Beta).
* Follow option 1 or 3 to test a feature branch from wp-calypso: PCYsg-Pp7-p2#how-to-test-a-feature-branch-from-wp-calypso.
* Ensure the legacy Countries module is visible
* Now switch to Jetpack v14.2 or higher
* Ensure the new Locations module is visible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?