### PR TITLE
E2E: Remove invalid test after Settings > Media untangling

### DIFF
--- a/test/e2e/specs/media/settings__media.ts
+++ b/test/e2e/specs/media/settings__media.ts
@@ -6,7 +6,6 @@
 import {
 	DataHelper,
 	TestAccount,
-	SidebarComponent,
 	envVariables,
 	getTestAccountByFeature,
 	envToFeatureKey,
@@ -51,14 +50,7 @@ describe( DataHelper.createSuiteTitle( 'Jetpack Settings: Media' ), function () 
 		let wpAdminMediaSettingsPage: WpAdminMediaSettingsPage;
 
 		it( 'Navigate to Settings > Media', async function () {
-			// eCommerce plan loads WP-Admin for home dashboard,
-			// so instead navigate straight to the Media page.
-			if ( testAccount.accountName === 'jetpackAtomicEcommPlanUser' ) {
-				await page.goto( `${ testAccount.getSiteURL() }wp-admin/options-media.php` );
-			} else {
-				const sidebarComponent = new SidebarComponent( page );
-				await sidebarComponent.navigate( 'Settings', 'Media' );
-			}
+			await page.goto( `${ testAccount.getSiteURL() }wp-admin/options-media.php` );
 			wpAdminMediaSettingsPage = new WpAdminMediaSettingsPage( page );
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

We redirect Settings > Media to wp-admin for 90% users, so this test can be considered obsolete now.

## Testing Instructions

```
yarn workspace wp-e2e-tests test -- test/e2e/specs/media/settings__media.ts
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
