### PR TITLE
A4A > Marketplace: Fix WordPress.com hosting discount calculation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -501,6 +501,7 @@ module.exports = {
 					'__experimentalNavigatorProvider',
 					'__experimentalNavigatorScreen',
 					'__experimentalUseNavigator',
+					'__experimentalNumberControl',
 					'__unstableComposite',
 					'__unstableCompositeItem',
 					'__unstableUseCompositeState',

--- a/client/a8c-for-agencies/components/a4a-number-input-v2/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-number-input-v2/index.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
 import { __experimentalNumberControl as NumberControl } from '@wordpress/components';
 
 import './style.scss';
@@ -19,7 +18,9 @@ export default function A4ANumberInputV2( {
 	increment = 1,
 }: Props ) {
 	const handleOnChange = ( newValue: unknown ) => {
-		onChange( newValue as number );
+		// Force convert to number, if NaN use minimum
+		const numberValue = Number( newValue ) || minimum;
+		onChange( numberValue );
 	};
 
 	return (


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1751

## Proposed Changes

This PR fixes the WordPress.com hosting discount calculation while using the Number Input component. It converts the value from the OnChange event to a number, as the previously provided value was a string. 

## Why are these changes being made?

* To fix the wrongly calculated discount for WordPress.com hosting.

## Testing Instructions

* Open the A4A live link
* Go to Marketplace: Hosting > Go to Standard Agency Hosting tab > Click the `+` button on the Number Input and verify that the discount is as per the number of plans added, not the max discount. Also, verify the pointer on the slider is not at the right place(as per the no of plans), not at the end.


| Before | After |
|--------|--------|
| <img width="1409" alt="Screenshot 2025-02-06 at 10 33 43 AM" src="https://github.com/user-attachments/assets/9611b508-dd65-44c8-8915-883c9d5bcd47" />| <img width="1409" alt="Screenshot 2025-02-06 at 10 33 41 AM" src="https://github.com/user-attachments/assets/f73fa5b6-7e82-4ccf-ab06-f72029f7e9d8" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
