### PR TITLE
Deps: Use sass-loader v13

### DIFF
--- a/apps/happy-blocks/block-library/education-header/style.scss
+++ b/apps/happy-blocks/block-library/education-header/style.scss
@@ -1,5 +1,5 @@
 @import "@automattic/calypso-color-schemes";
-@import "~@automattic/color-studio/dist/color-variables";
+@import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/onboarding/styles/mixins";
 
 $breakpoint-mobile: 782px; //Mobile size.

--- a/apps/happy-blocks/block-library/pricing-plans/view.scss
+++ b/apps/happy-blocks/block-library/pricing-plans/view.scss
@@ -1,8 +1,8 @@
-@import "~@automattic/typography/styles/variables";
-@import "~@automattic/color-studio/dist/color-variables";
-@import "~@wordpress/base-styles/colors";
-@import "~@wordpress/base-styles/breakpoints";
-@import "~@wordpress/base-styles/mixins";
+@import "@automattic/typography/styles/variables";
+@import "@automattic/color-studio/dist/color-variables";
+@import "@wordpress/base-styles/colors";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 $brand-text: "SF Pro Text", $sans;
 $brand-display: "SF Pro Display", $sans;

--- a/client/blocks/importer/wordpress/upgrade-plan/skeleton/style.scss
+++ b/client/blocks/importer/wordpress/upgrade-plan/skeleton/style.scss
@@ -1,5 +1,5 @@
-@import "~@automattic/color-studio/dist/color-variables";
-@import "~@wordpress/base-styles/colors";
+@import "@automattic/color-studio/dist/color-variables";
+@import "@wordpress/base-styles/colors";
 
 @keyframes import-upgrade-plan-skeleton__animation {
 	0% {

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -2,7 +2,7 @@
 @import "@wordpress/base-styles/mixins";
 @import "calypso/assets/stylesheets/p2-extends";
 
-@import "~@automattic/color-studio/dist/color-variables";
+@import "@automattic/color-studio/dist/color-variables";
 
 $breakpoint-mobile: 782px; //Mobile size.
 

--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -1,4 +1,4 @@
-@import "~@automattic/color-studio/dist/color-variables";
+@import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/global-styles/src/components/search-control-styles";
 @import "@wordpress/base-styles/breakpoints";
 

--- a/client/components/bloganuary-header/style.scss
+++ b/client/components/bloganuary-header/style.scss
@@ -1,5 +1,5 @@
-@import "~@wordpress/base-styles/breakpoints";
-@import "~@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 .bloganuary-header {
 	background-color: var(--color-sidebar-background);

--- a/client/components/reviews-rating-stars/reviews-ratings-stars.scss
+++ b/client/components/reviews-rating-stars/reviews-ratings-stars.scss
@@ -1,4 +1,4 @@
-@import "~@automattic/color-studio/dist/color-variables";
+@import "@automattic/color-studio/dist/color-variables";
 @import "@wordpress/base-styles/variables";
 
 .reviews-ratings-stars__star-bar {

--- a/client/jetpack-connect/colors.scss
+++ b/client/jetpack-connect/colors.scss
@@ -1,4 +1,4 @@
-@import "~@automattic/color-studio/dist/color-variables";
+@import "@automattic/color-studio/dist/color-variables";
 
 @mixin jetpack-connect-colors() {
 	// Override accent variables with Jetpack colors

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -10,7 +10,7 @@
 /**
  * Importers styles
  */
-@import "~calypso/blocks/import/style/base";
+@import "calypso/blocks/import/style/base";
 
 /**
  * General onboarding styling

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/style.scss
@@ -1,5 +1,5 @@
-@import "~@automattic/color-studio/dist/color-variables";
-@import "~@wordpress/base-styles/colors";
+@import "@automattic/color-studio/dist/color-variables";
+@import "@wordpress/base-styles/colors";
 
 @keyframes migration-key-skeleton__animation {
 	0% {

--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -1,5 +1,5 @@
-@import "~@wordpress/base-styles/breakpoints";
-@import "~@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 body.is-group-me.is-section-help,
 body.is-section-me {

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -1,6 +1,6 @@
 @import '@wordpress/base-styles/variables';
 @import '@wordpress/base-styles/breakpoints';
-@import "~@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/mixins";
 @import '@wordpress/dataviews/build-style/style.css';
 
 $padding-standard: 16px;
@@ -8,7 +8,6 @@ $padding-standard: 16px;
 body.is-section-subscribers,
 .theme-jetpack-cloud.is-group-jetpack-cloud.is-section-jetpack-subscribers
  {
-    
     .layout:not(.has-no-sidebar),
     .has-no-masterbar {
         .layout__content {
@@ -44,11 +43,11 @@ body.is-section-subscribers,
             height: calc(
                 100vh - var(--masterbar-height) - #{$padding-standard * 2}
             );
-        
+
             @media ( max-width: $break-small ) {
                 padding: 0;
             }
-        
+
             button {
                 cursor: pointer;
                 max-width: 100%;
@@ -58,7 +57,7 @@ body.is-section-subscribers,
                     background: none;
                 }
             }
-        
+
             .subscriber-data-views__square-avatar {
                 border-radius: 0;
                 cursor: pointer;
@@ -68,7 +67,7 @@ body.is-section-subscribers,
                 border-bottom: 1px dotted var(--studio-gray-60);
                 cursor: pointer;
             }
-        
+
             &__list {
                 flex: 1 1 auto;
                 transition: width 0.15s ease-in-out;
@@ -79,10 +78,10 @@ body.is-section-subscribers,
                 overflow: hidden;
                 display: flex;
                 flex-direction: column;
-        
+
                 .navigation-header {
                     padding: $padding-standard 48px;
-        
+
                     // 430px is the DataViews padding breakpoint.
                     @media ( max-width: 430px ) {
                         padding: $padding-standard 24px;
@@ -133,19 +132,19 @@ body.is-section-subscribers,
                     }
                 }
             }
-        
+
             &.has-selected-subscriber {
                 .subscriber-data-views__list {
                     flex: 0 0 25%;
                     width: 25%;
                     min-width: 300px;
-        
+
                     .navigation-header {
                         padding: $padding-standard 24px;
 
                         .add-subscribers-button {
                             min-height: 37px;
-                            
+
                             .add-subscribers-button-text {
                                 display: none;
                             }
@@ -165,7 +164,7 @@ body.is-section-subscribers,
                         display: none;
                     }
                 }
-        
+
                 .subscriber-data-views__details {
                     display: block;
                     flex: 1 1 auto;
@@ -182,7 +181,7 @@ body.is-section-subscribers,
                             margin-bottom: 24px;
                             margin-top: 0;
                         }
-    
+
                         &__close-button {
                             margin-left: auto;
                             border-radius: 4px;
@@ -206,17 +205,17 @@ body.is-section-subscribers,
                     }
                 }
             }
-        
+
             &__details {
                 background: var( --color-surface );
                 display: none;
             }
-        
+
             .subscriber-profile.subscriber-profile--compact {
                 @media ( max-width: $break-wide ) {
                     max-width: 195px;
                 }
-        
+
                 .subscriber-profile__user-details {
                     .subscriber-profile__name,
                     .subscriber-profile__email {

--- a/client/site-profiler/components/skeleton-screen/style.scss
+++ b/client/site-profiler/components/skeleton-screen/style.scss
@@ -1,5 +1,5 @@
-@import "~@automattic/color-studio/dist/color-variables";
-@import "~@wordpress/base-styles/colors";
+@import "@automattic/color-studio/dist/color-variables";
+@import "@wordpress/base-styles/colors";
 
 @keyframes site-profiler-skeleton__animation {
 	0% {

--- a/client/sites/components/panel-sidebar/style.scss
+++ b/client/sites/components/panel-sidebar/style.scss
@@ -1,8 +1,8 @@
 
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-@import "~@automattic/color-studio/dist/color-variables";
-@import "~@automattic/typography/styles/variables";
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/typography/styles/variables";
 
 .panel-with-sidebar {
 	display: flex;

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -55,7 +55,7 @@
 		"postcss-loader": "^6.2.1",
 		"recursive-copy": "^2.0.14",
 		"sass": "1.54.0",
-		"sass-loader": "^12.1.0",
+		"sass-loader": "^13.1.0",
 		"semver": "^7.3.2",
 		"stream-browserify": "^3.0.0",
 		"terser-webpack-plugin": "^5.3.11",

--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -41,6 +41,9 @@ module.exports.loader = ( { includePaths, prelude, postCssOptions } ) => ( {
 					includePaths,
 					quietDeps: true,
 				},
+				// The warnRuleAsWarning can be removed once sass-loader is updated to v14. It defaults to true in that version.
+				// @see https://github.com/webpack-contrib/sass-loader/tree/v14.0.0?tab=readme-ov-file#warnruleaswarning
+				warnRuleAsWarning: true,
 			},
 		},
 	],

--- a/packages/calypso-storybook/package.json
+++ b/packages/calypso-storybook/package.json
@@ -35,7 +35,7 @@
 		"css-loader": "^6.11.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"sass-loader": "^12.1.0",
+		"sass-loader": "^13.1.0",
 		"style-loader": "^1.3.0",
 		"webpack": "^5.97.1"
 	},

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -53,7 +53,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"redux": "^5.0.1",
-		"sass-loader": "^10.1.1",
+		"sass-loader": "^13.1.0",
 		"style-loader": "^1.3.0",
 		"typescript": "^5.3.3",
 		"webpack": "^5.97.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -298,7 +298,7 @@ __metadata:
     postcss-loader: "npm:^6.2.1"
     recursive-copy: "npm:^2.0.14"
     sass: "npm:1.54.0"
-    sass-loader: "npm:^12.1.0"
+    sass-loader: "npm:^13.1.0"
     semver: "npm:^7.3.2"
     stream-browserify: "npm:^3.0.0"
     terser-webpack-plugin: "npm:^5.3.11"
@@ -527,7 +527,7 @@ __metadata:
     css-loader: "npm:^6.11.0"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    sass-loader: "npm:^12.1.0"
+    sass-loader: "npm:^13.1.0"
     style-loader: "npm:^1.3.0"
     webpack: "npm:^5.97.1"
   peerDependencies:
@@ -1631,7 +1631,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-router-dom: "npm:^6.23.1"
     redux: "npm:^5.0.1"
-    sass-loader: "npm:^10.1.1"
+    sass-loader: "npm:^13.1.0"
     style-loader: "npm:^1.3.0"
     tslib: "npm:^2.5.0"
     typescript: "npm:^5.3.3"
@@ -23885,7 +23885,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"klona@npm:^2.0.4, klona@npm:^2.0.5":
+"klona@npm:^2.0.5":
   version: 2.0.5
   resolution: "klona@npm:2.0.5"
   checksum: 5b752c11ca8e2996612386699f52cc5aed802aa4116663d26239ac0b054fae25191dacb95587ecf1a167b039daa9fc3fa2da17dfd5d0821f3037de3821d9a9e5
@@ -31359,53 +31359,6 @@ __metadata:
   dependencies:
     truncate-utf8-bytes: "npm:^1.0.0"
   checksum: 16ff47556a6e54e228c28db096bedd303da67b030d4bea4925fd71324932d6b02c7b0446f00ad33987b25b6414f24ae968e01a1a1679ce599542e82c4b07eb1f
-  languageName: node
-  linkType: hard
-
-"sass-loader@npm:^10.1.1":
-  version: 10.2.1
-  resolution: "sass-loader@npm:10.2.1"
-  dependencies:
-    klona: "npm:^2.0.4"
-    loader-utils: "npm:^2.0.0"
-    neo-async: "npm:^2.6.2"
-    schema-utils: "npm:^3.0.0"
-    semver: "npm:^7.3.2"
-  peerDependencies:
-    fibers: ">= 3.1.0"
-    node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0
-    sass: ^1.3.0
-    webpack: ^4.36.0 || ^5.0.0
-  peerDependenciesMeta:
-    fibers:
-      optional: true
-    node-sass:
-      optional: true
-    sass:
-      optional: true
-  checksum: 03286a3b46c6d1c606c7e382cf9fefc569e45758d7d6e813a20a5b00926336baa8a45e833a7a4e461b4092aac22f6859052437e7d7c0d6f726c71328f8c25173
-  languageName: node
-  linkType: hard
-
-"sass-loader@npm:^12.1.0":
-  version: 12.1.0
-  resolution: "sass-loader@npm:12.1.0"
-  dependencies:
-    klona: "npm:^2.0.4"
-    neo-async: "npm:^2.6.2"
-  peerDependencies:
-    fibers: ">= 3.1.0"
-    node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0
-    sass: ^1.3.0
-    webpack: ^5.0.0
-  peerDependenciesMeta:
-    fibers:
-      optional: true
-    node-sass:
-      optional: true
-    sass:
-      optional: true
-  checksum: 4fe94e330239ecf4eb35bf2fcb0abe7981380d3e308761d3ab774b6e8741ef11d5f513734aa0bb43c06b91a26d24f365c2d71bdbf4027f897b6abc98648247cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed Changes

Consistently use `sass-loader@13` instead of 3 different versions.

## Why are these changes being made?

During the latest WordPress monorepo upgrade (https://github.com/Automattic/wp-calypso/pull/96470) I noticed this inconsistency and thought it might make sense to be fixed.

## Testing Instructions

* Build should work well and all checks should be green.
* Do some smoke testing and verify things work well. 