### PR TITLE
Checkout: Set Google and Apple Pay button to 100% width

### DIFF
--- a/packages/wpcom-checkout/src/payment-request-button.tsx
+++ b/packages/wpcom-checkout/src/payment-request-button.tsx
@@ -88,7 +88,7 @@ const ApplePayButton = styled.button`
 	-apple-pay-button-style: black;
 	-apple-pay-button-type: plain;
 	height: 38px;
-	width: calc( 100% - 60px );
+	width: 100%;
 	position: relative;
 
 	&::after {
@@ -115,7 +115,7 @@ const ApplePayButton = styled.button`
 const GooglePayButtonWrapper = styled.button`
 	background-color: #000;
 	border-radius: 4px;
-	width: calc( 100% - 60px );
+	width: 100%;
 	padding: 12px 24px 10px;
 	position: relative;
 	text-align: center;


### PR DESCRIPTION
Google and Apple pay have a 60px reduction added to their '100%' width, which I can only presume was to accommodate the support button when it still existed.

Since these two payment buttons handle their styling separately from the other payment buttons, its possible this wasn't updated when the support button was removed. Either way, this PR removes the calculation and simply sets the buttons to be 100% wide.

| Before | After |
| ----- | ----- |
| <img width="530" alt="image" src="https://github.com/user-attachments/assets/1183ab7c-e9dd-41fe-900c-65be3bd32181" /> | <img width="530" alt="image" src="https://github.com/user-attachments/assets/d0584262-f65e-4baf-81d3-773e3d88e102" /> |


Related to #99214 

## Testing Instructions

* Its always hard to test these buttons since they require an https connection
* You can follow the original test instructions outlined [here](https://github.com/Automattic/wp-calypso/pull/52311), or simply wait for the Calypso Live link to be generated for this PR and use that instead
* Make sure your browser has Google Pay or Apple Pay set up, you'll likely use Chrome to test Google Pay and Safari for Apple Pay
* Go to Checkout and edit your payment details, you should see the payment options available
* Shrink the browser width and ensure the payment button is full width at all browser sizes

