### PR TITLE
Reveal domain transfer link in hundred year plan flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -602,11 +602,6 @@
 			.domain-search-results__domain-available-notice-icon {
 				margin-right: 4px;
 			}
-
-			/* hide transfer link */
-			a {
-				display: none;
-			}
 		}
 
 		// Hide the domain explanation image
@@ -627,12 +622,6 @@
 				align-items: flex-end;
 				align-self: center;
 				margin-right: 16px;
-			}
-		}
-
-		.domain-search-results__domain-available-notice {
-			a {
-				display: unset;
 			}
 		}
 	}


### PR DESCRIPTION
This PR "unhides" the transfer link in the hundred year plans purchase flow.

**Before**
<img width="1255" alt="image" src="https://github.com/user-attachments/assets/062c8a9f-aef7-450d-b975-5fb4e1227810" />


**After**
<img width="1256" alt="image" src="https://github.com/user-attachments/assets/b3fa3ae6-3bd7-4dd4-9b93-bff1316be6bf" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/setup/hundred-year-plan/domains?ref=100-year-lp` and make your way to the domains screen. Try thenextweb.com.
* Test `/setup/hundred-year-domain/domains` to see if it still works. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
