### PR TITLE
Domain management: Match domain item click behavior with /sites

### DIFF
--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
-import page from '@automattic/calypso-router';
 import { PartialDomainData } from '@automattic/data-stores';
 import { CheckboxControl } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
@@ -112,7 +111,9 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 
 	const handleSelect = () => {
 		if ( isAllDomainManagementEnabled && ( isHostingOverview || isAllSitesView ) ) {
-			page.show( domainManagementLink );
+			if ( canSelectAnyDomains && canBulkUpdate( domain ) ) {
+				handleSelectDomain( domain );
+			}
 			return;
 		}
 
@@ -120,7 +121,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 	};
 
 	const handleDomainLinkClick = ( e: MouseEvent ) =>
-		isAllDomainManagementEnabled ? e.preventDefault() : e.stopPropagation();
+		isAllDomainManagementEnabled ? undefined : e.stopPropagation();
 
 	return (
 		<tr

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
+import page from '@automattic/calypso-router';
 import { PartialDomainData } from '@automattic/data-stores';
 import { CheckboxControl } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
@@ -58,6 +59,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 		selectedFeature,
 		isHostingOverview,
 		hasConnectableSites,
+		sidebarMode,
 	} = useDomainsTable();
 
 	const renderSiteCell = () => {
@@ -109,11 +111,15 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 		return currentDomainData.owner.replace( / \((?!.*\().+\)$/, '' );
 	};
 
-	const handleSelect = () => {
+	const handleSelect = (): void => {
 		if ( isAllDomainManagementEnabled && ( isHostingOverview || isAllSitesView ) ) {
 			if ( canSelectAnyDomains && canBulkUpdate( domain ) ) {
-				handleSelectDomain( domain );
+				return handleSelectDomain( domain );
 			}
+			if ( sidebarMode ) {
+				return page.show( domainManagementLink );
+			}
+
 			return;
 		}
 

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -116,6 +116,7 @@ type Value = {
 	onSortChange: ( selectedColumn: DomainsTableColumn, direction?: 'asc' | 'desc' ) => void;
 	handleSelectDomain: ( domain: PartialDomainData ) => void;
 	onDomainsRequiringAttentionChange: ( domainsRequiringAttention: number ) => void;
+	sidebarMode?: boolean;
 	selectedDomains: Set< string >;
 	hasSelectedDomains: boolean;
 	completedJobs: JobStatus[];
@@ -428,6 +429,7 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 		handleSelectDomain,
 		onDomainsRequiringAttentionChange,
 		filteredData,
+		sidebarMode,
 		selectedDomains,
 		hasSelectedDomains,
 		currentUsersOwnsAllSelectedDomains,

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -459,4 +459,8 @@ main.domains-overview main.domains-overview__list .hosting-dashboard-layout-colu
 		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 		color: var(--theme-base-color);
 	}
+
+	.domains-table__row:has(a.domains-table__domain-name) {
+		cursor: pointer;
+	}
 }

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -108,7 +108,7 @@
 	.domains-table__row {
 		&:has(a.domains-table__domain-name) {
 			&:hover td {
-				background-color: #f7faff;
+				background-color: var(--color-print);
 			}
 		}
 	}

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -107,8 +107,6 @@
 
 	.domains-table__row {
 		&:has(a.domains-table__domain-name) {
-			cursor: pointer;
-
 			&:hover td {
 				background-color: #f7faff;
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/99117

## Proposed Changes

* Open the domain page when clicking on the domain settings screen instead of the row.
* When the row is clicked, select it. This used to open the domain settings screen instead.
* Remove the cursor pointer when hovering on the row.
* When hovering on the domain row, use the same background color as /sites.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of the domain management revamp project.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/domains/manage
* Click on a domain row. Make sure the row is selected if that's possible.
* Click on the domain row link (first column). Make sure the domain settings screen is displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
