### PR TITLE
i18n: Update highlight-cards component to use i18n-calypso `numberFormat`

### DIFF
--- a/packages/components/src/highlight-cards/lib/numbers.ts
+++ b/packages/components/src/highlight-cards/lib/numbers.ts
@@ -1,18 +1,15 @@
-import importedFormatNumber, {
-	DEFAULT_LOCALE,
-	STANDARD_FORMATTING_OPTIONS,
-	COMPACT_FORMATTING_OPTIONS,
-	PERCENTAGE_FORMATTING_OPTIONS,
-} from '../../number-formatters/lib/format-number';
+import { numberFormat } from 'i18n-calypso';
 
 export function formatNumber( number: number | null, isShortened = true, showSign = false ) {
-	const option = isShortened
-		? { ...COMPACT_FORMATTING_OPTIONS }
-		: { ...STANDARD_FORMATTING_OPTIONS };
-	if ( showSign ) {
-		option.signDisplay = 'exceptZero';
-	}
-	return importedFormatNumber( number, DEFAULT_LOCALE, option );
+	const numberFormatOptions: Intl.NumberFormatOptions = isShortened
+		? {
+				notation: 'compact',
+				maximumFractionDigits: 1,
+				...( showSign && { signDisplay: 'exceptZero' } ),
+		  }
+		: { notation: 'standard', ...( showSign && { signDisplay: 'exceptZero' } ) };
+
+	return number !== null ? numberFormat( number, { numberFormatOptions } ) : '-';
 }
 
 export function formatPercentage(
@@ -21,11 +18,11 @@ export function formatPercentage(
 ) {
 	// If the number is < 1%, then use 2 significant digits and maximumFractionDigits of 2.
 	// Otherwise, use the default percentage formatting options.
-	const option =
+	const numberFormatOptions: Intl.NumberFormatOptions =
 		usePreciseSmallPercentages && number && number < 0.01
-			? { ...PERCENTAGE_FORMATTING_OPTIONS, maximumFractionDigits: 2, maximumSignificantDigits: 2 }
-			: PERCENTAGE_FORMATTING_OPTIONS;
-	return importedFormatNumber( number, DEFAULT_LOCALE, option );
+			? { style: 'percent', maximumFractionDigits: 2, maximumSignificantDigits: 2 }
+			: { style: 'percent' };
+	return number !== null ? numberFormat( number, { numberFormatOptions } ) : '-';
 }
 
 export function subtract( a: number | null, b: number | null | undefined ): number | null {

--- a/packages/components/src/highlight-cards/mobile-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/mobile-highlight-cards.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@wordpress/icons';
-import ShortenedNumber from '../number-formatters';
+import { numberFormat } from 'i18n-calypso';
 import { TrendComparison } from './count-comparison-card';
 import './style.scss';
 
@@ -47,7 +47,20 @@ function MobileHighlightCard( {
 				</span>
 			) }
 			<span className="mobile-highlight-cards__item-count">
-				{ preformattedValue ? preformattedValue : <ShortenedNumber value={ count } /> }
+				{ preformattedValue ? (
+					preformattedValue
+				) : (
+					<span className="shortened-number">
+						{ count !== null
+							? numberFormat( count, {
+									numberFormatOptions: {
+										notation: 'compact',
+										maximumFractionDigits: 1,
+									},
+							  } )
+							: '-' }
+					</span>
+				) }
 			</span>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/934

## Proposed Changes

* Updates `@automattic/components` highligh-cards to use `numberFormat` in place of `number-formatters` lib
* This fixes cases of missing translations where the component was used

## Media

### Before

<img width="800" alt="Screenshot 2025-02-03 at 7 31 20 PM" src="https://github.com/user-attachments/assets/0ffe1ae5-d8f2-483c-9866-09834086bf38" />

### After

<img width="800" alt="Screenshot 2025-02-03 at 7 31 01 PM" src="https://github.com/user-attachments/assets/53095536-3add-4361-83ba-04ddae109c15" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See https://github.com/Automattic/i18n-issues/issues/934

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Switch language to EL/DE
- Go to `/stats/insights/:site` and confirm the numbers render in respective language (Greek in the media above)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
