### PR TITLE
Verbum: fix weird styling issue

### DIFF
--- a/packages/verbum-block-editor/src/editor/editor-style.scss
+++ b/packages/verbum-block-editor/src/editor/editor-style.scss
@@ -44,6 +44,7 @@
 
 				.block-editor-block-contextual-toolbar.components-accessible-toolbar {
 					border-bottom: none;
+					box-shadow: none;
 				}
 
 				.block-editor-block-toolbar {
@@ -119,6 +120,7 @@
 
 	iframe[name="editor-canvas"] {
 		background-color: inherit;
+		border: none;
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

* Remove extra border from toolbar
* Remove inset border from iframe

## Why are these changes being made?

| Before | After |
|--------|--------|
| <img width="1428" alt="Screen Shot on 2025-01-29 at 10-16-22" src="https://github.com/user-attachments/assets/93f9e7cd-e69b-428a-a3a7-ab259cd944b4" /> | <img width="1446" alt="Screen Shot on 2025-01-29 at 10-15-58" src="https://github.com/user-attachments/assets/61060601-b15d-434d-af6e-8dec8d7763cc" /> |

## Testing Instructions

1. Checkout branch on your local device
2. `cd packages/verbum-block-editor && yarn dev --sync`
3. Sandbox widgets.wp.com
4. Go to a SIMPLE site post and check out the comment box.
5. Make sure there are no regressions and that it looks pretty