### PR TITLE
Reader User Profile: Add back button to profile page

### DIFF
--- a/client/reader/user-profile/components/user-profile-header/style.scss
+++ b/client/reader/user-profile/components/user-profile-header/style.scss
@@ -14,7 +14,7 @@
 
 		&__main {
 			display: flex;
-			padding: 36px 0 24px;
+			padding: 0 0 24px;
 			align-items: center;
 
 			@include breakpoint-deprecated( '<660px' ) {

--- a/client/reader/user-profile/controller.tsx
+++ b/client/reader/user-profile/controller.tsx
@@ -1,4 +1,4 @@
-import { Context } from '@automattic/calypso-router';
+import page, { Context } from '@automattic/calypso-router';
 import { ReactElement } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import { trackPageLoad, trackScrollPage } from 'calypso/reader/controller-helper';
@@ -22,6 +22,10 @@ export function userPosts( ctx: Context, next: () => void ): void {
 
 	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
+	function goBack() {
+		page.back( ctx.lastRoute );
+	}
+
 	context.primary = (
 		<AsyncLoad
 			require="calypso/reader/user-profile"
@@ -34,6 +38,8 @@ export function userPosts( ctx: Context, next: () => void ): void {
 				analyticsPageTitle,
 				mcKey
 			) }
+			showBack={ !! ctx.lastRoute }
+			handleBack={ goBack }
 		/>
 	);
 	next();

--- a/client/reader/user-profile/index.tsx
+++ b/client/reader/user-profile/index.tsx
@@ -71,8 +71,8 @@ export function UserProfile( props: UserProfileProps ): JSX.Element | null {
 
 	return (
 		<div className="user-profile">
-			{ showBack && <BackButton onClick={ handleBack } /> }
-			<div className="user-profile__content-wrapper">
+			<div className={ `user-profile__content-wrapper${ showBack ? ' has-back-button' : '' }` }>
+				{ showBack && <BackButton onClick={ handleBack } /> }
 				<div className="user-profile__content">{ renderContent() }</div>
 			</div>
 		</div>

--- a/client/reader/user-profile/index.tsx
+++ b/client/reader/user-profile/index.tsx
@@ -2,6 +2,7 @@ import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { connect } from 'react-redux';
+import BackButton from 'calypso/components/back-button';
 import EmptyContent from 'calypso/components/empty-content';
 import { UserData } from 'calypso/lib/user/user';
 import { getUserProfileUrl } from 'calypso/reader/user-profile/user-profile.utils';
@@ -15,6 +16,8 @@ interface UserProfileProps {
 	user: UserData;
 	isLoading: boolean;
 	requestUser: ( userLogin: string ) => Promise< void >;
+	showBack: boolean;
+	handleBack: () => void;
 }
 
 type UserProfileState = {
@@ -27,7 +30,7 @@ type UserProfileState = {
 };
 
 export function UserProfile( props: UserProfileProps ): JSX.Element | null {
-	const { userLogin, requestUser, user, isLoading } = props;
+	const { userLogin, requestUser, user, isLoading, showBack, handleBack } = props;
 	const translate = useTranslate();
 
 	useEffect( () => {
@@ -69,6 +72,7 @@ export function UserProfile( props: UserProfileProps ): JSX.Element | null {
 	return (
 		<div className="user-profile">
 			<div className="user-profile__content-wrapper">
+				{ showBack && <BackButton onClick={ handleBack } /> }
 				<div className="user-profile__content">{ renderContent() }</div>
 			</div>
 		</div>

--- a/client/reader/user-profile/index.tsx
+++ b/client/reader/user-profile/index.tsx
@@ -71,8 +71,8 @@ export function UserProfile( props: UserProfileProps ): JSX.Element | null {
 
 	return (
 		<div className="user-profile">
+			{ showBack && <BackButton onClick={ handleBack } /> }
 			<div className="user-profile__content-wrapper">
-				{ showBack && <BackButton onClick={ handleBack } /> }
 				<div className="user-profile__content">{ renderContent() }</div>
 			</div>
 		</div>

--- a/client/reader/user-profile/style.scss
+++ b/client/reader/user-profile/style.scss
@@ -3,6 +3,7 @@
 .is-section-reader {
 
 	.user-profile {
+		position: relative;
 
 		.back-button {
 			position: absolute;
@@ -15,10 +16,6 @@
 				padding-left: 5px;
 			}
 		}
-
-		&__content-wrapper {
-			position: relative;
-		}
 	}
 
 	.user-profile__404.empty-content {
@@ -28,7 +25,7 @@
 	}
 
 	div.user-profile__content {
-		padding-top: 24px;
+		padding-top: 17px;
 
 		main.main.is-user-profile {
 			padding: 0;

--- a/client/reader/user-profile/style.scss
+++ b/client/reader/user-profile/style.scss
@@ -11,6 +11,7 @@
 			left: 0;
 			right: unset;
 			padding-top: 3px;
+			background: transparent;
 
 			@include breakpoint-deprecated( '<660px' ) {
 				padding-left: 5px;

--- a/client/reader/user-profile/style.scss
+++ b/client/reader/user-profile/style.scss
@@ -1,4 +1,25 @@
+@import "calypso/assets/stylesheets/shared/mixins/breakpoints";
+
 .is-section-reader {
+
+	.user-profile {
+
+		.back-button {
+			position: absolute;
+			top: 0;
+			left: 0;
+			right: unset;
+			padding-top: 3px;
+
+			@include breakpoint-deprecated( '<660px' ) {
+				padding-left: 5px;
+			}
+		}
+
+		&__content-wrapper {
+			position: relative;
+		}
+	}
 
 	.user-profile__404.empty-content {
 		max-width: initial;
@@ -7,6 +28,8 @@
 	}
 
 	div.user-profile__content {
+		padding-top: 24px;
+
 		main.main.is-user-profile {
 			padding: 0;
 			border-block-end: none;

--- a/client/reader/user-profile/style.scss
+++ b/client/reader/user-profile/style.scss
@@ -2,35 +2,55 @@
 
 .is-section-reader {
 
-	.user-profile {
-		position: relative;
-
-		.back-button {
-			position: absolute;
-			top: 0;
-			left: 0;
-			right: unset;
-			padding-top: 3px;
-			background: transparent;
-
-			@include breakpoint-deprecated( '<660px' ) {
-				padding-left: 5px;
-			}
-		}
-	}
-
 	.user-profile__404.empty-content {
 		max-width: initial;
 		margin: initial;
 		padding-top: 150px;
 	}
 
-	div.user-profile__content {
-		padding-top: 17px;
+	.user-profile {
+		position: relative;
 
-		main.main.is-user-profile {
-			padding: 0;
-			border-block-end: none;
+		&__content-wrapper {
+
+			div.user-profile__content {
+				padding-top: 36px;
+
+				@include breakpoint-deprecated( '<660px' ) {
+					padding-top: 0;
+				}
+
+				main.main.is-user-profile {
+					padding: 0;
+					border-block-end: none;
+				}
+			}
+
+			.back-button {
+				position: relative;
+				background: transparent;
+				top: 0;
+				height: auto;
+				border: none;
+
+				.button.is-compact.is-borderless {
+					padding: 20px 0 20px 20px;
+
+					@include breakpoint-deprecated( '<660px' ) {
+						padding: 20px 0 0 20px;
+					}
+				}
+			}
+
+			&.has-back-button {
+				div.user-profile__content {
+					padding-top: 0;
+				}
+
+				main.main.is-user-profile {
+					margin-top: 0;
+				}
+			}
 		}
 	}
 

--- a/packages/calypso-router/types/index.d.ts
+++ b/packages/calypso-router/types/index.d.ts
@@ -177,6 +177,11 @@ interface Page {
 	 * Current path
 	 */
 	current: string;
+
+	/**
+	 * Navigate back to the previous route
+	 */
+	back: ( path: string ) => void;
 }
 
 class Route {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98855

## Proposed Changes

- This adds a back button to the profile page using the BackButton component.
- It creates a couple of new props to determine whether the button should be shown, and uses the `page` element from `automattic/calypso-router` to navigate.
- It also updates the styles.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want to add a back button to be consistent with other pages in the Reader and improve the UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit the user profile `/read/users/artemiosans` directly — make sure the back button does not appear.
- Navigate to another page, such as the Likes page, then click on a username that leads to the profile page.
- Ensure the back button renders and navigates to the previous page as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
