### PR TITLE
Big Sky: A quick patch to disable the Big Sky onboarding experience

### DIFF
--- a/client/landing/stepper/declarative-flow/helpers/use-bigsky-before-plans-experiment.ts
+++ b/client/landing/stepper/declarative-flow/helpers/use-bigsky-before-plans-experiment.ts
@@ -1,10 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { setPlansListExperiment } from '@automattic/calypso-products';
-import { ONBOARDING_FLOW } from '@automattic/onboarding';
-import { useMemo } from 'react';
-import { useExperiment } from 'calypso/lib/explat';
-import { getFlowFromURL } from '../../utils/get-flow-from-url';
-import { useGoalsFirstExperiment } from './use-goals-first-experiment';
+//import { ONBOARDING_FLOW } from '@automattic/onboarding';
+//import { useMemo } from 'react';
+//import { useExperiment } from 'calypso/lib/explat';
+//import { getFlowFromURL } from '../../utils/get-flow-from-url';
+//import { useGoalsFirstExperiment } from './use-goals-first-experiment';
 
 export const EXPERIMENT_NAME = 'calypso_signup_onboarding_goals_first_bigsky_202501_v1';
 
@@ -14,29 +14,36 @@ export const EXPERIMENT_NAME = 'calypso_signup_onboarding_goals_first_bigsky_202
  * Returns [ isLoading, isBigSkyBeforePlans ]
  */
 export function useBigSkyBeforePlans(): [ boolean, boolean ] {
-	const flow = useMemo( () => getFlowFromURL(), [] );
-	const [ isLoadingGoalsFirst, isGoalsFirstExperiment ] = useGoalsFirstExperiment();
-
-	const [ isLoading, experimentAssignment ] = useExperiment( EXPERIMENT_NAME, {
-		isEligible:
-			! isLoadingGoalsFirst &&
-			isGoalsFirstExperiment &&
-			flow === ONBOARDING_FLOW &&
-			! isEnabled( 'onboarding/force-big-sky-before-plan' ),
-	} );
-
 	if ( isEnabled( 'onboarding/force-big-sky-before-plan' ) ) {
 		setPlansListExperiment( EXPERIMENT_NAME, 'treatment' );
 		return [ false, true ];
 	}
 
-	/**
-	 * This fallback is necessary because experimentAssignment returns null when the user
-	 * is not eligible, and we're using this hook within steps that are used by other flows.
-	 */
-	const variationName = experimentAssignment?.variationName ?? 'control';
+	return [ false, false ];
 
-	setPlansListExperiment( EXPERIMENT_NAME, variationName );
-
-	return [ isLoading, variationName === 'treatment' ];
+	//const flow = useMemo( () => getFlowFromURL(), [] );
+	//const [ isLoadingGoalsFirst, isGoalsFirstExperiment ] = useGoalsFirstExperiment();
+	//
+	//const [ isLoading, experimentAssignment ] = useExperiment( EXPERIMENT_NAME, {
+	//	isEligible:
+	//		! isLoadingGoalsFirst &&
+	//		isGoalsFirstExperiment &&
+	//		flow === ONBOARDING_FLOW &&
+	//		! isEnabled( 'onboarding/force-big-sky-before-plan' ),
+	//} );
+	//
+	//if ( isEnabled( 'onboarding/force-big-sky-before-plan' ) ) {
+	//	setPlansListExperiment( EXPERIMENT_NAME, 'treatment' );
+	//	return [ false, true ];
+	//}
+	//
+	///**
+	// * This fallback is necessary because experimentAssignment returns null when the user
+	// * is not eligible, and we're using this hook within steps that are used by other flows.
+	// */
+	//const variationName = experimentAssignment?.variationName ?? 'control';
+	//
+	//setPlansListExperiment( EXPERIMENT_NAME, variationName );
+	//
+	//return [ isLoading, variationName === 'treatment' ];
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Disables the Big Sky in goals-first flow experience

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is a ready made revert PR which will disable the Big Sky in Goals-First Flow experience. **This PR isn't meant to be merged unless something has gone wrong**

See the instructions here:
p1738565971424099-slack-C085HCWCEDN

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/setup/onboarding` will no longer show the Big Sky choice screen after the goals screen.
