### PR TITLE
Coupon Box Experiment Code Clean Up 

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -23,11 +23,10 @@ import {
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { useExperiment } from 'calypso/lib/explat';
 import { useSelector } from 'calypso/state';
 import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import useCartKey from '../../use-cart-key';
-import { getAffiliateCouponLabel, getCouponLabel } from '../../utils';
+import { getAffiliateCouponLabel } from '../../utils';
 import type { Theme } from '@automattic/composite-checkout';
 import type { LineItemCostOverrideForDisplay } from '@automattic/wpcom-checkout';
 
@@ -324,10 +323,6 @@ export function CouponCostOverride( {
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 	const isOnboardingAffiliateFlow = useSelector( getIsOnboardingAffiliateFlow );
-	const productSlugs = responseCart.products?.map( ( product ) => product.product_slug );
-	const [ , experimentAssignment ] = useExperiment( 'calypso_checkout_hide_coupon_box_v2', {
-		isEligible: ! productSlugs.some( ( slug ) => 'wp_difm_lite' === slug ),
-	} );
 
 	if ( ! responseCart.coupon || ! responseCart.coupon_savings_total_integer ) {
 		return null;
@@ -338,9 +333,7 @@ export function CouponCostOverride( {
 		args: { couponCode: responseCart.coupon },
 	} );
 
-	const label = isOnboardingAffiliateFlow
-		? getAffiliateCouponLabel()
-		: getCouponLabel( couponLabel as string, experimentAssignment?.variationName );
+	const label = isOnboardingAffiliateFlow ? getAffiliateCouponLabel() : couponLabel;
 	return (
 		<CostOverridesListStyle>
 			<div className="cost-overrides-list-item cost-overrides-list-item--coupon">

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -9,7 +9,6 @@ import { styled, joinClasses } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useCallback } from 'react';
 import { hasP2PlusPlan } from 'calypso/lib/cart-values/cart-items';
-import { useExperiment } from 'calypso/lib/explat';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -17,7 +16,6 @@ import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/co
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
-import { isCouponBoxHidden } from '../../utils';
 import Coupon from './coupon';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
 import type { OnChangeItemVariant } from './item-variation-picker';
@@ -199,9 +197,6 @@ export function CouponFieldArea( {
 	const translate = useTranslate();
 	const { setCouponFieldValue } = couponFieldStateProps;
 	const isOnboardingAffiliateFlow = useSelector( getIsOnboardingAffiliateFlow );
-	const cartKey = useCartKey();
-	const { responseCart } = useShoppingCart( cartKey );
-	const productSlugs = responseCart.products?.map( ( product ) => product.product_slug );
 
 	useEffect( () => {
 		if ( couponStatus === 'applied' ) {
@@ -210,16 +205,7 @@ export function CouponFieldArea( {
 		}
 	}, [ couponStatus, setCouponFieldValue ] );
 
-	const [ , experimentAssignment ] = useExperiment( 'calypso_checkout_hide_coupon_box_v2', {
-		isEligible: ! productSlugs.some( ( slug ) => 'wp_difm_lite' === slug ),
-	} );
-
-	if (
-		isPurchaseFree ||
-		couponStatus === 'applied' ||
-		isOnboardingAffiliateFlow ||
-		isCouponBoxHidden( productSlugs, experimentAssignment?.variationName )
-	) {
+	if ( isPurchaseFree || couponStatus === 'applied' || isOnboardingAffiliateFlow ) {
 		return null;
 	}
 

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -21,14 +21,13 @@ import {
 import styled from '@emotion/styled';
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { has100YearPlan } from 'calypso/lib/cart-values/cart-items';
-import { useExperiment } from 'calypso/lib/explat';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/src/hooks/product-variants';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
-import { getAffiliateCouponLabel, getCouponLabel, isCouponBoxHidden } from '../../utils';
+import { getAffiliateCouponLabel } from '../../utils';
 import { AkismetProQuantityDropDown } from './akismet-pro-quantity-dropdown';
 import { ItemVariationPicker } from './item-variation-picker';
 import type { OnChangeAkProQuantity } from './akismet-pro-quantity-dropdown';
@@ -95,18 +94,11 @@ export function WPOrderReviewLineItems( {
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
 	const isOnboardingAffiliateFlow = useSelector( getIsOnboardingAffiliateFlow );
-	const productSlugs = responseCart.products?.map( ( product ) => product.product_slug );
-	const [ , experimentAssignment ] = useExperiment( 'calypso_checkout_hide_coupon_box_v2', {
-		isEligible: ! productSlugs.some( ( slug ) => 'wp_difm_lite' === slug ),
-	} );
 
 	if ( couponLineItem ) {
 		couponLineItem.label = isOnboardingAffiliateFlow
 			? getAffiliateCouponLabel()
-			: getCouponLabel( couponLineItem.label, experimentAssignment?.variationName );
-		if ( isCouponBoxHidden( productSlugs, experimentAssignment?.variationName ) ) {
-			couponLineItem.hasDeleteButton = false;
-		}
+			: couponLineItem.label;
 	}
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;

--- a/client/my-sites/checkout/utils.ts
+++ b/client/my-sites/checkout/utils.ts
@@ -135,24 +135,3 @@ export function getAffiliateCouponLabel(): string {
 	// translators: The label of the coupon line item in checkout
 	return translate( 'Exclusive Offer Applied' );
 }
-
-export function getCouponLabel(
-	originalLabel: string,
-	experimentVariationName: string | null | undefined
-): string {
-	return experimentVariationName === 'treatment' ? translate( 'Offer Applied' ) : originalLabel;
-}
-
-export function isCouponBoxHidden(
-	productSlugs: string[],
-	experimentVariationName: string | null | undefined
-): boolean {
-	const ignoredProductSlugs = [ 'wp_difm_lite' ];
-	const containsIgnoredProduct = productSlugs.some( ( slug ) =>
-		ignoredProductSlugs.includes( slug )
-	);
-	if ( containsIgnoredProduct ) {
-		return false;
-	}
-	return experimentVariationName === 'treatment' ? true : false;
-}


### PR DESCRIPTION
Related to # 
https://github.com/Automattic/wp-calypso/pull/93516
https://github.com/Automattic/wp-calypso/pull/95364 


## Proposed Changes

Remove unused code related to experiment 

## Why are these changes being made?

We have concluded the hide coupon box experiment and now need to remove unused code related to the test.

## Testing Instructions

1. Apply branch
2. Navigate to the checkout eg. *http://calypso.localhost:3000/start
3. Confirm you are seeing the `Have a coupon` section 

![image](https://github.com/user-attachments/assets/0b0220ee-e21d-41e3-997a-ee27d7961e36)

