### PR TITLE
Adds price badge to "Design with AI" choice button

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/design-choice.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/design-choice.scss
@@ -30,6 +30,7 @@
 
 	.design-choice__image-container {
 		display: flex;
+		position: relative; // Allows the price badge to be positioned absolutely
 		width: 308px;
 		min-height: 226px;
 		transition: transform ease-in 0.15s;
@@ -42,5 +43,16 @@
 		.design-choice__image-container {
 			transform: scale(1.05);
 		}
+	}
+
+	.badge--info-blue {
+		background-color: var(--wp-components-color-accent, var(--wp-admin-theme-color));
+		color: var(--wp-components-color-accent-inverted, #fff);
+	}
+
+	.design-choice__price-badge {
+		position: absolute;
+		top: -0.5em;
+		right: -0.5em;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/design-choice.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/design-choice.tsx
@@ -1,3 +1,4 @@
+import { Badge } from '@automattic/components';
 import clsx from 'clsx';
 import { preventWidows } from 'calypso/lib/formatting';
 import './design-choice.scss';
@@ -10,6 +11,7 @@ interface Props {
 	destination: string;
 	footer?: React.ReactNode;
 	onSelect: ( destination: string ) => void;
+	badgeLabel?: React.ReactElement | string | number;
 }
 
 const DesignChoice = ( {
@@ -20,6 +22,7 @@ const DesignChoice = ( {
 	destination,
 	footer,
 	onSelect,
+	badgeLabel,
 }: Props ) => (
 	<button
 		className={ clsx( 'design-choice', className ) }
@@ -29,6 +32,11 @@ const DesignChoice = ( {
 		<div className="design-choice__title">{ title }</div>
 		<div className="design-choice__description">{ preventWidows( description ) }</div>
 		<div className="design-choice__image-container">
+			{ badgeLabel && (
+				<Badge type="info-blue" className="design-choice__price-badge">
+					{ badgeLabel }
+				</Badge>
+			) }
 			<img src={ imageSrc } alt={ title } />
 			{ footer ? <div className="design-choice__footer">{ footer }</div> : null }
 		</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
@@ -1,6 +1,7 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { themesIllustrationImage } from '@automattic/design-picker';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { StepContainer } from '@automattic/onboarding';
+import { StepContainer, isOnboardingFlow } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -51,6 +52,17 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 		submit?.( { destination } );
 	};
 
+	const bigSkyBadgeLabel =
+		! isLoading &&
+		isEligible &&
+		isOnboardingFlow( flow ) &&
+		isEnabled( 'onboarding/big-sky-before-plans' )
+			? translate( 'Starting at %(price)s/month', {
+					args: { price: '$4' },
+					comment: 'Translators: "price" is a per month price and will include a currency symbol',
+			  } )
+			: undefined;
+
 	return (
 		<>
 			<DocumentHead title={ headerText } />
@@ -78,6 +90,7 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 									) }
 									imageSrc={ hiBigSky }
 									destination="launch-big-sky"
+									badgeLabel={ bigSkyBadgeLabel }
 									footer={ preventWidows(
 										translate(
 											'To learn more about AI, you can review our {{a}}AI guidelines{{/a}}.',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
@@ -1,4 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { PLAN_PERSONAL } from '@automattic/calypso-products';
+import { OnboardSelect, ProductsList } from '@automattic/data-stores';
 import { themesIllustrationImage } from '@automattic/design-picker';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { StepContainer, isOnboardingFlow } from '@automattic/onboarding';
@@ -15,19 +17,30 @@ import kebabCase from '../../../../utils/kebabCase';
 import hiBigSky from './big-sky-no-text-small.png';
 import DesignChoice from './design-choice';
 import type { Step } from '../../types';
-import type { OnboardSelect } from '@automattic/data-stores';
 import './style.scss';
 
 /**
  * The design choices step
  */
 const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
+	const isGoalsFirstVariation =
+		isOnboardingFlow( flow ) && isEnabled( 'onboarding/big-sky-before-plans' );
+
 	const translate = useTranslate();
 	const { submit, goBack } = navigation;
 	const headerText = translate( 'Bring your vision to life' );
 	const intent = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
 		[]
+	);
+
+	const personalProduct = useSelect(
+		( select ) =>
+			// Ensure we only trigger network request when it's needed
+			isGoalsFirstVariation
+				? select( ProductsList.store ).getProductBySlug( PLAN_PERSONAL )
+				: undefined,
+		[ isGoalsFirstVariation ]
 	);
 
 	const { isEligible, isLoading } = useIsBigSkyEligible();
@@ -53,13 +66,10 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 	};
 
 	const bigSkyBadgeLabel =
-		! isLoading &&
-		isEligible &&
-		isOnboardingFlow( flow ) &&
-		isEnabled( 'onboarding/big-sky-before-plans' )
+		! isLoading && isEligible && personalProduct?.cost_per_month_display && isGoalsFirstVariation
 			? translate( 'Starting at %(price)s/month', {
-					args: { price: '$4' },
-					comment: 'Translators: "price" is a per month price and will include a currency symbol',
+					args: { price: personalProduct.cost_per_month_display },
+					comment: 'Translators: "price" is a per month price and includes a currency symbol',
 			  } )
 			: undefined;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
@@ -67,7 +67,7 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 
 	const bigSkyBadgeLabel =
 		! isLoading && isEligible && personalProduct?.cost_per_month_display && isGoalsFirstVariation
-			? translate( 'Starting at %(price)s/month', {
+			? translate( 'Starting at %(price)s a month', {
 					args: { price: personalProduct.cost_per_month_display },
 					comment: 'Translators: "price" is a per month price and includes a currency symbol',
 			  } )

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
-import { OnboardSelect, Onboard, UserSelect } from '@automattic/data-stores';
+import { PLAN_PERSONAL } from '@automattic/calypso-products';
+import { OnboardSelect, Onboard, UserSelect, ProductsList } from '@automattic/data-stores';
 import { ONBOARDING_FLOW, clearStepPersistedState } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
@@ -441,6 +442,21 @@ const onboarding: Flow = {
 				clearSignupCompleteSlug();
 			}
 		}, [ currentStepSlug, reduxDispatch, resetOnboardStore ] );
+
+		const [ isGoalsFirstExperimentLoading, isGoalsFirstExperiment ] = useGoalsFirstExperiment();
+		// The personal plan price appears on the design choice step under these conditions. Pre-load it so it doesn't flash into existence
+		const preloadPersonalProduct =
+			! isGoalsFirstExperimentLoading &&
+			isGoalsFirstExperiment &&
+			config.isEnabled( 'onboarding/big-sky-before-plans' );
+
+		useSelect(
+			( select ) =>
+				preloadPersonalProduct
+					? select( ProductsList.store ).getProductBySlug( PLAN_PERSONAL )
+					: undefined,
+			[ preloadPersonalProduct ]
+		);
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -163,7 +163,11 @@ const onboarding: Flow = {
 		const isDesignChoicesStepEnabled = isBigSkyEligible && isGoalsAtFrontExperiment;
 
 		const getPostCheckoutDestination = ( providedDependencies: ProvidedDependencies ) => {
-			if ( createWithBigSky ) {
+			if (
+				createWithBigSky &&
+				config.isEnabled( 'onboarding/big-sky-before-plans' ) &&
+				isGoalsAtFrontExperiment
+			) {
 				return addQueryArgs( '/setup/site-setup/launch-big-sky', {
 					siteSlug: providedDependencies.siteSlug,
 				} );

--- a/packages/data-stores/src/products-list/types.ts
+++ b/packages/data-stores/src/products-list/types.ts
@@ -44,6 +44,7 @@ export interface RawAPIProduct {
 	available: boolean;
 	combined_cost_display: string;
 	cost: number;
+	cost_per_month_display?: string;
 	cost_smallest_unit: number;
 	currency_code: string;
 	description: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #99008

## Proposed Changes

Adds badge to design choice button to prepare users that if they use this choice they will need to buy a plan.
This badge should only appear when the Big Sky choice appears before the plans step.


![CleanShot 2025-01-30 at 18 33 29@2x](https://github.com/user-attachments/assets/117aed65-c60f-400b-b264-a612c6284215)


There are more design changes to make, which are in task #99026. This PR just adds the badge, since it's the absolute minimum needed to make the flow shippable.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
