### PR TITLE
Update the e2e tests for goals-first flow

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
@@ -5,7 +5,13 @@ import { Page } from 'playwright';
  *
  * @see client/landing/stepper/declarative-flow/site-setup-flow.ts for all step names
  */
-export type StepName = 'goals' | 'vertical' | 'intent' | 'designSetup' | 'options';
+export type StepName =
+	| 'goals'
+	| 'vertical'
+	| 'intent'
+	| 'designSetup'
+	| 'options'
+	| 'designChoices';
 type WriteActions = 'Start writing' | 'Start learning' | 'View designs';
 
 const selectors = {
@@ -26,6 +32,9 @@ const selectors = {
 	selectedGoalButton: ( goal: string ) =>
 		`.select-card-checkbox__container:has(:checked):has-text("${ goal }")`,
 
+	// Design choices
+	designChoiceButton: ( choice: string ) => `button.design-choice:has-text("${ choice }")`,
+
 	// Step containers
 	contentAgnosticContainer: '.step-container',
 	themePickerContainer: '.design-picker',
@@ -33,6 +42,7 @@ const selectors = {
 	verticalsStepContainer: '.site-vertical',
 	intentStepContainer: '.intent-step',
 	optionsStepContainer: '.is-step-write',
+	designChoicesStepContainer: '.design-choices',
 };
 
 /**
@@ -77,6 +87,9 @@ export class StartSiteFlow {
 		if ( ( await this.page.locator( selectors.optionsStepContainer ).count() ) > 0 ) {
 			return 'options';
 		}
+		if ( ( await this.page.locator( selectors.designChoicesStepContainer ).count() ) > 0 ) {
+			return 'designChoices';
+		}
 		throw new Error( `Unknown or invalid step` );
 	}
 
@@ -88,6 +101,18 @@ export class StartSiteFlow {
 	async selectGoal( goal: string ): Promise< void > {
 		await this.page.click( selectors.goalButton( goal ) );
 		await this.page.waitForSelector( selectors.selectedGoalButton( goal ) );
+	}
+
+	/**
+	 * Select a design choice by text.
+	 *
+	 * @param {string} choice The button text
+	 */
+	async clickDesignChoice( choice: 'theme' | 'ai' ): Promise< void > {
+		// It's best to select the element using accessible text
+		const choiceLabel = choice === 'theme' ? 'Choose a theme' : 'Design with AI';
+
+		await this.page.click( selectors.designChoiceButton( choiceLabel ) );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -45,7 +45,7 @@ export class SignupPickPlanPage {
 		}
 
 		const actions = [
-			this.page.waitForResponse( /.*sites\/new\?.*/ ),
+			this.page.waitForResponse( /.*sites\/new\?.*/, { timeout: 30 * 1000 } ),
 			this.page.waitForURL( url, { timeout: 30 * 1000 } ),
 			this.plansPage.selectPlan( name ),
 		];

--- a/test/e2e/specs/onboarding/onboarding__write.ts
+++ b/test/e2e/specs/onboarding/onboarding__write.ts
@@ -19,6 +19,8 @@ import { apiCloseAccount, fixme_retry } from '../shared';
 
 declare const browser: Browser;
 
+// wpcalypso is currently using the goals-first onboarding flow, so this is
+// skipped for now. Check out the "Goals-First Onboarding: Write Focus" test below.
 describe.skip( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () {
 	const blogName = DataHelper.getBlogName();
 	const testUser = DataHelper.getNewTestUser( {
@@ -145,6 +147,163 @@ describe.skip( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), functio
 			await page.getByRole( 'button', { name: 'Launch your site' } ).click();
 
 			await page.waitForURL( /setup\/write\/processing/ );
+		} );
+
+		it( 'Post-launch congratulatory message is shown', async function () {
+			// User is redirected to the Home dashboard.
+			await page.waitForURL( /home/ );
+
+			await page.getByRole( 'dialog' ).getByRole( 'heading', { name: 'Congrats' } ).waitFor();
+		} );
+
+		it( 'Close congratulatory message', async function () {
+			await page.getByRole( 'dialog' ).getByRole( 'button', { name: 'Close' } ).click();
+		} );
+	} );
+
+	afterAll( async function () {
+		if ( ! newUserDetails ) {
+			return;
+		}
+
+		const restAPIClient = new RestAPIClient(
+			{ username: testUser.username, password: testUser.password },
+			newUserDetails.body.bearer_token
+		);
+
+		await apiCloseAccount( restAPIClient, {
+			userID: newUserDetails.body.user_id,
+			username: newUserDetails.body.username,
+			email: testUser.email,
+		} );
+	} );
+} );
+
+// The steps in this test don't match what happens on production, because only wpcalypso
+// is using the goals-first onboarding flow. Check out the "Onboarding: Write Focus" test above
+// for the steps that work on production.
+describe( DataHelper.createSuiteTitle( 'Goals-First Onboarding: Write Focus' ), function () {
+	const themeName = 'Poema';
+	const blogName = DataHelper.getBlogName();
+	const testUser = DataHelper.getNewTestUser( {
+		usernamePrefix: 'signupfree',
+	} );
+
+	let newUserDetails: NewUserResponse;
+	let newSiteDetails: NewSiteResponse;
+	let page: Page;
+	let selectedFreeDomain: string;
+	let startSiteFlow: StartSiteFlow;
+
+	beforeAll( async function () {
+		page = await browser.newPage();
+	} );
+
+	describe( 'Register as new user with "Write" goal', function () {
+		let loginPage: LoginPage;
+
+		it( 'Navigate to the Login page', async function () {
+			loginPage = new LoginPage( page );
+			await loginPage.visit();
+		} );
+
+		it( 'Click on button to create a new account', async function () {
+			await loginPage.clickCreateNewAccount();
+		} );
+
+		it( 'Select "Publish a blog" goal', async function () {
+			await page.waitForURL( /setup\/onboarding\/goals/, { timeout: 30 * 1000 } );
+
+			startSiteFlow = new StartSiteFlow( page );
+			await startSiteFlow.selectGoal( 'Publish a blog' );
+			await startSiteFlow.clickButton( 'Next' );
+		} );
+
+		it( 'Choose to proceed with theme', async function () {
+			await startSiteFlow.clickDesignChoice( 'theme' );
+		} );
+
+		it( 'Select theme', async function () {
+			await startSiteFlow.clickButton( 'Show all Blog themes' );
+			await startSiteFlow.selectTheme( themeName );
+			await startSiteFlow.clickButton( 'Continue' );
+		} );
+
+		it( 'Sign up as a new user', async function () {
+			const userSignupPage = new UserSignupPage( page );
+			newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
+		} );
+
+		it( 'Select a .wordpress.com domain name', async function () {
+			const domainSearchComponent = new DomainSearchComponent( page );
+			await domainSearchComponent.search( blogName );
+			selectedFreeDomain = await domainSearchComponent.selectDomain( '.wordpress.com' );
+		} );
+
+		it( `Select WordPress.com Free plan`, async function () {
+			const signupPickPlanPage = new SignupPickPlanPage( page );
+			newSiteDetails = await signupPickPlanPage.selectPlan( 'Free' );
+		} );
+	} );
+
+	describe( 'Write', function () {
+		const postTitle = DataHelper.getRandomPhrase();
+
+		let editorPage: EditorPage;
+
+		it( 'Launchpad is shown', async function () {
+			// dirty hack to wait for the launchpad to load.
+			// Stepper has a quirk where it redirects twice. Playwright hooks to the first one and thinks it was aborted.
+			await fixme_retry( () => page.waitForURL( /launchpad/ ) );
+		} );
+
+		it( 'Write first post', async function () {
+			await page.getByRole( 'link', { name: 'Write your first post' } ).click();
+		} );
+
+		it( 'Editor loads', async function () {
+			editorPage = new EditorPage( page );
+			await editorPage.waitUntilLoaded();
+
+			await page.waitForURL( new RegExp( newSiteDetails.blog_details.site_slug ) );
+		} );
+
+		it( 'Enter blog title', async function () {
+			await editorPage.enterTitle( postTitle );
+		} );
+
+		it( 'Publish post', async function () {
+			await editorPage.publish();
+		} );
+
+		it( 'First post congratulatory message is shown', async function () {
+			const editorParent = await editorPage.getEditorParent();
+			await editorParent
+				.getByRole( 'heading', { name: 'Your first post is published!' } )
+				.waitFor();
+		} );
+
+		it( 'View Next Steps', async function () {
+			const editorParent = await editorPage.getEditorParent();
+			await editorParent.getByRole( 'button', { name: 'Next steps' } ).click();
+		} );
+	} );
+
+	describe( 'Launchpad', function () {
+		it( 'Launchpad is shown', async function () {
+			// dirty hack to wait for the launchpad to load.
+			// Stepper has a quirk where it redirects twice. Playwright hooks to the first one and thinks it was aborted.
+			await fixme_retry( () => page.waitForURL( /launchpad/ ) );
+		} );
+
+		it( 'Launch site', async function () {
+			await page.getByRole( 'button', { name: 'Launch your site' } ).click();
+
+			await page.waitForURL( /setup\/write\/processing/ );
+			//
+			// Additional assertions for the URL.
+			expect( page.url() ).toContain( 'siteSlug' );
+			expect( page.url() ).toContain( selectedFreeDomain );
 		} );
 
 		it( 'Post-launch congratulatory message is shown', async function () {

--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -15,10 +15,12 @@ import {
 	NewSiteResponse,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { apiDeleteSite } from '../shared';
+import { apiDeleteSite, fixme_retry } from '../shared';
 
 declare const browser: Browser;
 
+// wpcalypso is currently using the goals-first onboarding flow, so this is
+// skipped for now. Check out the "Plans: Create a WordPress.com/Business site with goals-first flow as existing user" test below.
 describe.skip(
 	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com/Business site as exising user' ),
 	function () {
@@ -77,6 +79,123 @@ describe.skip(
 				await page.waitForURL( /setup\/site-setup\/goals/ );
 				const startSiteFlow = new StartSiteFlow( page );
 				await startSiteFlow.clickButton( 'Skip to dashboard' );
+			} );
+
+			it( 'See Home', async function () {
+				await page.waitForURL( /home/ );
+			} );
+		} );
+
+		describe( `Validate WordPress.com ${ planName } functionality`, function () {
+			let sidebarComponent: SidebarComponent;
+
+			it( `Sidebar states user is on WordPress.com ${ planName } plan`, async function () {
+				sidebarComponent = new SidebarComponent( page );
+				const currentPlan = await sidebarComponent.getCurrentPlanName();
+				expect( currentPlan ).toBe( planName );
+			} );
+		} );
+
+		afterAll( async function () {
+			if ( ! siteCreatedFlag ) {
+				return;
+			}
+
+			const restAPIClient = new RestAPIClient( {
+				username: testAccount.credentials.username,
+				password: testAccount.credentials.password,
+			} );
+
+			await apiDeleteSite( restAPIClient, {
+				url: newSiteDetails.blog_details.url,
+				id: newSiteDetails.blog_details.blogid,
+				name: newSiteDetails.blog_details.blogname,
+			} );
+		} );
+	}
+);
+
+// The steps in this test don't match what happens on production, because only wpcalypso
+// is using the goals-first onboarding flow. Check out the "Plans: Create a WordPress.com/Business site as exising user" test above
+// for the steps that work on production.
+describe(
+	DataHelper.createSuiteTitle(
+		'Plans: Create a WordPress.com/Business site with goals-first flow as exising user'
+	),
+	function () {
+		const planName = 'Business';
+
+		let testAccount: TestAccount;
+		let page: Page;
+		let siteCreatedFlag = false;
+		let newSiteDetails: NewSiteResponse;
+		let startSiteFlow: StartSiteFlow;
+
+		beforeAll( async function () {
+			page = await browser.newPage();
+
+			testAccount = new TestAccount( 'calypsoPreReleaseUser' );
+			await testAccount.authenticate( page );
+		} );
+
+		describe( 'Create new site', function () {
+			let cartCheckoutPage: CartCheckoutPage;
+
+			beforeAll( async function () {
+				await BrowserManager.setStoreCookie( page );
+			} );
+
+			it( 'Navigate to /start', async function () {
+				await page.goto( DataHelper.getCalypsoURL( 'start' ) );
+			} );
+
+			it( 'Skip goal selection', async function () {
+				await page.waitForURL( /setup\/onboarding\/goals/, { timeout: 30 * 1000 } );
+
+				startSiteFlow = new StartSiteFlow( page );
+				await startSiteFlow.clickButton( 'Skip' );
+			} );
+
+			it( 'Choose to proceed with theme', async function () {
+				await startSiteFlow.clickDesignChoice( 'theme' );
+			} );
+
+			it( 'Skip theme selection', async function () {
+				await startSiteFlow.clickButton( 'Skip setup' );
+			} );
+
+			it( 'Skip domain selection', async function () {
+				const signupDomainPage = new SignupDomainPage( page );
+				await signupDomainPage.searchForFooDomains();
+				await signupDomainPage.skipDomainSelection();
+			} );
+
+			it( `Select WordPress.com ${ planName } plan`, async function () {
+				const signupPickPlanPage = new SignupPickPlanPage( page );
+				newSiteDetails = await signupPickPlanPage.selectPlan( planName );
+
+				siteCreatedFlag = true;
+			} );
+
+			it( 'See secure checkout', async function () {
+				cartCheckoutPage = new CartCheckoutPage( page );
+				await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+			} );
+
+			it( 'Enter payment details', async function () {
+				await cartCheckoutPage.selectSavedCard( 'End to End Testing' );
+			} );
+
+			it( 'Make purchase', async function () {
+				await cartCheckoutPage.purchase( { timeout: 75 * 1000 } );
+			} );
+
+			it( 'Skip the launchpad', async function () {
+				// dirty hack to wait for the launchpad to load.
+				// Stepper has a quirk where it redirects twice. Playwright hooks to the first one and thinks it was aborted.
+				await fixme_retry( () => page.waitForURL( /launchpad/ ) );
+
+				await page.getByRole( 'button', { name: 'Skip for now' } ).click();
 			} );
 
 			it( 'See Home', async function () {


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

Updates the onboarding e2e tests to work with goals-first onboarding.

The canary tests run against wpcalypso, where the goals-first onboarding is enabled.

This leaves the steps for the non-goals-first onboarding in place, but skips them.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

I had to quickly skip the onboarding tests in #99063 to unblock Calypso deploys.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
