### PR TITLE
Help Center: don't autoopen the Help Center in Support Sessions

### DIFF
--- a/packages/data-stores/src/help-center/index.ts
+++ b/packages/data-stores/src/help-center/index.ts
@@ -22,7 +22,10 @@ export const isSupportSession = () => {
 		return (
 			'isSupportSession' in window ||
 			// A bit hacky but much easier than passing down data from PHP in Jetpack
-			!! document.querySelector( '#wp-admin-bar-support-session-details' )
+			// Simple
+			!! document.querySelector( '#wp-admin-bar-support-session-details' ) ||
+			// Atomic
+			document.body.classList.contains( 'support-session' )
 		);
 	}
 	return false;
@@ -30,6 +33,7 @@ export const isSupportSession = () => {
 
 export function register(): typeof STORE_KEY {
 	const enabledPesistedOpenState = ! isE2ETest() && ! isSupportSession();
+
 	registerPlugins();
 
 	if ( ! isRegistered ) {

--- a/packages/data-stores/src/help-center/index.ts
+++ b/packages/data-stores/src/help-center/index.ts
@@ -17,7 +17,19 @@ const E2E_USER_AGENT = 'wp-e2e-tests';
 export const isE2ETest = () =>
 	typeof window !== 'undefined' && window.navigator.userAgent.includes( E2E_USER_AGENT );
 
+export const isSupportSession = () => {
+	if ( typeof window !== 'undefined' ) {
+		return (
+			'isSupportSession' in window ||
+			// A bit hacky but much easier than passing down data from PHP in Jetpack
+			!! document.querySelector( '#wp-admin-bar-support-session-details' )
+		);
+	}
+	return false;
+};
+
 export function register(): typeof STORE_KEY {
+	const enabledPesistedOpenState = ! isE2ETest() && ! isSupportSession();
 	registerPlugins();
 
 	if ( ! isRegistered ) {
@@ -28,7 +40,7 @@ export function register(): typeof STORE_KEY {
 			selectors,
 			persist: [ 'message', 'userDeclaredSite', 'userDeclaredSiteUrl', 'subject' ],
 			// Don't persist the open state for e2e users, because parallel tests will start interfering with each other.
-			resolvers: isE2ETest() ? undefined : { isHelpCenterShown },
+			resolvers: enabledPesistedOpenState ? { isHelpCenterShown } : undefined,
 		} );
 		isRegistered = true;
 	}


### PR DESCRIPTION
Fixes: pdDR7T-205-p2#comment-2548 
Fixes: https://github.com/Automattic/wp-calypso/issues/99073

## Proposed Changes

- This disables auto-opening the Help Center during Support Sessions.

## Testing Instructions

- Sandbox widgets.wp.com
- In apps/help-center run `yarn dev --sync`.
- **Chrome window 1**: Login as a normal user, feel free to use mine `sdfsdlfhsdjf` via SSP and https://wordpress.com/wp-login.php?no_calypso.
- Open the Help Center. 
- **Chrome window 2**: Go to the user's RC.
- Switch to user (make sure to do so in an A8C chrome instance).
- The HC should not open.
- Go to the editor of Atomic site https://dsfdsfdsfdsfsfds.wpcomstaging.com/wp-admin/post-new.php
- It shouldn't open.
- Go to the editor of Simple site: http://somesimpleusersimplesite.wordpress.com/wp-admin/post-new.php
- HC shouldn't open.