### PR TITLE
Align all domain overview pages to center (except upsells)

### DIFF
--- a/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
@@ -208,6 +208,17 @@
 		flex-wrap: wrap;
 	}
 
+	.domains-overview__details {
+		.main.is-wide-layout:not( .email-providers-in-depth-comparison-page ):not( .email-stacked-comparison-page ) {	
+			margin-left: 0;
+			max-width: 1040px;
+		}
+
+		.hosting-dashboard-layout-column__container .navigation-header div.navigation-header__main {
+			margin-left: 0;
+		}
+	}
+
 	.hosting-dashboard-item-view__content > div {
 		flex-grow: 1;
 

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -149,7 +149,9 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 		if ( ! domainHasEmail( selectedDomain ) ) {
 			return (
 				<EmailProvidersStackedComparisonPage
-					className={ clsx( { 'context-all-domain-management': isAllDomainManagementContext } ) }
+					className={ clsx( 'email-stacked-comparison-page', {
+						'context-all-domain-management': isAllDomainManagementContext,
+					} ) }
 					comparisonContext="email-home-selected-domain"
 					selectedDomainName={ selectedDomainName }
 					selectedEmailProviderSlug={ selectedEmailProviderSlug }

--- a/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/in-depth/index.tsx
@@ -95,7 +95,7 @@ const EmailProvidersInDepthComparison = ( {
 	const ComparisonComponent = isMobile ? ComparisonList : ComparisonTable;
 
 	return (
-		<Main wideLayout>
+		<Main wideLayout className="email-providers-in-depth-comparison-page">
 			<QueryProductsList />
 			{ showBackButton && (
 				<EmailUpsellNavigation


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99294

## Proposed Changes

* Align all domain overview and email pages and sub-pages to left. Except the email upsell and email plan comparison pages
* Make the max width 1040px.
* We left the upsell and plan comparison pages center aligned because they don't look good when left-aligned

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix alignment problems

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to /domains/manage
- Open a domain in flyout by clicking on the title of the domain
- Go through all domain main pages and sub pages
- Make sure all of them align to the left (except for the email upsell and plan comparison pages) and max-width always remains as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
