### PR TITLE
Reader - remove illustrations

### DIFF
--- a/client/blocks/conversations/empty.jsx
+++ b/client/blocks/conversations/empty.jsx
@@ -1,7 +1,6 @@
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import charactersImage from 'calypso/assets/images/reader/reader-conversations-characters.svg';
 import EmptyContent from 'calypso/components/empty-content';
 import { withReaderPerformanceTrackerStop } from 'calypso/reader/reader-performance-tracker';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
@@ -41,8 +40,7 @@ class ConversationsEmptyContent extends Component {
 				) }
 				action={ action }
 				secondaryAction={ secondaryAction }
-				illustration={ charactersImage }
-				illustrationWidth={ 400 }
+				illustration=""
 			/>
 		);
 	}

--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -32,12 +32,7 @@ class FeedError extends Component {
 
 		return (
 			<ReaderMain>
-				<EmptyContent
-					action={ action }
-					title={ this.props.message }
-					illustration="/calypso/images/illustrations/illustration-404.svg"
-					illustrationWidth={ 500 }
-				/>
+				<EmptyContent action={ action } title={ this.props.message } illustration="" />
 			</ReaderMain>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/reader/feed-stream/empty.jsx
+++ b/client/reader/feed-stream/empty.jsx
@@ -29,8 +29,7 @@ class FeedEmptyContent extends PureComponent {
 				title={ translate( 'No recent posts' ) }
 				line={ translate( 'This site has not posted anything recently.' ) }
 				action={ action }
-				illustration="/calypso/images/illustrations/illustration-empty-results.svg"
-				illustrationWidth={ 500 }
+				illustration=""
 			/>
 		);
 	}

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -34,8 +34,7 @@ class TagEmptyContent extends Component {
 				title={ this.props.translate( 'No likes yet' ) }
 				line={ this.props.translate( 'Posts that you like will appear here.' ) }
 				action={ action }
-				illustration="/calypso/images/illustrations/illustration-empty-results.svg"
-				illustrationWidth={ 400 }
+				illustration=""
 			/>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -125,7 +125,7 @@ function ReaderListEdit( props ) {
 		return (
 			<EmptyContent
 				title={ preventWidows( translate( "You don't have permission to manage this list." ) ) }
-				illustration="/calypso/images/illustrations/error.svg"
+				illustration=""
 			/>
 		);
 	}

--- a/client/reader/list-stream/empty.tsx
+++ b/client/reader/list-stream/empty.tsx
@@ -32,8 +32,7 @@ export default function ListEmptyContent(): JSX.Element {
 			title={ translate( 'No recent posts' ) }
 			line={ translate( 'The sites in this list have not posted anything recently.' ) }
 			action={ action }
-			illustration="/calypso/images/illustrations/illustration-empty-results.svg"
-			illustrationWidth={ 400 }
+			illustration=""
 		/>
 	);
 }

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -24,8 +24,7 @@ class ListMissing extends Component {
 					action={ this.props.translate( 'Back to Followed Sites' ) }
 					actionURL="/read"
 					actionCallback={ this.recordAction }
-					illustration="/calypso/images/illustrations/illustration-empty-results.svg"
-					illustrationWidth={ 500 }
+					illustration=""
 				/>
 			</ReaderMain>
 		);

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -273,8 +273,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 					<EmptyContent
 						title={ translate( 'Nothing Posted Yet' ) }
 						line={ translate( 'This feed is currently empty.' ) }
-						illustration="/calypso/images/illustrations/illustration-empty-results.svg"
-						illustrationWidth={ 400 }
+						illustration=""
 					/>
 				) }
 				{ data?.items.length > 0 && selectedItem && getPostFromItem( selectedItem ) && (

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -45,8 +45,7 @@ class SearchEmptyContent extends Component {
 				title={ this.props.translate( 'No results' ) }
 				line={ <p> { message } </p> }
 				action={ action }
-				illustration="/calypso/images/illustrations/illustration-empty-results.svg"
-				illustrationWidth={ 400 }
+				illustration=""
 			/>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/reader/site-blocked/index.jsx
+++ b/client/reader/site-blocked/index.jsx
@@ -45,8 +45,7 @@ class SiteBlocked extends Component {
 						},
 						comment: '%s is a site name - for example, "Discover"',
 					} ) }
-					illustration="/calypso/images/illustrations/error.svg"
-					illustrationWidth={ 500 }
+					illustration=""
 				/>
 			</ReaderMain>
 		);

--- a/client/reader/site-stream/empty.jsx
+++ b/client/reader/site-stream/empty.jsx
@@ -26,8 +26,7 @@ const SiteEmptyContent = ( { translate } ) => {
 			title={ translate( 'No posts' ) }
 			line={ translate( 'This site has not posted anything yet. Try back later.' ) }
 			action={ action }
-			illustration="/calypso/images/illustrations/illustration-empty-results.svg"
-			illustrationWidth={ 500 }
+			illustration=""
 		/>
 	);
 };

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -1,7 +1,6 @@
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import welcomeImage from 'calypso/assets/images/reader/reader-welcome-illustration.svg';
 import EmptyContent from 'calypso/components/empty-content';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
