### PR TITLE
Calypso Color Schemes: Scope the accent variable for GB components.

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -1,3 +1,8 @@
+/**
+ * Default color scheme for the WP.com Host interface.
+ * Note, this is different from the default wp-admin color scheme, which is either "Default" (_fresh.scss) or "Modern" (_modern.scss).
+ */
+
 :root {
 	/* Theme Properties */
 	--color-primary: var(--studio-blue-50);
@@ -363,6 +368,6 @@
 	--color-navredesign-sidebar-submenu-hover-text: #72aee6; /* Direct from wp-admin */
 
 	/* Gutenberg components */
-	--wp-admin-theme-color: var(--color-accent);
-	--wp-admin-theme-color-darker-20: var(--color-accent-60);
+	// We intentionally do not style --wp-admin-theme-color and --wp-admin-theme-color-darker-20 at the :root scope
+	// to avoid conflicts with the default wp-admin color scheme.
 }

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_fresh.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_fresh.scss
@@ -1,3 +1,8 @@
+/**
+ * Classic wp-admin color scheme, aka "Fresh".
+ * This is default in WordPress core. Modern is set as default for new Simple sites.
+ */
+
 .color-scheme.is-fresh {
 	--color-primary: #2271b1;
 	--color-accent: var(--color-primary);


### PR DESCRIPTION
Fixes #98823

## Proposed Changes

This PR removes the following code from the _default color scheme, which is the scheme that runs on the WordPress.com hosting layer:

```
--wp-admin-theme-color: var(--color-accent);
--wp-admin-theme-color-darker-20: var(--color-accent-60);
```

Note, this is not to be confused with the open WordPress core default color scheme, which is actually called "Fresh". That's this one:

![Screenshot 2025-01-31 at 12 45 47](https://github.com/user-attachments/assets/1a20c18f-b1b9-4fbd-8c43-c35516e7da2e)

That color scheme is still set by default for new Atomic sites, but for new Simple sites, the _Modern_ scheme is set:

![Screenshot 2025-01-31 at 12 45 51](https://github.com/user-attachments/assets/aa335b7c-b8ea-4b13-8e94-a2851689f491)

The issue at hand here is, that _if you have the classic blue color scheme set_, the one that uses the legacy WordPress blue, for the moment you still see the modern Blueberry color applied inside the site editor:

![before](https://github.com/user-attachments/assets/fe04682a-8285-4442-9c59-9d9872a93e06)

What you really should be seeing, and what this PR accomplishes, is the same accent color on the primary button, as is applied to other primary buttons in your admin. The classic blue:

![after](https://github.com/user-attachments/assets/ac4322ee-74b6-4d5d-b2d6-bf7b8f7980ae)

The problem is, that the CSS above, assigned at the `:root` level, and gets included in this same unscoped form via the Help Center (click the (?) button in the top left of the site editor). Through its inclusion there, it bleeds into the WordPress admin itself, and overrides the local admin color scheme. 

So basically, WP.com hosting dashboard modern scheme overrides only parts of the wp-admin color scheme.


## Testing Instructions

* Create or use an atomic test site.
* Go to the wp-admin of this test site, then Users > Profile. Ensure the color scheme is set to "Default", which uses the legacy blue.
* Ensure a block theme or hybrid theme is activated.
* Go to Appearance > Editor > Patterns, or Appearance > Patterns, depending on what type of theme you have. 
* The add new patterns button should be legacy blue, not Modern blue.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
