### PR TITLE
Login form: use `TextControl` from `@wordpress/components` instead of local one

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -4,7 +4,7 @@ import { Button, Card, FormInputValidation, FormLabel, Gridicon } from '@automat
 import { alert } from '@automattic/components/src/icons';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { suggestEmailCorrection } from '@automattic/onboarding';
-import { Spinner } from '@wordpress/components';
+import { Spinner, TextControl } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import cookie from 'cookie';
@@ -22,7 +22,6 @@ import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import Notice from 'calypso/components/notice';
 import { LastUsedSocialButton } from 'calypso/components/social-buttons';
-import TextControl from 'calypso/components/text-control';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import {
 	getSignupUrl,
@@ -491,6 +490,8 @@ export class LoginForm extends Component {
 									usernameOrEmail: value,
 								} );
 							} }
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
 						/>
 
 						{ requestError && requestError.field === 'usernameOrEmail' && (
@@ -515,6 +516,8 @@ export class LoginForm extends Component {
 										password: value,
 									} );
 								} }
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
 							/>
 
 							{ requestError && requestError.field === 'password' && (

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -364,7 +364,11 @@ $image-height: 47px;
 
 	.login form {
 
-		input,
+		// We shouldn't regularly use .components-* classnames. The following is
+		// an exception to opt-out from some style overrides. Ideally, all
+		// input instances would come from `@wordpress/components` and the
+		// following overrides could be safely deleted.
+		input:not(.components-text-control__input),
 		button {
 			/* Note: Same as `button.signup-form__submit, .signup-form__input.form-text-input` */
 			height: 44px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Replace `TextControl` from `client/components` with `TextControl` from `@wordpress/components` in the login form

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Re-using existing WordPress UI components for better consistency and less first-party code to maintain

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log out
* Visit `http://calypso.localhost:3000/log-in/jetpack?site=https%3A%2F%2Fyourjetpack.blog&redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000%2Fjetpack%2Fconnect%2Fauthorize%3Ffrom%3Dwoocommerce-onboarding%26_wp_nonce%3Dfoobar%26blogname%3DJust%2520Another%2520WordPress.com%2520Site%26client_id%3D12345%26close_window_after_login%3D0%26close_window_after_auth%3D0%26home_url%3Dhttps%3A%2F%2Fyourjetpack.blog%26redirect_uri%3Dhttps%3A%2F%2Fyourjetpack.blog%2Fwp-admin%2Fadmin.php%26scope%3Dadministrator%3A34579bf2a3185a47d1b31aab30125d%26secret%3D640fdbd69f96a8ca9e61%26site%3Dhttps%3A%2F%2Fyourjetpack.blog%26site_url%3Dhttps%3A%2F%2Fyourjetpack.blog%26state%3D1%26allow_site_connection%3D1%26installed_ext_success%3D1%26&from=woocommerce-onboarding&allow_site_connection=1`
* Make sure that the form looks fine and works as expected
  * Focus/Hover/Active styles
  * Error validation
  * Disabled while submitting
  * Login form works correctly
* If the password form is hidden, you can show it by manually toggling the `is-hidden` class on the `.login__form-password` div element, by manually overriding the result of the `isUsernameOrEmailView()` check, or (if you know how) by testing a flow where the password option is enabled.


You can also manually trigger this form by tweaking the `isJetpackWooCommerceFlow` and `isJetpackWooDnaFlow` conditions in this file:

https://github.com/Automattic/wp-calypso/blob/66588300b0d0f042607336f9d37e31f4e5c50563/client/blocks/login/login-form.jsx#L881-L890

| Before | After |
|---|---|
| ![Screenshot 2025-02-01 at 15 33 50](https://github.com/user-attachments/assets/71d5e129-ec18-4cf0-83bd-63ae22399dd1) | ![Screenshot 2025-02-04 at 15 46 59](https://github-production-user-asset-6210df.s3.amazonaws.com/1083581/408807224-89044db8-77de-4e0b-a4ce-aee2577009fb.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20250204%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250204T204601Z&X-Amz-Expires=300&X-Amz-Signature=6aeb0359e3105e7d97172c717477a200fd717502e7cea621f8ca7c700304fa5e&X-Amz-SignedHeaders=host) |

Notes:
- I sometimes am not able to test this locally, as I was getting an error about invoking the `window.AppBoot()` function
- The Jetpack logo seems to be broken on trunk anyway

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
