### PR TITLE
Add a handler for throttled errors.

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -1,6 +1,7 @@
 import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { Button, FormLabel } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { suggestEmailCorrection } from '@automattic/onboarding';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
@@ -142,13 +143,34 @@ class PasswordlessSignupForm extends Component {
 		this.submitTracksEvent( false, { action_message: error.message, error_code: error.error } );
 
 		if ( ! isExistingAccountError( error.error ) ) {
-			this.setState( {
-				errorMessages: [
-					this.props.translate(
-						'Sorry, something went wrong when trying to create your account. Please try again.'
-					),
-				],
-			} );
+			if ( error.error === 'throttled' ) {
+				this.setState( {
+					errorMessages: [
+						this.props.translate(
+							'Too many attempts. Please try again later. If you think this is in error, {{a}}contact support{{/a}}.',
+							{
+								components: {
+									a: (
+										<a
+											href={ localizeUrl( 'https://wordpress.com/support/contact/' ) }
+											target="_blank"
+											rel="noopener noreferrer"
+										></a>
+									),
+								},
+							}
+						),
+					],
+				} );
+			} else {
+				this.setState( {
+					errorMessages: [
+						this.props.translate(
+							'Sorry, something went wrong when trying to create your account. Please try again.'
+						),
+					],
+				} );
+			}
 		}
 
 		this.setState( {

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -1,7 +1,6 @@
 import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { Button, FormLabel } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { suggestEmailCorrection } from '@automattic/onboarding';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
@@ -16,6 +15,7 @@ import Notice from 'calypso/components/notice';
 import { recordRegistration } from 'calypso/lib/analytics/signup';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import { isExistingAccountError } from 'calypso/lib/signup/is-existing-account-error';
+import { isThrottledError, getThrottledErrorMessage } from 'calypso/lib/signup/is-throttled-error';
 import wpcom from 'calypso/lib/wp';
 import ValidationFieldset from 'calypso/signup/validation-fieldset';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -143,24 +143,9 @@ class PasswordlessSignupForm extends Component {
 		this.submitTracksEvent( false, { action_message: error.message, error_code: error.error } );
 
 		if ( ! isExistingAccountError( error.error ) ) {
-			if ( error.error === 'throttled' ) {
+			if ( isThrottledError( error.error ) ) {
 				this.setState( {
-					errorMessages: [
-						this.props.translate(
-							'Too many attempts. Please try again later. If you think this is in error, {{a}}contact support{{/a}}.',
-							{
-								components: {
-									a: (
-										<a
-											href={ localizeUrl( 'https://wordpress.com/support/contact/' ) }
-											target="_blank"
-											rel="noopener noreferrer"
-										></a>
-									),
-								},
-							}
-						),
-					],
+					errorMessages: [ getThrottledErrorMessage( this.props.translate ) ],
 				} );
 			} else {
 				this.setState( {

--- a/client/blocks/signup-form/test/passwordless.jsx
+++ b/client/blocks/signup-form/test/passwordless.jsx
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { thunk } from 'redux-thunk';
+import PasswordlessSignupForm from '../passwordless';
+
+describe( 'createAccountError', () => {
+	const mockStore = configureStore( [ thunk ] );
+
+	const renderFormAndSubmit = async () => {
+		const onCreateAccountError = jest.fn();
+		const store = mockStore( {} );
+
+		render(
+			<Provider store={ store }>
+				<PasswordlessSignupForm onCreateAccountError={ onCreateAccountError } />
+			</Provider>
+		);
+
+		const emailInput = screen.getByRole( 'textbox', { name: /email/i } );
+		fireEvent.change( emailInput, { target: { value: 'test@example.com' } } );
+
+		const submitButton = screen.getByRole( 'button', { name: /create your account/i } );
+		fireEvent.click( submitButton );
+	};
+
+	it( 'should handle throttled errors', async () => {
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/users/new' ).reply( 403, {
+			error: 'throttled',
+		} );
+
+		await renderFormAndSubmit();
+
+		await waitFor( () => {
+			expect( screen.getByText( /Too many attempts/i ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'should handle generic errors', async () => {
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/users/new' ).reply( 500, {
+			error: 'internal_server_error',
+		} );
+
+		await renderFormAndSubmit();
+
+		await waitFor( () => {
+			expect( screen.getByText( /something went wrong /i ) ).toBeInTheDocument();
+		} );
+	} );
+} );

--- a/client/lib/signup/is-throttled-error.tsx
+++ b/client/lib/signup/is-throttled-error.tsx
@@ -1,0 +1,24 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+
+export function isThrottledError( errorSlug: string ) {
+	return 'throttled' === errorSlug;
+}
+
+export function getThrottledErrorMessage(
+	translate: ( key: string, options?: Record< string, unknown > ) => string
+): string {
+	return translate(
+		'Too many attempts. Please try again later. If you think this is in error, {{a}}contact support{{/a}}.',
+		{
+			components: {
+				a: (
+					<a
+						href={ localizeUrl( 'https://wordpress.com/support/contact/' ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					></a>
+				),
+			},
+		}
+	);
+}


### PR DESCRIPTION
Related to #99318


## Proposed Changes

* Add a custom message for throttle users in the passwordless signup form.

## Why are these changes being made?

When using the passwordless signup and a user is throttled, we don't instruct users to wait or contact customer support. As such, a prospective user can make their throttling worse as we increase the time delay with subsequent failure. They may also abandon their onboarding without clear next steps. The messages from the backend are not passed to the view but do include looks to customer support meaning, they were once displayed in the view.

Honestly, I'm not completely sure how often users encounter this throttling. I got to it while manually testing different accounts suggesting to me that it can occur.


### Screenshots

| Before | After |
|--------|--------|
| <img width="421" alt="Screenshot 2025-02-05 at 3 45 00 PM" src="https://github.com/user-attachments/assets/f503f017-ee3f-4d81-9072-0dd3be3e0d99" /> | <img width="416" alt="Screenshot 2025-02-05 at 3 42 28 PM" src="https://github.com/user-attachments/assets/cd6051a3-ba2c-4b27-825b-349b2d335699" /> | 

## Considerations

Maybe we don't want to broadcast the throttling.

## Testing Instructions

I don't know how to fake/trigger the throttling, but you can patch the create user endpoint in your sandbox to return the error:

```
return new WP_Error( 'throttled', __( 'Error message that is not displayed in the view.' ), 403 );
```

* Click "Get Started" from the homepage
* Select "Continue with email"
* Enter any email
* Verify you see the error message.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
