### PR TITLE
GMClosureNotice: Move to `help-center` package and rename

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,7 +1,13 @@
 ## Next
 
+### Breaking changes
+
+- Remove unused corporate logos ([#99229](https://github.com/Automattic/wp-calypso/pull/99229)).
+- Remove GMClosureNotice ([#99309](https://github.com/Automattic/wp-calypso/pull/99309)).
+
+### Enhancements
+
 - Add FlowQuestion component
-- Remove unused corporate logos (#99229)
 
 ## 2.1.1
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -30,7 +30,6 @@ export { default as PaginationControl } from './pagination-control';
 export { Gravatar } from './gravatar';
 export { Spinner } from './spinner';
 export { SpinnerExample } from './spinner/example';
-export { GMClosureNotice } from './gm-closure-notice/gm-closure-notice';
 export { default as WordPressWordmark } from './wordpress-wordmark';
 export { default as MaterialIcon } from './material-icon';
 export { ListTile } from './list-tile';

--- a/packages/help-center/src/components/help-center-closure-notice.scss
+++ b/packages/help-center/src/components/help-center-closure-notice.scss
@@ -1,6 +1,6 @@
 @import "@automattic/typography/styles/variables";
 
-.a8c-components__gm-closure-notice {
+.help-center-closure-notice {
 	margin-bottom: 1em;
 
 	.components-panel__row {

--- a/packages/help-center/src/components/help-center-closure-notice.tsx
+++ b/packages/help-center/src/components/help-center-closure-notice.tsx
@@ -2,7 +2,7 @@ import { Panel, PanelBody, PanelRow } from '@wordpress/components';
 import { format } from '@wordpress/date';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import './gm-closure-notice.scss';
+import './help-center-closure-notice.scss';
 
 const DATE_FORMAT_SHORT = 'F d';
 const DATE_FORMAT_LONG = 'l, F jS h:i A';
@@ -19,7 +19,7 @@ function inBetween( start: Date, end: Date ) {
 	return date >= start && date <= end;
 }
 
-export function GMClosureNotice( { displayAt, closesAt, reopensAt, enabled }: Props ) {
+export function HelpCenterClosureNotice( { displayAt, closesAt, reopensAt, enabled }: Props ) {
 	const { __ } = useI18n();
 
 	if ( ! enabled ) {
@@ -74,7 +74,7 @@ export function GMClosureNotice( { displayAt, closesAt, reopensAt, enabled }: Pr
 	);
 
 	return (
-		<Panel className="a8c-components__gm-closure-notice">
+		<Panel className="help-center-closure-notice">
 			<PanelBody initialOpen={ period === 'during' } title={ heading }>
 				<PanelRow>{ MAIN_MESSAGES[ period ] }</PanelRow>
 			</PanelBody>

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -4,7 +4,7 @@
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { getPlan } from '@automattic/calypso-products';
-import { Spinner, GMClosureNotice } from '@automattic/components';
+import { Spinner } from '@automattic/components';
 import { HelpCenterSite } from '@automattic/data-stores';
 import { getLanguage, useIsEnglishLocale, useLocale } from '@automattic/i18n-utils';
 import { useGetSupportInteractions } from '@automattic/odie-client/src/data';
@@ -24,6 +24,7 @@ import { EMAIL_SUPPORT_LOCALES } from '../constants';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useChatStatus, useShouldRenderEmailOption, useStillNeedHelpURL } from '../hooks';
 import { Mail } from '../icons';
+import { HelpCenterClosureNotice } from './help-center-closure-notice';
 import HelpCenterContactSupportOption from './help-center-contact-support-option';
 import { HelpCenterActiveTicketNotice } from './help-center-notice';
 import { generateContactOnClickEvent } from './utils';
@@ -155,7 +156,7 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 					<h3>{ __( 'Contact our WordPress.com experts', __i18n_text_domain__ ) }</h3>
 				) }
 				{ supportActivity && <HelpCenterActiveTicketNotice tickets={ supportActivity } /> }
-				<GMClosureNotice
+				<HelpCenterClosureNotice
 					displayAt="2023-12-26 00:00Z"
 					closesAt="2023-12-31 00:00Z"
 					reopensAt="2024-01-02 07:00Z"


### PR DESCRIPTION
## Proposed Changes

Moves the `GMClosureNotice` to the `help-center` package, where it is the only place used (including all A8C repos on GitHub).

Also renames the component to `HelpCenterClosureNotice`, since it isn't exclusively used for GM (Grand Meetup) closures anymore.

## Why are these changes being made?

- To reduce maintenance cost of the `@automattic/components` package by removing components that are not for company-wide reuse.
- To remove as many `@wordpress/components` dependencies from the `@automattic/components` package as possible, as this will complicate things when a single view ends up with more than one version of `@wordpress/components` (CSS collisions, etc).

## Testing Instructions

I couldn't figure out whether the affected component can be seen organically in the app, so here is an approximation:

First, apply this diff:

```diff
diff --git a/packages/help-center/src/components/help-center-chat.tsx b/packages/help-center/src/components/help-center-chat.tsx
index 3840e6a5d6..d946e16c52 100644
--- a/packages/help-center/src/components/help-center-chat.tsx
+++ b/packages/help-center/src/components/help-center-chat.tsx
@@ -8,6 +8,7 @@ import { useEffect } from '@wordpress/element';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useShouldUseWapuu } from '../hooks';
+import { HelpCenterContactPage } from './help-center-contact-page';
 import { ExtraContactOptions } from './help-center-extra-contact-option';
 
 /**
@@ -52,6 +53,7 @@ export function HelpCenterChat( {
 				<ExtraContactOptions isUserEligible={ isUserEligibleForPaidSupport } />
 			}
 		>
+			<HelpCenterContactPage isUserEligible={ isUserEligibleForPaidSupport } />
 			<div className="help-center__container-chat">
 				<OdieAssistant />
 			</div>
diff --git a/packages/help-center/src/components/help-center-contact-page.tsx b/packages/help-center/src/components/help-center-contact-page.tsx
index e5c29b89de..23991431c6 100644
--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -158,8 +158,8 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 				{ supportActivity && <HelpCenterActiveTicketNotice tickets={ supportActivity } /> }
 				<HelpCenterClosureNotice
 					displayAt="2023-12-26 00:00Z"
-					closesAt="2023-12-31 00:00Z"
-					reopensAt="2024-01-02 07:00Z"
+					closesAt="2025-12-31 00:00Z"
+					reopensAt="2026-01-02 07:00Z"
 					enabled={ ! renderEmail.render }
 				/>
 				{ renderEmail.render
```

I believe this is [close enough](https://github.com/Automattic/wp-calypso/pull/93212) to where it was (would be?) shown.

1. Make sure your test user is eligible for paid support.
1. Run `SECTION_LIMIT=help yarn start` and go to `/help`.
1. Scroll down to "Contact Us" and click the "Get help" button.

<img width="433" alt="Help center closure notice" src="https://github.com/user-attachments/assets/df98c898-7b7d-4301-859b-5d69f85b6524" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
