### PR TITLE
Removes the Design with AI button from the design picker

### DIFF
--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -315,7 +315,7 @@ interface DesignPickerProps {
 
 const DesignPicker: React.FC< DesignPickerProps > = ( {
 	locale,
-	onDesignWithAI,
+	//onDesignWithAI,
 	onPreview,
 	onChangeVariation,
 	designs,
@@ -398,7 +398,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						/>
 					</DesignPickerFilterGroup>
 				) }
-				{ isBigSkyEligible && (
+				{ /* isBigSkyEligible && (
 					<DesignPickerFilterGroup>
 						<Button
 							className={ clsx(
@@ -412,7 +412,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 							{ translate( 'Design with AI' ) }
 						</Button>
 					</DesignPickerFilterGroup>
-				) }
+				) */ }
 			</div>
 
 			{ isMultiFilterEnabled && selectedCategoriesWithoutDesignTier.length > 1 && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* Removes the "Design with AI" button from the design picker, regardless of whether the user is in goals-first or user-first flow

i.e. this button is gone

![image](https://github.com/user-attachments/assets/79b1ba7a-ffb2-4a05-a64e-7b54b4c8cd3f)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See discussion p1738554541066579-slack-C085HCWCEDN

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself to goals-first and big sky experiments
  * Choose big sky compatible goals
  * Choose to create your site with a theme
  * Design picker loads, but there's no Design with AI button
* Assign yourself to user-first flow
  * Choose big sky compatible plan
  * Complete checkout
  * Choose big sky compatible goals
  * Choose to create your with with a theme
  * Design picker loads, but there's no Design with AI button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?