### PR TITLE
Plans Grid: update design for storage dropdown

### DIFF
--- a/packages/plans-grid-next/src/_shared.scss
+++ b/packages/plans-grid-next/src/_shared.scss
@@ -41,7 +41,6 @@ $mobile-card-max-width: 440px;
 	text-align: left;
 
 	.plans-grid-next-storage-dropdown__addon-offset-price {
-		color: var(--studio-green-50);
 		font-size: $font-body-extra-small;
 		font-weight: 500;
 	}
@@ -52,11 +51,13 @@ $mobile-card-max-width: 440px;
 	line-height: 20px;
 	min-height: 30px;
 	padding-top: 5px;
+	font-size: 0.75rem;
+	text-align: start;
 }
 
-.plans-grid-next-storage-dropdown__option-title {
+.plans-grid-next-storage-dropdown__option-title, .plans-grid-next-storage-dropdown__option .title {
 	color: var(--color-text);
-	font-weight: 500;
+	font-weight: 600;
 
 	.plans-grid-next-features-grid__mobile-plan-card & {
 		font-size: 0.875rem;

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -602,7 +602,6 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 						planSlug={ planSlug }
 						onStorageAddOnClick={ onStorageAddOnClick }
 						showUpgradeableStorage={ showUpgradeableStorage }
-						priceOnSeparateLine
 					/>
 				</>
 			) : (

--- a/packages/plans-grid-next/src/components/shared/storage/components/plan-storage.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/plan-storage.tsx
@@ -12,7 +12,6 @@ type Props = {
 	options?: {
 		isTableCell?: boolean;
 	};
-	priceOnSeparateLine?: boolean;
 };
 
 const PlanStorage = ( {
@@ -20,7 +19,6 @@ const PlanStorage = ( {
 	planSlug,
 	options,
 	showUpgradeableStorage,
-	priceOnSeparateLine,
 }: Props ) => {
 	const { siteId, gridPlansIndex } = usePlansGridContext();
 	const { availableForPurchase, current } = gridPlansIndex[ planSlug ];
@@ -42,11 +40,7 @@ const PlanStorage = ( {
 	return (
 		<div className="plans-grid-next-plan-storage">
 			{ canUpgradeStorageForPlan ? (
-				<StorageDropdown
-					planSlug={ planSlug }
-					onStorageAddOnClick={ onStorageAddOnClick }
-					priceOnSeparateLine={ priceOnSeparateLine }
-				/>
+				<StorageDropdown planSlug={ planSlug } onStorageAddOnClick={ onStorageAddOnClick } />
 			) : (
 				<StorageFeatureLabel planSlug={ planSlug } />
 			) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/3676

## Proposed Changes

* Updates the design for the storage dropdown on the plans grid.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* p58i-jlJ-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Onboarding Flow

* Go to `/setup/onboarding/plans`.
* Confirm that the storage dropdown renders correctly and matches the design (3De4YM0tRV3Qs691ui6QAW-fi-7997_5824)
<img width="1606" alt="image" src="https://github.com/user-attachments/assets/6fb87cef-996a-4b9d-b032-c9591deabb18" />

* Confirm that selecting an option correctly renders the price below the dropdown.
<img width="267" alt="image" src="https://github.com/user-attachments/assets/da324cb7-2a13-48f0-bcc2-5bc140f81433" />

### /plans Page

* Go to `/plans/<site slug>` for a site on the Business plan.
* Confirm that the storage dropdown renders correctly.
<img width="1291" alt="image" src="https://github.com/user-attachments/assets/369db201-bbe3-49c1-a0ba-60094779f0dd" />
* Confirm that the dropdown renders correctly in the plans grid:

<img width="1308" alt="image" src="https://github.com/user-attachments/assets/c43bd825-33b4-4f17-b779-9230bc772b3f" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?