### PR TITLE
Purchase Settings: Update manage-purchase__header styles for better wrapping

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1300,7 +1300,7 @@ class ManagePurchase extends Component<
 				<Card className={ classes }>
 					<header className="manage-purchase__header">
 						{ this.renderPurchaseIcon() }
-						<div>
+						<div className="manage-purchase__header-content">
 							<h2 className="manage-purchase__title">{ this.getProductDisplayName() }</h2>
 							<div className="manage-purchase__description">
 								{ isHundredYearDomain
@@ -1331,6 +1331,13 @@ class ManagePurchase extends Component<
 								) }
 							</div>
 						</div>
+						{ isProductOwner && ! purchase.isLocked && (
+							<div className="manage-purchase__renew-upgrade-buttons">
+								{ preventRenewal && this.renderSelectNewButton() }
+								{ this.renderUpgradeButton( preventRenewal ) }
+								{ ! preventRenewal && this.renderRenewButton() }
+							</div>
+						) }
 					</header>
 					{ this.renderPurchaseDescription() }
 					{ ! isPartnerPurchase( purchase ) && (
@@ -1343,13 +1350,6 @@ class ManagePurchase extends Component<
 								getChangePaymentMethodUrlFor ?? getChangePaymentMethodPath
 							}
 						/>
-					) }
-					{ isProductOwner && ! purchase.isLocked && (
-						<div className="manage-purchase__renew-upgrade-buttons">
-							{ preventRenewal && this.renderSelectNewButton() }
-							{ this.renderUpgradeButton( preventRenewal ) }
-							{ ! preventRenewal && this.renderRenewButton() }
-						</div>
 					) }
 				</Card>
 				{ ! isPartnerPurchase( purchase ) && (

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -399,16 +399,23 @@
 
 .manage-purchase__renew-upgrade-buttons {
 	display: flex; /* Ensures button expands */
+	flex-direction: column;
 	flex-shrink: 0;
+	gap: .75rem;
+
+	> button {
+		flex-grow: 1; /* Ensures button expands based on its text */
+		white-space: nowrap;
+	}
+
+	@include breakpoint-deprecated( ">480px" ) {
+		margin-inline-end: auto;
+		flex-direction: row;
+	}
 
 	@include breakpoint-deprecated( ">660px" ) {
         align-self: flex-start;
         margin-inline-start: auto;
-
-		> button {
-			flex-grow: 1; /* Ensures button expands based on its text */
-			white-space: nowrap;
-		}
 	}
 }
 

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -128,6 +128,8 @@
 
 	@include breakpoint-deprecated( "<660px" ) {
 		padding: 16px;
+		overflow-wrap: break-word;
+		flex-direction: column;
 	}
 }
 
@@ -372,7 +374,7 @@
 }
 
 .manage-purchase__renewal-text {
-	display: inline-block;		
+	display: inline-block;
 }
 
 .manage-purchase__detail .user__name {

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -125,10 +125,11 @@
 .manage-purchase__header,
 .manage-purchase__content {
 	padding: 16px 24px;
+	word-wrap: break-word;
+	overflow-wrap: break-word;
 
 	@include breakpoint-deprecated( "<660px" ) {
 		padding: 16px;
-		overflow-wrap: break-word;
 		flex-direction: column;
 	}
 }
@@ -138,9 +139,14 @@
 }
 
 .manage-purchase__header {
-	overflow: auto;
 	border-bottom: 2px solid var(--color-accent);
 	display: flex;
+	gap: .75rem;
+
+	&-content {
+		flex: 1 1 auto;
+		min-width: 0;
+	}
 
 	.is-personal & {
 		border-bottom: 2px solid var(--color-plan-personal);
@@ -160,10 +166,8 @@
 }
 
 .manage-purchase__plan-icon {
-	margin: 0 12px 0 0;
 	max-width: 56px;
 	width: 56px;
-	float: left;
 
 	.gridicon {
 		box-sizing: border-box;
@@ -202,7 +206,6 @@
 
 	@include breakpoint-deprecated( ">660px" ) {
 		font-size: $font-title-small;
-		padding-right: 100px;
 	}
 }
 
@@ -395,21 +398,16 @@
 }
 
 .manage-purchase__renew-upgrade-buttons {
-	display: none;
+	display: flex; /* Ensures button expands */
+	flex-shrink: 0;
 
 	@include breakpoint-deprecated( ">660px" ) {
-		display: initial;
-		position: absolute;
-		right: 24px;
-		top: 16px;
+        align-self: flex-start;
+        margin-inline-start: auto;
 
-		> a,
 		> button {
-			margin-inline-end: 8px;
-
-			&:last-child {
-				margin-inline-end: initial;
-			}
+			flex-grow: 1; /* Ensures button expands based on its text */
+			white-space: nowrap;
 		}
 	}
 }


### PR DESCRIPTION
The _Purchase Settings_ section doesn't handle text wrapping correctly in both the header and content components:

| 320px | 425px | 870px |
| ----- | ----- | ----- |
| <img width="321" alt="image" src="https://github.com/user-attachments/assets/2a09a7b3-f4ac-4028-a892-6617f8dcdb0e" /> | <img width="423" alt="image" src="https://github.com/user-attachments/assets/6626207c-e7bf-449c-be51-46c6c50ca484" /> | <img width="862" alt="image" src="https://github.com/user-attachments/assets/fdf48d49-0530-4684-be65-7bef5a41fc29" /> |

I also noticed that the `manage-purchase__renew-upgrade-buttons` are set to `display: none` on smaller devices and...I'm not sure why.

So along with the refactor of the header I also moved the renewal/upgrade buttons into the header section and added styling so they adjust their position across device sizes:

| < 480px | < 660px | Desktop |
| ----- | ----- | ----- |
| <img width="372" alt="image" src="https://github.com/user-attachments/assets/436529d6-3741-4866-9be2-390f449a5852" /> | <img width="498" alt="image" src="https://github.com/user-attachments/assets/2693eb56-6347-4a42-81be-f5b41c51c0c7" /> | <img width="764" alt="image" src="https://github.com/user-attachments/assets/b5f6f6e2-b546-47d0-8870-de2ea6373736" /> |

All units have been converted to their relative counterparts, i.e `margin-inline-start` or `flex-start/end` so this should remain responsive for LTR languages too.

Related to #98958 

## Testing Instructions

* Go to Purchases and select a purchase to open its Purchase Settings - its best to try a product with a long string of text, like a very long domain name (but try a number of products to hedge against any regressions)
* From there, open dev tools and adjust the window width to test out the new flexibility of the text and buttons
* Try a LTR language, it should behave similarly
* There shouldn't be any horizontal or vertical scrolling or clipping in the `manage-purchase__header` or `manage-purchase__content` sections
