### PR TITLE
Enables Global Styles on Personal plan in production

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -64,7 +64,7 @@
 		"cookie-banner": false,
 		"google-drive": true,
 		"google-my-business": true,
-		"global-styles/on-personal-plan": false,
+		"global-styles/on-personal-plan": true,
 		"help": true,
 		"help/gpt-response": true,
 		"home/launchpad-first": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -32,7 +32,7 @@
 		"devdocs": false,
 		"cookie-banner": true,
 		"google-my-business": false,
-		"global-styles/on-personal-plan": false,
+		"global-styles/on-personal-plan": true,
 		"help": true,
 		"home/launchpad-first": false,
 		"home/layout-dev": true,

--- a/config/production.json
+++ b/config/production.json
@@ -43,7 +43,7 @@
 		"current-site/stale-cart-notice": false,
 		"cookie-banner": true,
 		"google-my-business": true,
-		"global-styles/on-personal-plan": false,
+		"global-styles/on-personal-plan": true,
 		"help": true,
 		"help/gpt-response": true,
 		"home/launchpad-first": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -43,7 +43,7 @@
 		"dev/store-sandbox-helper": true,
 		"cookie-banner": false,
 		"google-my-business": true,
-		"global-styles/on-personal-plan": false,
+		"global-styles/on-personal-plan": true,
 		"help": true,
 		"help/gpt-response": true,
 		"home/launchpad-first": false,

--- a/config/test.json
+++ b/config/test.json
@@ -44,7 +44,7 @@
 		"difm/allow-extra-pages": false,
 		"cookie-banner": false,
 		"google-my-business": false,
-		"global-styles/on-personal-plan": false,
+		"global-styles/on-personal-plan": true,
 		"help": true,
 		"hosting-server-settings-enhancements": true,
 		"importers/newsletter": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -48,7 +48,7 @@
 		"email-accounts/enabled": true,
 		"cookie-banner": true,
 		"google-my-business": true,
-		"global-styles/on-personal-plan": false,
+		"global-styles/on-personal-plan": true,
 		"help": true,
 		"help/gpt-response": true,
 		"home/launchpad-first": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1738136972932859-slack-C085HCWCEDN

## Proposed Changes

* Enable GS on Personal in production

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to have GS on Personal for Big Sky.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Global Styles should be on the personal plan app-wide.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?