### PR TITLE
Stats: adds replacement subscribers chart

### DIFF
--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -165,7 +165,6 @@ export default function SubscribersChartSection( {
 					</div>
 				</div>
 			</div>
-			{ isChartLibraryEnabled && <div>chart library is enabled</div> }
 			{ isChartLoading && <StatsModulePlaceholder className="is-chart" isLoading /> }
 			{ ! isChartLoading && chartData.length === 0 && (
 				<p className="subscribers-section__no-data">
@@ -176,16 +175,42 @@ export default function SubscribersChartSection( {
 			{ ! isChartLoading && chartData.length !== 0 && (
 				<>
 					<div className="subscribers-section-legend" ref={ legendRef }></div>
-					<UplotChart
-						data={ chartData }
-						legendContainer={ legendRef }
-						period={ period }
-						// Use variable --studio-jetpack-green for chart colors on Odyssey Stats.
-						mainColor={ isOdysseyStats ? '#069e08' : undefined }
-						fillColorFrom={ isOdysseyStats ? 'rgba(6, 158, 8, 0.4)' : undefined }
-						fillColorTo={ isOdysseyStats ? 'rgba(6, 158, 8, 0)' : undefined }
-						yAxisFilter={ hideFractionNumber }
-					/>
+					{ isChartLibraryEnabled && (
+						<LineChart
+							chartData={ [
+								{
+									label: 'Subscribers',
+									options: {
+										stroke: '#069e08',
+									},
+									data: data?.data?.map( ( point ) => ( {
+										date: new Date( point.period ),
+										value: point.subscribers || 0,
+									} ) ) || [
+										// Fallback dummy data if no real data available
+										{ date: new Date( '2024-01-01' ), value: 10 },
+										{ date: new Date( '2024-01-08' ), value: 15 },
+										{ date: new Date( '2024-01-15' ), value: 12 },
+										{ date: new Date( '2024-01-22' ), value: 18 },
+										{ date: new Date( '2024-01-29' ), value: 20 },
+									],
+								},
+							] }
+							height={ 300 }
+						/>
+					) }
+					{ ! isChartLibraryEnabled && (
+						<UplotChart
+							data={ chartData }
+							legendContainer={ legendRef }
+							period={ period }
+							// Use variable --studio-jetpack-green for chart colors on Odyssey Stats.
+							mainColor={ isOdysseyStats ? '#069e08' : undefined }
+							fillColorFrom={ isOdysseyStats ? 'rgba(6, 158, 8, 0.4)' : undefined }
+							fillColorTo={ isOdysseyStats ? 'rgba(6, 158, 8, 0)' : undefined }
+							yAxisFilter={ hideFractionNumber }
+						/>
+					) }
 				</>
 			) }
 		</div>

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import UplotChart from 'calypso/components/chart-uplot';
+import LineChart from 'calypso/my-sites/stats/components/line-chart';
 import useSubscribersQuery from 'calypso/my-sites/stats/hooks/use-subscribers-query';
 import { useSelector } from 'calypso/state';
 import StatsModulePlaceholder from '../stats-module/placeholder';

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -3,8 +3,8 @@ import { UseQueryResult } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Intervals from 'calypso/blocks/stats-navigation/intervals';
+import AsyncLoad from 'calypso/components/async-load';
 import UplotChart from 'calypso/components/chart-uplot';
-import LineChart from 'calypso/my-sites/stats/components/line-chart';
 import useSubscribersQuery from 'calypso/my-sites/stats/hooks/use-subscribers-query';
 import { useSelector } from 'calypso/state';
 import StatsModulePlaceholder from '../stats-module/placeholder';
@@ -175,8 +175,9 @@ export default function SubscribersChartSection( {
 			{ ! isChartLoading && chartData.length !== 0 && (
 				<>
 					<div className="subscribers-section-legend" ref={ legendRef }></div>
-					{ isChartLibraryEnabled && (
-						<LineChart
+					{ isChartLibraryEnabled ? (
+						<AsyncLoad
+							require="calypso/my-sites/stats/components/line-chart"
 							chartData={ [
 								{
 									label: 'Subscribers',
@@ -198,8 +199,7 @@ export default function SubscribersChartSection( {
 							] }
 							height={ 300 }
 						/>
-					) }
-					{ ! isChartLibraryEnabled && (
+					) : (
 						<UplotChart
 							data={ chartData }
 							legendContainer={ legendRef }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR replaces the subscribers page line chart with the new chart library line chart
* It is only visible behind the feature flag
* It is not currently wired up for correct data, it's just dummy data
* This is a followon PR from https://github.com/Automattic/wp-calypso/pull/99316/


## Testing Instructions

* Open Calypso live branch
* Navigate to `/stats/subscribers/{URL}i?flags=stats/chart-library`
* Check everything appears as normal
* Append feature flag `flags=stats/chart-library`
* Check you can now see the new chart as pictured below

![image](https://github.com/user-attachments/assets/da3b257c-c7f9-40d9-99f0-2d7a3fe65ed8)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
