### PR TITLE
Update @automattic/color-studio package to version 4.1.0

### DIFF
--- a/apps/happy-blocks/package.json
+++ b/apps/happy-blocks/package.json
@@ -29,7 +29,7 @@
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/calypso-products": "workspace:^",
-		"@automattic/color-studio": "^3.0.1",
+		"@automattic/color-studio": "^4.1.0",
 		"@automattic/components": "workspace:^",
 		"@automattic/format-currency": "workspace:^",
 		"@automattic/typography": "workspace:^",

--- a/client/package.json
+++ b/client/package.json
@@ -28,7 +28,7 @@
 		"@automattic/calypso-sentry": "workspace:^",
 		"@automattic/calypso-stripe": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
-		"@automattic/color-studio": "^3.0.1",
+		"@automattic/color-studio": "^4.1.0",
 		"@automattic/command-palette": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/composite-checkout": "workspace:^",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/calypso-razorpay": "workspace:^",
 		"@automattic/calypso-router": "workspace:^",
-		"@automattic/color-studio": "^3.0.1",
+		"@automattic/color-studio": "^4.1.0",
 		"@automattic/command-palette": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -28,7 +28,7 @@
 	"devDependencies": {
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"@automattic/color-studio": "^3.0.1",
+		"@automattic/color-studio": "^4.1.0",
 		"postcss": "^8.4.5",
 		"postcss-custom-properties": "^11.0.0",
 		"sass": "^1.37.5"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,7 +30,7 @@
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
-		"@automattic/color-studio": "^3.0.1",
+		"@automattic/color-studio": "^4.1.0",
 		"@automattic/format-currency": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/load-script": "workspace:^",

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -46,7 +46,7 @@
 	"devDependencies": {
 		"@automattic/calypso-storybook": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"@automattic/color-studio": "^3.0.1",
+		"@automattic/color-studio": "^4.1.0",
 		"@storybook/cli": "^7.6.19",
 		"@storybook/react": "^7.6.19",
 		"@testing-library/dom": "^10.1.0",

--- a/packages/page-pattern-modal/package.json
+++ b/packages/page-pattern-modal/package.json
@@ -27,7 +27,7 @@
 	],
 	"types": "dist/types",
 	"dependencies": {
-		"@automattic/color-studio": "^3.0.1",
+		"@automattic/color-studio": "^4.1.0",
 		"@automattic/typography": "1.0.0",
 		"@wordpress/base-styles": "5.8.0",
 		"@wordpress/block-editor": "^14.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -322,7 +322,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-eslint-overrides": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
-    "@automattic/color-studio": "npm:^3.0.1"
+    "@automattic/color-studio": "npm:^4.1.0"
     postcss: "npm:^8.4.5"
     postcss-custom-properties: "npm:^11.0.0"
     sass: "npm:^1.37.5"
@@ -562,10 +562,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/color-studio@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@automattic/color-studio@npm:3.0.1"
-  checksum: 1fed9e35e5a4cf283055d323661bf94f8836fbe762c3a1ff7c514407c9cffcae9b05791fb2d4904050c097e939b745c8f2bc13cc84c9963d35c9d1aa57f1fbd8
+"@automattic/color-studio@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@automattic/color-studio@npm:4.1.0"
+  checksum: 545a3c6cf2bc0897e0a5b5630a411db027220f821fc1eba3b50cd6d6cb71ea8c6d1469ef93eaa059855010aa64125f32dbf9b763bc83a8c7af410ee4b9b45f90
   languageName: node
   linkType: hard
 
@@ -643,7 +643,7 @@ __metadata:
     "@automattic/calypso-storybook": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
-    "@automattic/color-studio": "npm:^3.0.1"
+    "@automattic/color-studio": "npm:^4.1.0"
     "@automattic/format-currency": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/load-script": "workspace:^"
@@ -697,7 +697,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-storybook": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
-    "@automattic/color-studio": "npm:^3.0.1"
+    "@automattic/color-studio": "npm:^4.1.0"
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
     "@storybook/cli": "npm:^7.6.19"
@@ -1616,7 +1616,7 @@ __metadata:
   resolution: "@automattic/page-pattern-modal@workspace:packages/page-pattern-modal"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    "@automattic/color-studio": "npm:^3.0.1"
+    "@automattic/color-studio": "npm:^4.1.0"
     "@automattic/typography": "npm:1.0.0"
     "@testing-library/react": "npm:^15.0.7"
     "@wordpress/base-styles": "npm:5.8.0"
@@ -13036,7 +13036,7 @@ __metadata:
     "@automattic/calypso-sentry": "workspace:^"
     "@automattic/calypso-stripe": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
-    "@automattic/color-studio": "npm:^3.0.1"
+    "@automattic/color-studio": "npm:^4.1.0"
     "@automattic/command-palette": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/composite-checkout": "workspace:^"
@@ -19656,7 +19656,7 @@ __metadata:
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-products": "workspace:^"
-    "@automattic/color-studio": "npm:^3.0.1"
+    "@automattic/color-studio": "npm:^4.1.0"
     "@automattic/components": "workspace:^"
     "@automattic/format-currency": "workspace:^"
     "@automattic/typography": "workspace:^"
@@ -34792,7 +34792,7 @@ __metadata:
     "@automattic/calypso-razorpay": "workspace:^"
     "@automattic/calypso-router": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
-    "@automattic/color-studio": "npm:^3.0.1"
+    "@automattic/color-studio": "npm:^4.1.0"
     "@automattic/command-palette": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/98732#discussion_r1933697098

## Proposed Changes

Update @automattic/color-studio package to the current latest version (`4.1.0`) across all packages in the repository

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This allows the project to consume the updated shades of blue released with version `4.0.1`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Looking at the [CHANGELOG](https://github.com/Automattic/color-studio/blob/trunk/CHANGELOG.md), it looks like there are 2 main changes affecting the web version when updating from `3.0.1` to `4.1.0`:

- Updated WooCommerce Purple color values. https://github.com/Automattic/color-studio/pull/747
- Blue to absorb the Blueberry values of WordPress Blue. Deprecated WordPress Blue. https://github.com/Automattic/color-studio/pull/748

This will affect the colors all over the repository, and therefore we should smoke test as many pages in as many environments as possible!

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
