### PR TITLE
A4A: Convert Bundle price selector to use core component.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/bundle-price-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/bundle-price-selector/index.tsx
@@ -1,10 +1,6 @@
-import { Button } from '@wordpress/components';
-import { chevronDown } from '@wordpress/icons';
-import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
-import { useCallback, useRef, useState } from 'react';
-import PopoverMenu from 'calypso/components/popover-menu';
-import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { SelectControl } from '@wordpress/components';
+import { numberFormat, useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
 
 import './style.scss';
 
@@ -16,17 +12,6 @@ type Props = {
 
 export function BundlePriceSelector( { options, value, onChange }: Props ) {
 	const translate = useTranslate();
-	const [ isMenuOpen, setIsMenuOpen ] = useState( false );
-
-	const buttonRef = useRef( null );
-
-	const onSelect = useCallback(
-		( option: number ) => {
-			setIsMenuOpen( false );
-			onChange( option );
-		},
-		[ onChange ]
-	);
 
 	const getDiscountPercentage = useCallback(
 		( bundleSize: number ) => {
@@ -64,43 +49,24 @@ export function BundlePriceSelector( { options, value, onChange }: Props ) {
 	);
 
 	return (
-		<>
-			<div className="bundle-price-selector">
-				<div className="bundle-price-selector__label">{ translate( 'Bundle & save' ) }</div>
-				<Button
-					ref={ buttonRef }
-					className="bundle-price-selector__menu-button"
-					variant="secondary"
-					onClick={ () => setIsMenuOpen( ! isMenuOpen ) }
-					icon={ chevronDown }
-					iconPosition="right"
-				>
-					<span>
-						{ value > 1 ? getLabel( value ) : translate( 'Explore bundle discounts to apply' ) }
-					</span>
-				</Button>
-			</div>
-
-			<PopoverMenu
-				isVisible={ isMenuOpen }
-				onClose={ () => setIsMenuOpen( false ) }
-				context={ buttonRef.current }
-				className="bundle-price-selector__popover"
-				autoPosition={ false }
-				position="bottom right"
-			>
-				{ options.map( ( option ) => (
-					<PopoverMenuItem
-						className={ clsx( {
-							'is-selected': value === option,
-						} ) }
-						onClick={ () => onSelect( option ) }
-						key={ `bundle-price-option-${ option }` }
-					>
-						{ getLabel( option ) }
-					</PopoverMenuItem>
-				) ) }
-			</PopoverMenu>
-		</>
+		<SelectControl
+			__next40pxDefaultSize
+			__nextHasNoMarginBottom
+			label={ translate( 'Bundle size' ) }
+			labelPosition="side"
+			value={ value }
+			onChange={ onChange }
+			options={ [
+				{
+					disabled: true,
+					label: translate( 'Explore bundle discounts to apply' ),
+					value: '1',
+				},
+				...options.map( ( option ) => ( {
+					label: getLabel( option ) as string,
+					value: `${ numberFormat( option ) }`,
+				} ) ),
+			] }
+		/>
 	);
 }


### PR DESCRIPTION
The existing bundle price selector utilizes a Calypso dropdown menu, which performs poorly in mobile view. This PR revises the selector to implement the SelectControl component from the Core package. This change guarantees that we are using a native select control that functions effectively on any screen device.

| Before | After |
|--------|--------|
| <img width="433" alt="Screenshot 2025-01-30 at 9 11 06 PM" src="https://github.com/user-attachments/assets/c6e54f08-b414-4004-9e77-c0b19abbddad" /> | <img width="418" alt="Screenshot 2025-01-30 at 9 10 32 PM" src="https://github.com/user-attachments/assets/d2dbcf2f-4475-4714-9e08-a47e6f0857e7" /> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1703

## Proposed Changes

* Update the `BundleSizeSelector` component to use the `SelectControl` component from core. This ensures that the component functions correctly on any screen type.

## Why are these changes being made?

* This is part of the UX marketplace improvement project.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace/products` page.
* Select the Bundle size selector.
* Confirm it now uses the core component (See screenshot above).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
