### PR TITLE
Reader User Profile: Add Read More link

### DIFF
--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -43,6 +43,7 @@ export type OptionalUserData = {
 	user_ip_country_code: string;
 	user_URL: string;
 	username: string;
+	profile_URL: string;
 	visible_site_count: number;
 	jetpack_visible_site_count?: number;
 	atomic_visible_site_count?: number;

--- a/client/reader/user-profile/components/user-profile-header/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/index.tsx
@@ -1,5 +1,7 @@
 import page from '@automattic/calypso-router';
+import { external, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import React, { useEffect, useRef, useState } from 'react';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
@@ -36,6 +38,26 @@ const UserProfileHeader = ( { user }: UserProfileHeaderProps ): JSX.Element => {
 		<ReaderAvatar author={ { ...user, has_avatar: !! user.avatar_URL } } iconSize={ 116 } />
 	);
 
+	const bioRef = useRef< HTMLSpanElement >( null );
+	const [ isClamped, setIsClamped ] = useState( false );
+
+	useEffect( () => {
+		if ( bioRef.current ) {
+			const element = bioRef.current;
+			const originalHeight = element.offsetHeight;
+
+			// Temporarily remove the clamp
+			element.style.webkitLineClamp = 'unset';
+			const fullHeight = element.scrollHeight;
+
+			// Restore the clamp
+			element.style.webkitLineClamp = '3';
+
+			// Determine if the text is clamped
+			setIsClamped( fullHeight > originalHeight );
+		}
+	}, [ user.bio ] );
+
 	return (
 		<div className="user-profile-header">
 			<header className="user-profile-header__main">
@@ -51,7 +73,16 @@ const UserProfileHeader = ( { user }: UserProfileHeaderProps ): JSX.Element => {
 					</div>
 					{ user.bio && (
 						<div className="user-profile-header__bio">
-							<p className="user-profile-header__bio-desc">{ user.bio }</p>
+							<p className="user-profile-header__bio-desc">
+								<span ref={ bioRef } className="user-profile-header__bio-desc-text">
+									{ user.bio }
+								</span>
+								{ isClamped && (
+									<a className="user-profile-header__bio-desc-link" href={ user.profile_URL }>
+										{ translate( 'Read More' ) } <Icon icon={ external } />
+									</a>
+								) }
+							</p>
 						</div>
 					) }
 				</div>

--- a/client/reader/user-profile/components/user-profile-header/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/index.tsx
@@ -77,7 +77,7 @@ const UserProfileHeader = ( { user }: UserProfileHeaderProps ): JSX.Element => {
 								<span ref={ bioRef } className="user-profile-header__bio-desc-text">
 									{ user.bio }
 								</span>
-								{ isClamped && (
+								{ isClamped && user.profile_URL && (
 									<a className="user-profile-header__bio-desc-link" href={ user.profile_URL }>
 										{ translate( 'Read More' ) } <Icon icon={ external } />
 									</a>

--- a/client/reader/user-profile/components/user-profile-header/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/index.tsx
@@ -79,7 +79,8 @@ const UserProfileHeader = ( { user }: UserProfileHeaderProps ): JSX.Element => {
 								</span>
 								{ isClamped && user.profile_URL && (
 									<a className="user-profile-header__bio-desc-link" href={ user.profile_URL }>
-										{ translate( 'Read More' ) } <Icon icon={ external } />
+										{ translate( 'Read More' ) }{ ' ' }
+										<Icon width={ 18 } height={ 18 } icon={ external } />
 									</a>
 								) }
 							</p>

--- a/client/reader/user-profile/components/user-profile-header/style.scss
+++ b/client/reader/user-profile/components/user-profile-header/style.scss
@@ -90,12 +90,18 @@
 
 		&__bio-desc {
 			margin: 0;
-			display: -webkit-box;
-			-webkit-line-clamp: 3;
-			line-clamp: 3;
-			-webkit-box-orient: vertical;
-			overflow: hidden;
-			text-overflow: ellipsis;
+
+			&-text {
+				-webkit-line-clamp: 3;
+				line-clamp: 3;
+				display: -webkit-box;
+				-webkit-box-orient: vertical;
+				overflow: hidden;
+			}
+
+			&-link {
+				display: inline-flex;
+			}
 		}
 
 		.section-nav {

--- a/client/reader/user-profile/components/user-profile-header/style.scss
+++ b/client/reader/user-profile/components/user-profile-header/style.scss
@@ -101,6 +101,8 @@
 
 			&-link {
 				display: inline-flex;
+				gap: 4px;
+				align-items: center;
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/374

## Proposed Changes

* Adds a Read More link using `user.profile_URL`
* Adds a check to make sure the text is clamped before showing the link
* Updates styles

<img width="959" alt="Screenshot 2025-02-03 at 13 50 47" src="https://github.com/user-attachments/assets/94bfeef5-85e9-41dd-bade-cefbf38910b9" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This creates a way for users to read full profile page descriptions when they're very long (context: p1738598402355249-slack-C083J8DHLLD) 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the profile at `/read/users/robertbpugh`; ensure the View More link renders
* Visit `/read/users/lessbloat`; ensure the link does not render
* Test a few more profiles and make sure the profile, if longer than 3 lines, is capped and the link appears. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?