@@ -38,8 +37,7 @@ class FollowingEmptyContent extends Component {
 				line={ this.props.translate( 'Recent posts from sites you follow will appear here.' ) }
 				action={ action }
 				secondaryAction={ secondaryAction }
-				illustration={ welcomeImage }
-				illustrationWidth={ 350 }
+				illustration=""
 			/>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -67,8 +67,7 @@ class TagEmptyContent extends Component {
 				line={ message }
 				action={ action }
 				secondaryAction={ secondaryAction }
-				illustration="/calypso/images/illustrations/illustration-empty-results.svg"
-				illustrationWidth={ 400 }
+				illustration=""
 			/>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/reader/user-profile/index.tsx
+++ b/client/reader/user-profile/index.tsx
@@ -41,7 +41,7 @@ export function UserProfile( props: UserProfileProps ): JSX.Element | null {
 	if ( ! user ) {
 		return (
 			<EmptyContent
-				illustration="/calypso/images/illustrations/illustration-404.svg"
+				illustration=""
 				title={ translate( 'Uh oh. User not found.' ) }
 				line={ translate( 'Sorry, the user you were looking for could not be found.' ) }
 				action={ translate( 'Return to Reader' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/98425

## Proposed Changes

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Removes illustrations from the reader. Before/after examples shown below:
    * Most of these illustrations we cannot remove from the codebase due to their usage elsewhere. Although I plan to follow-up to remove `calypso/assets/images/reader/reader-welcome-illustration.svg` and `calypso/assets/images/reader/reader-conversations-characters.svg`. The latter is still used in reader/conversations/intro, which I cannot seem to find a case where it is visibly rendered anymore, so I want to look at removing this component entirely as well... but in a follow up to separate the scope and concerns.

Search
<img src="https://github.com/user-attachments/assets/8f444493-6997-4f7e-9020-060503bddbdb" width=300 />
<img src="https://github.com/user-attachments/assets/feae7dad-32e2-4981-bcef-3896d682afbe" width=300 />

Recent/Following (Same as Discover)
<img src="https://github.com/user-attachments/assets/2c52274b-c05d-4df4-a98a-5f8651dccfc5" width=300 />
<img src="https://github.com/user-attachments/assets/a97b0c45-4c6f-4cc1-ba8f-88aab17f23a5" width=300 />

Conversations
<img src="https://github.com/user-attachments/assets/f1a5081c-bdd6-4af3-a87f-6aae761cbe1b" width=300 />
<img src="https://github.com/user-attachments/assets/2036dd11-cc1f-49b7-acc2-44520d4d901c" width=300 />

Tags
<img src="https://github.com/user-attachments/assets/20b2a329-aeb1-4764-b4cb-9face188885d" width=300 />
<img src="https://github.com/user-attachments/assets/5288eb3d-a257-4cc9-abbd-2a13f526357e" width=300 />

Lists
<img src="https://github.com/user-attachments/assets/eeb1c34c-ef8f-41ee-af68-147091328e50" width=300 />
<img src="https://github.com/user-attachments/assets/0c0c3883-0945-43b5-87b4-57f2a79761f0" width=300 />

Likes
<img src="https://github.com/user-attachments/assets/15ccac8b-96bb-42b6-9f92-99cafb1d4f2e" width=300 />
<img src="https://github.com/user-attachments/assets/817230dc-6c0b-45b3-b440-28e8a9f11f36" width=300 />

Site Stream
<img src="https://github.com/user-attachments/assets/3e2ed031-3f7b-4a1d-930f-a5d02ede5118" width=300 />
<img src="https://github.com/user-attachments/assets/d68cc412-7f99-492f-b862-06a860a35cd3" width=300 />

Feed Error (found in multiple places in case of errors):
<img src="https://github.com/user-attachments/assets/9bf6e9cd-10db-45e8-9de0-6c09643c740d" width=300 />
<img src="https://github.com/user-attachments/assets/6ea1bec8-1b05-42eb-8ea3-47a8795a274e" width=300 />

Site Blocked
<img src="https://github.com/user-attachments/assets/c2164765-05a3-41bd-9777-8c29dbc83be8" width=300 />
<img src="https://github.com/user-attachments/assets/fa47ad6c-4804-4e9a-b1bc-40742c1ec362" width=300 />

List Manage Error
<img src="https://github.com/user-attachments/assets/9d31134a-2305-40db-916a-d97d91a64ae2" width=300 />
<img src="https://github.com/user-attachments/assets/a9b15a15-74cc-40e1-b6cf-09a9470734d7" width=300 />

User Profile Error
<img src="https://github.com/user-attachments/assets/21ae1242-d700-4579-b89d-13a80a3c0601" width=300 />
<img src="https://github.com/user-attachments/assets/b9791919-3547-4797-bb32-7bf40d0ff230" width=300 />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

It is difficult to naturally test all these changes due to the cases they may appear under. I have edited the code to force show certain components to retrieve the screenshots above.

* Test the reader for various empty content and error states, verify the outdated illustrations are no longer rendered. This may be easier in some cases with a new account, removal of subscriptions, etc.
* Check the changelog, verify none of the illustrations being removed are outside of the reader. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
