### PR TITLE
Build: Bump base image execution timeout limit

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -222,7 +222,7 @@ object BuildBaseImages : BuildType({
 	}
 
 	failureConditions {
-		executionTimeoutMin = 30
+		executionTimeoutMin = 40
 	}
 
 	features {


### PR DESCRIPTION
## Proposed Changes

Bumping the Calypso base image execution timeout limit (from 30 to 40 min).

## Why are these changes being made?

Currently, the Calypso base images are timing out right at the end of the process.

As we're looking at fixing things, let's allow for the base image to build correctly in order to let developers have faster Docker builds. This has a massive impact in rush hour when there are multiple deploys stacked.

## Testing Instructions

No testing should be necessary. 