### PR TITLE
Add Tracks events when a default dns record notice is showed

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { englishLocales } from '@automattic/i18n-utils';
 import { Icon, info } from '@wordpress/icons';
 import i18n, { getLocaleSlug, localize } from 'i18n-calypso';
@@ -207,6 +208,10 @@ class DnsRecords extends Component {
 			return null;
 		}
 
+		recordTracksEvent( 'calypso_domain_management_dns_default_a_records_notice_show', {
+			domain_name: this.props.selectedDomainName,
+		} );
+
 		return (
 			<div className="dns-records-notice">
 				<Icon
@@ -241,6 +246,10 @@ class DnsRecords extends Component {
 		if ( this.hasDefaultCnameRecord() ) {
 			return null;
 		}
+
+		recordTracksEvent( 'calypso_domain_management_dns_default_cname_record_notice_show', {
+			domain_name: this.props.selectedDomainName,
+		} );
 
 		return (
 			<div className="dns-records-notice">


### PR DESCRIPTION
Related to #96196 

## Proposed Changes
This PR tigger a track event whener the restore A/CNAME record notice is displayed in Calypso, under DNS management age


## Why are these changes being made?
We want to track when the messages to restore default A/CNAME records are showed in Calypso in order to identify is there any bug that prevent these messages from being displayed.

## Testing Instructions
Open DNS edit page for a domain that is not using default A records and verify that a Tracks event is fired (`calypso_domain_management_dns_default_a_records_notice_show`)

<img width="722" alt="Screenshot 2025-02-07 alle 13 41 25" src="https://github.com/user-attachments/assets/a9e01363-e78b-43a0-ad4f-8d96f89bfe73" />


## Pre-merge 

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
