### PR TITLE
Stats: prompt users to update the Jetpack plugin

### DIFF
--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -255,14 +255,21 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 		</>
 	);
 
-	let upsellOverlay = null;
-	if ( shouldGate ) {
-		upsellOverlay = (
-			<StatsCardUpsell siteId={ siteId } statType={ optionLabels[ selectedOption ].feature } />
-		);
-	} else if ( showJetpackUpgradePrompt ) {
-		upsellOverlay = <StatsCardUpdateJetpackVersion siteId={ siteId } statType="locations" />;
-	}
+	const getModuleOverlay = () => {
+		if ( shouldGate ) {
+			return (
+				<StatsCardUpsell siteId={ siteId } statType={ optionLabels[ selectedOption ].feature } />
+			);
+		}
+
+		if ( showJetpackUpgradePrompt ) {
+			return <StatsCardUpdateJetpackVersion siteId={ siteId } statType="locations" />;
+		}
+
+		return null;
+	};
+
+	const moduleOverlay = getModuleOverlay();
 
 	return (
 		<>
@@ -315,7 +322,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 								: undefined
 						}
 						onShowMoreClick={ onShowMoreClick }
-						overlay={ upsellOverlay }
+						overlay={ moduleOverlay }
 					/>
 				</>
 			) }

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -15,6 +15,8 @@ import StatsListCard from 'calypso/my-sites/stats/stats-list/stats-list-card';
 import StatsModulePlaceholder from 'calypso/my-sites/stats/stats-module/placeholder';
 import { trackStatsAnalyticsEvent } from 'calypso/my-sites/stats/utils';
 import { useSelector } from 'calypso/state';
+import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
+import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
 import { SUPPORT_URL, JETPACK_SUPPORT_URL_TRAFFIC } from '../../../const';
@@ -25,6 +27,7 @@ import {
 	STATS_FEATURE_LOCATION_CITY_VIEWS,
 } from '../../../constants';
 import Geochart from '../../../geochart';
+import StatsCardUpdateJetpackVersion from '../../../stats-card-upsell/stats-card-update-jetpack-version';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
 import StatsInfoArea from '../shared/stats-info-area';
 import CountryFilter from './country-filter';
@@ -98,14 +101,24 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 	const geoMode = GEO_MODES[ selectedOption ];
 	const title = optionLabels[ selectedOption ]?.selectLabel;
 
+	const { supportsLocationsStats: supportsLocationsStatsFeature } = useSelector( ( state ) =>
+		getEnvStatsFeatureSupportChecks( state, siteId )
+	);
+
 	// Main location data query
 	const {
-		data = [],
+		data: locationsViewsData = [],
 		isLoading: isRequestingData,
 		isError,
 	} = useLocationViewsQuery< StatsLocationViewsData >( siteId, geoMode, query, countryFilter, {
-		enabled: ! shouldGate,
+		enabled: ! shouldGate && supportsLocationsStatsFeature,
 	} );
+
+	const countriesViewsData = useSelector( ( state ) =>
+		getSiteStatsNormalizedData( state, siteId, statType, query )
+	) as [ id: number, label: string ];
+
+	const data = supportsLocationsStatsFeature ? locationsViewsData : countriesViewsData;
 
 	// Only fetch separate countries list if we're not already in country tab
 	// This is to avoid fetching the same data twice.
@@ -219,9 +232,13 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 		</StatsInfoArea>
 	);
 
-	const hasLocationData = Array.isArray( data ) && data.length > 0;
+	const showJetpackUpgradePrompt = geoMode !== 'country' && ! supportsLocationsStatsFeature;
 
-	const locationData = shouldGate ? sampleLocations : data;
+	const showUpsell = shouldGate || showJetpackUpgradePrompt;
+
+	const locationData = showUpsell ? sampleLocations : data;
+
+	const hasLocationData = Array.isArray( locationData ) && locationData.length > 0;
 
 	const heroElement = (
 		<>
@@ -237,6 +254,15 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 			) }
 		</>
 	);
+
+	let upsellOverlay = null;
+	if ( shouldGate ) {
+		upsellOverlay = (
+			<StatsCardUpsell siteId={ siteId } statType={ optionLabels[ selectedOption ].feature } />
+		);
+	} else if ( showJetpackUpgradePrompt ) {
+		upsellOverlay = <StatsCardUpdateJetpackVersion siteId={ siteId } statType="locations" />;
+	}
 
 	return (
 		<>
@@ -289,14 +315,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 								: undefined
 						}
 						onShowMoreClick={ onShowMoreClick }
-						overlay={
-							shouldGate && (
-								<StatsCardUpsell
-									siteId={ siteId }
-									statType={ optionLabels[ selectedOption ].feature }
-								/>
-							)
-						}
+						overlay={ upsellOverlay }
 					/>
 				</>
 			) }

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -114,11 +114,13 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 		enabled: ! shouldGate && supportsLocationsStatsFeature,
 	} );
 
