### PR TITLE
A4A: remote install woo plugin

### DIFF
--- a/client/a8c-for-agencies/data/sites/use-fetch-site-plugins.ts
+++ b/client/a8c-for-agencies/data/sites/use-fetch-site-plugins.ts
@@ -1,0 +1,55 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+type Response = { data: Plugin[] };
+
+type Plugin = {
+	plugin: string;
+	status: string;
+	name: string;
+	plugin_uri?: string;
+	author?: string;
+	author_uri?: string;
+	description?: {
+		raw: string;
+		rendered: string;
+	};
+	version: string;
+	network_only?: boolean;
+	requires_wp?: string;
+	requires_php?: string;
+	textdomain?: string;
+};
+
+interface FetchSitePluginsParams {
+	siteId?: number;
+}
+
+/**
+ * Hook to fetch plugins for a specific site
+ * @param params Object containing siteId and optional status and slug filters
+ * @returns UseQueryResult with plugins data
+ */
+export default function useFetchSitePlugins(
+	params: FetchSitePluginsParams
+): UseQueryResult< Response, Error > {
+	const { siteId } = params;
+
+	return useQuery( {
+		queryKey: [ 'a4a-site-plugins', siteId ],
+		queryFn: async () => {
+			return wpcom.req.get(
+				{
+					path: `/jetpack-blogs/${ siteId }/rest-api/`,
+					apiNamespace: 'rest/v1.1',
+				},
+				{
+					path: '/wp/v2/plugins/',
+					json: true,
+				}
+			);
+		},
+		enabled: !! siteId,
+		refetchOnWindowFocus: false,
+	} );
+}

--- a/client/a8c-for-agencies/data/sites/use-install-site-plugins.ts
+++ b/client/a8c-for-agencies/data/sites/use-install-site-plugins.ts
@@ -1,0 +1,75 @@
+import {
+	useMutation,
+	UseMutationOptions,
+	UseMutationResult,
+	useQueryClient,
+} from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+export interface APIError {
+	status: number;
+	code: string;
+	message: string;
+}
+
+export interface InstallPluginParams {
+	siteId?: number;
+	slug: string;
+	status?: 'active' | 'inactive';
+}
+
+interface APIResponse {
+	id: string;
+	name: string;
+	plugin: string;
+	slug: string;
+	status: string;
+	version: string;
+	// Add other plugin properties as needed
+}
+
+function installPluginMutation( params: InstallPluginParams ): Promise< APIResponse > {
+	const { siteId, slug, status = 'active' } = params;
+
+	return wpcom.req.post(
+		{
+			path: `/jetpack-blogs/${ siteId }/rest-api/`,
+			apiNamespace: 'rest/v1.1',
+		},
+		{
+			path: '/wp/v2/plugins/',
+			body: JSON.stringify( {
+				slug,
+				status,
+			} ),
+			json: true,
+		}
+	);
+}
+
+/**
+ * Hook to install and optionally activate a plugin on a specific site
+ * @param options Optional mutation options
+ * @returns UseMutationResult for installing plugins
+ */
+export default function useInstallSitePlugins< TContext = unknown >(
+	options?: UseMutationOptions< APIResponse, APIError, InstallPluginParams, TContext >
+): UseMutationResult< APIResponse, APIError, InstallPluginParams, TContext > {
+	const queryClient = useQueryClient();
+
+	return useMutation< APIResponse, APIError, InstallPluginParams, TContext >( {
+		...options,
+		mutationFn: installPluginMutation,
+		onSuccess: ( data, variables, context ) => {
+			// Invalidate the site plugins query to refetch the updated list
+			queryClient.invalidateQueries( {
+				queryKey: [ 'site-plugins', variables.siteId ],
+			} );
+
+			// Call the original onSuccess if provided
+			if ( options?.onSuccess ) {
+				options.onSuccess( data, variables, context );
+			}
+		},
+	} );
+}

