### PR TITLE
Sites: Don't navigate when right-clicking title

### DIFF
--- a/client/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
@@ -80,6 +80,11 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 	const onSiteClick = ( event: React.MouseEvent ) => {
 		event.preventDefault();
 
+		// Ignore if not left or middle click
+		if ( event.button > 1 ) {
+			return;
+		}
+
 		let openInNewTab = false;
 		if ( event.ctrlKey || event.metaKey ) {
 			openInNewTab = true;


### PR DESCRIPTION
Related to #97755

## Proposed Changes

Prevents the sites dashboard from triggering a navigation when the site title is right-clicked.

### After

<img src="https://github.com/user-attachments/assets/ec430e6c-a0a0-4fbd-8d42-72807d7b772d" alt="Right clicking the site title shows context menu" width="548">

## Why are these changes being made?

The site title is implemented as a `button` rather than an `anchor`, which then required additional custom implementation to handle command clicks and middle clicks (which will open the destination in a new tab). This custom click handler didn't reject right clicks appropriately.

This PR is just meant as an incremental fix to this small issue. Separately, I'm looking into fixing the underlying issue of this not being an `anchor` (#98627), which is not only a general UX issue but fundamentally an accessibility problem. Eventually, we'll probably want to abstract this in some way for reuse, since there is a widespread need for links that trigger Tracks calls and/or client-side router calls. I hope we can also put in some preventative measures (linting?) in place so devs stop writing `button`s that push items onto the browser history stack.


## Testing Instructions

1. Go to `/sites`.
1. Right click on a site title and verify that it just opens the context menu, not trigger a navigation.
2. Command clicks and middle clicks should continue to open the destination in a new tab.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
