### PR TITLE
Components: Remove circular client reference from `Suggestions` example

### DIFF
--- a/packages/components/src/suggestions/docs/example.jsx
+++ b/packages/components/src/suggestions/docs/example.jsx
@@ -1,10 +1,9 @@
-import { useCallback, useMemo, useState } from 'react';
-import FormTextInput from 'calypso/components/forms/form-text-input';
+import { TextControl } from '@wordpress/components';
+import { useMemo, useState } from 'react';
 import Suggestions from '..';
 
 export default function SuggestionsExample() {
 	const [ query, setQuery ] = useState( '' );
-	const updateInput = useCallback( ( e ) => setQuery( e.target.value ), [ setQuery ] );
 
 	const suggestions = useMemo( () => {
 		if ( ! query ) {
@@ -18,14 +17,16 @@ export default function SuggestionsExample() {
 	return (
 		<div className="docs__suggestions-container">
 			<div>
-				<FormTextInput
+				<TextControl
 					value={ query }
-					onChange={ updateInput }
+					onChange={ setQuery }
 					autoComplete="off"
 					autoCorrect="off"
 					autoCapitalize="off"
 					spellCheck={ false }
 					placeholder="Type Foo, Bar or Baz…"
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 				<p>
 					<span role="img" aria-label="Warning">


### PR DESCRIPTION
## Proposed Changes

Removing the circular `client` reference from the `Suggestions` example.

## Why are these changes being made?

Currently, the `Suggestions` devdocs example uses a `FormTextInput` component, creating a circular reference since `client` depends on `@automattic/components` and not the way around. 

However, this isn't necessary, we can just use `TextControl` from `@wordpress/components`.

As a result this removes one of the undeclared dependencies on `calypso`:

```
/packages/components/src/suggestions/docs/example.jsx:2:1: Undeclared dependency on calypso
```

## Testing Instructions

* Go to `/devdocs/design/suggestions`
* Verify the example still works well - note that some visual changes on the input field are expected, but we're totally fine with that:

|Before|After|
|---|---|
|![Screenshot 2025-01-30 at 17 35 30](https://github.com/user-attachments/assets/c70c5f51-5372-4840-a5c8-e7abde60ff60)|![Screenshot 2025-01-30 at 17 35 45](https://github.com/user-attachments/assets/1cc6f7b6-6d5f-420a-905e-f4c9f4e94c3d)|
