### PR TITLE
Stats Locations: Add tracking for Locations' module interactions

### DIFF
--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -1,4 +1,3 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { SimplifiedSegmentedControl, StatsCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -14,6 +13,7 @@ import { QueryStatsParams } from 'calypso/my-sites/stats/hooks/utils';
 import StatsCardUpsell from 'calypso/my-sites/stats/stats-card-upsell';
 import StatsListCard from 'calypso/my-sites/stats/stats-list/stats-list-card';
 import StatsModulePlaceholder from 'calypso/my-sites/stats/stats-module/placeholder';
+import { trackStatsAnalyticsEvent } from 'calypso/my-sites/stats/utils';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
@@ -125,13 +125,17 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 
 	const changeViewButton = ( selection: SelectOptionType ) => {
 		const filter = selection.value;
-
-		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-		recordTracksEvent( `${ event_from }_locations_module_menu_clicked`, {
-			button: optionLabels[ filter ]?.analyticsId ?? filter,
+		trackStatsAnalyticsEvent( 'stats_locations_module_menu_clicked', {
+			stat_type: optionLabels[ filter ].feature,
 		} );
 
 		setSelectedOption( filter );
+	};
+
+	const onShowMoreClick = () => {
+		trackStatsAnalyticsEvent( 'stats_locations_module_show_more_clicked', {
+			stat_type: optionLabels[ selectedOption ].feature,
+		} );
 	};
 
 	const toggleControlComponent = (
@@ -279,6 +283,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 								  }
 								: undefined
 						}
+						onShowMoreClick={ onShowMoreClick }
 						overlay={
 							shouldGate && (
 								<StatsCardUpsell

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -67,10 +67,6 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 
 	const [ countryFilter, setCountryFilter ] = useState< string | null >( null );
 
-	const onCountryChange = ( value: string ) => {
-		setCountryFilter( value );
-	};
-
 	const optionLabels = {
 		[ OPTION_KEYS.COUNTRIES ]: {
 			selectLabel: translate( 'Countries' ),
@@ -122,6 +118,15 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 			enabled: ! shouldGate && geoMode !== 'country',
 		}
 	);
+
+	const onCountryChange = ( value: string ) => {
+		trackStatsAnalyticsEvent( 'stats_locations_module_country_filter_changed', {
+			stat_type: optionLabels[ selectedOption ].feature,
+			country: value,
+		} );
+
+		setCountryFilter( value );
+	};
 
 	const changeViewButton = ( selection: SelectOptionType ) => {
 		const filter = selection.value;

--- a/client/my-sites/stats/stats-list/stats-list-card.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-card.jsx
@@ -41,6 +41,7 @@ const StatsListCard = ( {
 	overlay, // an overlay used to hide the module behind a blur overlay
 	hasNoBackground,
 	formatValue,
+	onShowMoreClick,
 } ) => {
 	const moduleNameTitle = titlecase( moduleType );
 	const debug = debugFactory( `calypso:stats:list:${ moduleType }` );
@@ -132,6 +133,7 @@ const StatsListCard = ( {
 					? {
 							url: showMore?.url,
 							label: showMore?.label,
+							onClick: onShowMoreClick || undefined,
 					  }
 					: undefined
 			}

--- a/client/my-sites/stats/stats-module/all-time-nav.jsx
+++ b/client/my-sites/stats/stats-module/all-time-nav.jsx
@@ -19,7 +19,7 @@ import {
 } from '../constants';
 import { shouldGateStats } from '../hooks/use-should-gate-stats';
 import DatePicker from '../stats-date-picker';
-
+import { trackStatsAnalyticsEvent } from '../utils';
 import './summary-nav.scss';
 
 export const StatsModuleSummaryLinks = ( props ) => {
@@ -55,6 +55,10 @@ export const StatsModuleSummaryLinks = ( props ) => {
 
 	const recordStats = ( item ) => {
 		props.recordGoogleEvent( 'Stats', `Clicked Summary Link: ${ path } ${ item.stat }` );
+		trackStatsAnalyticsEvent( 'stats_summary_nav_period_clicked', {
+			path,
+			stat_type: item.statType,
+		} );
 	};
 
 	const handleClick = ( item ) => ( event ) => {

--- a/packages/components/src/horizontal-bar-list/stats-hero-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-hero-card.tsx
@@ -96,6 +96,7 @@ const StatsHeroCard = ( {
 									comment: '"View all posts & pages", "View all referrers", etc.',
 								} ) as string
 							}
+							onClick={ footerAction?.onClick }
 						>
 							{ footerAction.label || translate( 'View all' ) }
 						</a>

--- a/packages/components/src/horizontal-bar-list/types.ts
+++ b/packages/components/src/horizontal-bar-list/types.ts
@@ -79,6 +79,7 @@ export type StatsCardProps = {
 	footerAction?: {
 		label?: string;
 		url?: string;
+		onClick?: ( event?: React.MouseEvent | React.KeyboardEvent ) => void;
 	};
 	/**
 	 * @property {boolean} isEmpty - renders an empty card with a message (`emptyMessage`) when true. It doesn't render column labels.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-roadmap/issues/2098

## Proposed Changes
* Add an optional `onClick` handler for footer actions in stats cards
* Add tracking for Locations module interactions
* Add tracking for summary navigation period clicks

## Tracks Events
> [!NOTE]
> If it is triggered in Calypso, it will have the `calypso_` prefix; otherwise, it will have the `jetpack_odyssey_` prefix.

* **stats_locations_module_menu_clicked**
  * **Description:** Tracks when the user clicks on the Locations module tabs
  * **Props:**
    * **stat_type:** The feature associated with the item clicked (e.g., `StatsModuleLocations/country`)

  ![CleanShot 2025-02-04 at 22 37 08@2x](https://github.com/user-attachments/assets/f3ecb2cd-a2fd-461e-be4d-c17e551f90ce)

* **stats_locations_module_show_more_clicked**
  * **Description:** Tracks when the user clicks on `View all` / `View details` in the Locations module
  * **Props:** 
    * **stat_type:** The feature associated with the item clicked (e.g., `StatsModuleLocations/region`)

  ![CleanShot 2025-02-04 at 22 38 22@2x](https://github.com/user-attachments/assets/d6ac77df-b984-4fac-82e5-3580ed6a29cb)

* **stats_locations_module_country_filter_changed**
  * **Description:** Tracks when the user filters visitors by country in the Locations module
  * **Props:** 
    * **stat_type:** The feature associated with the item clicked (e.g., `StatsModuleLocations/city`)
    * **country:** ISO 3166-1 country code (e.g., `US`, `PA`, `GB`)

  ![CleanShot 2025-02-04 at 22 39 13@2x](https://github.com/user-attachments/assets/6463d38e-7cdf-4f97-815a-0e6e57b5ec64)

* **stats_summary_nav_period_clicked**
  * **Description:** Tracks when the user clicks on a period in the Summary page
  * **Props:** 
    * **path:** The path of the module the user is viewing, associated with the item clicked (e.g., `locations`, `referrers`)
    * **stat_type:** The feature associated with the item clicked (e.g., `StatsModuleSummaryLinks/30_days`)

  ![CleanShot 2025-02-04 at 22 39 37@2x](https://github.com/user-attachments/assets/b6425d83-33f5-4f36-b9b0-967e2fe2b2ca)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want to collect some metrics on feature usage.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]  
> For brevity in describing the test steps, when we say "validate that event X was triggered," it means you should see a request to `t.gif` with the described event name.  
>  
> You can also use this extension to make it easier: p7H4VZ-4cf-p2.  

* Spin up the Calypso Live Branch or test it on Odyssey using option 2: PCYsg-Pp7-p2.  
* Open the **Network** tab in your developer tools.  
* Navigate to the **Stats** page.  
* In the **Locations** module, click on `Cities`.  
  * Validate that the event `*_stats_locations_module_menu_clicked` was triggered, passing the `stat_type` prop with the value `StatsModuleLocations/city`.  
* Click on `View all` or `View details`.  
  * Validate that the event `*_stats_locations_module_show_more_clicked` was triggered, passing the `stat_type` prop with the value `StatsModuleLocations/city`.  
* It should navigate to the **Locations module's summary page**.  
* On the summary page, click on the `City` tab.  
* Use the dropdown to filter by a country, for example, **United States**.  
  * Validate that the event `stats_locations_module_country_filter_changed` was triggered, passing the `stat_type` prop with the value `StatsModuleLocations/city` and the `country` prop with the value `US`.  
* Change the date period using the tabs at the top of the page. Click on `Quarter`.  
  * Validate that the event `*_stats_summary_nav_period_clicked` was triggered, passing the `path` prop with the value `locations` and the `stat_type` prop with the value `StatsModuleSummaryLinks/quarter`.
* You can also try triggering the previous event by clicking on the period tabs on other modules' summary pages, for example, in the Referrers module (`/stats/day/referrers/{site_slug}`).

Given that we added an `onClick` handler for footer actions in stats cards, it would be good to validate that clicking on `View all` in other modules doesn’t throw any errors and correctly redirects you to the right page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?