### PR TITLE
Add (standard) focus styles to all “Select” buttons on domain picker

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -254,11 +254,6 @@
 	margin-top: 10px;
 	margin-left: 0;
 
-	&:focus {
-		box-shadow: none !important;
-		border-color: #c3c4c7 !important;
-	}
-
 	@media (min-width: 660px) {
 		width: auto;
 		flex: 1 0 auto;
@@ -280,11 +275,6 @@
 		padding: 0;
 		display: flex;
 		align-items: center;
-
-		&:focus {
-			box-shadow: none !important;
-			border-color: transparent !important;
-		}
 
 		/* Checkmark for selected domains */
 		svg {
@@ -512,11 +502,6 @@ body.is-section-signup.is-white-signup {
 				@include break-mobile {
 					padding: 0.65em 2.8em;
 					width: 100%;
-				}
-
-				&:focus {
-					border-color: var(--color-primary);
-					box-shadow: 0 0 0 2px var(--color-primary-light);
 				}
 			}
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -495,7 +495,6 @@ body.is-section-signup.is-white-signup {
 				line-height: 20px;
 				padding: 0.57em 1.17em;
 				border-radius: 4px;
-				border: 1px solid #c3c4c7;
 				letter-spacing: 0.32px;
 				font-size: 0.875rem;
 

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -273,15 +273,8 @@ body.is-section-signup.is-white-signup {
 			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			line-height: 1.25rem;
 
-			box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-
 			@include break-mobile {
 				padding: 0.65em 2.8em;
-			}
-
-			&:focus {
-				border-color: var(--color-primary);
-				box-shadow: 0 0 0 2px var(--color-primary-light);
 			}
 		}
 	}

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -454,10 +454,6 @@ body.is-section-signup.is-white-signup {
 			transform: scaleX(-1);
 		}
 
-		.search-component__icon-navigation.components-button:focus:not(:disabled) {
-			box-shadow: 0 0 0 1px var(--color-primary);
-		}
-
 		.search-component__icon-search {
 			fill: #a7aaad;
 			margin: 8px 6px 8px 8px;
@@ -484,8 +480,7 @@ body.is-section-signup.is-white-signup {
 		}
 
 		.button {
-			&:hover,
-			&:focus {
+			&:hover {
 				box-shadow: none;
 			}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/10405

## Proposed Changes

* Remove custom focus styles from domain selector elements to allow base focus styles to appear

Once these custom styles have been removed we can move onto updating the base styles across the app in https://github.com/Automattic/dotcom-forge/issues/10406

Note that the focus rings use `--color-primary: var(--studio-blue-50);` which is still the old WordPress blue, until https://github.com/Automattic/wp-calypso/pull/99033 lands and updates it to the modern WordPress blue (Blueberry).

![calypso localhost_3000_setup_onboarding_domains(Desktop) (1)](https://github.com/user-attachments/assets/8c028b2a-7ec9-419b-84e9-d56d0d145d1e)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It's important for interactive elements to have focus styles for accessibility reasons.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to http://calypso.localhost:3000/setup/onboarding/domains
* Enter a search term and wait for the list of options to be populated
* Use the tab key to move through the page focusing the interactive 'Select' button elements
* Observe that all buttons in the page have matching visible focus styles

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
