### PR TITLE
Fix AI copy not being displayed when plans page is refreshed

### DIFF
--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -169,6 +169,11 @@ const onboarding: Flow = {
 		const { isEligible: isBigSkyEligible } = useIsBigSkyEligible();
 		const isDesignChoicesStepEnabled = isBigSkyEligible && isGoalsAtFrontExperiment;
 
+		if ( typeof window !== 'undefined' && createWithBigSky ) {
+			window.__a8cBigSkyOnboarding = true;
+		} else if ( typeof window !== 'undefined' ) {
+			window.__a8cBigSkyOnboarding = false;
+		}
 		/**
 		 * Returns [destination, backDestination] for the post-checkout destination.
 		 */
@@ -248,15 +253,9 @@ const onboarding: Flow = {
 					// See is-big-sky-onboarding.ts
 					if ( providedDependencies.destination === 'launch-big-sky' ) {
 						setCreateWithBigSky( true );
-						if ( typeof window !== 'undefined' ) {
-							window.__a8cBigSkyOnboarding = true;
-						}
 						return navigate( 'domains' );
 					}
 					setCreateWithBigSky( false );
-					if ( typeof window !== 'undefined' ) {
-						window.__a8cBigSkyOnboarding = false;
-					}
 					return navigate( providedDependencies.destination as string );
 				}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* attach `__a8cBigSkyOnboarding` boolean to the widow object when `createWithBigSky`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix issue with copy not showing

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `setup/onboarding` choose big sky
* Verify copy `Unlimited AI Website Builder edits` is shown on the plan step features
* Choose a plan go to cart then close the cart, you will return to plan step and copy should still be shown.

![image](https://github.com/user-attachments/assets/88767699-1071-4c4a-a888-c3954f1fe0ef)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
