### PR TITLE
AI Assembler: prevent launchpad redirection as it's now a removed flow

### DIFF
--- a/client/landing/stepper/utils/flow-redirect-handler.ts
+++ b/client/landing/stepper/utils/flow-redirect-handler.ts
@@ -3,6 +3,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 // Flows to redirect
 const REMOVED_TAILORED_FLOWS = [
+	{ flow: 'ai-assembler', to: '/start:lang?' },
 	{ flow: BLOG_FLOW, to: '/start:lang?' },
 	{ flow: 'free', to: '/start/free:lang?' },
 	{ flow: 'link-in-bio', to: '/start:lang?' },


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes:

- https://github.com/Automattic/wp-calypso/issues/99071

## Proposed Changes

This PR fixes the mandatory redirection to the launchpad step for the `ai-assembler` flow, as it's been removed by:

- https://github.com/Automattic/wp-calypso/pull/98200

This caused an issue for the users who hadn't had a chance to complete the launchpad steps before the entire flow was removed. The user is forced to go to `/setup/ai-assembler/launchpad` (and then redirected to `/setup/ai-assembler/goals` subsequently), which is now a dead URL.

Ref:

https://github.com/Automattic/wp-calypso/blob/f49044f2c5e91dc33bd7b54a74ec84e157d166b3/client/my-sites/customer-home/controller.jsx#L112

This PR adds `ai-assembler` site intent to the existing list of removed flows, so that it won't get redirected to the launchpad step anymore.

Ref:

https://github.com/Automattic/wp-calypso/blob/f49044f2c5e91dc33bd7b54a74ec84e157d166b3/client/my-sites/customer-home/controller.jsx#L93

## Why are these changes being made?

Fixes an escalated, blocker issue.

## Testing Instructions

* First, verify you can reproduce the issue:
   1. Go to `/start`.
   2. Skip the Goals screen.
   3. Pick any free theme.
   4. Don't launch the site yet.
   5. Go to `<yoursite.wordpress.com>/wp-admin/options.php`, and update the following options:
       * `site_intent` => `ai-assembler`
       * `launchpad_screen` => `full`
   6. Go to `https://wordpress.com/home/<yoursite.wordpress.com>`.
   7. Verify you get stuck in a blank goals screen.
* Verify this PR fixes the issue:
   1. Go to `<Calypso Live URL>/home/<yoursite.wordpress.com>`.
   2. Verify that you land in My Home.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
