### PR TITLE
RDV: Update overriding preference

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -411,7 +411,7 @@ export const redirectIfDuplicatedView = ( wpAdminPath ) => async ( context, next
 
 	const overrideAssignment = getPreference(
 		context.store.getState(),
-		'remove_duplicate_views_experiment_assignment'
+		'remove_duplicate_views_experiment_assignment_160125'
 	);
 
 	if ( 'control' === overrideAssignment ) {


### PR DESCRIPTION
## Proposed Changes

In https://github.com/Automattic/jetpack/pull/41378, we changed the preference used to override the RDV experiment assignment, but we forgot to update the Calypso counterpart.

This PR updates the preference in Calypso so both Calypso and Jetpack use the same preference.

## Why are these changes being made?

Because the RDV escape hatch (p7DVsv-m73-p2) doesn't work if both Jetpack and Calypso use the same preference.

## Testing Instructions

See https://github.com/Automattic/wp-calypso/pull/98696

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?