### PR TITLE
Subscribers: Add totals

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -127,10 +127,12 @@ const SubscriberDataViews = ( {
 		subscribers,
 		is_owner_subscribed: isOwnerSubscribed,
 		pages,
+		total,
 	} = subscribersQueryResult || {
 		subscribers: [],
 		is_owner_subscribed: false,
 		pages: 0,
+		total: 0,
 	};
 
 	const {
@@ -381,7 +383,7 @@ const SubscriberDataViews = ( {
 					<>
 						<SubscriberTotals
 							totalSubscribers={ grandTotal }
-							filteredCount={ subscribers.length }
+							filteredCount={ total }
 							filterOption={ filterOption }
 							searchTerm={ searchTerm }
 							isLoading={ isLoading }

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -10,6 +10,7 @@ import TimeSince from 'calypso/components/time-since';
 import { useSubscribedNewsletterCategories } from 'calypso/data/newsletter-categories';
 import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
 import { SubscriberLaunchpad } from 'calypso/my-sites/subscribers/components/subscriber-launchpad';
+import SubscriberTotals from 'calypso/my-sites/subscribers/components/subscriber-totals';
 import { useSubscriptionPlans, useUnsubscribeModal } from 'calypso/my-sites/subscribers/hooks';
 import { Subscriber } from 'calypso/my-sites/subscribers/types';
 import { useSelector } from 'calypso/state';
@@ -377,28 +378,37 @@ const SubscriberDataViews = ( {
 				{ shouldShowLaunchpad ? (
 					<EmptyComponent />
 				) : (
-					<DataViews< Subscriber >
-						data={ data }
-						fields={ fields }
-						view={ currentView }
-						onClickItem={ handleSubscriberOnClick }
-						onChangeView={ setCurrentView }
-						selection={
-							selectedSubscriber ? [ selectedSubscriber.subscription_id.toString() ] : undefined
-						}
-						onChangeSelection={ handleSubscriberSelect }
-						isLoading={ isLoading }
-						paginationInfo={ paginationInfo }
-						getItemId={ ( item: Subscriber ) => item.subscription_id.toString() }
-						defaultLayouts={ selectedSubscriber ? { list: {} } : { table: {} } }
-						actions={ actions }
-						search
-						searchLabel={
-							isEnglishLocale || hasTranslation( 'Search subscribers…' )
-								? translate( 'Search subscribers…' )
-								: translate( 'Search by name, username or email…' )
-						}
-					/>
+					<>
+						<SubscriberTotals
+							totalSubscribers={ grandTotal }
+							filteredCount={ subscribers.length }
+							filterOption={ filterOption }
+							searchTerm={ searchTerm }
+							isLoading={ isLoading }
+						/>
+						<DataViews< Subscriber >
+							data={ data }
+							fields={ fields }
+							view={ currentView }
+							onClickItem={ handleSubscriberOnClick }
+							onChangeView={ setCurrentView }
+							selection={
+								selectedSubscriber ? [ selectedSubscriber.subscription_id.toString() ] : undefined
+							}
+							onChangeSelection={ handleSubscriberSelect }
+							isLoading={ isLoading }
+							paginationInfo={ paginationInfo }
+							getItemId={ ( item: Subscriber ) => item.subscription_id.toString() }
+							defaultLayouts={ selectedSubscriber ? { list: {} } : { table: {} } }
+							actions={ actions }
+							search
+							searchLabel={
+								isEnglishLocale || hasTranslation( 'Search subscribers…' )
+									? translate( 'Search subscribers…' )
+									: translate( 'Search by name, username or email…' )
+							}
+						/>
+					</>
 				) }
 			</section>
 			{ selectedSubscriber &&

--- a/client/my-sites/subscribers/components/subscriber-totals/index.tsx
+++ b/client/my-sites/subscribers/components/subscriber-totals/index.tsx
@@ -1,0 +1,79 @@
+import { translate } from 'i18n-calypso';
+import { SubscribersFilterBy } from '../../constants';
+import './style.scss';
+
+type SubscriberTotalsProps = {
+	totalSubscribers: number;
+	filteredCount: number;
+	filterOption: SubscribersFilterBy;
+	searchTerm: string;
+	isLoading: boolean;
+};
+
+const getFilterLabel = ( filterOption: SubscribersFilterBy, count: number ): string => {
+	switch ( filterOption ) {
+		case SubscribersFilterBy.Paid:
+			return count === 1 ? translate( 'paid supporter' ) : translate( 'paid supporters' );
+		case SubscribersFilterBy.Free:
+			return count === 1 ? translate( 'free subscriber' ) : translate( 'free subscribers' );
+		case SubscribersFilterBy.EmailSubscriber:
+			return count === 1 ? translate( 'email subscriber' ) : translate( 'email subscribers' );
+		case SubscribersFilterBy.ReaderSubscriber:
+			return count === 1 ? translate( 'Reader follower' ) : translate( 'Reader followers' );
+		default:
+			return count === 1 ? translate( 'subscriber' ) : translate( 'subscribers' );
+	}
+};
+
+const SubscriberTotals: React.FC< SubscriberTotalsProps > = ( {
+	totalSubscribers,
+	filteredCount,
+	filterOption,
+	searchTerm,
+	isLoading,
+} ) => {
+	if ( isLoading ) {
+		return <div className="subscriber-totals is-loading" />;
+	}
+
+	const isFiltered = filterOption !== SubscribersFilterBy.All || !! searchTerm;
+	const filterLabel = getFilterLabel( filterOption, filteredCount );
+
+	return (
+		<div className="subscriber-totals">
+			<div className="subscriber-totals__counts">
+				{ isFiltered ? (
+					<>
+						<span className="subscriber-totals__filtered-count">
+							{ searchTerm
+								? translate( '%(count)d matching result', '%(count)d matching results', {
+										count: filteredCount,
+										args: { count: filteredCount },
+								  } )
+								: translate( '%(count)d %(filterLabel)s', {
+										args: {
+											count: filteredCount,
+											filterLabel,
+										},
+								  } ) }
+						</span>
+						<span className="subscriber-totals__total">
+							{ translate( 'out of %(total)d total subscribers', {
+								args: { total: totalSubscribers },
+							} ) }
+						</span>
+					</>
+				) : (
+					<span className="subscriber-totals__total-count">
+						{ translate( '%(count)d total subscriber', '%(count)d total subscribers', {
+							count: totalSubscribers,
+							args: { count: totalSubscribers },
+						} ) }
+					</span>
+				) }
+			</div>
+		</div>
+	);
+};
+
+export default SubscriberTotals;

--- a/client/my-sites/subscribers/components/subscriber-totals/index.tsx
+++ b/client/my-sites/subscribers/components/subscriber-totals/index.tsx
@@ -41,37 +41,35 @@ const SubscriberTotals: React.FC< SubscriberTotalsProps > = ( {
 
 	return (
 		<div className="subscriber-totals">
-			<div className="subscriber-totals__counts">
-				{ isFiltered ? (
-					<>
-						<span className="subscriber-totals__filtered-count">
-							{ searchTerm
-								? translate( '%(count)d matching result', '%(count)d matching results', {
+			{ isFiltered ? (
+				<>
+					<span className="subscriber-totals__filtered-count">
+						{ searchTerm
+							? translate( '%(count)d matching result', '%(count)d matching results', {
+									count: filteredCount,
+									args: { count: filteredCount },
+							  } )
+							: translate( '%(count)d %(filterLabel)s', {
+									args: {
 										count: filteredCount,
-										args: { count: filteredCount },
-								  } )
-								: translate( '%(count)d %(filterLabel)s', {
-										args: {
-											count: filteredCount,
-											filterLabel,
-										},
-								  } ) }
-						</span>
-						<span className="subscriber-totals__total">
-							{ translate( 'out of %(total)d total subscribers', {
-								args: { total: totalSubscribers },
-							} ) }
-						</span>
-					</>
-				) : (
-					<span className="subscriber-totals__total-count">
-						{ translate( '%(count)d total subscriber', '%(count)d total subscribers', {
-							count: totalSubscribers,
-							args: { count: totalSubscribers },
+										filterLabel,
+									},
+							  } ) }
+					</span>
+					<span className="subscriber-totals__total">
+						{ translate( 'out of %(total)d total subscribers', {
+							args: { total: totalSubscribers },
 						} ) }
 					</span>
-				) }
-			</div>
+				</>
+			) : (
+				<span className="subscriber-totals__total-count">
+					{ translate( '%(count)d total subscriber', '%(count)d total subscribers', {
+						count: totalSubscribers,
+						args: { count: totalSubscribers },
+					} ) }
+				</span>
+			) }
 		</div>
 	);
 };

--- a/client/my-sites/subscribers/components/subscriber-totals/index.tsx
+++ b/client/my-sites/subscribers/components/subscriber-totals/index.tsx
@@ -13,13 +13,13 @@ type SubscriberTotalsProps = {
 const getFilterLabel = ( filterOption: SubscribersFilterBy, count: number ): string => {
 	switch ( filterOption ) {
 		case SubscribersFilterBy.Paid:
-			return count === 1 ? translate( 'paid supporter' ) : translate( 'paid supporters' );
+			return count === 1 ? translate( 'paid subscriber' ) : translate( 'paid subscribers' );
 		case SubscribersFilterBy.Free:
 			return count === 1 ? translate( 'free subscriber' ) : translate( 'free subscribers' );
 		case SubscribersFilterBy.EmailSubscriber:
 			return count === 1 ? translate( 'email subscriber' ) : translate( 'email subscribers' );
 		case SubscribersFilterBy.ReaderSubscriber:
-			return count === 1 ? translate( 'Reader follower' ) : translate( 'Reader followers' );
+			return count === 1 ? translate( 'reader subscriber' ) : translate( 'reader subscribers' );
 		default:
 			return count === 1 ? translate( 'subscriber' ) : translate( 'subscribers' );
 	}

--- a/client/my-sites/subscribers/components/subscriber-totals/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-totals/style.scss
@@ -2,8 +2,13 @@
 @import '@wordpress/base-styles/mixins';
 
 .subscriber-totals {
-	padding: 16px 48px;
+	padding: 0 48px;
 	margin-bottom: 8px;
+
+	// 430px is the DataViews padding breakpoint.
+	@media ( max-width: 430px ) {
+		padding: 0 24px;
+	}
 	
 	&.is-loading {
 		min-height: 24px;

--- a/client/my-sites/subscribers/components/subscriber-totals/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-totals/style.scss
@@ -1,0 +1,29 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.subscriber-totals {
+	padding: 16px 48px;
+	margin-bottom: 8px;
+	
+	&.is-loading {
+		min-height: 24px;
+	}
+
+	&__counts {
+		font-size: 14px;
+		color: var(--studio-gray-60);
+	}
+
+	&__filtered-count {
+		font-weight: 600;
+		margin-right: 4px;
+	}
+
+	&__total {
+		color: var(--studio-gray-40);
+	}
+
+	&__total-count {
+		font-weight: 600;
+	}
+} 

--- a/client/my-sites/subscribers/components/subscriber-totals/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-totals/style.scss
@@ -4,6 +4,7 @@
 .subscriber-totals {
 	padding: 0 48px;
 	margin-bottom: 8px;
+	font-size: $font-code;
 
 	// 430px is the DataViews padding breakpoint.
 	@media ( max-width: 430px ) {
@@ -12,11 +13,6 @@
 	
 	&.is-loading {
 		min-height: 24px;
-	}
-
-	&__counts {
-		font-size: 14;
-		color: var(--studio-gray-60);
 	}
 
 	&__filtered-count {
@@ -31,4 +27,4 @@
 	&__total-count {
 		font-weight: 600;
 	}
-} 
+}

--- a/client/my-sites/subscribers/components/subscriber-totals/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-totals/style.scss
@@ -10,7 +10,7 @@
 	}
 
 	&__counts {
-		font-size: 14px;
+		font-size: 14;
 		color: var(--studio-gray-60);
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up to https://github.com/Automattic/wp-calypso/pull/99130

## Proposed Changes

* Add a subscriber totals component that updates as you filter and search.

https://github.com/user-attachments/assets/97f6e380-00d1-4023-8f24-0d82f1d2a78e

<img width="496" alt="Screen Shot 2025-02-06 at 10 12 16 AM" src="https://github.com/user-attachments/assets/c041ac88-cf86-425a-9740-bd4d69af9c72" />
<img width="471" alt="Screen Shot 2025-02-06 at 10 11 50 AM" src="https://github.com/user-attachments/assets/81237862-29d4-4424-aa2b-c3238ebd28af" />
<img width="488" alt="Screen Shot 2025-02-06 at 10 11 33 AM" src="https://github.com/user-attachments/assets/a514e35a-beba-4d9a-aca8-f1a4cc332ae5" />
<img width="477" alt="Screen Shot 2025-02-06 at 10 11 22 AM" src="https://github.com/user-attachments/assets/aa2d2df4-25ef-4321-88f4-d5d320d246ba" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We removed the subscriber grand total when we implemented DataViews. See request: https://github.com/Automattic/wp-calypso/pull/99130#issuecomment-2627809642

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /subscribers/{ site url} and see the total update as you filter and search.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
