### PR TITLE
Storybook: Remove `@storybook/preset-scss`

### DIFF
--- a/packages/calypso-storybook/package.json
+++ b/packages/calypso-storybook/package.json
@@ -29,7 +29,6 @@
 		"@storybook/addon-actions": "^7.6.19",
 		"@storybook/addon-controls": "^7.6.19",
 		"@storybook/addon-docs": "^7.6.19",
-		"@storybook/preset-scss": "^1.0.3",
 		"@storybook/react-webpack5": "^7.6.19",
 		"css-loader": "^6.11.0",
 		"react": "^18.3.1",

--- a/packages/calypso-storybook/src/index.js
+++ b/packages/calypso-storybook/src/index.js
@@ -43,7 +43,6 @@ module.exports = function storybookDefaultConfig( {
 			'@storybook/addon-controls',
 			'@storybook/addon-docs',
 			'@storybook/addon-viewport',
-			'@storybook/preset-scss',
 		],
 		typescript: {
 			check: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -520,7 +520,6 @@ __metadata:
     "@storybook/addon-controls": "npm:^7.6.19"
     "@storybook/addon-docs": "npm:^7.6.19"
     "@storybook/addon-viewport": "npm:^7.6.19"
-    "@storybook/preset-scss": "npm:^1.0.3"
     "@storybook/react-webpack5": "npm:^7.6.19"
     css-loader: "npm:^6.11.0"
     react: "npm:^18.3.1"
@@ -7504,17 +7503,6 @@ __metadata:
     typescript:
       optional: true
   checksum: 195016181d078d2822a1670408538f866b1acd1ee005f5ced63c5581e12f12aef232f86d1748cad27a1669409d7046c9423cf00c39a8c59883bd4a880a15d75e
-  languageName: node
-  linkType: hard
-
-"@storybook/preset-scss@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "@storybook/preset-scss@npm:1.0.3"
-  peerDependencies:
-    css-loader: "*"
-    sass-loader: "*"
-    style-loader: "*"
-  checksum: 6df3a8edb0d9ff36ad20954355ebda979b5cf32f3e3c24fea995cf22edbff6efbf349f96cbd867b3afb39af069e7e15e347fa15b7caed34a8e06a9e8cfe7eb60
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed Changes

Removes an unnecessary addon from our Storybook config, which also cleans up this build warning.

```
WARN Could not resolve addon "@storybook/preset-scss", skipping. Is it installed?
```

## Why are these changes being made?

- `@storybook/preset-scss` is [deprecated](https://github.com/storybookjs/presets/tree/master/packages/preset-scss). The  plugin recommended to migrate to is also deprecated. These are old.
- The [source code](https://github.com/storybookjs/presets/blob/0182bfa78cee05124d662b57c7903d1d976aa9bb/packages/preset-scss/index.js#L32-L36) shows that the `preset-scss` plugin is basically doing what we already do:
    
    https://github.com/Automattic/wp-calypso/blob/a1abc2cf0cc591c6740c0b20da268815dc74e312/packages/calypso-storybook/src/index.js#L59-L66

## Testing Instructions

Smoke test the Storybook to see that styles aren't broken.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
