### PR TITLE
Revert "Site Migration: Send `from` query param to the Atomic transfer API to be set on the back end"

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
@@ -58,7 +58,7 @@ describe( 'SiteMigrationIdentify', () => {
 		restoreIsMigrationExperimentEnabled();
 	} );
 
-	it( 'continues the flow when the platform is wordpress', async () => {
+	it( 'continues the flow and saves the migration domain when the platform is wordpress', async () => {
 		useSiteSlug.mockReturnValue( MOCK_WORDPRESS_SITE_SLUG );
 
 		const submit = jest.fn();
@@ -68,6 +68,15 @@ describe( 'SiteMigrationIdentify', () => {
 			.get( '/wpcom/v2/imports/analyze-url' )
 			.query( { site_url: 'https://example.com' } )
 			.reply( 200, API_RESPONSE_WORDPRESS_PLATFORM );
+
+		const saveSettingsMock = mockApi()
+			.post(
+				`/rest/v1.4/sites/${ MOCK_WORDPRESS_SITE_SLUG }/settings`,
+				JSON.stringify( { migration_source_site_domain: API_RESPONSE_WORDPRESS_PLATFORM.url } )
+			)
+			.reply( 200, {
+				updated: { migration_source_site_domain: API_RESPONSE_WORDPRESS_PLATFORM.url },
+			} );
 
 		await userEvent.type( getInput(), 'https://example.com' );
 
@@ -80,6 +89,7 @@ describe( 'SiteMigrationIdentify', () => {
 					from: API_RESPONSE_WORDPRESS_PLATFORM.url,
 				} )
 			);
+			expect( saveSettingsMock.isDone() ).toBeTruthy();
 		} );
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -106,7 +106,7 @@ const SiteMigrationInstructions: Step = function ( { navigation, flow } ) {
 		completed: preparationCompleted,
 		error: preparationError,
 		migrationKey,
-	} = usePrepareSiteForMigration( siteId, fromUrl );
+	} = usePrepareSiteForMigration( siteId );
 
 	const migrationKeyStatus = detailedStatus.migrationKey;
 

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -266,7 +266,6 @@ const siteMigration: Flow = {
 							{
 								siteId,
 								siteSlug,
-								from: fromQueryParam,
 							},
 							STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug
 						)
@@ -348,7 +347,6 @@ const siteMigration: Flow = {
 							stepName: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
 							siteSlug: siteSlug,
 							destination: destination,
-							from: fromQueryParam ?? undefined,
 							plan: providedDependencies.plan as string,
 							cancelDestination: `/setup/${ flowPath }/${
 								STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -525,7 +525,6 @@ describe( 'Site Migration Flow', () => {
 					destination: `/setup/site-migration/${ STEPS.SITE_MIGRATION_INSTRUCTIONS.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com`,
 					extraQueryParams: { hosting_intent: HOSTING_INTENT_MIGRATE },
 					flowName: 'site-migration',
-					from: 'https://site-to-be-migrated.com',
 					siteSlug: 'example.wordpress.com',
 					stepName: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
 					cancelDestination: `/setup/site-migration/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com`,

--- a/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
+++ b/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
@@ -141,9 +141,9 @@ const useTransferTimeTracking = (
  *  Hook to manage the site to prepare a site for migration.
  *  This hook manages the site transfer, plugin installation and migration key fetching.
  */
-export const usePrepareSiteForMigration = ( siteId?: number, from?: string ) => {
+export const usePrepareSiteForMigration = ( siteId?: number ) => {
 	const plugin = { name: 'wpcom-migration/wpcom_migration', slug: 'wpcom-migration' };
-	const siteTransferState = useSiteTransfer( siteId, { from } );
+	const siteTransferState = useSiteTransfer( siteId );
 	const pluginInstallationState = usePluginAutoInstallation( plugin, siteId, {
 		enabled: Boolean( siteTransferState.completed ),
 	} );

--- a/client/landing/stepper/hooks/use-site-transfer/index.ts
+++ b/client/landing/stepper/hooks/use-site-transfer/index.ts
@@ -4,7 +4,7 @@ import { useSiteTransferMutation } from './mutation';
 import { useSiteTransferStatusQuery } from './query';
 
 type Status = 'idle' | 'pending' | 'success' | 'error';
-type Options = Pick< UseQueryOptions, 'retry' > & { from?: string };
+type Options = Pick< UseQueryOptions, 'retry' >;
 
 /**
  * Hook to initiate a site transfer and monitor its progress

--- a/client/landing/stepper/hooks/use-site-transfer/mutation.ts
+++ b/client/landing/stepper/hooks/use-site-transfer/mutation.ts
@@ -9,21 +9,17 @@ interface InitiateAtomicTransferResponse {
 	atomic_transfer_id: string;
 }
 
-const startTransfer = (
-	siteId: number,
-	from?: string
-): Promise< InitiateAtomicTransferResponse > =>
+const startTransfer = ( siteId: number ): Promise< InitiateAtomicTransferResponse > =>
 	wpcom.req.post( {
 		path: `/sites/${ siteId }/atomic/transfers`,
 		apiNamespace: 'wpcom/v2',
 		body: {
 			context: 'unknown',
 			transfer_intent: 'migrate',
-			migration_source_site_domain: from,
 		},
 	} );
 
-type Options = Pick< UseMutationOptions, 'retry' > & { from?: string };
+type Options = Pick< UseMutationOptions, 'retry' >;
 /**
  *  Mutation hook to initiate a site transfer
  */
@@ -31,9 +27,7 @@ export const useSiteTransferMutation = ( siteId?: number, options?: Options ) =>
 	const query = useQueryClient();
 
 	const mutation = () =>
-		siteId
-			? startTransfer( siteId, options?.from )
-			: Promise.reject( new Error( 'siteId is required' ) );
+		siteId ? startTransfer( siteId ) : Promise.reject( new Error( 'siteId is required' ) );
 
 	const refreshSiteStatus = ( data: InitiateAtomicTransferResponse ) => {
 		query.setQueryData( getSiteTransferStatusQueryKey( siteId! ), data );

--- a/client/landing/stepper/utils/checkout.ts
+++ b/client/landing/stepper/utils/checkout.ts
@@ -11,7 +11,6 @@ interface GoToCheckoutProps {
 	stepName: string;
 	siteSlug: string;
 	destination: string;
-	from?: string;
 	plan?: string;
 	cancelDestination?: string;
 	extraProducts?: string[];


### PR DESCRIPTION
Reverts Automattic/wp-calypso#98938 

e2e tests are failing and I want to be 100% sure these changes did not impact them.