### PR TITLE
A4A: Add few improvements on the new product marketplace.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
@@ -81,14 +81,15 @@ const getDisplayableFeaturedProducts = (
 	filteredProductsAndBundles: APIProductFamilyProduct[]
 ) => {
 	const featuredProductSlugs = [
-		'woocommerce-advanced-notifications',
-		'jetpack-boost',
-		'woocommerce-bulk-stock-management',
+		'woocommerce-woopayments',
+		'jetpack-security-t1',
+		'woocommerce-subscriptions',
 	]; // For now, we hardcode this until we understand how we want pick featured products.
 
-	return filteredProductsAndBundles.filter( ( product ) =>
-		featuredProductSlugs.includes( product.slug )
-	);
+	// We do it this way to ensure we follow the same order as the featuredProductSlugs.
+	return featuredProductSlugs
+		.map( ( slug ) => filteredProductsAndBundles.find( ( product ) => product.slug === slug ) )
+		.filter( ( product ) => product !== undefined ) as APIProductFamilyProduct[];
 };
 
 const getDisplayableWoocommerceExtensions = (

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/style.scss
@@ -41,7 +41,7 @@
 	.hosting-dashboard-layout__header-actions {
 		background-color: var(--color-surface);
 		border-radius: 8px; /* stylelint-disable-line */
-		padding: 8px 16px;
+		padding: 8px 24px 8px 20px;
 
 		.shopping-cart {
 			margin: 0;

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/style.scss
@@ -50,7 +50,7 @@ $action-panel-height-mobile: 128px;
 	.hosting-dashboard-layout__header-actions {
 		background-color: var(--color-surface);
 		border-radius: 8px; /* stylelint-disable-line */
-		padding: 8px 16px;
+		padding: 8px 24px 8px 20px;
 
 		.shopping-cart {
 			margin: 0;

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/hooks/use-product-filter-options.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/hooks/use-product-filter-options.tsx
@@ -60,6 +60,11 @@ export default function useProductFilterOptions() {
 				  ]
 				: [] ),
 			{
+				key: PRODUCT_CATEGORY_PAYMENTS,
+				label: translate( 'Payments' ) as string,
+				icon: currencyDollar,
+			},
+			{
 				key: PRODUCT_CATEGORY_SECURITY,
 				label: translate( 'Security' ) as string,
 				icon: lock,
@@ -71,11 +76,6 @@ export default function useProductFilterOptions() {
 			},
 			{ key: PRODUCT_CATEGORY_SOCIAL, label: translate( 'Social' ) as string, icon: people },
 			{ key: PRODUCT_CATEGORY_GROWTH, label: translate( 'Growth' ) as string, icon: trendingUp },
-			{
-				key: PRODUCT_CATEGORY_PAYMENTS,
-				label: translate( 'Payments' ) as string,
-				icon: currencyDollar,
-			},
 			{
 				key: PRODUCT_CATEGORY_SHIPPING_DELIVERY_FULFILLMENT,
 				label: translate( 'Shipping, Delivery, and Fulfillment' ) as string,

--- a/client/components/jetpack/jetpack-product-info/section.tsx
+++ b/client/components/jetpack/jetpack-product-info/section.tsx
@@ -40,6 +40,7 @@ const JetpackProductInfoSection: FunctionComponent< Props > = ( {
 					clickableHeader
 					smooth
 					contentExpandedStyle={ contentStyle }
+					expanded
 				>
 					<div ref={ ref }>{ children }</div>
 				</FoldableCard>


### PR DESCRIPTION
This PR implements small enhancements to the new product marketplace based on the feedback we collected.

Context: pfunGA-4Un-p2#comment-8080

## Proposed Changes

| Description | Before | After |
|--------|--------|--------|
| We placed the Payments category immediately after the Brand categories to enhance the discoverability of the Payment addons. | <img width="1580" alt="Screenshot 2025-01-30 at 7 26 57 PM" src="https://github.com/user-attachments/assets/7190ac48-4cf4-41c3-bb21-c92ca06ef39e" /> | <img width="1573" alt="Screenshot 2025-01-30 at 7 27 34 PM" src="https://github.com/user-attachments/assets/df8b3d4b-9b0d-4894-9b6d-cac2ff291c22" /> |
| We have updated the featured products to include WooPayments, Jetpack Security, and Woo Subscriptions, as this makes more sense based on popularity. | <img width="1592" alt="Screenshot 2025-01-30 at 7 29 07 PM" src="https://github.com/user-attachments/assets/398ab97a-0016-405f-93d8-7996c94f0700" /> | <img width="1537" alt="Screenshot 2025-01-30 at 7 29 37 PM" src="https://github.com/user-attachments/assets/d8476e29-27ab-430b-a9fc-3f089bfcb7b7" /> |
| The product lightbox now expands the collapsible description in mobile view. | <img width="408" alt="Screenshot 2025-01-30 at 7 30 56 PM" src="https://github.com/user-attachments/assets/b6b9b1ce-924f-405f-8eb9-d42b1772163e" /> | <img width="418" alt="Screenshot 2025-01-30 at 7 30 50 PM" src="https://github.com/user-attachments/assets/5ad6ef4a-8b41-4153-8a10-e1ab3a3ccfb9" /> | 


## Why are these changes being made?

* This is part of the UX marketplace improvement project.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace/products` page.
* Test the 3 items above if it is working as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?