### PR TITLE
Components: Remove `react-click-outside` in favor of `withFocusOutside`

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1133,32 +1133,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
-## <https://github.com/kentor/react-click-outside>
-
-```
-The MIT License (MIT)
-
-Copyright (c) 2015 Kenneth Chung
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
-
 ## <https://github.com/guille/ms.js>
 
 ```text

--- a/client/components/text-control/index.js
+++ b/client/components/text-control/index.js
@@ -1,7 +1,7 @@
 import { FormLabel } from '@automattic/components';
+import { withFocusOutside } from '@wordpress/components';
 import clsx from 'clsx';
 import { Component } from 'react';
-import wrapWithClickOutside from 'react-click-outside';
 
 /*
  * This component is temporary until we can pull in `@wordpress/components` and merge https://github.com/Automattic/wp-calypso/pull/34277.
@@ -13,7 +13,7 @@ class MurielTextControl extends Component {
 		isFocused: false,
 	};
 
-	handleClickOutside() {
+	handleFocusOutside() {
 		this.setState( { isFocused: false } );
 	}
 
@@ -87,4 +87,4 @@ class MurielTextControl extends Component {
 	}
 }
 
-export default wrapWithClickOutside( MurielTextControl );
+export default withFocusOutside( MurielTextControl );

--- a/client/my-sites/picker/index.jsx
+++ b/client/my-sites/picker/index.jsx
@@ -1,6 +1,6 @@
+import { withFocusOutside } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import wrapWithClickOutside from 'react-click-outside';
 import { connect } from 'react-redux';
 import CloseOnEscape from 'calypso/components/close-on-escape';
 import SiteSelector from 'calypso/components/site-selector';
@@ -85,7 +85,7 @@ class SitePicker extends Component {
 		}
 	};
 
-	handleClickOutside = () => {
+	handleFocusOutside = () => {
 		this.closePicker( null );
 	};
 
@@ -127,5 +127,5 @@ function mapStateToProps( state ) {
 }
 
 export default connect( mapStateToProps, { setNextLayoutFocus, setLayoutFocus } )(
-	wrapWithClickOutside( SitePicker )
+	withFocusOutside( SitePicker )
 );

--- a/client/package.json
+++ b/client/package.json
@@ -183,7 +183,6 @@
 		"qrcode.react": "^3.1.0",
 		"qs": "^6.9.1",
 		"react": "^18.3.1",
-		"react-click-outside": "^3.0.1",
 		"react-day-picker": "^7.4.10",
 		"react-dom": "^18.3.1",
 		"react-element-to-jsx-string": "^15.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13245,7 +13245,6 @@ __metadata:
     qrcode.react: "npm:^3.1.0"
     qs: "npm:^6.9.1"
     react: "npm:^18.3.1"
-    react-click-outside: "npm:^3.0.1"
     react-day-picker: "npm:^7.4.10"
     react-dom: "npm:^18.3.1"
     react-element-to-jsx-string: "npm:^15.0.0"
@@ -20021,13 +20020,6 @@ __metadata:
     minimalistic-assert: "npm:^1.0.0"
     minimalistic-crypto-utils: "npm:^1.0.1"
   checksum: f3d9ba31b40257a573f162176ac5930109816036c59a09f901eb2ffd7e5e705c6832bedfff507957125f2086a0ab8f853c0df225642a88bf1fcaea945f20600d
-  languageName: node
-  linkType: hard
-
-"hoist-non-react-statics@npm:^2.1.1":
-  version: 2.5.5
-  resolution: "hoist-non-react-statics@npm:2.5.5"
-  checksum: 79c204446a61ad490cc9342b2deeedea5a17f03a5fc091f367b6c08f29387c8d5578634ebfb8733043422a5e1182b372893d63f8737ac4b75da3a2ec4a316162
   languageName: node
   linkType: hard
 
@@ -28206,15 +28198,6 @@ __metadata:
     react: ^0.14.0 || ^15.0.0 || ^16.0.0
     react-dom: ^0.14.0 || ^15.0.0 || ^16.0.0
   checksum: 3b791f2455808682241c9fc00cccce31804cb696c489a4800cd124fce8be6b624a4c21836e06568b6d7d45b6a8e4945460249c77235990ce015f9899cda10a7f
-  languageName: node
-  linkType: hard
-
-"react-click-outside@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "react-click-outside@npm:3.0.1"
-  dependencies:
-    hoist-non-react-statics: "npm:^2.1.1"
-  checksum: fd7c5c9984bcd1eb6214b5e180aa38dda1dce2cb5286a8ee57b84be2e4821a51eb791c275ebef345c23a010d3f026617c345fbb520bfb3babbc55fdbd08f244d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed Changes

Removing `react-click-outside` in favor of `withFocusOutside`.

There seem to be some further cleanup opportunities here, but I'll leave them for another, less-convoluted-to-test PR.

## Why are these changes being made?

While chasing where the first `findDOMNode` error comes from, I found that it comes from the `react-click-outside` package, and I realized we can replace that package completely with `withFocusOutside` from `@wordpress/components`. We only need to rename the method. See how it was done in Gutenberg: https://github.com/WordPress/gutenberg/pull/16878

So, 3 good reasons:
- Getting rid of an `findDOMNode` instance
- Removing an old, unmaintained package
- Reusing existing bundled functionality instead of 3rd party packages.

## Testing Instructions

* Bear with me and spin up a local Calypso instance 😅 
* Use case 1:
  * Start as a logged-out user.
  * Go to `http://calypso.localhost:3000/jetpack/connect/authorize?from=woocommerce-onboarding&_wp_nonce=foobar&blogname=Just%20Another%20WordPress.com%20Site&client_id=12345&close_window_after_login=0&close_window_after_auth=0&home_url=https://yourjetpack.blog&redirect_uri=https://yourjetpack.blog/wp-admin/admin.php&scope=administrator:34579bf2a3185a47d1b31aab30125d&secret=640fdbd69f96a8ca9e61&site=https://yourjetpack.blog&site_url=https://yourjetpack.blog&state=1&allow_site_connection=1&installed_ext_success=1&` in order to simulate the "Woo onboarding" version of the Jetpack Connect signup form.
  * Verify that as you focus the email field, its great-parent element receives `active` class.
  * Verify that as you blur the email field, its great-parent element loses the `active` class.
* Use case 2 (note that we're exploiting this one a bit):
  * Apply this diff:
```diff
diff --git a/client/my-sites/customer-home/main.tsx b/client/my-sites/customer-home/main.tsx
index d9e5e9c2a8d..7e34331320d 100644
--- a/client/my-sites/customer-home/main.tsx
+++ b/client/my-sites/customer-home/main.tsx
@@ -7,9 +7,13 @@ import shouldShowLaunchpadFirst from 'calypso/state/selectors/should-show-launch
 import { FullScreenLaunchpad } from './components/full-screen-launchpad';
 import HomeContent from './components/home-content';
 import type { SiteDetails } from '@automattic/data-stores';
+import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
+import { useDispatch } from 'calypso/state';

 export default function CustomerHome( { site }: { site: SiteDetails } ) {
        const showLaunchpadFirst = shouldShowLaunchpadFirst( site );
+       const dispatch = useDispatch();
+       dispatch( setLayoutFocus( 'sites' ) );

        const isSiteLaunched = site?.launch_status === 'launched' || false;
```
  * Go to `/home/:site`
  * You should see the site selector expanded in a broken way on the left side of the sidebar. Don't worry about it too much.
  * Click outside of the site selector, for example somewhere in the right area of your screen (the white)
  * Verify that the site selector still closes.
* Use case 3
  * Nope, there's no case 3. Thank you for reaching the end and for testing thoroughly 🙇 