### PR TITLE
Fix: anonymous user who chooses Big Sky on Personal Plan stuck in onboarding loop

### DIFF
--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -178,9 +178,16 @@ const onboarding: Flow = {
 			if ( createWithBigSky && isBigSkyBeforePlansExperiment && isGoalsAtFrontExperiment ) {
 				const destination = addQueryArgs( '/setup/site-setup/launch-big-sky', {
 					siteSlug: providedDependencies.siteSlug,
+					flags: 'onboarding/force-big-sky-before-plan',
 				} );
 
-				return [ destination, addQueryArgs( '/setup/onboarding/plans', { skippedCheckout: 1 } ) ];
+				return [
+					destination,
+					addQueryArgs( '/setup/onboarding/plans', {
+						skippedCheckout: 1,
+						flags: 'onboarding/force-big-sky-before-plan',
+					} ),
+				];
 			}
 
 			const destination = addQueryArgs( '/setup/site-setup', {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes pdtkmj-3kX-p2#comment-6254

## Proposed Changes

Ensures that users who started with the Big Sky flow, continue with that
flow, regardless of their experiment assignment.

If users started the Big Sky flow while anonymous for example, then after they log in they should continue with the Big Sky flow. Even if their logged in experiment assignment is different.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start from `/setup/onboarding`, logged out
* Use Explat method for assigning logged out user to Big Sky flow
* Start creating your site, so that you will eventually get big sky. Eventually you will need to log in
* After the checkout, you should successfully be sent to Big Sky

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
