### PR TITLE
Checkout: Refactor checkout submit button styles

### DIFF
--- a/client/my-sites/checkout/src/components/CheckoutMoneyBackGuarantee.tsx
+++ b/client/my-sites/checkout/src/components/CheckoutMoneyBackGuarantee.tsx
@@ -4,38 +4,19 @@ import styled from '@emotion/styled';
 import { CheckoutSummaryRefundWindows } from './wp-checkout-order-summary';
 
 const CheckoutMoneyBackGuaranteeWrapper = styled.div`
-	display: grid;
-	grid-template-columns: 20px 1fr 70px;
-	column-gap: 1em;
-	align-items: center;
-	margin: 1.5em 0 0;
-
 	& li {
+		display: flex;
+		align-items: center;
+		justify-content: center;
 		list-style: none;
 		font-size: 14px;
-		margin-bottom: 0;
 		padding: 0;
-		svg {
-			display: none;
+		margin: 0;
+		gap: 0.5rem;
+
+		& svg {
+			margin: 0;
 		}
-	}
-
-	.rtl & {
-		grid-template-columns: 20px 1fr;
-		padding: 10px 80px 10px 20px;
-
-		& li {
-			padding: 0;
-		}
-	}
-
-	@media ( ${ ( props ) => props.theme.breakpoints.bigPhoneUp } ) {
-		grid-template-columns: 20px minmax( min-content, 300px ) 70px;
-	}
-
-	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		grid-template-columns: 20px minmax( 150px, max-content );
-		justify-content: center;
 	}
 `;
 

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1139,8 +1139,6 @@ const JetpackSealText = styled.span`
 const SubmitButtonHeaderWrapper = styled.div`
 	display: none;
 	font-size: 13px;
-	margin-top: -5px;
-	margin-bottom: 10px;
 	text-align: center;
 
 	.checkout__step-wrapper--last-step & {

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -315,7 +315,7 @@ function CheckoutSummaryGiftFeaturesList( { siteSlug }: { siteSlug: string } ) {
 export function CheckoutSummaryRefundWindows( {
 	cart,
 	highlight = false,
-	includeRefundIcon,
+	includeRefundIcon = false,
 }: {
 	cart: ResponseCart;
 	highlight?: boolean;
@@ -412,9 +412,12 @@ export function CheckoutSummaryRefundWindows( {
 
 	return (
 		<>
-			{ includeRefundIcon && <StyledIcon icon={ reusableBlock } size={ 24 } /> }
 			<CheckoutSummaryFeaturesListItem>
-				<WPCheckoutCheckIcon id="features-list-refund-text" />
+				{ includeRefundIcon ? (
+					<StyledIcon icon={ reusableBlock } size={ 24 } />
+				) : (
+					<WPCheckoutCheckIcon id="features-list-refund-text" />
+				) }
 				{ highlight ? <strong>{ text }</strong> : text }
 			</CheckoutSummaryFeaturesListItem>
 		</>

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -535,10 +535,10 @@ export const CheckoutStepAreaWrapper = styled.div`
 `;
 
 export const SubmitButtonWrapper = styled.div`
+	position: relative;
+	bottom: 0;
 	background: ${ ( props ) => props.theme.colors.surface };
 	padding: 24px;
-	bottom: 0;
-	left: 0;
 	box-sizing: border-box;
 	width: 100%;
 	z-index: 10;
@@ -548,42 +548,21 @@ export const SubmitButtonWrapper = styled.div`
 		box-shadow: 0 -3px 10px 0 #0000001f;
 	}
 
-	.rtl & {
-		right: 0;
-		left: auto;
-	}
-
-	.checkout-button {
-		margin: 0 auto;
+	& .checkout-steps__submit-button-content {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		.checkout-button {
-			width: 100%;
-		}
+		padding-inline-start: 40px;
+		padding-inline-end: 0;
+		position: relative;
 
 		.checkout__step-wrapper--last-step & {
 			position: relative;
 			box-shadow: none;
 		}
-
-		.checkout__step-wrapper & {
-			padding: 24px 0px 24px 40px;
-
-			.rtl & {
-				padding: 24px 40px 24px 0px;
-			}
-		}
-	}
-`;
-
-// Set right padding so that text doesn't overlap with inline help floating button.
-export const SubmitFooterWrapper = styled.div`
-	padding-right: 0;
-	min-height: 45px;
-
-	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		padding-right: 0;
 	}
 `;
 
@@ -653,15 +632,17 @@ export function CheckoutFormSubmit( {
 	} )();
 	return (
 		<SubmitButtonWrapper className="checkout-steps__submit-button-wrapper" ref={ submitWrapperRef }>
-			{ submitButtonHeader || null }
-			{ submitButton || (
-				<CheckoutSubmitButton
-					validateForm={ validateForm }
-					disabled={ isDisabled }
-					onLoadError={ onSubmitButtonLoadError }
-				/>
-			) }
-			<SubmitFooterWrapper>{ submitButtonFooter || null }</SubmitFooterWrapper>
+			<div className="checkout-steps__submit-button-content">
+				{ submitButtonHeader || null }
+				{ submitButton || (
+					<CheckoutSubmitButton
+						validateForm={ validateForm }
+						disabled={ isDisabled }
+						onLoadError={ onSubmitButtonLoadError }
+					/>
+				) }
+				{ submitButtonFooter || null }
+			</div>
 		</SubmitButtonWrapper>
 	);
 }

--- a/packages/composite-checkout/src/components/checkout-submit-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-submit-button.tsx
@@ -10,8 +10,16 @@ import { useHandlePaymentProcessorResponse } from './use-process-payment';
 import type { PaymentMethod, PaymentProcessorSubmitData, ProcessPayment } from '../types';
 
 const CheckoutSubmitButtonWrapper = styled.div`
-	& > button {
-		height: 50px;
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	height: 47.5px;
+	overflow: hidden;
+	justify-content: center;
+	border-radius: 4px;
+
+	& > * {
+		display: flex;
 	}
 
 	&.checkout-submit-button--inactive {


### PR DESCRIPTION
The `CheckoutSubmitButton` component and its various supporting wrapper styled components is a rather complex part of Checkout.

The component, like most components in `composite-checkout` is meant to be agnostic of the content that is passed to it - in this case, the individual payment buttons.

But since payment buttons come in all shapes and sizes, managing their individual needs in a scalable and agnostic way becomes increasingly difficult.

This PR aims to refactor some of the more inflexible CSS patterns and replace them with flexbox and relative values like `padding-inline-start` etc.

Additionally, this PR takes the opportunity to clean up the styles that were added over the years to account for the now deprecated lower-corner support icon.

Related to #

## Proposed Changes

*

## Testing Instructions

*
