### PR TITLE
Signup form: use `TextControl` from `@wordpress/components`

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { FormInputValidation, FormLabel } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { Spinner } from '@wordpress/components';
+import { Spinner, TextControl } from '@wordpress/components';
 import clsx from 'clsx';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
@@ -37,7 +37,6 @@ import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
 import Notice from 'calypso/components/notice';
-import TextControl from 'calypso/components/text-control';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import formState from 'calypso/lib/form-state';
@@ -809,9 +808,13 @@ class SignupForm extends Component {
 	};
 
 	renderWooCommerce() {
+		// As we migrate more inputs to @wordpress/components' <TextControl />,
+		// we should extend this classname and realted styles for better coherency.
+		const inputClassName = 'signup-form__woo-input';
 		return (
 			<div>
 				<TextControl
+					className={ inputClassName }
 					label={ this.props.translate( 'Your email address' ) }
 					disabled={
 						this.state.submitting || !! this.props.disabled || !! this.props.disableEmailInput
@@ -827,6 +830,8 @@ class SignupForm extends Component {
 							value,
 						} );
 					} }
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
 				/>
 				{ this.emailDisableExplanation() }
 
@@ -837,6 +842,7 @@ class SignupForm extends Component {
 				{ this.props.displayUsernameInput && (
 					<>
 						<TextControl
+							className={ inputClassName }
 							label={ this.props.translate( 'Choose a username' ) }
 							disabled={ this.state.submitting || this.props.disabled }
 							id="username"
@@ -849,6 +855,8 @@ class SignupForm extends Component {
 									value,
 								} );
 							} }
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
 						/>
 
 						{ formState.isFieldInvalid( this.state.form, 'username' ) && (
@@ -858,6 +866,7 @@ class SignupForm extends Component {
 				) }
 
 				<TextControl
+					className={ inputClassName }
 					label={ this.props.translate( 'Choose a password' ) }
 					disabled={ this.state.submitting || this.props.disabled }
 					id="password"
@@ -871,6 +880,8 @@ class SignupForm extends Component {
 							value,
 						} );
 					} }
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
 				/>
 
 				{ this.passwordValidationExplanation() }

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -808,13 +808,9 @@ class SignupForm extends Component {
 	};
 
 	renderWooCommerce() {
-		// As we migrate more inputs to @wordpress/components' <TextControl />,
-		// we should extend this classname and realted styles for better coherency.
-		const inputClassName = 'signup-form__woo-input';
 		return (
-			<div>
+			<div className="signup-form__woocommerce-inputs-wrapper">
 				<TextControl
-					className={ inputClassName }
 					label={ this.props.translate( 'Your email address' ) }
 					disabled={
 						this.state.submitting || !! this.props.disabled || !! this.props.disableEmailInput
@@ -842,7 +838,6 @@ class SignupForm extends Component {
 				{ this.props.displayUsernameInput && (
 					<>
 						<TextControl
-							className={ inputClassName }
 							label={ this.props.translate( 'Choose a username' ) }
 							disabled={ this.state.submitting || this.props.disabled }
 							id="username"
@@ -866,7 +861,6 @@ class SignupForm extends Component {
 				) }
 
 				<TextControl
-					className={ inputClassName }
 					label={ this.props.translate( 'Choose a password' ) }
 					disabled={ this.state.submitting || this.props.disabled }
 					id="password"

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -23,10 +23,6 @@
 	}
 }
 
-.signup-form__woo-input {
-	margin: 14px 0;
-}
-
 .signup-form__terms-of-service-link {
 	font-size: $font-body-extra-small;
 	margin: 0 0 20px;

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -23,6 +23,10 @@
 	}
 }
 
+.signup-form__woo-input {
+	margin: 14px 0;
+}
+
 .signup-form__terms-of-service-link {
 	font-size: $font-body-extra-small;
 	margin: 0 0 20px;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -937,11 +937,6 @@ $colophon-height: 50px;
 			margin-right: auto;
 		}
 
-		.logged-out-form input:focus {
-			border: 0;
-			box-shadow: none;
-		}
-
 		.signup-form__terms-of-service-link,
 		.signup-form__terms-of-service-link a {
 			text-align: left;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1021,6 +1021,14 @@ $colophon-height: 50px;
 			padding-top: 8px;
 		}
 
+
+		.signup-form__woocommerce-inputs-wrapper {
+			padding: 12px 0;
+			display: flex;
+			flex-direction: column;
+			gap: 14px;
+		}
+
 		.form-input-validation {
 			padding-bottom: 0;
 			padding-top: 0;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -288,40 +288,6 @@ body.is-section-signup .layout:not(.dops):not(.is-wccom-oauth-flow) .formatted-h
 		display: none;
 	}
 
-	.signup-form__woocommerce-wrapper {
-		text-align: center;
-		border-bottom: 1px solid var(--color-neutral-50);
-		position: absolute;
-		left: 0;
-		top: 0;
-		width: 100%;
-		height: 56px;
-
-		svg > g {
-			transform: translateX(50%);
-		}
-	}
-
-	.signup-form__woocommerce-logo {
-		margin: 0;
-		text-align: center;
-		margin-right: auto;
-		margin-left: auto;
-		padding-left: 0;
-		display: block;
-		height: 56px;
-		border-bottom: 1px solid var(--color-woocommerce-header-border);
-		background: var(--color-text-inverted);
-
-		svg {
-			margin-top: 15px;
-		}
-	}
-
-	.signup-form__woocommerce-heading {
-		margin-top: 32px;
-	}
-
 	.formatted-header {
 		max-width: 476px;
 		margin-right: auto;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Replace `TextControl` from `client/components` with `TextControl` from `@wordpress/components` in the signup form

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Re-using existing WordPress UI components for better consistency and less first-party code to maintain

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log out
* Visit `http://calypso.localhost:3000/jetpack/connect/authorize?from=woocommerce-onboarding&_wp_nonce=foobar&blogname=Just%20Another%20WordPress.com%20Site&client_id=12345&close_window_after_login=0&close_window_after_auth=0&home_url=https://yourjetpack.blog&redirect_uri=https://yourjetpack.blog/wp-admin/admin.php&scope=administrator:34579bf2a3185a47d1b31aab30125d&secret=640fdbd69f96a8ca9e61&site=https://yourjetpack.blog&site_url=https://yourjetpack.blog&state=1&allow_site_connection=1&installed_ext_success=1&`
* Make sure that the form looks fine and works as expected
  * Focus/Hover/Active styles
  * Error validation
  * Disabled while submitting
  * Signup form works correctly

Notes:
- The following instructions go though what's called "jetpack woo commerce flow". This form is also rendered in the so-called "jetpack woo DNA flow", although I wasn't able to find up to date testing instructions for this flow easily around the repo (PRs often lack testing instructions)

| Before | After |
|---|---|
| ![Screenshot 2025-02-01 at 14 49 44](https://github.com/user-attachments/assets/71c3216c-e031-4210-a48b-e8773a0cba63) | ![Screenshot 2025-02-01 at 14 33 46](https://github.com/user-attachments/assets/fafbfd0e-b1e9-4589-95cb-ddfc064231ab) |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
