### PR TITLE
Fix design picker active theme styles during /setup/site-setup

### DIFF
--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -36,7 +36,7 @@
 		@include break-large {
 			margin-bottom: 64px;
 		}
-		
+
 		.design-picker__design-card-title {
 			position: sticky;
 			top: 0;
@@ -66,7 +66,9 @@
 
 		.theme-card__info {
 			margin-top: 8px;
-			height: auto;
+			&:not(:has(.theme-card__info-badge-container)) {
+				height: auto;
+			}
 
 			@include break-small {
 				margin-top: 12px;

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -16,6 +16,7 @@ $theme-card-info-margin-top: 16px;
 		.theme-card__image-container {
 			box-shadow: 0 0 0 2px var(--color-primary);
 			border-radius: 4px;
+			z-index: 10;
 		}
 	}
 
@@ -64,7 +65,7 @@ $theme-card-info-margin-top: 16px;
 .theme-card--is-actionable {
 	.theme-card__image {
 		transition: transform 300ms ease-in-out;
-		
+
 		&:hover,
 		&:focus {
 			transform: scale(1.03);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99195

## Proposed Changes

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/user-attachments/assets/0f27e3e0-6235-4dd9-8c5e-a8d016bd6c14">  | <img src="https://github.com/user-attachments/assets/b1c80fc5-8aab-44af-8d1c-5ef7031d6df7">|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Style fixes

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/onboarding
* Started from, logged in, https://wordpress.com/setup/onboarding, selected free domain + free plan + publish a blog goal (not goals-first flow)
* Make sure /themes and other theme page's styles are not broken

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
