### PR TITLE
Reader: clean up scrolling on disabled onboarding modal

### DIFF
--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -306,79 +306,81 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 			<Modal
 				onRequestClose={ handleClose }
 				isFullScreen
-				className="subscribe-modal"
+				className={ clsx( 'subscribe-modal', {
+					'is-disabled': promptVerification,
+				} ) }
 				headerActions={ headerActions }
 				isDismissible={ false }
 			>
-				{ promptVerification && <SubscribeVerificationNudge /> }
-				<div
-					className={ clsx( 'subscribe-modal__content', {
-						'subscribe-modal__disabled-for-verification': promptVerification,
-					} ) }
-				>
-					<div className="subscribe-modal__site-list-column">
-						<h2 className="subscribe-modal__title">{ __( "Discover sites that you'll love" ) }</h2>
-						<p className="subscribe-modal__description">
-							{ __(
-								'Preview sites by clicking below, then subscribe to any site that inspires you.'
+				<div className="subscribe-modal__container">
+					{ promptVerification && <SubscribeVerificationNudge /> }
+					<div className="subscribe-modal__content">
+						<div className="subscribe-modal__site-list-column">
+							<h2 className="subscribe-modal__title">
+								{ __( "Discover sites that you'll love" ) }
+							</h2>
+							<p className="subscribe-modal__description">
+								{ __(
+									'Preview sites by clicking below, then subscribe to any site that inspires you.'
+								) }
+							</p>
+							{ isLoading && <LoadingPlaceholder /> }
+							{ ! isLoading && combinedRecommendations.length === 0 && (
+								<p>{ __( 'No recommendations available at the moment.' ) }</p>
 							) }
-						</p>
-						{ isLoading && <LoadingPlaceholder /> }
-						{ ! isLoading && combinedRecommendations.length === 0 && (
-							<p>{ __( 'No recommendations available at the moment.' ) }</p>
-						) }
-						{ ! isLoading && combinedRecommendations.length > 0 && (
-							<div className="subscribe-modal__recommended-sites">
-								{ displayedRecommendations.map( ( site: CardData ) => (
-									<ConnectedReaderSubscriptionListItem
-										key={ site.feed_ID }
-										feedId={ site.feed_ID }
-										siteId={ site.site_ID }
-										site={ site }
-										url={ site.site_URL }
-										showLastUpdatedDate={ false }
-										showNotificationSettings={ false }
-										showFollowedOnDate={ false }
-										followSource="reader-onboarding-modal"
-										disableSuggestedFollows
-										replaceStreamClickWithItemClick
-										onItemClick={ () => handleItemClick( site ) }
-										isSelected={ selectedSite?.feed_ID === site.feed_ID }
-										onFollowToggle={ ( following: boolean ) =>
-											handleFollowToggle( site, following )
-										}
-									/>
-								) ) }
-							</div>
-						) }
-						{ currentPage < maxPages && (
-							<Button
-								className="subscribe-modal__load-more-button"
-								onClick={ handleLoadMore }
-								variant="link"
-							>
-								{ __( 'Load more recommendations' ) }
-							</Button>
-						) }
-					</div>
-					<div className="subscribe-modal__preview-column">
-						<div className="subscribe-modal__preview-placeholder">
-							{ selectedSite && (
-								<>
-									<div className="subscribe-modal__preview-stream-header">
-										<h3>{ formatUrl( selectedSite.site_URL ) }</h3>
-									</div>
-									<div className="subscribe-modal__preview-stream-container">
-										<TypedStream
-											streamKey={ `feed:${ selectedSite.feed_ID }` }
-											className="is-site-stream subscribe-modal__preview-stream"
-											followSource="reader_subscribe_modal"
-											useCompactCards
-											trackScrollPage={ trackScrollPage.bind( null ) }
+							{ ! isLoading && combinedRecommendations.length > 0 && (
+								<div className="subscribe-modal__recommended-sites">
+									{ displayedRecommendations.map( ( site: CardData ) => (
+										<ConnectedReaderSubscriptionListItem
+											key={ site.feed_ID }
+											feedId={ site.feed_ID }
+											siteId={ site.site_ID }
+											site={ site }
+											url={ site.site_URL }
+											showLastUpdatedDate={ false }
+											showNotificationSettings={ false }
+											showFollowedOnDate={ false }
+											followSource="reader-onboarding-modal"
+											disableSuggestedFollows
+											replaceStreamClickWithItemClick
+											onItemClick={ () => handleItemClick( site ) }
+											isSelected={ selectedSite?.feed_ID === site.feed_ID }
+											onFollowToggle={ ( following: boolean ) =>
+												handleFollowToggle( site, following )
+											}
 										/>
-									</div>
-								</>
+									) ) }
+								</div>
 							) }
+							{ currentPage < maxPages && (
+								<Button
+									className="subscribe-modal__load-more-button"
+									onClick={ handleLoadMore }
+									variant="link"
+								>
+									{ __( 'Load more recommendations' ) }
+								</Button>
+							) }
+						</div>
+						<div className="subscribe-modal__preview-column">
+							<div className="subscribe-modal__preview-placeholder">
+								{ selectedSite && (
+									<>
+										<div className="subscribe-modal__preview-stream-header">
+											<h3>{ formatUrl( selectedSite.site_URL ) }</h3>
+										</div>
+										<div className="subscribe-modal__preview-stream-container">
+											<TypedStream
+												streamKey={ `feed:${ selectedSite.feed_ID }` }
+												className="is-site-stream subscribe-modal__preview-stream"
+												followSource="reader_subscribe_modal"
+												useCompactCards
+												trackScrollPage={ trackScrollPage.bind( null ) }
+											/>
+										</div>
+									</>
+								) }
+							</div>
 						</div>
 					</div>
 				</div>

--- a/client/reader/onboarding/subscribe-modal/style.scss
+++ b/client/reader/onboarding/subscribe-modal/style.scss
@@ -41,11 +41,6 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 		}
 	}
 
-	&__disabled-for-verification {
-		opacity: 0.5;
-		pointer-events: none;
-	}
-
 	&__site-list-column {
 		flex: 1;
 		padding: 20px 20px 0;
@@ -152,6 +147,22 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 			&.is-primary {
 				margin-left: 16px;
 			}
+		}
+	}
+
+	&.is-disabled {
+		.subscribe-modal__container {
+			height: calc( 100vh - 188px ); // Modal margin + modal padding + modal heading
+			overflow: hidden;
+			padding: 1px;
+		}
+		.subscribe-modal__content {
+			opacity: 0.5;
+			pointer-events: none;
+		}
+		.subscribe-modal__preview-stream-container,
+		.subscribe-modal__site-list-column {
+			overflow-y: hidden;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/wp-calypso#99135

## Proposed Changes

* Add a container around the onboarding subscriber modal to prevent scrolling when disabled

**Before**

https://github.com/user-attachments/assets/58c8f140-b207-4485-b472-e7bcf8c58f28

**After**

https://github.com/user-attachments/assets/5da63319-15c9-48a5-8b82-2695a6f15bad

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Polish the UX

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new account that has an unverified email.
* Nav to `/read` and start onboarding
* When you get to the site subscription modal, make sure the content doesn't scroll. Check various breakpoints.
* Verifiy your email and check for regressions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
