### PR TITLE
Make card border and spacing consistent in Reader

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -28,7 +28,6 @@
 .reader-post-card.card {
 	border-bottom: 5px solid var(--color-neutral-5);
 	border-radius: 6px; /* stylelint-disable-line scales/radii */
-	box-shadow: rgba(0, 0, 0, 0.05) 0 0 0 1px inset;
 	margin: 0;
 	margin-bottom: 24px;
 	position: relative;
@@ -40,7 +39,7 @@
 	}
 
 	@include breakpoint-deprecated( ">660px" ) {
-		border-bottom: 1px solid #e9e9ea;
+		border-bottom: none;
 	}
 
 	&.is-selected {

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -646,7 +646,8 @@
 			}
 
 			@include breakpoint-deprecated( "<660px" ) {
-				margin: 0 16px;
+				margin-left: 16px;
+				margin-right: 16px;
 			}
 
 			@include break-medium {

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -646,8 +646,7 @@
 			}
 
 			@include breakpoint-deprecated( "<660px" ) {
-				margin-left: 16px;
-				margin-right: 16px;
+				margin-inline: 16px 16px;
 			}
 
 			@include break-medium {

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -627,6 +627,7 @@
 		.app-promo {
 			border-radius: 6px; /* stylelint-disable-line scales/radii */
 			background-color: transparent;
+			margin-bottom: 24px;
 
 			.app-promo__qr-code {
 				margin: -10px 0 0;

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -646,7 +646,7 @@
 			}
 
 			@include breakpoint-deprecated( "<660px" ) {
-				margin-inline: 16px 16px;
+				margin-inline: 17px 17px;
 			}
 
 			@include break-medium {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10304, specifically [this comment](https://github.com/Automattic/dotcom-forge/issues/10304#issuecomment-2630502561):

> For the card itself, yes, I don't see a good reason for this card to look different than any other cards. That's my major takeaway as I refamiliarize myself with this: we have too many different styles for the same, so the more CSS we can remove and de-duplicate, the better! And in doing so, perhaps we can also fix this double-underline the cared has:

Currently the Reader cards have custom border styles comprised of a very light box-shadow with an extra border below, which becomes thicker on small screens to become a divider. The Jetpack app promo card is rendered within this list in the Discover view, with mismatched border styles. This PR unifies the styles, by removing the custom styles from the Reader cards and adjusting the spacing around the Jetpack card.

**Note that the updates to the non promo cards affects all the cards in Reader, not just the Discover view.** 

Also note that on mobile sized screens the Jetpack card does not behave like the others; it maintains an outline border inset from the screen edges (see screenshots below). The inconsistency in this view also leads to perceived lower quality in my opinion. We could standardize this behaviour and make it transform into an edge-to-edge card with a divider too.  @jasmussen what do you think?

## Proposed Changes

* Update the Jetpack app promo card bottom spacing so that it matches that of the other cards
* Remove custom border styles from the Reader cards, which allows them to match the Jetpack card, and other cards in Calypso

### Screenshots

#### Desktop

| Before | After |
|-|-|
| ![calypso localhost_3000_discover(Desktop) (1)](https://github.com/user-attachments/assets/800114e4-71be-46c0-8091-b29f763762d7) | ![calypso localhost_3000_discover(Desktop)](https://github.com/user-attachments/assets/11958c2d-85cb-4af1-a01c-4a84efce92ff) |

#### Tablet

| Before | After |
|-|-|
| ![calypso localhost_3000_discover(iPad) (1)](https://github.com/user-attachments/assets/90ef0cf2-caaf-4539-937b-694acc5dd3dd) | ![calypso localhost_3000_discover(iPad)](https://github.com/user-attachments/assets/c548c0ce-8b99-477b-8291-5ec75ad036a0) |

#### Mobile

| Before | After |
|-|-|
| ![calypso localhost_3000_discover(iPhone 12 Pro) (1)](https://github.com/user-attachments/assets/3a5b6165-a041-4753-a98b-4c94b889b747) | ![calypso localhost_3000_discover(iPhone 12 Pro)](https://github.com/user-attachments/assets/1a6c4787-43f3-4184-a402-6980dc2c1333) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fixing small UI imperfections like this lead to higher perceived quality of the app

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit http://calypso.localhost:3000/discover
* Scroll down until you reach the Jetpack app promo card titled 'Read on the go with the Jetpack Mobile App'
* Compare the spacing around the card, and the border style with the cards above and below. They should be the same.
* Test on smaller screens. The Jetpack card should have the same space below it as on desktop (24px).
* Test other reader views and check card display; all cards should have the simplified slightly darker border.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
