### PR TITLE
WebPreview: Remove site launch button

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -70,8 +70,8 @@
 	border-bottom: 1px solid var(--color-neutral-10);
 	border-radius: 2px 2px 0 0;
 	display: flex;
-	gap: 10px;
-	padding: 6px 10px;
+	gap: 24px;
+	padding: 0 12px;
 	align-items: center;
 }
 

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -70,6 +70,9 @@
 	border-bottom: 1px solid var(--color-neutral-10);
 	border-radius: 2px 2px 0 0;
 	display: flex;
+	gap: 10px;
+	padding: 6px 10px;
+	align-items: center;
 }
 
 .web-preview__close.button {
@@ -103,9 +106,7 @@
 	}
 }
 
-.web-preview__external,
-.web-preview__launch-site {
-	margin: 3px 0;
+.web-preview__external {
 	min-width: 120px;
 	text-align: center;
 }
@@ -121,12 +122,6 @@
 	display: flex;
 	justify-content: flex-end;
 	gap: 8px;
-
-	@include break-large {
-		// Matches __device-switcher width + margin
-		// and allows the center area to flex equally
-		min-width: 212px;
-	}
 }
 
 .web-preview__device-switcher {
@@ -134,13 +129,11 @@
 
 	@include break-small {
 		display: flex;
-		margin: 6px 12px 0;
 	}
 }
 
 .web-preview__url-clipboard-input {
 	flex-grow: 1;
-	margin: 6px 10px;
 	width: auto;
 
 	.form-text-input {
@@ -204,17 +197,6 @@
 
 	@include break-small {
 		display: none;
-	}
-}
-
-.web-preview__toolbar-tray {
-	.button {
-		margin: 4px;
-		&:not(:last-child) {
-			@include breakpoint-deprecated( "<660px" ) {
-				display: none;
-			}
-		}
 	}
 }
 

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -120,6 +120,7 @@
 	margin-left: auto;
 	display: flex;
 	justify-content: flex-end;
+	align-items: center;
 	gap: 8px;
 }
 

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -112,7 +112,6 @@
 }
 
 .web-preview__edit.button {
-	margin: 3px 0;
 	min-width: 100px;
 	text-align: center;
 }

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -9,7 +9,6 @@ import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import getIsUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
-import { launchSite } from 'calypso/state/sites/launch/actions';
 import { getCustomizerUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -49,7 +48,6 @@ class PreviewToolbar extends Component {
 		canUserEditThemeOptions: PropTypes.bool,
 		isUnlaunchedSite: PropTypes.bool,
 		selectedSiteId: PropTypes.number,
-		launchSite: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -204,5 +202,5 @@ export default connect(
 			selectedSiteId,
 		};
 	},
-	{ recordTracksEvent, launchSite }
+	{ recordTracksEvent }
 )( localize( PreviewToolbar ) );

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -60,11 +60,6 @@ class PreviewToolbar extends Component {
 		this.props.recordTracksEvent( 'calypso_editor_preview_toolbar_external_click' );
 	};
 
-	handleEditorWebPreviewLaunchSiteClick = () => {
-		this.props.recordTracksEvent( 'calypso_editor_preview_toolbar_launch_site__click' );
-		this.props.launchSite( this.props.selectedSiteId );
-	};
-
 	handleEditorWebPreviewClose = () => {
 		this.props.recordTracksEvent( 'calypso_editor_preview_close_click' );
 		this.props.onClose();
@@ -185,18 +180,9 @@ class PreviewToolbar extends Component {
 							>
 								{ translate( 'Visit site' ) }
 							</Button>
-							{ isUnlaunchedSite && (
-								<Button
-									primary
-									className="web-preview__launch-site"
-									onClick={ this.handleEditorWebPreviewLaunchSiteClick }
-								>
-									{ translate( 'Launch site' ) }
-								</Button>
-							) }
 						</>
 					) }
-					<div className="web-preview__toolbar-tray">{ this.props.children }</div>
+					{ this.props.children }
 				</div>
 			</div>
 		);


### PR DESCRIPTION
Closes #98901

## Proposed Changes

* Now that we have a consistent launch button in the admin bar, this PR removes the launch button that was being rendered in the "preview page / home page"

<img width="1470" alt="Screenshot 2025-01-29 at 11 30 40 AM" src="https://github.com/user-attachments/assets/783e8cfe-7e75-4167-a227-780b0b76b846" />

In addition to the change, I did some very light changes to the styles (especially the spacing) of the toolbar of the WebPreview component to simplify a little bit and make it more consistent.

## Testing Instructions

* Have an unlaunched site 
* Navigate to `wordpress.com/view/$domain`
* The launch button shouldn't be present in the web preview.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
