### PR TITLE
Storage Add-Ons: remove feature flag and launch

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -203,7 +203,6 @@
 		"titan/iframe-control-panel": false,
 		"two-factor/enhanced-security": true,
 		"upgrades/redirect-payments": true,
-		"upgrades/storage-add-on-v2": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"untangling/hosting-menu": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -174,7 +174,6 @@
 		"themes/text-search-lots": true,
 		"two-factor/enhanced-security": true,
 		"upgrades/redirect-payments": true,
-		"upgrades/storage-add-on-v2": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"untangling/hosting-menu": false,

--- a/packages/data-stores/src/add-ons/add-ons-list.ts
+++ b/packages/data-stores/src/add-ons/add-ons-list.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	PRODUCT_WPCOM_CUSTOM_DESIGN,
 	PRODUCT_WPCOM_UNLIMITED_THEMES,
@@ -60,53 +59,47 @@ export const getAddOnsList = (): AddOnMeta[] => {
 				'Take your site to the next level. Store all your media in one place without worrying about running out of space.'
 			),
 		},
+		{
+			addOnSlug: ADD_ON_150GB_STORAGE,
+			productSlug: PRODUCT_1GB_SPACE,
+			featureSlugs: null,
+			icon: spaceUpgradeIcon,
+			quantity: 150,
+			name: i18n.translate( '%d GB Storage', { args: [ 150 ] } ),
+		},
+		{
+			addOnSlug: ADD_ON_200GB_STORAGE,
+			productSlug: PRODUCT_1GB_SPACE,
+			featureSlugs: null,
+			icon: spaceUpgradeIcon,
+			quantity: 200,
+			name: i18n.translate( '%d GB Storage', { args: [ 200 ] } ),
+		},
+		{
+			addOnSlug: ADD_ON_250GB_STORAGE,
+			productSlug: PRODUCT_1GB_SPACE,
+			featureSlugs: null,
+			icon: spaceUpgradeIcon,
+			quantity: 250,
+			name: i18n.translate( '%d GB Storage', { args: [ 250 ] } ),
+		},
+		{
+			addOnSlug: ADD_ON_300GB_STORAGE,
+			productSlug: PRODUCT_1GB_SPACE,
+			featureSlugs: null,
+			icon: spaceUpgradeIcon,
+			quantity: 300,
+			name: i18n.translate( '%d GB Storage', { args: [ 300 ] } ),
+		},
+		{
+			addOnSlug: ADD_ON_350GB_STORAGE,
+			productSlug: PRODUCT_1GB_SPACE,
+			featureSlugs: null,
+			icon: spaceUpgradeIcon,
+			quantity: 350,
+			name: i18n.translate( '%d GB Storage', { args: [ 350 ] } ),
+		},
 	];
-
-	if ( config.isEnabled( 'upgrades/storage-add-on-v2' ) ) {
-		return [
-			...defaultAddOns,
-			{
-				addOnSlug: ADD_ON_150GB_STORAGE,
-				productSlug: PRODUCT_1GB_SPACE,
-				featureSlugs: null,
-				icon: spaceUpgradeIcon,
-				quantity: 150,
-				name: i18n.translate( '%d GB Storage', { args: [ 150 ] } ),
-			},
-			{
-				addOnSlug: ADD_ON_200GB_STORAGE,
-				productSlug: PRODUCT_1GB_SPACE,
-				featureSlugs: null,
-				icon: spaceUpgradeIcon,
-				quantity: 200,
-				name: i18n.translate( '%d GB Storage', { args: [ 200 ] } ),
-			},
-			{
-				addOnSlug: ADD_ON_250GB_STORAGE,
-				productSlug: PRODUCT_1GB_SPACE,
-				featureSlugs: null,
-				icon: spaceUpgradeIcon,
-				quantity: 250,
-				name: i18n.translate( '%d GB Storage', { args: [ 250 ] } ),
-			},
-			{
-				addOnSlug: ADD_ON_300GB_STORAGE,
-				productSlug: PRODUCT_1GB_SPACE,
-				featureSlugs: null,
-				icon: spaceUpgradeIcon,
-				quantity: 300,
-				name: i18n.translate( '%d GB Storage', { args: [ 300 ] } ),
-			},
-			{
-				addOnSlug: ADD_ON_350GB_STORAGE,
-				productSlug: PRODUCT_1GB_SPACE,
-				featureSlugs: null,
-				icon: spaceUpgradeIcon,
-				quantity: 350,
-				name: i18n.translate( '%d GB Storage', { args: [ 350 ] } ),
-			},
-		];
-	}
 
 	return defaultAddOns;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/97233

## Proposed Changes

* This PR enables the storage add-on v2 in all environments.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Feature launch.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review only.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
