### PR TITLE
Rollout site migration flow 2025 to all users. 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-migration-experiment/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-migration-experiment/index.ts
@@ -1,9 +1,0 @@
-import { useExperiment } from 'calypso/lib/explat';
-
-export function useMigrationExperiment( flowName: string ) {
-	const [ , experimentAssignment ] = useExperiment(
-		'calypso_signup_onboarding_site_migration_flow_202501_v1'
-	);
-
-	return 'treatment' === experimentAssignment?.variationName && 'site-migration' === flowName;
-}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/test/index.tsx
@@ -5,7 +5,6 @@ import { screen } from '@testing-library/react';
 import { ComponentProps } from 'react';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import SiteMigrationHowToMigrate from '../';
-import { useMigrationExperiment } from '../../../hooks/use-migration-experiment';
 import { defaultSiteDetails } from '../../launchpad/test/lib/fixtures';
 import { mockStepProps, renderStep, RenderStepOptions } from '../../test/helpers';
 
@@ -27,18 +26,7 @@ jest.mock( 'calypso/lib/presales-chat', () => ( {
 	usePresalesChat: () => {},
 } ) );
 
-jest.mock(
-	'calypso/landing/stepper/declarative-flow/internals/hooks/use-migration-experiment/index.ts',
-	() => ( {
-		useMigrationExperiment: jest.fn( ( flowName: string ) => flowName === 'site-migration' ),
-	} )
-);
-
 describe( 'SiteMigrationHowToMigrate', () => {
-	beforeEach( () => {
-		( useMigrationExperiment as jest.Mock ).mockReturnValue( true );
-	} );
-
 	afterEach( () => {
 		jest.resetAllMocks();
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -10,16 +10,11 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { GUIDED_ONBOARDING_FLOW_REFERRER } from 'calypso/signup/steps/initial-intent/constants';
-import { useMigrationExperiment } from '../../hooks/use-migration-experiment';
 import { useSitePreviewMShotImageHandler } from '../site-migration-instructions/site-preview/hooks/use-site-preview-mshot-image-handler';
 import type { Step } from '../../types';
 import type { UrlData } from 'calypso/blocks/import/types';
 
 import './style.scss';
-
-interface HostingDetailsProps {
-	items: { title: string; description: string }[];
-}
 
 interface HostingDetailsWithIconsProps {
 	items: {
@@ -54,28 +49,6 @@ const HostingDetailsWithIcons: FC< HostingDetailsWithIconsProps > = ( { items } 
 	);
 };
 
-const HostingDetails: FC< HostingDetailsProps > = ( { items } ) => {
-	const translate = useTranslate();
-
-	return (
-		<div className="import__site-identify-hosting-details">
-			<p className="import__site-identify-hosting-details--title">
-				{ translate( 'Why should you host with us?' ) }
-			</p>
-			<div className="import__site-identify-hosting-details--list">
-				{ items.map( ( item, index ) => (
-					<div key={ index } className="import__site-identify-hosting-details--list-item">
-						<p className="import__site-identify-hosting-details--list-item-title">{ item.title }</p>
-						<p className="import__site-identify-hosting-details--list-item-description">
-							{ item.description }
-						</p>
-					</div>
-				) ) }
-			</div>
-		</div>
-	);
-};
-
 interface Props {
 	hasError?: boolean;
 	onComplete: ( siteInfo: UrlData ) => void;
@@ -84,12 +57,7 @@ interface Props {
 	flowName: string;
 }
 
-export const Analyzer: FC< Props > = ( {
-	onComplete,
-	onSkip,
-	hideImporterListLink = false,
-	flowName,
-} ) => {
+export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLink = false } ) => {
 	const translate = useTranslate();
 	const [ siteURL, setSiteURL ] = useState< string >( '' );
 	const {
@@ -98,8 +66,6 @@ export const Analyzer: FC< Props > = ( {
 		isFetching,
 		isFetched,
 	} = useAnalyzeUrlQuery( siteURL, siteURL !== '' );
-
-	const isMigrationExperimentEnabled = useMigrationExperiment( flowName );
 
 	useEffect( () => {
 		if ( siteInfo ) {
@@ -111,49 +77,22 @@ export const Analyzer: FC< Props > = ( {
 		return <ScanningStep />;
 	}
 
-	let hostingDetailItems;
-
-	if ( isMigrationExperimentEnabled ) {
-		hostingDetailItems = {
-			'blazing-fast-speed': {
-				icon: next,
-				description: translate(
-					'Blazing fast speeds with lightning-fast load times for a seamless experience.'
-				),
-			},
-			'unmatched-uptime': {
-				icon: published,
-				description: translate(
-					'Unmatched reliability with 99.999% uptime and unmetered traffic.'
-				),
-			},
-			security: {
-				icon: shield,
-				description: translate( 'Round-the-clock security monitoring and DDoS protection.' ),
-			},
-		};
-	} else {
-		hostingDetailItems = {
-			'unmatched-uptime': {
-				title: translate( 'Unmatched Reliability and Uptime' ),
-				description: translate(
-					"Our infrastructure's 99.99% uptime, combined with our automatic update system, ensures your site remains accessible and secure."
-				),
-			},
-			'effortless-customization': {
-				title: translate( 'Effortless Customization' ),
-				description: translate(
-					'Our tools and options let you easily design a website to meet your needs, whether you’re a beginner or an expert.'
-				),
-			},
-			'blazing-fast-speed': {
-				title: translate( 'Blazing Fast Page Speed' ),
-				description: translate(
-					'Our global CDN with 28+ locations delivers lightning-fast load times for a seamless visitor experience.'
-				),
-			},
-		};
-	}
+	const hostingDetailItems = {
+		'blazing-fast-speed': {
+			icon: next,
+			description: translate(
+				'Blazing fast speeds with lightning-fast load times for a seamless experience.'
+			),
+		},
+		'unmatched-uptime': {
+			icon: published,
+			description: translate( 'Unmatched reliability with 99.999% uptime and unmetered traffic.' ),
+		},
+		security: {
+			icon: shield,
+			description: translate( 'Round-the-clock security monitoring and DDoS protection.' ),
+		},
+	};
 
 	return (
 		<div className="import__capture-wrapper">
@@ -181,11 +120,7 @@ export const Analyzer: FC< Props > = ( {
 					nextLabelText={ translate( 'Check my site' ) }
 				/>
 			</div>
-			{ isMigrationExperimentEnabled ? (
-				<HostingDetailsWithIcons items={ Object.values( hostingDetailItems ) } />
-			) : (
-				<HostingDetails items={ Object.values( hostingDetailItems ) } />
-			) }
+			<HostingDetailsWithIcons items={ Object.values( hostingDetailItems ) } />
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
@@ -165,11 +165,16 @@ describe( 'SiteMigrationIdentify', () => {
 		render( { navigation: { submit } } );
 
 		expect( screen.getByText( /Why should you host with us/ ) ).toBeVisible();
-		expect( screen.getByText( /Unmatched Reliability and Uptime/ ) ).toBeVisible();
 		expect(
 			screen.getByText(
-				/Our infrastructure's 99.99% uptime, combined with our automatic update system, ensures your site remains accessible and secure./
+				/Blazing fast speeds with lightning-fast load times for a seamless experience/
 			)
+		).toBeVisible();
+		expect(
+			screen.getByText( /Unmatched reliability with 99.999% uptime and unmetered traffic./ )
+		).toBeVisible();
+		expect(
+			screen.getByText( /Round-the-clock security monitoring and DDoS protection./ )
 		).toBeVisible();
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -12,12 +12,11 @@ import { useMigrationStickerMutation } from 'calypso/data/site-migration/use-mig
 import { useHostingProviderUrlDetails } from 'calypso/data/site-profiler/use-hosting-provider-url-details';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useMigrationExperiment } from '../../hooks/use-migration-experiment';
 import FlowCard from '../components/flow-card';
 import type { Step } from '../../types';
 import './style.scss';
 
-const SiteMigrationImportOrMigrate: Step = function ( { navigation, flow } ) {
+const SiteMigrationImportOrMigrate: Step = function ( { navigation } ) {
 	const translate = useTranslate();
 	const site = useSite();
 	const importSiteQueryParam = getQueryArg( window.location.href, 'from' )?.toString() || '';
@@ -25,22 +24,15 @@ const SiteMigrationImportOrMigrate: Step = function ( { navigation, flow } ) {
 	const { mutate: cancelMigration } = useMigrationCancellation( site?.ID );
 	const siteCanInstallPlugins = canInstallPlugins( site );
 	const isUpgradeRequired = ! siteCanInstallPlugins;
-	const isMigrationExperimentEnabled = useMigrationExperiment( flow );
 
 	const options = useMemo( () => {
-		const upgradeRequiredLabel = isMigrationExperimentEnabled
-			? translate( 'Available on %(planName)s with 50% off', {
-					args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-			  } )
-			: translate( 'Requires %(planName)s plan', {
-					args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-			  } );
+		const upgradeRequiredLabel = translate( 'Available on %(planName)s with 50% off', {
+			args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+		} );
 
-		const migrateOptionDescription = isMigrationExperimentEnabled
-			? translate(
-					"Best for WordPress sites. Seamlessly move all your site's content, themes, plugins, users, and customizations to WordPress.com."
-			  )
-			: translate( "All your site's content, themes, plugins, users and customizations." );
+		const migrateOptionDescription = translate(
+			"Best for WordPress sites. Seamlessly move all your site's content, themes, plugins, users, and customizations to WordPress.com."
+		);
 
 		return [
 			{
@@ -59,7 +51,7 @@ const SiteMigrationImportOrMigrate: Step = function ( { navigation, flow } ) {
 				value: 'import',
 			},
 		];
-	}, [ isMigrationExperimentEnabled, isUpgradeRequired, translate ] );
+	}, [ isUpgradeRequired, translate ] );
 
 	const { data: hostingProviderDetails } = useHostingProviderUrlDetails( importSiteQueryParam );
 	const hostingProviderName = hostingProviderDetails.name;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/test/index.tsx
@@ -90,21 +90,6 @@ describe( 'Site Migration Import or Migrate Step', () => {
 		expect( queryByText( /WP Engine/ ) ).toBeInTheDocument();
 	} );
 
-	it( "doesn't show the host identification message when the host is a8c", async () => {
-		useHostingProviderUrlDetails.mockReturnValue( {
-			data: {
-				name: 'WordPress.com',
-				is_unknown: false,
-				is_a8c: true,
-			},
-		} );
-
-		const { container, queryByText } = render();
-
-		expect( container.querySelectorAll( '.onboarding-subtitle' ) ).toHaveLength( 0 );
-		expect( queryByText( /WordPress.com/ ) ).not.toBeInTheDocument();
-	} );
-
 	it( "doesn't show the host identification message when the host is unknown", async () => {
 		useHostingProviderUrlDetails.mockReturnValue( {
 			data: {
@@ -140,7 +125,7 @@ describe( 'Site Migration Import or Migrate Step', () => {
 	it( 'shows the upgrade required badge when the site can not install plugins', () => {
 		render();
 
-		expect( screen.getByText( /Requires Business plan/ ) ).toBeInTheDocument();
+		expect( screen.getByText( /Available on Business with 50% off/ ) ).toBeInTheDocument();
 	} );
 
 	it( 'shows the included with your plan badge when the site can install plugins', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -15,6 +15,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useSelectedPlanUpgradeQuery } from 'calypso/data/import-flow/use-selected-plan-upgrade';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { MigrationAssistanceModal } from '../../components/migration-assistance-modal';
@@ -40,6 +41,7 @@ const SiteMigrationUpgradePlan: FC< Props > = ( {
 } ) => {
 	const showVariants = SITE_MIGRATION_FLOW === flow;
 	const { onSkip, skipLabelText, skipPosition } = props;
+	const siteItem = useSite();
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -6,7 +6,7 @@ import {
 	getPlanByPathSlug,
 } from '@automattic/calypso-products';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
-import { StepContainer } from '@automattic/onboarding';
+import { SITE_MIGRATION_FLOW, StepContainer } from '@automattic/onboarding';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { type FC } from 'react';
@@ -15,11 +15,9 @@ import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useSelectedPlanUpgradeQuery } from 'calypso/data/import-flow/use-selected-plan-upgrade';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
-import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { MigrationAssistanceModal } from '../../components/migration-assistance-modal';
-import { useMigrationExperiment } from '../../hooks/use-migration-experiment';
 import type { StepProps } from '../../types';
 import './style.scss';
 
@@ -40,9 +38,8 @@ const SiteMigrationUpgradePlan: FC< Props > = ( {
 	flow,
 	...props
 } ) => {
-	const showVariants = useMigrationExperiment( flow );
+	const showVariants = SITE_MIGRATION_FLOW === flow;
 	const { onSkip, skipLabelText, skipPosition } = props;
-	const siteItem = useSite();
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/test/index.tsx
@@ -8,6 +8,7 @@ import {
 	PlanSlug,
 } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
+import { MIGRATION_SIGNUP_FLOW } from '@automattic/onboarding';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
@@ -155,7 +156,7 @@ describe( 'SiteMigrationUpgradePlan', () => {
 
 	it( 'selects annual plan as default', async () => {
 		const navigation = { submit: jest.fn() };
-		render( { navigation } );
+		render( { navigation, flow: MIGRATION_SIGNUP_FLOW } );
 
 		await waitFor( async () => {
 			await userEvent.click( screen.getByRole( 'button', { name: /Upgrade and migrate/ } ) );
@@ -173,7 +174,7 @@ describe( 'SiteMigrationUpgradePlan', () => {
 		mockUseSelectedPlanUpgradeQuery( 'business-monthly' );
 
 		const navigation = { submit: jest.fn() };
-		render( { navigation } );
+		render( { navigation, flow: MIGRATION_SIGNUP_FLOW } );
 
 		await waitFor( async () => {
 			await userEvent.click( screen.getByRole( 'button', { name: /Pay monthly/ } ) );
@@ -189,7 +190,7 @@ describe( 'SiteMigrationUpgradePlan', () => {
 
 	it( 'selects annual plan', async () => {
 		const navigation = { submit: jest.fn() };
-		render( { navigation } );
+		render( { navigation, flow: MIGRATION_SIGNUP_FLOW } );
 
 		await waitFor( async () => {
 			await userEvent.click( screen.getByRole( 'button', { name: /Pay annually/ } ) );
@@ -207,7 +208,7 @@ describe( 'SiteMigrationUpgradePlan', () => {
 		mockTrialEligibilityAPI( API_RESPONSE_EMAIL_VERIFIED );
 
 		const navigation = { submit: jest.fn() };
-		render( { navigation } );
+		render( { navigation, flow: MIGRATION_SIGNUP_FLOW } );
 
 		await waitFor( async () => {
 			await userEvent.click( screen.getByRole( 'button', { name: /Try 7 days for free/ } ) );
@@ -224,7 +225,10 @@ describe( 'SiteMigrationUpgradePlan', () => {
 		nock.cleanAll();
 		mockTrialEligibilityAPI( API_RESPONSE_EMAIL_VERIFIED );
 
-		render( { data: { hideFreeMigrationTrialForNonVerifiedEmail: true } } );
+		render( {
+			data: { hideFreeMigrationTrialForNonVerifiedEmail: true },
+			flow: MIGRATION_SIGNUP_FLOW,
+		} );
 
 		await waitFor( () => {
 			expect( screen.queryByRole( 'button', { name: /Try 7 days for free/ } ) ).toBeInTheDocument();


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/10397

## Proposed Changes
Rollout site migration flow 2025 to all users, which introduced those UX improvements (ay0fZYgdXxPDbZbgPlz3hu-fi-1_70) on 4 steps of the migration flow.

Based on that discussion p1738708918671189-slack-C0Q664T29, we are cleaning up the old steps, except for `SITE_MIGRATION_UPGRADE_PLAN` which are still used by migration signup flow.

## Testing Instructions

### Testing hosted migration flow

Execute a regular migration from begin until the checkout step. Don't need to complete it.
Check that the steps introduced by this design (ay0fZYgdXxPDbZbgPlz3hu-fi-1_70) are applied.

####  SITE_MIGRATION_IDENTIFY
![image](https://github.com/user-attachments/assets/45e8523a-56c5-44d9-869b-142c73f6db24)
#### SITE_MIGRATION_IMPORT_OR_MIGRATE
![image](https://github.com/user-attachments/assets/cf5448b8-f65d-48fb-9b1c-516ee4badab4)
#### SITE_MIGRATION_HOW_TO_MIGRATE
![image](https://github.com/user-attachments/assets/d43423e2-1c11-4aef-94a4-904e31fb4a3a)
#### SITE_MIGRATION_UPGRADE_PLAN
![image](https://github.com/user-attachments/assets/c3b4e5eb-c0c4-49dc-8d17-38f1240079b3)

### Testing migration signup flow
Start the flow from http://calypso.localhost:3000/setup/migration-signup
The firs step `SITE_MIGRATION_IDENTIFY` should look as the new design.
But the `SITE_MIGRATION_UPGRADE_PLAN` should look like the **old design**.
![image](https://github.com/user-attachments/assets/456083eb-e94a-4236-8214-d051159e0548)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?