### PR TITLE
Upload Plugin: Fix condition to avoid showing error screen

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -170,13 +170,23 @@ const MarketplaceProductInstall = ( {
 		}
 	} );
 
+	const { primaryDomain } = useSelector( getPurchaseFlowState );
+
+	const shouldShowNoDirectAccessError = useMemo( () => {
+		return (
+			// Show error if:
+			// 1. This is a plugin upload flow (via zip file) and we don't have a primary domain set
+			( isPluginUploadFlow && ! primaryDomain ) ||
+			// 2. This is a marketplace plugin installation but the installation process hasn't started
+			( ! isPluginUploadFlow && ! marketplaceInstallationInProgress )
+		);
+	}, [ isPluginUploadFlow, marketplaceInstallationInProgress ] );
+
 	// Check that the site URL and the plugin slug are the same which were selected on the plugin page
 	useEffect( () => {
-		if ( ! isPluginUploadFlow && ! marketplaceInstallationInProgress ) {
+		if ( shouldShowNoDirectAccessError ) {
 			waitFor( 2 ).then( () => {
-				! isPluginUploadFlow &&
-					! marketplaceInstallationInProgress &&
-					setNoDirectAccessError( true );
+				shouldShowNoDirectAccessError && setNoDirectAccessError( true );
 			} );
 		}
 	}, [ marketplaceInstallationInProgress, isPluginUploadFlow ] );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -172,15 +172,11 @@ const MarketplaceProductInstall = ( {
 
 	const { primaryDomain } = useSelector( getPurchaseFlowState );
 
-	const shouldShowNoDirectAccessError = useMemo( () => {
-		return (
-			// Show error if:
-			// 1. This is a plugin upload flow (via zip file) and we don't have a primary domain set
-			( isPluginUploadFlow && ! primaryDomain ) ||
-			// 2. This is a marketplace plugin installation but the installation process hasn't started
-			( ! isPluginUploadFlow && ! marketplaceInstallationInProgress )
-		);
-	}, [ isPluginUploadFlow, marketplaceInstallationInProgress ] );
+	const shouldShowNoDirectAccessError =
+		// 1. This is a plugin upload flow (via zip file) and we don't have a primary domain set
+		( isPluginUploadFlow && ! primaryDomain ) ||
+		// 2. This is a marketplace plugin installation but the installation process hasn't started
+		( ! isPluginUploadFlow && ! marketplaceInstallationInProgress );
 
 	// Check that the site URL and the plugin slug are the same which were selected on the plugin page
 	useEffect( () => {
@@ -189,7 +185,7 @@ const MarketplaceProductInstall = ( {
 				shouldShowNoDirectAccessError && setNoDirectAccessError( true );
 			} );
 		}
-	}, [ marketplaceInstallationInProgress, isPluginUploadFlow ] );
+	}, [ shouldShowNoDirectAccessError ] );
 
 	// Upload flow startup
 	useEffect( () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -170,19 +170,14 @@ const MarketplaceProductInstall = ( {
 		}
 	} );
 
