### PR TITLE
Revert "Revert "Persisting subdomain during the free site setup Big Sky onboarding flow""

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -68,6 +68,12 @@ export default function PlansStepAdaptor( props: StepProps ) {
 		theme ? getThemeType( state, theme.id ) : ''
 	);
 	const isLoadingSelectedTheme = selectedDesign && ! theme;
+	const { siteUrl } = useSelect(
+		( select ) => ( {
+			siteUrl: ( select( ONBOARD_STORE ) as OnboardSelect ).getSiteUrl(),
+		} ),
+		[]
+	);
 
 	const signupDependencies = {
 		siteSlug,
@@ -77,6 +83,7 @@ export default function PlansStepAdaptor( props: StepProps ) {
 		domainItem,
 		domainCart: domainItems,
 		selectedThemeType,
+		siteUrl,
 	};
 
 	const postSignUpSiteSlugParam = getSignupCompleteSlug();


### PR DESCRIPTION
I'm adding back the code [created here](https://github.com/Automattic/wp-calypso/pull/99219). 
This revert was investigated here: p1738614527016829/1738614017.792949-slack-C02DQP0FP
It turns out it was a flaky test, so resending it.