### PR TITLE
Update experiment slug for goals-first experience

### DIFF
--- a/client/landing/stepper/declarative-flow/helpers/use-goals-first-experiment.ts
+++ b/client/landing/stepper/declarative-flow/helpers/use-goals-first-experiment.ts
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { useExperiment } from 'calypso/lib/explat';
 import { getFlowFromURL } from '../../utils/get-flow-from-url';
 
-export const EXPERIMENT_NAME = 'calypso_signup_onboarding_goals_first_flow_holdout_20241220';
+export const EXPERIMENT_NAME = 'calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131';
 
 /**
  * Check whether the user should have the "goals first" onboarding experience.
@@ -31,5 +31,11 @@ export function useGoalsFirstExperiment(): [ boolean, boolean ] {
 	 */
 	const variationName = experimentAssignment?.variationName ?? 'control';
 
-	return [ isLoading, variationName === 'treatment' ];
+	// There's a separate cohort for holdout reasons. But in terms of the "goals-first" experience,
+	// both treatment cohorts see it.
+	const isGoalsAtFrontExperiment = [ 'treatment_cumulative', 'treatment_frozen' ].includes(
+		variationName
+	);
+
+	return [ isLoading, isGoalsAtFrontExperiment ];
 }

--- a/config/development.json
+++ b/config/development.json
@@ -145,7 +145,7 @@
 		"onboarding/trail-map-feature-grid": false,
 		"onboarding/user-on-stepper-hosting": true,
 		"onboarding/big-sky-before-plans": true,
-		"onboarding/force-goals-first": true,
+		"onboarding/force-goals-first": false,
 		"p2/p2-plus": true,
 		"p2-enabled": false,
 		"page/export": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #99011

## Proposed Changes

* Switches to the new `calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131` experiment slug
* Stop forcing the goals-first experience in development

It implements the first branch in this flow chart

![Screenshot 2025-01-30 at 1 34 31 PM](https://github.com/user-attachments/assets/df38b8d3-aab3-42aa-b453-35f6635aa5a6)

p1738272885652059/1738193377.949839-slack-C085HCWCEDN

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We are adjusting weightings for the goal-first experience. It's now 10% control and 90% with the goals-first experience. That 90% is split into holdout and cumulative cohorts, but that doesn't make any difference for the `useGoalsFirstExperiment()` hook. Both treatment cohorts get the goals-first experience.

`wpcalypso` will continue to be forced onto the goals-first experience for stakeholders. But now that we have the new experiment slugs, developers should explicitly choose the cohorts they want to test with.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Explat to set the `calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131` experiment to your desired cohort 22180-explat-experiment
* Clear your local storage and visit `/setup/onboarding`
    * `control` sees the domains step (or account creation) as the first step
    * `treatment_frozen` and `treatment_cumulative` see the goals screen as the first step

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?