### PR TITLE
Add link to reader profile on /me page

### DIFF
--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -20,6 +20,7 @@ import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import DomainUpsell from 'calypso/me/domain-upsell';
 import withFormBase from 'calypso/me/form-base/with-form-base';
 import ReauthRequired from 'calypso/me/reauth-required';
+import { getUserProfileUrl } from 'calypso/reader/user-profile/user-profile.utils';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
 import WPAndGravatarLogo from './wp-and-gravatar-logo';
@@ -41,8 +42,8 @@ class Profile extends Component {
 
 	render() {
 		// We want to use a relative URL so we can test effectively in each
-		// environement, but show the absolute URL in the UI for end users.
-		const relativeProfileUrl = `/read/users/${ this.props.user.username }`;
+		// environment, but show the absolute URL in the UI for end users.
+		const relativeProfileUrl = getUserProfileUrl( this.props.user.username );
 		const absoluteProfileUrl = `https://wordpress.com${ relativeProfileUrl }`;
 
 		return (

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -134,7 +134,7 @@ class Profile extends Component {
 							<FormSettingExplanation>
 								<span>
 									{ this.props.translate(
-										'A list of your public posts and public lists can be found at {{a}}{{url/}}{{/a}}',
+										'You can find your public profile at {{a}}{{url/}}{{/a}}',
 										{
 											components: {
 												a: <a href={ relativeProfileUrl }></a>,

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -40,7 +40,10 @@ class Profile extends Component {
 	};
 
 	render() {
-		const profileUrl = `https://wordpress.com/read/users/${ this.props.user.username }`;
+		// We want to use a relative URL so we can test effectively in each
+		// environement, but show the absolute URL in the UI for end users.
+		const relativeProfileUrl = `/read/users/${ this.props.user.username }`;
+		const absoluteProfileUrl = `https://wordpress.com${ relativeProfileUrl }`;
 
 		return (
 			<Main wideLayout className="profile">
@@ -134,8 +137,8 @@ class Profile extends Component {
 										'A list of your public posts and public lists can be found at {{a}}{{url/}}{{/a}}',
 										{
 											components: {
-												a: <a href={ profileUrl }></a>,
-												url: <>{ profileUrl }</>,
+												a: <a href={ relativeProfileUrl }></a>,
+												url: <>{ absoluteProfileUrl }</>,
 											},
 										}
 									) }

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -40,6 +40,8 @@ class Profile extends Component {
 	};
 
 	render() {
+		const profileUrl = `https://wordpress.com/read/users/${ this.props.user.username }`;
+
 		return (
 			<Main wideLayout className="profile">
 				<PageViewTracker path="/me" title="Me > My Profile" />
@@ -125,6 +127,23 @@ class Profile extends Component {
 						</FormFieldset>
 
 						<FormFieldset>
+							<div className="form-label">{ this.props.translate( 'Public profile' ) }</div>
+							<FormSettingExplanation>
+								<span>
+									{ this.props.translate(
+										'A list of your public posts and public lists can be found at {{a}}{{url/}}{{/a}}',
+										{
+											components: {
+												a: <a href={ profileUrl }></a>,
+												url: <>{ profileUrl }</>,
+											},
+										}
+									) }
+								</span>
+							</FormSettingExplanation>
+						</FormFieldset>
+
+						<FormFieldset>
 							<FormLabel htmlFor="description">{ this.props.translate( 'About me' ) }</FormLabel>
 							<FormTextarea
 								disabled={ this.props.getDisabledState() }
@@ -180,6 +199,7 @@ export default compose(
 	connect(
 		( state ) => ( {
 			isFetchingUserSettings: isFetchingUserSettings( state ),
+			user: state.currentUser?.user,
 		} ),
 		{ recordGoogleEvent }
 	),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99015
Additional context here: p1738106541068789-slack-C083J8DHLLD

## Proposed Changes
Adds a link and description to the reader profile on the /me page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
We'd like to provide an easily accessible link to users so they can see their reader user profiles.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Go to the /me page
* Ensure the new link exists
* Ensure the correct username is being used
* Make sure the link works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?