### PR TITLE
Fix Odyssey stats size limit

### DIFF
--- a/apps/odyssey-stats/.size-limit.js
+++ b/apps/odyssey-stats/.size-limit.js
@@ -3,7 +3,7 @@ const path = require( 'path' );
 module.exports = [
 	{
 		path: path.join( __dirname, 'dist/build.min.js' ),
-		limit: '420 KiB',
+		limit: '430 KiB',
 	},
 	{
 		path: path.join( __dirname, 'dist/widget-loader.min.js' ),


### PR DESCRIPTION
Odyssey stats was breaking the build because it caps the build size to 420KB and it's 421. This increases the cap.