### PR TITLE
Domain-To-Plan Credit: Add feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -60,6 +60,7 @@
 		"dev/store-sandbox-helper": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
+		"domain-to-plan-credit": false,
 		"email-accounts/enabled": true,
 		"cookie-banner": false,
 		"google-drive": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -30,6 +30,7 @@
 		"current-site/stale-cart-notice": false,
 		"design-picker/use-assembler-styles": true,
 		"devdocs": false,
+		"domain-to-plan-credit": false,
 		"cookie-banner": true,
 		"google-my-business": false,
 		"global-styles/on-personal-plan": true,

--- a/config/production.json
+++ b/config/production.json
@@ -42,6 +42,7 @@
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
 		"cookie-banner": true,
+		"domain-to-plan-credit": false,
 		"google-my-business": true,
 		"global-styles/on-personal-plan": true,
 		"help": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -41,6 +41,7 @@
 		"current-site/stale-cart-notice": false,
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
+		"domain-to-plan-credit": false,
 		"cookie-banner": false,
 		"google-my-business": true,
 		"global-styles/on-personal-plan": true,

--- a/config/test.json
+++ b/config/test.json
@@ -42,6 +42,7 @@
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"difm/allow-extra-pages": false,
+		"domain-to-plan-credit": false,
 		"cookie-banner": false,
 		"google-my-business": false,
 		"global-styles/on-personal-plan": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -45,6 +45,7 @@
 		"dev/store-sandbox-helper": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
+		"domain-to-plan-credit": false,
 		"email-accounts/enabled": true,
 		"cookie-banner": true,
 		"google-my-business": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3660

## Proposed Changes

Adds support for the feature flag `domain-to-plan-credit` in all environments.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To control the visibility of changes for the [domain-to-plan project](https://github.com/Automattic/martech/issues/3643).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
