### PR TITLE
Move user to /plans page when exiting and clearing cart from checkout

### DIFF
--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -353,12 +353,19 @@ const onboarding: Flow = {
 					if ( providedDependencies.goToCheckout ) {
 						const siteSlug = providedDependencies.siteSlug as string;
 
+						const checkoutBackUrl =
+							createWithBigSky && isBigSkyBeforePlansExperiment && isGoalsAtFrontExperiment
+								? '/setup/onboarding/plans'
+								: destination;
+
 						// replace the location to delete processing step from history.
 						window.location.replace(
 							addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
 								redirect_to: destination,
 								signup: 1,
-								checkoutBackUrl: pathToUrl( addQueryArgs( destination, { skippedCheckout: 1 } ) ),
+								checkoutBackUrl: pathToUrl(
+									addQueryArgs( checkoutBackUrl, { skippedCheckout: 1 } )
+								),
 								coupon,
 							} )
 						);

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -162,24 +162,33 @@ const onboarding: Flow = {
 		const { isEligible: isBigSkyEligible } = useIsBigSkyEligible();
 		const isDesignChoicesStepEnabled = isBigSkyEligible && isGoalsAtFrontExperiment;
 
-		const getPostCheckoutDestination = ( providedDependencies: ProvidedDependencies ) => {
+		/**
+		 * Returns [destination, backDestination] for the post-checkout destination.
+		 */
+		const getPostCheckoutDestination = (
+			providedDependencies: ProvidedDependencies
+		): [ string, string ] => {
 			if (
 				createWithBigSky &&
 				config.isEnabled( 'onboarding/big-sky-before-plans' ) &&
 				isGoalsAtFrontExperiment
 			) {
-				return addQueryArgs( '/setup/site-setup/launch-big-sky', {
+				const destination = addQueryArgs( '/setup/site-setup/launch-big-sky', {
 					siteSlug: providedDependencies.siteSlug,
 				} );
+
+				return [ destination, addQueryArgs( '/setup/onboarding/plans', { skippedCheckout: 1 } ) ];
 			}
 
-			return addQueryArgs( '/setup/site-setup', {
+			const destination = addQueryArgs( '/setup/site-setup', {
 				siteSlug: providedDependencies.siteSlug,
 				...( isGoalsAtFrontExperiment && { 'goals-at-front-experiment': true } ),
 				...( config.isEnabled( 'onboarding/newsletter-goal' ) && {
 					flags: 'onboarding/newsletter-goal',
 				} ),
 			} );
+
+			return [ destination, addQueryArgs( destination, { skippedCheckout: 1 } ) ];
 		};
 
 		clearUseMyDomainsQueryParams( currentStepSlug );
@@ -344,7 +353,8 @@ const onboarding: Flow = {
 				case 'create-site':
 					return navigate( 'processing', undefined, true );
 				case 'processing': {
-					const destination = getPostCheckoutDestination( providedDependencies );
+					const [ destination, backDestination ] =
+						getPostCheckoutDestination( providedDependencies );
 
 					persistSignupDestination( destination );
 					setSignupCompleteFlowName( flowName );
@@ -353,19 +363,12 @@ const onboarding: Flow = {
 					if ( providedDependencies.goToCheckout ) {
 						const siteSlug = providedDependencies.siteSlug as string;
 
-						const checkoutBackUrl =
-							createWithBigSky && isBigSkyBeforePlansExperiment && isGoalsAtFrontExperiment
-								? '/setup/onboarding/plans'
-								: destination;
-
 						// replace the location to delete processing step from history.
 						window.location.replace(
 							addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
 								redirect_to: destination,
 								signup: 1,
-								checkoutBackUrl: pathToUrl(
-									addQueryArgs( checkoutBackUrl, { skippedCheckout: 1 } )
-								),
+								checkoutBackUrl: pathToUrl( backDestination ),
 								coupon,
 							} )
 						);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99151

Big Sky is a paid feature, and sometimes users will give up at the last minute during the checkout. We need to ensure they still have other plans options when doing that.

## Proposed Changes

* We're moving the user to the /plans page when they select Big Sky and bail from checkout


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* From the [/setup/onboarding](http://calypso.localhost:3000/setup/onboarding), select Big Sky
* Select a paid plan
* In the checkout, bail with any option you want
* Make sure you won't have big sky and yet, have an option of selecting another plan

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
