### PR TITLE
Components: Remove circular client reference from `Button` example

### DIFF
--- a/packages/components/src/button/docs/example.jsx
+++ b/packages/components/src/button/docs/example.jsx
@@ -1,176 +1,174 @@
-import { PureComponent } from 'react';
-import DocsExample from 'calypso/devdocs/docs-example';
 import Button from '..';
 import Card from '../../card';
 import Gridicon from '../../gridicon';
 
-export default class ButtonExample extends PureComponent {
-	static displayName = 'ButtonExample';
-
-	static defaultProps = {
-		exampleCode: (
-			<Card>
-				<div className="docs__design-button-row">
-					<Button>Button</Button>
-					<Button>
-						<Gridicon icon="heart" />
-						<span>Icon button</span>
-					</Button>
-					<Button>
-						<Gridicon icon="plugins" />
-					</Button>
-					<Button disabled>Disabled button</Button>
-				</div>
-				<div className="docs__design-button-row">
-					<Button scary>Scary button</Button>
-					<Button scary>
-						<Gridicon icon="globe" />
-						<span>Scary icon button</span>
-					</Button>
-					<Button scary>
-						<Gridicon icon="pencil" />
-					</Button>
-					<Button scary disabled>
-						Scary disabled button
-					</Button>
-				</div>
-				<div className="docs__design-button-row">
-					<Button primary>Primary button</Button>
-					<Button primary>
-						<Gridicon icon="camera" />
-						<span>Primary icon button</span>
-					</Button>
-					<Button primary>
-						<Gridicon icon="time" />
-					</Button>
-					<Button primary disabled>
-						Primary disabled button
-					</Button>
-				</div>
-				<div className="docs__design-button-row">
-					<Button primary scary>
-						Primary scary button
-					</Button>
-					<Button primary scary>
-						<Gridicon icon="user-circle" />
-						<span>Primary scary icon button</span>
-					</Button>
-					<Button primary scary>
-						<Gridicon icon="cart" />
-					</Button>
-					<Button primary scary disabled>
-						Primary scary disabled button
-					</Button>
-				</div>
-				<div className="docs__design-button-row">
-					<Button borderless>
-						<Gridicon icon="cross" />
-						<span>Remove</span>
-					</Button>
-					<Button borderless>
-						<Gridicon icon="trash" />
-						<span>Trash</span>
-					</Button>
-					<Button borderless>
-						<Gridicon icon="link-break" />
-						<span>Disconnect</span>
-					</Button>
-					<Button borderless>
-						<Gridicon icon="trash" />
-					</Button>
-					<Button borderless disabled>
-						<Gridicon icon="cross" />
-						<span>Remove</span>
-					</Button>
-				</div>
-				<div className="docs__design-button-row">
-					<Button borderless primary>
-						<Gridicon icon="cross" />
-						<span>Remove</span>
-					</Button>
-					<Button borderless primary>
-						<Gridicon icon="trash" />
-						<span>Trash</span>
-					</Button>
-					<Button borderless primary>
-						<Gridicon icon="link-break" />
-						<span>Disconnect</span>
-					</Button>
-					<Button borderless primary>
-						<Gridicon icon="trash" />
-					</Button>
-					<Button borderless primary disabled>
-						<Gridicon icon="cross" />
-						<span>Remove</span>
-					</Button>
-				</div>
-				<div className="docs__design-button-row">
-					<Button borderless scary>
-						<Gridicon icon="cross" />
-						<span>Remove</span>
-					</Button>
-					<Button borderless scary>
-						<Gridicon icon="trash" />
-						<span>Trash</span>
-					</Button>
-					<Button borderless scary>
-						<Gridicon icon="link-break" />
-						<span>Disconnect</span>
-					</Button>
-					<Button borderless scary>
-						<Gridicon icon="trash" />
-					</Button>
-					<Button borderless scary disabled>
-						<Gridicon icon="cross" />
-						<span>Remove</span>
-					</Button>
-				</div>
-				<div className="docs__design-button-row">
-					<Button compact>
-						<Gridicon icon="cross" />
-						<span>Remove</span>
-					</Button>
-					<Button compact>
-						<Gridicon icon="trash" />
-						<span>Trash</span>
-					</Button>
-					<Button compact>
-						<Gridicon icon="link-break" />
-						<span>Disconnect</span>
-					</Button>
-					<Button compact>
-						<Gridicon icon="trash" />
-					</Button>
-					<Button compact disabled>
-						<Gridicon icon="cross" />
-						<span>Remove</span>
-					</Button>
-				</div>
-				<div className="docs__design-button-row">
-					<Button busy>Busy button</Button>
-					<Button primary busy>
-						<Gridicon icon="time" />
-					</Button>
-					<Button primary busy>
-						Primary busy button
-					</Button>
-					<Button scary busy>
-						Scary busy button
-					</Button>
-					<Button primary scary busy>
-						<Gridicon icon="trash" />
-						<span>Primary scary busy button</span>
-					</Button>
-				</div>
-
-				<div className="docs__design-button-row">
-					<Button plain>Plain button</Button>
-				</div>
-			</Card>
-		),
-	};
-
-	render() {
-		return <DocsExample>{ this.props.exampleCode }</DocsExample>;
-	}
+function ButtonExample( props ) {
+	return props.exampleCode;
 }
+
+ButtonExample.displayName = 'Button';
+
+ButtonExample.defaultProps = {
+	exampleCode: (
+		<Card>
+			<div className="docs__design-button-row">
+				<Button>Button</Button>
+				<Button>
+					<Gridicon icon="heart" />
+					<span>Icon button</span>
+				</Button>
+				<Button>
+					<Gridicon icon="plugins" />
+				</Button>
+				<Button disabled>Disabled button</Button>
+			</div>
+			<div className="docs__design-button-row">
+				<Button scary>Scary button</Button>
+				<Button scary>
+					<Gridicon icon="globe" />
+					<span>Scary icon button</span>
+				</Button>
+				<Button scary>
+					<Gridicon icon="pencil" />
+				</Button>
+				<Button scary disabled>
+					Scary disabled button
+				</Button>
+			</div>
+			<div className="docs__design-button-row">
+				<Button primary>Primary button</Button>
+				<Button primary>
+					<Gridicon icon="camera" />
+					<span>Primary icon button</span>
+				</Button>
+				<Button primary>
+					<Gridicon icon="time" />
+				</Button>
+				<Button primary disabled>
+					Primary disabled button
+				</Button>
+			</div>
+			<div className="docs__design-button-row">
+				<Button primary scary>
+					Primary scary button
+				</Button>
+				<Button primary scary>
+					<Gridicon icon="user-circle" />
+					<span>Primary scary icon button</span>
+				</Button>
+				<Button primary scary>
+					<Gridicon icon="cart" />
+				</Button>
+				<Button primary scary disabled>
+					Primary scary disabled button
+				</Button>
+			</div>
+			<div className="docs__design-button-row">
+				<Button borderless>
+					<Gridicon icon="cross" />
+					<span>Remove</span>
+				</Button>
+				<Button borderless>
+					<Gridicon icon="trash" />
+					<span>Trash</span>
+				</Button>
+				<Button borderless>
+					<Gridicon icon="link-break" />
+					<span>Disconnect</span>
+				</Button>
+				<Button borderless>
+					<Gridicon icon="trash" />
+				</Button>
+				<Button borderless disabled>
+					<Gridicon icon="cross" />
+					<span>Remove</span>
+				</Button>
+			</div>
+			<div className="docs__design-button-row">
+				<Button borderless primary>
+					<Gridicon icon="cross" />
+					<span>Remove</span>
+				</Button>
+				<Button borderless primary>
+					<Gridicon icon="trash" />
+					<span>Trash</span>
+				</Button>
+				<Button borderless primary>
+					<Gridicon icon="link-break" />
+					<span>Disconnect</span>
+				</Button>
+				<Button borderless primary>
+					<Gridicon icon="trash" />
+				</Button>
+				<Button borderless primary disabled>
+					<Gridicon icon="cross" />
+					<span>Remove</span>
+				</Button>
+			</div>
+			<div className="docs__design-button-row">
+				<Button borderless scary>
+					<Gridicon icon="cross" />
+					<span>Remove</span>
+				</Button>
+				<Button borderless scary>
+					<Gridicon icon="trash" />
+					<span>Trash</span>
+				</Button>
+				<Button borderless scary>
+					<Gridicon icon="link-break" />
+					<span>Disconnect</span>
+				</Button>
+				<Button borderless scary>
+					<Gridicon icon="trash" />
+				</Button>
+				<Button borderless scary disabled>
+					<Gridicon icon="cross" />
+					<span>Remove</span>
+				</Button>
+			</div>
+			<div className="docs__design-button-row">
+				<Button compact>
+					<Gridicon icon="cross" />
+					<span>Remove</span>
+				</Button>
+				<Button compact>
+					<Gridicon icon="trash" />
+					<span>Trash</span>
+				</Button>
+				<Button compact>
+					<Gridicon icon="link-break" />
+					<span>Disconnect</span>
+				</Button>
+				<Button compact>
+					<Gridicon icon="trash" />
+				</Button>
+				<Button compact disabled>
+					<Gridicon icon="cross" />
+					<span>Remove</span>
+				</Button>
+			</div>
+			<div className="docs__design-button-row">
+				<Button busy>Busy button</Button>
+				<Button primary busy>
+					<Gridicon icon="time" />
+				</Button>
+				<Button primary busy>
+					Primary busy button
+				</Button>
+				<Button scary busy>
+					Scary busy button
+				</Button>
+				<Button primary scary busy>
+					<Gridicon icon="trash" />
+					<span>Primary scary busy button</span>
+				</Button>
+			</div>
+
+			<div className="docs__design-button-row">
+				<Button plain>Plain button</Button>
+			</div>
+		</Card>
+	),
+};
+
+export default ButtonExample;


### PR DESCRIPTION
## Proposed Changes

Removing the circular `client` reference from the `Button` example.

Might be easier to review with whitespace changes ignored (https://github.blog/news-insights/product-news/ignore-white-space-in-code-review/)

## Why are these changes being made?

Currently, the `Button` devdocs example uses the `DocsExample` component directly, but this is not necessary, because devdocs already handle that, as long as the example content is provided through a prop.

Furthermore, this creates a circular reference since `client` depends on `@automattic/components` and not the way around. 

Last, but not least, this removes one of the undeclared dependencies on `calypso`:

```
/packages/components/src/button/docs/example.jsx:2:1: Undeclared dependency on calypso
```

## Testing Instructions

* Go to `/devdocs/design/button`
* Verify the example still works well, and the live code playground works well, just like it does for `/devdocs/design/action-card`.

![Screenshot 2025-01-30 at 17 22 44](https://github.com/user-attachments/assets/86768982-3bc7-42e7-9da4-316b291b071c)
