### PR TITLE
Stats: navigate by full periods

### DIFF
--- a/client/my-sites/stats/hooks/use-moment-site-zone.ts
+++ b/client/my-sites/stats/hooks/use-moment-site-zone.ts
@@ -4,6 +4,7 @@ import moment from 'moment';
 import { useSelector } from 'calypso/state';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { DATE_FORMAT } from '../constants';
 
 export const getMomentSiteZone = createSelector(
 	( state: object, siteId: number | null ) => {
@@ -16,7 +17,9 @@ export const getMomentSiteZone = createSelector(
 
 		const gmtOffset = getSiteOption( state, siteId, 'gmt_offset' ) as number;
 		if ( Number.isFinite( gmtOffset ) ) {
-			return localizedMoment.utcOffset( gmtOffset );
+			// In all the components, `moment` is directly used, which defaults to the browser's local timezone.
+			// As a result, we need to convert the moment object to the site's timezone for easier comparison like `isSame`.
+			return moment( localizedMoment.utcOffset( gmtOffset ).format( DATE_FORMAT ) );
 		}
 
 		// Falls back to the browser's local timezone if no GMT offset is found

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -581,6 +581,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 						showArrows={ ! wpcomShowUpsell }
 						slug={ slug }
 						dateRange={ customChartRange }
+						appliedShortcut={ appliedShortcut }
 					>
 						{ ' ' }
 						<DatePicker

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -581,7 +581,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 						showArrows={ ! wpcomShowUpsell }
 						slug={ slug }
 						dateRange={ customChartRange }
-						appliedShortcut={ appliedShortcut }
 					>
 						{ ' ' }
 						<DatePicker

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -39,7 +39,6 @@ class StatsPeriodNavigation extends PureComponent {
 		startDate: PropTypes.bool,
 		endDate: PropTypes.bool,
 		isWithNewDateControl: PropTypes.bool,
-		appliedShortcut: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -51,7 +50,6 @@ class StatsPeriodNavigation extends PureComponent {
 		startDate: false,
 		endDate: false,
 		isWithNewDateControl: false,
-		appliedShortcut: null,
 	};
 
 	handleArrowEvent = ( arrow, href ) => {
@@ -143,7 +141,7 @@ class StatsPeriodNavigation extends PureComponent {
 
 	// TODO: refactor to extract logic with `dateForCustomRange` from `client/my-sites/stats/stats-date-picker/index.jsx`.
 	getFullPeriod = () => {
-		const { moment, dateRange, appliedShortcut, momentSiteZone } = this.props;
+		const { moment, dateRange, momentSiteZone } = this.props;
 		const localizedStartDate = moment( dateRange.chartStart );
 		const localizedEndDate = moment( dateRange.chartEnd );
 
@@ -152,7 +150,7 @@ class StatsPeriodNavigation extends PureComponent {
 			localizedStartDate.isSame( localizedStartDate.clone().startOf( 'month' ), 'day' ) &&
 			localizedEndDate.isSame( momentSiteZone, 'day' ) &&
 			localizedStartDate.isSame( localizedEndDate, 'month' ) &&
-			( ! appliedShortcut || appliedShortcut.id === 'month_to_date' )
+			( ! dateRange.shortcutId || dateRange.shortcutId === 'month_to_date' )
 		) {
 			return 'month';
 		}
@@ -162,7 +160,7 @@ class StatsPeriodNavigation extends PureComponent {
 			localizedStartDate.isSame( localizedStartDate.clone().startOf( 'year' ), 'day' ) &&
 			localizedEndDate.isSame( momentSiteZone, 'day' ) &&
 			localizedStartDate.isSame( localizedEndDate, 'year' ) &&
-			( ! appliedShortcut || appliedShortcut.id === 'year_to_date' )
+			( ! dateRange.shortcutId || dateRange.shortcutId === 'year_to_date' )
 		) {
 			return 'year';
 		}

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -320,7 +320,8 @@ class StatsPeriodNavigation extends PureComponent {
 			momentSiteZone,
 			'day'
 		);
-		const showArrowsForDateRange = showArrows && dateRange?.daysInRange <= 31;
+		// Make sure we only show arrows for date ranges that are less than 3 years for performance reasons.
+		const showArrowsForDateRange = showArrows && dateRange?.daysInRange <= 365 * 3;
 
 		return (
 			<div

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -39,6 +39,7 @@ class StatsPeriodNavigation extends PureComponent {
 		startDate: PropTypes.bool,
 		endDate: PropTypes.bool,
 		isWithNewDateControl: PropTypes.bool,
+		appliedShortcut: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -50,6 +51,7 @@ class StatsPeriodNavigation extends PureComponent {
 		startDate: false,
 		endDate: false,
 		isWithNewDateControl: false,
+		appliedShortcut: null,
 	};
 
 	handleArrowEvent = ( arrow, href ) => {
@@ -139,6 +141,58 @@ class StatsPeriodNavigation extends PureComponent {
 		this.handleArrowNavigation( false );
 	};
 
+	// TODO: refactor to extract logic with `dateForCustomRange` from `client/my-sites/stats/stats-date-picker/index.jsx`.
+	getFullPeriod = () => {
+		const { moment, dateRange, appliedShortcut, momentSiteZone } = this.props;
+		const localizedStartDate = moment( dateRange.chartStart );
+		const localizedEndDate = moment( dateRange.chartEnd );
+
+		// If it's a partial month but ends today.
+		if (
+			localizedStartDate.isSame( localizedStartDate.clone().startOf( 'month' ), 'day' ) &&
+			localizedEndDate.isSame( momentSiteZone, 'day' ) &&
+			localizedStartDate.isSame( localizedEndDate, 'month' ) &&
+			( ! appliedShortcut || appliedShortcut.id === 'month_to_date' )
+		) {
+			return 'month';
+		}
+
+		// If it's a partial year but ends today.
+		if (
+			localizedStartDate.isSame( localizedStartDate.clone().startOf( 'year' ), 'day' ) &&
+			localizedEndDate.isSame( momentSiteZone, 'day' ) &&
+			localizedStartDate.isSame( localizedEndDate, 'year' ) &&
+			( ! appliedShortcut || appliedShortcut.id === 'year_to_date' )
+		) {
+			return 'year';
+		}
+
+		// If it's the same day, show single date.
+		if ( localizedStartDate.isSame( localizedEndDate, 'day' ) ) {
+			return 'day';
+		}
+
+		// If it's a full month.
+		if (
+			localizedStartDate.isSame( localizedStartDate.clone().startOf( 'month' ), 'day' ) &&
+			localizedEndDate.isSame( localizedEndDate.clone().endOf( 'month' ), 'day' ) &&
+			localizedStartDate.isSame( localizedEndDate, 'month' )
+		) {
+			return 'month';
+		}
+
+		// If it's a full year.
+		if (
+			localizedStartDate.isSame( localizedStartDate.clone().startOf( 'year' ), 'day' ) &&
+			localizedEndDate.isSame( localizedEndDate.clone().endOf( 'year' ), 'day' ) &&
+			localizedStartDate.isSame( localizedEndDate, 'year' )
+		) {
+			return 'year';
+		}
+
+		return null;
+	};
+
 	handleArrowNavigation = ( previousOrNext = false ) => {
 		const { moment, period, slug, dateRange } = this.props;
 
@@ -152,14 +206,34 @@ class StatsPeriodNavigation extends PureComponent {
 		const navigationStart = moment( dateRange.chartStart );
 		const navigationEnd = moment( dateRange.chartEnd );
 
-		if ( previousOrNext ) {
-			// Navigate to the previous date range.
-			navigationStart.subtract( dateRange.daysInRange, 'days' );
-			navigationEnd.subtract( dateRange.daysInRange, 'days' );
+		// If it's a full month then we need to navigate to the previous/next month.
+		// If it's a full year then we need to navigate to the previous/next year.
+
+		const fullPeriod = this.getFullPeriod();
+		if ( ! fullPeriod ) {
+			// Usual flow - only based on the days in range.
+			if ( previousOrNext ) {
+				// Navigate to the previous date range.
+				navigationStart.subtract( dateRange.daysInRange, 'days' );
+				navigationEnd.subtract( dateRange.daysInRange, 'days' );
+			} else {
+				// Navigate to the next date range.
+				navigationStart.add( dateRange.daysInRange, 'days' );
+				navigationEnd.add( dateRange.daysInRange, 'days' );
+			}
 		} else {
-			// Navigate to the next date range.
-			navigationStart.add( dateRange.daysInRange, 'days' );
-			navigationEnd.add( dateRange.daysInRange, 'days' );
+			// Navigate range by full periods.
+			if ( previousOrNext ) {
+				// Navigate to the previous period.
+				navigationStart.subtract( 1, fullPeriod );
+				navigationEnd.subtract( 1, fullPeriod );
+			} else {
+				// Navigate to the next period.
+				navigationStart.add( 1, fullPeriod );
+				navigationEnd.add( 1, fullPeriod );
+			}
+			navigationStart.startOf( fullPeriod );
+			navigationEnd.endOf( fullPeriod );
 		}
 
 		const chartStart = navigationStart.format( 'YYYY-MM-DD' );

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -192,7 +192,7 @@ class StatsPeriodNavigation extends PureComponent {
 	};
 
 	handleArrowNavigation = ( previousOrNext = false ) => {
-		const { moment, period, slug, dateRange } = this.props;
+		const { moment, momentSiteZone, period, slug, dateRange } = this.props;
 
 		const isWPAdmin = config.isEnabled( 'is_odyssey' );
 		const event_from = isWPAdmin ? 'jetpack_odyssey' : 'calypso';
@@ -202,7 +202,7 @@ class StatsPeriodNavigation extends PureComponent {
 		} );
 
 		const navigationStart = moment( dateRange.chartStart );
-		const navigationEnd = moment( dateRange.chartEnd );
+		let navigationEnd = moment( dateRange.chartEnd );
 
 		// If it's a full month then we need to navigate to the previous/next month.
 		// If it's a full year then we need to navigate to the previous/next year.
@@ -232,6 +232,9 @@ class StatsPeriodNavigation extends PureComponent {
 			}
 			navigationStart.startOf( fullPeriod );
 			navigationEnd.endOf( fullPeriod );
+			if ( navigationEnd.isAfter( momentSiteZone, 'day' ) ) {
+				navigationEnd = momentSiteZone;
+			}
 		}
 
 		const chartStart = navigationStart.format( 'YYYY-MM-DD' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-roadmap/issues/2181 - Partial fix

## Proposed Changes

* Navigate by full periods - year, month whenever possible

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Enhancement

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live
* Choose Month to date
* Click arrows to change date range
* Ensure it changes back/forward by full month
* Try with Year to date
* Ensure similar behaviour by only by years

https://github.com/user-attachments/assets/63f31310-7d79-4e7a-b265-c53cdb4f7031




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
