### PR TITLE
Staging Sites: Add `Delete staging site` button to the Staging Site tab (when managing staging site) - other approach

### DIFF
--- a/client/sites/tools/staging-site/components/staging-site-card/index.js
+++ b/client/sites/tools/staging-site/components/staging-site-card/index.js
@@ -257,6 +257,7 @@ export const StagingSiteCard = ( {
 		setProgress( ( prevProgress ) => {
 			switch ( stagingSiteStatus ) {
 				case null:
+				case StagingSiteStatus.INITIATE_REVERTING:
 					return 0.1;
 				case transferStates.RELOCATING_REVERT:
 				case transferStates.ACTIVE:

--- a/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
@@ -28,9 +28,13 @@ import { LoadingPlaceholder } from './loading-placeholder';
 
 const ActionButtons = styled.div( {
 	display: 'flex',
-	'@media ( max-width: 768px )': {
+	gap: '1em',
+
+	'@media screen and (max-width: 768px)': {
+		gap: '0.5em',
 		flexDirection: 'column',
-		alignItems: 'stretch',
+		'.button': { flexGrow: 1 },
+		alignSelf: 'stretch',
 	},
 } );
 

--- a/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { localize } from 'i18n-calypso';
@@ -6,18 +6,23 @@ import { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Notice from 'calypso/components/notice';
+import { navigate } from 'calypso/lib/navigate';
 import { urlToSlug } from 'calypso/lib/url';
 import { showSitesPage } from 'calypso/sites/components/sites-dashboard';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { getSiteUrl } from 'calypso/state/sites/selectors';
+import getSiteUrl from 'calypso/state/selectors/get-site-url';
+import { setStagingSiteStatus } from 'calypso/state/staging-site/actions';
+import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
 import { getIsSyncingInProgress } from 'calypso/state/sync/selectors/get-is-syncing-in-progress';
 import { IAppState } from 'calypso/state/types';
+import { useDeleteStagingSite } from '../../hooks/use-delete-staging-site';
 import { useProductionSiteDetail, ProductionSite } from '../../hooks/use-production-site-detail';
 import { usePullFromStagingMutation, usePushToStagingMutation } from '../../hooks/use-staging-sync';
 import { CardContentWrapper } from './card-content/card-content-wrapper';
 import { SiteSyncCard } from './card-content/staging-sync-card';
+import { ConfirmationModal } from './confirmation-modal';
 import { LoadingPlaceholder } from './loading-placeholder';
 
 const ActionButtons = styled.div( {
@@ -42,6 +47,7 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 	const [ syncError, setSyncError ] = useState< string | null >( null );
+	const [ deleteError, setDeleteError ] = useState< string | null >( null );
 	const stagingSiteUrl = useSelector( ( state ) => getSiteUrl( state, siteId ) );
 
 	const {
@@ -98,6 +104,52 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 		},
 	} );
 
+	const {
+		deleteStagingSite,
+		isLoading: isDeleting,
+		isReverting,
+	} = useDeleteStagingSite( {
+		siteId: productionSite?.id as number,
+		stagingSiteId: siteId,
+		transferStatus: null,
+		onMutate: () => {
+			showSitesPage( `/staging-site/${ urlToSlug( productionSite?.url || '' ) }` );
+		},
+		onError: ( error ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_hosting_configuration_staging_site_delete_failure', {
+					code: error.code,
+				} )
+			);
+			setDeleteError( error.code );
+		},
+	} );
+
+	const handleDeleteClick = () => {
+		dispatch(
+			setStagingSiteStatus( productionSite?.id as number, StagingSiteStatus.INITIATE_REVERTING )
+		);
+		deleteStagingSite();
+	};
+
+	const DeleteStagingSiteButton = () => (
+		<ConfirmationModal
+			disabled={ disabled || isSyncInProgress || isDeleting || isReverting }
+			onConfirm={ handleDeleteClick }
+			isBusy={ isDeleting }
+			isScary
+			modalTitle={ translate( 'Confirm staging site deletion' ) }
+			modalMessage={ translate(
+				'Are you sure you want to delete the staging site? This action cannot be undone.'
+			) }
+			confirmLabel={ translate( 'Delete staging site' ) }
+			cancelLabel={ translate( 'Cancel' ) }
+		>
+			<Gridicon icon="trash" />
+			<span>{ translate( 'Delete staging site' ) }</span>
+		</ConfirmationModal>
+	);
+
 	const getLoadingErrorContent = ( message: string ) => {
 		return (
 			<Notice status="is-error" showDismiss={ false }>
@@ -112,11 +164,20 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 				<ActionButtons>
 					<Button
 						primary
-						onClick={ () => showSitesPage( `/overview/${ urlToSlug( productionSite.url ) }` ) }
+						onClick={ () => {
+							navigate(
+								`/overview/${ urlToSlug( productionSite.url ) }?search=${ urlToSlug(
+									productionSite.url
+								) }`,
+								false,
+								true
+							);
+						} }
 						disabled={ disabled || isSyncInProgress }
 					>
 						<span>{ __( 'Switch to production site' ) }</span>
 					</Button>
+					<DeleteStagingSiteButton />
 				</ActionButtons>
 				<SyncActionsContainer>
 					<SiteSyncCard
@@ -137,7 +198,13 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 	};
 
 	let cardContent;
-	if ( ! isLoading && productionSite ) {
+	if ( deleteError ) {
+		cardContent = (
+			<Notice status="is-error" showDismiss={ false }>
+				{ translate( 'Failed to delete staging site. Please try again.' ) }
+			</Notice>
+		);
+	} else if ( ! isLoading && productionSite ) {
 		cardContent = getManageStagingSiteContent( productionSite );
 	} else if ( isLoading ) {
 		cardContent = <LoadingPlaceholder />;
@@ -152,7 +219,7 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 	return (
 		<CardContentWrapper
 			subtitle={ translate(
-				'This staging site lets you preview and troubleshoot changes before updating the production site. {{a}}Learn more{{/a}}',
+				'This staging site lets you preview and troubleshoot changes before updating the production site. {{a}}Learn more{{/a}}.',
 				{
 					components: {
 						a: <InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />,

--- a/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
@@ -1,5 +1,6 @@
 import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { localize } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -11,6 +12,7 @@ import { showSitesPage } from 'calypso/sites/components/sites-dashboard';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 import { getSiteUrl } from 'calypso/state/sites/selectors';
 import { setStagingSiteStatus } from 'calypso/state/staging-site/actions';
 import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
@@ -46,7 +48,6 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 	const [ syncError, setSyncError ] = useState< string | null >( null );
-	const [ deleteError, setDeleteError ] = useState< string | null >( null );
 	const stagingSiteUrl = useSelector( ( state ) => getSiteUrl( state, siteId ) );
 
 	const {
@@ -120,11 +121,20 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 					code: error.code,
 				} )
 			);
-			setDeleteError( error.code );
+			dispatch(
+				errorNotice(
+					// translators: "reason" is why deleting the staging site failed.
+					sprintf( __( 'Could not delete staging site: %(reason)s' ), { reason: error.message } ),
+					{
+						id: 'staging-site-delete-failure',
+					}
+				)
+			);
 		},
 	} );
 
 	const handleDeleteClick = () => {
+		removeNotice( 'staging-site-delete-failure' );
 		dispatch(
 			setStagingSiteStatus( productionSite?.id as number, StagingSiteStatus.INITIATE_REVERTING )
 		);
@@ -189,13 +199,7 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 	};
 
 	let cardContent;
-	if ( deleteError ) {
-		cardContent = (
-			<Notice status="is-error" showDismiss={ false }>
-				{ translate( 'Failed to delete staging site. Please try again.' ) }
-			</Notice>
-		);
-	} else if ( ! isLoading && productionSite ) {
+	if ( ! isLoading && productionSite ) {
 		cardContent = getManageStagingSiteContent( productionSite );
 	} else if ( isLoading ) {
 		cardContent = <LoadingPlaceholder />;

--- a/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/staging-site-production-card.tsx
@@ -6,13 +6,12 @@ import { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Notice from 'calypso/components/notice';
-import { navigate } from 'calypso/lib/navigate';
 import { urlToSlug } from 'calypso/lib/url';
 import { showSitesPage } from 'calypso/sites/components/sites-dashboard';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import getSiteUrl from 'calypso/state/selectors/get-site-url';
+import { getSiteUrl } from 'calypso/state/sites/selectors';
 import { setStagingSiteStatus } from 'calypso/state/staging-site/actions';
 import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
 import { getIsSyncingInProgress } from 'calypso/state/sync/selectors/get-is-syncing-in-progress';
@@ -164,15 +163,7 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 				<ActionButtons>
 					<Button
 						primary
-						onClick={ () => {
-							navigate(
-								`/overview/${ urlToSlug( productionSite.url ) }?search=${ urlToSlug(
-									productionSite.url
-								) }`,
-								false,
-								true
-							);
-						} }
+						onClick={ () => showSitesPage( `/overview/${ urlToSlug( productionSite.url ) }` ) }
 						disabled={ disabled || isSyncInProgress }
 					>
 						<span>{ __( 'Switch to production site' ) }</span>
@@ -219,7 +210,7 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 	return (
 		<CardContentWrapper
 			subtitle={ translate(
-				'This staging site lets you preview and troubleshoot changes before updating the production site. {{a}}Learn more{{/a}}.',
+				'This staging site lets you preview and troubleshoot changes before updating the production site. {{a}}Learn more{{/a}}',
 				{
 					components: {
 						a: <InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
