### PR TITLE
Jetpack WooCommerce login: fix logo

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -625,9 +625,8 @@ class Login extends Component {
 						require="calypso/components/jetpack-header"
 						placeholder={ null }
 						partnerSlug={ this.props.partnerSlug }
-						isWoo
+						isWooOnboarding
 						width={ 200 }
-						lightColorScheme
 					/>
 				</div>
 			);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Found while working on #99188

## Proposed Changes

Fix logo in Jetpack + WooCommerce login screen flow

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently, the page shows an oversized Jetpack logo
* There are a few issues with it:
  * The logo's size is obviously wrong
  * The logo itself may be wrong, since we are in the Jetpack WooCommerce flow
  * The JSX code also shows a few unusual aspects

https://github.com/Automattic/wp-calypso/blob/fad438421aed243967057e58cd306c9904bbc848/client/blocks/login/index.jsx#L624-L630

In particular:

- The `lightColorScheme` prop doesn't exist on the component
  -  I decided to simply remove it, since the component supports a `darkColorScheme` prop instead which is `undefined` by default
- The `isWoo` prop doesn't exist on the component
  - I decided to replace it with the `isWooOnboarding` prop, which changes the logo to the Jetpack+Woo logo 
  - One thing to notice, though, is that the component is passed a `partnerSlug` prop, [which is not compatible with the `isWooOnboarding` prop.](https://github.com/Automattic/wp-calypso/blob/trunk/client/components/jetpack-header/index.jsx#L40)

Can anyone help me understand what's the right approach here?

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log out
* Visit `http://calypso.localhost:3000/log-in/jetpack?site=https%3A%2F%2Fyourjetpack.blog&redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000%2Fjetpack%2Fconnect%2Fauthorize%3Ffrom%3Dwoocommerce-onboarding%26_wp_nonce%3Dfoobar%26blogname%3DJust%2520Another%2520WordPress.com%2520Site%26client_id%3D12345%26close_window_after_login%3D0%26close_window_after_auth%3D0%26home_url%3Dhttps%3A%2F%2Fyourjetpack.blog%26redirect_uri%3Dhttps%3A%2F%2Fyourjetpack.blog%2Fwp-admin%2Fadmin.php%26scope%3Dadministrator%3A34579bf2a3185a47d1b31aab30125d%26secret%3D640fdbd69f96a8ca9e61%26site%3Dhttps%3A%2F%2Fyourjetpack.blog%26site_url%3Dhttps%3A%2F%2Fyourjetpack.blog%26state%3D1%26allow_site_connection%3D1%26installed_ext_success%3D1%26&from=woocommerce-onboarding&allow_site_connection=1`
* Make sure the logo appears correctly


You can also manually trigger this form by tweaking the `isJetpackWooCommerceFlow` and `isJetpackWooDnaFlow` conditions in this file:

https://github.com/Automattic/wp-calypso/blob/66588300b0d0f042607336f9d37e31f4e5c50563/client/blocks/login/login-form.jsx#L881-L890

| Before | After |
|---|---|
| ![Screenshot 2025-02-01 at 15 33 50](https://github.com/user-attachments/assets/71d5e129-ec18-4cf0-83bd-63ae22399dd1) | ![Screenshot 2025-02-04 at 15 23 06](https://github.com/user-attachments/assets/69282171-a21c-48c1-b69b-ebdc3119a3a5) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
