### PR TITLE
Help Center: Fix attachments on Atomic

### DIFF
--- a/packages/zendesk-client/src/use-attach-file.tsx
+++ b/packages/zendesk-client/src/use-attach-file.tsx
@@ -56,7 +56,7 @@ export const useAttachFileToConversation = () => {
 					'x-smooch-clientid': clientId,
 					'x-smooch-sdk': 'web/zendesk/0.1',
 				},
-			} ).then( ( response ) => response.json() );
+			} );
 		},
 	} );
 };

--- a/packages/zendesk-client/src/use-attach-file.tsx
+++ b/packages/zendesk-client/src/use-attach-file.tsx
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { useMutation } from '@tanstack/react-query';
-import apiFetch, { APIFetchOptions } from '@wordpress/api-fetch';
 import {
 	SMOOCH_APP_ID,
 	SMOOCH_APP_ID_STAGING,
@@ -47,8 +46,7 @@ export const useAttachFileToConversation = () => {
 			formData.append( 'message', JSON.stringify( {} ) );
 			formData.append( 'source', file );
 
-			return apiFetch( {
-				path: `${ url }/sc/sdk/v2/apps/${ appId }/conversations/${ conversationId }/files`,
+			return fetch( `${ url }/sc/sdk/v2/apps/${ appId }/conversations/${ conversationId }/files`, {
 				method: 'POST',
 				body: formData,
 				credentials: 'include',
@@ -58,7 +56,7 @@ export const useAttachFileToConversation = () => {
 					'x-smooch-clientid': clientId,
 					'x-smooch-sdk': 'web/zendesk/0.1',
 				},
-			} as APIFetchOptions );
+			} ).then( ( response ) => response.json() );
 		},
 	} );
 };


### PR DESCRIPTION


## Proposed Changes

`apiFetch` was not working correctly on Atomic websites, as it was using the wrong URL.
Being an external URL (the attachment URL), this PR switches to use `fetch` instead.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to your Atomic website and open the Help Center.
* Start a conversation and try to attach an image. Check that it is not working, and in the Network tab the URL has errors.
* Sandbox widgets.wp.com
* Checkout the branch.
* `cd apps/help-center` and then `yarn dev --sync`
* Go to your Atomic website and open the Help Center.
* Start a conversation and try to attach an image.
* It should now work.