### PR TITLE
E2E: Fix media settings test on Atomic

### DIFF
--- a/test/e2e/specs/media/settings__media.ts
+++ b/test/e2e/specs/media/settings__media.ts
@@ -43,6 +43,16 @@ describe( DataHelper.createSuiteTitle( 'Jetpack Settings: Media' ), function () 
 		} else {
 			await testAccount.authenticate( page );
 		}
+
+		// Atomic tests sites might have local users, so the Jetpack SSO login will
+		// show up when visiting the Jetpack dashboard directly. We can bypass it if
+		// we simulate a redirect from Calypso to WP Admin with a hardcoded referer.
+		// @see https://github.com/Automattic/jetpack/blob/12b3b9a4771169398d4e1982573aaec820babc17/projects/plugins/wpcomsh/wpcomsh.php#L230-L254
+		const siteUrl = testAccount.getSiteURL( { protocol: true } );
+		await page.goto( `${ siteUrl }wp-admin/`, {
+			timeout: 15 * 1000,
+			referer: 'https://wordpress.com/',
+		} );
 	} );
 
 	if ( envVariables.JETPACK_TARGET !== 'remote-site' ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

PR #99393 switched from clicking the link in Calypso to visiting wp-admin directly. On Atomic this runs into the SSO login screen. Copy-paste the workaround used in other tests to avoid that.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Test is broken. This seems to fix it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Affected Jetpack Edge site: `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/media/settings__media.ts`
* Previously-working Jetpack Edge site: `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="ecomm-plan" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/media/settings__media.ts`
* Previously-working(?) generic Atomic site: `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" TEST_ON_ATOMIC="true" yarn workspace wp-e2e-tests test test/e2e/specs/media/settings__media.ts`
* Previously-working Simple site: `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" yarn workspace wp-e2e-tests test test/e2e/specs/media/settings__media.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
