### PR TITLE
Domains: Remove email restrictions for Gravatar domains

### DIFF
--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -772,9 +772,7 @@ const Settings = ( {
 		}
 		return (
 			<>
-				{ ! domain.isGravatarRestrictedDomain && (
-					<DomainEmailInfoCard selectedSite={ selectedSite } domain={ domain } />
-				) }
+				<DomainEmailInfoCard selectedSite={ selectedSite } domain={ domain } />
 				{ ! domain.isHundredYearDomain && (
 					<DomainTransferInfoCard selectedSite={ selectedSite } domain={ domain } />
 				) }

--- a/client/my-sites/email/email-management/home/email-plan-warning-notice.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-warning-notice.tsx
@@ -5,7 +5,6 @@ import {
 } from 'calypso/lib/domains';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import {
-	EMAIL_WARNING_CODE_GRAVATAR_DOMAIN,
 	EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION,
 	EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL,
 } from 'calypso/lib/emails/email-provider-constants';
@@ -21,25 +20,15 @@ type EmailPlanWarningNoticeProps = {
 export const EmailPlanWarningNotice = ( props: EmailPlanWarningNoticeProps ) => {
 	const { domain, selectedSite } = props;
 
-	const cannotAddEmailWarningReason = getCurrentUserCannotAddEmailReason( domain );
-	const cannotAddEmailWarningMessage = cannotAddEmailWarningReason?.message ?? '';
-	const cannotAddEmailWarningCode = cannotAddEmailWarningReason?.code ?? null;
-
-	if ( cannotAddEmailWarningCode === EMAIL_WARNING_CODE_GRAVATAR_DOMAIN ) {
-		return (
-			<div className="email-plan-warning-notice__warning">
-				<div className="email-plan-warning-notice__message">
-					<span>{ cannotAddEmailWarningMessage }</span>
-				</div>
-			</div>
-		);
-	}
-
 	// If email and domain are owned by different users, none of the users will be able to make a purchase and the only way to resolve this
 	// is to reach out to support. Therefore, we should surface a different message to address this scenario.
 	if ( ! isDomainAndEmailSubscriptionsOwnedByDifferentUsers( domain ) ) {
 		return <EmailDifferentDomainOwnerMessage />;
 	}
+
+	const cannotAddEmailWarningReason = getCurrentUserCannotAddEmailReason( domain );
+	const cannotAddEmailWarningMessage = cannotAddEmailWarningReason?.message ?? '';
+	const cannotAddEmailWarningCode = cannotAddEmailWarningReason?.code ?? null;
 
 	switch ( cannotAddEmailWarningCode ) {
 		case EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL:

--- a/client/my-sites/email/email-management/home/utils.ts
+++ b/client/my-sites/email/email-management/home/utils.ts
@@ -1,6 +1,6 @@
 import { translate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { canCurrentUserAddEmail, getCurrentUserCannotAddEmailReason } from 'calypso/lib/domains';
+import { canCurrentUserAddEmail } from 'calypso/lib/domains';
 import { getEmailForwardsCount, hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import { isRecentlyRegistered } from 'calypso/lib/domains/utils';
 import {
@@ -8,7 +8,6 @@ import {
 	hasUnusedMailboxWarning,
 	hasUnverifiedEmailForward,
 } from 'calypso/lib/emails';
-import { EMAIL_WARNING_CODE_GRAVATAR_DOMAIN } from 'calypso/lib/emails/email-provider-constants';
 import {
 	getGSuiteMailboxCount,
 	getGSuiteSubscriptionId,
@@ -133,23 +132,6 @@ export function resolveEmailPlanStatus(
 			comment: 'Current user is not allowed to manage email subscription',
 		} ),
 	};
-
-	const gravatarDomainStatus = {
-		statusClass: 'warning',
-		icon: 'info',
-		text: translate( 'Gravatar domain', {
-			comment: 'Current user is not allowed to purchase new email subscriptions',
-		} ),
-	};
-
-	// Some Gravatar domains already had email purchased for them before we disabled it.
-	// These domains have a specific warning message.
-	if (
-		! canCurrentUserAddEmail( domain ) &&
-		getCurrentUserCannotAddEmailReason( domain )?.code === EMAIL_WARNING_CODE_GRAVATAR_DOMAIN
-	) {
-		return gravatarDomainStatus;
-	}
 
 	if ( hasGSuiteWithUs( domain ) ) {
 		if ( ! canCurrentUserAddEmail( domain ) ) {

--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -13,18 +13,12 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
 import Main from 'calypso/components/main';
-import Notice from 'calypso/components/notice';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import {
-	getSelectedDomain,
-	canCurrentUserAddEmail,
-	getCurrentUserCannotAddEmailReason,
-} from 'calypso/lib/domains';
+import { getSelectedDomain, canCurrentUserAddEmail } from 'calypso/lib/domains';
 import {
 	hasEmailForwards,
 	getDomainsWithEmailForwards,
 } from 'calypso/lib/domains/email-forwarding';
-import { EMAIL_WARNING_CODE_GRAVATAR_DOMAIN } from 'calypso/lib/emails/email-provider-constants';
 import { hasGSuiteSupportedDomain } from 'calypso/lib/gsuite';
 import { GOOGLE_WORKSPACE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
 import { domainAddNew } from 'calypso/my-sites/domains/paths';
@@ -98,9 +92,6 @@ const EmailProvidersStackedComparison = ( {
 
 	const currentUserCanAddEmail = canCurrentUserAddEmail( domain );
 	const showNonOwnerMessage = ! currentUserCanAddEmail && ! isDomainInCart;
-	const cannotAddEmailWarningReason = getCurrentUserCannotAddEmailReason( domain );
-	const isGravatarRestrictedDomain =
-		cannotAddEmailWarningReason?.code === EMAIL_WARNING_CODE_GRAVATAR_DOMAIN;
 
 	const isGSuiteSupported =
 		domain && canPurchaseGSuite && ( isDomainInCart || hasGSuiteSupportedDomain( [ domain ] ) );
@@ -296,19 +287,12 @@ const EmailProvidersStackedComparison = ( {
 			{ ! isDomainInCart && domain && <EmailExistingPaidServiceNotice domain={ domain } /> }
 
 			<>
-				{ showNonOwnerMessage && ! isGravatarRestrictedDomain && (
+				{ showNonOwnerMessage && (
 					<EmailNonDomainOwnerMessage
 						domain={ domain }
 						selectedSite={ selectedSite }
 						source="email-comparison"
 					/>
-				) }
-				{ isGravatarRestrictedDomain && (
-					<Notice showDismiss={ false } className="email-providers-stacked-comparison__notice">
-						{ translate(
-							'This domain is associated with a Gravatar profile and cannot be used for email services at this time.'
-						) }
-					</Notice>
 				) }
 				{ shouldPromoteGoogleWorkspace ? [ ...emailProviderCards ].reverse() : emailProviderCards }
 			</>


### PR DESCRIPTION
Related to https://github.com/Automattic/nomado-issues/issues/1243

## Proposed Changes

This PR removes email restrictions from Gravatar domains. This means that now free Gravatar domains can have Professional email attached to them if the user pays for it.

This PR basically reverts the Professional email restrictions added in #96085.

This is part of the Gravatar Domains i3 project (pcYYhz-2vx-p2).

## Why are these changes being made?

We want to allow free Gravatar domain owners to attach email to their domains, but only if they pay for it in order to prevent abuse.

## Testing Instructions

This depends on 172418-ghe-Automattic/wpcom.

Go to the domain management page for a domain that has both the `usage_gravatar` and `usage_gravatar_restricted` domain flags

- Ensure the Professional email purchase CTA is shown on the right column:

![Markup on 2025-02-06 at 09:43:08](https://github.com/user-attachments/assets/dc2dceab-3557-486e-b2b2-8b9811c6c8a3)

- Ensure the free 3-month introductory offer is not available:

![Markup on 2025-02-06 at 09:43:43](https://github.com/user-attachments/assets/58195fc1-d35c-469d-a65a-f242550a7623)

- Ensure the checkout price also looks correct:

![Markup on 2025-02-06 at 09:44:11](https://github.com/user-attachments/assets/2219e540-b095-4ed0-ba20-a7a1a846d4c0)

Now try to purchase Professional email for a domain that has **only** the `usage_gravatar` flag, i.e. it's a free Gravatar domain that was renewed.

- Ensure the 3-month introductory offer is available:

![Markup on 2025-02-06 at 09:47:43](https://github.com/user-attachments/assets/e5a56b3d-30a1-4bca-ad8d-f0751c1d0dae)

- Ensure the introductory offer is also correct in checkout:

![Markup on 2025-02-06 at 09:48:04](https://github.com/user-attachments/assets/2ba3e35c-5d93-42c5-8343-f253f429a618)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?