### PR TITLE
Stats: Memoize gated intervals selector

### DIFF
--- a/client/my-sites/stats/hooks/use-intervals.tsx
+++ b/client/my-sites/stats/hooks/use-intervals.tsx
@@ -1,3 +1,4 @@
+import { createSelector } from '@automattic/state-utils';
 import { translate } from 'i18n-calypso';
 import {
 	STATS_FEATURE_INTERVAL_DROPDOWN_DAY,
@@ -43,8 +44,8 @@ const intervals = {
 	},
 };
 
-function useIntervals( siteId: number | null ): IntervalsType {
-	const gatedIntervals = useSelector( ( state ) => {
+const getGatedIntervals = createSelector(
+	( state, siteId ) => {
 		return Object.keys( intervals ).reduce( ( acc, key ) => {
 			const interval = intervals[ key ];
 
@@ -56,9 +57,16 @@ function useIntervals( siteId: number | null ): IntervalsType {
 				},
 			};
 		}, {} );
-	} );
+	},
+	Object.values( intervals ).map(
+		( { statType } ) =>
+			( state: object, siteId ) =>
+				shouldGateStats( state, siteId, statType )
+	)
+);
 
-	return gatedIntervals;
+function useIntervals( siteId: number | null ): IntervalsType {
+	return useSelector( ( state ) => getGatedIntervals( state, siteId ) );
 }
 
 export default useIntervals;


### PR DESCRIPTION
## Proposed Changes

Memoize the `getGatedIntervals` selector.

Note that #99170 takes care of the other similar warning that appears on this page.

## Why are these changes being made?

The `getGatedIntervals ` selector currently triggers a bunch of re-renders because it generates new objects on every run, and that's unnecessary since nothing really changes.

By memoizing the selector, we remove a bunch of unnecessary re-renders and fix this warning:

![Screenshot 2025-01-31 at 17 39 04](https://github.com/user-attachments/assets/571c617e-a082-4d0b-aede-046a4def5cd8)


## Testing Instructions

* Open `/stats/day/:site` where `:site` is a site on a high-tier plan.
* Verify you no longer see the warning from the screenshot. 