### PR TITLE
Fix link button color in domain forward accordion

### DIFF
--- a/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
@@ -208,8 +208,18 @@
 		flex-wrap: wrap;
 	}
 
-	.hosting-dashboard-item-view__content div {
+	.hosting-dashboard-item-view__content > div {
 		flex-grow: 1;
+
+		.domain-forwarding-card__fields:last-child {
+			margin-bottom: 0;
+		}
+
+		.domain-forwarding-card__accordion .foldable-card__content {
+		   > :not(:last-child):not(.domain-forwarding-card-notice) {
+			  margin-bottom: 1.5rem;
+		   }
+		}
 
 		.domain-forwarding-card__accordion .link-button {
 			color: var(--color-link);

--- a/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
@@ -210,6 +210,10 @@
 
 	.hosting-dashboard-item-view__content div {
 		flex-grow: 1;
+
+		.domain-forwarding-card__accordion .link-button {
+			color: var(--color-link);
+		}
 	}
 
 	.domain-settings-page {

--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -626,14 +626,15 @@ export default function DomainForwardingCard( {
 						},
 					} ) }
 			</form>
-
-			<Button
-				borderless
-				className="add-forward-button  link-button"
-				onClick={ () => handleAddForward() }
-			>
-				{ translate( '+ Add forward' ) }
-			</Button>
+			{ editingId !== -1 && (
+				<Button
+					borderless
+					className="add-forward-button  link-button"
+					onClick={ () => handleAddForward() }
+				>
+					{ translate( '+ Add forward' ) }
+				</Button>
+			) }
 		</>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98910

## Proposed Changes

* Fix the button color in the domain forward accordion

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Domain management revamp

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /domains/manage
* Click on a domain to open it in flyout pane
* Expand the "Domain Forwarding" accordion
* Make sure that the color of the "Add Forward" link matches all the other links

<img width="824" alt="image" src="https://github.com/user-attachments/assets/930fd888-ab84-4694-80c1-118d4462a662" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
