### PR TITLE
A4A > Agency Tier: Allow agencies to download the agency tier badges

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/download-badges/download-link.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/download-badges/download-link.tsx
@@ -38,12 +38,12 @@ function DownloadLink( {
 		woocommerce: {
 			'agency-partner': {
 				name: translate( 'Woo Agency Partner' ),
-				href: 'https://automattic.com/wp-content/uploads/2024/10/agency_tier_woo_partner.zip',
+				href: 'https://automattic.com/wp-content/uploads/2025/02/agency_tier_woo_partner.zip',
 				icon: <img src={ WooLogo } alt="WooCommerce" />,
 			},
 			'pro-agency-partner': {
 				name: translate( 'Woo Pro Agency Partner' ),
-				href: 'https://automattic.com/wp-content/uploads/2024/10/agency_tier_woo_pro_partner.zip',
+				href: 'https://automattic.com/wp-content/uploads/2025/02/agency_tier_woo_pro_partner.zip',
 				icon: <img src={ WooLogo } alt="WooCommerce" />,
 			},
 		},

--- a/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/index.tsx
@@ -34,15 +34,9 @@ export default function AgencyTierOverview() {
 
 	const ALL_TIERS: AgencyTier[] = [ 'emerging-partner', 'agency-partner', 'pro-agency-partner' ];
 
-	// todo: Restore this. We have to hide temporary the 'Download your badges' button until the WooCommerce ones are ready
-	// A4A GH issue: 1500
-	const temporaryHideDownloadBadges = true;
-
 	// Show download badges button for Agency Partner and Pro Agency Partner tiers
 	const showDownloadBadges =
-		! temporaryHideDownloadBadges &&
-		currentAgencyTier &&
-		[ 'agency-partner', 'pro-agency-partner' ].includes( currentAgencyTier );
+		currentAgencyTier && [ 'agency-partner', 'pro-agency-partner' ].includes( currentAgencyTier );
 
 	return (
 		<Layout className="agency-tier-overview" title={ title } wide>


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1682


## Proposed Changes

This PR:

- Enables the "Download your badges" button to allow agencies to download the agency tier badges.
- Updates the Woo badges with the newly rebranded ones.

Please note: we show badges for the approved directories in the Partner Directory only. So, please use the Partner Directory MC tool and accept the directory only for time being. Also, click the "eye" icon to be able to display the badges. Please hide it using the "eye" icon once you are done testing or reject the directory. 

Another way is to test this locally and change this [line](https://github.com/Automattic/wp-calypso/blob/228254947d935f2b6a858301d20c88f076f84d24/client/a8c-for-agencies/sections/agency-tier/download-badges/index.tsx#L21) to:

```
const partnerDirectorties = [ 'wordpress', 'woocommerce', 'jetpack', 'pressable' ];
```

## Why are these changes being made?

* To allow agencies to download the various badges per their agency tier.

## Testing Instructions

* Use the Agency MC tool and set the agency tier to `Agency Partner`.
* Open the A4A live link > Go to Agency Tier > Verify that the download button is displayed as shown below

<img width="1423" alt="Screenshot 2025-02-05 at 12 49 37 PM" src="https://github.com/user-attachments/assets/165ad379-c4b7-4efd-80c0-f002f4bfeacb" />

- Click the `Download your badges` button > Verify that the modal is displayed as shown below > Download all the badges for the partner directories and verify it is accurate. 

<img width="793" alt="Screenshot 2025-02-05 at 12 32 18 PM" src="https://github.com/user-attachments/assets/9bf59cea-8e90-46e1-9121-9442bece33a3" />

* Use the Agency MC tool and set the agency tier to `Pro Agency Partner`.
* Refresh the page > Click the `Download your badges` button > Verify that the modal is displayed as shown below > Download all the badges for the partner directories and verify it is accurate. 

<img width="793" alt="Screenshot 2025-02-05 at 12 33 27 PM" src="https://github.com/user-attachments/assets/fba3523f-8b16-4228-b529-b2b894993e24" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
