### PR TITLE
For email actions use the same icon as in Sites

### DIFF
--- a/client/my-sites/email/email-forwarding/actions-menu/index.tsx
+++ b/client/my-sites/email/email-forwarding/actions-menu/index.tsx
@@ -5,7 +5,7 @@ import {
 	__experimentalVStack as VStack,
 	DropdownMenu,
 } from '@wordpress/components';
-import { rotateLeft, trash, moreHorizontalMobile } from '@wordpress/icons';
+import { rotateLeft, trash, moreVertical } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { getEmailForwardAddress } from 'calypso/lib/emails';
@@ -49,7 +49,7 @@ export const ActionsMenu = ( { mailbox }: { mailbox: Mailbox } ) => {
 				</VStack>
 			</ConfirmationDialog>
 			<DropdownMenu
-				icon={ moreHorizontalMobile }
+				icon={ moreVertical }
 				label={ translate( 'More options' ) }
 				controls={
 					mailbox.warnings?.length

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Dialog, MaterialIcon } from '@automattic/components';
+import { Icon, moreVertical } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useState } from 'react';
@@ -312,7 +313,11 @@ const EmailMailboxActionMenu = ( { account, domain, mailbox } ) => {
 					visible={ removeTitanMailboxDialogVisible }
 				/>
 			) }
-			<EllipsisMenu position="bottom left" className="email-mailbox-action-menu__main">
+			<EllipsisMenu
+				position="bottom left"
+				className="email-mailbox-action-menu__main"
+				icon={ <Icon icon={ moreVertical } /> }
+			>
 				{ menuItems.map(
 					( {
 						href,

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/context-menu.tsx
@@ -1,5 +1,14 @@
 import { isDesktop } from '@automattic/viewport';
-import { Icon, desktop, mobile, cloudUpload, payment, settings, login } from '@wordpress/icons';
+import {
+	Icon,
+	desktop,
+	mobile,
+	cloudUpload,
+	payment,
+	settings,
+	login,
+	moreVertical,
+} from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
@@ -133,6 +142,7 @@ export default function ContextMenu( { className, domain }: Props ) {
 			className={ className }
 			popoverClassName={ `${ className }-popover` }
 			position="bottom"
+			icon={ <Icon icon={ moreVertical } /> }
 		>
 			{ contextMenuOptions.map( ( option, key ) => (
 				<PopoverMenuItem


### PR DESCRIPTION
Related to #99287 

## Proposed Changes

* For email actions use the same icon as in Sites.

## Why are these changes being made?

* This is part of the domain management revamp project.

## Testing Instructions

* Make sure you have 3 domains with different email setup: Titan, Google, Forwarding.
* Go to http://calypso.localhost:3000/domains/manage
* Open each domain and go to Email tab.
* Make sure you see an updated icon (vertical three dots, each looks like a square if you zoom it in). Examples on the screenshots below.
* Check the icons in mobile versions as well.

## Screenshots
<img width="1033" alt="Google" src="https://github.com/user-attachments/assets/a04b5160-a963-4ef1-808d-e1eb8aed318c" />
<img width="1043" alt="Titan" src="https://github.com/user-attachments/assets/6106984c-573f-49b3-913d-7c86312ee696" />
<img width="1052" alt="Forwarding" src="https://github.com/user-attachments/assets/3a4ad6a4-6292-4417-a5d4-120704738af9" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
