### PR TITLE
Stats: Memoize moment site timezone selector

### DIFF
--- a/client/my-sites/stats/hooks/use-moment-site-zone.ts
+++ b/client/my-sites/stats/hooks/use-moment-site-zone.ts
@@ -1,25 +1,29 @@
+import { createSelector } from '@automattic/state-utils';
 import i18n from 'i18n-calypso';
 import moment from 'moment';
 import { useSelector } from 'calypso/state';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-export function getMomentSiteZone( state: object, siteId: number | null ) {
-	let localeSlug = i18n.getLocaleSlug();
-	if ( localeSlug === null ) {
-		localeSlug = 'en';
-	}
+export const getMomentSiteZone = createSelector(
+	( state: object, siteId: number | null ) => {
+		let localeSlug = i18n.getLocaleSlug();
+		if ( localeSlug === null ) {
+			localeSlug = 'en';
+		}
 
-	const localizedMoment = moment().locale( localeSlug );
+		const localizedMoment = moment().locale( localeSlug );
 
-	const gmtOffset = getSiteOption( state, siteId, 'gmt_offset' ) as number;
-	if ( Number.isFinite( gmtOffset ) ) {
-		return localizedMoment.utcOffset( gmtOffset );
-	}
+		const gmtOffset = getSiteOption( state, siteId, 'gmt_offset' ) as number;
+		if ( Number.isFinite( gmtOffset ) ) {
+			return localizedMoment.utcOffset( gmtOffset );
+		}
 
-	// Falls back to the browser's local timezone if no GMT offset is found
-	return localizedMoment;
-}
+		// Falls back to the browser's local timezone if no GMT offset is found
+		return localizedMoment;
+	},
+	[ ( state, siteId ) => getSiteOption( state, siteId, 'gmt_offset' ), () => i18n.getLocaleSlug() ]
+);
 
 /**
  * Get moment object based on site timezone.


### PR DESCRIPTION
## Proposed Changes

Memoize the `getMomentSiteZone` selector.

Note that #99171 takes care of the other similar warning that appears on this page.

## Why are these changes being made?

The `getMomentSiteZone` selector currently triggers a bunch of re-renders because it generates new `moment` objects on every run.

By memoizing the selector, we remove a bunch of unnecessary re-renders and fix this warning:

![Screenshot 2025-01-31 at 17 39 15](https://github.com/user-attachments/assets/75a920f5-9afc-44f0-92df-eeec6db0e191)

## Testing Instructions

* Open `/stats/day/:site` where `:site` is a site on a high-tier plan.
* Verify you no longer see the warning from the screenshot. 