### PR TITLE
Remove custom style from highlight selection

### DIFF
--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -69,11 +69,6 @@ body {
 	}
 }
 
-::selection {
-	background: rgba(var(--color-primary-light-rgb), 0.7);
-	color: var(--color-text);
-}
-
 button {
 	font-size: $font-body-small;
 }


### PR DESCRIPTION
## Proposed Changes

Currently, we have an override on the highlighted selection with custom styling, which adds many accessibility issues and, in some cases (e.g., Onboarding), uses old colors. I propose removing this override and defaulting to browser agent styling. 

This is my first PR, so bear with me.

## Testing Instructions

1. Go to any page (e.g. https://wordpress.com/home/)
2. HIghlight anything (e.g., with `ctrl` + `a`)

### Before
![screen 2025-02-03 at 13 10 06](https://github.com/user-attachments/assets/e904c03a-ff3e-4b74-b30c-28fdd998a5b9)

### After
![screen 2025-02-03 at 13 10 32](https://github.com/user-attachments/assets/583d6b09-6fde-460c-b4e5-21981c73b3bf)


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
