### PR TITLE
Streamline `@automattic/components` Storybook devex

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,7 +6,6 @@ const storybookConfig = storybookDefaultConfig( {
 	stories: [
 		'../client/**/*.stories.{js,jsx,ts,tsx}',
 		'../packages/design-picker/src/**/*.stories.{ts,tsx}',
-		'../packages/components/src/**/*.stories.{js,jsx,ts,tsx}',
 		'../packages/domains-table/src/**/*.stories.{js,jsx,ts,tsx}',
 	],
 } );

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
 		"clean:packages": "yarn workspaces foreach --all --parallel --verbose --exclude 'wp-calypso' run clean",
 		"clean:public": "rm -rf public",
 		"clean:translations": "rm -rf build/strings calypso-strings.pot chunks-map.*.json || true",
-		"components:storybook:start": "echo 'Deprecated, run `yarn workspace @automattic/components run storybook` instead'",
+		"components:storybook:start": "yarn workspace @automattic/components run storybook",
 		"composite-checkout:storybook:start": "echo 'Deprecated, run `yarn workspace @automattic/composite-checkout run storybook` instead'",
 		"distclean": "yarn run clean && rm -rf **/node_modules **/.cache .yarn/install-state.gz || true",
 		"docker": "docker run -it --name wp-calypso --rm -p 80:3000 wp-calypso",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -92,6 +92,6 @@
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
 		"prepack": "yarn run clean && yarn run build",
-		"storybook": "sb dev"
+		"storybook": "sb dev -p 56833"
 	}
 }


### PR DESCRIPTION
## Proposed Changes

Streamlines the devex for `@automattic/components` Storybook by:

- Removing the `@automattic/components` stories from the root-level Storybook, because that Storybook loads too many Calypso-specific styles for it to be an appropriate environment for isolated testing.
- Adds a functioning `components:storybook:start` command to the root package.json.
- Adds a stable port number to the Storybook instance so it can always reload in the same tab after rebooting.

## Testing Instructions

`yarn components:storybook:start` at repo root should boot the `@automattic/components` Storybook. Stopping and re-running the command should maintain the same port number.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
