### PR TITLE
Domain-To-Plan Credit: Don't apply domain proration cost override to plans grid

### DIFF
--- a/packages/data-stores/src/plans/constants.ts
+++ b/packages/data-stores/src/plans/constants.ts
@@ -71,4 +71,5 @@ export const PERIOD_LIST = [
 
 export const COST_OVERRIDE_REASONS = {
 	RECENT_PLAN_PRORATION: 'recent-plan-proration',
+	RECENT_DOMAIN_PRORATION: 'recent-domain-proration',
 };

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -230,7 +230,7 @@ const usePricingMetaForGridPlans = ( {
 						full: getTotalPrice( sitePlan?.pricing.originalPrice.full, storageAddOnPriceYearly ),
 					};
 
-					// Do not return discounted prices if discount is due to plan proration
+					// Do not return discounted prices if discount is due to plan or domain proration.
 					// If there is, however, a sale coupon, show the discounted price
 					// without proration. This isn't ideal, but is intentional. Because of
 					// this, the price will differ between the plans grid and checkout screen.

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -234,11 +234,17 @@ const usePricingMetaForGridPlans = ( {
 					// If there is, however, a sale coupon, show the discounted price
 					// without proration. This isn't ideal, but is intentional. Because of
 					// this, the price will differ between the plans grid and checkout screen.
+					const costOverrideCode = sitePlan?.pricing?.costOverrides?.[ 0 ]?.overrideCode;
+					const hasProratedCostOverride =
+						costOverrideCode &&
+						[
+							COST_OVERRIDE_REASONS.RECENT_PLAN_PRORATION,
+							COST_OVERRIDE_REASONS.RECENT_DOMAIN_PRORATION,
+						].includes( costOverrideCode );
 					if (
 						! sitePlan?.pricing?.hasSaleCoupon &&
 						! withProratedDiscounts &&
-						sitePlan?.pricing?.costOverrides?.[ 0 ]?.overrideCode ===
-							COST_OVERRIDE_REASONS.RECENT_PLAN_PRORATION
+						hasProratedCostOverride
 					) {
 						return [
 							planSlug,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3669

## Proposed Changes

Requires: 170944-ghe-Automattic/wpcom

For users who have unused domain credit after purchasing a domain and no plan, we will be [displaying a credit notice above the plans grid](https://github.com/Automattic/wp-calypso/pull/98792), however we do not want to display the discount in the plan grid itself.

| Old | New |
| -- | -- |
|![CleanShot 2025-02-03 at 17 02 17@2x](https://github.com/user-attachments/assets/a9e5d691-a7b2-459d-8579-bc9a361bc460)|![CleanShot 2025-02-03 at 17 03 19@2x](https://github.com/user-attachments/assets/d2d5106f-8e9b-4c16-9629-de133efe4e27)|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To avoid a source of confusion and align with the existing approach mentioned https://github.com/Automattic/martech/issues/3643#issuecomment-2625670498.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Requires using 170944-ghe-Automattic/wpcom on your sandbox.

1. Create a domain-only site
2. Navigate to `/plans/:site`
3. Verify that the domain-to-plan credit discount is not applied in the plans grid

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?