### PR TITLE
A4A: Add upgrade link to WordPress.com/Pressable licenses

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -3,6 +3,10 @@ import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState, useEffect } from 'react';
 import {
+	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
+	A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
 	isPressableHostingProduct,
 	isWPCOMHostingProduct,
 } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
@@ -125,7 +129,9 @@ export default function LicenseDetailsActions( {
 					<Button
 						compact
 						href={
-							isPressableLicense ? '/marketplace/hosting/pressable' : '/marketplace/hosting/wpcom'
+							isPressableLicense
+								? A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK
+								: A4A_MARKETPLACE_HOSTING_WPCOM_LINK
 						}
 					>
 						{ translate( 'Upgrade' ) }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -2,7 +2,10 @@ import { Button } from '@automattic/components';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState, useEffect } from 'react';
-import { isPressableHostingProduct } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
+import {
+	isPressableHostingProduct,
+	isWPCOMHostingProduct,
+} from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
 import {
 	LicenseRole,
 	LicenseState,
@@ -25,6 +28,7 @@ interface Props {
 	licenseType: LicenseType;
 	hasDownloads: boolean;
 	isChildLicense?: boolean;
+	isClientLicense?: boolean;
 }
 
 export default function LicenseDetailsActions( {
@@ -35,6 +39,7 @@ export default function LicenseDetailsActions( {
 	licenseType,
 	hasDownloads,
 	isChildLicense,
+	isClientLicense,
 }: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -45,6 +50,7 @@ export default function LicenseDetailsActions( {
 
 	const [ revokeDialog, setRevokeDialog ] = useState( false );
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
+	const isWPCOMHostingLicense = isWPCOMHostingProduct( licenseKey );
 	const pressableManageUrl = 'https://my.pressable.com/agency/auth';
 
 	const debugUrl = siteUrl ? `https://jptools.wordpress.com/debug/?url=${ siteUrl }` : null;
@@ -112,6 +118,19 @@ export default function LicenseDetailsActions( {
 					{ translate( 'Manage in Pressable' ) } <Icon icon={ external } size={ 18 } />
 				</Button>
 			) }
+
+			{ ( isPressableLicense || isWPCOMHostingLicense ) &&
+				licenseState !== LicenseState.Revoked &&
+				! isClientLicense && (
+					<Button
+						compact
+						href={
+							isPressableLicense ? '/marketplace/hosting/pressable' : '/marketplace/hosting/wpcom'
+						}
+					>
+						{ translate( 'Upgrade' ) }
+					</Button>
+				) }
 
 			{ canRevoke &&
 				( isChildLicense

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -130,6 +130,7 @@ export default function LicenseDetails( {
 				licenseType={ licenseType }
 				hasDownloads={ hasDownloads }
 				isChildLicense={ isChildLicense }
+				isClientLicense={ !! ( isAutomatedReferralsEnabled && referral ) }
 			/>
 		</Card>
 	);

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -378,6 +378,7 @@ export default function LicensePreview( {
 							revokedAt={ revokedAt }
 							licenseType={ licenseType }
 							isChildLicense={ isChildLicense }
+							isClientLicense={ !! isClientLicense }
 						/>
 					) : (
 						/*

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
@@ -12,6 +12,7 @@ interface Props {
 	revokedAt: string | null;
 	licenseType: LicenseType;
 	isChildLicense?: boolean;
+	isClientLicense?: boolean;
 }
 
 export default function LicenseActions( {
@@ -21,6 +22,7 @@ export default function LicenseActions( {
 	revokedAt,
 	licenseType,
 	isChildLicense,
+	isClientLicense,
 }: Props ) {
 	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
 
@@ -32,7 +34,8 @@ export default function LicenseActions( {
 		attachedAt,
 		revokedAt,
 		licenseType,
-		isChildLicense
+		isChildLicense,
+		isClientLicense
 	);
 
 	const handleActionClick = ( action: LicenseAction ) => {

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import { A4A_MARKETPLACE_HOSTING_WPCOM_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import getLicenseState from 'calypso/jetpack-cloud/sections/partner-portal/lib/get-license-state';
 import {
 	LicenseState,
@@ -85,7 +86,7 @@ export default function useLicenseActions(
 			},
 			{
 				name: translate( 'Upgrade' ),
-				href: `/marketplace/hosting/wpcom`,
+				href: A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
 				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_upgrade_click' ),
 				isExternalLink: false,
 				isEnabled: ! isClientLicense,

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
@@ -18,7 +18,8 @@ export default function useLicenseActions(
 	attachedAt: string | null,
 	revokedAt: string | null,
 	licenseType: LicenseType,
-	isChildLicense?: boolean
+	isChildLicense?: boolean,
+	isClientLicense?: boolean
 ): LicenseAction[] {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -87,7 +88,7 @@ export default function useLicenseActions(
 				href: `/marketplace/hosting/wpcom`,
 				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_upgrade_click' ),
 				isExternalLink: false,
-				isEnabled: true,
+				isEnabled: ! isClientLicense,
 			},
 			{
 				name: translate( 'Revoke' ),
@@ -109,6 +110,7 @@ export default function useLicenseActions(
 		canRevoke,
 		dispatch,
 		isChildLicense,
+		isClientLicense,
 		isDevSite,
 		licenseType,
 		revokedAt,

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
@@ -83,6 +83,13 @@ export default function useLicenseActions(
 				isEnabled: licenseState === LicenseState.Attached,
 			},
 			{
+				name: translate( 'Upgrade' ),
+				href: `/marketplace/hosting/wpcom`,
+				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_upgrade_click' ),
+				isExternalLink: false,
+				isEnabled: true,
+			},
+			{
 				name: translate( 'Revoke' ),
 				href: `https://wordpress.com/purchases/subscriptions/${ siteSlug }`,
 				isExternalLink: true,


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/606

## Proposed Changes

* Adds an upgrade button to Licenses details and action dropdown


## Why are these changes being made?

If one goes to the agency platform then purchases there is no clear way to upgrade the currently existing plan.

## Testing Instructions

* Open the live link
* Login as `a4ademo`
* Go to Purchases > Licenses
* Find a WordPress.com license / Pressable license that is not a referral
* Confirm you see the Upgrade button and that it links to the WordPress / Pressable links.

<img width="425" alt="Screenshot 2025-01-31 at 17 20 24" src="https://github.com/user-attachments/assets/b68bf3d2-be5b-42ba-926a-f1c4a371c5a3" />
<img width="884" alt="Screenshot 2025-01-31 at 17 20 09" src="https://github.com/user-attachments/assets/a596395a-3e23-47ba-a314-bac41666bf98" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
