### PR TITLE
Reader Onboarding: Remove wide screen flex style

### DIFF
--- a/client/reader/onboarding/style.scss
+++ b/client/reader/onboarding/style.scss
@@ -5,15 +5,13 @@
 	margin-bottom: 24px;
 	padding: 20px 20px 5px 20px;
 
-	.reader-onboarding__intro-column {
-		h2 {
-			font-weight: 600;
-			clear: initial;
-		}
+	h2 {
+		font-weight: 600;
+		clear: initial;
+	}
 
-		.circular__progress-bar {
-			float: right;
-			margin: 5px 5px 5px 10px;
-		}
+	.circular__progress-bar {
+		float: right;
+		margin: 5px 5px 5px 10px;
 	}
 }

--- a/client/reader/onboarding/style.scss
+++ b/client/reader/onboarding/style.scss
@@ -6,8 +6,16 @@
 	margin-bottom: 24px;
 	padding: 20px 20px 5px 20px;
 
-	h2 {
-		font-weight: 600;
-		margin-top: 20px;
+	.reader-onboarding__intro-column {
+		h2 {
+			font-weight: 600;
+			clear: initial;
+			text-wrap: pretty;
+		}
+
+		.circular__progress-bar {
+			float: right;
+			margin: 5px 5px 5px 10px;
+		}
 	}
 }

--- a/client/reader/onboarding/style.scss
+++ b/client/reader/onboarding/style.scss
@@ -1,4 +1,3 @@
-@import '@wordpress/base-styles/breakpoints';
 .reader-onboarding {
 	background-color: var( --color-surface-1 );
 	border-radius: 6px; /* stylelint-disable-line scales/radii */
@@ -10,7 +9,6 @@
 		h2 {
 			font-weight: 600;
 			clear: initial;
-			text-wrap: pretty;
 		}
 
 		.circular__progress-bar {

--- a/client/reader/onboarding/style.scss
+++ b/client/reader/onboarding/style.scss
@@ -1,28 +1,13 @@
-@import "@wordpress/base-styles/breakpoints";
+@import '@wordpress/base-styles/breakpoints';
 .reader-onboarding {
-	display: flex;
-	flex-wrap: wrap;
-	background-color: var(--color-surface-1);
+	background-color: var( --color-surface-1 );
 	border-radius: 6px; /* stylelint-disable-line scales/radii */
-	box-shadow: rgba(0, 0, 0, 0.05) 0 0 0 1px inset;
+	box-shadow: rgba( 0, 0, 0, 0.05 ) 0 0 0 1px inset;
 	margin-bottom: 24px;
-	padding: 10px;
-	gap: 20px;
+	padding: 20px 20px 5px 20px;
 
 	h2 {
 		font-weight: 600;
 		margin-top: 20px;
-	}
-
-	&__steps-column {
-		flex-grow: 2;
-	}
-
-	@media ( min-width: $break-mobile ) {
-		padding: 20px;
-	}
-
-	@media ( min-width: $break-huge ) {
-		gap: 40px;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/319

## Proposed Changes

* Removes the Reader Onboarding panel's widescreen style because Reader Onboarding is constrained to the stream column max-width and, therefore, only goes "widescreen" on a very narrow range of browser widths.
* To decrease the vertical space consumed by Reader Onboarding this PR floats the progress circle to the right of the header and reduces the margin between the header and steps.

Narrow style on desktop:
Before | After
--|--
<img width="1046" alt="Screenshot 2025-02-05 at 5 24 28 PM" src="https://github.com/user-attachments/assets/8bbbf505-ee1c-4674-b4ad-7df1768a6b6b" />  |  <img width="1050" alt="Screenshot 2025-02-05 at 5 24 37 PM" src="https://github.com/user-attachments/assets/6c9b44c5-c85d-476a-9998-246088361059" />

Wide style (now narrow style in the after) on desktop:
Before | After
--|--
<img width="1111" alt="Screenshot 2025-02-05 at 5 23 12 PM" src="https://github.com/user-attachments/assets/dcf9d187-299a-49cf-b21f-94e498787f85" /> |  <img width="1111" alt="Screenshot 2025-02-05 at 5 23 28 PM" src="https://github.com/user-attachments/assets/9c77f084-98c6-4a1a-9e57-2c207c8bfc49" />

Mobile view:
Before | After
--|--
<img width="383" alt="Screenshot 2025-02-05 at 5 22 37 PM" src="https://github.com/user-attachments/assets/8a3fc3ca-8445-41b2-95d4-f3ba9c027102" /> |  <img width="386" alt="Screenshot 2025-02-05 at 5 22 21 PM" src="https://github.com/user-attachments/assets/2f5467ee-13ef-4677-8521-8646043a63b1" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve UX by decreasing the amount of space taken up by Reader Onboarding.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The easiest way to test this is to create a new account on Calypso Live via /start/reader/user-social That should direct your to /reader
* On /reader view Reader Onboarding in various widths and on mobile. Does it look good?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
