### PR TITLE
A4A: add signup multiple steps form

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
@@ -1,0 +1,167 @@
+import { Gridicon } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import Form from 'calypso/a8c-for-agencies/components/form';
+import FormField from 'calypso/a8c-for-agencies/components/form/field';
+import QuerySmsCountries from 'calypso/components/data/query-countries/sms';
+import FormPhoneInput from 'calypso/components/forms/form-phone-input';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import { useGetSupportedSMSCountries } from 'calypso/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/hooks';
+import './style.scss';
+
+type FormData = {
+	firstName: string;
+	lastName: string;
+	email: string;
+	agencyName: string;
+	businessUrl: string;
+	phoneNumber: string;
+};
+
+type Props = {
+	onContinue: () => void;
+};
+
+const SignupContactForm = ( { onContinue }: Props ) => {
+	const translate = useTranslate();
+
+	const countriesList = useGetSupportedSMSCountries();
+	const noCountryList = countriesList.length === 0;
+
+	const [ formData, setFormData ] = useState< FormData >( {
+		firstName: '',
+		lastName: '',
+		email: '',
+		agencyName: '',
+		businessUrl: '',
+		phoneNumber: '',
+	} );
+
+	const handlePhoneInputChange = ( data: { phoneNumberFull: string } ) => {
+		setFormData( ( prev ) => ( {
+			...prev,
+			phoneNumber: data.phoneNumberFull,
+		} ) );
+	};
+
+	const handleInputChange =
+		( field: keyof FormData ) => ( event: React.ChangeEvent< HTMLInputElement > ) => {
+			setFormData( ( prev ) => ( {
+				...prev,
+				[ field ]: event.target.value,
+			} ) );
+		};
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		onContinue();
+	};
+
+	return (
+		<Form
+			className="signup-contact-form"
+			title={ translate( 'Sign up' ) }
+			description={ translate(
+				'Join 5000+ agencies and grow your business with Automattic for Agencies. It only takes two minutes!'
+			) }
+		>
+			<div className="signup-multi-step-form__fields">
+				<div className="signup-multi-step-form__name-fields">
+					<FormField label={ translate( 'Your first name' ) } isRequired>
+						<FormTextInput
+							name="firstName"
+							value={ formData.firstName }
+							onChange={ handleInputChange( 'firstName' ) }
+						/>
+					</FormField>
+
+					<FormField label={ translate( 'Last name' ) } isRequired>
+						<FormTextInput
+							name="lastName"
+							value={ formData.lastName }
+							onChange={ handleInputChange( 'lastName' ) }
+						/>
+					</FormField>
+				</div>
+
+				<FormField label={ translate( 'Email' ) } isRequired>
+					<FormTextInput
+						name="email"
+						type="email"
+						value={ formData.email }
+						onChange={ handleInputChange( 'email' ) }
+					/>
+				</FormField>
+
+				<FormField label={ translate( 'Agency name' ) } isRequired>
+					<FormTextInput
+						name="agencyName"
+						value={ formData.agencyName }
+						onChange={ handleInputChange( 'agencyName' ) }
+					/>
+				</FormField>
+
+				<FormField label={ translate( 'Business URL' ) } isRequired>
+					<FormTextInput
+						name="businessUrl"
+						value={ formData.businessUrl }
+						onChange={ handleInputChange( 'businessUrl' ) }
+					/>
+				</FormField>
+
+				{ noCountryList && <QuerySmsCountries /> }
+
+				<FormField label={ translate( 'Phone number' ) } showOptionalLabel>
+					<FormPhoneInput
+						countrySelectProps={ {
+							'data-testid': 'a4a-signup-country-code-select',
+						} }
+						phoneInputProps={ {
+							'data-testid': 'a4a-signup-phone-number-input',
+						} }
+						isDisabled={ noCountryList }
+						countriesList={ countriesList }
+						onChange={ handlePhoneInputChange }
+						className="contact-form__phone-input"
+					/>
+				</FormField>
+
+				<div className="signup-contact-form__tos">
+					<p>
+						{ translate(
+							"By clicking 'Continue', you agree to the{{break}}{{/break}}{{link}}Terms of the Automattic for Agencies Platform Agreement{{icon}}{{/icon}}{{/link}}.",
+							{
+								components: {
+									break: <br />,
+									link: (
+										<a
+											href={ localizeUrl(
+												'https://automattic.com/for-agencies/platform-agreement/'
+											) }
+											target="_blank"
+											rel="noopener noreferrer"
+										></a>
+									),
+									icon: <Gridicon icon="external" size={ 18 } />,
+								},
+							}
+						) }
+					</p>
+				</div>
+				<div className="company-details-form__controls">
+					<Button
+						variant="primary"
+						onClick={ handleSubmit }
+						className="company-details-form__submit"
+					>
+						{ translate( 'Continue' ) }
+					</Button>
+				</div>
+			</div>
+		</Form>
+	);
+};
+
+export default SignupContactForm;

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/style.scss
@@ -1,0 +1,139 @@
+.signup-multi-step-form__fields {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	overflow-y: auto;
+	flex: 1;
+
+	// Customize scrollbar
+	&::-webkit-scrollbar {
+		width: 8px;
+	}
+
+	&::-webkit-scrollbar-track {
+		background: var(--studio-gray-0);
+		border-radius: 4px;
+	}
+
+	&::-webkit-scrollbar-thumb {
+		background: var(--studio-gray-20);
+		border-radius: 4px;
+
+		&:hover {
+			background: var(--studio-gray-30);
+		}
+	}
+}
+
+.signup-contact-form {
+    &.a4a-form {
+        gap: 1rem;
+    }
+    & .a4a-form__heading {
+        text-align: left;
+        margin-bottom: 0;
+
+        & .a4a-form__heading-description {
+            margin: 0;
+        }
+    }
+}
+
+.contact-form__phone-input {
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+
+    .form-phone-input__country {   
+        flex: 1;
+    }
+
+    .form-phone-input__phone-number {   
+        flex: 1;
+    }
+}
+
+.signup-contact-form__tos {
+    p {
+        font-size: 0.875rem;
+    }
+}
+
+.signup-multi-step-form__name-fields {
+    display: flex;
+    flex-direction: row;
+	gap: 24px;
+
+    div {
+        flex-grow: 1;
+    }
+}
+
+.signup-multi-step-form__terms {
+	text-align: center;
+	font-size: 0.875rem;
+	color: var(--studio-gray-40);
+	margin-top: 16px;
+
+	a {
+		color: var(--studio-wordpress-blue);
+		text-decoration: none;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+// Form field styles
+.a4a-form__section-field {
+	margin-bottom: 0;
+	padding: 2px;
+
+	&-label {
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: var(--studio-gray-80);
+		margin-bottom: 8px;
+	}
+
+	&-required {
+		color: var(--studio-red-50);
+		margin-left: 4px;
+	}
+
+	&-optional {
+		color: var(--studio-gray-20);
+		font-weight: normal;
+		margin-left: 4px;
+	}
+}
+
+.form-text-input {
+	width: 100%;
+	padding: 8px 12px;
+	border: 1px solid var(--studio-gray-10);
+	border-radius: 4px;
+	font-size: 1rem;
+	transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+	&:focus {
+		border-color: var(--studio-wordpress-blue);
+		box-shadow: 0 0 0 2px var(--studio-wordpress-blue-20);
+		outline: none;
+	}
+
+	&.is-error {
+		border-color: var(--studio-red-50);
+	}
+}
+
+.a4a-form__error {
+	color: var(--studio-red-50);
+	font-size: 0.75rem;
+	margin-top: 4px;
+
+	&.hidden {
+		display: none;
+	}
+}

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
@@ -1,0 +1,44 @@
+import { useTranslate } from 'i18n-calypso';
+import { useMemo, useState } from 'react';
+import StepProgress from '../step-progress';
+import SignupContactForm from './contact-form';
+
+import './style.scss';
+
+const MultiStepForm = () => {
+	const translate = useTranslate();
+	const [ currentStep, setCurrentStep ] = useState( 1 );
+
+	const steps = [
+		{ label: translate( 'Sign up' ), isActive: currentStep === 1, isComplete: currentStep > 1 },
+		{ label: translate( 'Personalize' ), isActive: currentStep === 2, isComplete: currentStep > 2 },
+		{
+			label: translate( 'Complete setup' ),
+			isActive: currentStep === 3,
+			isComplete: currentStep > 3,
+		},
+	];
+
+	const currentForm = useMemo( () => {
+		switch ( currentStep ) {
+			case 1:
+				return <SignupContactForm onContinue={ () => setCurrentStep( 2 ) } />;
+			case 2:
+				return <SignupContactForm onContinue={ () => setCurrentStep( 3 ) } />;
+			case 3:
+				return <div>Finish</div>;
+			default:
+				return null;
+		}
+	}, [ currentStep ] );
+
+	return (
+		<div className="signup-multi-step-form">
+			<StepProgress steps={ steps } />
+
+			{ currentForm }
+		</div>
+	);
+};
+
+export default MultiStepForm;

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
@@ -1,0 +1,40 @@
+.signup-multi-step-form {
+	display: flex;
+	flex-direction: column;
+	height: 100vh;
+
+	.step-progress {
+		flex-shrink: 0;
+	}
+
+	.a4a-form {
+		flex: 1;
+		overflow: hidden;
+		display: flex;
+		flex-direction: column;
+		padding: 48px 24px;
+		max-width: 600px;
+		margin: 0 auto;
+		width: 100%;
+	}
+
+	.a4a-form__heading {
+		text-align: center;
+		margin-bottom: 40px;
+		flex-shrink: 0;
+
+		&-title {
+			font-size: 2rem;
+			font-weight: 600;
+			margin-bottom: 16px;
+			color: var(--studio-gray-100);
+		}
+
+		&-description {
+			font-size: 1rem;
+			color: var(--studio-gray-60);
+			max-width: 460px;
+			margin: 0 auto;
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/step-progress/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/step-progress/index.tsx
@@ -1,0 +1,37 @@
+import clsx from 'clsx';
+import './style.scss';
+
+type Step = {
+	label: string;
+	isActive: boolean;
+	isComplete: boolean;
+};
+
+type Props = {
+	steps: Step[];
+};
+
+const StepProgress = ( { steps }: Props ) => {
+	return (
+		<div className="step-progress">
+			<div className="step-progress__steps">
+				<div className="step-progress__steps-container">
+					{ steps.map( ( step ) => (
+						<div
+							key={ step.label }
+							className={ clsx( 'step-progress__step', {
+								'is-active': step.isActive,
+								'is-complete': step.isComplete,
+							} ) }
+						>
+							<div className="step-progress__step-indicator" />
+							<span className="step-progress__step-label">{ step.label }</span>
+						</div>
+					) ) }
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default StepProgress;

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/step-progress/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/step-progress/style.scss
@@ -1,0 +1,73 @@
+.step-progress {
+	width: 100%;
+	background: var(--studio-white);
+
+	&__steps {
+		max-width: 600px;
+		margin: 0 auto;
+		width: 100%;
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+	}
+
+	&__steps-container {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: 8px;
+		width: 100%;
+	}
+
+	&__step {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+
+		&.is-active {
+			.step-progress__step-indicator {
+				background-color: var(--studio-wordpress-blue);
+			}
+
+			.step-progress__step-label {
+				color: var(--studio-gray-80);
+				font-weight: 600;
+			}
+		}
+
+		&.is-complete {
+			.step-progress__step-indicator {
+				background-color: var(--studio-wordpress-blue);
+			}
+
+			.step-progress__step-label {
+				color: var(--studio-gray-80);
+				font-weight: 600;
+			}
+		}
+
+		&:not(.is-active):not(.is-complete) {
+			.step-progress__step-indicator {
+				background-color: var(--studio-gray-5);
+			}
+
+			.step-progress__step-label {
+				color: var(--studio-gray-40);
+			}
+		}
+	}
+
+	&__step-indicator {
+		height: 8px;
+		width: 100%;
+		border-radius: 4px;
+		transition: background-color 0.2s ease;
+	}
+
+	&__step-label {
+		font-size: 0.875rem;
+		font-weight: 500;
+		transition: color 0.2s ease;
+		order: -1;
+		margin-bottom: 4px;
+	}
+} 

--- a/client/a8c-for-agencies/sections/signup/signup-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/index.tsx
@@ -1,15 +1,10 @@
+import MultiStepForm from './components/multi-step-form';
 import SignupWrapper from './components/signup-wrapper';
 
-type Flow = 'regular' | 'wc-asia';
-
-type Props = {
-	flow?: Flow;
-};
-
-const AgencySignupV2 = ( { flow }: Props ) => {
+const AgencySignupV2 = () => {
 	return (
 		<SignupWrapper>
-			<div>Agency Signup V2: { flow }</div>
+			<MultiStepForm />
 		</SignupWrapper>
 	);
 };

--- a/client/a8c-for-agencies/sections/signup/signup-v2/types.ts
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/types.ts
@@ -1,0 +1,1 @@
+export type Flow = 'regular' | 'wc-asia';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1728

## Proposed Changes

This PR adds new Mutiple step contact form. The main purpose is to have a skeleton, so it's not 100% properly styled yet. Validation is disabled as well.

The main goal is to bootstrap all the steps and attach necessary logic. 

This also adds form for the first page.

<img width="654" alt="Screenshot 2025-01-30 at 5 06 04 PM" src="https://github.com/user-attachments/assets/9425e101-88e6-4c13-82db-b60422f45058" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link below navigate to `/signup/wc-asia`.
- Check multiple steps by clicking `Continue` button.


https://github.com/user-attachments/assets/90961ce9-a148-4c30-b395-49b8dcb4468a



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
