### PR TITLE
Reader: Update /read recent posts empty message

### DIFF
--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -8,8 +8,8 @@ import { UnknownAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import AsyncLoad from 'calypso/components/async-load';
-import EmptyContent from 'calypso/components/empty-content';
 import NavigationHeader from 'calypso/components/navigation-header';
+import FollowingEmptyContent from 'calypso/reader/stream/empty';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 import { requestPaginatedStream } from 'calypso/state/reader/streams/actions';
 import { viewStream } from 'calypso/state/reader-ui/actions';
@@ -269,13 +269,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 				{ ! ( selectedItem && getPostFromItem( selectedItem ) ) && isLoading && (
 					<RecentPostSkeleton />
 				) }
-				{ ! isLoading && data?.items.length === 0 && (
-					<EmptyContent
-						title={ translate( 'Nothing Posted Yet' ) }
-						line={ translate( 'This feed is currently empty.' ) }
-						illustration=""
-					/>
-				) }
+				{ ! isLoading && data?.items.length === 0 && <FollowingEmptyContent /> }
 				{ data?.items.length > 0 && selectedItem && getPostFromItem( selectedItem ) && (
 					<>
 						<AsyncLoad

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { getSelectedFeedId } from 'calypso/state/reader-ui/sidebar/selectors';
 import { withReaderPerformanceTrackerStop } from '../reader-performance-tracker';
 
 class FollowingEmptyContent extends Component {
@@ -11,39 +12,47 @@ class FollowingEmptyContent extends Component {
 		return false;
 	}
 
-	recordAction = () => {
-		recordAction( 'clicked_search_on_empty' );
-		recordGaEvent( 'Clicked Search on EmptyContent' );
-		this.props.recordReaderTracksEvent( 'calypso_reader_search_on_empty_stream_clicked' );
+	recordAction = ( isFullSiteFeed = false ) => {
+		if ( isFullSiteFeed ) {
+			recordAction( 'clicked_visit_full_site_feed_on_empty' );
+			recordGaEvent( 'Clicked Visit Full Site Feed on EmptyContent' );
+			this.props.recordReaderTracksEvent(
+				'calypso_reader_visit_full_site_feed_on_empty_stream_clicked'
+			);
+		} else {
+			recordAction( 'clicked_discover_on_empty' );
+			recordGaEvent( 'Clicked Discover on EmptyContent' );
+			this.props.recordReaderTracksEvent( 'calypso_reader_discover_on_empty_stream_clicked' );
+		}
 	};
 
 	render() {
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		const action = (
-			<a
-				className="empty-content__action button is-primary"
-				onClick={ this.recordAction }
-				href="/read/search"
-			>
-				{ this.props.translate( 'Find sites to follow' ) }
-			</a>
-		);
-		const secondaryAction = null;
+		const { selectedFeedId, translate } = this.props;
+		const isFullSiteFeed = !! selectedFeedId;
 
 		return (
 			<EmptyContent
 				className="stream__empty"
-				title={ this.props.translate( 'Welcome to Reader' ) }
-				line={ this.props.translate( 'Recent posts from sites you follow will appear here.' ) }
-				action={ action }
-				secondaryAction={ secondaryAction }
+				title={ translate( "You're all caught up." ) }
+				line={ translate( 'No new posts in the last 60 days.' ) }
+				action={
+					isFullSiteFeed
+						? translate( 'Visit the Full Site Feed' )
+						: translate( 'Discover New Sites' )
+				}
+				actionURL={ isFullSiteFeed ? `/read/feeds/${ selectedFeedId }` : '/discover' }
+				actionCallback={ () => this.recordAction( isFullSiteFeed ) }
 				illustration=""
 			/>
 		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 }
 
-export default connect( null, {
-	recordReaderTracksEvent,
-} )( withReaderPerformanceTrackerStop( localize( FollowingEmptyContent ) ) );
+export default connect(
+	( state ) => ( {
+		selectedFeedId: getSelectedFeedId( state ),
+	} ),
+	{
+		recordReaderTracksEvent,
+	}
+)( withReaderPerformanceTrackerStop( localize( FollowingEmptyContent ) ) );

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -402,7 +402,7 @@ body.is-section-reader {
 	}
 
 	&.stream__empty {
-		margin-top: 25px;
+		margin-top: 40px;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98883

## Proposed Changes

* Small refactor to reuse the `FollowingEmptyContent` component in both "Full post" and "Scrolling feed" views.
* Updates the `FollowingEmptyContent` component message seen in the "Recent" "Full post" and "Scrolling feed" views. (aka /read)
* Increased CSS top margin on the empty message.

### Full Post View

Specific sites CTA links to the full site feed if there are no results less than 60 days old.

Before | After
--|--
<img width="1279" alt="Screenshot 2025-01-30 at 4 02 11 PM" src="https://github.com/user-attachments/assets/d8e34651-8f6a-41c2-9f31-07ed38ef92d0" />  | <img width="1279" alt="Screenshot 2025-01-30 at 4 02 22 PM" src="https://github.com/user-attachments/assets/02524889-1f46-4c5e-8747-d0926ea6dfe8" />

"All" sites CTA links to the Discover page if there are no results less than 60 days old.

Before | After
--|--
<img width="1278" alt="Screenshot 2025-01-30 at 4 11 16 PM" src="https://github.com/user-attachments/assets/677463d5-ef01-42e7-ab06-dc50235c03b4" /> | <img width="1276" alt="Screenshot 2025-01-30 at 4 07 06 PM" src="https://github.com/user-attachments/assets/1f986929-5f26-4069-8692-3a6504512bf5" />


### Scrolling Feed View

Specific sites CTA links to the full site feed if there are no results less than 60 days old.

Before | After
--|--
<img width="1278" alt="Screenshot 2025-01-30 at 4 19 00 PM" src="https://github.com/user-attachments/assets/e19c73b4-4b20-410a-a3b3-61c70e10eb30" /> | <img width="1277" alt="Screenshot 2025-01-30 at 4 18 15 PM" src="https://github.com/user-attachments/assets/ef177d81-1a67-4ff1-af4f-b0979a33152f" />



"All" sites CTA links to the Discover page if there are no results less than 60 days old.

Before | After
--|--
<img width="1278" alt="Screenshot 2025-01-30 at 4 14 39 PM" src="https://github.com/user-attachments/assets/d96f4bcf-2391-4bd7-853b-f0f900cd5107" /> |  <img width="1278" alt="Screenshot 2025-01-30 at 4 16 25 PM" src="https://github.com/user-attachments/assets/f6b78b64-3f59-4f0c-801d-8d134d23587a" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* With https://github.com/Automattic/wp-calypso/pull/98944 (waiting for translations to merge), both "Full post" and "Scrolling post" views only return posts less than 60 days old. This updates the empty content message to communicate better why there are no posts.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The easiest way to test this is to run this PR locally and update the Stream API so it returns no results. Like this:

```diff
--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -202,7 +202,7 @@ const streamApis = {
                        // If no after param is provided, default to 60 days ago
                        if ( ! filteredExtras.after && ! filteredExtras.pageHandle?.after ) {
                                const sixtyDaysAgo = new Date();
-                               sixtyDaysAgo.setDate( sixtyDaysAgo.getDate() - 60 );
+                               sixtyDaysAgo.setDate( sixtyDaysAgo.getDate() - 0 );
                                filteredExtras.after = sixtyDaysAgo.toISOString().split( '.' )[ 0 ] + 'Z';
                        }
 
@@ -220,6 +220,7 @@ const streamApis = {
                                // 'recent' without a suffix means don't filter by feedId
                                queryParams.feed_id = feedId;
                        }
+                       queryParams.feed_id = 0;
                        return getQueryString( queryParams );
                },
        },
```

Now you can view the changes on http://calypso.localhost:3000/read and confirm they match the screenshots above. The CTA buttons should be clickable and include Tracks events when clicked.

Confirm that the `FollowingEmptyContent` isn't used somewhere else where these copy changes wouldn't make sense.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
