### PR TITLE
Master Bar: Track launch button clicks

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -424,7 +424,10 @@ class MasterbarLoggedIn extends Component {
 		return (
 			<Item
 				className="masterbar__item-launch-site"
-				onClick={ () => this.props.launchSiteOrRedirectToLaunchSignupFlow( siteId ) }
+				onClick={ () => {
+					this.props.recordTracksEvent( 'calypso_masterbar_launch_site' );
+					this.props.launchSiteOrRedirectToLaunchSignupFlow( siteId );
+				} }
 			>
 				{ translate( 'Launch site' ) }
 			</Item>


### PR DESCRIPTION
Related to #98860

## Proposed Changes

Tracks `calypso_masterbar_launch_site` event when the user clicks on the "launch button" of the Calypso master bar.
In a different PR I4m going to add an event to track clicks on the admin bar button as well.


## Testing Instructions

* Nothing really, this just adds a small track event. You can try launching a site from the "launch button" in calypso's master bar .
