### PR TITLE
Domains: Update “Learn more” links to open the help center

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -416,10 +416,6 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/domains/custom-dns/view-or-restore-default-dns-records/#default-cname-record',
 		post_id: 386585,
 	},
-	'edit-or-delete-dns-records': {
-		link: 'https://wordpress.com/support/domains/custom-dns/edit-or-delete-dns-records/',
-		post_id: 386584,
-	},
 	'add-a-new-dns-record': {
 		link: 'https://wordpress.com/support/domains/custom-dns/add-a-new-dns-record/',
 		post_id: 386583,

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -400,6 +400,46 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/check-your-sites-performance/',
 		post_id: 386816,
 	},
+	'manage-your-dns-records': {
+		link: 'https://wordpress.com/support/domains/custom-dns/',
+		post_id: 6595,
+	},
+	'dns-default-mx-records': {
+		link: 'https://wordpress.com/support/domains/custom-dns/view-or-restore-default-dns-records/#default-mx-records',
+		post_id: 386585,
+	},
+	'dns-default-a-records': {
+		link: 'https://wordpress.com/support/domains/custom-dns/view-or-restore-default-dns-records/#default-a-records',
+		post_id: 386585,
+	},
+	'dns-default-cname-records': {
+		link: 'https://wordpress.com/support/domains/custom-dns/view-or-restore-default-dns-records/#default-cname-record',
+		post_id: 386585,
+	},
+	'edit-or-delete-dns-records': {
+		link: 'https://wordpress.com/support/domains/custom-dns/edit-or-delete-dns-records/',
+		post_id: 386584,
+	},
+	'add-a-new-dns-record': {
+		link: 'https://wordpress.com/support/domains/custom-dns/add-a-new-dns-record/',
+		post_id: 386583,
+	},
+	'edit-or-delete-dns-record': {
+		link: 'https://wordpress.com/support/domains/custom-dns/edit-or-delete-dns-records/',
+		post_id: 386584,
+	},
+	'domain-designated-agent': {
+		link: 'https://wordpress.com/support/domains/update-contact-information/#designated-agent',
+		post_id: 3441,
+	},
+	'transfer-domain-registration': {
+		link: 'https://wordpress.com/support/transfer-domain-registration/',
+		post_id: 41298,
+	},
+	'public-vs-private-registration-and-gdpr': {
+		link: 'https://wordpress.com/support/domains/register-domain/#public-versus-private-registration-and-gdpr',
+		post_id: 2784,
+	},
 };
 
 export default contextLinks;

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -433,7 +433,7 @@ const contextLinks = {
 		post_id: 3441,
 	},
 	'transfer-domain-registration': {
-		link: 'https://wordpress.com/support/transfer-domain-registration/',
+		link: 'https://wordpress.com/support/domains/transfer-domain-registration/#before-you-get-started',
 		post_id: 41298,
 	},
 	'public-vs-private-registration-and-gdpr': {

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -444,6 +444,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/domains/https-ssl/',
 		post_id: 2110,
 	},
+	'transfer-domain-to-another-registrar': {
+		link: 'https://wordpress.com/support/domains/transfer-domain-registration/',
+		post_id: 41298,
+	},
 };
 
 export default contextLinks;

--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -440,6 +440,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/domains/register-domain/#public-versus-private-registration-and-gdpr',
 		post_id: 2784,
 	},
+	'https-ssl': {
+		link: 'https://wordpress.com/support/domains/https-ssl/',
+		post_id: 2110,
+	},
 };
 
 export default contextLinks;

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -7,6 +7,7 @@ import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import QueryDomainDns from 'calypso/components/data/query-domain-dns';
 import ExternalLink from 'calypso/components/external-link';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import DomainHeader from 'calypso/my-sites/domains/domain-management/components/domain-header';
