### PR TITLE
Newsletter: Add hide category selection modal setting

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -43,6 +43,7 @@ type Fields = {
 	wpcom_featured_image_in_email?: boolean;
 	wpcom_newsletter_categories?: number[];
 	wpcom_newsletter_categories_enabled?: boolean;
+	wpcom_newsletter_categories_modal_hidden_enabled?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
 	jetpack_subscriptions_reply_to?: string;
 	jetpack_subscriptions_from_name?: string;
@@ -69,6 +70,7 @@ const getFormSettings = ( settings?: Fields ) => {
 		wpcom_featured_image_in_email,
 		wpcom_newsletter_categories,
 		wpcom_newsletter_categories_enabled,
+		wpcom_newsletter_categories_modal_hidden_enabled,
 		wpcom_subscription_emails_use_excerpt,
 		jetpack_subscriptions_reply_to,
 		jetpack_subscriptions_from_name,
@@ -90,6 +92,8 @@ const getFormSettings = ( settings?: Fields ) => {
 		wpcom_featured_image_in_email: !! wpcom_featured_image_in_email,
 		wpcom_newsletter_categories: wpcom_newsletter_categories || [],
 		wpcom_newsletter_categories_enabled: !! wpcom_newsletter_categories_enabled,
+		wpcom_newsletter_categories_modal_hidden_enabled:
+			!! wpcom_newsletter_categories_modal_hidden_enabled,
 		wpcom_subscription_emails_use_excerpt: !! wpcom_subscription_emails_use_excerpt,
 		jetpack_subscriptions_reply_to: jetpack_subscriptions_reply_to || '',
 		jetpack_subscriptions_from_name: jetpack_subscriptions_from_name || '',
@@ -315,7 +319,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 			</Card>
 			<SettingsSectionHeader
 				id="newsletter-categories-settings"
-				title={ translate( 'Newsletter categories' ) }
+				title={ translate( 'Newsletter categoriesssss' ) }
 				showButton
 				onButtonClick={ onSubmit }
 				disabled={ disabled }
@@ -325,6 +329,9 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 				disabled={ disabled }
 				newsletterCategoryIds={ fields.wpcom_newsletter_categories || defaultNewsletterCategoryIds }
 				newsletterCategoriesEnabled={ fields.wpcom_newsletter_categories_enabled }
+				newsletterCategoriesModalHiddenEnabled={
+					fields.wpcom_newsletter_categories_modal_hidden_enabled
+				}
 				handleToggle={ handleToggle }
 				updateFields={ updateFields }
 			/>

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -43,7 +43,7 @@ type Fields = {
 	wpcom_featured_image_in_email?: boolean;
 	wpcom_newsletter_categories?: number[];
 	wpcom_newsletter_categories_enabled?: boolean;
-	wpcom_newsletter_categories_modal_hidden_enabled?: boolean;
+	wpcom_newsletter_categories_modal_hidden?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
 	jetpack_subscriptions_reply_to?: string;
 	jetpack_subscriptions_from_name?: string;
@@ -70,7 +70,7 @@ const getFormSettings = ( settings?: Fields ) => {
 		wpcom_featured_image_in_email,
 		wpcom_newsletter_categories,
 		wpcom_newsletter_categories_enabled,
-		wpcom_newsletter_categories_modal_hidden_enabled,
+		wpcom_newsletter_categories_modal_hidden,
 		wpcom_subscription_emails_use_excerpt,
 		jetpack_subscriptions_reply_to,
 		jetpack_subscriptions_from_name,
@@ -92,8 +92,7 @@ const getFormSettings = ( settings?: Fields ) => {
 		wpcom_featured_image_in_email: !! wpcom_featured_image_in_email,
 		wpcom_newsletter_categories: wpcom_newsletter_categories || [],
 		wpcom_newsletter_categories_enabled: !! wpcom_newsletter_categories_enabled,
-		wpcom_newsletter_categories_modal_hidden_enabled:
-			!! wpcom_newsletter_categories_modal_hidden_enabled,
+		wpcom_newsletter_categories_modal_hidden: !! wpcom_newsletter_categories_modal_hidden,
 		wpcom_subscription_emails_use_excerpt: !! wpcom_subscription_emails_use_excerpt,
 		jetpack_subscriptions_reply_to: jetpack_subscriptions_reply_to || '',
 		jetpack_subscriptions_from_name: jetpack_subscriptions_from_name || '',
@@ -319,7 +318,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 			</Card>
 			<SettingsSectionHeader
 				id="newsletter-categories-settings"
-				title={ translate( 'Newsletter categoriesssss' ) }
+				title={ translate( 'Newsletter categories' ) }
 				showButton
 				onButtonClick={ onSubmit }
 				disabled={ disabled }
@@ -329,9 +328,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 				disabled={ disabled }
 				newsletterCategoryIds={ fields.wpcom_newsletter_categories || defaultNewsletterCategoryIds }
 				newsletterCategoriesEnabled={ fields.wpcom_newsletter_categories_enabled }
-				newsletterCategoriesModalHiddenEnabled={
-					fields.wpcom_newsletter_categories_modal_hidden_enabled
-				}
+				newsletterCategoriesModalHiddenEnabled={ fields.wpcom_newsletter_categories_modal_hidden }
 				handleToggle={ handleToggle }
 				updateFields={ updateFields }
 			/>

--- a/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-hide-modal-toggle.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-hide-modal-toggle.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 
 export const NEWSLETTER_CATEGORIES_MODAL_HIDDEN_ENABLED_OPTION =
-	'wpcom_newsletter_categories_modal_hidden_enabled';
+	'wpcom_newsletter_categories_modal_hidden';
 
 type NewsletterCategoriesHideModalToggleProps = {
 	disabled?: boolean;

--- a/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-hide-modal-toggle.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-hide-modal-toggle.tsx
@@ -1,0 +1,40 @@
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+
+export const NEWSLETTER_CATEGORIES_MODAL_HIDDEN_ENABLED_OPTION =
+	'wpcom_newsletter_categories_modal_hidden_enabled';
+
+type NewsletterCategoriesHideModalToggleProps = {
+	disabled?: boolean;
+	value?: boolean;
+	handleToggle: ( field: string ) => ( value: boolean ) => void;
+};
+
+const NewsletterCategoriesHideModalToggle = ( {
+	disabled,
+	handleToggle,
+	value = false,
+}: NewsletterCategoriesHideModalToggleProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<div className="newsletter-categories-hide-toggle">
+			<ToggleControl
+				checked={ !! value }
+				onChange={ handleToggle( NEWSLETTER_CATEGORIES_MODAL_HIDDEN_ENABLED_OPTION ) }
+				disabled={ disabled }
+				label={ translate( 'Hide category selection modal' ) }
+			/>
+			<FormSettingExplanation>
+				{ translate( 'After subscribing, new users skip the category selection modal.' ) +
+					' ' +
+					translate(
+						'Instead, you can manually assign the default categories within each subscriber block.'
+					) }
+			</FormSettingExplanation>
+		</div>
+	);
+};
+
+export default NewsletterCategoriesHideModalToggle;

--- a/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-section.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-section.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import TermTreeSelector from 'calypso/blocks/term-tree-selector';
 import FormLegend from 'calypso/components/forms/form-legend';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import NewsletterCategoriesHideModalToggle from './newsletter-categories-hide-modal-toggle';
 import NewsletterCategoriesToggle from './newsletter-categories-toggle';
 import './style.scss';
 
@@ -12,6 +13,7 @@ type NewsletterCategoriesSectionProps = {
 	disabled?: boolean;
 	handleToggle: ( field: string ) => ( value: boolean ) => void;
 	newsletterCategoriesEnabled?: boolean;
+	newsletterCategoriesModalHiddenEnabled?: boolean;
 	newsletterCategoryIds: number[];
 	updateFields: ( fields: { [ key: string ]: unknown } ) => void;
 };
@@ -20,6 +22,7 @@ const NewsletterCategoriesSection = ( {
 	disabled,
 	handleToggle,
 	newsletterCategoriesEnabled,
+	newsletterCategoriesModalHiddenEnabled,
 	newsletterCategoryIds,
 	updateFields,
 }: NewsletterCategoriesSectionProps ) => {
@@ -77,6 +80,23 @@ const NewsletterCategoriesSection = ( {
 						'When you add a new category, your existing subscribers will be automatically subscribed to it.'
 					) }
 				</FormSettingExplanation>
+			</Card>
+
+			<Card
+				className={ clsx(
+					'newsletter-categories-settings__hide-modal-toggle',
+					'site-settings__card',
+					{
+						hidden: ! newsletterCategoriesEnabled,
+					}
+				) }
+				aria-hidden={ ! newsletterCategoriesEnabled }
+			>
+				<NewsletterCategoriesHideModalToggle
+					disabled={ disabled }
+					handleToggle={ handleToggle }
+					value={ newsletterCategoriesModalHiddenEnabled }
+				/>
 			</Card>
 		</>
 	);

--- a/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-section.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-section.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -82,22 +83,24 @@ const NewsletterCategoriesSection = ( {
 				</FormSettingExplanation>
 			</Card>
 
-			<Card
-				className={ clsx(
-					'newsletter-categories-settings__hide-modal-toggle',
-					'site-settings__card',
-					{
-						hidden: ! newsletterCategoriesEnabled,
-					}
-				) }
-				aria-hidden={ ! newsletterCategoriesEnabled }
-			>
-				<NewsletterCategoriesHideModalToggle
-					disabled={ disabled }
-					handleToggle={ handleToggle }
-					value={ newsletterCategoriesModalHiddenEnabled }
-				/>
-			</Card>
+			{ config.isEnabled( 'newsletter-categories-section' ) && (
+				<Card
+					className={ clsx(
+						'newsletter-categories-settings__hide-modal-toggle',
+						'site-settings__card',
+						{
+							hidden: ! newsletterCategoriesEnabled,
+						}
+					) }
+					aria-hidden={ ! newsletterCategoriesEnabled }
+				>
+					<NewsletterCategoriesHideModalToggle
+						disabled={ disabled }
+						handleToggle={ handleToggle }
+						value={ newsletterCategoriesModalHiddenEnabled }
+					/>
+				</Card>
+			) }
 		</>
 	);
 };

--- a/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/style.scss
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/style.scss
@@ -26,6 +26,12 @@
 	}
 }
 
+.newsletter-categories-settings__hide-modal-toggle {
+	&.hidden {
+		display: none;
+	}
+}
+
 .newsletter-categories-settings__description {
 	&.form-setting-explanation {
 		margin-top: -12px;

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -106,7 +106,7 @@
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
 		"network-connection": true,
-		"newsletter-categories-section": false,
+		"newsletter-categories-section": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/loop/issues/377

## Proposed Changes

* Adds new `Hide category selection modal` option to the Newsletter settings

<img width="718" alt="Screenshot 2025-02-05 at 15 02 34" src="https://github.com/user-attachments/assets/f39710d3-f076-4f7f-9c33-fec784d58235" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Ref - pe7F0s-2tV-p2 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Requires Jetpack PR applied to sandbox https://github.com/Automattic/jetpack/pull/41552
* Requires public-api.wordpress.com
* Go to calypso.live - `/settings/newsletter/{site url}`
* Confirm you can see the new `Hide category selection modal` option in the Newsletter Category settings
* Confirm when you toggle the setting, that setting is saved on refresh

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?