### PR TITLE
i18n: Update several `/client` components to replace `formatNumnber` with i18n-calypso `numberFormat`

### DIFF
--- a/client/blocks/author-compact-profile/index.tsx
+++ b/client/blocks/author-compact-profile/index.tsx
@@ -1,6 +1,5 @@
-import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import clsx from 'clsx';
-import { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
@@ -92,7 +91,7 @@ export default function AuthorCompactProfile( props: AuthorCompactProfileProps )
 						{ translate( '%(followCount)s subscriber', '%(followCount)s subscribers', {
 							count: followCount,
 							args: {
-								followCount: formatNumber( followCount, getLocaleSlug() ?? 'en' ),
+								followCount: numberFormat( followCount ),
 							},
 						} ) }
 					</div>

--- a/client/blocks/author-compact-profile/index.tsx
+++ b/client/blocks/author-compact-profile/index.tsx
@@ -91,7 +91,12 @@ export default function AuthorCompactProfile( props: AuthorCompactProfileProps )
 						{ translate( '%(followCount)s subscriber', '%(followCount)s subscribers', {
 							count: followCount,
 							args: {
-								followCount: numberFormat( followCount ),
+								followCount: numberFormat( followCount, {
+									numberFormatOptions: {
+										notation: 'compact',
+										maximumFractionDigits: 1,
+									},
+								} ),
 							},
 						} ) }
 					</div>

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -1,7 +1,6 @@
 import { Gridicon } from '@automattic/components';
-import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import clsx from 'clsx';
-import { translate, getLocaleSlug } from 'i18n-calypso';
+import { translate, numberFormat } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import TagsList from 'calypso/blocks/reader-post-card/tags-list';
 import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
@@ -97,7 +96,7 @@ const ReaderFullPostHeader = ( { post, authorProfile, layout = 'default' } ) => 
 								{ translate( '%(followCount)s subscriber', '%(followCount)s subscribers', {
 									count: followCount,
 									args: {
-										followCount: formatNumber( followCount, getLocaleSlug() ),
+										followCount: numberFormat( followCount ),
 									},
 								} ) }
 							</span>

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -96,7 +96,9 @@ const ReaderFullPostHeader = ( { post, authorProfile, layout = 'default' } ) => 
 								{ translate( '%(followCount)s subscriber', '%(followCount)s subscribers', {
 									count: followCount,
 									args: {
-										followCount: numberFormat( followCount ),
+										followCount: numberFormat( followCount, {
+											numberFormatOptions: { notation: 'compact', maximumFractionDigits: 1 },
+										} ),
 									},
 								} ) }
 							</span>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-stats-column.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-stats-column.tsx
@@ -1,8 +1,7 @@
 import { Gridicon, ShortenedNumber } from '@automattic/components';
-import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import { Icon, arrowUp, arrowDown } from '@wordpress/icons';
 import clsx from 'clsx';
-import { translate } from 'i18n-calypso';
+import { translate, numberFormat } from 'i18n-calypso';
 import { useCallback, useContext } from 'react';
 import { DATAVIEWS_LIST } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
@@ -68,7 +67,7 @@ export default function SiteStatsColumn( { site, stats, siteError }: Props ) {
 				>
 					{ trendIcon }
 					<div className="sites-overview__stats">
-						<span className="shortened-number">{ formatNumber( totalViews ) }</span>
+						<span className="shortened-number">{ numberFormat( totalViews ) }</span>
 					</div>
 				</button>
 			);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-stats-column.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-stats-column.tsx
@@ -67,7 +67,11 @@ export default function SiteStatsColumn( { site, stats, siteError }: Props ) {
 				>
 					{ trendIcon }
 					<div className="sites-overview__stats">
-						<span className="shortened-number">{ numberFormat( totalViews ) }</span>
+						<span className="shortened-number">
+							{ numberFormat( totalViews, {
+								numberFormatOptions: { notation: 'compact', maximumFractionDigits: 1 },
+							} ) }
+						</span>
 					</div>
 				</button>
 			);

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -44,12 +44,14 @@ function getStepsForTiers( tiers: StatsPlanTierUI[], currencyCode: string ) {
 		return {
 			lhValue:
 				typeof tier.views === 'number'
-					? numberFormat( tier.views, {
-							numberFormatOptions: {
-								notation: 'compact',
-								maximumFractionDigits: 1,
-							},
-					  } )
+					? String(
+							numberFormat( tier.views, {
+								numberFormatOptions: {
+									notation: 'compact',
+									maximumFractionDigits: 1,
+								},
+							} )
+					  )
 					: '-',
 			rhValue: price,
 			originalPrice: tier.price,

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -1,6 +1,5 @@
-import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import formatCurrency from '@automattic/format-currency';
-import { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { EXTENSION_THRESHOLD_IN_MILLION } from 'calypso/my-sites/stats/hooks/use-available-upgrade-tiers';
@@ -43,7 +42,15 @@ function getStepsForTiers( tiers: StatsPlanTierUI[], currencyCode: string ) {
 
 		// Return the new step with string values.
 		return {
-			lhValue: formatNumber( tier.views, getLocaleSlug() ?? 'en' ),
+			lhValue:
+				typeof tier.views === 'number'
+					? numberFormat( tier.views, {
+							numberFormatOptions: {
+								notation: 'compact',
+								maximumFractionDigits: 1,
+							},
+					  } )
+					: '-',
 			rhValue: price,
 			originalPrice: tier.price,
 			upgradePrice: tierUpgradePricePerMonth

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -1,5 +1,4 @@
-import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
-import { getLocaleSlug, translate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import { useEffect } from 'react';
 import Pagination from 'calypso/components/pagination';
 import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
@@ -43,6 +42,7 @@ const SubscriberListContainer = ( {
 	} = useSubscribersPage();
 	useRecordSearch();
 
+	const translate = useTranslate();
 	const isSimple = useSelector( isSimpleSite );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 	const EmptyComponent = isSimple || isAtomic ? SubscriberLaunchpad : EmptyListView;
@@ -72,7 +72,7 @@ const SubscriberListContainer = ( {
 								isLoading ? 'loading-placeholder' : ''
 							}` }
 						>
-							{ formatNumber( total, getLocaleSlug() || undefined, { notation: 'standard' } ) }
+							{ numberFormat( total ) }
 						</span>
 					</div>
 

--- a/client/reader/stream/site-feed-sidebar/index.jsx
+++ b/client/reader/stream/site-feed-sidebar/index.jsx
@@ -1,5 +1,4 @@
-import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
-import { useTranslate, getLocaleSlug, numberFormat } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import ReaderFeedHeaderFollow from 'calypso/blocks/reader-feed-header/follow';
 import TagLink from 'calypso/blocks/reader-post-card/tag-link';
@@ -56,7 +55,9 @@ const FeedStreamSidebar = ( {
 					{ followerCount && (
 						<div className="reader-tag-sidebar-stats__item">
 							<span className="reader-tag-sidebar-stats__count">
-								{ formatNumber( followerCount, getLocaleSlug() ) }
+								{ numberFormat( followerCount, {
+									numberFormatOptions: { notation: 'compact', maximumFractionDigits: 1 },
+								} ) }
 							</span>
 							<span className="reader-tag-sidebar-stats__title">
 								{ translate( 'Subscriber', 'Subscribers', { count: followerCount } ) }

--- a/packages/components/src/number-formatters/lib/format-number.ts
+++ b/packages/components/src/number-formatters/lib/format-number.ts
@@ -8,9 +8,9 @@ export const DEFAULT_LOCALE =
 // Preset Options
 export const COMPACT_FORMATTING_OPTIONS = {
 	notation: 'compact',
-	maximumSignificantDigits: 3,
+	maximumSignificantDigits: 3, // TODO clk numberFormat deleted below?
 	maximumFractionDigits: 1,
-	compactDisplay: 'short',
+	compactDisplay: 'short', // TODO clk numberFormat already the default
 } as Intl.NumberFormatOptions;
 export const STANDARD_FORMATTING_OPTIONS = {
 	notation: 'standard',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/934

## Proposed Changes

- Refactors several `@automattic/components:formatNumber` instances to go through `i18n-calypso:numberFormat`
- These are straight forward cases of compact notation. The options are carried through inline for now. We may create an abstraction later.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See https://github.com/Automattic/i18n-issues/issues/934

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Various cases need to be tested separately, but one or two should suffice as they are all the same.

- go to `/devdocs` Blocks and confirm `AuthorCompactProfile` renders subscribers count without decimals

<img width="400" alt="Screenshot 2025-01-31 at 6 43 23 PM" src="https://github.com/user-attachments/assets/afda1961-4027-4cf2-9148-71891a4987de" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
