### PR TITLE
i18n: Update several cases of `formattedNumber` usage with `numberFormat`

### DIFF
--- a/apps/odyssey-stats/src/widget/highlights.tsx
+++ b/apps/odyssey-stats/src/widget/highlights.tsx
@@ -65,12 +65,7 @@ const ItemWrapper: FunctionComponent< ItemWrapperProps > = ( {
 			<span>
 				{ translate( '%(views)s Views', {
 					args: {
-						views: numberFormat( item.views, {
-							numberFormatOptions: {
-								notation: 'compact',
-								maximumFractionDigits: 1,
-							},
-						} ),
+						views: numberFormat( item.views ),
 					},
 				} ) }
 			</span>

--- a/apps/odyssey-stats/src/widget/highlights.tsx
+++ b/apps/odyssey-stats/src/widget/highlights.tsx
@@ -1,7 +1,7 @@
-import { formattedNumber, SegmentedControl } from '@automattic/components';
+import { SegmentedControl } from '@automattic/components';
 import { Icon, external } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import moment from 'moment';
 import { useState, FunctionComponent } from 'react';
 import useReferrersQuery from '../hooks/use-referrers-query';
@@ -64,7 +64,14 @@ const ItemWrapper: FunctionComponent< ItemWrapperProps > = ( {
 			<p>{ item.title }</p>
 			<span>
 				{ translate( '%(views)s Views', {
-					args: { views: formattedNumber( item.views ) },
+					args: {
+						views: numberFormat( item.views, {
+							numberFormatOptions: {
+								notation: 'compact',
+								maximumFractionDigits: 1,
+							},
+						} ),
+					},
 				} ) }
 			</span>
 		</div>

--- a/client/my-sites/stats/sections/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/sections/all-time-highlights-section/index.tsx
@@ -1,4 +1,4 @@
-import { Card, ComponentSwapper, formattedNumber, DotPager } from '@automattic/components';
+import { Card, ComponentSwapper, DotPager } from '@automattic/components';
 import {
 	formatPercentage,
 	percentCalculator,
@@ -254,7 +254,12 @@ function AllTimeStatsCard( { infoItems, siteId }: AllTimeStatsCardProps ) {
 										className="highlight-card-info-item-count"
 										title={ Number.isFinite( info.count ) ? String( info.count ) : undefined }
 									>
-										{ formattedNumber( info.count ) }
+										{ numberFormat( info.count, {
+											numberFormatOptions: {
+												notation: 'compact',
+												maximumFractionDigits: 1,
+											},
+										} ) }
 									</span>
 								</div>
 							);

--- a/client/my-sites/stats/sections/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/sections/all-time-highlights-section/index.tsx
@@ -254,12 +254,7 @@ function AllTimeStatsCard( { infoItems, siteId }: AllTimeStatsCardProps ) {
 										className="highlight-card-info-item-count"
 										title={ Number.isFinite( info.count ) ? String( info.count ) : undefined }
 									>
-										{ numberFormat( info.count, {
-											numberFormatOptions: {
-												notation: 'compact',
-												maximumFractionDigits: 1,
-											},
-										} ) }
+										{ numberFormat( info.count ) }
 									</span>
 								</div>
 							);

--- a/client/my-sites/stats/stats-plan-usage/index.tsx
+++ b/client/my-sites/stats/stats-plan-usage/index.tsx
@@ -91,12 +91,15 @@ const PlanUsage: React.FC< PlanUsageProps > = ( {
 									maximumFractionDigits: 1,
 								},
 							} ),
-							numberOfLimit: numberFormat( limit, {
-								numberFormatOptions: {
-									notation: 'compact',
-									maximumFractionDigits: 1,
-								},
-							} ),
+							numberOfLimit:
+								typeof limit === 'number'
+									? numberFormat( limit, {
+											numberFormatOptions: {
+												notation: 'compact',
+												maximumFractionDigits: 1,
+											},
+									  } )
+									: '-',
 						},
 					} ) }
 				</div>

--- a/client/my-sites/stats/stats-plan-usage/index.tsx
+++ b/client/my-sites/stats/stats-plan-usage/index.tsx
@@ -85,21 +85,8 @@ const PlanUsage: React.FC< PlanUsageProps > = ( {
 				<div key="usage">
 					{ translate( '%(numberOfUsage)s / %(numberOfLimit)s views', {
 						args: {
-							numberOfUsage: numberFormat( usage, {
-								numberFormatOptions: {
-									notation: 'compact',
-									maximumFractionDigits: 1,
-								},
-							} ),
-							numberOfLimit:
-								typeof limit === 'number'
-									? numberFormat( limit, {
-											numberFormatOptions: {
-												notation: 'compact',
-												maximumFractionDigits: 1,
-											},
-									  } )
-									: '-',
+							numberOfUsage: numberFormat( usage ),
+							numberOfLimit: typeof limit === 'number' ? numberFormat( limit ) : '-',
 						},
 					} ) }
 				</div>

--- a/client/my-sites/stats/stats-plan-usage/index.tsx
+++ b/client/my-sites/stats/stats-plan-usage/index.tsx
@@ -1,6 +1,5 @@
-import { formattedNumber } from '@automattic/components';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import React from 'react';
 import usePlanUsageQuery from 'calypso/my-sites/stats/hooks/use-plan-usage-query';
 
@@ -86,8 +85,18 @@ const PlanUsage: React.FC< PlanUsageProps > = ( {
 				<div key="usage">
 					{ translate( '%(numberOfUsage)s / %(numberOfLimit)s views', {
 						args: {
-							numberOfUsage: formattedNumber( usage ),
-							numberOfLimit: formattedNumber( limit ),
+							numberOfUsage: numberFormat( usage, {
+								numberFormatOptions: {
+									notation: 'compact',
+									maximumFractionDigits: 1,
+								},
+							} ),
+							numberOfLimit: numberFormat( limit, {
+								numberFormatOptions: {
+									notation: 'compact',
+									maximumFractionDigits: 1,
+								},
+							} ),
 						},
 					} ) }
 				</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/934
Fixes Automattic/i18n-issues#920

## Proposed Changes

- Updates several imports of `formattedNumber` from `@automattic/components` to replace with `numberFormat`
- Fixes the wrong/missing translations resulting from not using `numberFormat` with the correct locale

Some **notes** below: https://github.com/Automattic/wp-calypso/pull/99273#issuecomment-2637539659

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/934
Fixes Automattic/i18n-issues#920

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Code review
- All of these cases should be checked, but a few should also suffice. They are all handled similarly.

### `/stats/insights/:site` - All-time Highlights section

**Before (EL)**

<img width="800" alt="Screenshot 2025-02-05 at 6 40 46 PM" src="https://github.com/user-attachments/assets/4db59323-4cec-4143-8efe-dce7c957aaaa" />

**After (EL)**

<img width="800" alt="Screenshot 2025-02-05 at 7 05 22 PM" src="https://github.com/user-attachments/assets/4b052378-371c-47f9-9c68-7fbe4606cb75" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
