### PR TITLE
100 year domain - use "Paid until" label in domains list

### DIFF
--- a/packages/data-stores/src/queries/use-all-domains-query.ts
+++ b/packages/data-stores/src/queries/use-all-domains-query.ts
@@ -17,6 +17,7 @@ export type PartialDomainData = Pick<
 	| 'google_apps_subscription'
 	| 'has_registration'
 	| 'is_wpcom_staging_domain'
+	| 'is_hundred_year_domain'
 	| 'registration_date'
 	| 'titan_mail_subscription'
 	| 'tld_maintenance_end_time'

--- a/packages/domains-table/src/domains-table/domains-table-expires-renews-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-expires-renews-cell.tsx
@@ -23,7 +23,7 @@ function getNotice( {
 } ): string {
 	if ( isHundredYearDomain ) {
 		return sprintf(
-			/* translators: %s - The date on which a domain has expired */
+			/* translators: %s - The date until which a domain was paid for */
 			__( 'Paid until %s' ),
 			expiryDate
 		);

--- a/packages/domains-table/src/domains-table/domains-table-expires-renews-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-expires-renews-cell.tsx
@@ -14,11 +14,21 @@ function getNotice( {
 	expiryDate,
 	isAutoRenewing,
 	isExpired,
+	isHundredYearDomain,
 }: {
 	isAutoRenewing: boolean;
 	isExpired: boolean;
 	expiryDate: string;
+	isHundredYearDomain: boolean;
 } ): string {
+	if ( isHundredYearDomain ) {
+		return sprintf(
+			/* translators: %s - The date on which a domain has expired */
+			__( 'Paid until %s' ),
+			expiryDate
+		);
+	}
+
 	if ( isExpired ) {
 		return sprintf(
 			/* translators: %s - The date on which a domain has expired */
@@ -64,15 +74,20 @@ export const DomainsTableExpiresRenewsOnCell = ( {
 		domain.expiry && moment( domain.expiry ).utc().isBefore( moment().utc() )
 	);
 
+	const isHundredYearDomain = Boolean( domain.is_hundred_year_domain );
+
 	return (
 		<Element data-testid="expires-renews-on" className="domains-table-row__renews-on-cell">
 			{ expiryDate ? (
 				<>
 					{ ! isCompact && (
-						<Gridicon icon={ isExpired ? 'notice-outline' : 'reblog' } size={ 18 } />
+						<Gridicon
+							icon={ isExpired || isHundredYearDomain ? 'notice-outline' : 'reblog' }
+							size={ 18 }
+						/>
 					) }
 
-					{ getNotice( { expiryDate, isAutoRenewing, isExpired } ) }
+					{ getNotice( { expiryDate, isAutoRenewing, isExpired, isHundredYearDomain } ) }
 				</>
 			) : (
 				'-'

--- a/packages/domains-table/src/test-utils.tsx
+++ b/packages/domains-table/src/test-utils.tsx
@@ -36,6 +36,7 @@ export function testDomain(
 		blog_id: 113,
 		type: 'mapping',
 		is_wpcom_staging_domain: false,
+		is_hundred_year_domain: false,
 		has_registration: true,
 		registration_date: '2020-03-11T22:23:58+00:00',
 		expiry: '2026-03-11T00:00:00+00:00',


### PR DESCRIPTION
## Proposed Changes

This PR updates the label we show in domains table cell `EXPIRES\RENEWS ON` cell for 100 year domain.

## Why are these changes being made?
Expiration date for 100 year domain is different than their registration subscription expiration. So it's better use a different label that indicates the date doesn't refer to domain expiration date.

## Testing Instructions
This PR depends on WPCOM PR 171673-ghe-Automattic/wpcom

Apply this PR and verify that in the domains list, 100 year domains show `Paid until` label next to the expiration date.

![Markup on 2025-01-30 at 18:21:43](https://github.com/user-attachments/assets/db569c78-3c8f-4255-b0a7-030b2213479d)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?