### PR TITLE
Persisting subdomain during the free site setup Big Sky onboarding flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -68,6 +68,12 @@ export default function PlansStepAdaptor( props: StepProps ) {
 		theme ? getThemeType( state, theme.id ) : ''
 	);
 	const isLoadingSelectedTheme = selectedDesign && ! theme;
+	const { siteUrl } = useSelect(
+		( select ) => ( {
+			siteUrl: ( select( ONBOARD_STORE ) as OnboardSelect ).getSiteUrl(),
+		} ),
+		[]
+	);
 
 	const signupDependencies = {
 		siteSlug,
@@ -77,6 +83,7 @@ export default function PlansStepAdaptor( props: StepProps ) {
 		domainItem,
 		domainCart: domainItems,
 		selectedThemeType,
+		siteUrl,
 	};
 
 	const postSignUpSiteSlugParam = getSignupCompleteSlug();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/10388

## Proposed Changes

* We're persisting the free domain selection during the Big Sky onboarding flow


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [/setup/onboarding](http://calypso.localhost:3000/setup/onboarding)
* Select Big Sky AI design option
* Selected free domain: bigskytest51...
* Selected Free plan during the plans selection screen and make sure it will persist during the entire onboarding


https://github.com/user-attachments/assets/7e7888c7-89dd-4a16-834d-19b196da8624



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
