### PR TITLE
For domains overview pane, fix styling for navigation bottom border

### DIFF
--- a/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
@@ -85,11 +85,11 @@
 			.foldable-card__content {
 				padding: 0;
 			}
-	
+
 			.foldable-card__main > div {
 				flex-grow: 0;
 			}
-	
+
 			&.is-expanded .foldable-card__content {
 				padding: 0 24px 24px 0;
 			}
@@ -119,7 +119,7 @@
 			}
 		}
 	}
-	
+
 	.domain-info-card.action-card {
 		padding: 24px;
 
@@ -202,6 +202,12 @@
 		max-height: calc(100vh - 32px - var(--masterbar-height));
 		transition: flex-grow 0.2s;
 		width: auto;
+
+		.hosting-dashboard-item-view__navigation {
+			box-shadow: none;
+			border-bottom: 1px solid var(--color-border-subtle);
+			padding-top: 1px;
+		}
 	}
 
 	.hosting-dashboard-item-view__header-info {


### PR DESCRIPTION
Related to #99269 

## Proposed Changes

* Use the same styling as in Sites for the bottom border in the navigation of the pane.

## Why are these changes being made?

* This is part of the domain management revamp project.

## Testing Instructions

* Go to http://calypso.localhost:3000/domains/manage and open a domain in the side pane.
* Open http://calypso.localhost:3000/sites in another tab, open a site in the side pane.
* Make sure the border under navigation is of the same color.

Domains:
![CleanShot 2025-02-05 at 20 35 36@2x](https://github.com/user-attachments/assets/384ecd70-c34c-40cc-9ceb-d3f8d1dbd5aa)

Sites:
![CleanShot 2025-02-05 at 20 38 07@2x](https://github.com/user-attachments/assets/724314a7-cac8-4ac2-8172-acfc2d645c82)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
