### PR TITLE
ESLint: Discourage `findDOMNode` usage

### DIFF
--- a/packages/eslint-plugin-wpcalypso/lib/configs/react.js
+++ b/packages/eslint-plugin-wpcalypso/lib/configs/react.js
@@ -21,6 +21,7 @@ module.exports = {
 		'react/no-deprecated': 2,
 		'react/no-did-mount-set-state': 2,
 		'react/no-did-update-set-state': 2,
+		'react/no-find-dom-node': 1,
 		'react/no-is-mounted': 2,
 		'react/no-string-refs': 2,
 		'react/prefer-es6-class': 2,


### PR DESCRIPTION
## Proposed Changes

Trigger ESLint warnings for `findDOMNode` usage.

## Why are these changes being made?

Currently, the browser console in dev mode is cluttered with this kind of errors:

![Screenshot 2025-01-30 at 19 13 56](https://github.com/user-attachments/assets/45457117-a4ff-4866-aaf0-26591239d980)

We need to migrate all `findDOMNode` usages, but since no one is specifically focusing on that right now, enabling a specific warning could help motivate people to fix it so we can crowdsource the effort.

## Testing Instructions

* Run a fresh `yarn install`
* Pick an instance of `findDOMNode` in code and verify you're now getting an ESLint warning.