-	const countriesViewsData = useSelector( ( state ) =>
+	// The legacy endpoint that only supports countries (not regions or cities)
+	// will be used when the new Locations Stats feature is not available.
+	const legacyCountriesViewsData = useSelector( ( state ) =>
 		getSiteStatsNormalizedData( state, siteId, statType, query )
 	) as [ id: number, label: string ];
 
-	const data = supportsLocationsStatsFeature ? locationsViewsData : countriesViewsData;
+	const data = supportsLocationsStatsFeature ? locationsViewsData : legacyCountriesViewsData;
 
 	// Only fetch separate countries list if we're not already in country tab
 	// This is to avoid fetching the same data twice.

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -128,7 +128,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 		query,
 		null,
 		{
-			enabled: ! shouldGate && geoMode !== 'country',
+			enabled: ! shouldGate && supportsLocationsStatsFeature && geoMode !== 'country',
 		}
 	);
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -202,7 +202,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		supportsPlanUsage,
 		supportsUTMStats: supportsUTMStatsFeature,
 		supportsDevicesStats: supportsDevicesStatsFeature,
-		supportsLocationsStats: supportsLocationsStatsFeature,
 		isOldJetpack,
 		supportUserFeedback,
 	} = useSelector( ( state ) => getEnvStatsFeatureSupportChecks( state, siteId ) );
@@ -253,7 +252,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	const shouldShowUpsells = isOdysseyStats && ! isAtomic;
 	const supportsUTMStats = supportsUTMStatsFeature || isInternal;
 	const supportsDevicesStats = supportsDevicesStatsFeature || isInternal;
-	const supportsLocationsStats = supportsLocationsStatsFeature || isInternal;
 	const getAvailableLegend = () => {
 		const activeTab = getActiveTab( chartTab );
 		// TODO: remove this when we support hourly visitors.
@@ -635,7 +633,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 								className={ halfWidthModuleClasses }
 							/>
 
-							{ config.isEnabled( 'stats/locations' ) && supportsLocationsStats ? (
+							{ config.isEnabled( 'stats/locations' ) ? (
 								<>
 									<StatsModuleLocations
 										moduleStrings={ moduleStrings.locations }

--- a/client/my-sites/stats/stats-card-upsell/stats-card-update-jetpack-version.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-update-jetpack-version.tsx
@@ -43,6 +43,7 @@ const StatsCardUpdateJetpackVersion: React.FC< Props > = ( { className, siteId, 
 					{ translate( 'Update Jetpack plugin' ) }
 				</Button>
 			}
+			icon="info-outline"
 		/>
 	);
 };

--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-overlay.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-overlay.tsx
@@ -9,6 +9,7 @@ interface Props {
 	onClick: ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => void;
 	buttonLabel?: string | TranslateResult;
 	buttonComponent?: React.ReactNode;
+	icon?: string;
 }
 
 const StatsCardUpsell: React.FC< Props > = ( {
@@ -17,6 +18,7 @@ const StatsCardUpsell: React.FC< Props > = ( {
 	copyText,
 	buttonLabel,
 	buttonComponent,
+	icon = 'lock',
 } ) => {
 	const translate = useTranslate();
 
@@ -24,7 +26,7 @@ const StatsCardUpsell: React.FC< Props > = ( {
 		<div className={ clsx( 'stats-card-upsell', className ) }>
 			<div className="stats-card-upsell__content">
 				<div className="stats-card-upsell__lock">
-					<Gridicon icon="lock" />
+					<Gridicon icon={ icon } />
 				</div>
 				<p className="stats-card-upsell__text">{ copyText }</p>
 				{ buttonComponent ? (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/jetpack-roadmap#2219.

## Proposed Changes

* Prompt users to update the Jetpack plugin when they select Regions/Cities in the Locations card.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* (p1HpG7-rpL-p2)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> This feature is meant for Odyssey/self-hosted users. Jurassic Ninja should work perfectly for this scenario, specially when used with the [Jetpack Beta Tester plugin](https://jetpack.com/download-jetpack-beta/).

- Navigate to `Jetpack > Stats` on your self-hosted site.
- Add `&flags=stats/locations` to the URL.
- Scroll down to the Locations section, the different scenarios below can be observed:

### Outdated (14.1) or recent (14.2) Jetpack plugin, no commercial license

![image](https://github.com/user-attachments/assets/a17842bc-8527-47a5-8b8d-433ad410f2ce)

### Outdated (14.1) Jetpack plugin, commercial license available

![image](https://github.com/user-attachments/assets/78ea43e6-ad6d-45d9-ab8a-c1061b75a87e)

### Recent (14.2) Jetpack plugin, commercial license available

![image](https://github.com/user-attachments/assets/9b6e2cb7-9225-4476-ae68-486b892f7b2f)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
