### PR TITLE
Disable expiring notices for 100 year domains

### DIFF
--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -346,6 +346,10 @@ class PurchaseNotice extends Component<
 			return null;
 		}
 
+		if ( purchase.isHundredYearDomain ) {
+			return null;
+		}
+
 		if ( is100Year( purchase ) && ! isCloseToExpiration( purchase ) ) {
 			return null;
 		}
@@ -900,7 +904,8 @@ class PurchaseNotice extends Component<
 			isOneTimePurchase( purchase ) ||
 			isIncludedWithPlan( purchase ) ||
 			! this.props.selectedSite ||
-			! purchase.payment.creditCard
+			! purchase.payment.creditCard ||
+			purchase.isHundredYearDomain
 		) {
 			return null;
 		}

--- a/client/me/purchases/manage-purchase/purchase-meta-price.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-price.tsx
@@ -3,6 +3,7 @@ import {
 	isDomainTransfer,
 	PLAN_ANNUAL_PERIOD,
 	PLAN_BIENNIAL_PERIOD,
+	PLAN_CENTENNIAL_PERIOD,
 	PLAN_MONTHLY_PERIOD,
 	PLAN_TRIENNIAL_PERIOD,
 } from '@automattic/calypso-products';
@@ -92,6 +93,8 @@ function PurchaseMetaPrice( { purchase }: { purchase: Purchase } ) {
 				return translate( 'year' );
 			case PLAN_MONTHLY_PERIOD:
 				return translate( 'month' );
+			case PLAN_CENTENNIAL_PERIOD:
+				return translate( '100 years' );
 			case 7:
 				// Note: does this period ever happen? I don't think it does but it
 				// was added in https://github.com/Automattic/wp-calypso/pull/65006

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -105,6 +105,7 @@ describe( 'selectors', () => {
 				isDomain: false,
 				isDomainRegistration: false,
 				isLocked: false,
+				isHundredYearDomain: false,
 				isInAppPurchase: false,
 				isRechargeable: true,
 				isRefundable: false,

--- a/packages/data-stores/src/purchases/lib/assembler.ts
+++ b/packages/data-stores/src/purchases/lib/assembler.ts
@@ -58,6 +58,7 @@ export function createPurchaseObject( purchase: RawPurchase | RawPurchaseCreditC
 		isCancelable: Boolean( purchase.is_cancelable ),
 		isDomain: Boolean( purchase.is_domain ),
 		isDomainRegistration: Boolean( purchase.is_domain_registration ),
+		isHundredYearDomain: Boolean( purchase.is_hundred_year_domain ),
 		isLocked: Boolean( purchase.is_locked ),
 		isInAppPurchase: Boolean( purchase.is_iap_purchase ),
 		isRechargeable: Boolean( purchase.is_rechargable ),

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -29,6 +29,7 @@ export interface Purchase {
 	isCancelable: boolean;
 	isDomain?: boolean;
 	isDomainRegistration?: boolean;
+	isHundredYearDomain?: boolean;
 	isInAppPurchase: boolean;
 	isLocked: boolean;
 	isRechargeable: boolean;
@@ -203,6 +204,7 @@ export interface RawPurchase {
 	is_cancelable: boolean;
 	is_domain: boolean;
 	is_domain_registration: boolean;
+	is_hundred_year_domain: boolean;
 	is_locked: boolean;
 	is_iap_purchase: boolean;
 	is_rechargable: boolean;


### PR DESCRIPTION
## Proposed Changes

We want to disable subscription and payment method expiration notices for 100 year domains.

## Why are these changes being made?
100 year domains are fully managed by Automattic, so there's no need to display expiration notices (specially because every payment method will expire before domain expiration)

## Testing Instructions

This PR depends on 172022-ghe-Automattic/wpcom

Apply this patch and verify that no expiration notices are shown in the domain purchase page for a hundred year domain.

Verify also that the price showed after applying the backend PR is correct.

![100-before](https://github.com/user-attachments/assets/d4ee7a24-ed8d-4c97-b50b-743db8f6057f)

![100-after](https://github.com/user-attachments/assets/3ec12c10-4235-4b6b-9c72-98c1f7696899)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?