### PR TITLE
Updates to design choice step copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/goals-first-design-choice.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/goals-first-design-choice.scss
@@ -2,7 +2,7 @@
 
 .goals-first-design-choice {
 	position: relative;
-	width: 380px;
+	width: 336px;
 	padding: 24px;
 	border-radius: 4px;
 	outline: var( --studio-gray-5 ) solid 1px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
@@ -185,9 +185,17 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 								<GoalsFirstDesignChoice
 									title={ getCreateWithAILabel() }
 									ariaLabel={ translate( 'Create with AI (BETA)' ) }
-									description={ translate(
-										'Use our AI website builder to easily and quickly build the site of your dreams.'
-									) }
+									description={
+										hasEnTranslation(
+											'Use our AI Website Builder to quickly and easily create the site of your dreams.'
+										)
+											? translate(
+													'Use our AI Website Builder to quickly and easily create the site of your dreams.'
+											  )
+											: translate(
+													'Use our AI website builder to easily and quickly build the site of your dreams.'
+											  )
+									}
 									badgeLabel={ bigSkyBadgeLabel }
 									bgImageSrc={ bigSkyBg }
 									fgImageSrc={ bigSkyFg }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
@@ -98,13 +98,23 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 		return translate( 'Create with AI (BETA)' );
 	};
 
-	const bigSkyBadgeLabel =
-		! isLoading && isEligible && personalProduct?.cost_per_month_display && isGoalsFirstVariation
-			? translate( 'Starting at %(price)s a month', {
+	const bigSkyBadgeLabel = () => {
+		if ( ! isLoading && isEligible && personalProduct?.cost_per_month_display ) {
+			if ( hasEnTranslation( 'Starting at %(price)s/month' ) ) {
+				return translate( 'Starting at %(price)s/month', {
 					args: { price: personalProduct.cost_per_month_display },
 					comment: 'Translators: "price" is a per month price and includes a currency symbol',
-			  } )
-			: undefined;
+				} );
+			}
+
+			return translate( 'Starting at %(price)s a month', {
+				args: { price: personalProduct.cost_per_month_display },
+				comment: 'Translators: "price" is a per month price and includes a currency symbol',
+			} );
+		}
+
+		return undefined;
+	};
 
 	return (
 		<>
@@ -151,7 +161,6 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 									) }
 									imageSrc={ hiBigSky }
 									destination="launch-big-sky"
-									badgeLabel={ bigSkyBadgeLabel }
 									footer={ preventWidows(
 										translate(
 											'To learn more about AI, you can review our {{a}}AI guidelines{{/a}}.',
@@ -196,7 +205,7 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 													'Use our AI website builder to easily and quickly build the site of your dreams.'
 											  )
 									}
-									badgeLabel={ bigSkyBadgeLabel }
+									badgeLabel={ bigSkyBadgeLabel() }
 									bgImageSrc={ bigSkyBg }
 									fgImageSrc={ bigSkyFg }
 									destination="launch-big-sky"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdtkmj-3kX-p2#comment-6290
Fixes #99236 

## Proposed Changes

- Adjust width of design choice button in goals-first flow
- Update `Create with AI` choice description in goals-first flow
    - "quickly and easily", not "easily and quickly"
- Update price badge to use `/month` instead of `a month`
- Ensure copy changes only happen once translations are complete

**Before**

![CleanShot 2025-02-04 at 10 24 27@2x](https://github.com/user-attachments/assets/6adb1773-e3f1-4477-b074-b7f46d429541)


**After**

![CleanShot 2025-02-04 at 10 17 35@2x](https://github.com/user-attachments/assets/1a6bc089-bdb7-4798-ae4c-cf8dcb5ed6ee)

**The control path still looks like**
![CleanShot 2025-02-04 at 10 19 26@2x](https://github.com/user-attachments/assets/1e551d72-0ad4-4ed7-a8e3-6cb8bbc58c81)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

These changes were in the original Figma. It was pointed out during the CfT that the english copy could wrap a big nicer, and in the original Figma it did.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself to a treatment group in goals-first and big sky experiments
  * `/setup/onboarding`
  * Click `Next` on goals screen and observe design choice screen
* Assign yourself to control goals-first experiment
  * `/setup/onboarding`
  * Remember to choose a paid plan
  * Click next till you get to the design choice screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
