### PR TITLE
Onboarding: Prevent the user from seeing the designSetup step again after the upgrade flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -26,7 +26,7 @@ import { StepContainer, DESIGN_FIRST_FLOW, ONBOARDING_FLOW } from '@automattic/o
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import { useQueryProductsList } from 'calypso/components/data/query-products-list';
@@ -91,7 +91,6 @@ import useRecipe from './hooks/use-recipe';
 import useTrackFilters from './hooks/use-track-filters';
 import getThemeIdFromDesign from './utils/get-theme-id-from-design';
 import type { Step, ProvidedDependencies } from '../../types';
-import './style.scss';
 import type {
 	OnboardSelect,
 	SiteSelect,
@@ -172,7 +171,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		( select ) => site && ( select( SITE_STORE ) as SiteSelect ).isSiteAtomic( site.ID ),
 		[ site ]
 	);
-
+	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	const isComingFromTheUpgradeScreen = queryParams.get( 'continue' ) === '1';
 
 	useEffect( () => {
@@ -194,6 +193,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			[ site ]
 		)
 	);
+
+	const { setDesignOnSite, assembleSite } = useDispatch( SITE_STORE );
 
 	// ********** Logic for fetching designs
 	const selectStarterDesigns = ( allDesigns: StarterDesigns ) => {
@@ -603,6 +604,117 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		}
 	}
 
+	const handleSubmit = useCallback(
+		( providedDependencies?: ProvidedDependencies, optionalProps?: object ) => {
+			const _selectedDesign = providedDependencies?.selectedDesign as Design;
+			recordSelectedDesign( {
+				...commonFilterProperties,
+				flow,
+				intent,
+				design: _selectedDesign,
+				styleVariation: selectedStyleVariation,
+				colorVariation: selectedColorVariation,
+				fontVariation: selectedFontVariation,
+				optionalProps,
+			} );
+
+			submit?.( {
+				...providedDependencies,
+				eventProps: commonFilterProperties,
+			} );
+		},
+		[
+			commonFilterProperties,
+			flow,
+			intent,
+			selectedStyleVariation,
+			selectedColorVariation,
+			selectedFontVariation,
+			submit,
+		]
+	);
+
+	const pickDesign = useCallback(
+		async ( _selectedDesign: Design | undefined = selectedDesign ) => {
+			setSelectedDesign( _selectedDesign );
+
+			if ( siteSlugOrId ) {
+				await updateLaunchpadSettings( siteSlugOrId, {
+					checklist_statuses: { design_completed: true },
+				} );
+			}
+
+			if ( siteSlugOrId && _selectedDesign ) {
+				const positionIndex = designs.findIndex(
+					( design ) => design.slug === _selectedDesign?.slug
+				);
+
+				setPendingAction( () => {
+					if ( _selectedDesign?.is_virtual ) {
+						const themeId = getThemeIdFromStylesheet( _selectedDesign.recipe?.stylesheet ?? '' );
+						return Promise.resolve()
+							.then( () =>
+								reduxDispatch(
+									activateOrInstallThenActivate( themeId ?? '', site?.ID ?? 0, {
+										source: 'assembler',
+									} ) as ThunkAction< PromiseLike< string >, any, any, AnyAction >
+								)
+							)
+							.then( ( activeThemeStylesheet: string ) =>
+								assembleSite( siteSlugOrId, activeThemeStylesheet, {
+									homeHtml: _selectedDesign.recipe?.pattern_html,
+									headerHtml: _selectedDesign.recipe?.header_html,
+									footerHtml: _selectedDesign.recipe?.footer_html,
+									siteSetupOption: 'assembler-virtual-theme',
+								} )
+							);
+					}
+
+					return setDesignOnSite( siteSlugOrId, _selectedDesign, {
+						styleVariation: selectedStyleVariation,
+						globalStyles,
+					} ).then( ( theme: ActiveTheme ) => {
+						return reduxDispatch( setActiveTheme( site?.ID || -1, theme ) );
+					} );
+				} );
+
+				handleSubmit(
+					{
+						selectedDesign: _selectedDesign,
+					},
+					{ ...( positionIndex >= 0 && { position_index: positionIndex } ) }
+				);
+			} else if ( ! isSiteRequired && ! siteSlugOrId && _selectedDesign ) {
+				const positionIndex = designs.findIndex(
+					( design ) => design.slug === _selectedDesign?.slug
+				);
+				handleSubmit(
+					{
+						selectedDesign: _selectedDesign,
+						selectedSiteCategory: categorization.selections?.join( ',' ),
+					},
+					{ ...( positionIndex >= 0 && { position_index: positionIndex } ) }
+				);
+			}
+		},
+		[
+			assembleSite,
+			categorization.selections,
+			designs,
+			globalStyles,
+			handleSubmit,
+			isSiteRequired,
+			reduxDispatch,
+			selectedDesign,
+			selectedStyleVariation,
+			setDesignOnSite,
+			setPendingAction,
+			setSelectedDesign,
+			site?.ID,
+			siteSlugOrId,
+		]
+	);
+
 	function tryPremiumGlobalStyles() {
 		// These conditions should be true at this point, but just in case...
 		if ( shouldUnlockGlobalStyles ) {
@@ -619,96 +731,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		}
 	}
 
