### PR TITLE
Tracks Event: Add `is_in_signup` property to `calypso_plans_plan_type_selector_option_change`

### DIFF
--- a/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -58,6 +58,7 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 					recordTracksEvent( 'calypso_plans_plan_type_selector_option_change', {
 						interval_type: intervalType,
 						plans_intent: intent,
+						is_in_signup: isInSignup,
 					} );
 					onPlanIntervalUpdate &&
 						onPlanIntervalUpdate( intervalType as SupportedUrlFriendlyTermType );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add `is_in_signup` property to tracks event

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When the plan type selector dropdown selection changes, we're unable to determine whether or not it happened in or outside of signup

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out branch
* Navigate to `/start/plans`
* Select a different option for the plan term selection dropdown
* Verify that the tracks event `calypso_plans_plan_type_selector_option_change` has been fired with the `is_in_signup` property set to `true`
* Do the same for the `/start/{SITE_SLUG}` page and verify that the new property is set to `false`

![CleanShot 2025-02-03 at 13 21 16@2x](https://github.com/user-attachments/assets/7e6bda46-686c-43fd-8e31-1617bfa03654)

## Pre-merge Checklist
<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
