### PR TITLE
Revert "Login form: use `TextControl` from `@wordpress/components` instead of local one"

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -4,7 +4,7 @@ import { Button, Card, FormInputValidation, FormLabel, Gridicon } from '@automat
 import { alert } from '@automattic/components/src/icons';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { suggestEmailCorrection } from '@automattic/onboarding';
-import { Spinner, TextControl } from '@wordpress/components';
+import { Spinner } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import cookie from 'cookie';
@@ -22,6 +22,7 @@ import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import Notice from 'calypso/components/notice';
 import { LastUsedSocialButton } from 'calypso/components/social-buttons';
+import TextControl from 'calypso/components/text-control';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import {
 	getSignupUrl,
@@ -490,8 +491,6 @@ export class LoginForm extends Component {
 									usernameOrEmail: value,
 								} );
 							} }
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
 						/>
 
 						{ requestError && requestError.field === 'usernameOrEmail' && (
@@ -516,8 +515,6 @@ export class LoginForm extends Component {
 										password: value,
 									} );
 								} }
-								__next40pxDefaultSize
-								__nextHasNoMarginBottom
 							/>
 
 							{ requestError && requestError.field === 'password' && (

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -364,11 +364,7 @@ $image-height: 47px;
 
 	.login form {
 
-		// We shouldn't regularly use .components-* classnames. The following is
-		// an exception to opt-out from some style overrides. Ideally, all
-		// input instances would come from `@wordpress/components` and the
-		// following overrides could be safely deleted.
-		input:not(.components-text-control__input),
+		input,
 		button {
 			/* Note: Same as `button.signup-form__submit, .signup-form__input.form-text-input` */
 			height: 44px;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#99188 which seems to trigger some test failures