### PR TITLE
Add settings page redirects to wp-admin for duplicate view experiment

### DIFF
--- a/client/my-sites/site-settings/settings-controller.js
+++ b/client/my-sites/site-settings/settings-controller.js
@@ -1,5 +1,6 @@
 import page from '@automattic/calypso-router';
 import titlecase from 'to-title-case';
+import { redirectIfDuplicatedView } from 'calypso/controller';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
 import { navigate } from 'calypso/lib/navigate';
 import { getIsRemoveDuplicateViewsExperimentEnabled } from 'calypso/lib/remove-duplicate-views-experiment';
@@ -93,7 +94,7 @@ export async function redirectGeneralSettingsIfDuplicatedViewsEnabled( context, 
 		return page.redirect( `/sites/settings/site/${ siteSlug }` );
 	}
 
-	next();
+	redirectIfDuplicatedView( 'options-general.php' )( context, next );
 }
 
 export async function siteSettings( context, next ) {

--- a/client/my-sites/site-settings/settings-discussion/index.js
+++ b/client/my-sites/site-settings/settings-discussion/index.js
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import { makeLayout, render as clientRender, redirectIfDuplicatedView } from 'calypso/controller';
 import { navigation, siteSelection } from 'calypso/my-sites/controller';
 import { siteSettings } from 'calypso/my-sites/site-settings/settings-controller';
 import { discussion } from './controller';
@@ -8,6 +8,7 @@ export default function () {
 	page(
 		'/settings/discussion/:site_id',
 		siteSelection,
+		redirectIfDuplicatedView( 'options-discussion.php' ),
 		navigation,
 		siteSettings,
 		discussion,

--- a/client/my-sites/site-settings/settings-reading/index.ts
+++ b/client/my-sites/site-settings/settings-reading/index.ts
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import { makeLayout, render as clientRender, redirectIfDuplicatedView } from 'calypso/controller';
 import { navigation, siteSelection } from 'calypso/my-sites/controller';
 import { siteSettings } from 'calypso/my-sites/site-settings/settings-controller';
 import { createReadingSettings } from './controller';
@@ -8,6 +8,7 @@ export default function () {
 	page(
 		'/settings/reading/:site_id',
 		siteSelection,
+		redirectIfDuplicatedView( 'options-reading.php' ),
 		navigation,
 		siteSettings,
 		createReadingSettings,

--- a/client/my-sites/site-settings/settings-writing/index.js
+++ b/client/my-sites/site-settings/settings-writing/index.js
@@ -19,6 +19,7 @@ export default function () {
 	page(
 		'/settings/writing/:site_id',
 		siteSelection,
+		_redirectIfDuplicatedView( 'options-writing.php' ),
 		navigation,
 		siteSettings,
 		writing,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/98875, https://github.com/Automattic/jetpack/pull/40913, https://github.com/Automattic/wp-calypso/pull/98664

## Proposed Changes

This is a follow-up for https://github.com/Automattic/wp-calypso/pull/98875, redirecting settings pages from Calypso to wp-admin when the experiment is enabled.

> [!NOTE]
> It'd be nicer to deploy this PR after https://github.com/Automattic/jetpack/pull/40913 lands on Atomic. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Please refer to p7DVsv-mbN-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add yourself to the treatment group via 22167-explat-experiment
* Prepare a site with the Default interface style
* Observe the following redirections:

<img width="758" alt="Screenshot 2025-02-05 at 15 59 25" src="https://github.com/user-attachments/assets/d1a65398-5b7d-4a7d-bfd2-6a319c638e38" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?