### PR TITLE
Hundred Year Plan Site Picker: Replace  presales-chat with Help Center

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/index.tsx
@@ -140,7 +140,10 @@ const ConfirmationModal = ( {
 
 	const openHelpCenter = () => {
 		recordTracksEvent( 'calypso_hundred_year_plan_help_click' );
-		setNavigateToRoute( '/odie?provider=zendesk' );
+		setNavigateToRoute(
+			'/odie?provider=zendesk&userFieldMessage=' +
+				encodeURIComponent( 'This is a user looking to purchase the 100-Year Plan' )
+		);
 		setShowHelpCenter( true );
 		closeModal();
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/index.tsx
@@ -2,7 +2,6 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { PLAN_100_YEARS, getPlan } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
-import { useStillNeedHelpURL } from '@automattic/help-center/src/hooks';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { Button, Modal } from '@wordpress/components';
@@ -138,11 +137,10 @@ const ConfirmationModal = ( {
 	const hasEnTranslation = useHasEnTranslation();
 
 	const { setShowHelpCenter, setNavigateToRoute } = useDataStoreDispatch( HelpCenter.register() );
-	const { url } = useStillNeedHelpURL();
 
 	const openHelpCenter = () => {
 		recordTracksEvent( 'calypso_hundred_year_plan_help_click' );
-		setNavigateToRoute( url );
+		setNavigateToRoute( '/odie?provider=zendesk' );
 		setShowHelpCenter( true );
 		closeModal();
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/index.tsx
@@ -1,16 +1,18 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { PLAN_100_YEARS, getPlan } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
+import { HelpCenter } from '@automattic/data-stores';
+import { useStillNeedHelpURL } from '@automattic/help-center/src/hooks';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { Button, Modal } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useDispatch as useDataStoreDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import QuerySites from 'calypso/components/data/query-sites';
 import FormattedHeader from 'calypso/components/formatted-header';
 import SiteSelector from 'calypso/components/site-selector';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
-import { usePresalesChat } from 'calypso/lib/presales-chat';
 import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
 import { SMALL_BREAKPOINT } from '../hundred-year-plan-step-wrapper/constants';
 import type { Step } from '../../types';
@@ -135,7 +137,15 @@ const ConfirmationModal = ( {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
 
-	const { openChat } = usePresalesChat( 'wpcom' );
+	const { setShowHelpCenter, setNavigateToRoute } = useDataStoreDispatch( HelpCenter.register() );
+	const { url } = useStillNeedHelpURL();
+
+	const openHelpCenter = () => {
+		recordTracksEvent( 'calypso_hundred_year_plan_help_click' );
+		setNavigateToRoute( url );
+		setShowHelpCenter( true );
+		closeModal();
+	};
 
 	return (
 		<StyledModal
@@ -190,12 +200,12 @@ const ConfirmationModal = ( {
 							{ hasEnTranslation( 'Need help? {{ChatLink}}Contact us{{/ChatLink}}' )
 								? translate( 'Need help? {{ChatLink}}Contact us{{/ChatLink}}', {
 										components: {
-											ChatLink: <Button variant="link" onClick={ openChat } />,
+											ChatLink: <Button variant="link" onClick={ openHelpCenter } />,
 										},
 								  } )
 								: translate( 'Need help? {{ChatLink}}Chat with us{{/ChatLink}}', {
 										components: {
-											ChatLink: <Button variant="link" onClick={ openChat } />,
+											ChatLink: <Button variant="link" onClick={ openHelpCenter } />,
 										},
 								  } ) }
 						</HelpLink>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3670

## Proposed Changes

Remove `calypso/lib/presales-chat` in favor of `HelpCenter`. It follows the same implementation as [/help](https://wordpress.com/help):

https://github.com/Automattic/wp-calypso/blob/24a703ea71a4c0eac2cce908e9ef861b363f934c/client/me/help/help-contact-us-header.tsx

To skip the bot/AI I used as reference:

https://github.com/Automattic/wp-calypso/blob/24a703ea71a4c0eac2cce908e9ef861b363f934c/client/me/help/help-contact-us-header.tsx

But I would love help on this approach.

### Things that I would like feedback on how to implement

- [x] How to communicate to the Happiness Engineer this user came through the 100-Year Plan flow

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

In its current state, the 'Need help? Contact Us' chat button is not working. The best experience is to use Help Center:

p1738252192081029-slack-C07D72S1135

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/setup/hundred-year-plan/site-picker
* Select a test site
* Try clicking on "Need help? Contact us"
* Make sure the Help Center pops up and you can directly go to a human
  * Keep in mind that if you test this flow proxied, you won't get an actual response since the ZD interaction will go to the sandboxed version of Zendesk. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?