### PR TITLE
Newsletter: Remove gap in catergory selection

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/style.scss
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/style.scss
@@ -5,7 +5,6 @@
 .newsletter-categories-settings__term-tree-selector {
 	display: flex;
 	flex-direction: column;
-	gap: 24px;
 
 	&.hidden {
 		display: none;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/loop/issues/359

| **Before** | **After** |
| ---------- | ---------- |
| <img width="714" alt="Screenshot 2025-01-30 at 18 38 31" src="https://github.com/user-attachments/assets/6fded964-ee9f-4255-9737-04f97b76b8cb" /> | <img width="717" alt="Screenshot 2025-01-30 at 18 38 45" src="https://github.com/user-attachments/assets/e729f524-2498-4903-bb58-dd302ea432fe" /> |

## Proposed Changes

* Removes gap styling to remove spacing in newsletter category selection card

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Tidy up UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to calypso.live/settings/newsletter/{test site}
* Enable newsletter catergories

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
