### PR TITLE
Stats: adds chart library feature flag

### DIFF
--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -75,6 +75,7 @@ export default function SubscribersChartSection( {
 	period?: PeriodType;
 } ) {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	const isChartLibraryEnabled = config.isEnabled( 'stats/chart-library' );
 	const quantityDefault: QuantityDefaultType = {
 		day: 30,
 		week: 12,
@@ -163,6 +164,7 @@ export default function SubscribersChartSection( {
 					</div>
 				</div>
 			</div>
+			{ isChartLibraryEnabled && <div>chart library is enabled</div> }
 			{ isChartLoading && <StatsModulePlaceholder className="is-chart" isLoading /> }
 			{ ! isChartLoading && chartData.length === 0 && (
 				<p className="subscribers-section__no-data">

--- a/config/client.json
+++ b/config/client.json
@@ -21,6 +21,7 @@
 	"readerFollowingSource",
 	"siftscience_key",
 	"signup_url",
+	"stats/chart-library",
 	"stats/empty-module-traffic",
 	"stats/empty-module-v2",
 	"stats/real-time-tab",

--- a/config/development.json
+++ b/config/development.json
@@ -187,6 +187,7 @@
 		"sites/dashboard-survey": true,
 		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": false,
+		"stats/chart-library": false,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"stats/locations": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -122,6 +122,7 @@
 		"sites/dashboard-survey": true,
 		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": true,
+		"stats/chart-library": false,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,

--- a/config/production.json
+++ b/config/production.json
@@ -157,6 +157,7 @@
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
+		"stats/chart-library": false,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -152,6 +152,7 @@
 		"sites/dashboard-survey": true,
 		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": true,
+		"stats/chart-library": false,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"stats/locations": true,

--- a/config/test.json
+++ b/config/test.json
@@ -115,6 +115,7 @@
 		"sites/dashboard-survey": true,
 		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": true,
+		"stats/chart-library": false,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"subscribers-dataviews": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -159,6 +159,7 @@
 		"sites/dashboard-survey": true,
 		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": true,
+		"stats/chart-library": false,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"stats/locations": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR adds a feature flag for the upcoming changes to replacing the charts with the new chart library

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso live branch
* Navigate to `/stats/subscribers/{URL}i?flags=stats/chart-library`
* Check everything appears as normal
* Append feature flag `flags=stats/chart-library`
* Check you can now see the small `chart library is enabled` notice

![image](https://github.com/user-attachments/assets/6bd6e4f5-e738-48f2-bc2a-381e64ac3d09)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