--- a/client/a8c-for-agencies/sections/marketplace/download-products-form/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/download-products-form/index.tsx
@@ -1,13 +1,16 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import {
 	A4A_LICENSES_LINK,
 	A4A_SITES_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
+import useFetchSitePlugins from 'calypso/a8c-for-agencies/data/sites/use-fetch-site-plugins';
+import useInstallSitePlugins from 'calypso/a8c-for-agencies/data/sites/use-install-site-plugins';
 import {
 	getProductSlugFromLicenseKey,
 	isWooCommerceProduct,
@@ -29,6 +32,28 @@ export default function DownloadProductsForm() {
 
 	const site = sites.find( ( site ) => site?.ID === parseInt( attachedSiteId, 10 ) );
 	const siteDomain = site ? site.domain : null;
+
+	const { data: sitePlugins } = useFetchSitePlugins( {
+		siteId: site?.ID,
+	} );
+	const { mutate: installSitePlugins } = useInstallSitePlugins();
+
+	const shouldInstallWoo = useMemo( () => {
+		if ( ! isEnabled( 'a4a-post-purchase-woo-download' ) ) {
+			return false;
+		}
+		return (
+			sitePlugins?.data?.filter( ( plugin ) => plugin.plugin === 'woocommerce/woocommerce' )
+				.length === 0
+		);
+	}, [ sitePlugins ] );
+
+	const onInstallWoo = useCallback( () => {
+		installSitePlugins( {
+			siteId: site?.ID,
+			slug: 'woocommerce',
+		} );
+	}, [ installSitePlugins, site ] );
 
 	const wooKeys =
 		licenseKeys && licenseKeys.split( ',' ).filter( ( key ) => isWooCommerceProduct( key ) );
@@ -105,6 +130,25 @@ export default function DownloadProductsForm() {
 					</Button>
 				</div>
 			</div>
+			{ shouldInstallWoo && (
+				<div>
+					<p className="download-products-form__install-woodescription">
+						{ siteDomain &&
+							translate(
+								'This extension requires WooCommerce plugin installed on {{strong}}%(siteUrl)s{{/strong}}, do you want to install it?',
+								{
+									components: { strong: <strong /> },
+									args: { siteUrl: siteDomain || '' },
+								}
+							) }
+					</p>
+					<div className="download-products-form__install-woo-controls">
+						<Button primary className="download-products-form__navigate" onClick={ onInstallWoo }>
+							{ translate( 'Install WooCommerce' ) }
+						</Button>
+					</div>
+				</div>
+			) }
 			<div className="download-products-form__bottom">
 				{ !! jetpackProducts.length && (
 					<div className="download-products-form__action-items">

--- a/client/a8c-for-agencies/sections/marketplace/download-products-form/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/download-products-form/style.scss
@@ -108,3 +108,21 @@ p.download-products-form__description {
 		margin-inline-end: 1rem;
 	}
 }
+
+.download-products-form__install-woodescription {
+	flex: 1;
+	margin: 0;
+	font-size: 0.875rem;
+	color: var(--color-text-gray);
+}
+
+div:has(> .download-products-form__install-woodescription) {
+	display: flex;
+	align-items: center;
+	gap: 1rem;
+	padding: 1rem 0;
+
+	.download-products-form__install-woo-controls {
+		flex-shrink: 0;
+	}
+}

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -46,7 +46,8 @@
 		"a4a-migrations-page-v2": true,
 		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
-		"a4a-updated-add-new-site": true
+		"a4a-updated-add-new-site": true,
+		"a4a-post-purchase-woo-download": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -39,7 +39,8 @@
 		"a4a-migrations-page-v2": true,
 		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
-		"a4a-updated-add-new-site": true
+		"a4a-updated-add-new-site": true,
+		"a4a-post-purchase-woo-download": true
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1725

## Proposed Changes

Main purpose of this PR is to present new hooks (`useFetchSitePlugins` and `useInstallSitePlugins`) that will allow remote installation of public accessible plugins (WooCommerce in our case). 
I've additionally added a feature flag to have this logic tested, as we haven't agreed on UI approach yet. This logic will likely take place on the previous step.

<img width="949" alt="Screenshot 2025-01-29 at 4 01 08 PM" src="https://github.com/user-attachments/assets/d0285a72-8a72-473c-a782-5aa7ac20b6b1" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link below navigate to `marketplace` and purchase some Woo extensions
- Create a new JN site and install Automattic for Agencies client plugin
- Authorize it
- Using live link below navigate to `/purchases/licenses`
- Pick any Woo license and assign to the new site
- On the last step, you should see `Install WooCommerce` button
- Click it, and check on your website WooCommerce installed and active

<img width="298" alt="Screenshot 2025-01-29 at 4 15 30 PM" src="https://github.com/user-attachments/assets/c05a9339-6ec6-4875-84ca-6c5194f51ca9" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
