### PR TITLE
A4A: Change Woo Storefront benefits text to be all imperative.

### DIFF
--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -2124,7 +2124,7 @@ export const getJetpackProductsBenefits = (): Record< string, Array< TranslateRe
 	const woocommerceStorefrontExtensionsBundleBenefits = [
 		translate( 'Enhance Storefront theme functionality' ),
 		translate( 'Add various design and layout improvements' ),
-		translate( 'Includes multiple Storefront-specific plugins' ),
+		translate( 'Include multiple Storefront-specific plugins' ),
 		translate( 'Improve site performance with optimized extensions' ),
 	];
 	const woocommerceTableRateShippingBenefits = [


### PR DESCRIPTION
Minor improvements to the product description for the WooCommerce Storefront plugin.

Context: https://github.com/Automattic/wp-calypso/pull/98605#discussion_r1929433797

## Proposed Changes

* Text update and make all plugin benefits to be imperative.

## Why are these changes being made?

*

## Testing Instructions

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
