### PR TITLE
Remove Is Reskinned Flag: Untangle domain price of the isReskinned flag

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -17,7 +17,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
-class DomainProductPrice extends Component {
+export class DomainProductPrice extends Component {
 	static propTypes = {
 		isLoading: PropTypes.bool,
 		price: PropTypes.string,

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -35,42 +35,6 @@ class DomainProductPrice extends Component {
 		isMappingProduct: false,
 	};
 
-	renderFreeWithPlanText() {
-		const { isMappingProduct, translate } = this.props;
-
-		let message;
-		switch ( this.props.rule ) {
-			case 'FREE_WITH_PLAN':
-				if ( isMappingProduct ) {
-					message = translate( 'Free with your plan' );
-				} else {
-					return this.renderReskinFreeWithPlanText();
-				}
-				break;
-			case 'INCLUDED_IN_HIGHER_PLAN':
-				if ( isMappingProduct ) {
-					message = translate( 'Included in paid plans' );
-				} else {
-					return this.renderReskinFreeWithPlanText();
-				}
-				break;
-			case 'UPGRADE_TO_HIGHER_PLAN_TO_BUY':
-				message = translate( '%(planName)s plan required', {
-					args: { planName: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
-				} );
-				break;
-		}
-
-		return <div className="domain-product-price__free-text">{ message }</div>;
-	}
-
-	renderFreeWithPlanPrice() {
-		if ( this.props.isMappingProduct ) {
-			return;
-		}
-		return this.renderReskinDomainPrice();
-	}
-
 	renderRenewalPrice() {
 		const { price, renewPrice, translate } = this.props;
 		const isRenewCostDifferent = renewPrice && price !== renewPrice;
@@ -88,61 +52,15 @@ class DomainProductPrice extends Component {
 		}
 	}
 
-	renderReskinFreeWithPlanText() {
-		const {
-			isMappingProduct,
-			translate,
-			isCurrentPlan100YearPlan,
-			isBusinessOrEcommerceMonthlyPlan,
-		} = this.props;
-
-		const domainPriceElement = ( message ) => (
-			<div className="domain-product-price__free-text">{ message }</div>
-		);
-
-		if ( isMappingProduct ) {
-			return domainPriceElement( translate( 'Included in paid plans' ) );
-		}
-
-		if ( isCurrentPlan100YearPlan ) {
-			return domainPriceElement( translate( 'Free with your plan' ) );
-		}
-
-		if ( isBusinessOrEcommerceMonthlyPlan ) {
-			return domainPriceElement(
-				<>
-					<span className="domain-product-price__free-price">
-						{ translate( 'Free domain for one year' ) }
-					</span>
-				</>
-			);
-		}
-
-		const message = translate( '{{span}}Free for the first year with annual paid plans{{/span}}', {
-			components: { span: <span className="domain-product-price__free-price" /> },
-		} );
-
-		return domainPriceElement( message );
-	}
-
-	renderReskinDomainPrice() {
-		const priceText = this.props.translate( '%(cost)s/year', {
-			args: { cost: this.props.price },
-		} );
-
-		return (
-			<div className="domain-product-price__price">
-				<del>{ priceText }</del>
-			</div>
-		);
-	}
-
 	// This method returns "Free for the first year" text (different from "Free with plan")
 	renderFreeForFirstYear() {
 		const { translate } = this.props;
 
 		const className = clsx( 'domain-product-price', 'is-free-domain', {
 			'domain-product-price__domain-step-signup-flow': this.props.showStrikedOutPrice,
+		} );
+		const priceText = this.props.translate( '%(cost)s/year', {
+			args: { cost: this.props.price },
 		} );
 
 		return (
@@ -152,29 +70,57 @@ class DomainProductPrice extends Component {
 						{ translate( 'Free for the first year' ) }
 					</span>
 				</div>
-				{ this.renderReskinDomainPrice() }
+				<div className="domain-product-price__price">
+					<del>{ priceText }</del>
+				</div>
 			</div>
 		);
 	}
 
 	renderFreeWithPlan() {
-		const className = clsx( 'domain-product-price', 'is-free-domain', {
+		const {
+			isMappingProduct,
+			translate,
+			isCurrentPlan100YearPlan,
+			isBusinessOrEcommerceMonthlyPlan,
+		} = this.props;
+
+		const className = clsx( 'domain-product-price is-free-domain', {
 			'domain-product-price__domain-step-signup-flow': this.props.showStrikedOutPrice,
 		} );
 
-		if ( this.props.isReskinned ) {
-			return (
-				<div className={ className }>
-					{ this.renderReskinFreeWithPlanText() }
-					{ this.renderReskinDomainPrice() }
-				</div>
+		let message;
+		if (
+			( isMappingProduct && this.props.rule === 'FREE_WITH_PLAN' ) ||
+			isCurrentPlan100YearPlan
+		) {
+			message = translate( 'Free with your plan' );
+		} else if ( isMappingProduct ) {
+			message = translate( 'Included in paid plans' );
+		} else if ( isBusinessOrEcommerceMonthlyPlan ) {
+			message = (
+				<span className="domain-product-price__free-price">
+					{ translate( 'Free domain for one year' ) }
+				</span>
 			);
+		} else if ( this.props.rule === 'UPGRADE_TO_HIGHER_PLAN_TO_BUY' ) {
+			message = translate( '%(planName)s plan required', {
+				args: { planName: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
+			} );
+		} else {
+			message = translate( '{{span}}Free for the first year with annual paid plans{{/span}}', {
+				components: { span: <span className="domain-product-price__free-price" /> },
+			} );
 		}
 
 		return (
 			<div className={ className }>
-				{ this.renderFreeWithPlanText() }
-				{ this.renderFreeWithPlanPrice() }
+				{ this.props.isMappingProduct
+					? null
+					: this.props.translate( '%(cost)s/year', {
+							args: { cost: this.props.price },
+					  } ) }
+				<div className="domain-product-price__free-text">{ message }</div>
 			</div>
 		);
 	}

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -115,12 +115,12 @@ class DomainProductPrice extends Component {
 
 		return (
 			<div className={ className }>
+				<div className="domain-product-price__free-text">{ message }</div>
 				{ this.props.isMappingProduct
 					? null
 					: this.props.translate( '%(cost)s/year', {
 							args: { cost: this.props.price },
 					  } ) }
-				<div className="domain-product-price__free-text">{ message }</div>
 			</div>
 		);
 	}

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -116,11 +116,15 @@ export class DomainProductPrice extends Component {
 		return (
 			<div className={ className }>
 				<div className="domain-product-price__free-text">{ message }</div>
-				{ this.props.isMappingProduct
-					? null
-					: this.props.translate( '%(cost)s/year', {
-							args: { cost: this.props.price },
-					  } ) }
+				<div className="domain-product-price__price">
+					<del>
+						{ this.props.isMappingProduct
+							? null
+							: this.props.translate( '%(cost)s/year', {
+									args: { cost: this.props.price },
+							  } ) }
+					</del>
+				</div>
 			</div>
 		);
 	}

--- a/client/components/domains/domain-product-price/test/domain-product-price.tsx
+++ b/client/components/domains/domain-product-price/test/domain-product-price.tsx
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import React from 'react';
+import { reducer as ui } from 'calypso/state/ui/reducer';
+import { renderWithProvider as renderWithProviderHelper } from 'calypso/test-helpers/testing-library';
+import { DomainProductPrice } from '../index';
+
+const translate = ( str: string ) => {
+	return str;
+};
+const renderWithProvider = ( el: React.ReactNode ) => {
+	return renderWithProviderHelper( el, {
+		reducers: { ui },
+	} );
+};
+
+describe( 'DomainProductPrice', () => {
+	const defaultProps = {
+		domainsWithPlansOnly: true,
+		translate,
+		price: '$12',
+	};
+
+	describe( 'free with plan scenarios', () => {
+		test( 'shows correct label for mapping product with FREE_WITH_PLAN', () => {
+			renderWithProvider(
+				<DomainProductPrice { ...defaultProps } isMappingProduct rule="FREE_WITH_PLAN" />
+			);
+			expect( screen.getByText( 'Free with your plan' ) ).toBeInTheDocument();
+		} );
+
+		test( 'shows correct label for 100 year plan', () => {
+			renderWithProvider(
+				<DomainProductPrice { ...defaultProps } isCurrentPlan100YearPlan rule="FREE_WITH_PLAN" />
+			);
+			expect( screen.getByText( 'Free with your plan' ) ).toBeInTheDocument();
+		} );
+
+		test( 'shows correct label for mapping with higher plan', () => {
+			renderWithProvider(
+				<DomainProductPrice { ...defaultProps } isMappingProduct rule="INCLUDED_IN_HIGHER_PLAN" />
+			);
+			expect( screen.getByText( 'Included in paid plans' ) ).toBeInTheDocument();
+		} );
+
+		test( 'shows correct label for monthly business plans', () => {
+			renderWithProvider(
+				<DomainProductPrice
+					{ ...defaultProps }
+					isBusinessOrEcommerceMonthlyPlan
+					rule="FREE_WITH_PLAN"
+				/>
+			);
+			expect( screen.getByText( 'Free domain for one year' ) ).toBeInTheDocument();
+		} );
+
+		test( 'shows correct label for plan upgrade requirement', () => {
+			renderWithProvider(
+				<DomainProductPrice { ...defaultProps } rule="UPGRADE_TO_HIGHER_PLAN_TO_BUY" />
+			);
+			expect( screen.getByText( /plan required/ ) ).toBeInTheDocument();
+		} );
+
+		test( 'shows default label for FREE_WITH_PLAN', () => {
+			renderWithProvider( <DomainProductPrice { ...defaultProps } rule="FREE_WITH_PLAN" /> );
+			expect(
+				screen.getByText( /Free for the first year with annual paid plans/ )
+			).toBeInTheDocument();
+		} );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to: https://github.com/Automattic/wp-calypso/issues/95419

## Proposed Changes

* Refactors and removes the need for a reskin flag in domain price component.
* Adds some tests to highlight the various statuses involving the coi

<img width="1506" alt="Screenshot 2025-02-04 at 10 54 39 AM" src="https://github.com/user-attachments/assets/a18ac4ac-3c13-4452-b74c-5235b6901b2d" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Purge the is reskinned flag and also remove related dead/disorganised code.


## Testing Instructions
- Check the onboarding flow domain step`/start`  which should remain uneffected 
- Check the domains add page `/domains/add` which should remain uneffected 
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
