### PR TITLE
Newsletter imports: Handle errors correctly

### DIFF
--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -7,6 +7,7 @@ import { SiteDetails } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { AddSubscriberForm, UploadSubscribersForm } from '@automattic/subscriber';
 import { useHasStaleImportJobs } from '@automattic/subscriber/src/hooks/use-has-stale-import-jobs';
+import { useImportError } from '@automattic/subscriber/src/hooks/use-import-error';
 import { useInProgressState } from '@automattic/subscriber/src/hooks/use-in-progress-state';
 import { ExternalLink, Modal, __experimentalVStack as VStack } from '@wordpress/components';
 import { copy, upload, reusableBlock } from '@wordpress/icons';
@@ -67,14 +68,16 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 
 	const [ isUploading, setIsUploading ] = useState( false );
 	const onImportStarted = ( hasFile: boolean ) => setIsUploading( hasFile );
+
+	const importError = useImportError();
+	const isImportInProgress = useInProgressState();
+	const hasStaleImportJobs = useHasStaleImportJobs();
+
 	const onImportFinished = () => {
 		setIsUploading( false );
 		setAddingMethod( '' );
-		addSubscribersCallback();
+		addSubscribersCallback( importError );
 	};
-
-	const isImportInProgress = useInProgressState();
-	const hasStaleImportJobs = useHasStaleImportJobs();
 
 	if ( ! showAddSubscribersModal ) {
 		return null;

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -50,7 +50,7 @@ type SubscribersPageContextProps = {
 	showAddSubscribersModal: boolean;
 	showMigrateSubscribersModal: boolean;
 	setShowAddSubscribersModal: ( show: boolean ) => void;
-	addSubscribersCallback: ( importError?: null | unknown ) => void;
+	addSubscribersCallback: ( importError?: ImportSubscribersError ) => void;
 	migrateSubscribersCallback: ( sourceSiteId: number, targetSiteId: number ) => void;
 	closeAllModals: typeof closeAllModals;
 	siteId: number | null;

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -203,7 +203,12 @@ export const SubscribersPageProvider = ( {
 			}
 		} else {
 			let notice = translate( 'An unknown error has occurred. Please try again in a second.' );
-			const noticeArgs = { isPersistent: true };
+			interface NoticeArgs {
+				isPersistent: boolean;
+				button?: string;
+				href?: string;
+			}
+			const noticeArgs: NoticeArgs = { isPersistent: true };
 
 			if (
 				'error' in importError &&

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -11,6 +11,7 @@ import { usePagination } from 'calypso/my-sites/subscribers/hooks';
 import { Subscriber } from 'calypso/my-sites/subscribers/types';
 import { useSelector } from 'calypso/state';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import { isSimpleSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { SubscribersFilterBy, SubscribersSortBy } from '../../constants';
 import useManySubsSite from '../../hooks/use-many-subs-site';
@@ -95,7 +96,7 @@ export const SubscribersPageProvider = ( {
 	const [ showAddSubscribersModal, setShowAddSubscribersModal ] = useState( false );
 	const [ showMigrateSubscribersModal, setShowMigrateSubscribersModal ] = useState( false );
 	const [ debouncedSearchTerm ] = useDebounce( searchTerm, 300 );
-
+	const isSimple = useSelector( ( state ) => isSimpleSite( state, siteId ) );
 	useEffect( () => {
 		if ( hasManySubscribers ) {
 			setDataViewFilterOption( SubscribersFilterBy.WPCOM );
@@ -201,11 +202,29 @@ export const SubscribersPageProvider = ( {
 				);
 			}
 		} else {
-			const errorMessage =
-				'message' in importError && typeof importError.message === 'string'
-					? importError.message
-					: translate( 'An unknown error has occurred. Please try again in a second.' );
-			dispatch( errorNotice( errorMessage ) );
+			let notice = translate( 'An unknown error has occurred. Please try again in a second.' );
+			const noticeArgs = { isPersistent: true };
+
+			if (
+				'error' in importError &&
+				typeof importError.error === 'object' &&
+				importError.error &&
+				'code' in importError.error &&
+				'message' in importError.error
+			) {
+				const { code, message } = importError.error;
+				if ( code === 'subscriber_import_limit_reached' && typeof message === 'string' ) {
+					notice = message;
+					noticeArgs.button = translate( 'Upgrade' );
+					const siteSlug = selectedSiteSlug || ''; // Use a default if siteSlug is not available
+
+					noticeArgs.href = isSimple
+						? `https://wordpress.com/plans/${ siteSlug }`
+						: `https://cloud.jetpack.com/pricing/${ siteSlug }`;
+				}
+			}
+
+			dispatch( errorNotice( notice, noticeArgs ) );
 		}
 	};
 

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { updateLaunchpadSettings } from '@automattic/data-stores';
+import { ImportSubscribersError } from '@automattic/data-stores/src/subscriber/types';
 import { useActiveJobRecognition } from '@automattic/subscriber';
 import { useQueryClient } from '@tanstack/react-query';
 import { translate } from 'i18n-calypso';
@@ -49,7 +50,7 @@ type SubscribersPageContextProps = {
 	showAddSubscribersModal: boolean;
 	showMigrateSubscribersModal: boolean;
 	setShowAddSubscribersModal: ( show: boolean ) => void;
-	addSubscribersCallback: () => void;
+	addSubscribersCallback: ( importError?: null | ImportSubscribersError ) => void;
 	migrateSubscribersCallback: ( sourceSiteId: number, targetSiteId: number ) => void;
 	closeAllModals: typeof closeAllModals;
 	siteId: number | null;

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -205,11 +205,7 @@ export const SubscribersPageProvider = ( {
 				'message' in importError && typeof importError.message === 'string'
 					? importError.message
 					: translate( 'An unknown error has occurred. Please try again in a second.' );
-			dispatch(
-				errorNotice( errorMessage, {
-					duration: 5000,
-				} )
-			);
+			dispatch( errorNotice( errorMessage ) );
 		}
 	};
 

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -161,41 +161,53 @@ export const SubscribersPageProvider = ( {
 		queryClient.invalidateQueries( { queryKey: [ 'launchpad' ] } );
 	};
 
-	const addSubscribersCallback = () => {
+	const addSubscribersCallback = ( importError: { message?: unknown } | null = null ) => {
 		setShowAddSubscribersModal( false );
 		completeImportSubscribersTask();
 
-		if ( completedJob ) {
-			const { email_count, subscribed_count, already_subscribed_count, failed_subscribed_count } =
-				completedJob;
-			dispatch(
-				successNotice(
-					translate(
-						'Import completed. %(added)d subscribed, %(skipped)d already subscribed, and %(failed)d failed out of %(total)d %(totalLabel)s.',
+		if ( ! importError ) {
+			if ( completedJob ) {
+				const { email_count, subscribed_count, already_subscribed_count, failed_subscribed_count } =
+					completedJob;
+				dispatch(
+					successNotice(
+						translate(
+							'Import completed. %(added)d subscribed, %(skipped)d already subscribed, and %(failed)d failed out of %(total)d %(totalLabel)s.',
+							{
+								args: {
+									added: subscribed_count,
+									skipped: already_subscribed_count,
+									failed: failed_subscribed_count,
+									total: email_count,
+									totalLabel: translate( 'subscriber', 'subscribers', {
+										count: email_count,
+									} ),
+								},
+							}
+						)
+					)
+				);
+			} else {
+				dispatch(
+					successNotice(
+						translate(
+							"Your subscriber list is being processed. We'll send you an email when it's finished importing."
+						),
 						{
-							args: {
-								added: subscribed_count,
-								skipped: already_subscribed_count,
-								failed: failed_subscribed_count,
-								total: email_count,
-								totalLabel: translate( 'subscriber', 'subscribers', {
-									count: email_count,
-								} ),
-							},
+							duration: 5000,
 						}
 					)
-				)
-			);
+				);
+			}
 		} else {
+			const errorMessage =
+				importError.message && typeof importError.message === 'string'
+					? importError.message
+					: translate( 'An unknown error has occurred. Please try again in a second.' );
 			dispatch(
-				successNotice(
-					translate(
-						"Your subscriber list is being processed. We'll send you an email when it's finished importing."
-					),
-					{
-						duration: 5000,
-					}
-				)
+				errorNotice( errorMessage, {
+					duration: 5000,
+				} )
 			);
 		}
 	};

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -218,8 +218,8 @@ export const SubscribersPageProvider = ( {
 				'message' in importError.error
 			) {
 				const { code, message } = importError.error;
+				notice = message;
 				if ( code === 'subscriber_import_limit_reached' && typeof message === 'string' ) {
-					notice = message;
 					noticeArgs.button = translate( 'Upgrade' );
 					const siteSlug = selectedSiteSlug || ''; // Use a default if siteSlug is not available
 

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -218,7 +218,7 @@ export const SubscribersPageProvider = ( {
 				'message' in importError.error
 			) {
 				const { code, message } = importError.error;
-				notice = message;
+				notice = message as string;
 				if ( code === 'subscriber_import_limit_reached' && typeof message === 'string' ) {
 					noticeArgs.button = translate( 'Upgrade' );
 					const siteSlug = selectedSiteSlug || ''; // Use a default if siteSlug is not available

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -202,7 +202,7 @@ export const SubscribersPageProvider = ( {
 			}
 		} else {
 			const errorMessage =
-				importError.message && typeof importError.message === 'string'
+				'message' in importError && typeof importError.message === 'string'
 					? importError.message
 					: translate( 'An unknown error has occurred. Please try again in a second.' );
 			dispatch(

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -50,7 +50,7 @@ type SubscribersPageContextProps = {
 	showAddSubscribersModal: boolean;
 	showMigrateSubscribersModal: boolean;
 	setShowAddSubscribersModal: ( show: boolean ) => void;
-	addSubscribersCallback: ( importError?: null | ImportSubscribersError ) => void;
+	addSubscribersCallback: ( importError?: null | unknown ) => void;
 	migrateSubscribersCallback: ( sourceSiteId: number, targetSiteId: number ) => void;
 	closeAllModals: typeof closeAllModals;
 	siteId: number | null;
@@ -162,7 +162,7 @@ export const SubscribersPageProvider = ( {
 		queryClient.invalidateQueries( { queryKey: [ 'launchpad' ] } );
 	};
 
-	const addSubscribersCallback = ( importError: { message?: unknown } | null = null ) => {
+	const addSubscribersCallback = ( importError?: ImportSubscribersError ) => {
 		setShowAddSubscribersModal( false );
 		completeImportSubscribersTask();
 

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -11,7 +11,7 @@ import { usePagination } from 'calypso/my-sites/subscribers/hooks';
 import { Subscriber } from 'calypso/my-sites/subscribers/types';
 import { useSelector } from 'calypso/state';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
-import { isSimpleSite } from 'calypso/state/sites/selectors';
+import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { SubscribersFilterBy, SubscribersSortBy } from '../../constants';
 import useManySubsSite from '../../hooks/use-many-subs-site';
@@ -96,7 +96,9 @@ export const SubscribersPageProvider = ( {
 	const [ showAddSubscribersModal, setShowAddSubscribersModal ] = useState( false );
 	const [ showMigrateSubscribersModal, setShowMigrateSubscribersModal ] = useState( false );
 	const [ debouncedSearchTerm ] = useDebounce( searchTerm, 300 );
-	const isSimple = useSelector( ( state ) => isSimpleSite( state, siteId ) );
+	const isJetpackNonAtomic = useSelector(
+		( state ) => siteId && isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
+	);
 	useEffect( () => {
 		if ( hasManySubscribers ) {
 			setDataViewFilterOption( SubscribersFilterBy.WPCOM );
@@ -222,10 +224,9 @@ export const SubscribersPageProvider = ( {
 				if ( code === 'subscriber_import_limit_reached' && typeof message === 'string' ) {
 					noticeArgs.button = translate( 'Upgrade' );
 					const siteSlug = selectedSiteSlug || ''; // Use a default if siteSlug is not available
-
-					noticeArgs.href = isSimple
-						? `https://wordpress.com/plans/${ siteSlug }`
-						: `https://cloud.jetpack.com/pricing/${ siteSlug }`;
+					noticeArgs.href = isJetpackNonAtomic
+						? `https://cloud.jetpack.com/pricing/${ siteSlug }`
+						: `https://wordpress.com/plans/${ siteSlug }`;
 				}
 			}
 

--- a/packages/data-stores/src/subscriber/actions.ts
+++ b/packages/data-stores/src/subscriber/actions.ts
@@ -71,15 +71,19 @@ export function createActions() {
 					[ 'parse_only', String( parseOnly ) ] as [ string, string ],
 				];
 
-				const data: ImportSubscribersResponse = await wpcomProxyRequest( {
+				const data = ( await wpcomProxyRequest( {
 					path: `/sites/${ encodeURIComponent( siteId ) }/subscribers/import`,
 					method: 'POST',
 					apiNamespace: 'wpcom/v2',
 					token: typeof token === 'string' ? token : undefined,
 					formData: formDataEntries as ( string | File )[][],
-				} );
+				} ) ) as ImportSubscribersResponse & { error?: { code: string; message: string } };
 
-				dispatch.importCsvSubscribersStartSuccess( siteId, data.upload_id );
+				if ( data.upload_id ) {
+					dispatch.importCsvSubscribersStartSuccess( siteId, data.upload_id );
+				} else {
+					dispatch.importCsvSubscribersStartFailed( siteId, data as ImportSubscribersError );
+				}
 			} catch ( error ) {
 				dispatch.importCsvSubscribersStartFailed( siteId, error as ImportSubscribersError );
 			}

--- a/packages/subscriber/src/hooks/use-import-error.ts
+++ b/packages/subscriber/src/hooks/use-import-error.ts
@@ -1,0 +1,13 @@
+import { Subscriber } from '@automattic/data-stores';
+import { useSelect } from '@wordpress/data';
+
+export function useImportError() {
+	const { importSelector } = useSelect( ( select ) => {
+		const subscriber = select( Subscriber.store );
+		return {
+			importSelector: subscriber.getImportSubscribersSelector(),
+		};
+	}, [] );
+
+	return importSelector?.error;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Manual imports and CSV imports error handling isn't happening currently, the UI always assumes the imports are successful. This PR fixes it by handling the responses from WPCOM. Keep in mind that you have to sandbox public-api against 171979-ghe-Automattic/wpcom to test this PR. 

- This PR adds error handling for imports. Also, to make a request to the WPCOM API, this code relies on wpcomProxyRequest.
-  `wpcomProxyRequest` unfortunately considers anything that's not 2xx code as an errror, but doesn't parse the response of the object correctly. 
- The WPCOM endpoint has been returning WP_Errors with a 200 status code, which is why we haven't been seeing these errors on the UI. 
- I attempted to fix the WPCOM and make it return a 400s' but  wpcomProxyRequest doesn't parse the resposne correctly and doesn't read the 400 JSON response from WPCOM, it converts it into a string. 
- Chaging wpcomProxyRequest's parsing could lead to side effects since other parts of the code use it as well. 
- I tried replacing wpcomProxyRequest with apiFetch but the proxy requests didn't work as expected. 
- Instead, I decided to change the formatting of the response in the WPCOM PR - 171979-ghe-Automattic/wpcom.  

## Proposed Changes

* Added the `useImportError` hook to see if the API call to import subscribers returns an error. 
* Added error code based error formatting. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To handle the errors from the endpoint that handles subscriber imports.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Happy Case

* On a free account with no subscribers, ensure you're able to add a subscriber manually and with a CSV file of 5 emails. You can ask Chatgpt to generate a csv of emails specyfing the format of the email.  
* On a paid account, ensure you're able to add a subscriber manually and with a CSV file of 100+ emails.

Testing this bug

* Sandbox  171979-ghe-Automattic/wpcom
* Cancel the subscription on your paid account from payments admin where you have 100+ subscribers, and try adding a subscriber manually. You should the error being shown in a notice. 
* Try importing a CSV file. You will see the error being shown in a notice. Clicking on Upgrade should take you to the upgrade page. 
* Repeat the above step on a free Jetpack site as well. 

Before:

https://github.com/user-attachments/assets/60d2bde3-2ee5-4587-861f-7248127c155e

After: 

https://github.com/user-attachments/assets/7d97021a-e923-48f2-9c45-7c3eed9e008e

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
