### PR TITLE
Server: re-read assets.json file when modified

### DIFF
--- a/client/server/middleware/assets.js
+++ b/client/server/middleware/assets.js
@@ -21,10 +21,9 @@ const getAssetType = ( asset ) => {
 const groupAssetsByType = ( assets ) => defaults( groupBy( assets, getAssetType ), EMPTY_ASSETS );
 
 export default () => {
-	let assetsFile;
+	let assetsFile = null;
 	let assetsFileModified = 0;
-
-	async function readAssets() {
+	async function doReadAssets() {
 		const fd = await open( ASSETS_FILE );
 		const stats = await fd.stat();
 		if ( ! assetsFile || stats.mtimeMs > assetsFileModified ) {
@@ -33,6 +32,17 @@ export default () => {
 		}
 		await fd.close();
 		return assetsFile;
+	}
+
+	let checking = null;
+	function readAssets() {
+		if ( ! checking ) {
+			checking = doReadAssets().finally( () => {
+				checking = null;
+			} );
+		}
+
+		return checking;
 	}
 
 	return asyncHandler( async ( req, res, next ) => {

--- a/client/server/middleware/assets.js
+++ b/client/server/middleware/assets.js
@@ -1,4 +1,4 @@
-import { readFile } from 'fs/promises';
+import { readFile, stat } from 'fs/promises';
 import path from 'path';
 import asyncHandler from 'express-async-handler';
 import { defaults, groupBy } from 'lodash';
@@ -22,9 +22,13 @@ const groupAssetsByType = ( assets ) => defaults( groupBy( assets, getAssetType 
 
 export default () => {
 	let assetsFile;
+	let assetsFileModified = 0;
+
 	async function readAssets() {
-		if ( ! assetsFile ) {
+		const stats = await stat( ASSETS_FILE );
+		if ( ! assetsFile || stats.mtimeMs > assetsFileModified ) {
 			assetsFile = JSON.parse( await readFile( ASSETS_FILE, 'utf8' ) );
+			assetsFileModified = stats.mtimeMs;
 		}
 		return assetsFile;
 	}

--- a/client/server/middleware/assets.js
+++ b/client/server/middleware/assets.js
@@ -1,4 +1,4 @@
-import { readFile, stat } from 'fs/promises';
+import { open } from 'fs/promises';
 import path from 'path';
 import asyncHandler from 'express-async-handler';
 import { defaults, groupBy } from 'lodash';
@@ -25,11 +25,13 @@ export default () => {
 	let assetsFileModified = 0;
 
 	async function readAssets() {
-		const stats = await stat( ASSETS_FILE );
+		const fd = await open( ASSETS_FILE );
+		const stats = await fd.stat();
 		if ( ! assetsFile || stats.mtimeMs > assetsFileModified ) {
-			assetsFile = JSON.parse( await readFile( ASSETS_FILE, 'utf8' ) );
+			assetsFile = JSON.parse( await fd.readFile( 'utf8' ) );
 			assetsFileModified = stats.mtimeMs;
 		}
+		await fd.close();
 		return assetsFile;
 	}
 


### PR DESCRIPTION
The Calypso server uses the `build/assets.json` file to construct the list of JS and CSS assets that will be shipped in the initial HTML page. The right entrypoint, and a preloaded section chunk.

Currently the server reads the `build/assets.json` file once and then caches it forever. That's fine in a production build, but in development people edit source files and webpack rebuilds the bundle and writes a new `assets.json` file. But the dev server will use a stale one.

This PR fixes that by checking the last modified time of the file and reloading it if there is a newer version. When you reload Calypso in your dev environment, it should always get the latest assets. This prevents bugs like when a new asset is added or when chunks are re-arranged -- then the `assets.json` info is no longer correct.

In production, this means that there is an extra `stats` call on every load of the "index.html" page. I guess this is OK because we do much more expensive operations during the production load, like user bootstrapping.

**How to test:**
You'll need to add some `console.log` statements to the code: log when the file is cached, when it's not cached, and what are the modification times.

Then run a dev server (`yarn start`), let it start up, load local Calypso. Then edit some file. After webpack finishes a rebuild, reload Calypso. The server console log should tell you that the file was reloaded from filesystem.