### PR TITLE
Fix: Handle introductory offer periods longer than billing periods

### DIFF
--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
@@ -121,6 +121,11 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 							{ args }
 					  );
 				// translation example: $1 first month then $2 per year
+			} else if ( productBillingTermInMonths === 1 && introTerm === 'year' ) {
+				return translate(
+					'%(formattedCurrentPrice)s first year then %(formattedPriceBeforeDiscounts)s per month',
+					{ args }
+				);
 			}
 			return translate(
 				'%(formattedCurrentPrice)s first month then %(formattedPriceBeforeDiscounts)s per month',
@@ -146,8 +151,18 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 					  );
 				// translation example: $1 first 3 months then $2 per 2 years
 			} else if ( productBillingTermInMonths === 12 ) {
+				return introTerm === 'month'
+					? translate(
+							'%(formattedCurrentPrice)s first %(introCount)s months then %(formattedPriceBeforeDiscounts)s per year',
+							{ args }
+					  )
+					: translate(
+							'%(formattedCurrentPrice)s first %(introCount)s years then %(formattedPriceBeforeDiscounts)s per year',
+							{ args }
+					  );
+			} else if ( productBillingTermInMonths === 1 && introTerm === 'year' ) {
 				return translate(
-					'%(formattedCurrentPrice)s first %(introCount)s months then %(formattedPriceBeforeDiscounts)s per year',
+					'%(formattedCurrentPrice)s first %(introCount)s years then %(formattedPriceBeforeDiscounts)s per month',
 					{ args }
 				);
 				// translation example: $1 first 3 months then $2 per year


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #94821

## Proposed Changes

Fix: Handle introductory offer periods longer than billing periods

- Updated `translatedIntroOfferDetails` function to correctly handle cases where the introductory offer period is longer than the billing period.
- Ensured the correct text strings are displayed for all combinations of introductory offer periods and billing periods.

CASE 1: Monthly subscription with a 1 year introductory offer
BEFORE
![Screenshot from 2025-01-21 14-03-59](https://github.com/user-attachments/assets/dba8d9ae-1bf2-454f-8760-492a7dbb3e55)

AFTER
![image](https://github.com/user-attachments/assets/c680b82e-b403-4604-8c9a-3e01c10e4679)

CASE 2: Yearly subscription with a 2 year introductory offer
BEFORE
![Screenshot from 2025-01-21 14-06-40](https://github.com/user-attachments/assets/9c391bf5-36f9-4c4c-8ef2-722900b116af)

AFTER
![image](https://github.com/user-attachments/assets/aa696336-39ba-46bb-a36e-d92e25ad5e1f)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

You can see that it doesn't seem to have any handling for certain combinations of introductory offer periods and billing periods where the introductory offer period is longer. For example:
- Monthly subscription with a 1 year introductory offer
- Yearly subscription with a 2 year introductory offer

In those cases, it seems like it would display the wrong text, e.g.. referencing "months" rather than "years".

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
