### PR TITLE
Reader User Profile: Add fader behind Read More link

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -303,6 +303,10 @@ $z-layers: (
 	".tag-stream__header-follow": (
 		".follow-button": 1,
 	),
+	"user-profile-header": (
+		".user-profile-header__bio-desc-fader": 1,
+		".user-profile-header__bio-desc-link": 2,
+	),
 );
 
 // allows us to do a nested fetch

--- a/client/reader/user-profile/components/user-profile-header/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/index.tsx
@@ -78,10 +78,13 @@ const UserProfileHeader = ( { user }: UserProfileHeaderProps ): JSX.Element => {
 									{ user.bio }
 								</span>
 								{ isClamped && user.profile_URL && (
-									<a className="user-profile-header__bio-desc-link" href={ user.profile_URL }>
-										{ translate( 'Read More' ) }{ ' ' }
-										<Icon width={ 18 } height={ 18 } icon={ external } />
-									</a>
+									<>
+										<div className="user-profile-header__bio-desc-fader"></div>
+										<a className="user-profile-header__bio-desc-link" href={ user.profile_URL }>
+											{ translate( 'Read More' ) }{ ' ' }
+											<Icon width={ 18 } height={ 18 } icon={ external } />
+										</a>
+									</>
 								) }
 							</p>
 						</div>

--- a/client/reader/user-profile/components/user-profile-header/style.scss
+++ b/client/reader/user-profile/components/user-profile-header/style.scss
@@ -90,6 +90,7 @@
 
 		&__bio-desc {
 			margin: 0;
+			position: relative;
 
 			&-text {
 				-webkit-line-clamp: 3;
@@ -99,10 +100,24 @@
 				overflow: hidden;
 			}
 
+			&-fader {
+				position: absolute;
+				bottom: 0;
+				right: 0;
+				background: linear-gradient(to right, transparent 0%, #fff 25%);
+				width: 140px;
+				height: 20px;
+				z-index: 1000;
+			}
+
 			&-link {
+				position: absolute;
+				bottom: 0;
+				right: 0;
 				display: inline-flex;
 				gap: 4px;
 				align-items: center;
+				z-index: 2000;
 			}
 		}
 

--- a/client/reader/user-profile/components/user-profile-header/style.scss
+++ b/client/reader/user-profile/components/user-profile-header/style.scss
@@ -118,6 +118,8 @@
 				gap: 4px;
 				align-items: center;
 				z-index: 2000;
+				color: var(--color-text-subtle);
+				text-decoration: underline;
 			}
 		}
 

--- a/client/reader/user-profile/components/user-profile-header/style.scss
+++ b/client/reader/user-profile/components/user-profile-header/style.scss
@@ -107,7 +107,7 @@
 				background: linear-gradient(to right, transparent 0%, #fff 25%);
 				width: 140px;
 				height: 20px;
-				z-index: 1000;
+				z-index: z-index("user-profile-header", ".user-profile-header__bio-desc-fader");
 			}
 
 			&-link {
@@ -117,7 +117,7 @@
 				display: inline-flex;
 				gap: 4px;
 				align-items: center;
-				z-index: 2000;
+				z-index: z-index("user-profile-header", ".user-profile-header__bio-desc-link");
 				color: var(--color-text-subtle);
 				text-decoration: underline;
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99275, https://github.com/Automattic/wp-calypso/pull/99225

## Proposed Changes

This moves the Read More link so that it's on top of the profile description and adds a white linear gradient background to improve the styles.

### Before

<img width="1260" alt="Screenshot 2025-02-04 at 13 09 35" src="https://github.com/user-attachments/assets/0e93e7c4-d81a-43e4-a5fe-0ae5d80ce14c" />

### After

<img width="1258" alt="Screenshot 2025-02-04 at 13 09 08" src="https://github.com/user-attachments/assets/80c4fa2f-8232-4ac9-87eb-e6b692211458" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
It will occupy less vertical space and makes it so the Read More link is not orphaned on a separate line.

## Testing Instructions
- Visit the profile at `/read/users/robertbpugh`; ensure the View More link render with the gradient background

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
