### PR TITLE
Reader: fix broken back navigation when mounting reader onboarding

### DIFF
--- a/client/reader/onboarding/index.tsx
+++ b/client/reader/onboarding/index.tsx
@@ -125,17 +125,16 @@ const ReaderOnboarding = ( {
 
 	// Reopen subscription onboarding page if prompted by query param.
 	useEffect( () => {
-		const params = new URLSearchParams( window.location.search );
-		const loadSubsStep = params.get( 'reloadSubscriptionOnboarding' );
-		if ( loadSubsStep ) {
+		const urlParams = new URLSearchParams( window.location.search );
+		const shouldReloadOnboarding = urlParams.has( 'reloadSubscriptionOnboarding' );
+
+		if ( shouldReloadOnboarding ) {
 			openDiscoverModal();
+			urlParams.delete( 'reloadSubscriptionOnboarding' );
+			page.redirect(
+				`${ window.location.pathname }${ urlParams.toString() ? '?' + urlParams.toString() : '' }`
+			);
 		}
-		params.delete( 'reloadSubscriptionOnboarding' );
-		window.history.replaceState(
-			{},
-			'',
-			`${ window.location.pathname }${ params.toString() ? '?' + params.toString() : '' }`
-		);
 	}, [] );
 
 	// Notify the parent component if onboarding will render.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

When working on reproducing Automattic/wp-calypso#98359, I discovered a similar but unrelated bug that was introduced in Automattic/wp-calypso#98679 where the browser's history state gets reset when the `<ReaderOnboarding/>` component mounts. This component mounts whenever the "stream" view of the Reader Recent feed is loaded, whether it's rendered or not. This causes the browser's back navigation to break whenever a user visited the recent stream view at `/read`.

https://github.com/user-attachments/assets/06d14dc8-d590-4ce0-8fae-42a3ce596784


## Proposed Changes

- Rework the `useEffect` callback logic to only update the router state when the related query param is present
- Use `page.redirect` instead of `history.replaceState` so this navigation is using the router library directly. This should have the same effect as `replaceState` but we don't have to worry about manually copying over state. Docs for that method here: https://visionmedia.github.io/page.js/#pageredirectpath

https://github.com/user-attachments/assets/1e995ba0-5f8f-4134-acf5-2c1d92adce89


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix back navigation when using the Reader

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/read` with a new user so onboarding is shown. Make sure you are viewing the "stream" view.
* Ensure there's no regression in functionality added in Automattic/wp-calypso#98679.
* Use the Reader normally and ensure the back button in the browser chrome and the Reader UI works as expected.
  * Specifically navigate to `/read` with the stream view active.
  * Click on a post, site feed link, or user icon to navigate away from the recent feed
  * Click the browser back button or Reader "back" UI button 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
