### PR TITLE
Domains: Add price to 100-year domain transfer flow before inputting the auth code

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domain-code-pair.tsx
@@ -130,7 +130,8 @@ export function DomainCodePair( {
 		onChange( id, { domain, auth, valid, rawPrice, saleCost, currencyCode } );
 	}, [ domain, id, onChange, auth, valid, loading, rawPrice, saleCost, currencyCode ] );
 
-	const shouldReportError = hasDuplicates || ( ! loading && domain && auth ? true : false );
+	const authCheck = ! isHundredYearDomainsTransferFlow ? Boolean( auth ) : message;
+	const shouldReportError = hasDuplicates || ( ! loading && domain && authCheck ? true : false );
 
 	useEffect( () => {
 		if ( shouldReportError && ! valid && message ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/styles.scss
@@ -28,6 +28,14 @@
 			}
 		}
 
+		&.step-route.hundred-year-domain-transfer.processing {
+			gap: 0;
+			width: 100%;
+			margin: 0;
+			max-width: none;
+			padding: 0;
+		}
+
 		.domains {
 			.step-container__header {
 				@media (max-width: $break-wide) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -20,6 +20,7 @@ export function useValidationMessage(
 	const [ authDebounced ] = useDebounce( auth, 500 );
 
 	const hasGoodDomain = doesStringResembleDomain( domainDebounced );
+	const hasAnyAuthCode = auth.trim().length > 0;
 	const hasGoodAuthCode = hasGoodDomain && auth.trim().length > 5;
 
 	const passedLocalValidation = hasGoodDomain && hasGoodAuthCode && ! hasDuplicates;
@@ -58,7 +59,7 @@ export function useValidationMessage(
 		};
 	}
 
-	if ( ! hasGoodAuthCode ) {
+	if ( hasAnyAuthCode && ! hasGoodAuthCode ) {
 		return {
 			valid: false,
 			loading: false,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -23,7 +23,8 @@ export function useValidationMessage(
 	const hasAnyAuthCode = auth.trim().length > 0;
 	const hasGoodAuthCode = hasGoodDomain && auth.trim().length > 5;
 
-	const passedLocalValidation = hasGoodDomain && hasGoodAuthCode && ! hasDuplicates;
+	const passedLocalValidation =
+		hasGoodDomain && ( ! hasAnyAuthCode || hasGoodAuthCode ) && ! hasDuplicates;
 
 	const isDebouncing = domainDebounced !== domain || authDebounced !== auth;
 
@@ -64,6 +65,9 @@ export function useValidationMessage(
 			valid: false,
 			loading: false,
 			message: __( 'Please enter a valid authentication code.' ),
+			rawPrice: validationResult?.raw_price,
+			saleCost: validationResult?.sale_cost,
+			currencyCode: validationResult?.currency_code,
 		};
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -76,7 +76,7 @@ export function useValidationMessage(
 		return {
 			valid: false,
 			loading: true,
-			message: __( 'Checking domain lock status.' ),
+			message: __( 'Checking domain status.' ),
 		};
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/use-validation-message.ts
@@ -104,7 +104,7 @@ export function useValidationMessage(
 			loading: false,
 			message: __( "Sorry, we don't support some higher tier premium domain transfers." ),
 		};
-	} else if ( validationResult?.auth_code_valid === false ) {
+	} else if ( hasAnyAuthCode && validationResult?.auth_code_valid === false ) {
 		// the auth check API has a bug and returns error 400 for incorrect auth codes,
 		// in which case, the `useIsDomainCodeValid` hook returns `false`.
 		return {
@@ -125,6 +125,16 @@ export function useValidationMessage(
 			currencyCode: validationResult?.currency_code,
 			refetch,
 			errorStatus: validationResult?.status,
+		};
+	} else if ( ! hasAnyAuthCode && validationResult?.auth_code_valid === false ) {
+		// We don't want to return a message here - an attempt was performed
+		// with an empty auth code, which is not an error.
+		return {
+			valid: false,
+			loading: false,
+			rawPrice: validationResult.raw_price,
+			saleCost: validationResult.sale_cost,
+			currencyCode: validationResult.currency_code,
 		};
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -268,6 +268,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 		if ( domain && isHundredYearDomainFlow( flow ) ) {
 			const leaveFlowFunction = exitFlow ?? window.location.assign;
 			leaveFlowFunction( `/setup/hundred-year-domain-transfer?new=${ domain }` );
+			return;
 		}
 
 		setShowUseYourDomain( true );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -267,7 +267,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 	const onUseYourDomainClick = ( domain?: string ) => {
 		if ( domain && isHundredYearDomainFlow( flow ) ) {
 			const leaveFlowFunction = exitFlow ?? window.location.assign;
-			leaveFlowFunction( `/setup/hundred-year-domain-transfer?new=${ domain }` );
+			leaveFlowFunction( `/setup/hundred-year-domain-transfer/domains?new=${ domain }` );
 			return;
 		}
 


### PR DESCRIPTION
A much better approach than the one used in #99226 - based on #99231 (thx @ramynasr 😬).

## Proposed Changes
We want to display the price for the 100-year domain transfer flow before inputting the auth code - this PR enables this possibility. 
It also fixes some minor bugs within the flow:
1. A bug where the `Use your domain` component gets briefly visible before we redirect to the 100-year domain transfer flow;
2. And another one where the WordPress.com logo blinks shortly after redirection.

## Testing Instructions
- Go to `/setup/hundred-year-domain`;
- Use a domain that is transferrable - or hack the back end to do so;
- Click the `Do you own it?` link, same as in the preview video. Then, ensure all of the following:
  1. The `Use your domain` component doesn't ever get visible;
  2. There should be no blinking WordPress.com logo after being redirected to the 100-year domain transfer flow
  3. The price for the 100-year domain transfer is correctly displayed as the page loads - no need for the auth code;
- Also, ensure the regular domain transfer flow (`/setup/domain-transfer`) still works correctly and is not affected by this PR.

## Preview
| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/44567143-50a4-428c-a04c-6f8d09c93cb0"/>    | <video src="https://github.com/user-attachments/assets/96f2193c-c81b-4f85-9587-c03bab6fff8f"/>   |\
| Auth code is always required to display the price. | No auth code is required to display the price. | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
