### PR TITLE
Fix promise and add timeout for more resilience

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
@@ -154,10 +154,13 @@ export class UserSignupPage {
 	async signupWoo( email: string ): Promise< NewUserResponse > {
 		await this.page.fill( selectors.emailInput, email );
 
-		const [ , response ] = await Promise.all( [
-			this.page.waitForURL( /.*woocommerce\.com*/, { waitUntil: 'networkidle' } ),
-			this.page.waitForResponse( /.*new\?.*/ ),
+		const [ response ] = await Promise.all( [
+			this.page.waitForResponse( /.*users\/new\?.*/ ),
 			this.page.click( selectors.submitButton ),
+			this.page.waitForURL( /.*woocommerce\.com*/, {
+				waitUntil: 'networkidle',
+				timeout: 25000,
+			} ),
 		] );
 
 		if ( ! response ) {

--- a/test/e2e/specs/onboarding/signup__woo-email.ts
+++ b/test/e2e/specs/onboarding/signup__woo-email.ts
@@ -55,7 +55,7 @@ describe(
 			} );
 
 			it( 'Activate account', async function () {
-				await page.goto( activationLink, { waitUntil: 'networkidle' } );
+				await page.goto( activationLink, { waitUntil: 'networkidle', timeout: 25000 } );
 			} );
 		} );
 


### PR DESCRIPTION
Related to p1738774264455659/1738772766.101499-slack-C02DQP0FP

## Proposed Changes

This PR adds a timeout in conjunction with wait. I suspect there are periods when signup takes more than 10 seconds which is the default timeout.

## Testing Instructions


[Pre-Release E2E Tests](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release?branch=fix%2Fwoo-e2e&buildTypeTab=overview) should pass

### To test locally:

* Checkout this branch
* Set up local e2e test env https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e
* Run `yarn workspace wp-e2e-tests test test/e2e/specs/onboarding/signup__woo-email.ts`
* Run tests a couple of times to see if it's flaky

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?