### PR TITLE
Apps/Notifications: prevent overscroll on notifications list

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -412,6 +412,7 @@ $with-sidebar-min-page-width: 1114px;
 		background-color: var(--color-neutral-0);
 		overflow-y: scroll;
 		-webkit-overflow-scrolling: touch;
+		overscroll-behavior: contain;
 		border-left: 1px solid var(--color-neutral-0);
 
 		&.is-empty-list {

--- a/apps/notifications/src/panel/templates/filter-bar.jsx
+++ b/apps/notifications/src/panel/templates/filter-bar.jsx
@@ -14,6 +14,10 @@ export class FilterBar extends Component {
 		if ( this.props.isPanelOpen ) {
 			this.focusOnSelectedTab();
 		}
+
+		this.filterListRef.current?.addEventListener( 'wheel', this.handleWheel, {
+			passive: false,
+		} );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -31,6 +35,15 @@ export class FilterBar extends Component {
 		if ( this.timerId ) {
 			window.clearTimeout( this.timerId );
 		}
+
+		this.filterListRef.current?.removeEventListener( 'wheel', this.handleWheel, {
+			passive: false,
+		} );
+	}
+
+	handleWheel( e ) {
+		// Using the wheel on the filter bar should not scroll the whole page.
+		e.preventDefault();
 	}
 
 	setFilterItems = () => {

--- a/apps/notifications/src/panel/templates/filter-bar.jsx
+++ b/apps/notifications/src/panel/templates/filter-bar.jsx
@@ -14,10 +14,6 @@ export class FilterBar extends Component {
 		if ( this.props.isPanelOpen ) {
 			this.focusOnSelectedTab();
 		}
-
-		this.filterListRef.current?.addEventListener( 'wheel', this.handleWheel, {
-			passive: false,
-		} );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -35,15 +31,6 @@ export class FilterBar extends Component {
 		if ( this.timerId ) {
 			window.clearTimeout( this.timerId );
 		}
-
-		this.filterListRef.current?.removeEventListener( 'wheel', this.handleWheel, {
-			passive: false,
-		} );
-	}
-
-	handleWheel( e ) {
-		// Using the wheel on the filter bar should not scroll the whole page.
-		e.preventDefault();
 	}
 
 	setFilterItems = () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Use the [`overscroll-behavior`](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior) CSS property on the scrolling list of notifications to prevent the rest of the document from scrolling when the list has reached the upper / lower limit of the scrolling area and the user keeps scrolling the list.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Legacy code for this behavior (which doesn't seem to work as intended anymore) is being removed in 171667-ghe-Automattic/wpcom . This PR adds the desired behavior directly to the app's source by taking advantage of the recent `overscroll-behavior` CSS property.

> [!Note]
> In its initial version, this PR adds the new overscroll behavior to _all instances_ of the notifications widget, including the ones that are not rendered inside a panel/iframe. I don't believe that this should be an issue, since the new code should result in a no-op in most of the scenarios. In case we wanted to be more specific and only activate the behavior when the widget is rendered inside the dotcom iframe, we use the `postMessage` interface.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start a connection with your sandbox and make sure you've downloaded the latest updates
* On your machine, `cd apps/notifications && yarn && yarn dev --sync` (this works only if your sandbox SSH configuration is named `wpcom-sandbox`)
* On your sandbox, run `git status` and make sure that the notifications widget build files have been updated
* Activate your sandbox and visit `{site_slug}/wp-admin`
* Scroll the page down a bit
* Wait for the notifications bell icon to appear in the top admin bar, and click it
* Place the cursor over the notifications list, and make sure that, when the upper / lower limit of the list is reached, further scrolling doesn't cause the underlying page to scroll
  * If you stop using your sandbox and repeat the test, the underlying page should scroll
* Smoke test all other instances in which the notifications widget/list is rendered inside calypso and make sure no regression was introduced

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?