### PR TITLE
Domain management: Update domain header font-size

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain-header/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain-header/index.tsx
@@ -49,6 +49,7 @@ const DomainHeader = ( {
 			mobileItem={ mobileItem }
 			title={ titleOverride || items[ items.length - 1 ].label }
 			subtitle={ subtitleOverride || items[ items.length - 1 ].subtitle }
+			className="domain-header"
 		>
 			{ renderButtons() }
 		</NavigationHeader>

--- a/client/my-sites/domains/domain-management/components/domain-header/style.scss
+++ b/client/my-sites/domains/domain-management/components/domain-header/style.scss
@@ -1,6 +1,17 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+.domain-header {
+	.navigation-header__main {
+		align-items: center;
+
+		.formatted-header__title {
+			font-size: 1.5rem;
+			line-height: 1.25;
+		}
+	}
+}
+
 .domain-header__header-spacer {
 	height: 58px;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/99267

## Proposed Changes

* Update the domain header font-size to match /sites.
* Vertically center the domain header title.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of the domain management revamp project.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/domains/manage.
* Make sure the header title font looks the same as the http://calypso.localhost:3000/sites page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
