### PR TITLE
Site settings: prevent console price formatting warnings

### DIFF
--- a/client/sites/settings/site/visibility/index.jsx
+++ b/client/sites/settings/site/visibility/index.jsx
@@ -34,6 +34,9 @@ import { LaunchSiteTrialUpsellNotice } from './launch-site-trial-notice';
 import './styles.scss';
 
 const createAgencyBillingMessage = ( agency, agencyLoading = false, agencyError = false ) => {
+	if ( ! agency ) {
+		return undefined;
+	}
 	const agencyName = agency.name;
 	const existingWPCOMLicenseCount = agency.existing_wpcom_license_count || 0;
 	const price = formatCurrency( agency.prices?.actual_price, agency.prices?.currency );
@@ -164,9 +167,7 @@ const LaunchSite = () => {
 		window.location.href = `https://agencies.automattic.com/marketplace/checkout?referral_blog_id=${ siteId }`;
 	};
 
-	const agencyBillingMessage = ! agency
-		? undefined
-		: createAgencyBillingMessage( agency, agencyLoading, agencyError );
+	const agencyBillingMessage = createAgencyBillingMessage( agency, agencyLoading, agencyError );
 
 	const renderConfirmationModal = () => {
 		return (

--- a/client/sites/settings/site/visibility/index.jsx
+++ b/client/sites/settings/site/visibility/index.jsx
@@ -33,6 +33,42 @@ import { LaunchConfirmationModal } from './launch-confirmation-modal';
 import { LaunchSiteTrialUpsellNotice } from './launch-site-trial-notice';
 import './styles.scss';
 
+const createAgencyBillingMessage = ( agency, agencyLoading = false, agencyError = false ) => {
+	const agencyName = agency.name;
+	const existingWPCOMLicenseCount = agency.existing_wpcom_license_count || 0;
+	const price = formatCurrency( agency.prices?.actual_price, agency.prices?.currency );
+
+	return agencyLoading || agencyError
+		? translate( "After launch, we'll bill your agency in the next billing cycle." )
+		: translate(
+				"After launch, we'll bill {{strong}}%(agencyName)s{{/strong}} in the next billing cycle. With %(licenseCount)s production hosting license, you will be charged %(price)s / license / month. {{a}}Learn more.{{/a}}",
+				"After launch, we'll bill {{strong}}%(agencyName)s{{/strong}} in the next billing cycle. With %(licenseCount)s production hosting licenses, you will be charged %(price)s / license / month. {{a}}Learn more.{{/a}}",
+				{
+					count: existingWPCOMLicenseCount + 1,
+					args: {
+						agencyName,
+						licenseCount: existingWPCOMLicenseCount + 1,
+						price,
+					},
+					components: {
+						strong: <strong />,
+						a: (
+							<a
+								className="site-settings__general-settings-launch-site-agency-learn-more"
+								href={ localizeUrl(
+									'https://agencieshelp.automattic.com/knowledge-base/free-development-licenses-for-wordpress-com-hosting/'
+								) }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+					},
+					comment:
+						'agencyName: name of the agency that will be billed for the site; licenseCount: number of licenses the agency will be billed for; price: price per license',
+				}
+		  );
+};
+
 const LaunchSite = () => {
 	const [ isLaunchConfirmationModalOpen, setLaunchConfirmationModalOpen ] = useState( false );
 	const openLaunchConfirmationModal = () => setLaunchConfirmationModalOpen( true );
@@ -73,9 +109,7 @@ const LaunchSite = () => {
 		error: agencyError,
 		isLoading: agencyLoading,
 	} = useFetchAgencyFromBlog( site?.ID, { enabled: !! site?.ID && isDevelopmentSite } );
-	const agencyName = agency?.name;
-	const existingWPCOMLicenseCount = agency?.existing_wpcom_license_count || 0;
-	const price = formatCurrency( agency?.prices?.actual_price, agency?.prices?.currency );
+
 	const siteReferralActive = agency?.referral_status === 'active';
 	const shouldShowReferToClientButton =
 		isDevelopmentSite && ! siteReferralActive && ! agencyLoading;
@@ -130,36 +164,9 @@ const LaunchSite = () => {
 		window.location.href = `https://agencies.automattic.com/marketplace/checkout?referral_blog_id=${ siteId }`;
 	};
 
-	const agencyBillingMessage =
-		agencyLoading || agencyError
-			? translate( "After launch, we'll bill your agency in the next billing cycle." )
-			: translate(
-					"After launch, we'll bill {{strong}}%(agencyName)s{{/strong}} in the next billing cycle. With %(licenseCount)s production hosting license, you will be charged %(price)s / license / month. {{a}}Learn more.{{/a}}",
-					"After launch, we'll bill {{strong}}%(agencyName)s{{/strong}} in the next billing cycle. With %(licenseCount)s production hosting licenses, you will be charged %(price)s / license / month. {{a}}Learn more.{{/a}}",
-					{
-						count: existingWPCOMLicenseCount + 1,
-						args: {
-							agencyName: agencyName,
-							licenseCount: existingWPCOMLicenseCount + 1,
-							price,
-						},
-						components: {
-							strong: <strong />,
-							a: (
-								<a
-									className="site-settings__general-settings-launch-site-agency-learn-more"
-									href={ localizeUrl(
-										'https://agencieshelp.automattic.com/knowledge-base/free-development-licenses-for-wordpress-com-hosting/'
-									) }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-						},
-						comment:
-							'agencyName: name of the agency that will be billed for the site; licenseCount: number of licenses the agency will be billed for; price: price per license',
-					}
-			  );
+	const agencyBillingMessage = ! agency
+		? undefined
+		: createAgencyBillingMessage( agency, agencyLoading, agencyError );
 
 	const renderConfirmationModal = () => {
 		return (

--- a/client/sites/settings/site/visibility/index.jsx
+++ b/client/sites/settings/site/visibility/index.jsx
@@ -37,39 +37,45 @@ const createAgencyBillingMessage = ( agency, agencyLoading = false, agencyError 
 	if ( ! agency ) {
 		return undefined;
 	}
+
+	const agencyPriceInfoIsDefined =
+		Number.isFinite( agency.prices?.actual_price ) && typeof agency.prices?.currency === 'string';
+
+	if ( agencyLoading || agencyError || ! agencyPriceInfoIsDefined ) {
+		return translate( "After launch, we'll bill your agency in the next billing cycle." );
+	}
+
 	const agencyName = agency.name;
 	const existingWPCOMLicenseCount = agency.existing_wpcom_license_count || 0;
-	const price = formatCurrency( agency.prices?.actual_price, agency.prices?.currency );
+	const price = formatCurrency( agency.prices.actual_price, agency.prices.currency );
 
-	return agencyLoading || agencyError
-		? translate( "After launch, we'll bill your agency in the next billing cycle." )
-		: translate(
-				"After launch, we'll bill {{strong}}%(agencyName)s{{/strong}} in the next billing cycle. With %(licenseCount)s production hosting license, you will be charged %(price)s / license / month. {{a}}Learn more.{{/a}}",
-				"After launch, we'll bill {{strong}}%(agencyName)s{{/strong}} in the next billing cycle. With %(licenseCount)s production hosting licenses, you will be charged %(price)s / license / month. {{a}}Learn more.{{/a}}",
-				{
-					count: existingWPCOMLicenseCount + 1,
-					args: {
-						agencyName,
-						licenseCount: existingWPCOMLicenseCount + 1,
-						price,
-					},
-					components: {
-						strong: <strong />,
-						a: (
-							<a
-								className="site-settings__general-settings-launch-site-agency-learn-more"
-								href={ localizeUrl(
-									'https://agencieshelp.automattic.com/knowledge-base/free-development-licenses-for-wordpress-com-hosting/'
-								) }
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
-						),
-					},
-					comment:
-						'agencyName: name of the agency that will be billed for the site; licenseCount: number of licenses the agency will be billed for; price: price per license',
-				}
-		  );
+	return translate(
+		"After launch, we'll bill {{strong}}%(agencyName)s{{/strong}} in the next billing cycle. With %(licenseCount)s production hosting license, you will be charged %(price)s / license / month. {{a}}Learn more.{{/a}}",
+		"After launch, we'll bill {{strong}}%(agencyName)s{{/strong}} in the next billing cycle. With %(licenseCount)s production hosting licenses, you will be charged %(price)s / license / month. {{a}}Learn more.{{/a}}",
+		{
+			count: existingWPCOMLicenseCount + 1,
+			args: {
+				agencyName,
+				licenseCount: existingWPCOMLicenseCount + 1,
+				price,
+			},
+			components: {
+				strong: <strong />,
+				a: (
+					<a
+						className="site-settings__general-settings-launch-site-agency-learn-more"
+						href={ localizeUrl(
+							'https://agencieshelp.automattic.com/knowledge-base/free-development-licenses-for-wordpress-com-hosting/'
+						) }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			},
+			comment:
+				'agencyName: name of the agency that will be billed for the site; licenseCount: number of licenses the agency will be billed for; price: price per license',
+		}
+	);
 };
 
 const LaunchSite = () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Change the computation of the agency billing message and its dependencies to be lazier

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Currently, the `price` (that is displayed in the agency billing message) is compute every render.
When there's no agency associated to the site, this causes the browser console to be flooded with warnings.

Those warnings should pollute the browser console and should actually only be shown when the price needs to be calculated/displayed.

> [!Note]
> The code in this page is quite messy, mixing logic about "untangled"/"tangled" sites, a4a and non-a4a site, and other forks in the logic. I tried to keep the scope of this PR as focused as possible on solving the warnings, but this file would definitely benefit from a refactor.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load a simple site's settings page (ie. `/settings/general/{SITE_SLUG}`, make sure that:
  * the page looks and behaves as expected
  * the browser console doesn't show warnings about the value and currency not being defined correctly

![Screenshot 2025-01-29 at 17 48 58](https://github.com/user-attachments/assets/27e70eb2-a194-498e-b299-cb24f3a2674f)


* Test that the billing message is displayed correctly for a4a development sites:
  * Create an A4A development site (I followed instructions from pdtkmj-2Te-p2 )
  * In calypso WPCom environment, visit `settings/general/{A4A_DEV_SITE_SLUG}`
  * Make sure that the page behaves and looks as expected. In particular, check that:
    * the "Launch site" and "Refer to client" buttons work as expected;
    * the billing message is shows correctly next to the "launch site" button
    * when clicking the "Launch site" button, a modal is shown with the same billing message as its contents

![Screenshot 2025-01-29 at 17 10 37](https://github.com/user-attachments/assets/32976caf-4843-4e6e-aa18-f746391f8e00)
![Screenshot 2025-01-29 at 17 09 14](https://github.com/user-attachments/assets/ba6e0a28-3c1c-46d6-a97a-6f560aa0608b)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?