### PR TITLE
Adds gravatar wont load notice

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
@@ -309,6 +309,7 @@ function DnsMenuOptionsButton( {
 			<RestoreDefaultCnameRecordDialog
 				visible={ isRestoreCnameRecordDialogVisible }
 				onClose={ closeRestoreCnameRecordDialog }
+				domain={ domain }
 			/>
 
 			<RestoreDefaultEmailRecordsDIalog

--- a/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
@@ -303,7 +303,7 @@ function DnsMenuOptionsButton( {
 			<RestoreDefaultARecordsDialog
 				visible={ isRestoreARecordsDialogVisible }
 				onClose={ closeRestoreARecordsDialog }
-				defaultRecords={ null }
+				domain={ domain }
 			/>
 
 			<RestoreDefaultCnameRecordDialog

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -230,7 +230,7 @@ class DnsRecords extends Component {
 		);
 		if ( selectedDomain?.isGravatarDomain ) {
 			translatedMessage = translate(
-				'Your domain is not using default A records. This means it may not be pointing to your Gravatar Profile correctly. To restore default A records, click on the three dots menu and select "Restore default A records". {{defaultRecordsLink}}Learn more{{/defaultRecordsLink}}.',
+				'Your domain is not using default A records. This means it may not be pointing to your Gravatar profile correctly. To restore default A records, click on the three dots menu and select "Restore default A records". {{defaultRecordsLink}}Learn more{{/defaultRecordsLink}}.',
 				{
 					components: {
 						defaultRecordsLink: (
@@ -268,6 +268,28 @@ class DnsRecords extends Component {
 		recordTracksEvent( 'calypso_domain_management_dns_default_cname_record_notice_show', {
 			domain_name: this.props.selectedDomainName,
 		} );
+		let translatedMessage = translate(
+			'Your domain is not using the default WWW CNAME record. This means your WordPress.com site may not be reached correctly using the www prefix. To restore the default WWW CNAME record, click on the three dots menu and select "Restore default CNAME record". {{defaultRecordsLink}}Learn more{{/defaultRecordsLink}}.',
+			{
+				components: {
+					defaultRecordsLink: (
+						<InlineSupportLink supportContext="dns_default_records" showIcon={ false } />
+					),
+				},
+			}
+		);
+		if ( this.getSelectedDomain()?.isGravatarDomain ) {
+			translatedMessage = translate(
+				'Your domain is not using the default WWW CNAME record. This means your Gravatar profile may not be reached correctly using the www prefix. To restore the default WWW CNAME record, click on the three dots menu and select "Restore default CNAME record". {{defaultRecordsLink}}Learn more{{/defaultRecordsLink}}.',
+				{
+					components: {
+						defaultRecordsLink: (
+							<InlineSupportLink supportContext="dns_default_records" showIcon={ false } />
+						),
+					},
+				}
+			);
+		}
 
 		return (
 			<div className="dns-records-notice">
@@ -277,18 +299,7 @@ class DnsRecords extends Component {
 					className="dns-records-notice__icon gridicon"
 					viewBox="2 2 20 20"
 				/>
-				<div className="dns-records-notice__message">
-					{ translate(
-						'Your domain is not using the default WWW CNAME record. This means your WordPress.com site may not be reached correctly using the www prefix. To restore the default WWW CNAME record, click on the three dots menu and select "Restore default CNAME record". {{defaultRecordsLink}}Learn more{{/defaultRecordsLink}}.',
-						{
-							components: {
-								defaultRecordsLink: (
-									<InlineSupportLink supportContext="dns_default_records" showIcon={ false } />
-								),
-							},
-						}
-					) }
-				</div>
+				<div className="dns-records-notice__message">{ translatedMessage }</div>
 			</div>
 		);
 	};

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -51,6 +51,11 @@ class DnsRecords extends Component {
 		subtitleOverride: PropTypes.string,
 	};
 
+	getSelectedDomain = () => {
+		const { domains, selectedDomainName } = this.props;
+		return domains?.find( ( domain ) => domain?.name === selectedDomainName );
+	};
+
 	hasDefaultCnameRecord = () => {
 		const { dns, selectedDomainName } = this.props;
 		return dns?.records?.some(
@@ -99,13 +104,14 @@ class DnsRecords extends Component {
 	};
 
 	renderHeader = () => {
-		const { domains, translate, selectedSite, currentRoute, selectedDomainName, dns } = this.props;
+		const { translate, selectedSite, currentRoute, selectedDomainName, dns } = this.props;
 		const {
 			showBreadcrumb = true,
 			titleOverride,
 			subtitleOverride,
 		} = this.props.context?.params || {};
-		const selectedDomain = domains?.find( ( domain ) => domain?.name === selectedDomainName );
+
+		const selectedDomain = this.getSelectedDomain();
 
 		const items = [
 			{
@@ -199,6 +205,7 @@ class DnsRecords extends Component {
 
 	renderDefaultARecordsNotice = () => {
 		const { translate } = this.props;
+		const selectedDomain = this.getSelectedDomain();
 
 		if ( ! this.hasWpcomNameservers() ) {
 			return null;
@@ -211,6 +218,28 @@ class DnsRecords extends Component {
 		recordTracksEvent( 'calypso_domain_management_dns_default_a_records_notice_show', {
 			domain_name: this.props.selectedDomainName,
 		} );
+		let translatedMessage = translate(
+			'Your domain is not using default A records. This means it may not be pointing to your WordPress.com site correctly. To restore default A records, click on the three dots menu and select "Restore default A records". {{defaultRecordsLink}}Learn more{{/defaultRecordsLink}}.',
+			{
+				components: {
+					defaultRecordsLink: (
+						<InlineSupportLink supportContext="dns_default_records" showIcon={ false } />
+					),
+				},
+			}
+		);
+		if ( selectedDomain?.isGravatarDomain ) {
+			translatedMessage = translate(
+				'Your domain is not using default A records. This means it may not be pointing to your Gravatar Profile correctly. To restore default A records, click on the three dots menu and select "Restore default A records". {{defaultRecordsLink}}Learn more{{/defaultRecordsLink}}.',
+				{
+					components: {
+						defaultRecordsLink: (
+							<InlineSupportLink supportContext="dns_default_records" showIcon={ false } />
+						),
+					},
+				}
+			);
+		}
 
 		return (
 			<div className="dns-records-notice">
@@ -220,18 +249,7 @@ class DnsRecords extends Component {
 					className="dns-records-notice__icon gridicon"
 					viewBox="2 2 20 20"
 				/>
-				<div className="dns-records-notice__message">
-					{ translate(
-						'Your domain is not using default A records. This means it may not be pointing to your WordPress.com site correctly. To restore default A records, click on the three dots menu and select "Restore default A records". {{defaultRecordsLink}}Learn more{{/defaultRecordsLink}}.',
-						{
-							components: {
-								defaultRecordsLink: (
-									<InlineSupportLink supportContext="dns_default_records" showIcon={ false } />
-								),
-							},
-						}
-					) }
-				</div>
+				<div className="dns-records-notice__message">{ translatedMessage }</div>
 			</div>
 		);
 	};
@@ -276,8 +294,7 @@ class DnsRecords extends Component {
 	};
 
 	renderExternalNameserversNotice = () => {
-		const { translate, selectedSite, currentRoute, selectedDomainName, nameservers, domains } =
-			this.props;
+		const { translate, selectedSite, currentRoute, selectedDomainName, nameservers } = this.props;
 
 		if (
 			( ! englishLocales.includes( getLocaleSlug() ) &&
@@ -291,7 +308,7 @@ class DnsRecords extends Component {
 			return null;
 		}
 
-		const selectedDomain = domains?.find( ( domain ) => domain?.name === selectedDomainName );
+		const selectedDomain = this.getSelectedDomain();
 
 		let mappingSetupStep =
 			selectedDomain.connectionMode === modeType.ADVANCED
@@ -343,11 +360,11 @@ class DnsRecords extends Component {
 		);
 	};
 
-	renderMain() {
-		const { dns, selectedDomainName, selectedSite, translate, domains } = this.props;
+	renderMain = () => {
+		const { dns, selectedDomainName, selectedSite, translate } = this.props;
 		const { showDetails = true } = this.props.context?.params || {};
-		const selectedDomain = domains?.find( ( domain ) => domain?.name === selectedDomainName );
 		const headerText = translate( 'DNS Records' );
+		const selectedDomain = this.getSelectedDomain();
 
 		return (
 			<Main wideLayout className="dns-records">
@@ -373,7 +390,7 @@ class DnsRecords extends Component {
 				) }
 			</Main>
 		);
-	}
+	};
 
 	render() {
 		const { showPlaceholder, selectedDomainName } = this.props;

--- a/client/my-sites/domains/domain-management/dns/restore-default-a-records-dialog.tsx
+++ b/client/my-sites/domains/domain-management/dns/restore-default-a-records-dialog.tsx
@@ -1,8 +1,18 @@
 import { Dialog } from '@automattic/components';
-import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
 
-function RestoreDefaultARecordsDialog( { onClose, visible, defaultRecords } ) {
+interface RestoreDefaultARecordsDialogProps {
+	onClose: ( result: { shouldRestoreDefaultRecords: boolean } ) => void;
+	visible: boolean;
+	domain: ResponseDomain | undefined;
+}
+
+function RestoreDefaultARecordsDialog( {
+	onClose,
+	visible,
+	domain,
+}: RestoreDefaultARecordsDialogProps ) {
 	const { __ } = useI18n();
 
 	const onRestore = () => {
@@ -26,17 +36,18 @@ function RestoreDefaultARecordsDialog( { onClose, visible, defaultRecords } ) {
 		},
 	];
 
-	const message = defaultRecords
-		? sprintf(
-				'We will remove all A & AAAA records and set the A records to our default: %s.',
-				defaultRecords.join( ', ' )
-		  )
-		: __( 'We will remove all A & AAAA records and set the A records to our defaults.' );
+	const message = __(
+		'We will remove all A & AAAA records and set the A records to our defaults.'
+	);
+
+	const targetPlatformMessage = domain?.isGravatarDomain
+		? __( 'Restoring the records will point this domain to your Gravatar profile.' )
+		: __( 'Restoring the records will point this domain to your WordPress.com site' );
 
 	return (
 		<Dialog isVisible={ visible } buttons={ buttons } onClose={ onCancel }>
 			<h1>{ __( 'Restore default A records' ) }</h1>
-			<p>{ __( 'Restoring the records will point this domain to your WordPress.com site.' ) }</p>
+			<p>{ targetPlatformMessage }</p>
 			<p className="restore-default-a-records-dialog__message">{ message }</p>
 		</Dialog>
 	);

--- a/client/my-sites/domains/domain-management/dns/restore-default-cname-record-dialog.tsx
+++ b/client/my-sites/domains/domain-management/dns/restore-default-cname-record-dialog.tsx
@@ -1,7 +1,18 @@
 import { Dialog } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
 
-function RestoreDefaultCnameRecordDialog( { onClose, visible } ) {
+interface RestoreDefaultCnameRecordDialogProps {
+	visible: boolean;
+	onClose: ( result: { shouldRestoreDefaultRecords: boolean } ) => void;
+	domain: ResponseDomain | undefined;
+}
+
+function RestoreDefaultCnameRecordDialog( {
+	visible,
+	onClose,
+	domain,
+}: RestoreDefaultCnameRecordDialogProps ) {
 	const { __ } = useI18n();
 
 	const onRestore = () => {
@@ -25,14 +36,14 @@ function RestoreDefaultCnameRecordDialog( { onClose, visible } ) {
 		},
 	];
 
+	const targetPlatformMessage = domain?.isGravatarDomain
+		? __( 'Restoring the record will point this domain to your Gravatar profile.' )
+		: __( 'Restoring the record will point this domain to your WordPress.com site.' );
+
 	return (
 		<Dialog isVisible={ visible } buttons={ buttons } onClose={ onCancel }>
 			<h1>{ __( 'Restore default CNAME record' ) }</h1>
-			<p>
-				{ __(
-					'Restoring the record will create a www CNAME record pointing to your WordPress.com site.'
-				) }
-			</p>
+			<p>{ targetPlatformMessage }</p>
 			<p className="restore-default-cname-record-dialog__message">
 				{ __( 'In case a www CNAME record already exists, it will be deleted.' ) }
 			</p>

--- a/client/my-sites/domains/domain-management/dns/restore-default-cname-record-dialog.tsx
+++ b/client/my-sites/domains/domain-management/dns/restore-default-cname-record-dialog.tsx
@@ -37,8 +37,8 @@ function RestoreDefaultCnameRecordDialog( {
 	];
 
 	const targetPlatformMessage = domain?.isGravatarDomain
-		? __( 'Restoring the record will point this domain to your Gravatar profile.' )
-		: __( 'Restoring the record will point this domain to your WordPress.com site.' );
+		? __( 'Restoring the record will point the www subdomain to your Gravatar profile.' )
+		: __( 'Restoring the record will point the www subdomain to your WordPress.com site.' );
 
 	return (
 		<Dialog isVisible={ visible } buttons={ buttons } onClose={ onCancel }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/nomado-issues/issues/1244


## Proposed Changes

* Adds a modified message for gravatar domains that won't properly load with the default A records or CNAME records
* Modifies the message for the popups to reset A/AAAA and CNAME records to specify WordPress.com site or Gravatar profile
* Updates two components to Typescript for better type safety

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of the Gravatar i3 project
* To inform users who may have modified their Gravatar Domain's A Records and give them an easy way to recover

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Either wait for the backend ticket that changes how this works, or comment out the check at 2fb01bfd#49-og (enables loading the DNS management page with a gravatar flagged domain)
* Have a domain with the gravatar usage flag (but not the gravatar usage restricted flag)
* Also, modify your A records to something non standard, or just delete your A records

I'm still testing this, might need to adjust instructions a little bit


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
