### PR TITLE
i18n: Add a caching layer to i18n-calypso `numberFormat` to improve performance

### DIFF
--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -31,9 +31,12 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
+		"@testing-library/jest-dom": "^6.4.5",
+		"@types/jest": "^29.5.12",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"react-test-renderer": "^18.3.1"
+		"react-test-renderer": "^18.3.1",
+		"jest": "^29.7.0"
 	},
 	"peerDependencies": {
 		"react": "^18.3.1"

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -202,7 +202,7 @@ I18N.prototype.emit = function ( ...args ) {
  */
 I18N.prototype.numberFormat = function (
 	number,
-	{ decimals = 0, forceLatin = true, numberFormatOptions = {}, caching = 'optimal' } = {}
+	{ decimals = 0, forceLatin = true, numberFormatOptions = {}, caching = 'none' } = {}
 ) {
 	const browserSafeLocale = this.getBrowserSafeLocale();
 

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -126,6 +126,36 @@ function getTranslation( i18n, options ) {
 	return null;
 }
 
+const stringifyCache = new Map();
+function getFormatter__stringifyCache( locale, options ) {
+	const key = JSON.stringify( [ locale, options ] );
+
+	if ( ! stringifyCache.has( key ) ) {
+		stringifyCache.set( key, new Intl.NumberFormat( locale, options ) );
+	}
+
+	return stringifyCache.get( key );
+}
+
+const customCache = new Map();
+function getFormatter__customCache( locale, options ) {
+	if ( ! customCache.has( locale ) ) {
+		customCache.set( locale, new Map() );
+	}
+
+	const localeCache = customCache.get( locale );
+	const optionsKey = Object.entries( options )
+		.sort( ( [ a ], [ b ] ) => a.localeCompare( b ) )
+		.map( ( [ key, value ] ) => `${ key }:${ value }` )
+		.join( '|' );
+
+	if ( ! localeCache.has( optionsKey ) ) {
+		localeCache.set( optionsKey, new Intl.NumberFormat( locale, options ) );
+	}
+
+	return localeCache.get( optionsKey );
+}
+
 function I18N() {
 	if ( ! ( this instanceof I18N ) ) {
 		return new I18N();
@@ -172,7 +202,7 @@ I18N.prototype.emit = function ( ...args ) {
  */
 I18N.prototype.numberFormat = function (
 	number,
-	{ decimals = 0, forceLatin = true, numberFormatOptions = {} } = {}
+	{ decimals = 0, forceLatin = true, numberFormatOptions = {}, caching = 'optimal' } = {}
 ) {
 	const browserSafeLocale = this.getBrowserSafeLocale();
 
@@ -186,12 +216,21 @@ I18N.prototype.numberFormat = function (
 	}
 
 	try {
-		return Intl.NumberFormat( `${ browserSafeLocale }${ forceLatin ? '-u-nu-latn' : '' }`, {
+		const locale = `${ browserSafeLocale }${ forceLatin ? '-u-nu-latn' : '' }`;
+		const options = {
 			minimumFractionDigits: decimals, // default is 0
 			maximumFractionDigits: decimals, // default is the greater between minimumFractionDigits and 3
 			// TODO clk numberFormat this may be the only difference, where some cases use 2 (they can just pass the option to Intl.NumberFormat)
 			...numberFormatOptions,
-		} ).format( number );
+		};
+
+		if ( caching === 'custom' ) {
+			return getFormatter__customCache( locale, options ).format( number );
+		} else if ( caching === 'stringify' ) {
+			return getFormatter__stringifyCache( locale, options ).format( number );
+		}
+
+		return Intl.NumberFormat( locale, options ).format( number );
 	} catch ( error ) {
 		warn( 'numberFormat(): Error formatting number with Intl.NumberFormat: ', number, error );
 	}

--- a/packages/i18n-calypso/test/benchmark.ts
+++ b/packages/i18n-calypso/test/benchmark.ts
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import i18n from '../src';
+import data from './data';
+import type { NumberFormatOptions } from '../types';
+
+const testNumber = 1234567.89;
+const iterations = 100000;
+
+function benchmarkNumberFormat( options: NumberFormatOptions ) {
+	// use a variety of options to mimick common usage
+	const numberFormatOptions = {
+		minimumFractionDigits: 1,
+		maximumFractionDigits: 3,
+		style: 'currency',
+		currency: 'USD',
+		useGrouping: true,
+		notation: 'compact',
+	};
+
+	const start = Date.now();
+	for ( let i = 0; i < iterations; i++ ) {
+		i18n.numberFormat( testNumber, { ...options, numberFormatOptions } );
+	}
+	const end = Date.now();
+	return end - start;
+}
+
+describe( 'numberFormat caching strategies', () => {
+	beforeEach( function () {
+		i18n.setLocale( data.locale );
+	} );
+
+	afterEach( function () {
+		jest.clearAllMocks();
+		i18n.configure(); // ensure everything is reset
+	} );
+
+	it( 'each caching method returns correct results', () => {
+		expect(
+			i18n.numberFormat( testNumber, {
+				caching: 'custom',
+			} )
+		).toEqual( '1.234.568' );
+
+		expect(
+			i18n.numberFormat( testNumber, {
+				caching: 'stringify',
+			} )
+		).toEqual( '1.234.568' );
+
+		expect(
+			i18n.numberFormat( testNumber, {
+				caching: 'none',
+			} )
+		).toEqual( '1.234.568' );
+	} );
+
+	it( 'should benchmark caching', () => {
+		const customCacheTime = benchmarkNumberFormat( { caching: 'custom' } );
+		const stringifyCacheTime = benchmarkNumberFormat( { caching: 'stringify' } );
+		const noCacheTime = benchmarkNumberFormat( { caching: 'none' } );
+
+		// eslint-disable-next-line no-console
+		console.log(
+			`custom: ${ customCacheTime }, json.stringify: ${ stringifyCacheTime }, none: ${ noCacheTime }`
+		);
+
+		expect( noCacheTime ).toBeGreaterThan( stringifyCacheTime );
+		expect( stringifyCacheTime ).toBeGreaterThan( customCacheTime );
+	} );
+} );

--- a/packages/i18n-calypso/tsconfig.json
+++ b/packages/i18n-calypso/tsconfig.json
@@ -1,3 +1,12 @@
 {
-	"extends": "@automattic/calypso-typescript-config/js-package.json"
+	"extends": "@automattic/calypso-typescript-config/js-package.json",
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": false,
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src"
+	},
+	"include": [ "src" ],
+	"exclude": [ "**/test/*" ]
 }

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -78,6 +78,10 @@ export interface NumberFormatOptions {
 	 * `minimumFractionDigits` & `maximumFractionDigits` will override `decimals` if set.
 	 */
 	numberFormatOptions?: Intl.NumberFormatOptions;
+	/**
+	 * Temporary
+	 */
+	caching?: 'custom' | 'stringify' | 'none';
 }
 
 export type TranslateHook = (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/i18n-issues/issues/926

## Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/98405#discussion_r1919817746 where we introduce Intl.NumberFormat to i18n-calypso's `numberFormat` method. In this PR we cache the `Intl.NumberFormat` instance to avoid recreating on every call, which may be arbitrarily large due to components rerendering or just general use in the app. For the most part, usage-wise, the formatter is created with the same options.

The idea I am exploring is to not checklist the `Intl.NumberFormat` options to a selected few, but rather create the index/cache from arbitrary options. Two strategies in this PR:

1. A map with straight-forward use of `json.stringify` on the options passed.
2. A custom solution with some potential improvements (a nested map on locale first, options next). We can expand on this if we need improvements over `json.stringify`.

### Benchmark

I've added some plain comparison tests in the form of a Jest suite. It compares simple use with a static set of options across 100K or so iterations. The results that I get, probably consistently:

1. `json.stringify` fastest with `~201`
2. custom approach second with `~220`
3. no caching last with `~2245`

So we get a whopping 10x performance improvement with a bit of caching. `json.stringify` seems most straight forward with lest complexity. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Improve `numberFormat` (our go-to number formatter)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review
* Run the benchmark tests with `yarn test-packages -- packages/i18n-calypso`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
