### PR TITLE
Add a custom copy for account creation with Big Sky

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -1,6 +1,6 @@
 import configApi from '@automattic/calypso-config';
 import { OnboardSelect } from '@automattic/data-stores';
-import { StepContainer } from '@automattic/onboarding';
+import { isOnboardingFlow, StepContainer } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { select } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
@@ -41,7 +41,7 @@ const UserStepComponent: Step = function UserStep( {
 
 	const [ wpAccountCreateResponse, setWpAccountCreateResponse ] = useState< AccountCreateReturn >();
 	const { socialServiceResponse } = useSocialService();
-	const createdWithBigSky = ( select( ONBOARD_STORE ) as OnboardSelect ).getCreateWithBigSky();
+	const creatingWithBigSky = ( select( ONBOARD_STORE ) as OnboardSelect ).getCreateWithBigSky();
 
 	useEffect( () => {
 		if ( wpAccountCreateResponse && 'bearer_token' in wpAccountCreateResponse ) {
@@ -66,7 +66,11 @@ const UserStepComponent: Step = function UserStep( {
 	} );
 
 	const getSubHeaderText = () => {
-		if ( configApi.isEnabled( 'onboarding/big-sky-before-plans' ) && createdWithBigSky ) {
+		if (
+			configApi.isEnabled( 'onboarding/big-sky-before-plans' ) &&
+			isOnboardingFlow( flow ) &&
+			creatingWithBigSky
+		) {
 			return translate(
 				'Great choice! Pick an option to start building your site with our AI Website Builder.'
 			);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -1,5 +1,8 @@
+import configApi from '@automattic/calypso-config';
+import { OnboardSelect } from '@automattic/data-stores';
 import { StepContainer } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
+import { select } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
@@ -9,6 +12,7 @@ import SignupFormSocialFirst from 'calypso/blocks/signup-form/signup-form-social
 import FormattedHeader from 'calypso/components/formatted-header';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import { useFlowLocale } from 'calypso/landing/stepper/hooks/use-flow-locale';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { login } from 'calypso/lib/paths';
 import { AccountCreateReturn } from 'calypso/lib/signup/api/type';
@@ -37,6 +41,7 @@ const UserStepComponent: Step = function UserStep( {
 
 	const [ wpAccountCreateResponse, setWpAccountCreateResponse ] = useState< AccountCreateReturn >();
 	const { socialServiceResponse } = useSocialService();
+	const createdWithBigSky = ( select( ONBOARD_STORE ) as OnboardSelect ).getCreateWithBigSky();
 
 	useEffect( () => {
 		if ( wpAccountCreateResponse && 'bearer_token' in wpAccountCreateResponse ) {
@@ -59,6 +64,16 @@ const UserStepComponent: Step = function UserStep( {
 		redirectTo,
 		locale,
 	} );
+
+	const getSubHeaderText = () => {
+		if ( configApi.isEnabled( 'onboarding/big-sky-before-plans' ) && createdWithBigSky ) {
+			return translate(
+				'Great choice! Pick an option to start building your site with our AI Website Builder.'
+			);
+		}
+
+		return null;
+	};
 
 	const shouldRenderLocaleSuggestions = ! isLoggedIn; // For logged-in users, we respect the user language settings
 
@@ -86,6 +101,7 @@ const UserStepComponent: Step = function UserStep( {
 						<FormattedHeader
 							align="center"
 							headerText={ translate( 'Create your account' ) }
+							subHeaderText={ getSubHeaderText() }
 							brandFont
 						/>
 						<SignupFormSocialFirst

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -49,6 +49,16 @@
 					line-height: 3.25;
 				}
 			}
+			.formatted-header__title:has(+ p) {
+				@include break-small {
+					line-height: 1.9;
+				}
+			}
+			.formatted-header__subtitle {
+				@include break-small {
+					padding-bottom: 1em;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99025

## Proposed Changes

* Adds a custom copy for account creation with Big Sky
* Modify the style accordingly

| No subtitle | With subtitle |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/aecdad90-d9e2-4cc9-9943-9cf4a2db6658) | ![image](https://github.com/user-attachments/assets/ba92888a-bc92-4f50-8d2c-1d7e767291a4) |


Although mobile isn't supported for Big sky right now, let's make sure it works for the future:

| No subtitle | With subtitle |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/6e24693a-d945-42f8-a5b1-c53b5a0bdd04) | ![image](https://github.com/user-attachments/assets/741a4a14-31a4-47b2-a024-c659d9e5853b) |


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In your dev environment, test [the setup/onboarding flow](http://calypso.localhost:3000/setup/onboarding), select Big sky, and compare it with normal theme selection
* Make sure the spacing is good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
