### PR TITLE
Include query params in start-site-transfer redirect

### DIFF
--- a/client/my-sites/site-settings/settings-controller.js
+++ b/client/my-sites/site-settings/settings-controller.js
@@ -54,7 +54,11 @@ export const redirectToolsIfRemoveDuplicateViewsExperimentEnabled = async ( cont
 		if ( ! URL_MAP[ slug ] ) {
 			return next();
 		}
-		return page.redirect( `/sites/settings/site/${ context.params.site_id }/${ URL_MAP[ slug ] }` );
+
+		const queryParams = context.querystring ? `?${ context.querystring }` : '';
+		return page.redirect(
+			`/sites/settings/site/${ context.params.site_id }/${ URL_MAP[ slug ] }${ queryParams }`
+		);
 	}
 
 	next();


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/98875

## Proposed Changes

* Ensures query params are passed along with the transfer site redirect

## Why are these changes being made?

* Without the query param, users are unable to transfer sites, they land back on the first step of the transfer screen.

## Testing Instructions

* Transfer a site with the hold out treatment applied 