-	// ********** Logic for submitting the selected design
-
-	const { setDesignOnSite, assembleSite } = useDispatch( SITE_STORE );
-	const { setPendingAction } = useDispatch( ONBOARD_STORE );
-
-	async function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
-		setSelectedDesign( _selectedDesign );
-
-		if ( siteSlugOrId ) {
-			await updateLaunchpadSettings( siteSlugOrId, {
-				checklist_statuses: { design_completed: true },
-			} );
-		}
-
-		if ( siteSlugOrId && _selectedDesign ) {
-			const positionIndex = designs.findIndex(
-				( design ) => design.slug === _selectedDesign?.slug
-			);
-
-			setPendingAction( () => {
-				if ( _selectedDesign?.is_virtual ) {
-					const themeId = getThemeIdFromStylesheet( _selectedDesign.recipe?.stylesheet ?? '' );
-					return Promise.resolve()
-						.then( () =>
-							reduxDispatch(
-								activateOrInstallThenActivate( themeId ?? '', site?.ID ?? 0, {
-									source: 'assembler',
-								} ) as ThunkAction< PromiseLike< string >, any, any, AnyAction >
-							)
-						)
-						.then( ( activeThemeStylesheet: string ) =>
-							assembleSite( siteSlugOrId, activeThemeStylesheet, {
-								homeHtml: _selectedDesign.recipe?.pattern_html,
-								headerHtml: _selectedDesign.recipe?.header_html,
-								footerHtml: _selectedDesign.recipe?.footer_html,
-								siteSetupOption: 'assembler-virtual-theme',
-							} )
-						);
-				}
-
-				return setDesignOnSite( siteSlugOrId, _selectedDesign, {
-					styleVariation: selectedStyleVariation,
-					globalStyles,
-				} ).then( ( theme: ActiveTheme ) => {
-					return reduxDispatch( setActiveTheme( site?.ID || -1, theme ) );
-				} );
-			} );
-
-			handleSubmit(
-				{
-					selectedDesign: _selectedDesign,
-				},
-				{ ...( positionIndex >= 0 && { position_index: positionIndex } ) }
-			);
-		} else if ( ! isSiteRequired && ! siteSlugOrId && _selectedDesign ) {
-			const positionIndex = designs.findIndex(
-				( design ) => design.slug === _selectedDesign?.slug
-			);
-			handleSubmit(
-				{
-					selectedDesign: _selectedDesign,
-					selectedSiteCategory: categorization.selections?.join( ',' ),
-				},
-				{ ...( positionIndex >= 0 && { position_index: positionIndex } ) }
-			);
-		}
-	}
-
 	function pickUnlistedDesign( theme: string ) {
 		// TODO: move this logic from this step to the flow(s). See: https://wp.me/pdDR7T-KR
 		exitFlow?.( `/theme/${ theme }/${ siteSlug }` );
-	}
-
-	function handleSubmit( providedDependencies?: ProvidedDependencies, optionalProps?: object ) {
-		const _selectedDesign = providedDependencies?.selectedDesign as Design;
-		recordSelectedDesign( {
-			...commonFilterProperties,
-			flow,
-			intent,
-			design: _selectedDesign,
-			styleVariation: selectedStyleVariation,
-			colorVariation: selectedColorVariation,
-			fontVariation: selectedFontVariation,
-			optionalProps,
-		} );
-
-		submit?.( {
-			...providedDependencies,
-			eventProps: commonFilterProperties,
-		} );
 	}
 
 	function handleBackClick() {
@@ -781,7 +806,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		if ( isComingFromTheUpgradeScreen ) {
 			pickDesign();
 		}
-	}, [ isComingFromTheUpgradeScreen ] );
+	}, [ isComingFromTheUpgradeScreen, pickDesign ] );
 
 	// ********** Main render logic
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -102,6 +102,7 @@ import type { Design, StyleVariation } from '@automattic/design-picker';
 import type { GlobalStylesObject } from '@automattic/global-styles';
 import type { AnyAction } from 'redux';
 import type { ThunkAction } from 'redux-thunk';
