### PR TITLE
Hide free plan option with big sky

### DIFF
--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -2,6 +2,7 @@ import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { useBigSkyBeforePlans } from 'calypso/landing/stepper/declarative-flow/helpers/use-bigsky-before-plans-experiment';
 
 const Subheader = styled.p`
 	margin: -32px 0 40px 0;
@@ -112,19 +113,22 @@ const PlansPageSubheader = ( {
 	onFreePlanCTAClick: () => void;
 } ) => {
 	const translate = useTranslate();
+	const [ , isBigSkyBeforePlansExperiment ] = useBigSkyBeforePlans();
 
 	return (
 		<>
 			{ deemphasizeFreePlan && offeringFreePlan ? (
 				<Subheader>
-					{ translate(
-						`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
-						{
-							components: {
-								link: <Button onClick={ onFreePlanCTAClick } borderless />,
-							},
-						}
-					) }
+					{ isBigSkyBeforePlansExperiment
+						? translate( `Unlock a powerful bundle of features.` )
+						: translate(
+								`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
+								{
+									components: {
+										link: <Button onClick={ onFreePlanCTAClick } borderless />,
+									},
+								}
+						  ) }
 				</Subheader>
 			) : (
 				showPlanBenefits && <PlanBenefitHeader />

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -113,7 +113,11 @@ const PlansPageSubheader = ( {
 	onFreePlanCTAClick: () => void;
 } ) => {
 	const translate = useTranslate();
-	const [ , isBigSkyBeforePlansExperiment ] = useBigSkyBeforePlans();
+	const [ isLoading, isBigSkyBeforePlansExperiment ] = useBigSkyBeforePlans();
+
+	if ( isLoading ) {
+		return null;
+	}
 
 	return (
 		<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99082

## Proposed Changes

* We're removing any free plan option from the users when they're choosing Big Sky

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Big Sky doesn't work with Free plan

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [setup onboarding](http://calypso.localhost:3000/setup/onboarding) and select Big Sky as the template option
* Choose a paid domain
* You shouldn't see the `Or start with a free plan CTA` nor free plan option:

![image](https://github.com/user-attachments/assets/1366e3ff-2404-4b4a-9f21-43da7c7ab7e7)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
