### PR TITLE
Reader: `reader` and `account` flows set Reader as the user's default landing page

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -1,7 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { HOSTING_LP_FLOW, ONBOARDING_FLOW, ONBOARDING_GUIDED_FLOW } from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
-import { saveReaderAsLandingPage } from 'calypso/state/sites/selectors/has-reader-as-landing-page';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { READER_AS_LANDING_PAGE_PREFERENCE } from 'calypso/state/sites/selectors/has-reader-as-landing-page';
 
 const noop = () => {};
 
@@ -91,6 +92,14 @@ export function generateFlows( {
 			providesDependenciesInQuery: [ 'toStepper' ],
 			optionalDependenciesInQuery: [ 'toStepper' ],
 			hideProgressIndicator: true,
+			postCompleteCallback: async ( { dispatch } ) => {
+				dispatch(
+					savePreference( READER_AS_LANDING_PAGE_PREFERENCE, {
+						useReaderAsLandingPage: true,
+						updatedAt: Date.now(),
+					} )
+				);
+			},
 		},
 		{
 			name: 'business',
@@ -374,7 +383,12 @@ export function generateFlows( {
 			showRecaptcha: true,
 			hideProgressIndicator: true,
 			postCompleteCallback: async ( { dispatch } ) => {
-				dispatch( saveReaderAsLandingPage() );
+				dispatch(
+					savePreference( READER_AS_LANDING_PAGE_PREFERENCE, {
+						useReaderAsLandingPage: true,
+						updatedAt: Date.now(),
+					} )
+				);
 			},
 		},
 		{

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { HOSTING_LP_FLOW, ONBOARDING_FLOW, ONBOARDING_GUIDED_FLOW } from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
+import { saveReaderAsLandingPage } from 'calypso/state/sites/selectors/has-reader-as-landing-page';
 
 const noop = () => {};
 
@@ -372,6 +373,9 @@ export function generateFlows( {
 			lastModified: '2025-01-28',
 			showRecaptcha: true,
 			hideProgressIndicator: true,
+			postCompleteCallback: async ( { dispatch } ) => {
+				dispatch( saveReaderAsLandingPage() );
+			},
 		},
 		{
 			name: 'crowdsignal',

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -395,7 +395,11 @@ class Signup extends Component {
 
 		if ( flow.postCompleteCallback ) {
 			const siteId = dependencies && dependencies.siteId;
-			await flow.postCompleteCallback( { siteId, flowName: this.props.flowName } );
+			await flow.postCompleteCallback( {
+				siteId,
+				flowName: this.props.flowName,
+				dispatch: this.props.dispatch,
+			} );
 		}
 	};
 
@@ -631,7 +635,7 @@ class Signup extends Component {
 			dependencies.oauth2_client_id && ! progress?.[ 'oauth2-user' ]?.service; // service is set for social signup (e.g. Google, Apple)
 		// If the user is not logged in, we need to log them in first.
 		// And if it's regular oauth client signup, we perform the oauth login because the WPCC user creation code automatically logs the user in.
-		// There’s no need to turn the bearer token into a cookie. If we log user in again, it will cause an activation error.
+		// There's no need to turn the bearer token into a cookie. If we log user in again, it will cause an activation error.
 		// However, we need to skip this to perform a regular login for social sign in.
 		if ( ! userIsLoggedIn && ( config.isEnabled( 'oauth' ) || isRegularOauth2ClientSignup ) ) {
 			debug( `Handling oauth login` );
@@ -1012,9 +1016,10 @@ export default connect(
 			hostingFlow,
 		};
 	},
-	{
-		submitSignupStep,
-		removeStep,
-		addStep,
-	}
+	( dispatch ) => ( {
+		dispatch,
+		submitSignupStep: ( ...args ) => dispatch( submitSignupStep( ...args ) ),
+		removeStep: ( ...args ) => dispatch( removeStep( ...args ) ),
+		addStep: ( ...args ) => dispatch( addStep( ...args ) ),
+	} )
 )( Signup );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -1018,8 +1018,8 @@ export default connect(
 	},
 	( dispatch ) => ( {
 		dispatch,
-		submitSignupStep: ( ...args ) => dispatch( submitSignupStep( ...args ) ),
-		removeStep: ( ...args ) => dispatch( removeStep( ...args ) ),
-		addStep: ( ...args ) => dispatch( addStep( ...args ) ),
+		submitSignupStep,
+		removeStep,
+		addStep,
 	} )
 )( Signup );

--- a/client/state/sites/selectors/has-reader-as-landing-page.ts
+++ b/client/state/sites/selectors/has-reader-as-landing-page.ts
@@ -1,6 +1,4 @@
-import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
-import type { CalypsoDispatch } from 'calypso/state/types';
 import type { AppState } from 'calypso/types';
 
 export const READER_AS_LANDING_PAGE_PREFERENCE = 'reader-landing-page';
@@ -9,13 +7,4 @@ export const hasReadersAsLandingPage = ( state: AppState ): boolean => {
 	const preference = getPreference( state, READER_AS_LANDING_PAGE_PREFERENCE ) || {};
 	const { useReaderAsLandingPage = false } = preference;
 	return !! useReaderAsLandingPage;
-};
-
-export const saveReaderAsLandingPage = () => ( dispatch: CalypsoDispatch ) => {
-	return dispatch(
-		savePreference( READER_AS_LANDING_PAGE_PREFERENCE, {
-			useReaderAsLandingPage: true,
-			updatedAt: Date.now(),
-		} )
-	);
 };

--- a/client/state/sites/selectors/has-reader-as-landing-page.ts
+++ b/client/state/sites/selectors/has-reader-as-landing-page.ts
@@ -1,4 +1,6 @@
+import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
+import type { CalypsoDispatch } from 'calypso/state/types';
 import type { AppState } from 'calypso/types';
 
 export const READER_AS_LANDING_PAGE_PREFERENCE = 'reader-landing-page';
@@ -7,4 +9,13 @@ export const hasReadersAsLandingPage = ( state: AppState ): boolean => {
 	const preference = getPreference( state, READER_AS_LANDING_PAGE_PREFERENCE ) || {};
 	const { useReaderAsLandingPage = false } = preference;
 	return !! useReaderAsLandingPage;
+};
+
+export const saveReaderAsLandingPage = () => ( dispatch: CalypsoDispatch ) => {
+	return dispatch(
+		savePreference( READER_AS_LANDING_PAGE_PREFERENCE, {
+			useReaderAsLandingPage: true,
+			updatedAt: Date.now(),
+		} )
+	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/341

## Proposed Changes

* This PR saves a new user's landing page preference to the Reader when they sign-up from `/start/reader/user-social` or `/start/account/user-social`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When a user signs up via /discover or as a user account with no blog/site, it makes sense that their default landing page should be the Reader, since their site was created through social interaction and they have no sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live or localhost
* Go to /discover and click "Sign Up" in the upper right. This will take you to sign up via `/start/reader/user-social`
* Sign up using any method, try several.
* After sign-up is complete, you'll be redirected to /reader. If you go to `/me/account`, you'll see your "Default Landing Page" is set to "The Reader"
* Similarly, if you try to "Like" or "Comment" on a blog while logged out, you'll be prompted to create an account using `/start/account/user-social` Creating an account from this flow should also set your "Default Landing Page" to "The Reader"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