-	const purchaseFlowState = useSelector( getPurchaseFlowState );
-	const isDifferentFromPurchaseSite = purchaseFlowState.primaryDomain !== selectedSiteSlug;
-
 	// Check that the site URL and the plugin slug are the same which were selected on the plugin page
 	useEffect( () => {
-		if ( isDifferentFromPurchaseSite ) {
+		if ( ! marketplaceInstallationInProgress ) {
 			waitFor( 2 ).then( () => {
-				if ( isDifferentFromPurchaseSite ) {
-					setNoDirectAccessError( true );
-				}
+				! marketplaceInstallationInProgress && setNoDirectAccessError( true );
 			} );
 		}
-	}, [ isDifferentFromPurchaseSite ] );
+	}, [ marketplaceInstallationInProgress ] );
 
 	// Upload flow startup
 	useEffect( () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -171,21 +171,18 @@ const MarketplaceProductInstall = ( {
 	} );
 
 	const purchaseFlowState = useSelector( getPurchaseFlowState );
-	const hasCompletedInstallation =
-		purchaseFlowState.pluginInstallationStatus === MARKETPLACE_ASYNC_PROCESS_STATUS.COMPLETED &&
-		purchaseFlowState.primaryDomain === selectedSiteSlug;
+	const isDifferentFromPurchaseSite = purchaseFlowState.primaryDomain !== selectedSiteSlug;
 
 	// Check that the site URL and the plugin slug are the same which were selected on the plugin page
 	useEffect( () => {
-		if ( ! marketplaceInstallationInProgress && ! hasCompletedInstallation ) {
-			// Only show error if we haven't completed installation and there's no installation in progress
+		if ( isDifferentFromPurchaseSite ) {
 			waitFor( 2 ).then( () => {
-				if ( ! marketplaceInstallationInProgress && ! hasCompletedInstallation ) {
+				if ( isDifferentFromPurchaseSite ) {
 					setNoDirectAccessError( true );
 				}
 			} );
 		}
-	}, [ marketplaceInstallationInProgress, hasCompletedInstallation ] );
+	}, [ isDifferentFromPurchaseSite ] );
 
 	// Upload flow startup
 	useEffect( () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -170,14 +170,22 @@ const MarketplaceProductInstall = ( {
 		}
 	} );
 
+	const purchaseFlowState = useSelector( getPurchaseFlowState );
+	const hasCompletedInstallation =
+		purchaseFlowState.pluginInstallationStatus === MARKETPLACE_ASYNC_PROCESS_STATUS.COMPLETED &&
+		purchaseFlowState.primaryDomain === selectedSiteSlug;
+
 	// Check that the site URL and the plugin slug are the same which were selected on the plugin page
 	useEffect( () => {
-		if ( ! marketplaceInstallationInProgress ) {
+		if ( ! marketplaceInstallationInProgress && ! hasCompletedInstallation ) {
+			// Only show error if we haven't completed installation and there's no installation in progress
 			waitFor( 2 ).then( () => {
-				! marketplaceInstallationInProgress && setNoDirectAccessError( true );
+				if ( ! marketplaceInstallationInProgress && ! hasCompletedInstallation ) {
+					setNoDirectAccessError( true );
+				}
 			} );
 		}
-	}, [ marketplaceInstallationInProgress ] );
+	}, [ marketplaceInstallationInProgress, hasCompletedInstallation ] );
 
 	// Upload flow startup
 	useEffect( () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -172,12 +172,14 @@ const MarketplaceProductInstall = ( {
 
 	// Check that the site URL and the plugin slug are the same which were selected on the plugin page
 	useEffect( () => {
-		if ( ! marketplaceInstallationInProgress ) {
+		if ( ! isPluginUploadFlow && ! marketplaceInstallationInProgress ) {
 			waitFor( 2 ).then( () => {
-				! marketplaceInstallationInProgress && setNoDirectAccessError( true );
+				! isPluginUploadFlow &&
+					! marketplaceInstallationInProgress &&
+					setNoDirectAccessError( true );
 			} );
 		}
-	}, [ marketplaceInstallationInProgress ] );
+	}, [ marketplaceInstallationInProgress, isPluginUploadFlow ] );
 
 	// Upload flow startup
 	useEffect( () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/96916

## Proposed Changes

* Updates the condition to check that the Upload process has completed, so the error screen is not displayed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* That error screen was displayed unnecessarily

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch
* With a Business site selected that is **not** atomic, navigate to plugins, i.e. `/plugins/:siteId`
* Upload a plugin
* Accepts the eligibility warnings if required
* Check the process completes and no intermediate error screen is shown.
- Additionally, access this URL directly for any site and check that the error screen is displayed: `/marketplace/plugin/install/:siteDomain` 

#### After the fix

https://github.com/user-attachments/assets/77bee574-a86d-4b56-975d-e38b71d27523



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
