### PR TITLE
A4A: Update Migration Banner offer date & content

### DIFF
--- a/client/a8c-for-agencies/components/a4a-migration-offer-v3/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v3/index.tsx
@@ -47,7 +47,7 @@ const MigrationOfferV3 = ( { isExpanded, onToggleView }: Props ) => {
 				<h3 className="a4a-migration-offer-v3__title">
 					<span>
 						{ translate(
-							'{{b}}Limited time offer:{{/b}} Migrate your sites to Pressable or WordPress.com and earn up to $10,000!',
+							'{{b}}Limited time offer:{{/b}} Migrate your sites to Pressable or WordPress.com and earn up to $10,000!*',
 							{
 								components: {
 									b: <b />,
@@ -66,7 +66,7 @@ const MigrationOfferV3 = ( { isExpanded, onToggleView }: Props ) => {
 						<SimpleList
 							items={ [
 								translate(
-									"{{b}}WP Engine customers:{{/b}} You will receive $100 per site, up to $10,000. You will also get credited for the remaining time on your WP Engine contract, so you won't have to pay twice.",
+									'{{b}}All migrations:{{/b}} Your first month of hosting will be free when you migrate twenty or more sites to us from any host.',
 									{
 										components: {
 											b: <b />,
@@ -74,7 +74,15 @@ const MigrationOfferV3 = ( { isExpanded, onToggleView }: Props ) => {
 									}
 								),
 								translate(
-									'{{b}}For any other host:{{/b}} You will receive $100 per site migrated up to a maximum of $3,000.',
+									"{{b}}WP Engine customers:{{/b}} You will receive $100 per successful site migration up to $10,000. If you have an existing contract, we'll host your site(s) for free until your existing WP Engine contract ends.",
+									{
+										components: {
+											b: <b />,
+										},
+									}
+								),
+								translate(
+									'{{b}}For any other host:{{/b}} You will receive $100 per successful site migration, up to $3,000.',
 									{
 										components: {
 											b: <b />,
@@ -104,9 +112,9 @@ const MigrationOfferV3 = ( { isExpanded, onToggleView }: Props ) => {
 							</Button>
 
 							<span className="a4a-migration-offer-v3__body-actions-footnote">
-								{ translate( '* offer valid until %(endDate)s', {
+								{ translate( '*Offer valid until %(endDate)s', {
 									args: {
-										endDate: new Date( '2025-01-31T00:00:00' ).toLocaleDateString(
+										endDate: new Date( '2025-07-31T00:00:00' ).toLocaleDateString(
 											translate.localeSlug,
 											{
 												year: 'numeric',

--- a/client/a8c-for-agencies/components/a4a-migration-offer-v3/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v3/style.scss
@@ -55,7 +55,7 @@
 	flex-direction: column;
 
 	.simple-list {
-		max-width: 800px;
+		max-width: 850px;
 		margin-block-start: 24px;
 		margin-inline-start: 16px;
 	}

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-banner/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-banner/index.tsx
@@ -1,22 +1,14 @@
-import { Button, Card } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
+import { useState } from 'react';
+import MigrationOfferV3 from 'calypso/a8c-for-agencies/components/a4a-migration-offer-v3';
 import PageSection from 'calypso/a8c-for-agencies/components/page-section';
 import { BackgroundType5 } from 'calypso/a8c-for-agencies/components/page-section/backgrounds';
-import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
-import MigrationIcon from 'calypso/assets/images/a8c-for-agencies/migration-icon.svg';
-import { useDispatch } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './style.scss';
 
 export default function MigrationsBanner() {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
-
-	const onMigrateSiteClick = () => {
-		dispatch( recordTracksEvent( 'calypso_a8c_migration_banner_migrate_site_click' ) );
-	};
+	const [ isMigrationOfferExpanded, setIsMigrationOfferExpanded ] = useState( true );
 
 	return (
 		<PageSection
@@ -30,48 +22,10 @@ export default function MigrationsBanner() {
 			) }
 			background={ BackgroundType5 }
 		>
-			<Card className="migrations-banner">
-				<div className="migrations-banner__main">
-					<h2 className="migrations-banner__title">
-						<img className="migrations-banner__icon" src={ MigrationIcon } alt="" />
-						{ translate(
-							'Limited time offer: Migrate your sites to Pressable or WordPress.com and earn up to $10,000!'
-						) }
-					</h2>
-
-					<div className="migration-banner__content">
-						<SimpleList
-							items={ [
-								translate(
-									'{{b}}WP Engine customers:{{/b}} You will receive $100 per site, up to $10,000. You will also get credited for the remaining time on your WP Engine contract, so you won’t have to pay twice.',
-									{
-										components: {
-											b: <b />,
-										},
-									}
-								),
-								translate(
-									'{{b}}For any other host:{{/b}} will receive $100 per site migrated up to a maximum of $3,000.',
-									{
-										components: {
-											b: <b />,
-										},
-									}
-								),
-							] }
-						/>
-
-						<Button
-							className="migrations-banner__cta-button"
-							variant="secondary"
-							onClick={ onMigrateSiteClick }
-							href={ CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT }
-						>
-							{ translate( 'Migrate your sites' ) }
-						</Button>
-					</div>
-				</div>
-			</Card>
+			<MigrationOfferV3
+				isExpanded={ isMigrationOfferExpanded }
+				onToggleView={ () => setIsMigrationOfferExpanded( ( prev ) => ! prev ) }
+			/>
 		</PageSection>
 	);
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1718

## Proposed Changes

This PR: 
- Updates the Migration Banner content & offer date that is currently displayed on the Overview & Hosting pages
- Replaces the old banner with the new banner that we updated. 

## Why are these changes being made?

* To update the extended migration offer date and content.

## Testing Instructions

* Open the A4A live link
* Go to Overview > Verify the banner in the `Hosting` section is updated as shown below:

<img width="1470" alt="Screenshot 2025-01-30 at 10 53 56 AM" src="https://github.com/user-attachments/assets/64e8076a-4378-40aa-a8fa-250dea0a9677" />

* Go to Marketplace: Hosting > Verify the banner is updated as shown below:

<img width="1470" alt="Screenshot 2025-01-30 at 10 54 01 AM" src="https://github.com/user-attachments/assets/7f93fa4b-36d8-4436-b92d-1f4345efd4c5" />

* Go to Migrations: Overview > Verify the banner is updated as shown below:

<img width="1470" alt="Screenshot 2025-01-30 at 10 54 06 AM" src="https://github.com/user-attachments/assets/569d1109-9427-433f-bde6-5141d4241141" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
