### PR TITLE
Subscribers Dataview: fix missing export

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -84,12 +84,6 @@ body.is-section-subscribers.is-subscribers-dataviews,
                     @media ( max-width: 430px ) {
                         padding: $padding-standard 24px;
                     }
-
-                    @media ( min-width: $break-small ) {
-                        .gridicon {
-                            display: none;
-                        }
-                    }
                 }
 
                 .subscriber-launchpad {


### PR DESCRIPTION
Closes #99106

## Proposed Changes

* Remove media query for grid-icon

## Why are these changes being made?

Currently the action menu for subscribers is only visible in small screen orientations. Removing this style allows the menu to be present in all screen sizes

| Before | After |
|--------|--------|
| <img width="602" alt="Screen Shot on 2025-01-31 at 10-08-23" src="https://github.com/user-attachments/assets/3248549c-f89b-4f84-932e-7181ddf2cecd" /> | <img width="616" alt="Screen Shot on 2025-01-31 at 10-08-39" src="https://github.com/user-attachments/assets/b0022e34-2eb2-43c7-826f-5dbb875e250a" /> |


## Testing Instructions

1. Go to `/subscribers/[ YOUR SITE ]`
2. Look for the action menu next to the ADD SUBSCRIBERS button
3. Check all screen sizess
4. Look for regressions