### PR TITLE
Subscribers: Add Email subscriber field to subscribers table, with sorting and filtering

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -220,9 +220,9 @@ const SubscriberDataViews = ( {
 					</div>
 				),
 				elements: [
-					{ label: translate( 'Email' ), value: SubscribersFilterBy.EmailSubscriber },
+					{ label: translate( 'Subscribed' ), value: SubscribersFilterBy.EmailSubscriber },
 					{
-						label: translate( 'Reader' ),
+						label: translate( 'Not subscribed' ),
 						value: SubscribersFilterBy.ReaderSubscriber,
 					},
 				],

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -190,7 +190,7 @@ const SubscriberDataViews = ( {
 			},
 			{
 				id: 'plan',
-				label: translate( 'Type' ),
+				label: translate( 'Plan' ),
 				getValue: ( { item }: { item: Subscriber } ) =>
 					item.plans?.length ? SubscribersFilterBy.Paid : SubscribersFilterBy.Free,
 				render: ( { item }: { item: Subscriber } ) => <SubscriptionTypeCell subscriber={ item } />,

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -51,8 +51,9 @@ const defaultView: View = {
 		styles: {
 			media: { width: '60px' },
 			name: { width: '55%', minWidth: '195px' },
-			plan: { width: '25%' },
-			date_subscribed: { width: '25%' },
+			plan: { width: '15%' },
+			is_email_subscriber: { width: '15%' },
+			date_subscribed: { width: '15%' },
 		},
 	},
 };
@@ -189,19 +190,40 @@ const SubscriberDataViews = ( {
 			},
 			{
 				id: 'plan',
-				label: translate( 'Subscription type' ),
+				label: translate( 'Type' ),
 				getValue: ( { item }: { item: Subscriber } ) =>
 					item.plans?.length ? SubscribersFilterBy.Paid : SubscribersFilterBy.Free,
 				render: ( { item }: { item: Subscriber } ) => <SubscriptionTypeCell subscriber={ item } />,
 				elements: [
-					{ label: 'Paid', value: SubscribersFilterBy.Paid },
-					{ label: 'Free', value: SubscribersFilterBy.Free },
+					{ label: translate( 'Paid' ), value: SubscribersFilterBy.Paid },
+					{ label: translate( 'Free' ), value: SubscribersFilterBy.Free },
 				],
 				filterBy: {
 					operators: [ 'is' as Operator ],
 				},
-				enableSorting: true,
 				enableHiding: false,
+				enableSorting: true,
+			},
+			{
+				id: 'is_email_subscriber',
+				label: translate( 'Via' ),
+				getValue: ( { item }: { item: Subscriber } ) =>
+					getSubscriptionSourceLabel( item.is_email_subscriber ),
+				render: ( { item }: { item: Subscriber } ) => (
+					<div>{ getSubscriptionSourceLabel( item.is_email_subscriber ) }</div>
+				),
+				elements: [
+					{ label: getSubscriptionSourceLabel( true ), value: SubscribersFilterBy.EmailSubscriber },
+					{
+						label: getSubscriptionSourceLabel( false ),
+						value: SubscribersFilterBy.ReaderSubscriber,
+					},
+				],
+				filterBy: {
+					operators: [ 'is' as Operator ],
+				},
+				enableHiding: false,
+				enableSorting: true,
 			},
 			{
 				id: 'date_subscribed',

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -2,6 +2,7 @@ import { Gravatar } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { DataViews, type View, type Action, Operator } from '@wordpress/dataviews';
 import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
+import { Icon, check, close } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 import TimeSince from 'calypso/components/time-since';
 import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
@@ -206,16 +207,22 @@ const SubscriberDataViews = ( {
 			},
 			{
 				id: 'is_email_subscriber',
-				label: translate( 'Via' ),
+				label: translate( 'Email subscriber' ),
 				getValue: ( { item }: { item: Subscriber } ) =>
-					getSubscriptionSourceLabel( item.is_email_subscriber ),
+					item.is_email_subscriber ? 'email' : 'reader',
 				render: ( { item }: { item: Subscriber } ) => (
-					<div>{ getSubscriptionSourceLabel( item.is_email_subscriber ) }</div>
+					<div>
+						{ item.is_email_subscriber ? (
+							<Icon icon={ check } size={ 28 } />
+						) : (
+							<Icon icon={ close } size={ 24 } />
+						) }
+					</div>
 				),
 				elements: [
-					{ label: getSubscriptionSourceLabel( true ), value: SubscribersFilterBy.EmailSubscriber },
+					{ label: translate( 'Email' ), value: SubscribersFilterBy.EmailSubscriber },
 					{
-						label: getSubscriptionSourceLabel( false ),
+						label: translate( 'Reader' ),
 						value: SubscribersFilterBy.ReaderSubscriber,
 					},
 				],

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -207,8 +207,7 @@ const SubscriberDataViews = ( {
 			{
 				id: 'is_email_subscriber',
 				label: translate( 'Email subscriber' ),
-				getValue: ( { item }: { item: Subscriber } ) =>
-					item.is_email_subscriber ? 'email' : 'reader',
+				getValue: ( { item }: { item: Subscriber } ) => ( item.is_email_subscriber ? 'yes' : 'no' ),
 				render: ( { item }: { item: Subscriber } ) => (
 					<div>{ item.is_email_subscriber ? 'Yes' : 'No' }</div>
 				),

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -46,7 +46,7 @@ const defaultView: View = {
 	mediaField: 'media',
 	showTitle: true,
 	showMedia: true,
-	fields: [ 'plan', 'date_subscribed' ],
+	fields: [ 'plan', 'is_email_subscriber', 'date_subscribed' ],
 	layout: {
 		styles: {
 			media: { width: '60px' },

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -2,7 +2,6 @@ import { Gravatar } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { DataViews, type View, type Action, Operator } from '@wordpress/dataviews';
 import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
-import { Icon, check, close } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 import TimeSince from 'calypso/components/time-since';
 import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
@@ -211,13 +210,7 @@ const SubscriberDataViews = ( {
 				getValue: ( { item }: { item: Subscriber } ) =>
 					item.is_email_subscriber ? 'email' : 'reader',
 				render: ( { item }: { item: Subscriber } ) => (
-					<div>
-						{ item.is_email_subscriber ? (
-							<Icon icon={ check } size={ 28 } />
-						) : (
-							<Icon icon={ close } size={ 24 } />
-						) }
-					</div>
+					<div>{ item.is_email_subscriber ? 'Yes' : 'No' }</div>
 				),
 				elements: [
 					{ label: translate( 'Subscribed' ), value: SubscribersFilterBy.EmailSubscriber },

--- a/client/my-sites/subscribers/constants.ts
+++ b/client/my-sites/subscribers/constants.ts
@@ -2,7 +2,7 @@ export enum SubscribersSortBy {
 	Name = 'name',
 	DateSubscribed = 'date_subscribed',
 	Plan = 'plan',
-	Via = 'is_email_subscriber',
+	EmailSubscriber = 'is_email_subscriber',
 }
 
 export enum SubscribersFilterBy {

--- a/client/my-sites/subscribers/constants.ts
+++ b/client/my-sites/subscribers/constants.ts
@@ -2,6 +2,7 @@ export enum SubscribersSortBy {
 	Name = 'name',
 	DateSubscribed = 'date_subscribed',
 	Plan = 'plan',
+	Via = 'is_email_subscriber',
 }
 
 export enum SubscribersFilterBy {
@@ -10,6 +11,8 @@ export enum SubscribersFilterBy {
 	WPCOM = 'wpcom',
 	Free = 'free',
 	Paid = 'paid',
+	EmailSubscriber = 'email_subscriber',
+	ReaderSubscriber = 'reader_subscriber',
 }
 
 export const DEFAULT_PER_PAGE = 10;

--- a/client/my-sites/subscribers/types/index.ts
+++ b/client/my-sites/subscribers/types/index.ts
@@ -28,6 +28,7 @@ export type Subscriber = {
 	user_id: number;
 	subscription_id: number;
 	date_subscribed: string;
+	is_email_subscriber: boolean;
 	email_address: string;
 	avatar: string;
 	display_name: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/376

## Proposed Changes

* Change Subscription Type field to Plan.
* Add "Email Subscriber" field with Yes or No values that correspond to `email_subscriber` and `reader_subscriber` filtering on the back-end.

<img width="846" alt="Screen Shot 2025-02-05 at 10 05 40 AM" src="https://github.com/user-attachments/assets/7b1bbe20-fc72-40ed-ae2d-da491fc2580d" />


* Add sorting and filtering on Email Subscriber.

Plan filter | Email subscriber filter
---- | ----
<img width="254" alt="Screen Shot 2025-02-05 at 10 25 02 AM" src="https://github.com/user-attachments/assets/736d7d07-d2e3-431f-92da-f18432afc455" /> | <img width="488" alt="Screen Shot 2025-02-03 at 4 50 09 PM" src="https://github.com/user-attachments/assets/ee5c3af6-6d27-4f0b-b759-ab318705451d" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Requested feature: pe7F0s-2oe-p2#comment-3330

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/subscribers/{site URL}` with a site that has both email and non-email subscribers (you can unsubscribe from emails in /read/subscriptions).
* Check that there's an Email subscriber column that displays either "Yes" or "No."
* Sort by Email subscriber ascending and descending and check the results.
* Filter by Email subscriber and check the results.

Note that filtering by Type and Via simultaneously isn't currently possible. Follow-up: https://github.com/Automattic/loop/issues/391

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?