### PR TITLE
Big Sky: Updated free site modal copy, size and console error

### DIFF
--- a/client/landing/stepper/declarative-flow/helpers/use-goals-first-experiment.ts
+++ b/client/landing/stepper/declarative-flow/helpers/use-goals-first-experiment.ts
@@ -9,9 +9,9 @@ export const EXPERIMENT_NAME = 'calypso_signup_onboarding_goals_first_flow_holdo
 /**
  * Check whether the user should have the "goals first" onboarding experience.
  *
- * Returns [ isLoading, isGoalsAtFrontExperiment ]
+ * Returns [ isLoading, isGoalsAtFrontExperiment, variationName ]
  */
-export function useGoalsFirstExperiment(): [ boolean, boolean ] {
+export function useGoalsFirstExperiment(): [ boolean, boolean, string ] {
 	const flow = useMemo( () => getFlowFromURL(), [] );
 
 	const [ isLoading, experimentAssignment ] = useExperiment( EXPERIMENT_NAME, {
@@ -19,7 +19,7 @@ export function useGoalsFirstExperiment(): [ boolean, boolean ] {
 	} );
 
 	if ( isEnabled( 'onboarding/force-goals-first' ) ) {
-		return [ false, true ];
+		return [ false, true, 'control' ];
 	}
 
 	/**
@@ -37,5 +37,5 @@ export function useGoalsFirstExperiment(): [ boolean, boolean ] {
 		variationName
 	);
 
-	return [ isLoading, isGoalsAtFrontExperiment ];
+	return [ isLoading, isGoalsAtFrontExperiment, variationName ];
 }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
@@ -27,30 +27,31 @@ export default function SuggestedPlanSection( {
 	onPlanSelected,
 }: Props ) {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 	const suggestedPlans = [
 		{
 			planSlug: PLAN_PERSONAL,
-			description: useHasEnTranslation()( 'Free one-year domain and some premium themes' )
+			description: hasEnTranslation( 'Free one-year domain and some premium themes' )
 				? translate( 'Free one-year domain and some premium themes' )
 				: translate( 'Domain credit, some premium themes' ),
 			disabled: hidePersonalPlan,
 		},
 		{
 			planSlug: PLAN_PREMIUM,
-			description: useHasEnTranslation()( 'Free one-year domain and all premium themes' )
+			description: hasEnTranslation( 'Free one-year domain and all premium themes' )
 				? translate( 'Free one-year domain and all premium themes' )
 				: translate( 'Domain credit, all premium themes' ),
 			disabled: hidePremiumPlan,
 		},
 		{
 			planSlug: PLAN_BUSINESS,
-			description: useHasEnTranslation()( 'Free one-year domain, plugins, and all premium themes' )
+			description: hasEnTranslation( 'Free one-year domain, plugins, and all premium themes' )
 				? translate( 'Free one-year domain, plugins, and all premium themes' )
 				: translate( 'Domain credit, plugins, all premium themes' ),
 		},
 		{
 			planSlug: PLAN_ECOMMERCE,
-			description: useHasEnTranslation()(
+			description: hasEnTranslation(
 				'Free one-year domain, plugins, all premium and store themes, WooCommerce'
 			)
 				? translate( 'Free one-year domain, plugins, all premium and store themes, WooCommerce' )

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
@@ -64,9 +64,8 @@ export default function SuggestedPlanSection( {
 				.filter( ( plan ) => ! plan.disabled )
 				.slice( 0, 2 )
 				.map( ( { planSlug, description } ) => (
-					<RowWithBorder>
+					<RowWithBorder key={ planSlug }>
 						<PlanItem
-							key={ planSlug }
 							planSlug={ planSlug as PlanSlug }
 							description={ description }
 							isBusy={ isBusy }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
@@ -7,6 +7,7 @@ import {
 } from '@automattic/calypso-products';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
+import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
 import PlanItem from './plan-item';
 import { RowWithBorder } from '.';
 
@@ -28,34 +29,43 @@ export default function SuggestedPlanSection( {
 }: Props ) {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
+	const [ , , variationName ] = useGoalsFirstExperiment();
+	const shouldUseNewTranslation = variationName === 'treatment_cumulative';
+
 	const suggestedPlans = [
 		{
 			planSlug: PLAN_PERSONAL,
-			description: hasEnTranslation( 'Free one-year domain and some premium themes' )
-				? translate( 'Free one-year domain and some premium themes' )
-				: translate( 'Domain credit, some premium themes' ),
+			description:
+				hasEnTranslation( 'Free one-year domain and some premium themes' ) &&
+				shouldUseNewTranslation
+					? translate( 'Free one-year domain and some premium themes' )
+					: translate( 'Domain credit, some premium themes' ),
 			disabled: hidePersonalPlan,
 		},
 		{
 			planSlug: PLAN_PREMIUM,
-			description: hasEnTranslation( 'Free one-year domain and all premium themes' )
-				? translate( 'Free one-year domain and all premium themes' )
-				: translate( 'Domain credit, all premium themes' ),
+			description:
+				hasEnTranslation( 'Free one-year domain and all premium themes' ) && shouldUseNewTranslation
+					? translate( 'Free one-year domain and all premium themes' )
+					: translate( 'Domain credit, all premium themes' ),
 			disabled: hidePremiumPlan,
 		},
 		{
 			planSlug: PLAN_BUSINESS,
-			description: hasEnTranslation( 'Free one-year domain, plugins, and all premium themes' )
-				? translate( 'Free one-year domain, plugins, and all premium themes' )
-				: translate( 'Domain credit, plugins, all premium themes' ),
+			description:
+				hasEnTranslation( 'Free one-year domain, plugins, and all premium themes' ) &&
+				shouldUseNewTranslation
+					? translate( 'Free one-year domain, plugins, and all premium themes' )
+					: translate( 'Domain credit, plugins, all premium themes' ),
 		},
 		{
 			planSlug: PLAN_ECOMMERCE,
-			description: hasEnTranslation(
-				'Free one-year domain, plugins, all premium and store themes, WooCommerce'
-			)
-				? translate( 'Free one-year domain, plugins, all premium and store themes, WooCommerce' )
-				: translate( 'Domain credit, plugins, all premium and store themes, WooCommerce' ),
+			description:
+				hasEnTranslation(
+					'Free one-year domain, plugins, all premium and store themes, WooCommerce'
+				) && shouldUseNewTranslation
+					? translate( 'Free one-year domain, plugins, all premium and store themes, WooCommerce' )
+					: translate( 'Domain credit, plugins, all premium and store themes, WooCommerce' ),
 		},
 	];
 

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
@@ -30,14 +30,13 @@ export default function SuggestedPlanSection( {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
 	const [ , , variationName ] = useGoalsFirstExperiment();
-	const shouldUseNewTranslation = variationName === 'treatment_cumulative';
+	const shouldUseNewCopy = variationName === 'treatment_cumulative';
 
 	const suggestedPlans = [
 		{
 			planSlug: PLAN_PERSONAL,
 			description:
-				hasEnTranslation( 'Free one-year domain and some premium themes' ) &&
-				shouldUseNewTranslation
+				hasEnTranslation( 'Free one-year domain and some premium themes' ) && shouldUseNewCopy
 					? translate( 'Free one-year domain and some premium themes' )
 					: translate( 'Domain credit, some premium themes' ),
 			disabled: hidePersonalPlan,
@@ -45,7 +44,7 @@ export default function SuggestedPlanSection( {
 		{
 			planSlug: PLAN_PREMIUM,
 			description:
-				hasEnTranslation( 'Free one-year domain and all premium themes' ) && shouldUseNewTranslation
+				hasEnTranslation( 'Free one-year domain and all premium themes' ) && shouldUseNewCopy
 					? translate( 'Free one-year domain and all premium themes' )
 					: translate( 'Domain credit, all premium themes' ),
 			disabled: hidePremiumPlan,
@@ -54,7 +53,7 @@ export default function SuggestedPlanSection( {
 			planSlug: PLAN_BUSINESS,
 			description:
 				hasEnTranslation( 'Free one-year domain, plugins, and all premium themes' ) &&
-				shouldUseNewTranslation
+				shouldUseNewCopy
 					? translate( 'Free one-year domain, plugins, and all premium themes' )
 					: translate( 'Domain credit, plugins, all premium themes' ),
 		},
@@ -63,7 +62,7 @@ export default function SuggestedPlanSection( {
 			description:
 				hasEnTranslation(
 					'Free one-year domain, plugins, all premium and store themes, WooCommerce'
-				) && shouldUseNewTranslation
+				) && shouldUseNewCopy
 					? translate( 'Free one-year domain, plugins, all premium and store themes, WooCommerce' )
 					: translate( 'Domain credit, plugins, all premium and store themes, WooCommerce' ),
 		},

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
@@ -5,6 +5,7 @@ import {
 	PLAN_BUSINESS,
 	PLAN_ECOMMERCE,
 } from '@automattic/calypso-products';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import PlanItem from './plan-item';
 import { RowWithBorder } from '.';
@@ -29,21 +30,31 @@ export default function SuggestedPlanSection( {
 	const suggestedPlans = [
 		{
 			planSlug: PLAN_PERSONAL,
-			description: translate( 'Domain credit, some premium themes' ),
+			description: useHasEnTranslation()( 'Free one-year domain and some premium themes' )
+				? translate( 'Free one-year domain and some premium themes' )
+				: translate( 'Domain credit, some premium themes' ),
 			disabled: hidePersonalPlan,
 		},
 		{
 			planSlug: PLAN_PREMIUM,
-			description: translate( 'Domain credit, all premium themes' ),
+			description: useHasEnTranslation()( 'Free one-year domain and all premium themes' )
+				? translate( 'Free one-year domain and all premium themes' )
+				: translate( 'Domain credit, all premium themes' ),
 			disabled: hidePremiumPlan,
 		},
 		{
 			planSlug: PLAN_BUSINESS,
-			description: translate( 'Domain credit, plugins, all premium themes' ),
+			description: useHasEnTranslation()( 'Free one-year domain, plugins, and all premium themes' )
+				? translate( 'Free one-year domain, plugins, and all premium themes' )
+				: translate( 'Domain credit, plugins, all premium themes' ),
 		},
 		{
 			planSlug: PLAN_ECOMMERCE,
-			description: translate( 'Domain credit, plugins, all premium and store themes, WooCommerce' ),
+			description: useHasEnTranslation()(
+				'Free one-year domain, plugins, all premium and store themes, WooCommerce'
+			)
+				? translate( 'Free one-year domain, plugins, all premium and store themes, WooCommerce' )
+				: translate( 'Domain credit, plugins, all premium and store themes, WooCommerce' ),
 		},
 	];
 

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/index.tsx
@@ -68,7 +68,7 @@ export default function PlanUpsellModal( props: ModalContainerProps ) {
 			case PAID_PLAN_PAID_DOMAIN_DIALOG:
 			case PAID_PLAN_IS_REQUIRED_DIALOG:
 			default:
-				return '639px';
+				return '700px';
 		}
 	};
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99211

## Proposed Changes

* Updated free site modal copy with translation compatibility
* Increased the modal site so lines won't break
* Make sure the changes are only applied to the `treatment_cumulative` group only

![image](https://github.com/user-attachments/assets/91645a97-2f2e-4294-b45e-29632cbd0b8d)

* Fixed the `key` console error:

![image](https://github.com/user-attachments/assets/c976a4e0-eb99-4f5c-9957-597a0bf7fb8b)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [/setup/onboarding](http://calypso.localhost:3000/setup/onboarding) - with the proper experiments set - and choose Big Sky
* Go to plans page and click on `start with a free plan`
* Check the modal's copy to ensure they're good and compatible with the previous translation while we wait for the new one to come.
* Make sure you don't see any console error

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
