### PR TITLE
Allow right click

### DIFF
--- a/client/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
@@ -78,6 +78,11 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 	const isAdmin = useSelector( ( state ) => canCurrentUser( state, site.ID, 'manage_options' ) );
 
 	const onSiteClick = ( event: React.MouseEvent ) => {
+		// Bubble right click
+		if ( event.button === 2 ) {
+			return;
+		}
+
 		event.preventDefault();
 
 		let openInNewTab = false;


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/98875

## Proposed Changes

* Allows right click on site urls in the /sites dashboard. Previously right clicks were being treated as standard clicks.

## Testing Instructions

* /sites
* Right click a site name/url
