### PR TITLE
Add copy for Bi Sky design selection + free plan modal to get translation package in time

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -1,6 +1,7 @@
 import { isWooExpressFlow } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
+import { useTranslate } from 'i18n-calypso';
 import React, { lazy, useEffect } from 'react';
 import Modal from 'react-modal';
 import { generatePath, useParams } from 'react-router';
@@ -89,6 +90,20 @@ export const FlowRenderer: React.FC< { flow: Flow; steps: readonly StepperStep[]
 
 	const { __ } = useI18n();
 	useSaveQueryParams();
+
+	const translate = useTranslate();
+	const __copyToTranslate = [
+		// new design selection strings
+		__( 'Start with a theme' ),
+		__( 'Choose a professionally designed theme and make it yours.' ),
+		translate( 'Create with AI {{small}}(BETA){{/small}}', {
+			components: { small: <small></small> },
+		} ),
+		__( 'Use our AI Website Builder to quickly and easily create the site of your dreams.' ),
+
+		// new free plan modal
+		__( 'Our AI Website Builder is only available with a paid plan' ),
+	];
 
 	const { site, siteSlugOrId } = useSiteData();
 

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -1,4 +1,5 @@
 import { isWooExpressFlow } from '@automattic/onboarding';
+import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
@@ -103,6 +104,14 @@ export const FlowRenderer: React.FC< { flow: Flow; steps: readonly StepperStep[]
 
 		// new free plan modal
 		__( 'Our AI Website Builder is only available with a paid plan' ),
+		translate(
+			`Build your site quickly with our AI Website Builder or {{link}}start with a free plan{{/link}}.`,
+			{
+				components: {
+					link: <Button />,
+				},
+			}
+		),
 	];
 
 	const { site, siteSlugOrId } = useSiteData();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99120

## Proposed Changes

* We're anticipating strings translation. Adding `[Status] String Freeze` is enough to get the translation process started.

- [x] Add new modal strings

![Image](https://github.com/user-attachments/assets/cee59b78-f98c-45e8-8f5e-70ab02d88a4e)


- [x] Add [update screen strings](https://github.com/Automattic/wp-calypso/issues/99026)

![Image](https://github.com/user-attachments/assets/ed5c2446-9e9f-4618-a376-de95aff6183a)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure we have all the strings we need
