### PR TITLE
Launchpad - add handling for new `add_first_subscribers` task.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/subscribers/index.tsx
@@ -1,5 +1,6 @@
 import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { isNewsletterFlow } from '@automattic/onboarding';
+import { type TaskAction } from '../../types';
 
 const getSubscribersTask: TaskAction = ( task, flow, context ) => {
 	const { goToStep, isEmailVerified } = context;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/subscribers/index.tsx
@@ -18,17 +18,21 @@ const getSubscribersTask: TaskAction = ( task, flow, context ) => {
 };
 
 const addFirstSubscribersTask: TaskAction = ( task, flow, context ) => {
-	const { siteSlug, isEmailVerified } = context;
+	const { siteSlug, goToStep, isEmailVerified } = context;
 
 	const mustVerifyEmailBeforePosting = ! isEmailVerified;
 	return {
 		...task,
 		disabled: mustVerifyEmailBeforePosting || false,
-		useCalypsoPath: true,
 		actionDispatch: () => {
-			updateLaunchpadSettings( siteSlug, {
-				checklist_statuses: { add_first_subscribers: true },
-			} );
+			if ( goToStep ) {
+				// Mark this task completed on first use, as we don't want it to feel like a
+				// requirement for this flow and more of a nudge / discoverability.
+				updateLaunchpadSettings( siteSlug, {
+					checklist_statuses: { add_first_subscribers: true },
+				} );
+				goToStep( 'subscribers' );
+			}
 		},
 	};
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/subscribers/index.tsx
@@ -1,5 +1,5 @@
+import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { isNewsletterFlow } from '@automattic/onboarding';
-import { type TaskAction } from '../../types';
 
 const getSubscribersTask: TaskAction = ( task, flow, context ) => {
 	const { goToStep, isEmailVerified } = context;
@@ -16,6 +16,23 @@ const getSubscribersTask: TaskAction = ( task, flow, context ) => {
 	};
 };
 
+const addFirstSubscribersTask: TaskAction = ( task, flow, context ) => {
+	const { siteSlug, isEmailVerified } = context;
+
+	const mustVerifyEmailBeforePosting = ! isEmailVerified;
+	return {
+		...task,
+		disabled: mustVerifyEmailBeforePosting || false,
+		useCalypsoPath: true,
+		actionDispatch: () => {
+			updateLaunchpadSettings( siteSlug, {
+				checklist_statuses: { add_first_subscribers: true },
+			} );
+		},
+	};
+};
+
 export const actions = {
 	subscribers_added: getSubscribersTask,
+	add_first_subscribers: addFirstSubscribersTask,
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -36,6 +36,7 @@ export type TaskId =
 	| 'first_post_published'
 	| 'first_post_published_newsletter'
 	| 'subscribers_added'
+	| 'add_first_subscribers'
 	| 'plan_selected'
 	| 'plan_completed'
 	| 'newsletter_plan_created'

--- a/client/landing/stepper/declarative-flow/write.ts
+++ b/client/landing/stepper/declarative-flow/write.ts
@@ -12,6 +12,7 @@ import { USER_STORE } from '../stores';
 import { getLoginUrl } from '../utils/path';
 import LaunchPad from './internals/steps-repository/launchpad';
 import Processing from './internals/steps-repository/processing-step';
+import Subscribers from './internals/steps-repository/subscribers';
 import {
 	AssertConditionResult,
 	AssertConditionState,
@@ -29,6 +30,7 @@ const write: Flow = {
 	useSteps() {
 		return [
 			{ slug: 'launchpad', component: LaunchPad },
+			{ slug: 'subscribers', component: Subscribers },
 			{ slug: 'processing', component: Processing },
 		];
 	},
@@ -56,6 +58,9 @@ const write: Flow = {
 				case 'launchpad': {
 					return navigate( 'processing' );
 				}
+				case 'subscribers': {
+					return navigate( 'launchpad' );
+				}
 			}
 		};
 
@@ -73,7 +78,11 @@ const write: Flow = {
 			}
 		};
 
-		return { goNext, submit };
+		const goToStep = ( step: string ) => {
+			navigate( step );
+		};
+
+		return { goNext, goToStep, submit };
 	},
 
 	useAssertConditions(): AssertConditionResult {

--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -3,12 +3,11 @@ import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_UNLIMITED_SUBSCRIBERS } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Gridicon, FlowQuestion } from '@automattic/components';
-import { SiteDetails, updateLaunchpadSettings } from '@automattic/data-stores';
+import { SiteDetails } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { AddSubscriberForm, UploadSubscribersForm } from '@automattic/subscriber';
 import { useHasStaleImportJobs } from '@automattic/subscriber/src/hooks/use-has-stale-import-jobs';
 import { useInProgressState } from '@automattic/subscriber/src/hooks/use-in-progress-state';
-import { useQueryClient } from '@tanstack/react-query';
 import { ExternalLink, Modal, __experimentalVStack as VStack } from '@wordpress/components';
 import { copy, upload, reusableBlock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -22,7 +21,6 @@ import { isBusinessTrialSite } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
 import './style.scss';
 
@@ -42,8 +40,6 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 	// There is also a separate `importers/substack` flag but that refers to a separate Substack content importer.
 	// This flag refers to Substack free/paid subscriber + content importer.
 	const isSubstackSubscriberImporterEnabled = isEnabled( 'importers/newsletter' );
-	const queryClient = useQueryClient();
-	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 
 	useEffect( () => {
 		const handleHashChange = () => {
@@ -63,20 +59,6 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 			window.removeEventListener( 'hashchange', handleHashChange );
 		};
 	}, [] );
-
-	useEffect( () => {
-		// Mark first subscribers task (blogger flow nudge) complete when modal is opened.
-		// This should be separated from other tasks that require actually adding the subscribers to mark completion.
-		if ( showAddSubscribersModal && selectedSiteSlug ) {
-			const updateFirstSubscribersTask = async () => {
-				await updateLaunchpadSettings( selectedSiteSlug, {
-					checklist_statuses: { add_first_subscribers: true },
-				} );
-				queryClient.invalidateQueries( { queryKey: [ 'launchpad' ] } );
-			};
-			updateFirstSubscribersTask();
-		}
-	}, [ selectedSiteSlug, showAddSubscribersModal, queryClient ] );
 
 	const modalTitle = translate( 'Add subscribers to %s', {
 		args: [ site.title ],

--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -3,11 +3,12 @@ import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_UNLIMITED_SUBSCRIBERS } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Gridicon, FlowQuestion } from '@automattic/components';
-import { SiteDetails } from '@automattic/data-stores';
+import { SiteDetails, updateLaunchpadSettings } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { AddSubscriberForm, UploadSubscribersForm } from '@automattic/subscriber';
 import { useHasStaleImportJobs } from '@automattic/subscriber/src/hooks/use-has-stale-import-jobs';
 import { useInProgressState } from '@automattic/subscriber/src/hooks/use-in-progress-state';
+import { useQueryClient } from '@tanstack/react-query';
 import { ExternalLink, Modal, __experimentalVStack as VStack } from '@wordpress/components';
 import { copy, upload, reusableBlock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -18,11 +19,12 @@ import Notice from 'calypso/components/notice';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import { isBusinessTrialSite } from 'calypso/sites-dashboard/utils';
-import './style.scss';
 import { useSelector } from 'calypso/state';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
+import './style.scss';
 
 type AddSubscribersModalProps = {
 	site: SiteDetails;
@@ -40,6 +42,8 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 	// There is also a separate `importers/substack` flag but that refers to a separate Substack content importer.
 	// This flag refers to Substack free/paid subscriber + content importer.
 	const isSubstackSubscriberImporterEnabled = isEnabled( 'importers/newsletter' );
+	const queryClient = useQueryClient();
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 
 	useEffect( () => {
 		const handleHashChange = () => {
@@ -59,6 +63,20 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 			window.removeEventListener( 'hashchange', handleHashChange );
 		};
 	}, [] );
+
+	useEffect( () => {
+		// Mark first subscribers task (blogger flow nudge) complete when modal is opened.
+		// This should be separated from other tasks that require actually adding the subscribers to mark completion.
+		if ( showAddSubscribersModal && selectedSiteSlug ) {
+			const updateFirstSubscribersTask = async () => {
+				await updateLaunchpadSettings( selectedSiteSlug, {
+					checklist_statuses: { add_first_subscribers: true },
+				} );
+				queryClient.invalidateQueries( { queryKey: [ 'launchpad' ] } );
+			};
+			updateFirstSubscribersTask();
+		}
+	}, [ selectedSiteSlug, showAddSubscribersModal, queryClient ] );
 
 	const modalTitle = translate( 'Add subscribers to %s', {
 		args: [ site.title ],

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -8,6 +8,7 @@ import type { LaunchpadTaskActionsProps, Task } from './types';
 
 const TASKS_TO_COMPLETE_ON_CLICK = [
 	'add_about_page',
+	'add_first_subscribers',
 	'manage_paid_newsletter_plan',
 	'earn_money',
 	'manage_subscribers',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/loop#252 and Automattic/loop#253 and pe7F0s-2mv-p2

## Proposed Changes

Adds handling for a new task on the `write` launchpad ("Publish a blog" goal).

* Adds the `add_first_subscriber` task to the `TASKS_TO_COMPLETE_ON_CLICK` array, to ensure this task is markes as complete once clicked. This handles the completion from the calypso / my-home side.
* Adds a `addFirstSubscribersTask` action to the stepper launchpad task definitions, applying similar handling to the full-screen launchpad in stepper.
* Adds the `subscribers` step in the fullscreen/stepper launchpad flow for 'write' to be used with this task in the fullscreen version.


On my home:
![new-blog-task](https://github.com/user-attachments/assets/a24920e9-34b1-4760-93c9-5bb8832cc51c)

In stepper onboarding:
![fullscreen-blogger-launchpad](https://github.com/user-attachments/assets/6ab6dd30-923d-4d19-bc17-748321c03344)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to give the blogger launchpad a task to add subscribers. However, this task is intended to be more of a nudge and discoverability, rather than a hard requirement to add subscribers in this context. Therefore we set completion on clicking the task, as opposed to later on when subscribers are added.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the instructions to patch https://github.com/Automattic/jetpack/pull/41502 to your sandbox.
* sandbox the public-api
* Run this calypso branch.
* Create a new site.

1. Test full-screen launchpad flow:
* On the goals page, select "Publish a blog". 
* Follow the flow to the fullscreen launchpad that appears.
* Click the "add your first subscribers" task.
* Verify this goes to the full-screen subscribers form onboarding page.
* From here, whether you click to submit adding new subscribers or skip, this should lead back to the launchpad with the "add your first subscribers" task is marked as complete.
* Click the task again to test whichever functionality you didn't (skip vs. add), and ensure it works and leads back to the fullscreen launchpad as expected.
* Smoke test the launchpad flow and launch your site.

2. Test my-home launchpad flow (1):
* Create another new site the "Publish a blog" goal.
* Once arriving at the fullscreen launchpad, click the "skip" link in the top right to dismiss the fullscreen launchpad.
* Now in my home, select the "add your first subscribers task".
* Verify it loads the subscribers page with modal open.
* DO NOT ADD SUBSCRIBERS. Close the modal and go back to my home.
* Verify the task is marked as complete.
* Go back to the users->subscribers page. Verify the checklist item to add subscribers here is NOT complete, as we did not actually add any subscribers.

3. Test my-home launchpad flow (2):
* Create another new site the "Publish a blog" goal.
* Once arriving at the fullscreen launchpad, click the "skip" link in the top right to dismiss the fullscreen launchpad.
* DO NOT click the launchpad. Instead go to Users->subscribers in calypso.
* Select "add subscribers" and add a couple subscribers.
* Verify the checklist on users->subscribers shows the add subscribers task as complete.
* Go back to the launchpad in my-home. Verify the "add first subscribers" task is also marked as complete.

This is the separate subscribers checklist on users->subscribers mentioned in the 2 testing flows above. The point of this in the test is that adding subscribers without use of the launchpad checklist should check off both this task and the new task we added on the my home launchpad, BUT clicking the new my home launchpad task and bailing without adding subscribers should only mark off the my home launchpad task and not this one:
![Screenshot 2025-02-06 at 8 07 12 AM](https://github.com/user-attachments/assets/bf83882c-9e23-417b-a66d-5f178408a7fd)

4. Test with a new user / unverified email account
* Do the same flows as above on an account without a verified email address.
* Verify the launchpad shows a verify email task and that the subscribers task is disabled until email is verified.
* Verify other tasks past this are still usable (editor, launching) and that it does not hard block the flow.
* Smoke test email verification, but note we have not changed any of its logic here.

5. Smoke test without the jetpack diff on the sandbox.
* This tests how this will behave after this code is merged and waiting for the task definition to be shipped in jetpack-mu-wpcom.
* The flows should behave the same as they do in production right now.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?