### PR TITLE
A4A: Implement Core Badge component

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-product-categories.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-product-categories.ts
@@ -4,17 +4,17 @@ import { isWooCommerceProduct } from 'calypso/jetpack-cloud/sections/partner-por
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { isProductType } from '../lib/product-filter';
 import {
-	securityProductSlugs,
-	performanceProductSlugs,
-	socialProductSlugs,
-	growthProductSlugs,
-	paymentsProductSlugs,
-	shippingDeliveryFulfillmentProductSlugs,
-	conversionProductSlugs,
-	customerServiceProductSlugs,
-	merchandisingProductSlugs,
-	storeContentProductSlugs,
-	storeManagementProductSlugs,
+	SECURITY_PRODUCT_SLUGS,
+	PERFORMANCE_PRODUCT_SLUGS,
+	SOCIAL_PRODUCT_SLUGS,
+	GROWTH_PRODUCT_SLUGS,
+	PAYMENTS_PRODUCT_SLUGS,
+	SHIPPING_DELIVERY_FULFILLMENT_PRODUCT_SLUGS,
+	CONVERSION_PRODUCT_SLUGS,
+	CUSTOMER_SERVICE_PRODUCT_SLUGS,
+	MERCHANDISING_PRODUCT_SLUGS,
+	STORE_CONTENT_PRODUCT_SLUGS,
+	STORE_MANAGEMENT_PRODUCT_SLUGS,
 } from '../lib/product-slugs';
 
 type CategoryConfig = {
@@ -33,17 +33,17 @@ export function useProductCategories( product: APIProductFamilyProduct ): string
 			: [];
 
 		const CATEGORIES: CategoryConfig[] = [
-			{ slugs: securityProductSlugs, label: translate( 'security' ) },
-			{ slugs: performanceProductSlugs, label: translate( 'performance' ) },
-			{ slugs: socialProductSlugs, label: translate( 'social' ) },
-			{ slugs: growthProductSlugs, label: translate( 'growth' ) },
-			{ slugs: paymentsProductSlugs, label: translate( 'payments' ) },
-			{ slugs: shippingDeliveryFulfillmentProductSlugs, label: translate( 'shipping' ) },
-			{ slugs: conversionProductSlugs, label: translate( 'conversion' ) },
-			{ slugs: customerServiceProductSlugs, label: translate( 'customer service' ) },
-			{ slugs: merchandisingProductSlugs, label: translate( 'merchandising' ) },
-			{ slugs: storeContentProductSlugs, label: translate( 'store content' ) },
-			{ slugs: storeManagementProductSlugs, label: translate( 'store management' ) },
+			{ slugs: SECURITY_PRODUCT_SLUGS, label: translate( 'security' ) },
+			{ slugs: PERFORMANCE_PRODUCT_SLUGS, label: translate( 'performance' ) },
+			{ slugs: SOCIAL_PRODUCT_SLUGS, label: translate( 'social' ) },
+			{ slugs: GROWTH_PRODUCT_SLUGS, label: translate( 'growth' ) },
+			{ slugs: PAYMENTS_PRODUCT_SLUGS, label: translate( 'payments' ) },
+			{ slugs: SHIPPING_DELIVERY_FULFILLMENT_PRODUCT_SLUGS, label: translate( 'shipping' ) },
+			{ slugs: CONVERSION_PRODUCT_SLUGS, label: translate( 'conversion' ) },
+			{ slugs: CUSTOMER_SERVICE_PRODUCT_SLUGS, label: translate( 'customer service' ) },
+			{ slugs: MERCHANDISING_PRODUCT_SLUGS, label: translate( 'merchandising' ) },
+			{ slugs: STORE_CONTENT_PRODUCT_SLUGS, label: translate( 'store content' ) },
+			{ slugs: STORE_MANAGEMENT_PRODUCT_SLUGS, label: translate( 'store management' ) },
 		];
 
 		// Add regular categories

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-product-categories.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-product-categories.ts
@@ -22,16 +22,9 @@ type CategoryConfig = {
 	label: string;
 };
 
-const JETPACK_COMPLETE_SLUGS = [
-	...securityProductSlugs,
-	...performanceProductSlugs,
-	...socialProductSlugs,
-	...growthProductSlugs,
-];
-
 export function useProductCategories( product: APIProductFamilyProduct ): string[] {
 	const translate = useTranslate();
-	const { family_slug, slug } = product;
+	const { family_slug } = product;
 
 	return useMemo( () => {
 		// Add e-commerce category for WooCommerce products
@@ -56,10 +49,7 @@ export function useProductCategories( product: APIProductFamilyProduct ): string
 		// Add regular categories
 		categories.push(
 			...CATEGORIES.reduce( ( acc: string[], { slugs, label } ) => {
-				if (
-					slugs.includes( family_slug ) ||
-					( slug === 'jetpack-complete' && JETPACK_COMPLETE_SLUGS.includes( family_slug ) )
-				) {
+				if ( slugs.includes( family_slug ) ) {
 					acc.push( label );
 				}
 				return acc;
@@ -68,7 +58,7 @@ export function useProductCategories( product: APIProductFamilyProduct ): string
 
 		// Add product type categories
 		if ( family_slug === 'jetpack-packs' ) {
-			categories.push( translate( 'plan' ) );
+			categories.push( translate( 'bundle' ), translate( 'plan' ) );
 		} else if ( family_slug === 'jetpack-backup-storage' ) {
 			categories.push( translate( 'add-on' ) );
 		} else if ( isProductType( family_slug ) ) {
@@ -78,5 +68,5 @@ export function useProductCategories( product: APIProductFamilyProduct ): string
 		}
 
 		return categories;
-	}, [ family_slug, slug, translate ] );
+	}, [ family_slug, translate ] );
 }

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-product-categories.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-product-categories.ts
@@ -1,0 +1,82 @@
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { isWooCommerceProduct } from 'calypso/jetpack-cloud/sections/partner-portal/lib';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import { isProductType } from '../lib/product-filter';
+import {
+	securityProductSlugs,
+	performanceProductSlugs,
+	socialProductSlugs,
+	growthProductSlugs,
+	paymentsProductSlugs,
+	shippingDeliveryFulfillmentProductSlugs,
+	conversionProductSlugs,
+	customerServiceProductSlugs,
+	merchandisingProductSlugs,
+	storeContentProductSlugs,
+	storeManagementProductSlugs,
+} from '../lib/product-slugs';
+
+type CategoryConfig = {
+	slugs: string[];
+	label: string;
+};
+
+const JETPACK_COMPLETE_SLUGS = [
+	...securityProductSlugs,
+	...performanceProductSlugs,
+	...socialProductSlugs,
+	...growthProductSlugs,
+];
+
+export function useProductCategories( product: APIProductFamilyProduct ): string[] {
+	const translate = useTranslate();
+	const { family_slug, slug } = product;
+
+	return useMemo( () => {
+		// Add e-commerce category for WooCommerce products
+		const categories: string[] = isWooCommerceProduct( family_slug )
+			? [ translate( 'e-commerce' ) ]
+			: [];
+
+		const CATEGORIES: CategoryConfig[] = [
+			{ slugs: securityProductSlugs, label: translate( 'security' ) },
+			{ slugs: performanceProductSlugs, label: translate( 'performance' ) },
+			{ slugs: socialProductSlugs, label: translate( 'social' ) },
+			{ slugs: growthProductSlugs, label: translate( 'growth' ) },
+			{ slugs: paymentsProductSlugs, label: translate( 'payments' ) },
+			{ slugs: shippingDeliveryFulfillmentProductSlugs, label: translate( 'shipping' ) },
+			{ slugs: conversionProductSlugs, label: translate( 'conversion' ) },
+			{ slugs: customerServiceProductSlugs, label: translate( 'customer service' ) },
+			{ slugs: merchandisingProductSlugs, label: translate( 'merchandising' ) },
+			{ slugs: storeContentProductSlugs, label: translate( 'store content' ) },
+			{ slugs: storeManagementProductSlugs, label: translate( 'store management' ) },
+		];
+
+		// Add regular categories
+		categories.push(
+			...CATEGORIES.reduce( ( acc: string[], { slugs, label } ) => {
+				if (
+					slugs.includes( family_slug ) ||
+					( slug === 'jetpack-complete' && JETPACK_COMPLETE_SLUGS.includes( family_slug ) )
+				) {
+					acc.push( label );
+				}
+				return acc;
+			}, [] )
+		);
+
+		// Add product type categories
+		if ( family_slug === 'jetpack-packs' ) {
+			categories.push( translate( 'plan' ) );
+		} else if ( family_slug === 'jetpack-backup-storage' ) {
+			categories.push( translate( 'add-on' ) );
+		} else if ( isProductType( family_slug ) ) {
+			categories.push( translate( 'product' ) );
+		} else if ( isWooCommerceProduct( family_slug ) ) {
+			categories.push( translate( 'extension' ) );
+		}
+
+		return categories;
+	}, [ family_slug, slug, translate ] );
+}

--- a/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
@@ -37,17 +37,17 @@ import {
 } from '../constants';
 import { isPressableHostingProduct, isWPCOMHostingProduct } from '../lib/hosting';
 import {
-	securityProductSlugs,
-	performanceProductSlugs,
-	socialProductSlugs,
-	growthProductSlugs,
-	paymentsProductSlugs,
-	shippingDeliveryFulfillmentProductSlugs,
-	conversionProductSlugs,
-	customerServiceProductSlugs,
-	merchandisingProductSlugs,
-	storeContentProductSlugs,
-	storeManagementProductSlugs,
+	SECURITY_PRODUCT_SLUGS,
+	PERFORMANCE_PRODUCT_SLUGS,
+	SOCIAL_PRODUCT_SLUGS,
+	GROWTH_PRODUCT_SLUGS,
+	PAYMENTS_PRODUCT_SLUGS,
+	SHIPPING_DELIVERY_FULFILLMENT_PRODUCT_SLUGS,
+	CONVERSION_PRODUCT_SLUGS,
+	CUSTOMER_SERVICE_PRODUCT_SLUGS,
+	MERCHANDISING_PRODUCT_SLUGS,
+	STORE_CONTENT_PRODUCT_SLUGS,
+	STORE_MANAGEMENT_PRODUCT_SLUGS,
 } from './product-slugs';
 export type SelectedFilters = {
 	[ PRODUCT_FILTER_KEY_BRAND ]: string;
@@ -304,50 +304,50 @@ function filterProductsAndPlansByCategory(
 		case PRODUCT_CATEGORY_SECURITY:
 			return allProductsAndPlans.filter(
 				( { slug, family_slug } ) =>
-					securityProductSlugs.includes( family_slug ) || slug === 'jetpack-complete'
+					SECURITY_PRODUCT_SLUGS.includes( family_slug ) || slug === 'jetpack-complete'
 			);
 		case PRODUCT_CATEGORY_PERFORMANCE:
 			return allProductsAndPlans.filter(
 				( { slug, family_slug } ) =>
-					performanceProductSlugs.includes( family_slug ) || slug === 'jetpack-complete'
+					PERFORMANCE_PRODUCT_SLUGS.includes( family_slug ) || slug === 'jetpack-complete'
 			);
 		case PRODUCT_CATEGORY_SOCIAL:
 			return allProductsAndPlans.filter(
 				( { slug, family_slug } ) =>
-					socialProductSlugs.includes( family_slug ) || slug === 'jetpack-complete'
+					SOCIAL_PRODUCT_SLUGS.includes( family_slug ) || slug === 'jetpack-complete'
 			);
 		case PRODUCT_CATEGORY_GROWTH:
 			return allProductsAndPlans.filter(
 				( { slug, family_slug } ) =>
-					growthProductSlugs.includes( family_slug ) || slug === 'jetpack-complete'
+					GROWTH_PRODUCT_SLUGS.includes( family_slug ) || slug === 'jetpack-complete'
 			);
 		case PRODUCT_CATEGORY_PAYMENTS:
 			return allProductsAndPlans.filter( ( { family_slug } ) =>
-				paymentsProductSlugs.includes( family_slug )
+				PAYMENTS_PRODUCT_SLUGS.includes( family_slug )
 			);
 		case PRODUCT_CATEGORY_SHIPPING_DELIVERY_FULFILLMENT:
 			return allProductsAndPlans.filter( ( { family_slug } ) =>
-				shippingDeliveryFulfillmentProductSlugs.includes( family_slug )
+				SHIPPING_DELIVERY_FULFILLMENT_PRODUCT_SLUGS.includes( family_slug )
 			);
 		case PRODUCT_CATEGORY_CONVERSION:
 			return allProductsAndPlans.filter( ( { family_slug } ) =>
-				conversionProductSlugs.includes( family_slug )
+				CONVERSION_PRODUCT_SLUGS.includes( family_slug )
 			);
 		case PRODUCT_CATEGORY_CUSTOMER_SERVICE:
 			return allProductsAndPlans.filter( ( { family_slug } ) =>
-				customerServiceProductSlugs.includes( family_slug )
+				CUSTOMER_SERVICE_PRODUCT_SLUGS.includes( family_slug )
 			);
 		case PRODUCT_CATEGORY_MERCHANDISING:
 			return allProductsAndPlans.filter( ( { family_slug } ) =>
-				merchandisingProductSlugs.includes( family_slug )
+				MERCHANDISING_PRODUCT_SLUGS.includes( family_slug )
 			);
 		case PRODUCT_CATEGORY_STORE_CONTENT:
 			return allProductsAndPlans.filter( ( { family_slug } ) =>
-				storeContentProductSlugs.includes( family_slug )
+				STORE_CONTENT_PRODUCT_SLUGS.includes( family_slug )
 			);
 		case PRODUCT_CATEGORY_STORE_MANAGEMENT:
 			return allProductsAndPlans.filter( ( { family_slug } ) =>
-				storeManagementProductSlugs.includes( family_slug )
+				STORE_MANAGEMENT_PRODUCT_SLUGS.includes( family_slug )
 			);
 	}
 

--- a/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
@@ -36,7 +36,19 @@ import {
 	PRODUCT_TYPE_WPCOM_PLAN,
 } from '../constants';
 import { isPressableHostingProduct, isWPCOMHostingProduct } from '../lib/hosting';
-
+import {
+	securityProductSlugs,
+	performanceProductSlugs,
+	socialProductSlugs,
+	growthProductSlugs,
+	paymentsProductSlugs,
+	shippingDeliveryFulfillmentProductSlugs,
+	conversionProductSlugs,
+	customerServiceProductSlugs,
+	merchandisingProductSlugs,
+	storeContentProductSlugs,
+	storeManagementProductSlugs,
+} from './product-slugs';
 export type SelectedFilters = {
 	[ PRODUCT_FILTER_KEY_BRAND ]: string;
 	[ PRODUCT_FILTER_KEY_CATEGORIES ]: Record< string, boolean >;
@@ -199,6 +211,16 @@ function filterProductsAndPlansByCategories(
 	return Array.from( filteredData );
 }
 
+export const isProductType = ( family_slug: string ) => {
+	return (
+		family_slug !== 'jetpack-packs' &&
+		family_slug !== 'jetpack-backup-storage' &&
+		! isWooCommerceProduct( family_slug ) &&
+		! isWpcomHostingProduct( family_slug ) &&
+		! isPressableHostingProduct( family_slug )
+	);
+};
+
 /*
  * Filter products and plans by type.
  *
@@ -214,14 +236,7 @@ export function filterProductsAndPlansByType(
 		case PRODUCT_TYPE_JETPACK_PRODUCT:
 		case PRODUCT_TYPE_PRODUCT: // Right now this is the same as jetpack product but once we have more non-jetpack products we can separate them.
 			return (
-				allProductsAndPlans?.filter(
-					( { family_slug } ) =>
-						family_slug !== 'jetpack-packs' &&
-						family_slug !== 'jetpack-backup-storage' &&
-						! isWooCommerceProduct( family_slug ) &&
-						! isWpcomHostingProduct( family_slug ) &&
-						! isPressableHostingProduct( family_slug )
-				) || []
+				allProductsAndPlans?.filter( ( { family_slug } ) => isProductType( family_slug ) ) || []
 			);
 		case PRODUCT_TYPE_JETPACK_PLAN:
 		case PRODUCT_TYPE_PLAN: // Right now this is the same as jetpack plan but once we have more non-jetpack plans we can separate them.
@@ -289,107 +304,50 @@ function filterProductsAndPlansByCategory(
 		case PRODUCT_CATEGORY_SECURITY:
 			return allProductsAndPlans.filter(
 				( { slug, family_slug } ) =>
-					[
-						'jetpack-backup',
-						'jetpack-scan',
-						'jetpack-anti-spam',
-						'jetpack-monitor',
-						'jetpack-backup-storage',
-					].includes( family_slug ) || slug === 'jetpack-complete'
+					securityProductSlugs.includes( family_slug ) || slug === 'jetpack-complete'
 			);
 		case PRODUCT_CATEGORY_PERFORMANCE:
 			return allProductsAndPlans.filter(
 				( { slug, family_slug } ) =>
-					[ 'jetpack-boost', 'jetpack-search', 'jetpack-videopress' ].includes( family_slug ) ||
-					slug === 'jetpack-complete'
+					performanceProductSlugs.includes( family_slug ) || slug === 'jetpack-complete'
 			);
 		case PRODUCT_CATEGORY_SOCIAL:
 			return allProductsAndPlans.filter(
-				( { slug, family_slug } ) => family_slug === 'jetpack-social' || slug === 'jetpack-complete'
+				( { slug, family_slug } ) =>
+					socialProductSlugs.includes( family_slug ) || slug === 'jetpack-complete'
 			);
 		case PRODUCT_CATEGORY_GROWTH:
 			return allProductsAndPlans.filter(
 				( { slug, family_slug } ) =>
-					[ 'jetpack-creator', 'jetpack-ai', 'jetpack-stats' ].includes( family_slug ) ||
-					slug === 'jetpack-complete'
+					growthProductSlugs.includes( family_slug ) || slug === 'jetpack-complete'
 			);
 		case PRODUCT_CATEGORY_PAYMENTS:
-			return allProductsAndPlans.filter(
-				( { family_slug } ) => family_slug === 'woocommerce-woopayments'
+			return allProductsAndPlans.filter( ( { family_slug } ) =>
+				paymentsProductSlugs.includes( family_slug )
 			);
 		case PRODUCT_CATEGORY_SHIPPING_DELIVERY_FULFILLMENT:
 			return allProductsAndPlans.filter( ( { family_slug } ) =>
-				[
-					'woocommerce-advanced-notifications',
-					'woocommerce-all-products-woo-subscriptions',
-					'woocommerce-conditional-shipping-payments',
-					'woocommerce-flat-rate-box-shipping',
-					'woocommerce-per-product-shipping',
-					'woocommerce-shipping-multiple-addresses',
-					'woocommerce-table-rate-shipping',
-					'woocommerce-distance-rate-shipping',
-					'woocommerce-order-barcodes',
-					'woocommerce-shipping',
-				].includes( family_slug )
+				shippingDeliveryFulfillmentProductSlugs.includes( family_slug )
 			);
 		case PRODUCT_CATEGORY_CONVERSION:
 			return allProductsAndPlans.filter( ( { family_slug } ) =>
-				[
-					'woocommerce-back-in-stock-notifications',
-					'woocommerce-checkout-field-editor',
-					'woocommerce-product-recommendations',
-					'woocommerce-coupon-campaigns',
-					'woocommerce-points-and-rewards',
-					'woocommerce-product-add-ons',
-					'woocommerce-product-bundles',
-				].includes( family_slug )
+				conversionProductSlugs.includes( family_slug )
 			);
 		case PRODUCT_CATEGORY_CUSTOMER_SERVICE:
 			return allProductsAndPlans.filter( ( { family_slug } ) =>
-				[
-					'woocommerce-automatewoo',
-					'woocommerce-automatewoo-birthdays',
-					'woocommerce-automatewoo-refer-a-friend',
-					'woocommerce-returns-warranty-requests',
-					'woocommerce-shipment-tracking',
-				].includes( family_slug )
+				customerServiceProductSlugs.includes( family_slug )
 			);
 		case PRODUCT_CATEGORY_MERCHANDISING:
 			return allProductsAndPlans.filter( ( { family_slug } ) =>
-				[
-					'woocommerce-composite-products',
-					'woocommerce-eu-vat-number',
-					'woocommerce-gift-cards',
-					'woocommerce-gifting-wc-subscriptions',
-					'woocommerce-product-vendors',
-					'woocommerce-deposits',
-					'woocommerce-pre-orders',
-					'woocommerce-purchase-order-gateway',
-					'woocommerce-subscription-downloads',
-					'woocommerce-subscriptions',
-				].includes( family_slug )
+				merchandisingProductSlugs.includes( family_slug )
 			);
 		case PRODUCT_CATEGORY_STORE_CONTENT:
 			return allProductsAndPlans.filter( ( { family_slug } ) =>
-				[
-					'woocommerce-accommodations-bookings',
-					'woocommerce-additional-image-variations',
-					'woocommerce-bookings',
-					'woocommerce-bookings-availability',
-					'woocommerce-box-office',
-					'woocommerce-brands',
-					'woocommerce-minmax-quantities',
-					'woocommerce-one-page-checkout',
-				].includes( family_slug )
+				storeContentProductSlugs.includes( family_slug )
 			);
 		case PRODUCT_CATEGORY_STORE_MANAGEMENT:
 			return allProductsAndPlans.filter( ( { family_slug } ) =>
-				[
-					'woocommerce-bulk-stock-management',
-					'woocommerce-product-csv-import-suite',
-					'woocommerce-tax',
-					'woocommerce-woopayments',
-				].includes( family_slug )
+				storeManagementProductSlugs.includes( family_slug )
 			);
 	}
 

--- a/client/a8c-for-agencies/sections/marketplace/lib/product-slugs.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/product-slugs.ts
@@ -1,4 +1,4 @@
-export const securityProductSlugs = [
+export const SECURITY_PRODUCT_SLUGS = [
 	'jetpack-backup',
 	'jetpack-scan',
 	'jetpack-anti-spam',
@@ -6,15 +6,19 @@ export const securityProductSlugs = [
 	'jetpack-backup-storage',
 ];
 
-export const performanceProductSlugs = [ 'jetpack-boost', 'jetpack-search', 'jetpack-videopress' ];
+export const PERFORMANCE_PRODUCT_SLUGS = [
+	'jetpack-boost',
+	'jetpack-search',
+	'jetpack-videopress',
+];
 
-export const socialProductSlugs = [ 'jetpack-social' ];
+export const SOCIAL_PRODUCT_SLUGS = [ 'jetpack-social' ];
 
-export const growthProductSlugs = [ 'jetpack-creator', 'jetpack-ai', 'jetpack-stats' ];
+export const GROWTH_PRODUCT_SLUGS = [ 'jetpack-creator', 'jetpack-ai', 'jetpack-stats' ];
 
-export const paymentsProductSlugs = [ 'woocommerce-woopayments' ];
+export const PAYMENTS_PRODUCT_SLUGS = [ 'woocommerce-woopayments' ];
 
-export const shippingDeliveryFulfillmentProductSlugs = [
+export const SHIPPING_DELIVERY_FULFILLMENT_PRODUCT_SLUGS = [
 	'woocommerce-advanced-notifications',
 	'woocommerce-all-products-woo-subscriptions',
 	'woocommerce-conditional-shipping-payments',
@@ -26,7 +30,8 @@ export const shippingDeliveryFulfillmentProductSlugs = [
 	'woocommerce-order-barcodes',
 	'woocommerce-shipping',
 ];
-export const conversionProductSlugs = [
+
+export const CONVERSION_PRODUCT_SLUGS = [
 	'woocommerce-back-in-stock-notifications',
 	'woocommerce-checkout-field-editor',
 	'woocommerce-product-recommendations',
@@ -35,14 +40,16 @@ export const conversionProductSlugs = [
 	'woocommerce-product-add-ons',
 	'woocommerce-product-bundles',
 ];
-export const customerServiceProductSlugs = [
+
+export const CUSTOMER_SERVICE_PRODUCT_SLUGS = [
 	'woocommerce-automatewoo',
 	'woocommerce-automatewoo-birthdays',
 	'woocommerce-automatewoo-refer-a-friend',
 	'woocommerce-returns-warranty-requests',
 	'woocommerce-shipment-tracking',
 ];
-export const merchandisingProductSlugs = [
+
+export const MERCHANDISING_PRODUCT_SLUGS = [
 	'woocommerce-composite-products',
 	'woocommerce-eu-vat-number',
 	'woocommerce-gift-cards',
@@ -54,7 +61,8 @@ export const merchandisingProductSlugs = [
 	'woocommerce-subscription-downloads',
 	'woocommerce-subscriptions',
 ];
-export const storeContentProductSlugs = [
+
+export const STORE_CONTENT_PRODUCT_SLUGS = [
 	'woocommerce-accommodations-bookings',
 	'woocommerce-additional-image-variations',
 	'woocommerce-bookings',
@@ -64,7 +72,8 @@ export const storeContentProductSlugs = [
 	'woocommerce-minmax-quantities',
 	'woocommerce-one-page-checkout',
 ];
-export const storeManagementProductSlugs = [
+
+export const STORE_MANAGEMENT_PRODUCT_SLUGS = [
 	'woocommerce-bulk-stock-management',
 	'woocommerce-product-csv-import-suite',
 	'woocommerce-tax',

--- a/client/a8c-for-agencies/sections/marketplace/lib/product-slugs.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/product-slugs.ts
@@ -1,0 +1,72 @@
+export const securityProductSlugs = [
+	'jetpack-backup',
+	'jetpack-scan',
+	'jetpack-anti-spam',
+	'jetpack-monitor',
+	'jetpack-backup-storage',
+];
+
+export const performanceProductSlugs = [ 'jetpack-boost', 'jetpack-search', 'jetpack-videopress' ];
+
+export const socialProductSlugs = [ 'jetpack-social' ];
+
+export const growthProductSlugs = [ 'jetpack-creator', 'jetpack-ai', 'jetpack-stats' ];
+
+export const paymentsProductSlugs = [ 'woocommerce-woopayments' ];
+
+export const shippingDeliveryFulfillmentProductSlugs = [
+	'woocommerce-advanced-notifications',
+	'woocommerce-all-products-woo-subscriptions',
+	'woocommerce-conditional-shipping-payments',
+	'woocommerce-flat-rate-box-shipping',
+	'woocommerce-per-product-shipping',
+	'woocommerce-shipping-multiple-addresses',
+	'woocommerce-table-rate-shipping',
+	'woocommerce-distance-rate-shipping',
+	'woocommerce-order-barcodes',
+	'woocommerce-shipping',
+];
+export const conversionProductSlugs = [
+	'woocommerce-back-in-stock-notifications',
+	'woocommerce-checkout-field-editor',
+	'woocommerce-product-recommendations',
+	'woocommerce-coupon-campaigns',
+	'woocommerce-points-and-rewards',
+	'woocommerce-product-add-ons',
+	'woocommerce-product-bundles',
+];
+export const customerServiceProductSlugs = [
+	'woocommerce-automatewoo',
+	'woocommerce-automatewoo-birthdays',
+	'woocommerce-automatewoo-refer-a-friend',
+	'woocommerce-returns-warranty-requests',
+	'woocommerce-shipment-tracking',
+];
+export const merchandisingProductSlugs = [
+	'woocommerce-composite-products',
+	'woocommerce-eu-vat-number',
+	'woocommerce-gift-cards',
+	'woocommerce-gifting-wc-subscriptions',
+	'woocommerce-product-vendors',
+	'woocommerce-deposits',
+	'woocommerce-pre-orders',
+	'woocommerce-purchase-order-gateway',
+	'woocommerce-subscription-downloads',
+	'woocommerce-subscriptions',
+];
+export const storeContentProductSlugs = [
+	'woocommerce-accommodations-bookings',
+	'woocommerce-additional-image-variations',
+	'woocommerce-bookings',
+	'woocommerce-bookings-availability',
+	'woocommerce-box-office',
+	'woocommerce-brands',
+	'woocommerce-minmax-quantities',
+	'woocommerce-one-page-checkout',
+];
+export const storeManagementProductSlugs = [
+	'woocommerce-bulk-stock-management',
+	'woocommerce-product-csv-import-suite',
+	'woocommerce-tax',
+	'woocommerce-woopayments',
+];

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/multi-product-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/multi-product-card/index.tsx
@@ -17,6 +17,7 @@ import LicenseLightbox from 'calypso/jetpack-cloud/sections/partner-portal/licen
 import LicenseLightboxLink from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox-link';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import ProductBadges from '../product-badges';
 import ProductPriceWithDiscount from '../product-card/product-price-with-discount-info';
 
 import '../product-card/style.scss';
@@ -186,7 +187,7 @@ export default function MultiProductCard( props: Props ) {
 						<div className="product-card__main">
 							<div className="product-card__heading">
 								<h3 className="product-card__title">{ getProductShortTitle( product, true ) }</h3>
-
+								<ProductBadges product={ product } />
 								{ ! isRedesign && (
 									<MultipleChoiceQuestion
 										name={ `${ product.family_slug }-variant-options` }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-badges/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-badges/index.tsx
@@ -1,0 +1,21 @@
+import CoreBadge from 'calypso/components/core/badge';
+import { useProductCategories } from '../../hooks/use-product-categories';
+import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+
+import './style.scss';
+
+interface Props {
+	product: APIProductFamilyProduct;
+}
+
+export default function ProductBadges( { product }: Props ) {
+	const badges = useProductCategories( product );
+
+	return (
+		<div className="product-badges">
+			{ badges.map( ( badge: string ) => (
+				<CoreBadge key={ badge }>{ badge }</CoreBadge>
+			) ) }
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-badges/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-badges/style.scss
@@ -1,0 +1,5 @@
+.product-badges {
+	display: flex;
+	gap: 8px;
+	margin-block-start: 8px;
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/index.tsx
@@ -15,6 +15,7 @@ import LicenseLightbox from 'calypso/jetpack-cloud/sections/partner-portal/licen
 import LicenseLightboxLink from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox-link';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from '../../../../../state/partner-portal/types';
+import ProductBadges from '../product-badges';
 import ProductPriceWithDiscount from './product-price-with-discount-info';
 
 import './style.scss';
@@ -170,7 +171,7 @@ export default function ProductCard( props: Props ) {
 						<div className="product-card__main">
 							<div className="product-card__heading">
 								<h3 className="product-card__title">{ productTitle }</h3>
-
+								<ProductBadges product={ product } />
 								<div className="product-card__pricing is-compact">
 									<ProductPriceWithDiscount
 										product={ product }

--- a/client/components/core/badge/README.md
+++ b/client/components/core/badge/README.md
@@ -1,0 +1,41 @@
+# CoreBadge Component
+
+A wrapper component around WordPress's private `Badge` component from `@wordpress/components`.
+
+## Usage
+
+```jsx
+import CoreBadge from 'calypso/components/core/badge';
+
+function MyComponent() {
+	return <CoreBadge>Badge Content</CoreBadge>;
+}
+```
+
+## Important Notes
+
+### Private API Usage
+
+This component currently uses WordPress's private API through `@wordpress/private-apis`. The underlying `Badge` component is not yet part of the public API and may change or break in future versions of WordPress.
+
+We will migrate to the public version of this component once it becomes available in `@wordpress/components`.
+
+### Why a Wrapper?
+
+1. **Centralized Private API Management**: Without this wrapper, we would need to duplicate the private API acknowledgment code everywhere the Badge is used. This wrapper centralizes the code in one place and makes it easier to track its usage.
+
+2. **Future-Proofing**: When the Badge component becomes public, we'll only need to update this one wrapper component instead of finding and updating every direct usage throughout the codebase. This makes the eventual migration to the public API much simpler.
+
+### Scope
+
+For now, this component will remain in `client/components` (Calypso-only).
+
+Products that run in dependency-extracted environments (e.g., Jetpack, WooCommerce) should unlock the private component on their own from their globally available version. We can consider company-wide sharing when a non-dependency-extracted product needs to use this component.
+
+## Future Plans
+
+Once the Badge component becomes publicly available in `@wordpress/components`, we should:
+
+1. Remove the private API usage
+2. Update this wrapper to use the public API
+3. Eventually consider deprecating this wrapper in favor of direct Badge usage

--- a/client/components/core/badge/index.tsx
+++ b/client/components/core/badge/index.tsx
@@ -3,6 +3,8 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 import React from 'react';
 
 const CoreBadge = ( { children }: { children: React.ReactNode } ) => {
+	// TODO: When the component is publicly available, we should remove the private API usage and
+	// import it directly from @wordpress/components as it will cause a build error.
 	const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/components'

--- a/client/components/core/badge/index.tsx
+++ b/client/components/core/badge/index.tsx
@@ -1,0 +1,14 @@
+import { privateApis } from '@wordpress/components';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+import React from 'react';
+
+const CoreBadge = ( { children }: { children: React.ReactNode } ) => {
+	const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+		'@wordpress/components'
+	);
+	const { Badge } = unlock( privateApis );
+	return <Badge>{ children }</Badge>;
+};
+
+export default CoreBadge;

--- a/client/package.json
+++ b/client/package.json
@@ -104,6 +104,7 @@
 		"@wordpress/i18n": "^5.16.0",
 		"@wordpress/icons": "^10.16.0",
 		"@wordpress/is-shallow-equal": "^5.16.0",
+		"@wordpress/private-apis": "^1.16.0",
 		"@wordpress/react-i18n": "^4.16.0",
 		"@wordpress/url": "^4.16.0",
 		"@wordpress/warning": "^3.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13931,6 +13931,7 @@ __metadata:
     "@wordpress/i18n": "npm:^5.16.0"
     "@wordpress/icons": "npm:^10.16.0"
     "@wordpress/is-shallow-equal": "npm:^5.16.0"
+    "@wordpress/private-apis": "npm:^1.16.0"
     "@wordpress/react-i18n": "npm:^4.16.0"
     "@wordpress/url": "npm:^4.16.0"
     "@wordpress/warning": "npm:^3.16.0"


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1694

## Proposed Changes

This PR:

- Adds a badge component imported from a private Core Badge component. 
- Implements badges for product cards on the A4A Marketplace. 

NOTE: The logic to get the badges in the Marketplace is WIP.

## Why are these changes being made?

* Core alignment. 

## Testing Instructions

* Open the A4A live link
* Go to Marketplace: Products > Verify you can see the badges as shown below

<img width="1728" alt="Screenshot 2025-02-05 at 4 47 08 PM" src="https://github.com/user-attachments/assets/173cbc2b-da64-4fca-a65f-de4acaad3372" />

<img width="457" alt="Screenshot 2025-02-05 at 4 47 28 PM" src="https://github.com/user-attachments/assets/d4abe676-e44f-435e-8b3b-c52b763da21a" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
