### PR TITLE
E2E: Fix subscription tests

### DIFF
--- a/packages/calypso-e2e/src/email-client.ts
+++ b/packages/calypso-e2e/src/email-client.ts
@@ -65,7 +65,7 @@ export class EmailClient {
 		// initialized, or a specified timestamp.
 		const message = await this.client.messages.get( inboxId, searchCriteria, {
 			receivedAfter: receivedAfter !== undefined ? receivedAfter : this.startTimestamp,
-			timeout: 90 * 1000, // Sometimes SMS is slow to be received.
+			timeout: 120 * 1000, // Sometimes email is slow to be received.
 		} );
 		return message;
 	}

--- a/packages/calypso-e2e/src/lib/pages/subscribers-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/subscribers-page.ts
@@ -47,7 +47,7 @@ export class SubscribersPage {
 		await this.anchor
 			.getByRole( 'row' )
 			.filter( { hasText: identifier } )
-			.getByRole( 'button', { name: 'Open subscriber menu' } )
+			.getByRole( 'button', { name: 'Actions' } )
 			.click();
 
 		// Click on the remove menu item.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Subscription tests were failing after the subscriptions page switched to Dataviews (#99057, pe7F0s-2of-p2) due to a label name changing.

This PR updates the label. It also bumps the email client timeout, which sometimes is flaky.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

```
yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/users/newsletter__subscribe-remove.ts"
```
```
yarn workspace wp-e2e-tests build && VIEWPORT_NAME="mobile" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/users/newsletter__subscribe-remove.ts"
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?