### PR TITLE
Domain management: Take users to account level purchase page instead of site level page when they click on "Delete" or "Payment details" button

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
@@ -1,7 +1,9 @@
+import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { transferStatus, type as domainType } from 'calypso/lib/domains/constants';
 import { isCancelable, isRemovable } from 'calypso/lib/purchases';
+import { cancelPurchase } from 'calypso/me/purchases/paths';
 import RemovePurchase from 'calypso/me/purchases/remove-purchase';
 import { getCancelPurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import {
@@ -79,7 +81,11 @@ const DomainDeleteInfoCard = ( {
 	if ( ! isCancelable( purchase ) ) {
 		return null;
 	}
-	const link = getCancelPurchaseUrlFor( selectedSite.slug, purchase.id );
+
+	const link = config.isEnabled( 'calypso/all-domain-management' )
+		? cancelPurchase( selectedSite.slug, purchase.id )
+		: getCancelPurchaseUrlFor( selectedSite.slug, purchase.id );
+
 	return (
 		<DomainInfoCard
 			type="href"

--- a/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { getRenewalPrice, isExpiring } from 'calypso/lib/purchases';
 import AutoRenewToggle from 'calypso/me/purchases/manage-purchase/auto-renew-toggle';
+import { managePurchase } from 'calypso/me/purchases/paths';
 import RenewButton from 'calypso/my-sites/domains/domain-management/edit/card/renew-button';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { useSelector } from 'calypso/state';
@@ -143,11 +144,11 @@ const RegisteredDomainDetails = ( {
 		if ( ! domain.subscriptionId ) {
 			return null;
 		}
-		return (
-			<Button href={ getManagePurchaseUrlFor( selectedSite.slug, domain.subscriptionId ) }>
-				{ translate( 'Payment details' ) }
-			</Button>
-		);
+		const managePurchaseLink = config.isEnabled( 'calypso/all-domain-management' )
+			? managePurchase( selectedSite.slug, domain.subscriptionId )
+			: getManagePurchaseUrlFor( selectedSite.slug, domain.subscriptionId );
+
+		return <Button href={ managePurchaseLink }>{ translate( 'Payment details' ) }</Button>;
 	};
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/99004

## Proposed Changes

* Update the "Payment details" link to point to the account level purchase page.
* When deleting a domain and the purchase needs to be canceled, redirect the user to the account level cancel purchase page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of the domain management revamp project.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/domains/manage and click on a domain that you've purchased.
* Go to the "Details" tab and click "Payment details".
* Make sure it redirects you to http://calypso.localhost:3000/me/purchases/[domain]/[purchase].
* Go back to the domain screen and make sure the "Delete" screen is pointing to http://calypso.localhost:3000/me/purchases/[domain]/[purchase]/cancel.
* If the button is not a link but a modal, comment out the following from the `DomainDeleteInfoCard` component:
```js
	if ( isRemovable( purchase ) ) {
		return (
			<DomainInfoCard
				type="custom"
				title={ title }
				description={ getDescription() }
				cta={ removePurchaseRenderedComponent }
			/>
		);
	}
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
