### PR TITLE
Shrink Big Sky beta label and make use of partial translations

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/goals-first-design-choice.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/goals-first-design-choice.scss
@@ -46,6 +46,13 @@
 		font-weight: 500;
 		line-height: 24px;
 		text-align: left;
+
+		.design-choices__beta-label {
+          font-size: $font-body-extra-small;
+          font-weight: 600;
+          line-height: 14px;
+          text-align: left;
+		}
 	}
 
 	.goals-first-design-choice__description {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/goals-first-design-choice.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/goals-first-design-choice.tsx
@@ -5,7 +5,8 @@ import './goals-first-design-choice.scss';
 
 interface Props {
 	className?: string;
-	title: string;
+	title: string | React.ReactElement;
+	ariaLabel?: string;
 	description: string;
 	bgImageSrc?: string;
 	fgImageSrc?: string;
@@ -17,44 +18,49 @@ interface Props {
 const GoalsFirstDesignChoice = ( {
 	className,
 	title,
+	ariaLabel: _ariaLabel,
 	description,
 	bgImageSrc,
 	fgImageSrc,
 	destination,
 	onSelect,
 	badgeLabel,
-}: Props ) => (
-	<button
-		className={ clsx( 'goals-first-design-choice', className ) }
-		aria-label={ title }
-		onClick={ () => onSelect( destination ) }
-	>
-		<div className="goals-first-design-choice__content">
-			<div className="goals-first-design-choice__background">
-				{ badgeLabel && (
-					<Badge type="info-blue" className="goals-first-design-choice__price-badge">
-						{ badgeLabel }
-					</Badge>
-				) }
-				<div className="goals-first-design-choice__background-item">
-					{ bgImageSrc && <img src={ bgImageSrc } alt={ title } /> }
-					{ fgImageSrc && (
-						<img
-							className="goals-first-design-choice__foreground-image"
-							src={ fgImageSrc }
-							alt={ title }
-						/>
+}: Props ) => {
+	const ariaLabel = ! _ariaLabel && typeof title === 'string' ? title : _ariaLabel;
+
+	return (
+		<button
+			className={ clsx( 'goals-first-design-choice', className ) }
+			aria-label={ ariaLabel }
+			onClick={ () => onSelect( destination ) }
+		>
+			<div className="goals-first-design-choice__content">
+				<div className="goals-first-design-choice__background">
+					{ badgeLabel && (
+						<Badge type="info-blue" className="goals-first-design-choice__price-badge">
+							{ badgeLabel }
+						</Badge>
 					) }
+					<div className="goals-first-design-choice__background-item">
+						{ bgImageSrc && <img src={ bgImageSrc } alt={ ariaLabel } /> }
+						{ fgImageSrc && (
+							<img
+								className="goals-first-design-choice__foreground-image"
+								src={ fgImageSrc }
+								alt={ ariaLabel }
+							/>
+						) }
+					</div>
+				</div>
+				<div className="goals-first-design-choice__foreground">
+					<div className="goals-first-design-choice__title">{ title }</div>
+					<div className="goals-first-design-choice__description">
+						{ preventWidows( description ) }
+					</div>
 				</div>
 			</div>
-			<div className="goals-first-design-choice__foreground">
-				<div className="goals-first-design-choice__title">{ title }</div>
-				<div className="goals-first-design-choice__description">
-					{ preventWidows( description ) }
-				</div>
-			</div>
-		</div>
-	</button>
-);
+		</button>
+	);
+};
 
 export default GoalsFirstDesignChoice;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/goals-first-design-choice.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/goals-first-design-choice.tsx
@@ -5,7 +5,7 @@ import './goals-first-design-choice.scss';
 
 interface Props {
 	className?: string;
-	title: string | React.ReactElement;
+	title: string | number | React.ReactElement;
 	ariaLabel?: string;
 	description: string;
 	bgImageSrc?: string;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { PLAN_PERSONAL } from '@automattic/calypso-products';
 import { OnboardSelect, ProductsList } from '@automattic/data-stores';
 import { themesIllustrationImage } from '@automattic/design-picker';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer, isOnboardingFlow } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import clsx from 'clsx';
@@ -32,6 +32,7 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 		isOnboardingFlow( flow ) && isEnabled( 'onboarding/big-sky-before-plans' );
 
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 	const { submit, goBack } = navigation;
 	const headerText = isGoalsFirstVariation
 		? translate( 'How would you like to start?' )
@@ -73,6 +74,28 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 		} );
 
 		submit?.( { destination } );
+	};
+
+	const getCreateWithAILabel = () => {
+		if ( hasEnTranslation( 'Create with AI {{small}}(BETA){{/small}}' ) ) {
+			return translate( 'Create with AI {{small}}(BETA){{/small}}', {
+				components: {
+					small: <span className="design-choices__beta-label" />,
+				},
+			} );
+		}
+
+		if ( hasEnTranslation( 'Create with AI' ) ) {
+			return translate( '%s {{small}}(BETA){{/small}}', {
+				args: [ translate( 'Create with AI' ) ],
+				components: {
+					small: <span className="design-choices__beta-label" />,
+				},
+				comment: 'Do not translate',
+			} );
+		}
+
+		return translate( 'Create with AI (BETA)' );
 	};
 
 	const bigSkyBadgeLabel =
@@ -160,7 +183,8 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 							) }
 							{ ! isLoading && isEligible && isGoalsFirstVariation && (
 								<GoalsFirstDesignChoice
-									title={ translate( 'Create with AI (BETA)' ) }
+									title={ getCreateWithAILabel() }
+									ariaLabel={ translate( 'Create with AI (BETA)' ) }
 									description={ translate(
 										'Use our AI website builder to easily and quickly build the site of your dreams.'
 									) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #99146

## Proposed Changes

Adjusts size of the BETA label to match mockups

![CleanShot 2025-01-31 at 18 18 19@2x](https://github.com/user-attachments/assets/94d79fe3-2f05-4225-b86d-baf895cac4ef)

Also attempts to make use of some existing translations if they exist.
You can see that "Create with AI" and "Create with AI {{small}}(BETA){{/small}}" are already in the process of being translated.
https://translate.wordpress.com/projects/wpcom/es/default?filters%5Bterm%5D=Create+with+AI


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `calypso.localhost:3000/setup/onboarding` and choose Big Sky compatible goals.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
