### PR TITLE
Help Center: Remove webinars

### DIFF
--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -6,7 +6,7 @@ import WhatsNewGuide, { useWhatsNewAnnouncementsQuery } from '@automattic/whats-
 import { Button, SVG, Circle } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
-import { Icon, captureVideo, formatListNumbered, external, institution } from '@wordpress/icons';
+import { Icon, formatListNumbered, external, institution } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { NewReleases } from '../icons';
@@ -98,21 +98,6 @@ export const HelpCenterMoreResources = () => {
 						>
 							<Icon icon={ formatListNumbered } size={ 24 } />
 							<span>{ __( 'Support Guides', __i18n_text_domain__ ) }</span>
-							<Icon icon={ external } size={ 20 } />
-						</a>
-					</div>
-				</li>
-				<li className="help-center-more-resources__resource-item help-center-link__item">
-					<div className="help-center-more-resources__resource-cell help-center-link__cell">
-						<a
-							href={ localizeUrl( 'https://wordpress.com/webinars/' ) }
-							rel="noreferrer"
-							target="_blank"
-							onClick={ () => trackLearnButtonClick( 'webinairs' ) }
-							className="help-center-more-resources__capture-video"
-						>
-							<Icon icon={ captureVideo } size={ 24 } />
-							<span>{ __( 'Webinars', __i18n_text_domain__ ) }</span>
 							<Icon icon={ external } size={ 20 } />
 						</a>
 					</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Context: p1738725764467099-slack-C083G6L7WET

## Proposed Changes

Webinars on /learn are being removed, so we remove the link from the Help Center

![image](https://github.com/user-attachments/assets/d0d634a7-292f-4cab-a5fe-94e6d8a92f5f)
