### PR TITLE
Show the "Add Forward" button in Domain Forward accordion only when needed

### DIFF
--- a/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
@@ -211,7 +211,12 @@
 	.hosting-dashboard-item-view__content div {
 		flex-grow: 1;
 
+		.domain-forwarding-card__fields:last-child {
+			margin-bottom: 0;
+		}
+
 		.domain-forwarding-card__accordion .link-button {
+			margin-top: 1.5rem;
 			color: var(--color-link);
 		}
 	}

--- a/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
@@ -208,15 +208,20 @@
 		flex-wrap: wrap;
 	}
 
-	.hosting-dashboard-item-view__content div {
+	.hosting-dashboard-item-view__content > div {
 		flex-grow: 1;
 
 		.domain-forwarding-card__fields:last-child {
 			margin-bottom: 0;
 		}
 
+		.domain-forwarding-card__accordion .foldable-card__content {
+		   > :not(:last-child):not(.domain-forwarding-card-notice) {
+			  margin-bottom: 1.5rem;
+		   }
+		}
+
 		.domain-forwarding-card__accordion .link-button {
-			margin-top: 1.5rem;
 			color: var(--color-link);
 		}
 	}

--- a/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-forwarding-card.tsx
@@ -626,14 +626,15 @@ export default function DomainForwardingCard( {
 						},
 					} ) }
 			</form>
-
-			<Button
-				borderless
-				className="add-forward-button  link-button"
-				onClick={ () => handleAddForward() }
-			>
-				{ translate( '+ Add forward' ) }
-			</Button>
+			{ editingId !== -1 && (
+				<Button
+					borderless
+					className="add-forward-button  link-button"
+					onClick={ () => handleAddForward() }
+				>
+					{ translate( '+ Add forward' ) }
+				</Button>
+			) }
 		</>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98921

## Proposed Changes

* Shows the "Add Forward" button only when applicable

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Domain Management Revamp

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to '/domains/manage'
* Open a domain by clicking from the list
* Expand the Domain Forwarding accordion
* You only see the "Add Forward" button when there are no empty forms there

https://github.com/user-attachments/assets/28497937-c239-4db8-af39-5c90be5d879e

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
