### PR TITLE
Site Migration: Persist `from` param through flow, pass to Atomic transfer API

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -9,7 +9,6 @@ import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-q
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import wpcom from 'calypso/lib/wp';
 import { GUIDED_ONBOARDING_FLOW_REFERRER } from 'calypso/signup/steps/initial-intent/constants';
 import { useMigrationExperiment } from '../../hooks/use-migration-experiment';
 import { useSitePreviewMShotImageHandler } from '../site-migration-instructions/site-preview/hooks/use-site-preview-mshot-image-handler';
@@ -193,18 +192,6 @@ export const Analyzer: FC< Props > = ( {
 
 export type SiteMigrationIdentifyAction = 'continue' | 'skip_platform_identification';
 
-const saveSiteSettings = async ( siteSlug: string, settings: Record< string, unknown > ) => {
-	return wpcom.req.post(
-		`/sites/${ siteSlug }/settings`,
-		{
-			apiVersion: '1.4',
-		},
-		{
-			...settings,
-		}
-	);
-};
-
 const SiteMigrationIdentify: Step = function ( { navigation, variantSlug, flow } ) {
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
@@ -212,12 +199,6 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug, flow }
 
 	const handleSubmit = useCallback(
 		async ( action: SiteMigrationIdentifyAction, data?: { platform: string; from: string } ) => {
-			// If we have a site and URL, and we're coming from a WordPress site,
-			// record the migration source domain.
-			if ( siteSlug && 'wordpress' === data?.platform && data?.from ) {
-				await saveSiteSettings( siteSlug, { migration_source_site_domain: data.from } );
-			}
-
 			// If we have a URL of the source, we send requests to the mShots API to create screenshots
 			// early in the flow to avoid long loading times in the migration instructions step.
 			// Because mShots API can often take a long time to generate screenshots.

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
@@ -58,7 +58,7 @@ describe( 'SiteMigrationIdentify', () => {
 		restoreIsMigrationExperimentEnabled();
 	} );
 
-	it( 'continues the flow and saves the migration domain when the platform is wordpress', async () => {
+	it( 'continues the flow when the platform is wordpress', async () => {
 		useSiteSlug.mockReturnValue( MOCK_WORDPRESS_SITE_SLUG );
 
 		const submit = jest.fn();
@@ -68,15 +68,6 @@ describe( 'SiteMigrationIdentify', () => {
 			.get( '/wpcom/v2/imports/analyze-url' )
 			.query( { site_url: 'https://example.com' } )
 			.reply( 200, API_RESPONSE_WORDPRESS_PLATFORM );
-
-		const saveSettingsMock = mockApi()
-			.post(
-				`/rest/v1.4/sites/${ MOCK_WORDPRESS_SITE_SLUG }/settings`,
-				JSON.stringify( { migration_source_site_domain: API_RESPONSE_WORDPRESS_PLATFORM.url } )
-			)
-			.reply( 200, {
-				updated: { migration_source_site_domain: API_RESPONSE_WORDPRESS_PLATFORM.url },
-			} );
 
 		await userEvent.type( getInput(), 'https://example.com' );
 
@@ -89,7 +80,6 @@ describe( 'SiteMigrationIdentify', () => {
 					from: API_RESPONSE_WORDPRESS_PLATFORM.url,
 				} )
 			);
-			expect( saveSettingsMock.isDone() ).toBeTruthy();
 		} );
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -105,11 +105,7 @@ const SiteMigrationInstructions: Step = function ( { navigation, flow } ) {
 		completed: preparationCompleted,
 		error: preparationError,
 		migrationKey,
-<<<<<<< HEAD
-	} = usePrepareSiteForMigration( siteId, { retry: 10 } );
-=======
-	} = usePrepareSiteForMigration( siteId, fromUrl );
->>>>>>> d49643294d4 (Pass fromUrl param through flow, pass to Atomic transfer API)
+	} = usePrepareSiteForMigration( siteId, fromUrl, { retry: 10 } );
 
 	const migrationKeyStatus = detailedStatus.migrationKey;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -105,7 +105,11 @@ const SiteMigrationInstructions: Step = function ( { navigation, flow } ) {
 		completed: preparationCompleted,
 		error: preparationError,
 		migrationKey,
+<<<<<<< HEAD
 	} = usePrepareSiteForMigration( siteId, { retry: 10 } );
+=======
+	} = usePrepareSiteForMigration( siteId, fromUrl );
+>>>>>>> d49643294d4 (Pass fromUrl param through flow, pass to Atomic transfer API)
 
 	const migrationKeyStatus = detailedStatus.migrationKey;
 

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -269,6 +269,7 @@ const siteMigration: Flow = {
 							{
 								siteId,
 								siteSlug,
+								from: fromQueryParam,
 							},
 							STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug
 						)
@@ -350,6 +351,7 @@ const siteMigration: Flow = {
 							stepName: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
 							siteSlug: siteSlug,
 							destination: destination,
+							from: fromQueryParam ?? undefined,
 							plan: providedDependencies.plan as string,
 							cancelDestination: `/setup/${ flowPath }/${
 								STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -525,6 +525,7 @@ describe( 'Site Migration Flow', () => {
 					destination: `/setup/site-migration/${ STEPS.SITE_MIGRATION_INSTRUCTIONS.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com`,
 					extraQueryParams: { hosting_intent: HOSTING_INTENT_MIGRATE },
 					flowName: 'site-migration',
+					from: 'https://site-to-be-migrated.com',
 					siteSlug: 'example.wordpress.com',
 					stepName: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
 					cancelDestination: `/setup/site-migration/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com`,

--- a/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
+++ b/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
@@ -67,9 +67,14 @@ type Options = {
  *  Hook to manage the site to prepare a site for migration.
  *  This hook manages the site transfer, plugin installation and migration key fetching.
  */
-export const usePrepareSiteForMigration = ( siteId?: number, options: Options = {} ) => {
+export const usePrepareSiteForMigration = (
+	siteId?: number,
+	from?: string,
+	options: Options = {}
+) => {
 	const siteTransferState = useSiteTransfer( siteId, {
 		retry: options.retry ?? 0,
+		from,
 	} );
 
 	const {

--- a/client/landing/stepper/hooks/use-site-transfer/index.ts
+++ b/client/landing/stepper/hooks/use-site-transfer/index.ts
@@ -4,7 +4,7 @@ import { useSiteTransferMutation } from './mutation';
 import { useSiteTransferStatusQuery } from './query';
 
 type Status = 'idle' | 'pending' | 'success' | 'error';
-type Options = Pick< UseQueryOptions, 'retry' >;
+type Options = Pick< UseQueryOptions, 'retry' > & { from?: string };
 
 /**
  * Hook to initiate a site transfer and monitor its progress

--- a/client/landing/stepper/hooks/use-site-transfer/mutation.ts
+++ b/client/landing/stepper/hooks/use-site-transfer/mutation.ts
@@ -19,11 +19,8 @@ const startTransfer = (
 		body: {
 			context: 'unknown',
 			transfer_intent: 'migrate',
-<<<<<<< HEAD
 			plugin_slug: 'wpcom-migration',
-=======
 			migration_source_site_domain: from,
->>>>>>> d49643294d4 (Pass fromUrl param through flow, pass to Atomic transfer API)
 		},
 	} );
 

--- a/client/landing/stepper/hooks/use-site-transfer/mutation.ts
+++ b/client/landing/stepper/hooks/use-site-transfer/mutation.ts
@@ -9,18 +9,25 @@ interface InitiateAtomicTransferResponse {
 	atomic_transfer_id: string;
 }
 
-const startTransfer = ( siteId: number ): Promise< InitiateAtomicTransferResponse > =>
+const startTransfer = (
+	siteId: number,
+	from?: string
+): Promise< InitiateAtomicTransferResponse > =>
 	wpcom.req.post( {
 		path: `/sites/${ siteId }/atomic/transfers`,
 		apiNamespace: 'wpcom/v2',
 		body: {
 			context: 'unknown',
 			transfer_intent: 'migrate',
+<<<<<<< HEAD
 			plugin_slug: 'wpcom-migration',
+=======
+			migration_source_site_domain: from,
+>>>>>>> d49643294d4 (Pass fromUrl param through flow, pass to Atomic transfer API)
 		},
 	} );
 
-type Options = Pick< UseMutationOptions, 'retry' >;
+type Options = Pick< UseMutationOptions, 'retry' > & { from?: string };
 /**
  *  Mutation hook to initiate a site transfer
  */
@@ -28,7 +35,9 @@ export const useSiteTransferMutation = ( siteId?: number, options?: Options ) =>
 	const query = useQueryClient();
 
 	const mutation = () =>
-		siteId ? startTransfer( siteId ) : Promise.reject( new Error( 'siteId is required' ) );
+		siteId
+			? startTransfer( siteId, options?.from )
+			: Promise.reject( new Error( 'siteId is required' ) );
 
 	const refreshSiteStatus = ( data: InitiateAtomicTransferResponse ) => {
 		query.setQueryData( getSiteTransferStatusQueryKey( siteId! ), data );

--- a/client/landing/stepper/utils/checkout.ts
+++ b/client/landing/stepper/utils/checkout.ts
@@ -11,6 +11,7 @@ interface GoToCheckoutProps {
 	stepName: string;
 	siteSlug: string;
 	destination: string;
+	from?: string;
 	plan?: string;
 	cancelDestination?: string;
 	extraProducts?: string[];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #98937 and a redo of #98938 which was reverted due to test confusion.

## Proposed Changes

* Rather than attempting to save the `migration_source_site_domain` site option from the front end, pass it through the DIY flow and to the Atomic site transfer API so we can set it on the back end.
* This should also fix https://github.com/Automattic/wp-calypso/issues/98682 since we're passing the `from` query param through checkout to the migration instructions step.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* paYKcK-5KE-p2 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox `public-api.wordpress.com`
* Switch to this PR/use calypso.live
* Open your Network tab in the inspector. Filter by `transfers`
* Go through the migration flow from `start`: choose Import or Migrate at the goals step, put in your external WordPress test site URL, choose Migrate, choose Do it myself, upgrade/checkout.
* Check the call to the `transfers` endpoint; it should include a `migration_source_site_domain` param with the test site URL you set when going through the flow.
* The `from` query parameter should be visible in the URL on the instructions step.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?