### PR TITLE
Improve billing information loading state

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-prefill-checkout-contact-form.ts
+++ b/client/my-sites/checkout/src/hooks/use-prefill-checkout-contact-form.ts
@@ -128,10 +128,24 @@ export function usePrefillCheckoutContactForm( {
 }: {
 	setShouldShowContactDetailsValidationErrors?: ( allowed: boolean ) => void;
 	isLoggedOut?: boolean;
-} ): void {
-	const cachedContactDetails = useCachedContactDetails( { isLoggedOut } );
-	useCachedContactDetailsForCheckoutForm(
-		cachedContactDetails,
+} ): boolean {
+	const { contactDetails, isError } = useCachedContactDetails( { isLoggedOut } );
+
+	const hasCompleted = useCachedContactDetailsForCheckoutForm(
+		contactDetails,
 		setShouldShowContactDetailsValidationErrors
 	);
+
+	// If there is an error, we return it as true and let the form handle it.
+	if ( isError ) {
+		return true;
+	}
+
+	// We don't retrieve cached contact details if the user is logged out.
+	// Unless they already live in the checkout data store.
+	if ( isLoggedOut ) {
+		return true;
+	}
+
+	return hasCompleted;
 }

--- a/client/my-sites/checkout/src/payment-methods/pix.tsx
+++ b/client/my-sites/checkout/src/payment-methods/pix.tsx
@@ -97,7 +97,8 @@ function usePrefillState( state: PixPaymentMethodState ): void {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const isLoggedOut = responseCart.cart_key === 'no-user';
-	const contactDetails = useCachedContactDetails( { isLoggedOut } );
+	const { contactDetails } = useCachedContactDetails( { isLoggedOut } );
+
 	// Don't try to pre-fill if the form has been edited. (Also prevents
 	// infinite loops.)
 	if ( state.isTouched ) {

--- a/client/my-sites/checkout/src/test/checkout-contact-autocomplete.tsx
+++ b/client/my-sites/checkout/src/test/checkout-contact-autocomplete.tsx
@@ -75,6 +75,7 @@ describe( 'Checkout contact step', () => {
 	} );
 
 	it( 'does not complete the contact step when the contact step button has not been clicked and there are no cached details', async () => {
+		mockCachedContactDetailsEndpoint( {} );
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
 			legacyRoot: true,

--- a/client/my-sites/checkout/src/test/checkout-contact-step.tsx
+++ b/client/my-sites/checkout/src/test/checkout-contact-step.tsx
@@ -21,6 +21,7 @@ import {
 	mockMatchMediaOnWindow,
 	mockGetVatInfoEndpoint,
 	countryList,
+	mockCachedContactDetailsEndpoint,
 	mockGetPaymentMethodsEndpoint,
 	mockLogStashEndpoint,
 	mockGetSupportedCountriesEndpoint,
@@ -63,6 +64,8 @@ describe( 'Checkout contact step', () => {
 		mockGetPaymentMethodsEndpoint( [] );
 		mockLogStashEndpoint();
 		mockGetSupportedCountriesEndpoint( countryList );
+		mockCachedContactDetailsEndpoint( {} );
+		mockGetVatInfoEndpoint( {} );
 	} );
 
 	it( 'does render the contact step when the purchase is free and some items are recurring', async () => {

--- a/client/my-sites/checkout/src/test/checkout-extra-tax-fields.tsx
+++ b/client/my-sites/checkout/src/test/checkout-extra-tax-fields.tsx
@@ -17,6 +17,7 @@ import {
 	planWithBundledDomain,
 	planWithoutDomain,
 	mockSetCartEndpointWith,
+	mockCachedContactDetailsEndpoint,
 	getActivePersonalPlanDataForType,
 	mockContactDetailsValidationEndpoint,
 	getBasicCart,
@@ -82,6 +83,8 @@ describe( 'Checkout contact step extra tax fields', () => {
 		mockGetSupportedCountriesEndpoint( countryList );
 		mockGetVatInfoEndpoint( {} );
 		mockSetCachedContactDetailsEndpoint();
+		mockCachedContactDetailsEndpoint( {} );
+		mockGetVatInfoEndpoint( {} );
 	} );
 
 	it.each( [

--- a/client/my-sites/checkout/src/test/checkout-vat-form.tsx
+++ b/client/my-sites/checkout/src/test/checkout-vat-form.tsx
@@ -79,6 +79,8 @@ describe( 'Checkout contact step VAT form', () => {
 		mockMatchMediaOnWindow();
 		mockGetVatInfoEndpoint( {} );
 		mockSetCachedContactDetailsEndpoint();
+		mockCachedContactDetailsEndpoint( {} );
+		mockGetVatInfoEndpoint( {} );
 	} );
 
 	it( 'does not render the VAT field checkbox if the selected country does not support VAT', async () => {
@@ -359,6 +361,7 @@ describe( 'Checkout contact step VAT form', () => {
 			];
 		} );
 		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
+		mockSetVatInfoEndpoint();
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render(

--- a/client/my-sites/checkout/src/test/use-prefill-checkout-contact-form.tsx
+++ b/client/my-sites/checkout/src/test/use-prefill-checkout-contact-form.tsx
@@ -175,4 +175,17 @@ describe( 'usePrefillCheckoutContactForm', () => {
 		await expect( screen.findByText( 'Form Country: US' ) ).toNeverAppear();
 		await expect( screen.findByText( 'Form Postal: 10001' ) ).toNeverAppear();
 	} );
+
+	it( 'returns true if there is an error with the query', async () => {
+		mockGetSupportedCountriesEndpoint( countryList );
+		mockCachedContactDetailsEndpoint( {}, 500 ); // Simulating API failure
+
+		const reduxStore = createTestReduxStore();
+		const queryClient = new QueryClient();
+		render( <MyTestWrapper reduxStore={ reduxStore } queryClient={ queryClient } /> );
+
+		await waitFor( () => {
+			expect( screen.queryByTestId( 'contact-form--visible' ) ).toBeInTheDocument();
+		} );
+	} );
 } );

--- a/client/my-sites/checkout/src/test/util/index.ts
+++ b/client/my-sites/checkout/src/test/util/index.ts
@@ -1948,10 +1948,10 @@ export const expectedCreateAccountRequest = {
 	},
 };
 
-export function mockCachedContactDetailsEndpoint( responseData ): void {
+export function mockCachedContactDetailsEndpoint( responseData, responseCode = 200 ): void {
 	const endpoint = jest.fn();
 	endpoint.mockReturnValue( true );
-	const mockDomainContactResponse = () => [ 200, responseData ];
+	const mockDomainContactResponse = () => [ responseCode, responseData ];
 	nock( 'https://public-api.wordpress.com' )
 		.get( '/rest/v1.1/me/domain-contact-information' )
 		.reply( mockDomainContactResponse );


### PR DESCRIPTION
Related to #98527

## Proposed Changes

This PR updates the "Billing Information" loading state to reduce the number of visual changes that occur on cart load.

It does so by doing two things:
- Use the return value from `useCachedContactDetailsForCheckoutForm` to determine when the prefill action has been completed and display a loading string in the meantime.
- Hide the sibling `<button>` element .

## Before 
https://github.com/user-attachments/assets/e852e759-1427-426f-aba0-4ae106fd396a

## After
https://github.com/user-attachments/assets/5f48562a-ac30-4a6e-89ce-83373d60802d

## Screenshot

<img width="684" alt="Screenshot 2025-02-13 at 10 44 33 AM" src="https://github.com/user-attachments/assets/c3d92bda-0dc8-4db1-9ee3-bfbe2b09737f" />

## Why are these changes being made?
 
As described in #98527, there are multiple different loading states on cart load. This is a distracting experience.

## Considerations

I go into more detail about things I tried in the [original issue](https://github.com/Automattic/wp-calypso/issues/98527#issuecomment-2608872136). I tried a few other things, like calling the domain contact endpoint earlier on page load. That didn't have much of an effect. The visual state was more or less unchanged. 

Loading it synchronously is the most logical way to remove these intermediate states or maybe have a lazy load system for users who don't start their session on the checkout page. Regardless, [I agree with](https://github.com/Automattic/wp-calypso/issues/98527#issuecomment-2613616772) @sirbrillig that keeping it simple is probably the win.

## Testing Instructions

**Logged out cart**
- Go to [JetPack Pricing](https://cloud.jetpack.com/pricing), click "Get"
- Fill in "Enter your billing information" section.
- Click "Continue to payment".


**Cart without saved contact**
- In a new account, add items to cart.
- Fill in "Enter your billing information" section.
- Click "Continue to payment".

**Cart with saved contact**
- In the account used above, add items to cart
- Expect "Enter your billing information" to show the loading state.
- After a moment, expect to see "Billing Information" completely
- Click "Edit", change some details, reload the page.
- Expect to see the same flow with updates parameters

**Test Pix**

Pix also uses the cached contact details. You can test it using the instructions from https://github.com/Automattic/wp-calypso/pull/86826.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?