### PR TITLE
Close the dropdown when the user clicks outside of it

### DIFF
--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -40,7 +40,7 @@ import type {
 	ResponseCartProduct,
 	RemoveCouponFromCart,
 } from '@automattic/shopping-cart';
-import type { PropsWithChildren } from 'react';
+import type { PropsWithChildren, RefObject } from 'react';
 
 const WPOrderReviewList = styled.ul`
 	box-sizing: border-box;
@@ -308,26 +308,52 @@ function LineItemWrapper( {
 		isDeletable = false;
 	}
 
-	const isOpen = product.uuid === variantOpenId;
-	const dropdownRef = useRef< HTMLDivElement >( null );
+	const isVariantDropdownOpen = product.uuid === variantOpenId;
+	const isAkQuantityDropdownOpen = product.uuid === akQuantityOpenId;
+	const variantDropdownRef = useRef< HTMLDivElement >( null );
+	const akQuantityDropdownRef = useRef< HTMLDivElement >( null );
 
 	useEffect( () => {
-		const handleClickOutside = ( event: MouseEvent ) => {
-			if ( dropdownRef.current && ! dropdownRef.current.contains( event.target as Node ) ) {
-				toggleVariantSelector( null );
-			}
-		};
+		const handleClickOutside =
+			( ref: RefObject< HTMLDivElement >, toggle: ( key: string | null ) => void ) =>
+			( event: MouseEvent ): void => {
+				if ( ref.current && ! ref.current.contains( event.target as Node ) ) {
+					toggle( null );
+				}
+			};
 
-		if ( isOpen ) {
-			document.addEventListener( 'mousedown', handleClickOutside );
+		const handleClickOutsideVariantDropdown = handleClickOutside(
+			variantDropdownRef,
+			toggleVariantSelector
+		);
+
+		const handleClickOutsideAkQuantityDropdown = handleClickOutside(
+			akQuantityDropdownRef,
+			toggleAkQuantityDropdown
+		);
+
+		if ( isVariantDropdownOpen ) {
+			document.addEventListener( 'mousedown', handleClickOutsideVariantDropdown as EventListener );
 		} else {
-			document.removeEventListener( 'mousedown', handleClickOutside );
+			document.removeEventListener( 'mousedown', handleClickOutsideVariantDropdown );
+		}
+
+		if ( isAkQuantityDropdownOpen ) {
+			document.addEventListener( 'mousedown', handleClickOutsideAkQuantityDropdown );
+		} else {
+			document.removeEventListener( 'mousedown', handleClickOutsideAkQuantityDropdown );
 		}
 
 		return () => {
-			document.removeEventListener( 'mousedown', handleClickOutside );
+			document.removeEventListener( 'mousedown', handleClickOutsideVariantDropdown );
+			document.removeEventListener( 'mousedown', handleClickOutsideAkQuantityDropdown );
 		};
-	}, [ isOpen, toggleVariantSelector ] );
+	}, [
+		isVariantDropdownOpen,
+		toggleVariantSelector,
+		isAkQuantityDropdownOpen,
+		toggleAkQuantityDropdown,
+	] );
 
 	const shouldShowVariantSelector = ( () => {
 		if ( ! onChangeSelection ) {
@@ -398,27 +424,31 @@ function LineItemWrapper( {
 				isAkPro500Cart={ isAkPro500Cart }
 				shouldShowBillingInterval={ ! finalShouldShowVariantSelector }
 			>
-				<DropdownWrapper ref={ dropdownRef }>
+				<DropdownWrapper>
 					{ finalShouldShowVariantSelector && (
-						<ItemVariationPicker
-							id={ product.uuid }
-							selectedItem={ product }
-							onChangeItemVariant={ onChangeSelection }
-							isDisabled={ isDisabled }
-							variants={ variants }
-							toggle={ toggleVariantSelector }
-							isOpen={ isOpen }
-						/>
+						<div ref={ variantDropdownRef }>
+							<ItemVariationPicker
+								id={ product.uuid }
+								selectedItem={ product }
+								onChangeItemVariant={ onChangeSelection }
+								isDisabled={ isDisabled }
+								variants={ variants }
+								toggle={ toggleVariantSelector }
+								isOpen={ isVariantDropdownOpen }
+							/>
+						</div>
 					) }
 					{ ! isRenewal && isAkPro500Cart && (
-						<AkismetProQuantityDropDown
-							id={ product.uuid }
-							responseCart={ responseCart }
-							setForceShowAkQuantityDropdown={ setForceShowAkQuantityDropdown }
-							onChangeAkProQuantity={ onChangeAkProQuantity }
-							toggle={ toggleAkQuantityDropdown }
-							isOpen={ akQuantityOpenId === product.uuid }
-						/>
+						<div ref={ akQuantityDropdownRef }>
+							<AkismetProQuantityDropDown
+								id={ product.uuid }
+								responseCart={ responseCart }
+								setForceShowAkQuantityDropdown={ setForceShowAkQuantityDropdown }
+								onChangeAkProQuantity={ onChangeAkProQuantity }
+								toggle={ toggleAkQuantityDropdown }
+								isOpen={ isAkQuantityDropdownOpen }
+							/>
+						</div>
 					) }
 				</DropdownWrapper>
 			</LineItem>

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -19,7 +19,7 @@ import {
 	getPartnerCoupon,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { has100YearPlan } from 'calypso/lib/cart-values/cart-items';
 import { useExperiment } from 'calypso/lib/explat';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
@@ -308,6 +308,27 @@ function LineItemWrapper( {
 		isDeletable = false;
 	}
 
+	const isOpen = product.uuid === variantOpenId;
+	const dropdownRef = useRef< HTMLDivElement >( null );
+
+	useEffect( () => {
+		const handleClickOutside = ( event: MouseEvent ) => {
+			if ( dropdownRef.current && ! dropdownRef.current.contains( event.target as Node ) ) {
+				toggleVariantSelector( null );
+			}
+		};
+
+		if ( isOpen ) {
+			document.addEventListener( 'mousedown', handleClickOutside );
+		} else {
+			document.removeEventListener( 'mousedown', handleClickOutside );
+		}
+
+		return () => {
+			document.removeEventListener( 'mousedown', handleClickOutside );
+		};
+	}, [ isOpen, toggleVariantSelector ] );
+
 	const shouldShowVariantSelector = ( () => {
 		if ( ! onChangeSelection ) {
 			return false;
@@ -377,7 +398,7 @@ function LineItemWrapper( {
 				isAkPro500Cart={ isAkPro500Cart }
 				shouldShowBillingInterval={ ! finalShouldShowVariantSelector }
 			>
-				<DropdownWrapper>
+				<DropdownWrapper ref={ dropdownRef }>
 					{ finalShouldShowVariantSelector && (
 						<ItemVariationPicker
 							id={ product.uuid }
@@ -386,7 +407,7 @@ function LineItemWrapper( {
 							isDisabled={ isDisabled }
 							variants={ variants }
 							toggle={ toggleVariantSelector }
-							isOpen={ variantOpenId === product.uuid }
+							isOpen={ isOpen }
 						/>
 					) }
 					{ ! isRenewal && isAkPro500Cart && (


### PR DESCRIPTION
Related to #99090

There is an alternative of using [useClickAway](https://github.com/streamich/react-use/blob/master/docs/useClickAway.md), but it is a new dependency.

## Proposed Changes

* Handle the click outside the component and close the dropdown.

## Why are these changes being made?

* Need to click on the component to close the dropdown, which is not a convenient UX.

![CleanShot 2025-01-31 at 14 12 46](https://github.com/user-attachments/assets/09567dad-a6ed-4bd1-b492-f73eb62d1c48)


## Testing Instructions

* First, let's test WordPress.com hosting/domain purchase:
  * Go to `/start`, choose a paid product to appear on the Checkout step.
  * Open the dropdown with payment options.
  * Make sure you can close it by clicking outside the dropdown.
* There is also Akismet quantity dropdown, let's test it too:
  * Go to http://calypso.localhost:3000/checkout/akismet/ak_pro5h_yearly:-q-1
  * Test both dropdowns with payment period variants and number of licenses.
  * Make sure you can close each of them by clicking outside the dropdowns.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
