### PR TITLE
Help Center: Add bottom spacing for article content if notice is visible

### DIFF
--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -59,8 +59,6 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 	const messagesContainerRef = useRef< HTMLDivElement >( null );
 	const viewConversationNoticeRef = useRef< HTMLDivElement >( null );
 
-	const [ isNoticeVisible, setIsNoticeVisible ] = useState( false );
-
 	useZendeskMessageListener();
 	useAutoScroll( messagesContainerRef );
 
@@ -106,36 +104,6 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 		createZendeskConversation,
 	] );
 
-	// Detect odie notice visibility
-	useEffect( () => {
-		const observer = new MutationObserver( ( mutations ) => {
-			mutations.forEach( ( mutation ) => {
-				if ( mutation.type === 'childList' ) {
-					const noticeElement = document.querySelector( '.odie-notice' );
-					if ( noticeElement ) {
-						const isVisible =
-							noticeElement.getBoundingClientRect().top < window.innerHeight &&
-							noticeElement.getBoundingClientRect().bottom >= 0;
-						setIsNoticeVisible( isVisible );
-					} else {
-						setIsNoticeVisible( false );
-					}
-				}
-			} );
-		} );
-
-		const targetNode = document.querySelector( '.chatbox-messages' );
-		if ( targetNode ) {
-			observer.observe( targetNode, { childList: true, subtree: true } );
-		}
-
-		return () => {
-			if ( targetNode ) {
-				observer.disconnect();
-			}
-		};
-	}, [] );
-
 	// Used to apply the correct styling on messages
 	const isNextMessageFromSameSender = ( currentMessage: string, nextMessage: string ) => {
 		return currentMessage === nextMessage;
@@ -149,10 +117,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 
 	return (
 		<>
-			<div
-				className={ clsx( 'chatbox-messages' ) }
-				ref={ messagesContainerRef }
-			>
+			<div className={ clsx( 'chatbox-messages' ) } ref={ messagesContainerRef }>
 				<ChatDate chat={ chat } />
 				{ ! chatMessagesLoaded ? (
 					<LoadingChatSpinner />

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -57,7 +57,6 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 	const [ hasForwardedToZendesk, setHasForwardedToZendesk ] = useState( false );
 	const [ chatMessagesLoaded, setChatMessagesLoaded ] = useState( false );
 	const messagesContainerRef = useRef< HTMLDivElement >( null );
-	const viewConversationNoticeRef = useRef< HTMLDivElement >( null );
 
 	useZendeskMessageListener();
 	useAutoScroll( messagesContainerRef );
@@ -145,9 +144,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 							/>
 						) ) }
 						<JumpToRecent containerReference={ messagesContainerRef } />
-						{ chat.provider === 'odie' && (
-							<ViewMostRecentOpenConversationNotice ref={ viewConversationNoticeRef } />
-						) }
+						{ chat.provider === 'odie' && <ViewMostRecentOpenConversationNotice /> }
 						{ chat.status === 'dislike' && ! removeDislikeStatus && <DislikeThumb /> }
 						{ availableStatusWithFeedback.includes( chat.status ) && (
 							<div className="odie-chatbox__action-message">

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -1,22 +1,18 @@
 import { useResetSupportInteraction } from '@automattic/help-center/src/hooks/use-reset-support-interaction';
-import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { getShortDateString } from '@automattic/i18n-utils';
 import { Spinner } from '@wordpress/components';
-import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
-import { __, _n } from '@wordpress/i18n';
+import clsx from 'clsx';
 import { useEffect, useRef, useState } from 'react';
-import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { ThumbsDown } from '../../assets/thumbs-down';
 import { useOdieAssistantContext } from '../../context';
-import { useGetSupportInteractionById } from '../../data/use-get-support-interaction-by-id';
 import {
 	useAutoScroll,
 	useCreateZendeskConversation,
 	useZendeskMessageListener,
 } from '../../hooks';
-import { useGetMostRecentOpenConversation } from '../../hooks/use-get-most-recent-open-conversation';
 import { getOdieInitialMessage } from '../../utils';
-import OdieNotice from '../odie-notice';
+import { ViewMostRecentOpenConversationNotice } from '../odie-notice/view-most-recent-conversation-notice';
 import { DislikeFeedbackMessage } from './dislike-feedback-message';
 import { JumpToRecent } from './jump-to-recent';
 import { ThinkingPlaceholder } from './thinking-placeholder';
@@ -47,58 +43,6 @@ const ChatDate = ( { chat }: { chat: Chat } ) => {
 	return <div className="odie-chat__date">{ currentDate }</div>;
 };
 
-const ViewMostRecentOpenConversationNotice = () => {
-	const { mostRecentSupportInteractionId, totalNumberOfConversations } =
-		useGetMostRecentOpenConversation();
-
-	const fetchSupportInteraction =
-		mostRecentSupportInteractionId?.toString() && totalNumberOfConversations === 1
-			? mostRecentSupportInteractionId.toString()
-			: null;
-	const { data: supportInteraction } = useGetSupportInteractionById( fetchSupportInteraction );
-	const { setCurrentSupportInteraction } = useDataStoreDispatch( HELP_CENTER_STORE );
-	const { trackEvent } = useOdieAssistantContext();
-	const location = useLocation();
-	const navigate = useNavigate();
-	const shouldDisplayNotice = supportInteraction || totalNumberOfConversations > 1;
-
-	const handleNoticeOnClick = () => {
-		if ( supportInteraction ) {
-			setCurrentSupportInteraction( supportInteraction );
-			if ( ! location.pathname.includes( '/odie' ) ) {
-				navigate( '/odie' );
-			}
-		} else {
-			navigate( '/chat-history' );
-		}
-		trackEvent( 'chat_open_previous_conversation_notice', {
-			destination: supportInteraction ? 'support-interaction' : 'chat-history',
-			total_number_of_conversations: totalNumberOfConversations,
-		} );
-	};
-
-	return (
-		shouldDisplayNotice && (
-			<OdieNotice>
-				<div className="odie-notice__view-conversation">
-					<span>
-						{ __( 'You have another open conversation already started.', __i18n_text_domain__ ) }
-					</span>
-					&nbsp;
-					<button onClick={ handleNoticeOnClick }>
-						{ _n(
-							'View conversation',
-							'View conversations',
-							totalNumberOfConversations,
-							__i18n_text_domain__
-						) }
-					</button>
-				</div>
-			</OdieNotice>
-		)
-	);
-};
-
 interface ChatMessagesProps {
 	currentUser: CurrentUser;
 }
@@ -113,6 +57,10 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 	const [ hasForwardedToZendesk, setHasForwardedToZendesk ] = useState( false );
 	const [ chatMessagesLoaded, setChatMessagesLoaded ] = useState( false );
 	const messagesContainerRef = useRef< HTMLDivElement >( null );
+	const viewConversationNoticeRef = useRef< HTMLDivElement >( null );
+
+	const [ isNoticeVisible, setIsNoticeVisible ] = useState( false );
+
 	useZendeskMessageListener();
 	useAutoScroll( messagesContainerRef );
 
@@ -158,6 +106,36 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 		createZendeskConversation,
 	] );
 
+	// Detect odie notice visibility
+	useEffect( () => {
+		const observer = new MutationObserver( ( mutations ) => {
+			mutations.forEach( ( mutation ) => {
+				if ( mutation.type === 'childList' ) {
+					const noticeElement = document.querySelector( '.odie-notice' );
+					if ( noticeElement ) {
+						const isVisible =
+							noticeElement.getBoundingClientRect().top < window.innerHeight &&
+							noticeElement.getBoundingClientRect().bottom >= 0;
+						setIsNoticeVisible( isVisible );
+					} else {
+						setIsNoticeVisible( false );
+					}
+				}
+			} );
+		} );
+
+		const targetNode = document.querySelector( '.chatbox-messages' );
+		if ( targetNode ) {
+			observer.observe( targetNode, { childList: true, subtree: true } );
+		}
+
+		return () => {
+			if ( targetNode ) {
+				observer.disconnect();
+			}
+		};
+	}, [] );
+
 	// Used to apply the correct styling on messages
 	const isNextMessageFromSameSender = ( currentMessage: string, nextMessage: string ) => {
 		return currentMessage === nextMessage;
@@ -171,7 +149,12 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 
 	return (
 		<>
-			<div className="chatbox-messages" ref={ messagesContainerRef }>
+			<div
+				className={ clsx( 'chatbox-messages', {
+					'is-notice-visible': isNoticeVisible,
+				} ) }
+				ref={ messagesContainerRef }
+			>
 				<ChatDate chat={ chat } />
 				{ ! chatMessagesLoaded ? (
 					<LoadingChatSpinner />
@@ -199,7 +182,9 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 							/>
 						) ) }
 						<JumpToRecent containerReference={ messagesContainerRef } />
-						{ chat.provider === 'odie' && <ViewMostRecentOpenConversationNotice /> }
+						{ chat.provider === 'odie' && (
+							<ViewMostRecentOpenConversationNotice ref={ viewConversationNoticeRef } />
+						) }
 						{ chat.status === 'dislike' && ! removeDislikeStatus && <DislikeThumb /> }
 						{ availableStatusWithFeedback.includes( chat.status ) && (
 							<div className="odie-chatbox__action-message">

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -150,9 +150,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 	return (
 		<>
 			<div
-				className={ clsx( 'chatbox-messages', {
-					'is-notice-visible': isNoticeVisible,
-				} ) }
+				className={ clsx( 'chatbox-messages' ) }
 				ref={ messagesContainerRef }
 			>
 				<ChatDate chat={ chat } />

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -1,7 +1,6 @@
 import { useResetSupportInteraction } from '@automattic/help-center/src/hooks/use-reset-support-interaction';
 import { getShortDateString } from '@automattic/i18n-utils';
 import { Spinner } from '@wordpress/components';
-import clsx from 'clsx';
 import { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { ThumbsDown } from '../../assets/thumbs-down';
@@ -116,7 +115,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 
 	return (
 		<>
-			<div className={ clsx( 'chatbox-messages' ) } ref={ messagesContainerRef }>
+			<div className="chatbox-messages" ref={ messagesContainerRef }>
 				<ChatDate chat={ chat } />
 				{ ! chatMessagesLoaded ? (
 					<LoadingChatSpinner />

--- a/packages/odie-client/src/components/odie-notice/index.tsx
+++ b/packages/odie-client/src/components/odie-notice/index.tsx
@@ -6,7 +6,7 @@ interface OdieNoticeProps {
 	children: React.ReactNode;
 }
 
-const OdieNotice: React.FC< OdieNoticeProps > = ( props ) => {
+export const OdieNotice: React.FC< OdieNoticeProps > = ( props ) => {
 	const [ isNoticeVisible, setIsNoticeVisible ] = useState( true );
 
 	return (
@@ -25,5 +25,3 @@ const OdieNotice: React.FC< OdieNoticeProps > = ( props ) => {
 		)
 	);
 };
-
-export default OdieNotice;

--- a/packages/odie-client/src/components/odie-notice/view-most-recent-conversation-notice.tsx
+++ b/packages/odie-client/src/components/odie-notice/view-most-recent-conversation-notice.tsx
@@ -1,14 +1,13 @@
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { __, _n } from '@wordpress/i18n';
-import { forwardRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useOdieAssistantContext } from '../../context';
 import { useGetSupportInteractionById } from '../../data';
 import { useGetMostRecentOpenConversation } from '../../hooks/use-get-most-recent-open-conversation';
 import { OdieNotice } from '.';
 
-export const ViewMostRecentOpenConversationNotice = forwardRef< HTMLDivElement >( ( _, ref ) => {
+export const ViewMostRecentOpenConversationNotice = () => {
 	const { mostRecentSupportInteractionId, totalNumberOfConversations } =
 		useGetMostRecentOpenConversation();
 
@@ -41,7 +40,7 @@ export const ViewMostRecentOpenConversationNotice = forwardRef< HTMLDivElement >
 	return (
 		shouldDisplayNotice && (
 			<OdieNotice>
-				<div className="odie-notice__view-conversation" ref={ ref }>
+				<div className="odie-notice__view-conversation">
 					<span>
 						{ __( 'You have another open conversation already started.', __i18n_text_domain__ ) }
 					</span>
@@ -58,4 +57,4 @@ export const ViewMostRecentOpenConversationNotice = forwardRef< HTMLDivElement >
 			</OdieNotice>
 		)
 	);
-} );
+};

--- a/packages/odie-client/src/components/odie-notice/view-most-recent-conversation-notice.tsx
+++ b/packages/odie-client/src/components/odie-notice/view-most-recent-conversation-notice.tsx
@@ -1,0 +1,61 @@
+import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
+import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
+import { __, _n } from '@wordpress/i18n';
+import { forwardRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useOdieAssistantContext } from '../../context';
+import { useGetSupportInteractionById } from '../../data';
+import { useGetMostRecentOpenConversation } from '../../hooks/use-get-most-recent-open-conversation';
+import { OdieNotice } from '.';
+
+export const ViewMostRecentOpenConversationNotice = forwardRef< HTMLDivElement >( ( _, ref ) => {
+	const { mostRecentSupportInteractionId, totalNumberOfConversations } =
+		useGetMostRecentOpenConversation();
+
+	const fetchSupportInteraction =
+		mostRecentSupportInteractionId?.toString() && totalNumberOfConversations === 1
+			? mostRecentSupportInteractionId.toString()
+			: null;
+	const { data: supportInteraction } = useGetSupportInteractionById( fetchSupportInteraction );
+	const { setCurrentSupportInteraction } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const { trackEvent } = useOdieAssistantContext();
+	const location = useLocation();
+	const navigate = useNavigate();
+	const shouldDisplayNotice = supportInteraction || totalNumberOfConversations > 1;
+
+	const handleNoticeOnClick = () => {
+		if ( supportInteraction ) {
+			setCurrentSupportInteraction( supportInteraction );
+			if ( ! location.pathname.includes( '/odie' ) ) {
+				navigate( '/odie' );
+			}
+		} else {
+			navigate( '/chat-history' );
+		}
+		trackEvent( 'chat_open_previous_conversation_notice', {
+			destination: supportInteraction ? 'support-interaction' : 'chat-history',
+			total_number_of_conversations: totalNumberOfConversations,
+		} );
+	};
+
+	return (
+		shouldDisplayNotice && (
+			<OdieNotice>
+				<div className="odie-notice__view-conversation" ref={ ref }>
+					<span>
+						{ __( 'You have another open conversation already started.', __i18n_text_domain__ ) }
+					</span>
+					&nbsp;
+					<button onClick={ handleNoticeOnClick }>
+						{ _n(
+							'View conversation',
+							'View conversations',
+							totalNumberOfConversations,
+							__i18n_text_domain__
+						) }
+					</button>
+				</div>
+			</OdieNotice>
+		)
+	);
+} );

--- a/packages/odie-client/src/style.scss
+++ b/packages/odie-client/src/style.scss
@@ -38,7 +38,7 @@ $blueberry-blue: #3858e9;
 	overscroll-behavior: contain;
 	padding-top: 16px;
 
-	&.is-notice-visible {
+	&:has(.odie-notice) {
 		margin-bottom: 135px;
 	}
 

--- a/packages/odie-client/src/style.scss
+++ b/packages/odie-client/src/style.scss
@@ -38,6 +38,10 @@ $blueberry-blue: #3858e9;
 	overscroll-behavior: contain;
 	padding-top: 16px;
 
+	&.is-notice-visible {
+		margin-bottom: 135px;
+	}
+
 	.odie-chatbox-bottom-edge {
 		min-height: 8px;
 		width: 100%;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

FIxes: https://github.com/Automattic/wp-calypso/issues/99111

## Proposed Changes

* Add bottom spacing for article content if notice is visible. The content at the bottom is not visible because the notice covers it. These changes will allow you to scroll to the article's bottom and see all the content.

Before:

![CleanShot 2025-02-03 at 16 31 08@2x](https://github.com/user-attachments/assets/f6044ed6-8f2c-45db-b330-256d22157f04)


After:

![CleanShot 2025-02-03 at 16 30 21@2x](https://github.com/user-attachments/assets/99f620e2-510a-4ab4-a186-2bd74634a00b)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve UX and allow users to see all article content

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link.
* Open the Help Center , open a chat, and ask AI a question to fill up the chat with text. Such as "How do I change my site icon?"
* Verify the odie notice appears at the bottom of the article container.
* Verify you can scroll to the bottom of the article and the notice doesn't block the content.
* Close the notice and verify there is not extra spacing at the bottom of the article container.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
