### PR TITLE
Domain management: Fix redirect context on mailbox purchase

### DIFF
--- a/client/my-sites/email/add-mailboxes/index.tsx
+++ b/client/my-sites/email/add-mailboxes/index.tsx
@@ -18,12 +18,6 @@ import { GOOGLE_PROVIDER_NAME } from 'calypso/lib/gsuite/constants';
 import { getTitanProductName } from 'calypso/lib/titan';
 import { TITAN_PROVIDER_NAME } from 'calypso/lib/titan/constants';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
-import {
-	domainManagementAllEmailRoot,
-	domainSiteContextRoot,
-	isUnderDomainManagementAll,
-	isUnderDomainSiteContext,
-} from 'calypso/my-sites/domains/paths';
 import AddEmailAddressesCardPlaceholder from 'calypso/my-sites/email/add-mailboxes/add-users-placeholder';
 import EmailProviderPricingNotice from 'calypso/my-sites/email/add-mailboxes/email-provider-pricing-notice';
 import {
@@ -47,6 +41,7 @@ import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 import { usePasswordResetEmailField } from 'calypso/my-sites/email/hooks/use-password-reset-email-field';
 import { MAILBOXES_SOURCE } from 'calypso/my-sites/email/mailboxes/constants';
 import {
+	getEmailCheckoutPath,
 	getEmailManagementPath,
 	getMailboxesPath,
 	getTitanSetUpMailboxPath,
@@ -325,17 +320,12 @@ const MailboxesForm = ( {
 		recordContinueEvent( { canContinue: true } );
 		setIsAddingToCart( true );
 
-		const selectedSiteSlug = selectedSite?.slug ?? '';
-		let checkoutPath = '/checkout/' + selectedSiteSlug;
-
-		if ( isUnderDomainManagementAll( currentRoute ) ) {
-			const newEmail = mailboxOperations.mailboxes[ 0 ].getAsCartItem().email;
-			const redirectTo = isUnderDomainSiteContext( currentRoute )
-				? `${ domainSiteContextRoot() }/email/${ selectedDomainName }/${ selectedSiteSlug }?new-email=${ newEmail }`
-				: `${ domainManagementAllEmailRoot() }/${ selectedDomainName }/${ selectedSiteSlug }?new-email=${ newEmail }`;
-
-			checkoutPath += '?redirect_to=' + encodeURIComponent( redirectTo );
-		}
+		const checkoutPath = getEmailCheckoutPath(
+			selectedSite?.slug ?? '',
+			selectedDomainName,
+			currentRoute,
+			mailboxOperations.mailboxes[ 0 ].getAsCartItem().email
+		);
 
 		cartManager
 			.addProductsToCart( [ getCartItems( mailboxOperations.mailboxes, mailProperties ) ] )

--- a/client/my-sites/email/email-providers-comparison/stacked/provider-cards/get-on-submit-new-mailboxes-handler.ts
+++ b/client/my-sites/email/email-providers-comparison/stacked/provider-cards/get-on-submit-new-mailboxes-handler.ts
@@ -12,6 +12,7 @@ import {
 } from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-email-product-properties';
 import { MailboxOperations } from 'calypso/my-sites/email/form/mailboxes/components/utilities/mailbox-operations';
 import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
+import { getEmailCheckoutPath } from 'calypso/my-sites/email/paths';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 
@@ -26,6 +27,7 @@ export type GetOnSubmitNewMailboxesHandlerProps = {
 	shoppingCartManager: ShoppingCartManagerActions;
 	siteSlug: string;
 	source: string;
+	currentRoute: string;
 };
 
 const getEmailProductPropertiesForUpsell = (
@@ -51,6 +53,7 @@ const getOnSubmitNewMailboxesHandler =
 		shoppingCartManager,
 		siteSlug,
 		source,
+		currentRoute,
 	}: GetOnSubmitNewMailboxesHandlerProps ) =>
 	async ( mailboxOperations: MailboxOperations ) => {
 		setAddingToCart( true );
@@ -93,10 +96,17 @@ const getOnSubmitNewMailboxesHandler =
 			  )
 			: getEmailProductPropertiesForUpsell( emailProduct, numberOfMailboxes );
 
+		const checkoutPath = getEmailCheckoutPath(
+			siteSlug,
+			domain.name,
+			currentRoute,
+			mailboxOperations.mailboxes[ 0 ].getAsCartItem().email
+		);
+
 		shoppingCartManager
 			.addProductsToCart( [ getCartItems( mailboxOperations.mailboxes, emailProperties ) ] )
 			.then( () => {
-				page( '/checkout/' + siteSlug );
+				page( checkoutPath );
 			} )
 			.finally( () => setAddingToCart( false ) )
 			.catch( () => {

--- a/client/my-sites/email/email-providers-comparison/stacked/provider-cards/google-workspace-card.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/provider-cards/google-workspace-card.tsx
@@ -25,6 +25,7 @@ import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 import { usePasswordResetEmailField } from 'calypso/my-sites/email/hooks/use-password-reset-email-field';
 import { useDispatch, useSelector } from 'calypso/state';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { TranslateResult } from 'i18n-calypso';
@@ -73,6 +74,7 @@ const GoogleWorkspaceCard = ( props: EmailProvidersStackedCardProps ) => {
 		domains,
 		selectedDomainName: selectedDomainName,
 	} );
+	const currentRoute = useSelector( getCurrentRoute );
 
 	const cartKey = useCartKey();
 	const dispatch = useDispatch();
@@ -123,6 +125,7 @@ const GoogleWorkspaceCard = ( props: EmailProvidersStackedCardProps ) => {
 		setAddingToCart,
 		shoppingCartManager,
 		siteSlug,
+		currentRoute,
 	} );
 
 	googleWorkspace.onExpandedChange = onExpandedChange;

--- a/client/my-sites/email/email-providers-comparison/stacked/provider-cards/professional-email-card.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/provider-cards/professional-email-card.tsx
@@ -23,6 +23,7 @@ import {
 import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 import { usePasswordResetEmailField } from 'calypso/my-sites/email/hooks/use-password-reset-email-field';
 import { useDispatch, useSelector } from 'calypso/state';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { EmailProvidersStackedCardProps, ProviderCardProps } from './provider-card-props';
@@ -81,6 +82,7 @@ const ProfessionalEmailCard = ( props: EmailProvidersStackedCardProps ) => {
 		domains,
 		selectedDomainName: selectedDomainName,
 	} );
+	const currentRoute = useSelector( getCurrentRoute );
 
 	const provider = EmailProvider.Titan;
 	const emailProduct = useSelector( ( state ) =>
@@ -123,6 +125,7 @@ const ProfessionalEmailCard = ( props: EmailProvidersStackedCardProps ) => {
 		setAddingToCart,
 		shoppingCartManager,
 		siteSlug,
+		currentRoute,
 	} );
 
 	professionalEmail.formFields = (

--- a/client/my-sites/email/paths.ts
+++ b/client/my-sites/email/paths.ts
@@ -5,6 +5,7 @@ import {
 	isUnderDomainSiteContext,
 	domainManagementRoot,
 	domainSiteContextRoot,
+	domainManagementAllEmailRoot,
 } from 'calypso/my-sites/domains/paths';
 
 type QueryStringParameters = { [ key: string ]: string | undefined };
@@ -244,6 +245,29 @@ export const getProfessionalEmailCheckoutUpsellPath = (
 	domainName: string,
 	receiptId: number | string
 ) => `/checkout/offer-professional-email/${ domainName }/${ receiptId }/${ siteName }`;
+
+export const getEmailCheckoutPath = (
+	siteName: string,
+	domainName: string,
+	relativeTo?: string,
+	newEmail?: string
+): string => {
+	let checkoutPath = '/checkout/' + siteName;
+
+	if ( isUnderDomainManagementAll( relativeTo ) ) {
+		let redirectTo = isUnderDomainSiteContext( relativeTo )
+			? `${ domainSiteContextRoot() }/email/${ domainName }/${ siteName }`
+			: `${ domainManagementAllEmailRoot() }/${ domainName }/${ siteName }`;
+
+		if ( newEmail ) {
+			redirectTo += `?new-email=${ newEmail }`;
+		}
+
+		checkoutPath += '?redirect_to=' + encodeURIComponent( redirectTo );
+	}
+
+	return checkoutPath;
+};
 
 export const getMailboxesPath = ( siteName?: string | null ) =>
 	siteName ? `/mailboxes/${ siteName }` : `/mailboxes`;

--- a/client/my-sites/email/test/paths.ts
+++ b/client/my-sites/email/test/paths.ts
@@ -20,6 +20,7 @@ import {
 	getProfessionalEmailCheckoutUpsellPath,
 	getMailboxesPath,
 	isUnderEmailManagementAll,
+	getEmailCheckoutPath,
 } from '../paths';
 
 const siteName = 'hello.wordpress.com';
@@ -214,6 +215,31 @@ describe( 'path helper functions', () => {
 		);
 		expect( getProfessionalEmailCheckoutUpsellPath( ':site', ':domain', ':receiptId' ) ).toEqual(
 			'/checkout/offer-professional-email/:domain/:receiptId/:site'
+		);
+	} );
+
+	it( 'getEmailCheckoutPath', () => {
+		const email = 'hi@example.com';
+		const relativeToDomainManagement = '/domains/manage/all/email';
+		const relativeToSiteDomain = '/overview/site-domain/email';
+
+		expect( getEmailCheckoutPath( siteName, domainName ) ).toEqual( `/checkout/${ siteName }` );
+		expect( getEmailCheckoutPath( siteName, domainName, relativeToDomainManagement ) ).toEqual(
+			`/checkout/${ siteName }?redirect_to=${ encodeURIComponent(
+				`${ relativeToDomainManagement }/${ domainName }/${ siteName }`
+			) }`
+		);
+		expect(
+			getEmailCheckoutPath( siteName, domainName, relativeToDomainManagement, email )
+		).toEqual(
+			`/checkout/${ siteName }?redirect_to=${ encodeURIComponent(
+				`${ relativeToDomainManagement }/${ domainName }/${ siteName }?new-email=${ email }`
+			) }`
+		);
+		expect( getEmailCheckoutPath( siteName, domainName, relativeToSiteDomain, email ) ).toEqual(
+			`/checkout/${ siteName }?redirect_to=${ encodeURIComponent(
+				`${ relativeToSiteDomain }/${ domainName }/${ siteName }?new-email=${ email }`
+			) }`
 		);
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/99092

## Proposed Changes

* When a mailbox is purchased, the user is redirected back to the correct context, either to the domain management screen or the site overview screen.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of the domain management revamp project.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/domains/manage and pick a domain without an email.
* Go to the "Email" tab and purchase a professional email.
* Make sure you're redirected back to the domain management screen, i.e. http://calypso.localhost:3000/domains/manage/all/email/[site]/[domain]?new-email=[email]
* Go to http://calypso.localhost:3000/sites and pick a site with a domain without an email.
* In the `Active domains` section, click `Add email`, and purchase a professional email.
* Make sure you're redirected back to the site overview screen, i.e. http://calypso.localhost:3000/overview/site-domain/email/[site]/[domain]?new-email=[email]

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
