### PR TITLE
Subscribers Dataview: fix scrolling

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -161,10 +161,6 @@ body.is-section-subscribers.is-subscribers-dataviews,
                     padding: 24px;
                     overflow: auto;
 
-                    @media ( max-width: $break-wide ) {
-                        overflow: auto;
-                    }
-
                     .subscriber-details {
                         &__header {
                             display: flex;

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -159,6 +159,7 @@ body.is-section-subscribers.is-subscribers-dataviews,
                     /* stylelint-disable-next-line scales/radii */
                     border-radius: 8px;
                     padding: 24px;
+                    overflow: auto;
 
                     @media ( max-width: $break-wide ) {
                         overflow: auto;


### PR DESCRIPTION
## Proposed Changes

* Adds overflow to allow scrolling 

## Why are these changes being made?

When the browser window is short the selected subscriber section does not scroll and certain things are cut-off like the delete button.

## Testing Instructions

1. Go to `/subscribers/[ YOUR SITE ]?flags=subscribers-dataviews`
2. Make the browser short and click a subscriber.
3. You should be able to scroll now.
4. Look for regressions and check mobile.