+import './style.scss';
 
 const SiteIntent = Onboard.SiteIntent;
 
@@ -171,6 +172,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		( select ) => site && ( select( SITE_STORE ) as SiteSelect ).isSiteAtomic( site.ID ),
 		[ site ]
 	);
+
+	const isComingFromTheUpgradeScreen = queryParams.get( 'continue' ) === '1';
+
 	useEffect( () => {
 		if ( isAtomic ) {
 			// TODO: move this logic from this step to the flow(s). See: https://wp.me/pdDR7T-KR
@@ -501,7 +505,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			? addQueryArgs( `/marketplace/thank-you/${ wpcomSiteSlug ?? siteSlug }?onboarding`, {
 					themes: selectedDesign?.slug,
 			  } )
-			: window.location.href.replace( window.location.origin, '' );
+			: addQueryArgs( window.location.href.replace( window.location.origin, '' ), {
+					continue: 1,
+			  } );
 
 		goToCheckout( {
 			flowName: flow,
@@ -771,10 +777,20 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		);
 	}
 
+	useEffect( () => {
+		if ( isComingFromTheUpgradeScreen ) {
+			pickDesign();
+		}
+	}, [ isComingFromTheUpgradeScreen ] );
+
 	// ********** Main render logic
 
 	// Don't render until we've done fetching all the data needed for initial render.
-	if ( ( ! site && isSiteRequired ) || isLoadingDesigns || isGoalsAtFrontExperimentLoading ) {
+	const isSiteLoading = ! site && isSiteRequired;
+	const isDesignsLoading = isLoadingDesigns || isGoalsAtFrontExperimentLoading;
+	const isLoading = isSiteLoading || isDesignsLoading;
+
+	if ( isLoading || isComingFromTheUpgradeScreen ) {
 		return <StepperLoader />;
 	}
 
@@ -804,6 +820,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					<UpgradeModal
 						slug={ selectedDesign.slug }
 						isOpen={ showUpgradeModal }
+						//TODO: Fix NEEED typo
 						isMarketplacePlanSubscriptionNeeeded={ ! isExternallyManagedThemeAvailable }
 						isMarketplaceThemeSubscriptionNeeded={ isMarketplaceThemeSubscriptionNeeded }
 						marketplaceProduct={ selectedMarketplaceProduct }


### PR DESCRIPTION
Closes #99360

### Context
As demonstrated in the video above, the user is redirected again to the design setup step after the upgrade flow.



## Proposed Changes
* Add a new flag (continue=1) to the URL that the checkout page uses for redirecting the user back to the flow.
* Update the designSetup step to check for the existence of the flag and automatically advance the user to the next step, regardless of the flow. 


## Tech extra notes.
The change that fixed the bug is just 2a6ea5a45ff2d769522cbb572341f1caa4c25964.

The diff shows more changes because I had to update the position of "handleSubmit" and "pickDesign" to enable me to use the `useEffect` without issues. 

The previous version used the syntax `function,` which makes JS ignore the definition order, but in order to use `effect,` I had to update to the `const function = () => ` syntax. 



## Why are these changes being made?
* The intent is to make the user experience smoother, preventing the user from seeing the same screen again when it is unnecessary. 


### Before
https://github.com/user-attachments/assets/6da2d6bc-87a8-4ef2-8d28-19ec3b2aa646


### Updated

https://github.com/user-attachments/assets/f9d57752-4a9a-484e-a5a2-66982531e998



## Testing Instructions
/start
* Choose a free plan and premium theme.
* Pick any pattern.
* Accept the upgrade suggestion.
* Complete the payment process.
* Verify if you have been redirected to the next step instead of the `designSetup`.* 
* Check if you have been redirected to the next step instead of the `designSetup`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
