### PR TITLE
E2E TOTP auth test: Replace /settings/general redirect target with /plans

### DIFF
--- a/test/e2e/specs/authentication/authentication__totp.ts
+++ b/test/e2e/specs/authentication/authentication__totp.ts
@@ -23,7 +23,7 @@ describe( DataHelper.createSuiteTitle( 'Authentication: TOTP' ), function () {
 			// Test redirect to full URL.
 			await page.goto(
 				DataHelper.getCalypsoURL(
-					`log-in?site=${ credentials.primarySite }&redirect_to=%2Fsettings%2Fgeneral%2F${ credentials.primarySite }`
+					`log-in?site=${ credentials.primarySite }&redirect_to=%2Fplans%2F${ credentials.primarySite }`
 				)
 			);
 		} );
@@ -50,7 +50,7 @@ describe( DataHelper.createSuiteTitle( 'Authentication: TOTP' ), function () {
 		} );
 
 		it( 'User is redirected to Settings > General Settings', async function () {
-			const redirectedURL = DataHelper.getCalypsoURL( '/settings/general' );
+			const redirectedURL = DataHelper.getCalypsoURL( '/plans' );
 			await page.waitForURL( `${ redirectedURL }/${ credentials.primarySite }` );
 		} );
 

--- a/test/e2e/specs/authentication/authentication__totp.ts
+++ b/test/e2e/specs/authentication/authentication__totp.ts
@@ -62,8 +62,6 @@ describe( DataHelper.createSuiteTitle( 'Authentication: TOTP' ), function () {
 	describe( 'WooCommerce', function () {
 		beforeAll( async () => {
 			page = await browser.newPage();
-			// Wait 30s to avoid OTP code reuse error.
-			await page.waitForTimeout( 30000 );
 		} );
 
 		it( 'Navigate to Login page', async function () {
@@ -71,6 +69,8 @@ describe( DataHelper.createSuiteTitle( 'Authentication: TOTP' ), function () {
 			await loginPage.visit( {
 				path: SecretsManager.secrets.wooLoginPath,
 			} );
+			// Wait 30s to avoid OTP code reuse error.
+			await page.waitForTimeout( 30000 );
 		} );
 
 		it( 'Enter username', async function () {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/99155

## Proposed Changes

* The /settings/general calypso route is moving / being untangled. Since we don't know if that route will be around much longer, I'm updating this to look for a /plans redirect which is much more likely to survive untangling.
* The sleep for the woo test needed moving as it was causing a failure

## Testing Instructions

```
yarn workspace wp-e2e-tests test -- test/e2e/specs/authentication/authentication__totp.ts
```