### PR TITLE
style fixed for jetpack promoted posts pages for the outstanding balance notice

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaigns-table/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaigns-table/style.scss
@@ -277,8 +277,11 @@ $break-medium-expanded-menu: $break-medium + 272px;
 
 .promote-post-i2 {
 	.promote-post-i2__payment-blocked-notice {
+		border: none;
+		box-shadow: none;
 		max-width: 1040px;
 		width: calc(100% - 128px);
+		padding: 0;
 
 
 		@media screen and (max-width: $break-medium-collapsed-menu) {

--- a/client/my-sites/promote-post-i2/main.tsx
+++ b/client/my-sites/promote-post-i2/main.tsx
@@ -354,7 +354,7 @@ export default function PromotedPosts( { tab }: Props ) {
 						showDismiss={ false }
 						status="is-error"
 						icon="notice-outline"
-						className="promote-post-i2__payment-blocked-notice"
+						className="promote-post-i2__payment-blocked-notice wpcomsh-notice"
 					>
 						{ translate(
 							'Your account currently has an outstanding balance of $%(debtAmount)s. Please resolve this using the links below before creating new campaigns.',

--- a/client/my-sites/promote-post-i2/style.scss
+++ b/client/my-sites/promote-post-i2/style.scss
@@ -321,6 +321,12 @@ body.is-section-promote-post-i2 {
 			color: $studio-gray-100;
 		}
 
+		.section-nav-tab__link {
+			&:focus {
+				box-shadow: none;
+			}
+		}
+
 		.section-nav-tab__link .count {
 			background: var(--studio-gray-0);
 			color: $studio-gray-80;


### PR DESCRIPTION
Related to #

3078-gh-tumblr/a8c-dsp

## Proposed Changes

we noticed something broken in this notice in the promoted posts (advertising) pages

before 
<img width="1370" alt="Screenshot 2025-02-05 at 11 51 11 AM" src="https://github.com/user-attachments/assets/378b61f6-623b-4874-86b2-c34903795332" />


after
![Screenshot 2025-02-05 at 11 50 52 AM](https://github.com/user-attachments/assets/a6e0d2d7-7424-433b-ada5-9c8840637fbd)


I also noticed that in the tab buttons there is a stroke when active (so I am addressing this too in this PR)

![Screenshot 2025-02-05 at 11 52 15 AM](https://github.com/user-attachments/assets/e207b621-410b-4208-88cb-9d86c6f651a3)


*

## Testing Instructions

you need a jetpack site (to test this I used local JP with jurassic and bridged connection to calypso and my local DSP server) 
you don't necessary need this (I guess you can also test with live - but using local db was easier for me to change values in the user's debt and simulate different scenarios)

you can use this guide to setup local (I used the everything locally section)

PCYsg-SuD-p2

I changed my debt_amount in dsp_users table and I edited a few orders in dsp_woo_orders to be failed and have some amount in total 

navigate to /wp-admin/tools.php?page=advertising#!/advertising/posts/YOUR_BLOG_URL

please test also that the notice affected looks good in mobile and table views

you re it

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?