### PR TITLE
Big Sky: Insert some dummy content in the default home page 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
@@ -74,6 +74,7 @@ const LaunchBigSky: Step = function () {
 					body: {
 						title: 'Home',
 						status: 'publish',
+						content: '<!-- wp:paragraph -->\n<p>Hello world!</p>\n<!-- /wp:paragraph -->',
 					},
 				} )
 			);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1738265726282239/1738265400.742489-slack-C06121P56QZ

## Proposed Changes

Populate the default home page with some dummy content

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

On pages without any content, Gutenberg auto-expands the pattern inserter sidebar. 
Without this patch, initial builds are hitting this issue: 

![image](https://github.com/user-attachments/assets/0db51aab-e4c0-44d2-b253-014eb2881666)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

On an existing Big Sky site
1. Reset site metadata 
2. Trash all the pages 
3. `http://calypso.localhost:3000/setup/site-setup/design-choices?siteSlug=SITE_URL`
4. Onboard with Big Sky
5. Observe initial build no longer has the inserter popped out. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?