### PR TITLE
Stepper: Unify loading states

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
@@ -1,14 +1,11 @@
-import { isWooExpressFlow, isTransferringHostedSiteCreationFlow } from '@automattic/onboarding';
 import { ProgressBar } from '@wordpress/components';
 import clsx from 'clsx';
-import { LoadingBar } from 'calypso/components/loading-bar';
 import './style.scss';
 
 interface StepperLoaderProps {
 	title?: string;
 	subtitle?: React.ReactNode;
 	progress?: number;
-	flow?: string;
 	className?: string;
 }
 
@@ -16,19 +13,9 @@ const StepperLoader: React.FC< StepperLoaderProps > = ( {
 	title,
 	subtitle,
 	progress = -1,
-	flow = null,
 	className,
 } ) => {
 	const renderProgressComponent = () => {
-		if ( isWooExpressFlow( flow ) || isTransferringHostedSiteCreationFlow( flow ) ) {
-			return (
-				<LoadingBar
-					progress={ progress >= 0 ? progress : -1 }
-					className="processing-step__content woocommerce-install__content"
-				/>
-			);
-		}
-
 		return (
 			<ProgressBar
 				value={ progress >= 0 ? progress * 100 : undefined }

--- a/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
@@ -1,5 +1,6 @@
 import { isWooExpressFlow, isTransferringHostedSiteCreationFlow } from '@automattic/onboarding';
 import { ProgressBar } from '@wordpress/components';
+import clsx from 'clsx';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import './style.scss';
 
@@ -8,6 +9,7 @@ interface StepperLoaderProps {
 	subtitle?: React.ReactNode;
 	progress?: number;
 	flow?: string;
+	className?: string;
 }
 
 const StepperLoader: React.FC< StepperLoaderProps > = ( {
@@ -15,6 +17,7 @@ const StepperLoader: React.FC< StepperLoaderProps > = ( {
 	subtitle,
 	progress = -1,
 	flow = null,
+	className,
 } ) => {
 	const renderProgressComponent = () => {
 		if ( isWooExpressFlow( flow ) || isTransferringHostedSiteCreationFlow( flow ) ) {
@@ -35,7 +38,7 @@ const StepperLoader: React.FC< StepperLoaderProps > = ( {
 	};
 
 	return (
-		<div className="stepper-loader">
+		<div className={ clsx( 'stepper-loader', className ) }>
 			<h1 className="stepper-loader__title processing-step__progress-step">{ title }</h1>
 			{ renderProgressComponent() }
 			{ subtitle && <p className="stepper-loader__subtitle">{ subtitle }</p> }

--- a/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
@@ -7,15 +7,20 @@ interface StepperLoaderProps {
 	title?: string;
 	subtitle?: React.ReactNode;
 	progress?: number;
-	flow: string;
+	flow?: string;
 }
 
-const StepperLoader: React.FC< StepperLoaderProps > = ( { title, subtitle, progress, flow } ) => {
+const StepperLoader: React.FC< StepperLoaderProps > = ( {
+	title,
+	subtitle,
+	progress = -1,
+	flow = null,
+} ) => {
 	const renderProgressComponent = () => {
 		if ( isWooExpressFlow( flow ) || isTransferringHostedSiteCreationFlow( flow ) ) {
 			return (
 				<LoadingBar
-					progress={ progress !== undefined && progress >= 0 ? progress : -1 }
+					progress={ progress >= 0 ? progress : -1 }
 					className="processing-step__content woocommerce-install__content"
 				/>
 			);
@@ -23,7 +28,7 @@ const StepperLoader: React.FC< StepperLoaderProps > = ( { title, subtitle, progr
 
 		return (
 			<ProgressBar
-				value={ progress && progress >= 0 ? progress * 100 : undefined }
+				value={ progress >= 0 ? progress * 100 : undefined }
 				className="stepper-loader__progress-bar processing-step__progress-bar"
 			/>
 		);

--- a/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
@@ -15,19 +15,13 @@ const StepperLoader: React.FC< StepperLoaderProps > = ( {
 	progress = -1,
 	className,
 } ) => {
-	const renderProgressComponent = () => {
-		return (
-			<ProgressBar
-				value={ progress >= 0 ? progress * 100 : undefined }
-				className="stepper-loader__progress-bar processing-step__progress-bar"
-			/>
-		);
-	};
-
 	return (
 		<div className={ clsx( 'stepper-loader', className ) }>
-			<h1 className="stepper-loader__title processing-step__progress-step">{ title }</h1>
-			{ renderProgressComponent() }
+			<h1 className="stepper-loader__title">{ title }</h1>
+			<ProgressBar
+				value={ progress >= 0 ? progress * 100 : undefined }
+				className="stepper-loader__progress-bar"
+			/>
 			{ subtitle && <p className="stepper-loader__subtitle">{ subtitle }</p> }
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
@@ -6,7 +6,7 @@ import './style.scss';
 interface StepperLoaderProps {
 	title?: string;
 	subtitle?: React.ReactNode;
-	progress: number;
+	progress?: number;
 	flow: string;
 }
 
@@ -15,7 +15,7 @@ const StepperLoader: React.FC< StepperLoaderProps > = ( { title, subtitle, progr
 		if ( isWooExpressFlow( flow ) || isTransferringHostedSiteCreationFlow( flow ) ) {
 			return (
 				<LoadingBar
-					progress={ progress }
+					progress={ progress !== undefined ? progress * 100 : -1 }
 					className="processing-step__content woocommerce-install__content"
 				/>
 			);
@@ -23,14 +23,14 @@ const StepperLoader: React.FC< StepperLoaderProps > = ( { title, subtitle, progr
 
 		return (
 			<ProgressBar
-				value={ progress >= 0 ? progress * 100 : undefined }
+				value={ progress && progress >= 0 ? progress * 100 : undefined }
 				className="stepper-loader__progress-bar processing-step__progress-bar"
 			/>
 		);
 	};
 
 	return (
-		<div className="stepper-loader processing-step">
+		<div className="stepper-loader">
 			<h1 className="stepper-loader__title processing-step__progress-step">{ title }</h1>
 			{ renderProgressComponent() }
 			{ subtitle && <p className="processing-step__subtitle">{ subtitle }</p> }

--- a/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
@@ -15,7 +15,7 @@ const StepperLoader: React.FC< StepperLoaderProps > = ( { title, subtitle, progr
 		if ( isWooExpressFlow( flow ) || isTransferringHostedSiteCreationFlow( flow ) ) {
 			return (
 				<LoadingBar
-					progress={ progress !== undefined ? progress * 100 : -1 }
+					progress={ progress !== undefined && progress >= 0 ? progress : -1 }
 					className="processing-step__content woocommerce-install__content"
 				/>
 			);

--- a/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
@@ -1,10 +1,41 @@
-import clsx from 'clsx';
-import WordPressLogo from 'calypso/components/wordpress-logo';
+import { isWooExpressFlow, isTransferringHostedSiteCreationFlow } from '@automattic/onboarding';
+import { ProgressBar } from '@wordpress/components';
+import { LoadingBar } from 'calypso/components/loading-bar';
 import './style.scss';
 
-const StepperLoader = () => {
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
-	return <WordPressLogo size={ 72 } className={ clsx( 'wpcom-site__logo', 'stepper-loader' ) } />;
+interface StepperLoaderProps {
+	title?: string;
+	subtitle?: React.ReactNode;
+	progress: number;
+	flow: string;
+}
+
+const StepperLoader: React.FC< StepperLoaderProps > = ( { title, subtitle, progress, flow } ) => {
+	const renderProgressComponent = () => {
+		if ( isWooExpressFlow( flow ) || isTransferringHostedSiteCreationFlow( flow ) ) {
+			return (
+				<LoadingBar
+					progress={ progress }
+					className="processing-step__content woocommerce-install__content"
+				/>
+			);
+		}
+
+		return (
+			<ProgressBar
+				value={ progress >= 0 ? progress * 100 : undefined }
+				className="stepper-loader__progress-bar processing-step__progress-bar"
+			/>
+		);
+	};
+
+	return (
+		<div className="stepper-loader processing-step">
+			<h1 className="stepper-loader__title processing-step__progress-step">{ title }</h1>
+			{ renderProgressComponent() }
+			{ subtitle && <p className="processing-step__subtitle">{ subtitle }</p> }
+		</div>
+	);
 };
 
 export default StepperLoader;

--- a/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
@@ -38,7 +38,7 @@ const StepperLoader: React.FC< StepperLoaderProps > = ( {
 		<div className="stepper-loader">
 			<h1 className="stepper-loader__title processing-step__progress-step">{ title }</h1>
 			{ renderProgressComponent() }
-			{ subtitle && <p className="processing-step__subtitle">{ subtitle }</p> }
+			{ subtitle && <p className="stepper-loader__subtitle">{ subtitle }</p> }
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
@@ -12,16 +12,13 @@ interface StepperLoaderProps {
 const StepperLoader: React.FC< StepperLoaderProps > = ( {
 	title,
 	subtitle,
-	progress = -1,
+	progress,
 	className,
 } ) => {
 	return (
 		<div className={ clsx( 'stepper-loader', className ) }>
 			<h1 className="stepper-loader__title">{ title }</h1>
-			<ProgressBar
-				value={ progress >= 0 ? progress : undefined }
-				className="stepper-loader__progress-bar"
-			/>
+			<ProgressBar value={ progress } className="stepper-loader__progress-bar" />
 			{ subtitle && <p className="stepper-loader__subtitle">{ subtitle }</p> }
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
@@ -19,7 +19,7 @@ const StepperLoader: React.FC< StepperLoaderProps > = ( {
 		<div className={ clsx( 'stepper-loader', className ) }>
 			<h1 className="stepper-loader__title">{ title }</h1>
 			<ProgressBar
-				value={ progress >= 0 ? progress * 100 : undefined }
+				value={ progress >= 0 ? progress : undefined }
 				className="stepper-loader__progress-bar"
 			/>
 			{ subtitle && <p className="stepper-loader__subtitle">{ subtitle }</p> }

--- a/client/landing/stepper/declarative-flow/internals/components/stepper-loader/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/components/stepper-loader/style.scss
@@ -9,6 +9,10 @@
 	text-align: center;
 	margin: 32vh auto 0;
 
+	&.stepper-loader__boot {
+		margin-top: calc(32vh + 60px);
+	}
+
 	.stepper-loader__title {
 		@include onboarding-font-recoleta;
 		font-weight: 400;

--- a/client/landing/stepper/declarative-flow/internals/components/stepper-loader/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/components/stepper-loader/style.scss
@@ -6,7 +6,6 @@
 	--wp-components-color-foreground: #3858e9;
 	padding: 1em;
 	max-width: 540px;
-	text-align: center;
 	margin: 32vh auto 0;
 
 	&.stepper-loader__boot {

--- a/client/landing/stepper/declarative-flow/internals/components/stepper-loader/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/components/stepper-loader/style.scss
@@ -29,4 +29,12 @@
 	.stepper-loader__progress-bar {
 		margin: 46px auto 0 auto;
 	}
+
+	.stepper-loader__subtitle {
+		font-size: 1rem;
+		line-height: 21px;
+		letter-spacing: -0.02em;
+		color: var(--studio-gray-50);
+		margin-top: 24px;
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/components/stepper-loader/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/components/stepper-loader/style.scss
@@ -1,3 +1,32 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+@import "@automattic/onboarding/styles/mixins";
+
 .stepper-loader {
-	animation: loading-fade 1.6s ease-in-out infinite;
+	--wp-components-color-foreground: #3858e9;
+	padding: 1em;
+	max-width: 540px;
+	text-align: center;
+	margin: 32vh auto 0;
+
+	.stepper-loader__title {
+		@include onboarding-font-recoleta;
+		font-weight: 400;
+		height: 40px;
+		letter-spacing: -0.4px;
+		line-height: 40px;
+		margin: 0;
+		text-align: center;
+		vertical-align: middle;
+
+		font-size: $font-title-medium;
+
+		@include break-medium {
+			font-size: $font-title-large;
+		}
+	}
+
+	.stepper-loader__progress-bar {
+		margin: 46px auto 0 auto;
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -454,8 +454,10 @@ button {
 		font-weight: 600;
 		font-size: $font-title-large;
 	}
-	.loading-bar {
+	.stepper-loader__progress-bar {
+		--wp-components-color-foreground: var(--wooexpress-purple);
 		background-color: var(--studio-woocommerce-purple-5);
+		height: 6px;
 		width: 590px;
 		max-width: 100%;
 		margin-left: auto;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -470,7 +470,7 @@ button {
 		max-width: 640px;
 		box-sizing: border-box;
 	}
-	p.processing-step__subtitle {
+	p.stepper-loader__subtitle {
 		font-family: "SF Pro Text", $sans;
 		font-weight: 400;
 		letter-spacing: initial;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -406,17 +406,6 @@ button {
 	}
 }
 
-.wooexpress,
-.copy-site,
-.ecommerce {
-	.step-container.processing-step {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		margin-top: 25vh;
-	}
-}
-
 .assign-trial-plan,
 .processing {
 	&.wooexpress,
@@ -454,6 +443,12 @@ button {
 }
 
 .wooexpress {
+	.step-container.processing-step {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		margin-top: 9vh;
+	}
 	.step-container .step-container__content h1 {
 		font-family: proxima-nova, sans-serif;
 		font-weight: 600;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -108,7 +108,8 @@ button {
 .hundred-year-domain,
 .link-in-bio-tld,
 .entrepreneur,
-.generate-content {
+.generate-content,
+.processing {
 	box-sizing: border-box;
 
 	&.step-route {
@@ -224,6 +225,10 @@ button {
 	--wp-components-color-accent-darker-20: var(--studio-wordpress-blue-70);
 	--wp-components-color-accent: var(--studio-wordpress-blue-50);
 
+}
+
+.step-route.onboarding {
+	margin: 0 auto;
 }
 
 .import-focused .step-container.site-picker,

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -160,7 +160,7 @@ export const FlowRenderer: React.FC< { flow: Flow; steps: readonly StepperStep[]
 				if ( isWooExpressFlow( flow.name ) ) {
 					return <WordPressLogo size={ 72 } className="wpcom-site__logo stepper-loader" />;
 				}
-				return <StepperLoader flow={ flow.name } />;
+				return <StepperLoader />;
 			case AssertConditionState.FAILURE:
 				return null;
 		}

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -234,7 +234,7 @@ export const FlowRenderer: React.FC< { flow: Flow; steps: readonly StepperStep[]
 	useSignUpStartTracking( { flow } );
 
 	return (
-		<Boot fallback={ <StepperLoader /> }>
+		<Boot fallback={ <StepperLoader className="stepper-loader__boot" /> }>
 			<DocumentHead title={ getDocumentHeadTitle() } />
 
 			<Routes>

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -6,6 +6,7 @@ import Modal from 'react-modal';
 import { generatePath, useParams } from 'react-router';
 import { Route, Routes } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
+import WordPressLogo from 'calypso/components/wordpress-logo';
 import { STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
 import AsyncCheckoutModal from 'calypso/my-sites/checkout/modal/async';
 import { useSelector } from 'calypso/state';
@@ -156,7 +157,10 @@ export const FlowRenderer: React.FC< { flow: Flow; steps: readonly StepperStep[]
 	const renderStep = ( step: StepperStep ) => {
 		switch ( assertCondition.state ) {
 			case AssertConditionState.CHECKING:
-				return <StepperLoader />;
+				if ( isWooExpressFlow( flow.name ) ) {
+					return <WordPressLogo size={ 72 } className="wpcom-site__logo stepper-loader" />;
+				}
+				return <StepperLoader flow={ flow.name } />;
 			case AssertConditionState.FAILURE:
 				return null;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -1,10 +1,9 @@
-import { isWooExpressFlow, StepContainer } from '@automattic/onboarding';
+import { StepContainer } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import { LoadingBar } from 'calypso/components/loading-bar';
-import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import { StepperLoader } from 'calypso/landing/stepper/declarative-flow/internals/components';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import wpcom from 'calypso/lib/wp';
@@ -76,24 +75,14 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 				shouldHideNavButtons
 				hideFormattedHeader
 				stepName="assign-trial-step"
-				isHorizontalLayout
 				recordTracksEvent={ recordTracksEvent }
 				stepContent={
-					<>
-						<div className="assign-trial-step">
-							<h1 className="assign-trial-step__progress-step">{ getCurrentMessage() }</h1>
-							{ progress >= 0 || isWooExpressFlow( flow ) ? (
-								<LoadingBar progress={ progress } />
-							) : (
-								<LoadingEllipsis />
-							) }
-							{ isWooExpressFlow( flow ) ? (
-								<p className="processing-step__subtitle">{ getSubTitle() }</p>
-							) : (
-								<></>
-							) }
-						</div>
-					</>
+					<StepperLoader
+						title={ getCurrentMessage() }
+						subtitle={ getSubTitle() }
+						progress={ progress }
+						flow={ flow }
+					/>
 				}
 				showFooterWooCommercePowered={ false }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -13,7 +13,7 @@ import type { OnboardSelect } from '@automattic/data-stores';
 
 import './styles.scss';
 
-const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, data, flow } ) {
+const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, data } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
 	const progress = useSelect(
@@ -81,7 +81,6 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 						title={ getCurrentMessage() }
 						subtitle={ getSubTitle() }
 						progress={ progress }
-						flow={ flow }
 					/>
 				}
 				showFooterWooCommercePowered={ false }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/styles.scss
@@ -12,14 +12,12 @@
 		padding: 1em;
 		max-width: 540px;
 		text-align: center;
-		margin: 16vh auto 0;
 	}
 
 	> .assign-trial-step {
 		display: flex;
 		flex-direction: column;
 		align-items: center;
-		margin-top: 25vh;
 	}
 
 	.step-container {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/automated-copy-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/automated-copy-site/index.tsx
@@ -78,16 +78,16 @@ const AutomatedCopySite: Step = function AutomatedCopySite( { navigation } ) {
 
 				switch ( transferStatus ) {
 					case transferStates.PENDING:
-						setProgress( 0.2 );
+						setProgress( 20 );
 						break;
 					case transferStates.ACTIVE:
-						setProgress( 0.4 );
+						setProgress( 40 );
 						break;
 					case transferStates.PROVISIONED:
-						setProgress( 0.5 );
+						setProgress( 50 );
 						break;
 					case transferStates.COMPLETED:
-						setProgress( 0.7 );
+						setProgress( 70 );
 						break;
 				}
 
@@ -98,7 +98,7 @@ const AutomatedCopySite: Step = function AutomatedCopySite( { navigation } ) {
 				stopPollingTransfer = transferStatus === transferStates.COMPLETED;
 			}
 
-			setProgress( 1 );
+			setProgress( 100 );
 
 			return { finishedWaitingForCopy: true, siteSlug };
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-install-plugins/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-install-plugins/index.tsx
@@ -102,7 +102,7 @@ const BundleInstallPlugins: Step = function BundleInstallPlugins( { navigation }
 			let status: AtomicSoftwareStatus | undefined;
 			let currentProgress = 0;
 			const expectedStepCount = 5;
-			const progressStep = 1 / expectedStepCount;
+			const progressStep = 100 / expectedStepCount;
 			while ( ! status?.applied ) {
 				if ( maxFinishTime < new Date().getTime() ) {
 					handleTransferFailure( {
@@ -137,7 +137,7 @@ const BundleInstallPlugins: Step = function BundleInstallPlugins( { navigation }
 				setProgress( currentProgress );
 			}
 
-			setProgress( 1 );
+			setProgress( 100 );
 		} );
 
 		submit?.();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx
@@ -137,16 +137,16 @@ const BundleTransfer: Step = function BundleTransfer( { navigation, flow } ) {
 
 				switch ( transferStatus ) {
 					case transferStates.PENDING:
-						setProgress( 0.2 );
+						setProgress( 20 );
 						break;
 					case transferStates.ACTIVE:
-						setProgress( 0.4 );
+						setProgress( 40 );
 						break;
 					case transferStates.PROVISIONED:
-						setProgress( 0.5 );
+						setProgress( 50 );
 						break;
 					case transferStates.COMPLETED:
-						setProgress( 0.7 );
+						setProgress( 70 );
 						break;
 				}
 
@@ -208,7 +208,7 @@ const BundleTransfer: Step = function BundleTransfer( { navigation, flow } ) {
 					await wait( 3000 );
 				}
 			}
-			setProgress( 1 );
+			setProgress( 100 );
 		} );
 
 		submit?.();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -30,11 +30,10 @@ import { useI18n } from '@wordpress/react-i18n';
 import { getQueryArg } from '@wordpress/url';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import { LoadingBar } from 'calypso/components/loading-bar';
-import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import useAddEcommerceTrialMutation from 'calypso/data/ecommerce/use-add-ecommerce-trial-mutation';
 import useAddTempSiteToSourceOptionMutation from 'calypso/data/site-migration/use-add-temp-site-mutation';
 import { useSourceMigrationStatusQuery } from 'calypso/data/site-migration/use-source-migration-status-query';
+import { StepperLoader } from 'calypso/landing/stepper/declarative-flow/internals/components';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -310,18 +309,14 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 				shouldHideNavButtons
 				hideFormattedHeader
 				stepName="create-site"
-				isHorizontalLayout
 				recordTracksEvent={ recordTracksEvent }
 				stepContent={
-					<>
-						<h1>{ getCurrentMessage() }</h1>
-						{ progress >= 0 || isWooExpressFlow( flow ) ? (
-							<LoadingBar progress={ progress } />
-						) : (
-							<LoadingEllipsis />
-						) }
-						{ subTitle && <p className="processing-step__subtitle">{ subTitle }</p> }
-					</>
+					<StepperLoader
+						title={ getCurrentMessage() }
+						subtitle={ subTitle }
+						progress={ progress }
+						flow={ flow }
+					/>
 				}
 				showFooterWooCommercePowered={ false }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -315,7 +315,6 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 						title={ getCurrentMessage() }
 						subtitle={ subTitle }
 						progress={ progress }
-						flow={ flow }
 					/>
 				}
 				showFooterWooCommercePowered={ false }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/styles.scss
@@ -7,7 +7,6 @@ $font-family: "SF Pro Text", $sans;
 		padding: 1em;
 		max-width: 540px;
 		text-align: center;
-		margin: 16vh auto 0;
 
 		.step-container__content {
 			margin: auto;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
@@ -1,10 +1,10 @@
 import { Onboard } from '@automattic/data-stores';
 import { getAssemblerDesign } from '@automattic/design-picker';
-import { ProgressBar } from '@wordpress/components';
 import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, FormEvent, useState } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
+import { StepperLoader } from 'calypso/landing/stepper/declarative-flow/internals/components';
 import { SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { useIsBigSkyEligible } from '../../../../hooks/use-is-site-big-sky-eligible';
 import { useSiteData } from '../../../../hooks/use-site-data';
@@ -122,19 +122,14 @@ const LaunchBigSky: Step = function () {
 
 	function LaunchingBigSky() {
 		return (
-			<div className="processing-step__container">
-				<div className="processing-step">
-					<h1 className="processing-step__progress-step">
-						{ __( 'Launching the AI Website Builder' ) }
-					</h1>
-					{ ! isError && <ProgressBar className="processing-step__progress-bar" /> }
-					{ isError && (
-						<p className="processing-step__error">
-							{ __( 'Something unexpected happened. Please go back and try again.' ) }
-						</p>
-					) }
-				</div>
-			</div>
+			<>
+				<StepperLoader title={ __( 'Launching the AI Website Builder' ) } />
+				{ isError && (
+					<p className="processing-step__error">
+						{ __( 'Something unexpected happened. Please go back and try again.' ) }
+					</p>
+				) }
+			</>
 		);
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
@@ -123,7 +123,7 @@ const LaunchBigSky: Step = function () {
 	function LaunchingBigSky() {
 		return (
 			<>
-				<StepperLoader title={ __( 'Launching the AI Website Builder' ) } />
+				{ ! isError && <StepperLoader title={ __( 'Launching the AI Website Builder' ) } /> }
 				{ isError && (
 					<p className="processing-step__error">
 						{ __( 'Something unexpected happened. Please go back and try again.' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -300,6 +300,7 @@
 
 // Launchpad - Processing Screens
 .processing {
+	.stepper-loader__progress-bar,
 	.processing-step__progress-bar {
 		background-color: #fff;
 	}
@@ -340,7 +341,10 @@
 	.progress-bar {
 		display: none;
 	}
+}
 
+.stepper-loader {
+	h1.stepper-loader__title,
 	h1.processing-step__progress-step {
 		font-size: $font-title-medium;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -300,8 +300,7 @@
 
 // Launchpad - Processing Screens
 .processing {
-	.stepper-loader__progress-bar,
-	.processing-step__progress-bar {
+	.stepper-loader__progress-bar {
 		background-color: #fff;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -344,8 +344,7 @@
 }
 
 .stepper-loader {
-	h1.stepper-loader__title,
-	h1.processing-step__progress-step {
+	h1.stepper-loader__title {
 		font-size: $font-title-medium;
 
 		@include break-medium {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/README.md
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/README.md
@@ -59,13 +59,13 @@ setPendingAction( async () => {
    setProgress( 0 );
 
    await goToServerAndWork();
-   setProgress( 0.35 );
+   setProgress( 35 );
 
    await doMoreWork();
-   setProgress( 0.8 );
+   setProgress( 80 );
 
    await doEvenMoreWork();
-   setProgress( 1 );
+   setProgress( 100 );
 });
 
 submit?.();
@@ -105,15 +105,15 @@ setPendingAction( async () => {
 
    setProgressTitle( 'Working...' );
    await goToServerAndWork();
-   setProgress( 0.35 );
+   setProgress( 35 );
 
    setProgressTitle( 'Working harder!' );
    await doMoreWork();
-   setProgress( 0.8 );
+   setProgress( 80 );
 
    setProgressTitle( 'Almost done' );
    await doEvenMoreWork();
-   setProgress( 1 );
+   setProgress( 100 );
 });
 
 submit?.();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -5,19 +5,16 @@ import {
 	isNewSiteMigrationFlow,
 	isUpdateDesignFlow,
 	ECOMMERCE_FLOW,
-	isWooExpressFlow,
-	isTransferringHostedSiteCreationFlow,
 	HUNDRED_YEAR_DOMAIN_FLOW,
 	HUNDRED_YEAR_PLAN_FLOW,
 	HUNDRED_YEAR_DOMAIN_TRANSFER,
 	isAnyHostingFlow,
 } from '@automattic/onboarding';
-import { ProgressBar } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState, useRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import { LoadingBar } from 'calypso/components/loading-bar';
+import { StepperLoader } from 'calypso/landing/stepper/declarative-flow/internals/components';
 import availableFlows from 'calypso/landing/stepper/declarative-flow/registered-flows';
 import { useRecordSignupComplete } from 'calypso/landing/stepper/hooks/use-record-signup-complete';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
@@ -33,6 +30,7 @@ import TailoredFlowPreCheckoutScreen from './tailored-flow-precheckout-screen';
 import type { StepProps } from '../../types';
 import type { OnboardSelect } from '@automattic/data-stores';
 import './style.scss';
+
 interface ProcessingStepProps extends StepProps {
 	title?: string;
 	subtitle?: string;
@@ -195,26 +193,6 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 		return <HundredYearPlanFlowProcessingScreen />;
 	}
 
-	const subtitle = getSubtitle();
-
-	const renderProgressComponent = () => {
-		if ( isWooExpressFlow( flow ) || isTransferringHostedSiteCreationFlow( flow ) ) {
-			return (
-				<LoadingBar
-					progress={ progress }
-					className="processing-step__content woocommerce-install__content"
-				/>
-			);
-		}
-
-		return (
-			<ProgressBar
-				value={ progress >= 0 ? progress * 100 : undefined }
-				className="processing-step__progress-bar"
-			/>
-		);
-	};
-
 	return (
 		<>
 			<DocumentHead title={ __( 'Processing' ) } />
@@ -223,13 +201,12 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 				hideFormattedHeader
 				stepName="processing-step"
 				stepContent={
-					<>
-						<div className="processing-step">
-							<h1 className="processing-step__progress-step">{ getCurrentMessage() }</h1>
-							{ renderProgressComponent() }
-							{ subtitle && <p className="processing-step__subtitle">{ subtitle }</p> }
-						</div>
-					</>
+					<StepperLoader
+						title={ getCurrentMessage() }
+						subtitle={ getSubtitle() }
+						progress={ progress }
+						flow={ flow }
+					/>
 				}
 				recordTracksEvent={ recordTracksEvent }
 				showJetpackPowered={ isJetpackPowered }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -205,7 +205,6 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 						title={ getCurrentMessage() }
 						subtitle={ getSubtitle() }
 						progress={ progress }
-						flow={ flow }
 					/>
 				}
 				recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -17,10 +17,6 @@
 		vertical-align: middle;
 		margin: 0;
 	}
-
-	.stepper-loader__progress-bar {
-		margin: 46px auto 0 auto;
-	}
 }
 
 .processing-step__step-wrapper {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -8,7 +8,6 @@
 	padding: 1em;
 	max-width: 540px;
 	text-align: center;
-	margin: 16vh auto 0;
 
 	&__progress-step {
 		@include onboarding-font-recoleta;
@@ -20,6 +19,7 @@
 		margin: 0;
 	}
 
+	.stepper-loader__progress-bar,
 	.processing-step__progress-bar {
 		margin: 46px auto 0 auto;
 	}
@@ -49,16 +49,17 @@
 
 // Processing Copy Site Styles
 .copy-site.processing-copy {
-	.processing-step {
+	.processing-step, .stepper-loader {
 		margin: 5vh auto 0;
 		max-width: 660px;
 	}
 
-	.processing-step__progress-step {
+	.processing-step__progress-step, .stepper-loader__title {
 		font-size: 3rem;
 		margin-bottom: 24px;
 	}
 
+	.stepper-loader__progress-bar,
 	.processing-step__progress-bar {
 		max-width: 540px;
 		margin: 0 auto;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -4,7 +4,6 @@
 
 .processing-step {
 	--wp-components-color-foreground: #3858E9;
-
 	max-width: 540px;
 	text-align: center;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -38,14 +38,6 @@
 	width: 100%;
 }
 
-.processing-step__subtitle {
-	font-size: 1rem;
-	line-height: 21px;
-	letter-spacing: -0.02em;
-	color: var(--studio-gray-50);
-	margin-top: 24px;
-}
-
 // Processing Copy Site Styles
 .copy-site.processing-copy {
 	.processing-step, .stepper-loader {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -5,7 +5,6 @@
 .processing-step {
 	--wp-components-color-foreground: #3858E9;
 
-	padding: 1em;
 	max-width: 540px;
 	text-align: center;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -18,8 +18,7 @@
 		margin: 0;
 	}
 
-	.stepper-loader__progress-bar,
-	.processing-step__progress-bar {
+	.stepper-loader__progress-bar {
 		margin: 46px auto 0 auto;
 	}
 }
@@ -45,7 +44,7 @@
 		max-width: 660px;
 	}
 
-	.processing-step__progress-step, .stepper-loader__title {
+	.stepper-loader__title {
 		font-size: 3rem;
 		margin-bottom: 24px;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -44,8 +44,7 @@
 		margin-bottom: 24px;
 	}
 
-	.stepper-loader__progress-bar,
-	.processing-step__progress-bar {
+	.stepper-loader__progress-bar {
 		max-width: 540px;
 		margin: 0 auto;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/index.tsx
@@ -72,10 +72,12 @@ export default function TailoredFlowPreCheckoutScreen( { flowName }: { flowName:
 		};
 	}, [] );
 	/**
-	 * Completion progress: 0 <= progress <= 1
+	 * Completion progress: 0 <= progress <= 100
 	 */
-	const progress = ! hasStarted ? /* initial 10% progress */ 0.1 : ( currentStep + 1 ) / totalSteps;
-	const isComplete = progress >= 1;
+	const progress = ! hasStarted
+		? /* initial 10% progress */ 10
+		: ( ( currentStep + 1 ) * 100 ) / totalSteps;
+	const isComplete = progress >= 100;
 
 	useInterval(
 		() => setCurrentStep( ( s ) => s + 1 ),
@@ -85,10 +87,7 @@ export default function TailoredFlowPreCheckoutScreen( { flowName }: { flowName:
 
 	return (
 		<>
-			<StepperLoader
-				title={ steps.current[ currentStep ]?.title }
-				progress={ ! hasStarted ? /* initial 10% progress */ 0.1 : progress }
-			/>
+			<StepperLoader title={ steps.current[ currentStep ]?.title } progress={ progress } />
 			{ flowName === NEWSLETTER_FLOW && (
 				<div className="processing-step__jetpack-powered">
 					<JetpackLogo monochrome size={ 18 } /> <span>Jetpack powered</span>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/index.tsx
@@ -1,14 +1,9 @@
-import {
-	NEWSLETTER_FLOW,
-	LINK_IN_BIO_TLD_FLOW,
-	isNewsletterOrLinkInBioFlow,
-} from '@automattic/onboarding';
+import { NEWSLETTER_FLOW, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
 import { useRef, useState, useEffect } from 'react';
 import JetpackLogo from 'calypso/components/jetpack-logo';
-import { LoadingBar } from 'calypso/components/loading-bar';
-import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import { StepperLoader } from 'calypso/landing/stepper/declarative-flow/internals/components';
 import { useInterval } from 'calypso/lib/interval/use-interval';
 import './style.scss';
 
@@ -62,11 +57,12 @@ export default function TailoredFlowPreCheckoutScreen( { flowName }: { flowName:
 	const defaultDuration = DURATION_IN_MS / totalSteps;
 	const duration = steps.current[ currentStep ]?.duration || defaultDuration;
 
-	/**
-	 * Completion progress: 0 <= progress <= 1
-	 */
-	const progress = ( currentStep + 1 ) / totalSteps;
-	const isComplete = progress >= 1;
+	// Force animated progress bar to start at 0
+	const [ hasStarted, setHasStarted ] = useState( false );
+	useEffect( () => {
+		const id = setTimeout( () => setHasStarted( true ), 750 );
+		return () => clearTimeout( id );
+	}, [] );
 
 	// Temporarily override document styles to prevent scrollbars from showing
 	useEffect( () => {
@@ -75,6 +71,11 @@ export default function TailoredFlowPreCheckoutScreen( { flowName }: { flowName:
 			document.documentElement.classList.remove( 'no-scroll' );
 		};
 	}, [] );
+	/**
+	 * Completion progress: 0 <= progress <= 1
+	 */
+	const progress = ! hasStarted ? /* initial 10% progress */ 0.1 : ( currentStep + 1 ) / totalSteps;
+	const isComplete = progress >= 1;
 
 	useInterval(
 		() => setCurrentStep( ( s ) => s + 1 ),
@@ -82,33 +83,18 @@ export default function TailoredFlowPreCheckoutScreen( { flowName }: { flowName:
 		isComplete ? null : duration
 	);
 
-	// Force animated progress bar to start at 0
-	const [ hasStarted, setHasStarted ] = useState( false );
-	useEffect( () => {
-		const id = setTimeout( () => setHasStarted( true ), 750 );
-		return () => clearTimeout( id );
-	}, [] );
-
 	return (
-		<div className="processing-step__container">
-			<div className="processing-step">
-				<h1 className="processing-step__progress-step">{ steps.current[ currentStep ]?.title }</h1>
-				{ isNewsletterOrLinkInBioFlow( flowName ) ? (
-					<LoadingBar
-						className="processing-step__progress-bar"
-						progress={ ! hasStarted ? /* initial 10% progress */ 0.1 : progress }
-					/>
-				) : (
-					<LoadingEllipsis />
-				) }
-			</div>
-
+		<>
+			<StepperLoader
+				title={ steps.current[ currentStep ]?.title }
+				progress={ ! hasStarted ? /* initial 10% progress */ 0.1 : progress }
+			/>
 			{ flowName === NEWSLETTER_FLOW && (
 				<div className="processing-step__jetpack-powered">
 					<JetpackLogo monochrome size={ 18 } /> <span>Jetpack powered</span>
 				</div>
 			) }
-		</div>
+		</>
 	);
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/style.scss
@@ -18,6 +18,7 @@
 			}
 		}
 
+		.stepper-loader__progress-bar,
 		.processing-step__progress-bar {
 			background-color: var(--studio-white);
 		}
@@ -47,6 +48,7 @@
 			}
 		}
 
+		h1.stepper-loader__title,
 		h1.processing-step__progress-step {
 			font-size: $font-title-medium;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/style.scss
@@ -62,7 +62,7 @@
 			background-color: var(--studio-gray-0);
 		}
 
-		.processing-step__progress-bar {
+		.stepper-loader__progress-bar {
 			background-color: var(--studio-gray-5);
 			&::before {
 				background: var(--studio-black);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/style.scss
@@ -18,11 +18,6 @@
 			}
 		}
 
-		.stepper-loader__progress-bar,
-		.processing-step__progress-bar {
-			background-color: var(--studio-white);
-		}
-
 		.processing-step__container {
 			height: 100%;
 			width: 100%;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/style.scss
@@ -48,15 +48,6 @@
 			}
 		}
 
-		h1.stepper-loader__title,
-		h1.processing-step__progress-step {
-			font-size: $font-title-medium;
-
-			@include break-medium {
-				font-size: $font-title-large;
-			}
-		}
-
 		.processing-step__jetpack-powered {
 			display: flex;
 			justify-content: center;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/style.scss
@@ -62,7 +62,7 @@
 			background-color: var(--studio-gray-0);
 		}
 
-		.loading-bar {
+		.processing-step__progress-bar {
 			background-color: var(--studio-gray-5);
 			&::before {
 				background: var(--studio-black);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-launch/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-launch/index.tsx
@@ -1,9 +1,8 @@
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import { StepperLoader } from 'calypso/landing/stepper/declarative-flow/internals/components';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -45,14 +44,7 @@ const SiteLaunchStep: React.FC< SiteLaunchStepProps > = function ( props ) {
 				shouldHideNavButtons
 				hideFormattedHeader
 				stepName="processing-step"
-				stepContent={
-					<>
-						<div className="processing-step">
-							<h1 className="processing-step__progress-step">{ __( 'Launching blog' ) }</h1>
-							<LoadingEllipsis />
-						</div>
-					</>
-				}
+				stepContent={ <StepperLoader title={ __( 'Launching blog' ) } /> }
 				recordTracksEvent={ recordTracksEvent }
 			/>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-launch/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-launch/index.tsx
@@ -1,5 +1,6 @@
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import DocumentHead from 'calypso/components/data/document-head';
 import { StepperLoader } from 'calypso/landing/stepper/declarative-flow/internals/components';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/index.tsx
@@ -73,7 +73,7 @@ const SiteMigrationPluginInstall: Step = ( { navigation } ) => {
 				},
 			} );
 
-			setProgress( 1 );
+			setProgress( 100 );
 
 			return {
 				pluginInstalled: true,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/test/index.tsx
@@ -59,7 +59,7 @@ describe( 'SiteMigrationPluginInstall', () => {
 		expect( result.pluginInstalled ).toBe( true );
 
 		expect( nock.isDone() ).toBe( true );
-		expect( getProgress() ).toBe( 1 );
+		expect( getProgress() ).toBe( 100 );
 	} );
 
 	it( 'installs and activates the plugin when it is not installed', async () => {
@@ -85,7 +85,7 @@ describe( 'SiteMigrationPluginInstall', () => {
 		expect( result.pluginInstalled ).toBe( true );
 
 		expect( nock.isDone() ).toBe( true );
-		expect( getProgress() ).toBe( 1 );
+		expect( getProgress() ).toBe( 100 );
 	} );
 
 	it( 'polls the plugin endpoint until we have information about the plugins', async () => {
@@ -109,6 +109,6 @@ describe( 'SiteMigrationPluginInstall', () => {
 		expect( result.pluginInstalled ).toBe( true );
 
 		expect( nock.isDone() ).toBe( true );
-		expect( getProgress() ).toBe( 1 );
+		expect( getProgress() ).toBe( 100 );
 	} );
 } );

--- a/client/my-sites/checkout/checkout-thank-you/pending/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/pending/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/mixins";
+
 .pending-content__wrapper {
 	padding: 1em;
 	text-align: center;
@@ -6,27 +8,27 @@
 
 .pending-content__title {
 	@extend .wp-brand-font;
-	/* stylelint-disable-next-line scales/font-sizes */
-	font-size: 1.625rem;
 	line-height: 40px;
 	text-align: center;
 	vertical-align: middle;
 	margin: 0;
-}
+	font-size: $font-title-medium;
+}	
 
 .pending-content__progress-bar {
-	margin: 24px auto 0 auto;
+	--wp-components-color-foreground: #3858e9;
+	margin: 46px auto 0 auto;
 }
 
 .pending-content__info-text-container {
 	display: inline-block;
-    font-size: 1rem;
-    text-align: left;
-    border: 1px solid var( --studio-gray-5 );
-    padding: 1rem;
+	font-size: 1rem;
+	text-align: left;
+	border: 1px solid var( --studio-gray-5 );
+	padding: 1rem;
 	@extend .wp-brand-font;
-    border-radius: 4px;
-    background-color: var( --studio-gray-0 );
+	border-radius: 4px;
+	background-color: var( --studio-gray-0 );
 
 	.pending-content__info-text {
 		> span {

--- a/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/install-plugins.tsx
@@ -90,7 +90,7 @@ export default function InstallPlugins( {
 				return;
 			}
 
-			setProgress( progress + 0.2 );
+			setProgress( progress + 20 );
 			dispatch( requestAtomicSoftwareStatus( siteId, 'woo-on-plans' ) );
 		},
 		!! installFailed || softwareApplied ? null : 3000
@@ -104,7 +104,7 @@ export default function InstallPlugins( {
 
 		if ( softwareApplied ) {
 			trackRedirect();
-			setProgress( 1 );
+			setProgress( 100 );
 			// Allow progress bar to complete
 			setTimeout( () => {
 				window.location.assign( wcAdminUrl );

--- a/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/transfer-site.tsx
@@ -92,21 +92,21 @@ export default function TransferSite( {
 
 		switch ( transferStatus ) {
 			case transferStates.PENDING:
-				setProgress( 0.2 );
+				setProgress( 20 );
 				break;
 			case transferStates.ACTIVE:
-				setProgress( 0.4 );
+				setProgress( 40 );
 				break;
 			case transferStates.PROVISIONED:
-				setProgress( 0.5 );
+				setProgress( 50 );
 				break;
 			case transferStates.COMPLETED:
-				setProgress( 0.7 );
+				setProgress( 70 );
 				break;
 		}
 
 		if ( isTransferringStatusFailed || transferStatus === transferStates.ERROR ) {
-			setProgress( 1 );
+			setProgress( 100 );
 			setTransferFailed( true );
 
 			onFailure( {
@@ -133,7 +133,7 @@ export default function TransferSite( {
 
 		if ( softwareApplied ) {
 			trackRedirect();
-			setProgress( 1 );
+			setProgress( 100 );
 			// Allow progress bar to complete
 			setTimeout( () => {
 				window.location.assign( wcAdminUrl );

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -356,12 +356,12 @@ const pendingAction: Reducer< undefined | ( () => Promise< any > ), OnboardActio
 	return state;
 };
 
-const progress: Reducer< number, OnboardAction > = ( state = -1, action ) => {
+const progress: Reducer< number | undefined, OnboardAction > = ( state, action ) => {
 	if ( action.type === 'SET_PROGRESS' ) {
 		return action.progress;
 	}
 	if ( action.type === 'RESET_ONBOARD_STORE' ) {
-		return -1;
+		return undefined;
 	}
 	return state;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Conversation: p1738260526318899/1738058408.252399-slack-C07H21B2W59

Fixes https://github.com/Automattic/wp-calypso/issues/99258

**This PR will not change the W logo before the start of the flow and before checkout**

## Proposed Changes

Replace the pulsating WordPress logo with a ProgressBar during Onboarding, having the processing step and Stepper share the StepperLoader.

![image](https://github.com/user-attachments/assets/410a26f9-b640-46df-b13f-211b6b7f7b9a)

## Why

The experience is really fragmented:
https://github.com/user-attachments/assets/6d53f2a7-e855-4714-8467-c7fcd2340635


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Live Link
* Go through `/setup/onboarding`
* Test BigSky
* Test WooExpress flow
* Test Newsletter flow
* Test Free flow
* Test Launchpad step

## Following work

Use `StepperLoader`, or a more general step, also for Checkout [here](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/checkout/checkout-thank-you/pending/index.tsx#L110)