### PR TITLE
i18n: Update several cases of `ShortenedNumber` component with `numberFormat`

### DIFF
--- a/apps/odyssey-stats/src/widget/modules.tsx
+++ b/apps/odyssey-stats/src/widget/modules.tsx
@@ -1,7 +1,7 @@
-import { ShortenedNumber, Button } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { protect, akismet } from '@automattic/components/src/icons';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import { useState, FunctionComponent } from 'react';
 import wpcom from 'calypso/lib/wp';
 import useModuleDataQuery from '../hooks/use-module-data-query';
@@ -64,7 +64,14 @@ const ModuleCard: FunctionComponent< ModuleCardProps > = ( {
 				<>
 					{ ( ! isError || ! canManageModule ) && (
 						<div className="stats-widget-module__value">
-							<ShortenedNumber value={ value } />
+							<span>
+								{ numberFormat( value, {
+									numberFormatOptions: {
+										notation: 'compact',
+										maximumFractionDigits: 1,
+									},
+								} ) }
+							</span>
 						</div>
 					) }
 					{ isError && canManageModule && (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/insights-stats.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/insights-stats.tsx
@@ -1,7 +1,7 @@
-import { Button, ShortenedNumber } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { Icon, arrowUp, arrowDown, external } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import ExpandedCard from './expanded-card';
 import type { SiteStats } from '../types';
 
@@ -62,7 +62,14 @@ export default function InsightsStats( { stats, siteUrlWithScheme, trackEvent }:
 				<div className="site-expanded-content__card-content">
 					<div className="site-expanded-content__card-content-column">
 						<div className="site-expanded-content__card-content-score">
-							<ShortenedNumber value={ data.visitors } />
+							<span>
+								{ numberFormat( data.visitors, {
+									numberFormatOptions: {
+										notation: 'compact',
+										maximumFractionDigits: 1,
+									},
+								} ) }
+							</span>
 							{ getTrendContent( data.visitorsTrend, data.visitorsChange ) }
 						</div>
 						<div className="site-expanded-content__card-content-score-title">
@@ -71,7 +78,14 @@ export default function InsightsStats( { stats, siteUrlWithScheme, trackEvent }:
 					</div>
 					<div className="site-expanded-content__card-content-column">
 						<div className="site-expanded-content__card-content-score">
-							<ShortenedNumber value={ data.views } />
+							<span>
+								{ numberFormat( data.views, {
+									numberFormatOptions: {
+										notation: 'compact',
+										maximumFractionDigits: 1,
+									},
+								} ) }
+							</span>
 							{ getTrendContent( data.viewsTrend, data.viewsChange ) }
 						</div>
 						<div className="site-expanded-content__card-content-score-title">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-stats-column.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-stats-column.tsx
@@ -1,4 +1,4 @@
-import { Gridicon, ShortenedNumber } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
 import { Icon, arrowUp, arrowDown } from '@wordpress/icons';
 import clsx from 'clsx';
 import { translate, numberFormat } from 'i18n-calypso';
@@ -109,7 +109,14 @@ export default function SiteStatsColumn( { site, stats, siteError }: Props ) {
 			{ trendIcon }
 
 			<div className="sites-overview__stats">
-				<ShortenedNumber value={ totalViews } />
+				<span>
+					{ numberFormat( totalViews, {
+						numberFormatOptions: {
+							notation: 'compact',
+							maximumFractionDigits: 1,
+						},
+					} ) }
+				</span>
 			</div>
 		</span>
 	);

--- a/client/my-sites/stats/sections/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/sections/all-time-highlights-section/index.tsx
@@ -1,10 +1,4 @@
-import {
-	Card,
-	ComponentSwapper,
-	formattedNumber,
-	ShortenedNumber,
-	DotPager,
-} from '@automattic/components';
+import { Card, ComponentSwapper, formattedNumber, DotPager } from '@automattic/components';
 import {
 	formatPercentage,
 	percentCalculator,
@@ -12,7 +6,7 @@ import {
 import { eye } from '@automattic/components/src/icons';
 import { Icon, people, postContent, starEmpty, commentContent } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import React, { useMemo } from 'react';
 import QueryPosts from 'calypso/components/data/query-posts';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
@@ -154,7 +148,16 @@ export default function AllTimeHighlightsSection( {
 				{
 					id: 'views',
 					header: translate( 'Views' ),
-					content: <ShortenedNumber value={ viewsBestDayTotal } />,
+					content: (
+						<span>
+							{ numberFormat( viewsBestDayTotal, {
+								numberFormatOptions: {
+									notation: 'compact',
+									maximumFractionDigits: 1,
+								},
+							} ) }
+						</span>
+					),
 					footer: translate( '%(percent)s of views', {
 						args: { percent: formatPercentage( bestViewsEverPercent, true ) },
 						context: 'Stats: Percentage of views',

--- a/client/my-sites/stats/stats-email-top-row/top-card.jsx
+++ b/client/my-sites/stats/stats-email-top-row/top-card.jsx
@@ -1,5 +1,5 @@
-import { Card, ShortenedNumber, Spinner } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
+import { Card, Spinner } from '@automattic/components';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 
 /* This is a very stripped down version of HighlightCard
  * HighlightCard doesn't support non-numeric values
@@ -25,7 +25,12 @@ const TopCardValue = ( { value, isLoading } ) => {
 
 	return (
 		<span className="highlight-card-count-value" title={ String( value ) }>
-			<ShortenedNumber value={ value } />
+			{ numberFormat( value, {
+				numberFormatOptions: {
+					notation: 'compact',
+					maximumFractionDigits: 1,
+				},
+			} ) }
 		</span>
 	);
 };

--- a/client/my-sites/subscribers/components/subscriber-stats-card/subscriber-stats-card.tsx
+++ b/client/my-sites/subscribers/components/subscriber-stats-card/subscriber-stats-card.tsx
@@ -1,4 +1,5 @@
-import { Card, ShortenedNumber, Spinner } from '@automattic/components';
+import { Card, Spinner } from '@automattic/components';
+import { numberFormat } from 'i18n-calypso';
 import { ReactNode } from 'react';
 import InfoPopover from 'calypso/components/info-popover';
 import '@automattic/components/src/highlight-cards/style.scss';
@@ -41,7 +42,14 @@ const SubscriberStatsCardValue = ( {
 			className="highlight-card-count-value subscriber-stats-card__value"
 			title={ String( value ) }
 		>
-			<ShortenedNumber value={ value as number } />
+			{ typeof value === 'number'
+				? numberFormat( value, {
+						numberFormatOptions: {
+							notation: 'compact',
+							maximumFractionDigits: 1,
+						},
+				  } )
+				: '-' }
 		</span>
 	);
 };

--- a/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx
+++ b/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx
@@ -3,7 +3,6 @@ import { Icon, chevronDown, chevronUp, tag, file } from '@wordpress/icons';
 import clsx from 'clsx';
 import { numberFormat } from 'i18n-calypso';
 import React, { Fragment, useState } from 'react';
-import ShortenedNumber from '../number-formatters';
 import type { HorizontalBarListItemProps } from './types';
 
 import './style.scss';
@@ -106,8 +105,18 @@ const HorizontalBarListItem = ( {
 
 	const renderValue = () => {
 		if ( useShortNumber ) {
-			return <ShortenedNumber value={ value } />;
+			return (
+				<span>
+					{ numberFormat( value, {
+						numberFormatOptions: {
+							notation: 'compact',
+							maximumFractionDigits: 1,
+						},
+					} ) }
+				</span>
+			);
 		}
+
 		if ( formatValue ) {
 			return formatValue( value, data );
 		}

--- a/packages/components/src/post-stats-card/index.tsx
+++ b/packages/components/src/post-stats-card/index.tsx
@@ -1,9 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Icon, commentContent, starEmpty } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import { useMemo } from 'react';
-import { Card, ShortenedNumber, Button } from '../';
+import { Card, Button } from '../';
 import { eye } from '../icons';
 import './style.scss';
 
@@ -78,21 +78,48 @@ export default function PostStatsCard( {
 					<Icon className="gridicon" icon={ eye } />
 					<div className="post-stats-card__count-header">{ translate( 'Views' ) }</div>
 					<div className="post-stats-card__count-value">
-						<ShortenedNumber value={ isLoading ? null : viewCount } />
+						<span>
+							{ ! isLoading && viewCount !== null
+								? numberFormat( viewCount, {
+										numberFormatOptions: {
+											notation: 'compact',
+											maximumFractionDigits: 1,
+										},
+								  } )
+								: '-' }
+						</span>
 					</div>
 				</div>
 				<div className="post-stats-card__count post-stats-card__count--like">
 					<Icon className="gridicon" icon={ starEmpty } />
 					<div className="post-stats-card__count-header">{ translate( 'Likes' ) }</div>
 					<div className="post-stats-card__count-value">
-						<ShortenedNumber value={ isLoading ? null : likeCount } />
+						<span>
+							{ ! isLoading && likeCount !== null
+								? numberFormat( likeCount, {
+										numberFormatOptions: {
+											notation: 'compact',
+											maximumFractionDigits: 1,
+										},
+								  } )
+								: '-' }
+						</span>
 					</div>
 				</div>
 				<div className="post-stats-card__count post-stats-card__count--comment">
 					<Icon className="gridicon" icon={ commentContent } />
 					<div className="post-stats-card__count-header">{ translate( 'Comments' ) }</div>
 					<div className="post-stats-card__count-value">
-						<ShortenedNumber value={ isLoading ? null : commentCount } />
+						<span>
+							{ ! isLoading && commentCount !== null
+								? numberFormat( commentCount, {
+										numberFormatOptions: {
+											notation: 'compact',
+											maximumFractionDigits: 1,
+										},
+								  } )
+								: '-' }
+						</span>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/934
Fixes https://github.com/Automattic/i18n-issues/issues/937
Fixes https://github.com/Automattic/i18n-issues/issues/938

## Proposed Changes

- Updates several imports of `ShortenedNumber` from `@automattic/components` to replace with `numberFormat`
- Fixes the wrong/missing translations resultant from not using `numberFormat` with correct locale

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/934

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Code review
- All of the affected cases should be checked, but a few should also suffice.

### `/stats/insights/:site` "Most popular day" stats

**Before**

<img width="800" alt="Screenshot 2025-02-05 at 10 40 47 AM" src="https://github.com/user-attachments/assets/ee7f89b2-4747-4fc8-a452-a8e45579e89e" />

**After**

<img width="800" alt="Screenshot 2025-02-05 at 10 41 01 AM" src="https://github.com/user-attachments/assets/fc17df06-76cc-47c9-b32d-1b92c82fc1cd" />

### `/stats/insights/:site` "Latest post"

<img width="398" alt="Screenshot 2025-02-05 at 11 32 38 AM" src="https://github.com/user-attachments/assets/febaf29f-7518-4e64-b37f-0e45c3a6dc25" />

### `/subscribers/:site` - individual stats

Click on a subscriber to view individual subscriber stats. May have to enable it through the `?flags=individual-subscriber-stats`

**Before**

<img width="800" alt="Screenshot 2025-02-05 at 11 49 26 AM" src="https://github.com/user-attachments/assets/ff6cd9b3-2223-434c-8cd7-38df3165bf41" />

**After**

<img width="800" alt="Screenshot 2025-02-05 at 11 49 59 AM" src="https://github.com/user-attachments/assets/cce3ecae-78e2-4606-a154-fee5fe7cd22a" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
