### PR TITLE
Jetpack Cloud: fix subscriber data view email alignment

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -217,7 +217,8 @@ body.is-section-subscribers.is-subscribers-dataviews,
                 }
         
                 .subscriber-profile__user-details {
-                    .subscriber-profile__name {
+                    .subscriber-profile__name,
+                    .subscriber-profile__email {
                         text-align: left;
                     }
                 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/loop#370

## Proposed Changes

| Before | After |
|-|-|
| <img width="1170" alt="Screenshot 2025-01-30 at 4 24 55 PM" src="https://github.com/user-attachments/assets/3a62d7ff-9108-4b5f-a84d-b62d4818aacd" /> | <img width="1170" alt="Screenshot 2025-01-30 at 4 24 28 PM" src="https://github.com/user-attachments/assets/92388be8-dd59-4f32-8890-cb0fddae17f1" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Polish up subscriber data views

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On Jetpack Cloud, navigate to Subscribers
* Populate your subscribers list with wpcom accounts so both an email and name are displayed
* The email field should be left aligned
* To truly test this make sure the email is shorter than the name to force the text alignment to have an effect
  * You can do this by editing the email in your browser dev tools to something shorter if you need to 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
