### PR TITLE
Stats: add subdivisions tooltip

### DIFF
--- a/client/my-sites/stats/features/modules/stats-locations/country-filter.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/country-filter.tsx
@@ -5,7 +5,8 @@ const CountryFilter: React.FC< {
 	defaultLabel: string;
 	selectedCountry: string | null;
 	onCountryChange: ( value: string ) => void;
-} > = ( { countries, defaultLabel, selectedCountry, onCountryChange } ) => {
+	tooltip?: React.ReactNode;
+} > = ( { countries, defaultLabel, selectedCountry, onCountryChange, tooltip } ) => {
 	const onChange = ( value: string ) => {
 		onCountryChange( value );
 	};
@@ -19,14 +20,16 @@ const CountryFilter: React.FC< {
 	];
 
 	return (
-		<SelectControl
-			__next40pxDefaultSize
-			__nextHasNoMarginBottom
-			className="stats-module-locations__country-filter"
-			onChange={ onChange }
-			options={ options }
-			value={ selectedCountry ?? '' }
-		/>
+		<div className="stats-module-locations__country-filter">
+			<SelectControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				onChange={ onChange }
+				options={ options }
+				value={ selectedCountry ?? '' }
+			/>
+			<div className="stats-module-locations__country-filter--tooltip"> { tooltip } </div>
+		</div>
 	);
 };
 

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -170,6 +170,27 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 		/>
 	);
 
+	const divisionsTooltip = (
+		<StatsInfoArea>
+			{ translate(
+				'Countries and their subdivisions are based on {{link}}ISO 3166{{/link}} standards.',
+				{
+					comment: '{{link}} links to ISO standards.',
+					components: {
+						link: (
+							<a
+								target="_blank"
+								rel="noreferrer"
+								href="https://www.iso.org/maintenance_agencies.html#72482"
+							/>
+						),
+					},
+					context: 'Stats: Link in a popover for Regions/Cities module when the module has data',
+				}
+			) }
+		</StatsInfoArea>
+	);
+
 	const titleTooltip = (
 		<StatsInfoArea>
 			{ translate( 'Stats on visitors and their {{link}}viewing location{{/link}}.', {
@@ -200,9 +221,25 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 		{ label: 'Netherlands', countryCode: 'NL', value: 500, region: '155' },
 		{ label: 'Spain', countryCode: 'ES', value: 400, region: '039' },
 	];
+
 	const hasLocationData = Array.isArray( data ) && data.length > 0;
 
 	const locationData = shouldGate ? fakeData : data;
+
+	const heroElement = (
+		<>
+			<Geochart data={ locationData } geoMode={ geoMode } skipQuery customHeight={ 480 } />
+			{ geoMode !== 'country' && ! summaryUrl && (
+				<CountryFilter
+					countries={ countriesList }
+					defaultLabel={ optionLabels[ selectedOption ].countryFilterLabel }
+					selectedCountry={ countryFilter }
+					onCountryChange={ onCountryChange }
+					tooltip={ divisionsTooltip }
+				/>
+			) }
+		</>
+	);
 
 	return (
 		<>
@@ -236,24 +273,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 						metricLabel={ translate( 'Views' ) }
 						loader={ isRequestingData && <StatsModulePlaceholder isLoading={ isRequestingData } /> }
 						splitHeader
-						heroElement={
-							<>
-								<Geochart
-									data={ locationData }
-									geoMode={ geoMode }
-									skipQuery
-									customHeight={ 480 }
-								/>
-								{ geoMode !== 'country' && ! summaryUrl && (
-									<CountryFilter
-										countries={ countriesList }
-										defaultLabel={ optionLabels[ selectedOption ].countryFilterLabel }
-										selectedCountry={ countryFilter }
-										onCountryChange={ onCountryChange }
-									/>
-								) }
-							</>
-						}
+						heroElement={ heroElement }
 						mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
 						toggleControl={ toggleControlComponent }
 						showMore={

--- a/client/my-sites/stats/features/modules/stats-locations/style.scss
+++ b/client/my-sites/stats/features/modules/stats-locations/style.scss
@@ -27,6 +27,12 @@ $locations-horizontal-bar-width: 380px;
 	.stats-module-locations__country-filter {
 		margin: 12px 24px 0;
 		width: fit-content;
+		display: flex;
+	}
+
+	.stats-module-locations__country-filter--tooltip {
+		margin-left: 12px;
+		margin-top: 8px;
 	}
 
 	.stats-card__content {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/jetpack-roadmap#2214.

## Proposed Changes

* Add tooltip specifying the source for countries subdivisions.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* (p1HpG7-rpL-p2)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Access the Calypso Live preview linked below.
- Go to the locations/summary page, like `/stats/day/locations/jetpack.com`
- Ensure there's a tooltip right beside the country filter dropdown for both `Regions` and `Cities`.

| Before | After |
| - | - |
| <img alt="image" src="https://github.com/user-attachments/assets/217359a8-3742-497e-b070-de34e4482a41" /> | <img alt="image" src="https://github.com/user-attachments/assets/d4270658-d5a0-4d83-8c8b-967fe2ff1414" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
