### PR TITLE
For domain actions button Use the same icon that is used in Sites

### DIFF
--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -1,5 +1,5 @@
-import { Gridicon } from '@automattic/components';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { moreVertical } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { ComponentType } from 'react';
 import { canSetAsPrimary } from '../utils/can-set-as-primary';
@@ -183,7 +183,7 @@ export const DomainsTableRowActions = ( {
 	return (
 		<DropdownMenu
 			className="domains-table-row__actions"
-			icon={ <Gridicon icon="ellipsis" /> }
+			icon={ moreVertical }
 			label={ __( 'Domain actions' ) }
 		>
 			{ ( { onClose } ) => (


### PR DESCRIPTION
Related to #99285 

## Proposed Changes

* For domain actions button Use the same icon that is used in Sites.

## Why are these changes being made?

* This is part of the domain management revamp project.

## Testing Instructions

* Open http://calypso.localhost:3000/domains/manage and http://calypso.localhost:3000/sites in two tabs.
* Select a site/domain in both of them so the side pane is open.
* Make sure both use the same "three dots" icon.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
