### PR TITLE
Update Design Choices copy in big-sky-before-plans onboarding flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
@@ -28,7 +28,12 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 
 	const translate = useTranslate();
 	const { submit, goBack } = navigation;
-	const headerText = translate( 'Bring your vision to life' );
+	const headerText = isGoalsFirstVariation
+		? translate( 'How would you like to start?' )
+		: translate( 'Bring your vision to life' );
+	const subHeaderText = isGoalsFirstVariation
+		? translate( 'Select an option to begin. You can always change your mind later.' )
+		: undefined;
 	const intent = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
 		[]
@@ -80,7 +85,9 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 				flowName={ flow }
 				stepName={ stepName }
 				isHorizontalLayout={ false }
-				formattedHeader={ <FormattedHeader headerText={ headerText } /> }
+				formattedHeader={
+					<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
+				}
 				stepContent={
 					<>
 						<div className="design-choices__body">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/style.scss
@@ -2,6 +2,12 @@
 	.step-container__header {
 		margin-top: 96px;
 		margin-bottom: 50px;
+
+		.formatted-header {
+			.formatted-header__subtitle {
+				text-align: center;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #99074

## Proposed Changes

* Updates header and subheader text in Design Choice
* But only in the `big-sky-before-plan` flow

![CleanShot 2025-01-30 at 19 55 16@2x](https://github.com/user-attachments/assets/035d1835-328e-4e45-860a-c593cf518c97)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
