### PR TITLE
Big Sky GF: Show only big sky eligible plans 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -91,8 +91,6 @@ export default function PlansStepAdaptor( props: StepProps ) {
 			: getHidePlanPropsBasedOnThemeType( selectedThemeType || '' );
 
 	/**
-	/**
-	/**
 	 * The plans step has a quirk where it calls `submitSignupStep` then synchronously calls `goToNextStep` after it.
 	 * This doesn't give `setStepState` a chance to update and the data is not passed to `submit`.
 	 */

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -13,7 +13,10 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
-import { getHidePlanPropsBasedOnThemeType } from 'calypso/my-sites/plans-features-main/components/utils/utils';
+import {
+	getHidePlanPropsBasedOnCreateWithBigSky,
+	getHidePlanPropsBasedOnThemeType,
+} from 'calypso/my-sites/plans-features-main/components/utils/utils';
 import { getSignupCompleteSiteID, getSignupCompleteSlug } from 'calypso/signup/storageUtils';
 import { useSelector, useDispatch as useReduxDispatch } from 'calypso/state';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
@@ -31,15 +34,21 @@ export default function PlansStepAdaptor( props: StepProps ) {
 	const [ stepState, setStepState ] = useStepPersistedState< ProvidedDependencies >( 'plans-step' );
 	const siteSlug = useSiteSlug();
 
-	const { siteTitle, domainItem, domainItems, selectedDesign } = useSelect(
+	const { siteTitle, domainItem, domainItems, selectedDesign, createWithBigSky } = useSelect(
 		( select: ( key: string ) => OnboardSelect ) => {
-			const { getSelectedSiteTitle, getDomainCartItem, getDomainCartItems, getSelectedDesign } =
-				select( ONBOARD_STORE );
+			const {
+				getSelectedSiteTitle,
+				getDomainCartItem,
+				getDomainCartItems,
+				getSelectedDesign,
+				getCreateWithBigSky,
+			} = select( ONBOARD_STORE );
 			return {
 				siteTitle: getSelectedSiteTitle(),
 				domainItem: getDomainCartItem(),
 				domainItems: getDomainCartItems(),
 				selectedDesign: getSelectedDesign(),
+				createWithBigSky: getCreateWithBigSky(),
 			};
 		},
 		[]
@@ -76,8 +85,13 @@ export default function PlansStepAdaptor( props: StepProps ) {
 	const site = useSite( postSignUpSiteSlugParam || postSignUpSiteIdParam );
 	const customerType = useQuery().get( 'customerType' ) ?? undefined;
 	const [ planInterval, setPlanInterval ] = useState< string | undefined >( undefined );
-	const hidePlanProps = getHidePlanPropsBasedOnThemeType( selectedThemeType || '' );
+	const hidePlanProps =
+		createWithBigSky && isGoalFirstExperiment
+			? getHidePlanPropsBasedOnCreateWithBigSky()
+			: getHidePlanPropsBasedOnThemeType( selectedThemeType || '' );
 
+	/**
+	/**
 	/**
 	 * The plans step has a quirk where it calls `submitSignupStep` then synchronously calls `goToNextStep` after it.
 	 * This doesn't give `setStepState` a chance to update and the data is not passed to `submit`.

--- a/client/my-sites/plans-features-main/components/utils/utils.ts
+++ b/client/my-sites/plans-features-main/components/utils/utils.ts
@@ -52,3 +52,11 @@ export const getHidePlanPropsBasedOnThemeType = ( themeType: string ) => {
 
 	return {};
 };
+
+export const getHidePlanPropsBasedOnCreateWithBigSky = () => {
+	return {
+		hideFreePlan: true,
+		hideEcommercePlan: true,
+		hideEnterprisePlan: true,
+	};
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/99024

## Proposed Changes
This PR shows only big sky eligible plans. At the moment big sky is not supported on personal plans however that is being worked on as discussed p1738136972932859-slack-C085HCWCEDN

* Show only big sky enabled plans

![image](https://github.com/user-attachments/assets/1474a7cf-c139-4191-b200-1ca24cfa60c1)
 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `setup/onboarding` in the goals first flow
* Select BigSky at the design choice
* On the plan screen we should only see `personal`,`premium` and `business` plans.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?