### PR TITLE
Remove Jetpack Carousel settings tests for calypso

### DIFF
--- a/test/e2e/specs/media/settings__media.ts
+++ b/test/e2e/specs/media/settings__media.ts
@@ -11,7 +11,6 @@ import {
 	getTestAccountByFeature,
 	envToFeatureKey,
 	WpAdminMediaSettingsPage,
-	WritingSettingsPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { skipItIf } from '../../jest-helpers';

--- a/test/e2e/specs/media/settings__media.ts
+++ b/test/e2e/specs/media/settings__media.ts
@@ -47,37 +47,7 @@ describe( DataHelper.createSuiteTitle( 'Jetpack Settings: Media' ), function () 
 		}
 	} );
 
-	if ( envVariables.JETPACK_TARGET === 'remote-site' ) {
-		// For self-hosted sites with Jetpack plugin installed.
-		describe( 'Under writing settings for a remote site', function () {
-			let writingSettingsPage: WritingSettingsPage;
-
-			it( 'Navigate to Settings > Writing', async function () {
-				const sidebarComponent = new SidebarComponent( page );
-				await sidebarComponent.navigate( 'Settings', 'Writing' );
-
-				writingSettingsPage = new WritingSettingsPage( page );
-			} );
-
-			it( 'Toggle Carousel', async function () {
-				await writingSettingsPage.toggleOn(
-					'parent',
-					'Transform standard image galleries into full-screen slideshows'
-				);
-			} );
-
-			it( 'Toggle photo metadata', async function () {
-				await writingSettingsPage.toggleOn(
-					'child',
-					'Show photo metadata in carousel, when available'
-				);
-			} );
-
-			it( 'Select "Black" for carousel background color', async function () {
-				await writingSettingsPage.selectCarouselBackgroundColor( 'Black' );
-			} );
-		} );
-	} else {
+	if ( envVariables.JETPACK_TARGET !== 'remote-site' ) {
 		// For WPCOM hosted sites.
 		let wpAdminMediaSettingsPage: WpAdminMediaSettingsPage;
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/99155

## Proposed Changes

* Removes Jetpack Carousel settings tests for calypso

## Why are these changes being made?

* These options are no longer available in calypso after https://github.com/Automattic/wp-calypso/pull/98875
* These options are still available in wp-admin and the Jetpack settings dashboard.

## Testing Instructions

```
yarn workspace wp-e2e-tests test -- test/e2e/specs/media/settings__media.ts
```