### PR TITLE
Add from url param to Substack importer URL

### DIFF
--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -37,6 +37,7 @@ export default function ListStep( props: Props ) {
 	const urlQueryParams = useQuery();
 	const { siteSlug, submit, getFinalImporterUrl, onNavBack } = props;
 	const backToFlow = urlQueryParams.get( 'backToFlow' );
+	const fromSite = urlQueryParams.get( 'from' );
 	const title = props.title || __( 'Import content from another platform' );
 	const subTitle = props.subTitle || __( 'Select the platform where your content lives' );
 
@@ -52,7 +53,7 @@ export default function ListStep( props: Props ) {
 	const onImporterSelect = ( platform: ImporterPlatform ): void => {
 		const importerUrl = getFinalImporterUrl(
 			siteSlug ?? '',
-			'',
+			fromSite ?? '',
 			platform,
 			backToFlow ?? undefined
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -185,6 +185,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 	const { addTempSiteToSourceOption } = useAddTempSiteToSourceOptionMutation();
 	const urlQueryParams = useQuery();
 	const sourceSiteSlug = urlQueryParams.get( 'from' ) || '';
+	const skipMigration = urlQueryParams.get( 'skipMigration' ) || '';
 	const { data: sourceMigrationStatus } = useSourceMigrationStatusQuery( sourceSiteSlug );
 	const useThemeHeadstart =
 		! isStartWritingFlow( flow ) &&
@@ -275,6 +276,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 			goToCheckout: shouldGoToCheckout,
 			hasSetPreselectedTheme: Boolean( preselectedThemeSlug ),
 			siteCreated: true,
+			skipMigration,
 		};
 	}
 

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -136,7 +136,9 @@ const siteMigration: Flow = {
 							// siteId/siteSlug wont be defined here if coming from a direct link/signup.
 							// We need to make sure there's a site to import into.
 							if ( ! siteSlugParam ) {
-								return navigate( STEPS.SITE_CREATION_STEP.slug );
+								return navigate(
+									addQueryArgs( { from, skipMigration: true }, STEPS.SITE_CREATION_STEP.slug )
+								);
 							}
 						}
 						return exitFlow(
@@ -211,7 +213,7 @@ const siteMigration: Flow = {
 
 				case STEPS.PROCESSING.slug: {
 					if ( providedDependencies?.siteCreated ) {
-						if ( ! fromQueryParam ) {
+						if ( ! fromQueryParam || providedDependencies?.skipMigration ) {
 							// If we get to this point without a fromQueryParam then we are coming from a direct
 							// pick your current platform link. That's why we navigate to the importList step.
 							return exitFlow(
@@ -221,6 +223,7 @@ const siteMigration: Flow = {
 										siteSlug,
 										origin: STEPS.SITE_MIGRATION_IDENTIFY.slug,
 										backToFlow: `/${ flowPath }/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }`,
+										...( fromQueryParam && { from: fromQueryParam } ),
 									},
 									'/setup/site-setup/importList'
 								)

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -77,6 +77,15 @@ export default function Content( {
 		importerStatus?.importerState !== appStates.IMPORTING &&
 		importerStatus?.importerState !== appStates.IMPORT_SUCCESS;
 
+	const normalizedFromSite = normalizeFromSite( fromSite );
+	const baseUrl = normalizedFromSite.startsWith( 'http' )
+		? normalizedFromSite
+		: `https://${ normalizedFromSite }`;
+
+	const settingsUrl = `${
+		baseUrl.endsWith( '/' ) ? baseUrl.slice( 0, -1 ) : baseUrl
+	}/publish/settings?search=export`;
+
 	return (
 		<Card>
 			<Interval onTick={ fetchImporters } period={ EVERY_FIVE_SECONDS } />
@@ -100,7 +109,7 @@ export default function Content( {
 						className="export-content"
 					/>
 					<Button
-						href={ `https://${ normalizeFromSite( fromSite ) }/publish/settings?search=export` }
+						href={ settingsUrl }
 						target="_blank"
 						rel="noreferrer noopener"
 						icon={ external }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/98687

## Proposed Changes

When the from URL is available in the importer list, we need to pass it down to the specific importer so the user does not have to load it again.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When the user enters their URL in the analyze step it's expected for the URL to be remembered by the UI across the complete flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR or use the Calypso live link below
* Go to `/setup/hosted-site-migration`
* Set `https://arun136657.substack.com/` as source site
* Select Substack as import platform
* Verify that you arrive to the Substack importer with the correct URL set 
<img width="771" alt="image" src="https://github.com/user-attachments/assets/754fdf2f-d86c-4ac1-8db9-cbf0cf5b761a" />

* Verify the `Open Substack settings` button has the correct href

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
