### PR TITLE
E2E Tests: Fix the publish button is unavailable due to welcome guide

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-welcome-guide-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-welcome-guide-component.ts
@@ -1,0 +1,37 @@
+import { Page } from 'playwright';
+import { EditorComponent } from './editor-component';
+
+const selectors = {
+	// Welcome guide
+	welcomeGuideCloseButton: '.edit-post-welcome-guide button[aria-label="Close"]',
+};
+
+/**
+ * Represents the welcome guide that shows in a popover when the editor loads.
+ */
+export class EditorWelcomeGuideComponent {
+	private page: Page;
+	private editor: EditorComponent;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 * @param {EditorComponent} editor The EditorComponent instance.
+	 */
+	constructor( page: Page, editor: EditorComponent ) {
+		this.page = page;
+		this.editor = editor;
+	}
+
+	/**
+	 * close the welcome guide if needed.
+	 */
+	async closeWelcomeGuideIfNeeded(): Promise< void > {
+		const editorParent = await this.editor.parent();
+		if ( await this.page.isVisible( selectors.welcomeGuideCloseButton ) ) {
+			const locator = editorParent.locator( selectors.welcomeGuideCloseButton );
+			await locator.click();
+		}
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/editor-welcome-guide-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-welcome-guide-component.ts
@@ -2,8 +2,9 @@ import { Page } from 'playwright';
 import { EditorComponent } from './editor-component';
 
 const selectors = {
+	welcomeGuideWrapper: '.edit-post-welcome-guide',
 	// Welcome guide
-	welcomeGuideCloseButton: '.edit-post-welcome-guide button[aria-label="Close"]',
+	welcomeGuideCloseButton: 'button[aria-label="Close"]',
 };
 
 /**
@@ -29,8 +30,11 @@ export class EditorWelcomeGuideComponent {
 	 */
 	async closeWelcomeGuideIfNeeded(): Promise< void > {
 		const editorParent = await this.editor.parent();
-		// TODO: It would be better to check whether the element is visible or not. However, it may not be available at the beginning.
-		const locator = editorParent.locator( selectors.welcomeGuideCloseButton );
-		await locator.click();
+
+		const welcomGuideWrapper = editorParent.locator( selectors.welcomeGuideWrapper );
+		await welcomGuideWrapper.waitFor( { state: 'visible' } );
+
+		const closeBtn = editorParent.locator( selectors.welcomeGuideCloseButton );
+		await closeBtn.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-welcome-guide-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-welcome-guide-component.ts
@@ -29,9 +29,8 @@ export class EditorWelcomeGuideComponent {
 	 */
 	async closeWelcomeGuideIfNeeded(): Promise< void > {
 		const editorParent = await this.editor.parent();
-		if ( await this.page.isVisible( selectors.welcomeGuideCloseButton ) ) {
-			const locator = editorParent.locator( selectors.welcomeGuideCloseButton );
-			await locator.click();
-		}
+		// TODO: It would be better to check whether the element is visible or not. However, it may not be available at the beginning.
+		const locator = editorParent.locator( selectors.welcomeGuideCloseButton );
+		await locator.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -24,6 +24,7 @@ export * from './editor-gutenberg-component';
 export * from './editor-block-list-view-component';
 export * from './editor-sidebar-block-inserter-component';
 export * from './editor-welcome-tour-component';
+export * from './editor-welcome-guide-component';
 export * from './editor-popover-menu-component';
 export * from './editor-site-styles-component';
 export * from './editor-color-picker-component';

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -13,6 +13,7 @@ import {
 	EditorInlineBlockInserterComponent,
 	EditorSidebarBlockInserterComponent,
 	EditorWelcomeTourComponent,
+	EditorWelcomeGuideComponent,
 	EditorBlockToolbarComponent,
 	EditorTemplateModalComponent,
 	EditorPopoverMenuComponent,
@@ -57,6 +58,7 @@ export class EditorPage {
 	private editorSidebarBlockInserterComponent: EditorSidebarBlockInserterComponent;
 	private editorInlineBlockInserterComponent: EditorInlineBlockInserterComponent;
 	private editorWelcomeTourComponent: EditorWelcomeTourComponent;
+	private editorWelcomeGuideComponent: EditorWelcomeGuideComponent;
 	private editorBlockToolbarComponent: EditorBlockToolbarComponent;
 	private editorTemplateModalComponent: EditorTemplateModalComponent;
 	private editorPopoverMenuComponent: EditorPopoverMenuComponent;
@@ -78,6 +80,7 @@ export class EditorPage {
 		this.editorPublishPanelComponent = new EditorPublishPanelComponent( page, this.editor );
 		this.editorBlockListViewComponent = new EditorBlockListViewComponent( page, this.editor );
 		this.editorWelcomeTourComponent = new EditorWelcomeTourComponent( page, this.editor );
+		this.editorWelcomeGuideComponent = new EditorWelcomeGuideComponent( page, this.editor );
 		this.editorBlockToolbarComponent = new EditorBlockToolbarComponent( page, this.editor );
 		this.editorSidebarBlockInserterComponent = new EditorSidebarBlockInserterComponent(
 			page,
@@ -138,6 +141,9 @@ export class EditorPage {
 
 		// Dismiss the Welcome Tour.
 		await this.editorWelcomeTourComponent.forceDismissWelcomeTour();
+
+		// Dismiss the Welcome Guide.
+		await this.editorWelcomeGuideComponent.closeWelcomeGuideIfNeeded();
 
 		// Accept the Cookie banner.
 		await this.cookieBannerComponent.acceptCookie();

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -142,9 +142,6 @@ export class EditorPage {
 		// Dismiss the Welcome Tour.
 		await this.editorWelcomeTourComponent.forceDismissWelcomeTour();
 
-		// Dismiss the Welcome Guide.
-		await this.editorWelcomeGuideComponent.closeWelcomeGuideIfNeeded();
-
 		// Accept the Cookie banner.
 		await this.cookieBannerComponent.acceptCookie();
 	}
@@ -994,6 +991,13 @@ export class EditorPage {
 	 */
 	async openEditorOptionsMenu(): Promise< void > {
 		return this.editorToolbarComponent.openMoreOptionsMenu();
+	}
+
+	/**
+	 * Close the
+	 */
+	async closeWelcomeGuideIfNeeded(): Promise< void > {
+		return this.editorWelcomeGuideComponent.closeWelcomeGuideIfNeeded();
 	}
 
 	//#endregion

--- a/test/e2e/specs/onboarding/onboarding__write.ts
+++ b/test/e2e/specs/onboarding/onboarding__write.ts
@@ -264,6 +264,7 @@ describe( DataHelper.createSuiteTitle( 'Goals-First Onboarding: Write Focus' ), 
 		it( 'Editor loads', async function () {
 			editorPage = new EditorPage( page );
 			await editorPage.waitUntilLoaded();
+			await editorPage.closeWelcomeGuideIfNeeded();
 
 			await page.waitForURL( new RegExp( newSiteDetails.blog_details.site_slug ) );
 		} );

--- a/test/e2e/specs/onboarding/signup__start-writing-tailored.ts
+++ b/test/e2e/specs/onboarding/signup__start-writing-tailored.ts
@@ -40,6 +40,7 @@ describe( 'Signup: Tailored Start Writing Flow', () => {
 	it( 'Publish first post', async function () {
 		const editorPage = new EditorPage( page );
 		await editorPage.waitUntilLoaded();
+		await editorPage.closeWelcomeGuideIfNeeded();
 		await editorPage.enterTitle( 'my first post title' );
 		await editorPage.publish();
 		await page.getByText( "Your blog's almost ready!" ).waitFor();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1738841704366159-slack-C02DQP0FP

## Proposed Changes

* The publish button is not able to be clicked because of the Welcome Guide in the Editor. So, this PR proposed to close the Welcome Guide if it exists when navigating to the Editor.

![image](https://github.com/user-attachments/assets/fe5d6ba9-c23c-4a6f-98df-c5e8074c30f6)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Trigger Pre-Release E2E tests

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?