### PR TITLE
i18n: Update a8c-for-agencies to use numberFormat from i18n-calypso. Fix untranslated numbers.

### DIFF
--- a/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
+++ b/client/a8c-for-agencies/components/pressable-usage-details/index.tsx
@@ -1,10 +1,6 @@
 import { ProgressBar } from '@automattic/components';
-import formatNumber, {
-	DEFAULT_LOCALE,
-	STANDARD_FORMATTING_OPTIONS,
-} from '@automattic/components/src/number-formatters/lib/format-number';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import getPressablePlan from 'calypso/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-pressable-plan';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -101,16 +97,8 @@ export default function PressableUsageDetails( { existingPlan }: Props ) {
 						<div className="pressable-usage-details__info-top-right">
 							{ translate( '%(visits_count)s of %(max_visits)s', {
 								args: {
-									max_visits: formatNumber(
-										planInfo.visits,
-										DEFAULT_LOCALE,
-										STANDARD_FORMATTING_OPTIONS
-									),
-									visits_count: formatNumber(
-										planUsage?.visits_count ?? 0,
-										DEFAULT_LOCALE,
-										STANDARD_FORMATTING_OPTIONS
-									),
+									max_visits: numberFormat( planInfo.visits ),
+									visits_count: numberFormat( planUsage?.visits_count ?? 0 ),
 								},
 								comment:
 									'%(visits_count)s is the number of month visits of the site and %(max_visits)s is the maximum number of visits.',

--- a/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
@@ -1,5 +1,4 @@
-import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import wpcomIcon from 'calypso/assets/images/icons/wordpress-logo.svg';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
 import { useLicenseLightboxData } from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox/hooks/use-license-lightbox-data';
@@ -38,7 +37,7 @@ export default function ProductInfo( {
 			{
 				args: {
 					install: presablePlan.install,
-					visits: formatNumber( presablePlan.visits ),
+					visits: numberFormat( presablePlan.visits ),
 					storage: presablePlan.storage,
 				},
 				count: presablePlan.install,

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -218,7 +218,9 @@ export default function PressablePlanSection( {
 							),
 							translate( '{{b}}%(count)s visits{{/b}} per month*', {
 								args: {
-									count: numberFormat( selectedPlanInfo?.visits ?? 0 ),
+									count: numberFormat( selectedPlanInfo?.visits ?? 0, {
+										numberFormatOptions: { notation: 'compact' },
+									} ),
 								},
 								components: {
 									b: <b />,

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -1,6 +1,5 @@
-import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import { external } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import { useState, useCallback, useEffect, useMemo } from 'react';
 import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
 import useProductAndPlans from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans';
@@ -219,7 +218,7 @@ export default function PressablePlanSection( {
 							),
 							translate( '{{b}}%(count)s visits{{/b}} per month*', {
 								args: {
-									count: formatNumber( selectedPlanInfo?.visits ?? 0 ),
+									count: numberFormat( selectedPlanInfo?.visits ?? 0 ),
 								},
 								components: {
 									b: <b />,

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-slider-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-slider-options.ts
@@ -1,4 +1,4 @@
-import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
+import { numberFormat } from 'i18n-calypso';
 import { FILTER_TYPE_INSTALL, FILTER_TYPE_STORAGE, FILTER_TYPE_VISITS } from '../constants';
 import { FilterType } from '../types';
 import { PressablePlan } from './get-pressable-plan';
@@ -19,7 +19,7 @@ export default function getSliderOptions(
 			if ( type === FILTER_TYPE_INSTALL ) {
 				label = `${ plan.install }`;
 			} else if ( type === FILTER_TYPE_VISITS ) {
-				label = `${ formatNumber( plan.visits ) }`;
+				label = `${ numberFormat( plan.visits ) }`;
 			} else if ( type === FILTER_TYPE_STORAGE ) {
 				label = `${ plan.storage }${ compact ? '' : 'GB' }`;
 			}

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-slider-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-slider-options.ts
@@ -19,7 +19,9 @@ export default function getSliderOptions(
 			if ( type === FILTER_TYPE_INSTALL ) {
 				label = `${ plan.install }`;
 			} else if ( type === FILTER_TYPE_VISITS ) {
-				label = `${ numberFormat( plan.visits ) }`;
+				label = `${ numberFormat( plan.visits, {
+					numberFormatOptions: { notation: 'compact', maximumFractionDigits: 1 },
+				} ) }`;
 			} else if ( type === FILTER_TYPE_STORAGE ) {
 				label = `${ plan.storage }${ compact ? '' : 'GB' }`;
 			}

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -115,11 +115,11 @@ export default function PlanSelectionDetails( {
 						items={ [
 							info?.install
 								? translate(
-										'{{b}}%(count)s{{/b}} WordPress install',
-										'{{b}}%(count)s{{/b}} WordPress installs',
+										'{{b}}%(installsCount)s{{/b}} WordPress install',
+										'{{b}}%(installsCount)s{{/b}} WordPress installs',
 										{
 											args: {
-												count: numberFormat( info.install ),
+												installsCount: numberFormat( info.install ),
 											},
 											count: info.install,
 											components: { b: <b /> },

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -1,8 +1,7 @@
 import { Button, Tooltip } from '@automattic/components';
-import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import formatCurrency from '@automattic/format-currency';
 import { Icon, external } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
 import { CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
 import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
@@ -116,11 +115,11 @@ export default function PlanSelectionDetails( {
 						items={ [
 							info?.install
 								? translate(
-										'{{b}}%(count)d{{/b}} WordPress install',
-										'{{b}}%(count)d{{/b}} WordPress installs',
+										'{{b}}%(count)s{{/b}} WordPress install',
+										'{{b}}%(count)s{{/b}} WordPress installs',
 										{
 											args: {
-												count: info.install,
+												count: numberFormat( info.install ),
 											},
 											count: info.install,
 											components: { b: <b /> },
@@ -130,7 +129,7 @@ export default function PlanSelectionDetails( {
 								: translate( 'Custom WordPress installs' ),
 							translate( '{{b}}%(count)s{{/b}} visits per month*', {
 								args: {
-									count: info ? formatNumber( info.visits ) : customString,
+									count: info ? numberFormat( info.visits ) : customString,
 								},
 								components: { b: <b /> },
 								comment: '%(count)s is the number of visits per month.',

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -129,7 +129,11 @@ export default function PlanSelectionDetails( {
 								: translate( 'Custom WordPress installs' ),
 							translate( '{{b}}%(count)s{{/b}} visits per month*', {
 								args: {
-									count: info ? numberFormat( info.visits ) : customString,
+									count: info
+										? numberFormat( info.visits, {
+												numberFormatOptions: { notation: 'compact' },
+										  } )
+										: customString,
 								},
 								components: { b: <b /> },
 								comment: '%(count)s is the number of visits per month.',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

PArtly addresses https://github.com/Automattic/i18n-issues/issues/921

## Proposed Changes

Updates a8c-for-agencies section components to use i18n-calypso's `numberFormat` method for number translations. 

So far the section was either missing or using a different number formatted, which result in wrong/missing notation e.g. dot `.` in place of comma `,` or missing entirely.

## Media 

EL/DE locale

### Before

<img width="800" alt="Screenshot 2025-01-29 at 7 15 13 PM" src="https://github.com/user-attachments/assets/7bab4cd1-e87b-4f2d-a8a2-a5d90fd4bb9e" />

<img width="400" alt="Screenshot 2025-01-29 at 7 03 02 PM" src="https://github.com/user-attachments/assets/64492c1c-ecf1-43cd-b2e3-ce6dbdd785b6" />

### After

<img width="800" alt="Screenshot 2025-01-29 at 7 14 28 PM" src="https://github.com/user-attachments/assets/8fd1cc1c-8dbf-454e-bbba-aea830f3edaa" />

I think, ideally, this should only render if translations exist (and fall back to EN/previous), so we don't get mixed words. But this is the same behavior as before (we've only switched the formatter to i18n-calypso's):

<img width="400" alt="Screenshot 2025-01-29 at 7 17 14 PM" src="https://github.com/user-attachments/assets/dd35c14d-1cba-4688-a4d9-ad104b854046" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix missing translations in `a8c-for-agencies` section
* Part of a wider goal of unifying our number formatters behind `i18n-calypso`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Switch locale to EL/DE through settings
- Go to the A4A live link and sign up / complete the form
- Go to `/marketplace/hosting/pressable` and confirm the media above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