@@ -122,22 +123,17 @@ class AddDnsRecord extends Component {
 		const { domains, dns, selectedDomainName, selectedSite, translate } = this.props;
 		const recordBeingEdited = this.getRecordBeingEdited();
 
-		const dnsSupportPageLink = (
-			<ExternalLink
-				href={
-					recordBeingEdited
-						? localizeUrl( DNS_RECORDS_EDITING_OR_DELETING )
-						: localizeUrl( DNS_RECORDS_ADD )
-				}
-				target="_blank"
-				icon={ false }
-			/>
-		);
+		const dnsSupportPageLink = recordBeingEdited
+			? 'edit-or-delete-dns-record'
+			: 'add-a-new-dns-record';
+
 		const explanationText = translate(
 			'Custom DNS records allow you to connect your domain to third-party services that are not hosted on WordPress.com, such as an email provider. {{supportLink}}Learn more{{/supportLink}}.',
 			{
 				components: {
-					supportLink: dnsSupportPageLink,
+					supportLink: (
+						<InlineSupportLink supportContext={ dnsSupportPageLink } showIcon={ false } />
+					),
 				},
 			}
 		);

--- a/client/my-sites/domains/domain-management/dns/dns-details.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-details.jsx
@@ -1,7 +1,6 @@
-import { localizeUrl } from '@automattic/i18n-utils';
-import { CUSTOM_DNS } from '@automattic/urls';
 import { localize } from 'i18n-calypso';
 import { PureComponent } from 'react';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 
 class DnsDetails extends PureComponent {
 	render() {
@@ -16,7 +15,7 @@ class DnsDetails extends PureComponent {
 					{
 						components: {
 							customDnsLink: (
-								<a href={ localizeUrl( CUSTOM_DNS ) } target="_blank" rel="noopener noreferrer" />
+								<InlineSupportLink supportContext="manage-your-dns-records" showIcon={ false } />
 							),
 						},
 					}

--- a/client/my-sites/domains/domain-management/dns/dns-record-data.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-record-data.jsx
@@ -1,13 +1,7 @@
-import {
-	DNS_RECORDS_DEFAULT,
-	DNS_RECORDS_DEFAULT_MX,
-	DNS_RECORDS_DEFAULT_A,
-	DNS_RECORDS_DEFAULT_CNAME,
-} from '@automattic/urls';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import ExternalLink from 'calypso/components/external-link';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import DnsRecordsListItem from './dns-records-list-item';
 
 class DnsRecordData extends Component {
@@ -30,16 +24,16 @@ class DnsRecordData extends Component {
 
 		// TODO: Remove this once we stop displaying the protected records
 		if ( dnsRecord.protected_field ) {
-			let url = DNS_RECORDS_DEFAULT;
+			let supportContext = 'dns_default_records';
 			switch ( type ) {
 				case 'MX':
-					url = DNS_RECORDS_DEFAULT_MX;
+					supportContext = 'dns-default-mx-records';
 					break;
 				case 'A':
-					url = DNS_RECORDS_DEFAULT_A;
+					supportContext = 'dns-default-a-records';
 					break;
 				case 'CNAME':
-					url = DNS_RECORDS_DEFAULT_CNAME;
+					supportContext = 'dns-default-cname-records';
 					break;
 			}
 
@@ -48,7 +42,9 @@ class DnsRecordData extends Component {
 					'Mail handled by WordPress.com email forwarding. {{supportLink}}Learn more{{/supportLink}}.',
 					{
 						components: {
-							supportLink: <ExternalLink href={ url } target="_blank" icon={ false } />,
+							supportLink: (
+								<InlineSupportLink supportContext={ supportContext } showIcon={ false } />
+							),
 						},
 					}
 				);
@@ -56,7 +52,7 @@ class DnsRecordData extends Component {
 
 			return translate( 'Handled by WordPress.com. {{supportLink}}Learn more{{/supportLink}}.', {
 				components: {
-					supportLink: <ExternalLink href={ url } target="_blank" icon={ false } />,
+					supportLink: <InlineSupportLink supportContext={ supportContext } showIcon={ false } />,
 				},
 			} );
 		}

--- a/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
@@ -113,19 +113,16 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ) => {
 		const { privacyAvailable } = props;
 		return privacyAvailable ? (
 			<p className="contact-information__toggle-item">
-				{ translate(
-					'We recommend keeping privacy protection on. {{supportLink}}Learn more{{/supportLink}}',
-					{
-						components: {
-							supportLink: (
-								<InlineSupportLink
-									supportContext="public-vs-private-registration-and-gdpr"
-									showIcon={ false }
-								/>
-							),
-						},
-					}
-				) }
+				{ translate( 'We recommend keeping privacy protection on. {{a}}Learn more{{/a}}', {
+					components: {
+						a: (
+							<InlineSupportLink
+								supportContext="public-vs-private-registration-and-gdpr"
+								showIcon={ false }
+							/>
+						),
+					},
+				} ) }
 			</p>
 		) : null;
 	};

--- a/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
@@ -1,9 +1,10 @@
 import { Button, Card } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { PRIVACY_PROTECTION, PUBLIC_VS_PRIVATE } from '@automattic/urls';
+import { PRIVACY_PROTECTION } from '@automattic/urls';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import useDomainTransferRequestQuery from 'calypso/data/domains/transfers/use-domain-transfer-request-query';
@@ -112,11 +113,19 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ) => {
 		const { privacyAvailable } = props;
 		return privacyAvailable ? (
 			<p className="contact-information__toggle-item">
-				{ translate( 'We recommend keeping privacy protection on. {{a}}Learn more{{/a}}', {
-					components: {
-						a: <a href={ localizeUrl( PUBLIC_VS_PRIVATE ) } target="blank" />,
-					},
-				} ) }
+				{ translate(
+					'We recommend keeping privacy protection on. {{supportLink}}Learn more{{/supportLink}}',
+					{
+						components: {
+							supportLink: (
+								<InlineSupportLink
+									supportContext="public-vs-private-registration-and-gdpr"
+									showIcon={ false }
+								/>
+							),
+						},
+					}
+				) }
 			</p>
 		) : null;
 	};

--- a/client/my-sites/domains/domain-management/settings/cards/domain-security-details/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-security-details/index.tsx
@@ -1,10 +1,11 @@
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { CONTACT, HTTPS_SSL } from '@automattic/urls';
+import { CONTACT } from '@automattic/urls';
 import { Icon, lock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { ReactElement, useEffect, useState } from 'react';
 import Accordion from 'calypso/components/domains/accordion';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import useSslDetailsQuery from 'calypso/data/domains/ssl/use-ssl-details-query';
 import useProvisionCertificateMutation from 'calypso/data/domains/ssl/use-ssl-provision-certificate-mutation';
 import { useDispatch } from 'calypso/state';
@@ -164,8 +165,12 @@ const DomainSecurityDetails = ( { domain, isDisabled }: SecurityCardProps ) => {
 						) }
 					<div className="domain-security-details__description-help-text">
 						{ translate(
-							'We give you strong HTTPS encryption with your domain for free. This provides a trust indicator for your visitors and keeps their connection to your site secure. {{a}}Learn more{{/a}}',
-							{ components: { a: <a href={ localizeUrl( HTTPS_SSL ) } /> } }
+							'We give you strong HTTPS encryption with your domain for free. This provides a trust indicator for your visitors and keeps their connection to your site secure. {{supportLink}}Learn more{{/supportLink}}',
+							{
+								components: {
+									supportLink: <InlineSupportLink supportContext="https-ssl" showIcon={ false } />,
+								},
+							}
 						) }
 					</div>
 				</div>

--- a/client/my-sites/domains/domain-management/settings/cards/domain-security-details/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-security-details/index.tsx
@@ -165,10 +165,10 @@ const DomainSecurityDetails = ( { domain, isDisabled }: SecurityCardProps ) => {
 						) }
 					<div className="domain-security-details__description-help-text">
 						{ translate(
-							'We give you strong HTTPS encryption with your domain for free. This provides a trust indicator for your visitors and keeps their connection to your site secure. {{supportLink}}Learn more{{/supportLink}}',
+							'We give you strong HTTPS encryption with your domain for free. This provides a trust indicator for your visitors and keeps their connection to your site secure. {{a}}Learn more{{/a}}',
 							{
 								components: {
-									supportLink: <InlineSupportLink supportContext="https-ssl" showIcon={ false } />,
+									a: <InlineSupportLink supportContext="https-ssl" showIcon={ false } />,
 								},
 							}
 						) }

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -320,13 +320,11 @@ const TransferPage = ( props: TransferPageProps ) => {
 			return createInterpolateElement(
 				sprintf(
 					// translators: %s is a date string, e.g. April 1, 2020
-					__(
-						'You can unlock this domain after %s. <supportLink>Why is my domain locked?</supportLink>'
-					),
+					__( 'You can unlock this domain after %s. <a>Why is my domain locked?</a>' ),
 					moment( domain.transferAwayEligibleAt ).format( 'LL' )
 				),
 				{
-					supportLink: <InlineSupportLink supportContext={ supportLink } showIcon={ false } />,
+					a: <InlineSupportLink supportContext={ supportLink } showIcon={ false } />,
 				}
 			);
 		}

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -1,8 +1,7 @@
 import { Button, Card, Spinner } from '@automattic/components';
-import { localizeUrl, useHasEnTranslation } from '@automattic/i18n-utils';
-import { TRANSFER_DOMAIN_REGISTRATION } from '@automattic/urls';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
-import { createElement, createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { Icon, lock } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -446,10 +445,15 @@ const TransferPage = ( props: TransferPageProps ) => {
 							<br />
 							{ createInterpolateElement(
 								__(
-									'However, transferring a domain to another provider can take five to seven days during which no changes to the domain can be made. Read <a>this important information</a> before starting a transfer.'
+									'However, transferring a domain to another provider can take five to seven days during which no changes to the domain can be made. Read <supportLink>this important information</supportLink> before starting a transfer.'
 								),
 								{
-									a: createElement( 'a', { href: localizeUrl( TRANSFER_DOMAIN_REGISTRATION ) } ),
+									supportLink: (
+										<InlineSupportLink
+											supportContext="transfer-domain-to-another-registrar"
+											showIcon={ false }
+										/>
+									),
 								}
 							) }
 						</p>

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -443,10 +443,10 @@ const TransferPage = ( props: TransferPageProps ) => {
 							<br />
 							{ createInterpolateElement(
 								__(
-									'However, transferring a domain to another provider can take five to seven days during which no changes to the domain can be made. Read <supportLink>this important information</supportLink> before starting a transfer.'
+									'However, transferring a domain to another provider can take five to seven days during which no changes to the domain can be made. Read <a>this important information</a> before starting a transfer.'
 								),
 								{
-									supportLink: (
+									a: (
 										<InlineSupportLink
 											supportContext="transfer-domain-to-another-registrar"
 											showIcon={ false }

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Card, Spinner } from '@automattic/components';
 import { localizeUrl, useHasEnTranslation } from '@automattic/i18n-utils';
-import { DESIGNATED_AGENT, TRANSFER_DOMAIN_REGISTRATION } from '@automattic/urls';
+import { TRANSFER_DOMAIN_REGISTRATION } from '@automattic/urls';
 import { ToggleControl } from '@wordpress/components';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
 import ActionCard from 'calypso/components/action-card';
 import CardHeading from 'calypso/components/card-heading';
 import QueryDomainInfo from 'calypso/components/data/query-domain-info';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Layout from 'calypso/components/layout';
 import Column from 'calypso/components/layout/column';
 import Main from 'calypso/components/main';
@@ -313,18 +314,20 @@ const TransferPage = ( props: TransferPageProps ) => {
 	const renderTransferMessage = () => {
 		const registrationDatePlus60Days = moment.utc( domain?.registrationDate ).add( 60, 'days' );
 		const supportLink = moment.utc().isAfter( registrationDatePlus60Days )
-			? DESIGNATED_AGENT
-			: TRANSFER_DOMAIN_REGISTRATION;
+			? 'domain-designated-agent'
+			: 'transfer-domain-registration';
 
 		if ( domain?.transferAwayEligibleAt ) {
 			return createInterpolateElement(
 				sprintf(
 					// translators: %s is a date string, e.g. April 1, 2020
-					__( 'You can unlock this domain after %s. <a>Why is my domain locked?</a>' ),
+					__(
+						'You can unlock this domain after %s. <supportLink>Why is my domain locked?</supportLink>'
+					),
 					moment( domain.transferAwayEligibleAt ).format( 'LL' )
 				),
 				{
-					a: createElement( 'a', { href: localizeUrl( supportLink ) } ),
+					supportLink: <InlineSupportLink supportContext={ supportLink } showIcon={ false } />,
 				}
 			);
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/9790

## Proposed Changes

*  Update links within the domain pages to open articles in the Help Center.

`/domains/manage/all/{PAID_DOMAIN}/transfer/{SIMPLE_SITE}`

![CleanShot 2025-01-29 at 17 57 31@2x](https://github.com/user-attachments/assets/5bf44ba9-22e9-41b5-a42a-55ae2c2c3c40)

`/domains/manage/all/testdomainob1.blog/edit/testdomainob1.blog`

![CleanShot 2025-01-29 at 18 05 43@2x](https://github.com/user-attachments/assets/998e89a2-b17e-46f5-84ca-8b627ce96a05)

`/domains/manage/{PAID_DOMAIN}/dns/{PAID_DOMAIN}`

![CleanShot 2025-01-29 at 18 13 47@2x](https://github.com/user-attachments/assets/8e7dd6d4-112e-4a66-a983-62fa0be84466)

Edit the CNAME entry on this page `/domains/manage/{PAID_DOMAIN}/dns/{PAID_DOMAIN}`
Add a new record on this page `/domains/manage/{PAID_DOMAIN}/dns/{PAID_DOMAIN}`

You should an edit version and add version of the learn more link on the right sidebar

![CleanShot 2025-01-29 at 18 34 24@2x](https://github.com/user-attachments/assets/b2b5781f-1ff7-4d0d-ba5b-3f995faf593d)




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Remain on domain pages while reading related article in the Help Center instead of a new tab.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Navigate to links above and test help center article links

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
