### PR TITLE
Fix 100 year domain logo in purchase page

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -965,7 +965,7 @@ class ManagePurchase extends Component<
 		if ( this.isHundredYearDomain( purchase ) ) {
 			return (
 				<div className="manage-purchase__plan-icon">
-					<HundredYearPlanLogo width={ 50 } />
+					<HundredYearPlanLogo width={ 60 } />
 				</div>
 			);
 		}
@@ -1300,34 +1300,36 @@ class ManagePurchase extends Component<
 				<Card className={ classes }>
 					<header className="manage-purchase__header">
 						{ this.renderPurchaseIcon() }
-						<h2 className="manage-purchase__title">{ this.getProductDisplayName() }</h2>
-						<div className="manage-purchase__description">
-							{ isHundredYearDomain
-								? translate( '100-Year Domain Registration' )
-								: purchaseType( purchase ) }
-						</div>
-						<div className="manage-purchase__price">
-							{ isPartnerPurchase( purchase ) ? (
-								<div className="manage-purchase__contact-partner">
-									{ translate( 'Please contact %(partnerName)s for details', {
-										args: {
-											partnerName: getPartnerName( purchase ) ?? '',
-										},
-									} ) }
-								</div>
-							) : (
-								<>
-									{ isOneTimePurchase( purchase ) && (
-										<PlanPrice
-											rawPrice={ purchase.regularPriceInteger }
-											isSmallestUnit
-											currencyCode={ purchase.currencyCode }
-											taxText={ purchase.taxText }
-											isOnSale={ !! purchase.saleAmount }
-										/>
-									) }
-								</>
-							) }
+						<div>
+							<h2 className="manage-purchase__title">{ this.getProductDisplayName() }</h2>
+							<div className="manage-purchase__description">
+								{ isHundredYearDomain
+									? translate( '100-Year Domain Registration' )
+									: purchaseType( purchase ) }
+							</div>
+							<div className="manage-purchase__price">
+								{ isPartnerPurchase( purchase ) ? (
+									<div className="manage-purchase__contact-partner">
+										{ translate( 'Please contact %(partnerName)s for details', {
+											args: {
+												partnerName: getPartnerName( purchase ) ?? '',
+											},
+										} ) }
+									</div>
+								) : (
+									<>
+										{ isOneTimePurchase( purchase ) && (
+											<PlanPrice
+												rawPrice={ purchase.regularPriceInteger }
+												isSmallestUnit
+												currencyCode={ purchase.currencyCode }
+												taxText={ purchase.taxText }
+												isOnSale={ !! purchase.saleAmount }
+											/>
+										) }
+									</>
+								) }
+							</div>
 						</div>
 					</header>
 					{ this.renderPurchaseDescription() }

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -138,6 +138,7 @@
 .manage-purchase__header {
 	overflow: auto;
 	border-bottom: 2px solid var(--color-accent);
+	display: flex;
 
 	.is-personal & {
 		border-bottom: 2px solid var(--color-plan-personal);
@@ -182,6 +183,11 @@
 	.gridicons-themes {
 		/* stylelint-disable-next-line  scales/radii */
 		border-radius: 8px; /* stylelint-disable-line scales/radii */
+	}
+
+	.hundred-year-plan-logo {
+		filter: invert(1);
+		padding-top: 6px;
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

This PR fixes a regression introduced in #97262. The new log is white and it's not visibile on the domain purchase page, since the background is white as well.

## Why are these changes being made?
We want to show a specific logo next to 100 year domain purchases.

![Markup on 2025-02-03 at 13:10:01](https://github.com/user-attachments/assets/a6163597-2aaf-4dc8-82d2-2dfcc5667dca)

## Testing Instructions
Apply this PR and verify that new 100 year domain logo is showed next to the domain name, in the purchase page.

Verified also that the layout is not broken for other purchase types (i.e. regular domains, plans...)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
