### PR TITLE
Allow users to change their minds about Big Sky on the plans page

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
@@ -16,6 +16,7 @@ type Props = {
 	paidDomainName?: string | null;
 	intent?: string | null;
 	selectedThemeType?: string;
+	createWithBigSky?: boolean;
 };
 
 /**
@@ -27,6 +28,7 @@ export function useModalResolutionCallback( {
 	paidDomainName,
 	intent,
 	selectedThemeType,
+	createWithBigSky,
 }: Props ) {
 	return useCallback(
 		( currentSelectedPlan?: string | null ): ModalType | null => {
@@ -45,6 +47,10 @@ export function useModalResolutionCallback( {
 				return FREE_PLAN_FREE_DOMAIN_DIALOG;
 			}
 
+			if ( createWithBigSky && ONBOARDING_FLOW === flowName ) {
+				return PAID_PLAN_IS_REQUIRED_DIALOG;
+			}
+
 			// TODO: look into decoupling the flowName from here as well.
 			if (
 				paidDomainName &&
@@ -58,6 +64,13 @@ export function useModalResolutionCallback( {
 
 			return null;
 		},
-		[ isCustomDomainAllowedOnFreePlan, flowName, paidDomainName, intent, selectedThemeType ]
+		[
+			isCustomDomainAllowedOnFreePlan,
+			flowName,
+			paidDomainName,
+			intent,
+			selectedThemeType,
+			createWithBigSky,
+		]
 	);
 }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
@@ -1,8 +1,11 @@
 import { LoadingPlaceholder } from '@automattic/components';
+import { type OnboardSelect } from '@automattic/data-stores';
 import { FREE_THEME } from '@automattic/design-picker';
 import { PlanButton } from '@automattic/plans-grid-next';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getHidePlanPropsBasedOnThemeType } from '../utils/utils';
 import { ButtonContainer, DialogContainer, Heading, Row } from './components';
@@ -21,6 +24,11 @@ export const PaidPlanIsRequiredDialog = ( {
 	const [ isBusy, setIsBusy ] = useState( false );
 	const isPaidTheme = selectedThemeType && selectedThemeType !== FREE_THEME;
 	const hidePlanProps = getHidePlanPropsBasedOnThemeType( selectedThemeType || '' );
+	const { setCreateWithBigSky } = useDispatch( ONBOARD_STORE );
+	const createWithBigSky = useSelect( ( select: ( key: string ) => OnboardSelect ) => {
+		const { getCreateWithBigSky } = select( ONBOARD_STORE );
+		return getCreateWithBigSky();
+	}, [] );
 
 	const getUpsellTitle = () => {
 		if ( isPaidTheme && paidDomainName ) {
@@ -31,12 +39,24 @@ export const PaidPlanIsRequiredDialog = ( {
 			return translate( 'Premium themes are only available with a paid plan' );
 		}
 
+		if ( createWithBigSky && paidDomainName ) {
+			return translate( 'Domains and our AI Website Builder are only available with a paid plan' );
+		}
+
+		if ( createWithBigSky ) {
+			return translate( 'Our AI Website Builder is only available with a paid plan' );
+		}
+
 		return translate( 'Custom domains are only available with a paid plan' );
 	};
 
 	const handleFreeDomainClick = () => {
 		setIsBusy( true );
 		onFreePlanSelected();
+
+		if ( createWithBigSky ) {
+			setCreateWithBigSky( false );
+		}
 	};
 
 	useEffect( () => {

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-paid-domain-dialog.tsx
@@ -48,15 +48,21 @@ export function PaidPlanPaidDomainDialog( {
 		}
 	}
 
-	const upsellDescription = translate(
-		"Custom domains are only available with a paid plan. Choose annual billing and receive the domain's first year free."
-	);
+	const upsellDescription = createWithBigSky
+		? ''
+		: translate(
+				"Custom domains are only available with a paid plan. Choose annual billing and receive the domain's first year free."
+		  );
+
+	const bigSkyHeader = paidDomainName
+		? translate( 'Domains and our AI Website Builder are only available with a paid plan' )
+		: translate( 'Our AI Website Builder is only available with a paid plan' );
 
 	return (
 		<DialogContainer>
 			<Heading id="plan-upsell-modal-title" shrinkMobileFont>
 				{ createWithBigSky
-					? translate( 'Our AI Website Builder is only available with a paid plan' )
+					? bigSkyHeader
 					: translate( 'A paid plan is required for your domain.' ) }
 			</Heading>
 			<SubHeading id="plan-upsell-modal-description">{ upsellDescription }</SubHeading>

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-paid-domain-dialog.tsx
@@ -1,7 +1,10 @@
 import { LoadingPlaceholder } from '@automattic/components';
+import { OnboardSelect } from '@automattic/data-stores';
 import { PlanButton } from '@automattic/plans-grid-next';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	ButtonContainer,
@@ -21,6 +24,12 @@ export function PaidPlanPaidDomainDialog( {
 	onFreePlanSelected,
 	onPlanSelected,
 }: DomainPlanDialogProps ) {
+	const { setCreateWithBigSky } = useDispatch( ONBOARD_STORE );
+	const createWithBigSky = useSelect( ( select: ( key: string ) => OnboardSelect ) => {
+		const { getCreateWithBigSky } = select( ONBOARD_STORE );
+		return getCreateWithBigSky();
+	}, [] );
+
 	const translate = useTranslate();
 	const [ isBusy, setIsBusy ] = useState( false );
 
@@ -33,6 +42,10 @@ export function PaidPlanPaidDomainDialog( {
 	function handleFreeDomainClick() {
 		setIsBusy( true );
 		onFreePlanSelected();
+
+		if ( createWithBigSky ) {
+			setCreateWithBigSky( false );
+		}
 	}
 
 	const upsellDescription = translate(
@@ -42,7 +55,9 @@ export function PaidPlanPaidDomainDialog( {
 	return (
 		<DialogContainer>
 			<Heading id="plan-upsell-modal-title" shrinkMobileFont>
-				{ translate( 'A paid plan is required for your domain.' ) }
+				{ createWithBigSky
+					? translate( 'Our AI Website Builder is only available with a paid plan' )
+					: translate( 'A paid plan is required for your domain.' ) }
 			</Heading>
 			<SubHeading id="plan-upsell-modal-description">{ upsellDescription }</SubHeading>
 			<ButtonContainer>

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-paid-domain-dialog.tsx
@@ -1,10 +1,7 @@
 import { LoadingPlaceholder } from '@automattic/components';
-import { OnboardSelect } from '@automattic/data-stores';
 import { PlanButton } from '@automattic/plans-grid-next';
-import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	ButtonContainer,
@@ -24,12 +21,6 @@ export function PaidPlanPaidDomainDialog( {
 	onFreePlanSelected,
 	onPlanSelected,
 }: DomainPlanDialogProps ) {
-	const { setCreateWithBigSky } = useDispatch( ONBOARD_STORE );
-	const createWithBigSky = useSelect( ( select: ( key: string ) => OnboardSelect ) => {
-		const { getCreateWithBigSky } = select( ONBOARD_STORE );
-		return getCreateWithBigSky();
-	}, [] );
-
 	const translate = useTranslate();
 	const [ isBusy, setIsBusy ] = useState( false );
 
@@ -42,28 +33,16 @@ export function PaidPlanPaidDomainDialog( {
 	function handleFreeDomainClick() {
 		setIsBusy( true );
 		onFreePlanSelected();
-
-		if ( createWithBigSky ) {
-			setCreateWithBigSky( false );
-		}
 	}
 
-	const upsellDescription = createWithBigSky
-		? ''
-		: translate(
-				"Custom domains are only available with a paid plan. Choose annual billing and receive the domain's first year free."
-		  );
-
-	const bigSkyHeader = paidDomainName
-		? translate( 'Domains and our AI Website Builder are only available with a paid plan' )
-		: translate( 'Our AI Website Builder is only available with a paid plan' );
+	const upsellDescription = translate(
+		"Custom domains are only available with a paid plan. Choose annual billing and receive the domain's first year free."
+	);
 
 	return (
 		<DialogContainer>
 			<Heading id="plan-upsell-modal-title" shrinkMobileFont>
-				{ createWithBigSky
-					? bigSkyHeader
-					: translate( 'A paid plan is required for your domain.' ) }
+				{ translate( 'A paid plan is required for your domain.' ) }
 			</Heading>
 			<SubHeading id="plan-upsell-modal-description">{ upsellDescription }</SubHeading>
 			<ButtonContainer>

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -1,7 +1,10 @@
 import { Button, Gridicon } from '@automattic/components';
+import { OnboardSelect } from '@automattic/data-stores';
 import styled from '@emotion/styled';
+import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 
 const Subheader = styled.p`
 	margin: -32px 0 40px 0;
@@ -113,18 +116,32 @@ const PlansPageSubheader = ( {
 } ) => {
 	const translate = useTranslate();
 
+	const createWithBigSky = useSelect( ( select: ( key: string ) => OnboardSelect ) => {
+		const { getCreateWithBigSky } = select( ONBOARD_STORE );
+		return getCreateWithBigSky();
+	}, [] );
+
 	return (
 		<>
 			{ deemphasizeFreePlan && offeringFreePlan ? (
 				<Subheader>
-					{ translate(
-						`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
-						{
-							components: {
-								link: <Button onClick={ onFreePlanCTAClick } borderless />,
-							},
-						}
-					) }
+					{ createWithBigSky
+						? translate(
+								`Build your site quickly with our AI Website Builder or {{link}}start with a free plan{{/link}}.`,
+								{
+									components: {
+										link: <Button onClick={ onFreePlanCTAClick } borderless />,
+									},
+								}
+						  )
+						: translate(
+								`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
+								{
+									components: {
+										link: <Button onClick={ onFreePlanCTAClick } borderless />,
+									},
+								}
+						  ) }
 				</Subheader>
 			) : (
 				showPlanBenefits && <PlanBenefitHeader />

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -123,25 +123,28 @@ const PlansPageSubheader = ( {
 
 	return (
 		<>
-			{ deemphasizeFreePlan && offeringFreePlan ? (
+			{ createWithBigSky && (
 				<Subheader>
-					{ createWithBigSky
-						? translate(
-								`Build your site quickly with our AI Website Builder or {{link}}start with a free plan{{/link}}.`,
-								{
-									components: {
-										link: <Button onClick={ onFreePlanCTAClick } borderless />,
-									},
-								}
-						  )
-						: translate(
-								`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
-								{
-									components: {
-										link: <Button onClick={ onFreePlanCTAClick } borderless />,
-									},
-								}
-						  ) }
+					{ translate(
+						`Build your site quickly with our AI Website Builder or {{link}}start with a free plan{{/link}}.`,
+						{
+							components: {
+								link: <Button onClick={ onFreePlanCTAClick } borderless />,
+							},
+						}
+					) }
+				</Subheader>
+			) }
+			{ ! createWithBigSky && deemphasizeFreePlan && offeringFreePlan ? (
+				<Subheader>
+					{ translate(
+						`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
+						{
+							components: {
+								link: <Button onClick={ onFreePlanCTAClick } borderless />,
+							},
+						}
+					) }
 				</Subheader>
 			) : (
 				showPlanBenefits && <PlanBenefitHeader />

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -20,7 +20,7 @@ import {
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
-import { WpcomPlansUI, AddOns, Plans } from '@automattic/data-stores';
+import { WpcomPlansUI, AddOns, Plans, OnboardSelect } from '@automattic/data-stores';
 import { isAnyHostingFlow, isOnboardingGuidedFlow } from '@automattic/onboarding';
 import {
 	FeaturesGrid,
@@ -32,7 +32,7 @@ import {
 } from '@automattic/plans-grid-next';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import styled from '@emotion/styled';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	useCallback,
 	useEffect,
@@ -50,6 +50,7 @@ import QueryActivePromotions from 'calypso/components/data/query-active-promotio
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySites from 'calypso/components/data/query-sites';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
@@ -248,12 +249,20 @@ const PlansFeaturesMain = ( {
 
 	const longerPlanTermDefaultExperiment = useLongerPlanTermDefaultExperiment( flowName );
 
+	const { createWithBigSky } = useSelect(
+		( select ) => ( {
+			createWithBigSky: ( select( ONBOARD_STORE ) as OnboardSelect ).getCreateWithBigSky(),
+		} ),
+		[]
+	);
+
 	const resolveModal = useModalResolutionCallback( {
 		isCustomDomainAllowedOnFreePlan,
 		flowName,
 		paidDomainName,
 		intent: intentFromProps,
 		selectedThemeType,
+		createWithBigSky,
 	} );
 
 	const toggleShowPlansComparisonGrid = () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99085

## Proposed Changes

### Plan page Header changes

* Big Sky + paid/free domain, the plans page shows a custom subtitle text:

![image](https://github.com/user-attachments/assets/da7a3736-fc49-410b-b98a-9e6b838a4740)


* No Big Sky + paid domain = Current behavior:

![image](https://github.com/user-attachments/assets/b2f102d6-e33e-448c-a2fb-f4505f8f0655)


* No Big Sky + free domain = Current behavior:

![image](https://github.com/user-attachments/assets/ae6b1645-133e-4db9-9a2f-cfca6bc332d4)


### Modal changes

* Big sky + free domain + `Start with a free plan`: Will show this modal:

![CleanShot 2025-01-31 at 16 17 01@2x](https://github.com/user-attachments/assets/29d13dfa-06c2-45eb-896e-401b31aa618e)

* Big sky + paid domain + `Start with a free plan`: Will show this modal:

![CleanShot 2025-01-31 at 16 17 51@2x](https://github.com/user-attachments/assets/e1b763c5-05e3-43c7-b7e1-c8c5eb445954)

* No Big sky + paid domain = current behavior (title + subtitle):

![image](https://github.com/user-attachments/assets/54659699-67e5-4c8a-9ea7-3e41f852766c)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Select the Big Sky option
2. Select a paid domain
3. Check that on the plans page, we have a custom subtitle for Big Sky
5. Click con `Start with a free plan`
6. Check that we have a custom modal title
7. Click on `Continue with a free plan`
8. Make sure the user goes to launchpad instead of checkout/Big Sky and has a free plan


https://github.com/user-attachments/assets/097bff2c-e9f7-42dc-8d6d-10fe84f8ef67





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
