### PR TITLE
Align WP.com icon with the table underneath

### DIFF
--- a/client/my-sites/email/email-management/home/email-type-icon.jsx
+++ b/client/my-sites/email/email-management/home/email-type-icon.jsx
@@ -8,7 +8,8 @@ import { hasTitanMailWithUs } from 'calypso/lib/titan';
 
 const EmailTypeIcon = ( { translate, domain } ) => {
 	if ( hasTitanMailWithUs( domain ) ) {
-		return <Gridicon icon="my-sites" size={ 36 } />;
+		// The my-sites SVG has a bit of extra padding on the left, so we need to adjust the position
+		return <Gridicon style={ { marginLeft: -3 } } icon="my-sites" size={ 36 } />;
 	}
 
 	if ( hasGSuiteWithUs( domain ) ) {

--- a/client/my-sites/email/email-management/home/email-type-icon.jsx
+++ b/client/my-sites/email/email-management/home/email-type-icon.jsx
@@ -8,8 +8,7 @@ import { hasTitanMailWithUs } from 'calypso/lib/titan';
 
 const EmailTypeIcon = ( { translate, domain } ) => {
 	if ( hasTitanMailWithUs( domain ) ) {
-		// The my-sites SVG has a bit of extra padding on the left, so we need to adjust the position
-		return <Gridicon style={ { marginLeft: -3 } } icon="my-sites" size={ 36 } />;
+		return <Gridicon icon="my-sites" size={ 36 } />;
 	}
 
 	if ( hasGSuiteWithUs( domain ) ) {

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -550,6 +550,11 @@
 				height: 24px;
 				fill: var(--color-accent);
 			}
+
+			// The my-sites SVG has a bit of extra padding on the sides, so we need to adjust the position.
+			.gridicon.gridicons-my-sites {
+				margin-left: -3px;
+			}
 		}
 
 		&__notice {


### PR DESCRIPTION
The my-sites SVG has a two pixel gap. This compensates against that to align.

## Proposed Changes

**Before**

![image](https://github.com/user-attachments/assets/01b34510-965f-4038-8e42-bd4093634eed)


**After**

![image](https://github.com/user-attachments/assets/2eb5d887-2114-4ce1-8b5d-9ecf6637673e)


