### PR TITLE
Show Global Styles under the Personal plan (if eligible)

### DIFF
--- a/packages/calypso-products/src/is-global-styles-on-personal-enabled.ts
+++ b/packages/calypso-products/src/is-global-styles-on-personal-enabled.ts
@@ -1,3 +1,5 @@
+import { isEnabled } from '@automattic/calypso-config';
+
 declare global {
 	interface Window {
 		isGlobalStylesOnPersonal?: boolean;
@@ -7,5 +9,12 @@ export function isGlobalStylesOnPersonalEnabled(): boolean {
 	if ( typeof window === 'undefined' ) {
 		return false;
 	}
+
+	if ( window.isGlobalStylesOnPersonal ) {
+		return true;
+	}
+
+	window.isGlobalStylesOnPersonal = isEnabled( 'global-styles/on-personal-plan' );
+
 	return !! window.isGlobalStylesOnPersonal;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

* 3681-gh-Automattic/martech
* https://github.com/Automattic/wp-calypso/pull/98538
* pcNC1U-1vN-p2


## Proposed Changes

* This fixes a bug that caused the Global Styles to not show under the Personal plan in plan pages, when the feature is enabled for Personal plans.

### BEFORE
<img width="760" alt="Screenshot 2025-02-06 at 5 20 43 PM" src="https://github.com/user-attachments/assets/6d08ee59-d99c-4635-a47e-27cd6004b323" />

<img width="1234" alt="Screenshot 2025-02-06 at 5 20 57 PM" src="https://github.com/user-attachments/assets/76358693-8b91-4a48-9480-034f4d2ae098" />


### AFTER
<img width="1246" alt="Screenshot 2025-02-06 at 5 23 04 PM" src="https://github.com/user-attachments/assets/ddd52d4b-9982-4d46-845f-ff2103579d3d" />
<img width="719" alt="Screenshot 2025-02-06 at 5 22 55 PM" src="https://github.com/user-attachments/assets/1afca7f3-5668-489d-adcd-53768e36ff17" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Global Styles were set to be made available on the Personal plan in https://github.com/Automattic/wp-calypso/pull/99152 as part of the Big Sky launch. The plan page needs to accurately reflect the status.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/start` as a new user and verify that in the plans step, you can see the feature "Customize fonts and colors sitewide" under the Personal plan. 
    * Also verify that in the plan comparison grid (click "Compare plans" button), the feature is checked (available) under the Personal plan
* Visit the logged-in `/plans` page and verify that you can see the feature "Customize fonts and colors sitewide" under the Personal plan. 
    * Also verify that in the plan comparison grid (click "Compare plans" button), the feature is checked (available) under the Personal plan


