### PR TITLE
A4A: Fix discrepancies in the Signup form v2 styling.

### DIFF
--- a/client/a8c-for-agencies/components/form/footer/index.tsx
+++ b/client/a8c-for-agencies/components/form/footer/index.tsx
@@ -1,0 +1,9 @@
+import './style.scss';
+
+type Props = {
+	children: React.ReactNode;
+};
+
+export default function FormFooter( { children }: Props ) {
+	return <footer className="a4a-form__footer">{ children }</footer>;
+}

--- a/client/a8c-for-agencies/components/form/footer/style.scss
+++ b/client/a8c-for-agencies/components/form/footer/style.scss
@@ -1,0 +1,5 @@
+.a4a-form__footer {
+	margin-block-start: 8px;
+	display: flex;
+	gap: 24px;
+}

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import Form from 'calypso/a8c-for-agencies/components/form';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
+import FormFooter from 'calypso/a8c-for-agencies/components/form/footer';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -40,139 +41,135 @@ const BlueprintForm: React.FC< Props > = ( { onContinue } ) => {
 				"We'll send you a custom blueprint to grow your business based on your answers below."
 			) }
 		>
-			<div className="blueprint-form__fields">
-				<FormField
-					label={ translate( 'What is your top goal when partnering with a technology provider?' ) }
-					isRequired
-				>
-					<div className="blueprint-form__radio-group">
-						<FormRadio
-							label={ translate( 'Access to cutting-edge technology' ) }
-							checked={ formData.topGoal === 'cutting_edge_tech' }
-							onChange={ () => setFormData( { ...formData, topGoal: 'cutting_edge_tech' } ) }
-						/>
-						<FormRadio
-							label={ translate( 'Comprehensive support and troubleshooting' ) }
-							checked={ formData.topGoal === 'comprehensive_support' }
-							onChange={ () => setFormData( { ...formData, topGoal: 'comprehensive_support' } ) }
-						/>
-						<FormRadio
-							label={ translate( 'Lead generation and new business opportunities' ) }
-							checked={ formData.topGoal === 'lead_generation' }
-							onChange={ () => setFormData( { ...formData, topGoal: 'lead_generation' } ) }
-						/>
-						<FormRadio
-							label={ translate( 'Training and education for your team' ) }
-							checked={ formData.topGoal === 'training_education' }
-							onChange={ () => setFormData( { ...formData, topGoal: 'training_education' } ) }
-						/>
-						<FormRadio
-							label={ translate( 'Exclusive discounts or revenue-sharing options' ) }
-							checked={ formData.topGoal === 'exclusive_discounts' }
-							onChange={ () => setFormData( { ...formData, topGoal: 'exclusive_discounts' } ) }
-						/>
-					</div>
-				</FormField>
-
-				<FormField
-					label={ translate( 'What is the main goal you hope to achieve in 2025?' ) }
-					isRequired
-				>
-					<div className="blueprint-form__radio-group">
-						<FormRadio
-							label={ translate( 'Scaling the agency significantly' ) }
-							checked={ formData.mainGoal2025 === 'scaling_agency' }
-							onChange={ () => setFormData( { ...formData, mainGoal2025: 'scaling_agency' } ) }
-						/>
-						<FormRadio
-							label={ translate( 'Diversifying offered services' ) }
-							checked={ formData.mainGoal2025 === 'diversifying_services' }
-							onChange={ () =>
-								setFormData( { ...formData, mainGoal2025: 'diversifying_services' } )
-							}
-						/>
-						<FormRadio
-							label={ translate( 'Increasing the number of long-term clients' ) }
-							checked={ formData.mainGoal2025 === 'increasing_clients' }
-							onChange={ () => setFormData( { ...formData, mainGoal2025: 'increasing_clients' } ) }
-						/>
-						<FormRadio
-							label={ translate( 'Expanding into new markets or territories' ) }
-							checked={ formData.mainGoal2025 === 'expanding_markets' }
-							onChange={ () => setFormData( { ...formData, mainGoal2025: 'expanding_markets' } ) }
-						/>
-						<FormRadio
-							label={ translate( "Strengthening the agency's brand and reputation" ) }
-							checked={ formData.mainGoal2025 === 'strengthening_brand' }
-							onChange={ () => setFormData( { ...formData, mainGoal2025: 'strengthening_brand' } ) }
-						/>
-					</div>
-				</FormField>
-
-				<FormField
-					label={ translate(
-						"How does your agency typically work with clients regarding Automattic's solutions?"
-					) }
-					isRequired
-				>
-					<div className="blueprint-form__radio-group">
-						<FormRadio
-							label={ translate(
-								'We refer customers to Automattic products/services to purchase on their own'
-							) }
-							checked={ formData.workModel === 'refer_customers' }
-							onChange={ () => setFormData( { ...formData, workModel: 'refer_customers' } ) }
-						/>
-						<FormRadio
-							label={ translate(
-								"We purchase on our clients' behalf and resell Automattic products/services"
-							) }
-							checked={ formData.workModel === 'purchase_resell' }
-							onChange={ () => setFormData( { ...formData, workModel: 'purchase_resell' } ) }
-						/>
-						<FormRadio
-							label={ translate( 'A combination of referring and reselling' ) }
-							checked={ formData.workModel === 'combination' }
-							onChange={ () => setFormData( { ...formData, workModel: 'combination' } ) }
-						/>
-						<FormRadio
-							label={ translate( 'Other models (please explain)' ) }
-							checked={ formData.workModel === 'other' }
-							onChange={ () => setFormData( { ...formData, workModel: 'other' } ) }
-						/>
-						{ formData.workModel === 'other' && (
-							<FormTextarea
-								value={ formData.specificApproach }
-								onChange={ () => {
-									// TODO: form data
-									return;
-								} }
-								placeholder={ translate( 'Add your explanation' ) }
-							/>
-						) }
-					</div>
-				</FormField>
-
-				<FormField
-					label={ translate(
-						`Is there anything specific about your agency's approach or any challenges you face that you would like us to consider when creating your blueprint?`
-					) }
-				>
-					<FormTextarea
-						value={ formData.specificApproach }
-						onChange={ ( e: React.ChangeEvent< HTMLTextAreaElement > ) =>
-							setFormData( { ...formData, specificApproach: e.target.value } )
-						}
-						placeholder={ translate( 'Add your approach' ) }
+			<FormField
+				label={ translate( 'What is your top goal when partnering with a technology provider?' ) }
+				isRequired
+			>
+				<div className="blueprint-form__radio-group">
+					<FormRadio
+						label={ translate( 'Access to cutting-edge technology' ) }
+						checked={ formData.topGoal === 'cutting_edge_tech' }
+						onChange={ () => setFormData( { ...formData, topGoal: 'cutting_edge_tech' } ) }
 					/>
-				</FormField>
-
-				<div className="blueprint-form__controls">
-					<Button variant="primary" onClick={ handleSubmit } className="blueprint-form__submit">
-						{ translate( 'Continue' ) }
-					</Button>
+					<FormRadio
+						label={ translate( 'Comprehensive support and troubleshooting' ) }
+						checked={ formData.topGoal === 'comprehensive_support' }
+						onChange={ () => setFormData( { ...formData, topGoal: 'comprehensive_support' } ) }
+					/>
+					<FormRadio
+						label={ translate( 'Lead generation and new business opportunities' ) }
+						checked={ formData.topGoal === 'lead_generation' }
+						onChange={ () => setFormData( { ...formData, topGoal: 'lead_generation' } ) }
+					/>
+					<FormRadio
+						label={ translate( 'Training and education for your team' ) }
+						checked={ formData.topGoal === 'training_education' }
+						onChange={ () => setFormData( { ...formData, topGoal: 'training_education' } ) }
+					/>
+					<FormRadio
+						label={ translate( 'Exclusive discounts or revenue-sharing options' ) }
+						checked={ formData.topGoal === 'exclusive_discounts' }
+						onChange={ () => setFormData( { ...formData, topGoal: 'exclusive_discounts' } ) }
+					/>
 				</div>
-			</div>
+			</FormField>
+
+			<FormField
+				label={ translate( 'What is the main goal you hope to achieve in 2025?' ) }
+				isRequired
+			>
+				<div className="blueprint-form__radio-group">
+					<FormRadio
+						label={ translate( 'Scaling the agency significantly' ) }
+						checked={ formData.mainGoal2025 === 'scaling_agency' }
+						onChange={ () => setFormData( { ...formData, mainGoal2025: 'scaling_agency' } ) }
+					/>
+					<FormRadio
+						label={ translate( 'Diversifying offered services' ) }
+						checked={ formData.mainGoal2025 === 'diversifying_services' }
+						onChange={ () => setFormData( { ...formData, mainGoal2025: 'diversifying_services' } ) }
+					/>
+					<FormRadio
+						label={ translate( 'Increasing the number of long-term clients' ) }
+						checked={ formData.mainGoal2025 === 'increasing_clients' }
+						onChange={ () => setFormData( { ...formData, mainGoal2025: 'increasing_clients' } ) }
+					/>
+					<FormRadio
+						label={ translate( 'Expanding into new markets or territories' ) }
+						checked={ formData.mainGoal2025 === 'expanding_markets' }
+						onChange={ () => setFormData( { ...formData, mainGoal2025: 'expanding_markets' } ) }
+					/>
+					<FormRadio
+						label={ translate( "Strengthening the agency's brand and reputation" ) }
+						checked={ formData.mainGoal2025 === 'strengthening_brand' }
+						onChange={ () => setFormData( { ...formData, mainGoal2025: 'strengthening_brand' } ) }
+					/>
+				</div>
+			</FormField>
+
+			<FormField
+				label={ translate(
+					"How does your agency typically work with clients regarding Automattic's solutions?"
+				) }
+				isRequired
+			>
+				<div className="blueprint-form__radio-group">
+					<FormRadio
+						label={ translate(
+							'We refer customers to Automattic products/services to purchase on their own'
+						) }
+						checked={ formData.workModel === 'refer_customers' }
+						onChange={ () => setFormData( { ...formData, workModel: 'refer_customers' } ) }
+					/>
+					<FormRadio
+						label={ translate(
+							"We purchase on our clients' behalf and resell Automattic products/services"
+						) }
+						checked={ formData.workModel === 'purchase_resell' }
+						onChange={ () => setFormData( { ...formData, workModel: 'purchase_resell' } ) }
+					/>
+					<FormRadio
+						label={ translate( 'A combination of referring and reselling' ) }
+						checked={ formData.workModel === 'combination' }
+						onChange={ () => setFormData( { ...formData, workModel: 'combination' } ) }
+					/>
+					<FormRadio
+						label={ translate( 'Other models (please explain)' ) }
+						checked={ formData.workModel === 'other' }
+						onChange={ () => setFormData( { ...formData, workModel: 'other' } ) }
+					/>
+					{ formData.workModel === 'other' && (
+						<FormTextarea
+							value={ formData.specificApproach }
+							onChange={ () => {
+								// TODO: form data
+								return;
+							} }
+							placeholder={ translate( 'Add your explanation' ) }
+						/>
+					) }
+				</div>
+			</FormField>
+
+			<FormField
+				label={ translate(
+					`Is there anything specific about your agency's approach or any challenges you face that you would like us to consider when creating your blueprint?`
+				) }
+			>
+				<FormTextarea
+					value={ formData.specificApproach }
+					onChange={ ( e: React.ChangeEvent< HTMLTextAreaElement > ) =>
+						setFormData( { ...formData, specificApproach: e.target.value } )
+					}
+					placeholder={ translate( 'Add your approach' ) }
+				/>
+			</FormField>
+
+			<FormFooter>
+				<Button variant="primary" onClick={ handleSubmit } __next40pxDefaultSize>
+					{ translate( 'Continue' ) }
+				</Button>
+			</FormFooter>
 		</Form>
 	);
 };

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
@@ -5,8 +5,11 @@ import Form from 'calypso/a8c-for-agencies/components/form';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
 import FormFooter from 'calypso/a8c-for-agencies/components/form/footer';
 import FormRadio from 'calypso/components/forms/form-radio';
+import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import { preventWidows } from 'calypso/lib/formatting';
+
+import './style.scss';
 
 type Props = {
 	onContinue: () => void;
@@ -17,6 +20,32 @@ type FormData = {
 	mainGoal2025: string;
 	workModel: string;
 	specificApproach: string;
+};
+
+const BluePrintFormRadio = ( {
+	label,
+	checked,
+	onChange,
+}: {
+	label: string;
+	checked: boolean;
+	onChange: () => void;
+} ) => {
+	return (
+		<div
+			className="blue-print-form__radio"
+			onClick={ onChange }
+			role="button"
+			tabIndex={ 0 }
+			onKeyDown={ ( e ) => {
+				if ( e.key === 'Enter' ) {
+					onChange();
+				}
+			} }
+		>
+			<FormRadio label={ label } checked={ checked } onChange={ onChange } />
+		</div>
+	);
 };
 
 const BlueprintForm: React.FC< Props > = ( { onContinue } ) => {
@@ -33,6 +62,52 @@ const BlueprintForm: React.FC< Props > = ( { onContinue } ) => {
 		onContinue();
 	};
 
+	const topGoalOptions = [
+		{ label: translate( 'Access to cutting-edge technology' ), value: 'cutting_edge_tech' },
+		{
+			label: translate( 'Comprehensive support and troubleshooting' ),
+			value: 'comprehensive_support',
+		},
+		{
+			label: translate( 'Lead generation and new business opportunities' ),
+			value: 'lead_generation',
+		},
+		{ label: translate( 'Training and education for your team' ), value: 'training_education' },
+		{
+			label: translate( 'Exclusive discounts or revenue-sharing options' ),
+			value: 'exclusive_discounts',
+		},
+	];
+
+	const mainGoal2025Options = [
+		{ label: translate( 'Scaling the agency significantly' ), value: 'scaling_agency' },
+		{ label: translate( 'Diversifying offered services' ), value: 'diversifying_services' },
+		{
+			label: translate( 'Increasing the number of long-term clients' ),
+			value: 'increasing_clients',
+		},
+		{ label: translate( 'Expanding into new markets or territories' ), value: 'expanding_markets' },
+		{
+			label: translate( "Strengthening the agency's brand and reputation" ),
+			value: 'strengthening_brand',
+		},
+	];
+
+	const workModelOptions = [
+		{
+			label: translate(
+				'Refer customers to Automattic products/services to purchase on their own'
+			),
+			value: 'refer_customers',
+		},
+		{
+			label: translate( "Purchase on our clients' behalf and resell Automattic products/services" ),
+			value: 'purchase_resell',
+		},
+		{ label: translate( 'A combination of referring and reselling' ), value: 'combination' },
+		{ label: translate( 'Other models (please explain)' ), value: 'other' },
+	];
+
 	return (
 		<Form
 			className="blueprint-form"
@@ -46,31 +121,14 @@ const BlueprintForm: React.FC< Props > = ( { onContinue } ) => {
 				isRequired
 			>
 				<div className="blueprint-form__radio-group">
-					<FormRadio
-						label={ translate( 'Access to cutting-edge technology' ) }
-						checked={ formData.topGoal === 'cutting_edge_tech' }
-						onChange={ () => setFormData( { ...formData, topGoal: 'cutting_edge_tech' } ) }
-					/>
-					<FormRadio
-						label={ translate( 'Comprehensive support and troubleshooting' ) }
-						checked={ formData.topGoal === 'comprehensive_support' }
-						onChange={ () => setFormData( { ...formData, topGoal: 'comprehensive_support' } ) }
-					/>
-					<FormRadio
-						label={ translate( 'Lead generation and new business opportunities' ) }
-						checked={ formData.topGoal === 'lead_generation' }
-						onChange={ () => setFormData( { ...formData, topGoal: 'lead_generation' } ) }
-					/>
-					<FormRadio
-						label={ translate( 'Training and education for your team' ) }
-						checked={ formData.topGoal === 'training_education' }
-						onChange={ () => setFormData( { ...formData, topGoal: 'training_education' } ) }
-					/>
-					<FormRadio
-						label={ translate( 'Exclusive discounts or revenue-sharing options' ) }
-						checked={ formData.topGoal === 'exclusive_discounts' }
-						onChange={ () => setFormData( { ...formData, topGoal: 'exclusive_discounts' } ) }
-					/>
+					{ topGoalOptions.map( ( option ) => (
+						<BluePrintFormRadio
+							key={ `goal-option-${ option.value }` }
+							label={ option.label }
+							checked={ formData.topGoal === option.value }
+							onChange={ () => setFormData( { ...formData, topGoal: option.value } ) }
+						/>
+					) ) }
 				</div>
 			</FormField>
 
@@ -79,31 +137,14 @@ const BlueprintForm: React.FC< Props > = ( { onContinue } ) => {
 				isRequired
 			>
 				<div className="blueprint-form__radio-group">
-					<FormRadio
-						label={ translate( 'Scaling the agency significantly' ) }
-						checked={ formData.mainGoal2025 === 'scaling_agency' }
-						onChange={ () => setFormData( { ...formData, mainGoal2025: 'scaling_agency' } ) }
-					/>
-					<FormRadio
-						label={ translate( 'Diversifying offered services' ) }
-						checked={ formData.mainGoal2025 === 'diversifying_services' }
-						onChange={ () => setFormData( { ...formData, mainGoal2025: 'diversifying_services' } ) }
-					/>
-					<FormRadio
-						label={ translate( 'Increasing the number of long-term clients' ) }
-						checked={ formData.mainGoal2025 === 'increasing_clients' }
-						onChange={ () => setFormData( { ...formData, mainGoal2025: 'increasing_clients' } ) }
-					/>
-					<FormRadio
-						label={ translate( 'Expanding into new markets or territories' ) }
-						checked={ formData.mainGoal2025 === 'expanding_markets' }
-						onChange={ () => setFormData( { ...formData, mainGoal2025: 'expanding_markets' } ) }
-					/>
-					<FormRadio
-						label={ translate( "Strengthening the agency's brand and reputation" ) }
-						checked={ formData.mainGoal2025 === 'strengthening_brand' }
-						onChange={ () => setFormData( { ...formData, mainGoal2025: 'strengthening_brand' } ) }
-					/>
+					{ mainGoal2025Options.map( ( option ) => (
+						<BluePrintFormRadio
+							key={ `main-goal-2025-option-${ option.value }` }
+							label={ option.label }
+							checked={ formData.mainGoal2025 === option.value }
+							onChange={ () => setFormData( { ...formData, mainGoal2025: option.value } ) }
+						/>
+					) ) }
 				</div>
 			</FormField>
 
@@ -114,32 +155,16 @@ const BlueprintForm: React.FC< Props > = ( { onContinue } ) => {
 				isRequired
 			>
 				<div className="blueprint-form__radio-group">
-					<FormRadio
-						label={ translate(
-							'We refer customers to Automattic products/services to purchase on their own'
-						) }
-						checked={ formData.workModel === 'refer_customers' }
-						onChange={ () => setFormData( { ...formData, workModel: 'refer_customers' } ) }
-					/>
-					<FormRadio
-						label={ translate(
-							"We purchase on our clients' behalf and resell Automattic products/services"
-						) }
-						checked={ formData.workModel === 'purchase_resell' }
-						onChange={ () => setFormData( { ...formData, workModel: 'purchase_resell' } ) }
-					/>
-					<FormRadio
-						label={ translate( 'A combination of referring and reselling' ) }
-						checked={ formData.workModel === 'combination' }
-						onChange={ () => setFormData( { ...formData, workModel: 'combination' } ) }
-					/>
-					<FormRadio
-						label={ translate( 'Other models (please explain)' ) }
-						checked={ formData.workModel === 'other' }
-						onChange={ () => setFormData( { ...formData, workModel: 'other' } ) }
-					/>
+					{ workModelOptions.map( ( option ) => (
+						<BluePrintFormRadio
+							key={ `work-model-option-${ option.value }` }
+							label={ option.label }
+							checked={ formData.workModel === option.value }
+							onChange={ () => setFormData( { ...formData, workModel: option.value } ) }
+						/>
+					) ) }
 					{ formData.workModel === 'other' && (
-						<FormTextarea
+						<FormTextInput
 							value={ formData.specificApproach }
 							onChange={ () => {
 								// TODO: form data

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
@@ -22,7 +22,7 @@ type FormData = {
 	specificApproach: string;
 };
 
-const BluePrintFormRadio = ( {
+const BlueprintFormRadio = ( {
 	label,
 	checked,
 	onChange,
@@ -122,7 +122,7 @@ const BlueprintForm: React.FC< Props > = ( { onContinue } ) => {
 			>
 				<div className="blueprint-form__radio-group">
 					{ topGoalOptions.map( ( option ) => (
-						<BluePrintFormRadio
+						<BlueprintFormRadio
 							key={ `goal-option-${ option.value }` }
 							label={ option.label }
 							checked={ formData.topGoal === option.value }
@@ -138,7 +138,7 @@ const BlueprintForm: React.FC< Props > = ( { onContinue } ) => {
 			>
 				<div className="blueprint-form__radio-group">
 					{ mainGoal2025Options.map( ( option ) => (
-						<BluePrintFormRadio
+						<BlueprintFormRadio
 							key={ `main-goal-2025-option-${ option.value }` }
 							label={ option.label }
 							checked={ formData.mainGoal2025 === option.value }
@@ -156,7 +156,7 @@ const BlueprintForm: React.FC< Props > = ( { onContinue } ) => {
 			>
 				<div className="blueprint-form__radio-group">
 					{ workModelOptions.map( ( option ) => (
-						<BluePrintFormRadio
+						<BlueprintFormRadio
 							key={ `work-model-option-${ option.value }` }
 							label={ option.label }
 							checked={ formData.workModel === option.value }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/style.scss
@@ -1,0 +1,13 @@
+.blueprint-form__radio-group {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.blue-print-form__radio {
+	cursor: pointer;
+
+	.form-radio__label {
+		@include a4a-font-body-md;
+	}
+}

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/index.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import Form from 'calypso/a8c-for-agencies/components/form';
+import FormFooter from 'calypso/a8c-for-agencies/components/form/footer';
 import { preventWidows } from 'calypso/lib/formatting';
 
 import './style.scss';
@@ -25,14 +26,24 @@ const ChoiceBlueprint: React.FC< Props > = ( { onContinue, onSkip } ) => {
 		>
 			<p className="choice-blueprint__text">{ translate( 'Ready?' ) }</p>
 
-			<div className="choice-blueprint__buttons">
-				<Button className="choice-blueprint__button" variant="primary" onClick={ onContinue }>
+			<FormFooter>
+				<Button
+					className="choice-blueprint__button"
+					variant="primary"
+					onClick={ onContinue }
+					__next40pxDefaultSize
+				>
 					{ translate( 'Yes' ) }
 				</Button>
-				<Button className="choice-blueprint__button" variant="secondary" onClick={ onSkip }>
+				<Button
+					className="choice-blueprint__button"
+					variant="secondary"
+					onClick={ onSkip }
+					__next40pxDefaultSize
+				>
 					{ translate( 'Not right now' ) }
 				</Button>
-			</div>
+			</FormFooter>
 		</Form>
 	);
 };

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/style.scss
@@ -1,16 +1,9 @@
 .choice-blueprint__text {
-    font-size: 1rem;
-    font-weight: 400;
+	@include a4a-font-body-lg;
     color: var(--color-neutral-60);
-    max-width: 460px;
 }
 
-.choice-blueprint__buttons {
-    display: flex;
-    gap: 24px;
-
-    .components-button {
-        width: 180px;
-        justify-content: center;
-    }
+.choice-blueprint__button {
+	width: 180px;
+	justify-content: center;
 }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import Form from 'calypso/a8c-for-agencies/components/form';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
+import FormFooter from 'calypso/a8c-for-agencies/components/form/footer';
 import QuerySmsCountries from 'calypso/components/data/query-countries/sms';
 import FormPhoneInput from 'calypso/components/forms/form-phone-input';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -70,100 +71,95 @@ const SignupContactForm = ( { onContinue }: Props ) => {
 				translate( 'Join 5000+ agencies and grow your business with Automattic for Agencies.' )
 			) }
 		>
-			<div className="signup-multi-step-form__fields">
-				<div className="signup-multi-step-form__name-fields">
-					<FormField label={ translate( 'Your first name' ) } isRequired>
-						<FormTextInput
-							name="firstName"
-							value={ formData.firstName }
-							onChange={ handleInputChange( 'firstName' ) }
-							placeholder={ translate( 'Your first name' ) }
-						/>
-					</FormField>
-
-					<FormField label={ translate( 'Last name' ) } isRequired>
-						<FormTextInput
-							name="lastName"
-							value={ formData.lastName }
-							onChange={ handleInputChange( 'lastName' ) }
-							placeholder={ translate( 'Your last name' ) }
-						/>
-					</FormField>
-				</div>
-
-				<FormField label={ translate( 'Email' ) } isRequired>
+			<div className="signup-multi-step-form__name-fields">
+				<FormField label={ translate( 'Your first name' ) } isRequired>
 					<FormTextInput
-						name="email"
-						type="email"
-						value={ formData.email }
-						onChange={ handleInputChange( 'email' ) }
-						placeholder={ translate( 'Your email' ) }
+						name="firstName"
+						value={ formData.firstName }
+						onChange={ handleInputChange( 'firstName' ) }
+						placeholder={ translate( 'Your first name' ) }
 					/>
 				</FormField>
 
-				<FormField label={ translate( 'Agency name' ) } isRequired>
+				<FormField label={ translate( 'Last name' ) } isRequired>
 					<FormTextInput
-						name="agencyName"
-						value={ formData.agencyName }
-						onChange={ handleInputChange( 'agencyName' ) }
-						placeholder={ translate( 'Agency name' ) }
+						name="lastName"
+						value={ formData.lastName }
+						onChange={ handleInputChange( 'lastName' ) }
+						placeholder={ translate( 'Your last name' ) }
 					/>
 				</FormField>
-
-				<FormField label={ translate( 'Business URL' ) } isRequired>
-					<FormTextInput
-						name="businessUrl"
-						value={ formData.businessUrl }
-						onChange={ handleInputChange( 'businessUrl' ) }
-						placeholder={ translate( 'Business URL' ) }
-					/>
-				</FormField>
-
-				{ noCountryList && <QuerySmsCountries /> }
-
-				<FormField label={ translate( 'Phone number' ) } showOptionalLabel>
-					<FormPhoneInput
-						isDisabled={ noCountryList }
-						countriesList={ countriesList }
-						onChange={ handlePhoneInputChange }
-						className="contact-form__phone-input"
-						phoneInputProps={ {
-							placeholder: translate( 'Phone number' ),
-						} }
-					/>
-				</FormField>
-
-				<div className="signup-contact-form__tos">
-					<p>
-						{ translate(
-							"By clicking 'Continue', you agree to the{{break}}{{/break}}{{link}}Terms of the Automattic for Agencies Platform Agreement ↗{{/link}}",
-							{
-								components: {
-									break: <br />,
-									link: (
-										<a
-											href={ localizeUrl(
-												'https://automattic.com/for-agencies/platform-agreement/'
-											) }
-											target="_blank"
-											rel="noopener noreferrer"
-										></a>
-									),
-								},
-							}
-						) }
-					</p>
-				</div>
-				<div className="company-details-form__controls">
-					<Button
-						variant="primary"
-						onClick={ handleSubmit }
-						className="company-details-form__submit"
-					>
-						{ translate( 'Continue' ) }
-					</Button>
-				</div>
 			</div>
+
+			<FormField label={ translate( 'Email' ) } isRequired>
+				<FormTextInput
+					name="email"
+					type="email"
+					value={ formData.email }
+					onChange={ handleInputChange( 'email' ) }
+					placeholder={ translate( 'Your email' ) }
+				/>
+			</FormField>
+
+			<FormField label={ translate( 'Agency name' ) } isRequired>
+				<FormTextInput
+					name="agencyName"
+					value={ formData.agencyName }
+					onChange={ handleInputChange( 'agencyName' ) }
+					placeholder={ translate( 'Agency name' ) }
+				/>
+			</FormField>
+
+			<FormField label={ translate( 'Business URL' ) } isRequired>
+				<FormTextInput
+					name="businessUrl"
+					value={ formData.businessUrl }
+					onChange={ handleInputChange( 'businessUrl' ) }
+					placeholder={ translate( 'Business URL' ) }
+				/>
+			</FormField>
+
+			{ noCountryList && <QuerySmsCountries /> }
+
+			<FormField label={ translate( 'Phone number' ) } showOptionalLabel>
+				<FormPhoneInput
+					isDisabled={ noCountryList }
+					countriesList={ countriesList }
+					onChange={ handlePhoneInputChange }
+					className="contact-form__phone-input"
+					phoneInputProps={ {
+						placeholder: translate( 'Phone number' ),
+					} }
+				/>
+			</FormField>
+
+			<div className="signup-contact-form__tos">
+				<p>
+					{ translate(
+						"By clicking 'Continue', you agree to the{{break}}{{/break}}{{link}}Terms of the Automattic for Agencies Platform Agreement ↗{{/link}}",
+						{
+							components: {
+								break: <br />,
+								link: (
+									<a
+										href={ localizeUrl(
+											'https://automattic.com/for-agencies/platform-agreement/'
+										) }
+										target="_blank"
+										rel="noopener noreferrer"
+									></a>
+								),
+							},
+						}
+					) }
+				</p>
+			</div>
+
+			<FormFooter>
+				<Button __next40pxDefaultSize variant="primary" onClick={ handleSubmit }>
+					{ translate( 'Continue' ) }
+				</Button>
+			</FormFooter>
 		</Form>
 	);
 };

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
@@ -1,4 +1,3 @@
-import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -9,6 +8,7 @@ import QuerySmsCountries from 'calypso/components/data/query-countries/sms';
 import FormPhoneInput from 'calypso/components/forms/form-phone-input';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { useGetSupportedSMSCountries } from 'calypso/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/hooks';
+import { preventWidows } from 'calypso/lib/formatting';
 
 import './style.scss';
 
@@ -63,9 +63,11 @@ const SignupContactForm = ( { onContinue }: Props ) => {
 	return (
 		<Form
 			className="signup-contact-form"
-			title={ translate( `Sign up and unlock the blueprint to grow your agency's business` ) }
-			description={ translate(
-				'Join 5000+ agencies and grow your business with Automattic for Agencies.'
+			title={ preventWidows(
+				translate( `Sign up and unlock the blueprint to grow your agency's business` )
+			) }
+			description={ preventWidows(
+				translate( 'Join 5000+ agencies and grow your business with Automattic for Agencies.' )
 			) }
 		>
 			<div className="signup-multi-step-form__fields">
@@ -75,6 +77,7 @@ const SignupContactForm = ( { onContinue }: Props ) => {
 							name="firstName"
 							value={ formData.firstName }
 							onChange={ handleInputChange( 'firstName' ) }
+							placeholder={ translate( 'Your first name' ) }
 						/>
 					</FormField>
 
@@ -83,6 +86,7 @@ const SignupContactForm = ( { onContinue }: Props ) => {
 							name="lastName"
 							value={ formData.lastName }
 							onChange={ handleInputChange( 'lastName' ) }
+							placeholder={ translate( 'Your last name' ) }
 						/>
 					</FormField>
 				</div>
@@ -93,6 +97,7 @@ const SignupContactForm = ( { onContinue }: Props ) => {
 						type="email"
 						value={ formData.email }
 						onChange={ handleInputChange( 'email' ) }
+						placeholder={ translate( 'Your email' ) }
 					/>
 				</FormField>
 
@@ -101,6 +106,7 @@ const SignupContactForm = ( { onContinue }: Props ) => {
 						name="agencyName"
 						value={ formData.agencyName }
 						onChange={ handleInputChange( 'agencyName' ) }
+						placeholder={ translate( 'Agency name' ) }
 					/>
 				</FormField>
 
@@ -109,6 +115,7 @@ const SignupContactForm = ( { onContinue }: Props ) => {
 						name="businessUrl"
 						value={ formData.businessUrl }
 						onChange={ handleInputChange( 'businessUrl' ) }
+						placeholder={ translate( 'Business URL' ) }
 					/>
 				</FormField>
 
@@ -120,13 +127,16 @@ const SignupContactForm = ( { onContinue }: Props ) => {
 						countriesList={ countriesList }
 						onChange={ handlePhoneInputChange }
 						className="contact-form__phone-input"
+						phoneInputProps={ {
+							placeholder: translate( 'Phone number' ),
+						} }
 					/>
 				</FormField>
 
 				<div className="signup-contact-form__tos">
 					<p>
 						{ translate(
-							"By clicking 'Continue', you agree to the{{break}}{{/break}}{{link}}Terms of the Automattic for Agencies Platform Agreement{{icon}}{{/icon}}{{/link}}.",
+							"By clicking 'Continue', you agree to the{{break}}{{/break}}{{link}}Terms of the Automattic for Agencies Platform Agreement ↗{{/link}}",
 							{
 								components: {
 									break: <br />,
@@ -139,7 +149,6 @@ const SignupContactForm = ( { onContinue }: Props ) => {
 											rel="noopener noreferrer"
 										></a>
 									),
-									icon: <Gridicon icon="external" size={ 18 } />,
 								},
 							}
 						) }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/style.scss
@@ -1,37 +1,37 @@
 .signup-multi-step-form__fields {
 	display: flex;
 	flex-direction: column;
-	gap: 8px;
-	overflow-y: auto;
-	flex: 1;
+	gap: 16px;
 }
 
 .contact-form__phone-input {
     display: flex;
     flex-direction: row;
-    gap: 1rem;
+    gap: 16px;
 
-    .form-phone-input__country {   
+    .form-phone-input__country {
         flex: 1;
     }
 
-    .form-phone-input__phone-number {   
+    .form-phone-input__phone-number {
         flex: 1;
     }
 }
 
-.signup-contact-form__tos {
-    p {
-        font-size: 0.875rem;
-    }
+.signup-contact-form__tos  p {
+	@include a4a-font-body-sm;
+
+	a {
+		text-decoration: underline;
+	}
 }
 
 .signup-multi-step-form__name-fields {
     display: flex;
     flex-direction: row;
-	gap: 24px;
+	gap: 16px;
 
-    div {
+    > * {
         flex-grow: 1;
     }
 }
@@ -43,57 +43,11 @@
 	margin-top: 16px;
 
 	a {
-		color: var(--studio-wordpress-blue);
+		color: var(--color-primary);
 		text-decoration: none;
 	}
 
 	.signup-multi-step-form__terms a:hover {
 		text-decoration: underline;
 	}
-}
-
-// Form field styles
-.a4a-form__section-field {
-	margin-bottom: 0;
-	padding: 2px;
-}
-
-.a4a-form__section-field-required {
-	color: var(--studio-red-50);
-	margin-left: 4px;
-}
-
-.a4a-form__section-field-optional {
-	color: var(--color-neutral-20);
-	font-weight: normal;
-	margin-left: 4px;
-}
-
-.form-text-input {
-	width: 100%;
-	padding: 8px 12px;
-	border: 1px solid var(--color-neutral-10);
-	border-radius: 4px;
-	font-size: 1rem;
-	transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.form-text-input:focus {
-	border-color: var(--studio-wordpress-blue);
-	box-shadow: 0 0 0 2px var(--studio-wordpress-blue-20);
-	outline: none;
-}
-
-.form-text-input.is-error {
-	border-color: var(--studio-red-50);
-}
-
-.a4a-form__error {
-	color: var(--studio-red-50);
-	font-size: 0.75rem;
-	margin-top: 4px;
-}
-
-.a4a-form__error.hidden {
-	display: none;
 }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/style.scss
@@ -1,9 +1,3 @@
-.signup-multi-step-form__fields {
-	display: flex;
-	flex-direction: column;
-	gap: 16px;
-}
-
 .contact-form__phone-input {
     display: flex;
     flex-direction: row;

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/finish-signup-survey/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/finish-signup-survey/index.tsx
@@ -18,7 +18,7 @@ const FinishSignupSurvey: React.FC< Props > = ( { onContinue } ) => {
 			) }
 		>
 			<FormFooter>
-				<Button variant="primary" onClick={ onContinue }>
+				<Button variant="primary" onClick={ onContinue } __next40pxDefaultSize>
 					{ translate( 'Close survey' ) }
 				</Button>
 			</FormFooter>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/finish-signup-survey/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/finish-signup-survey/index.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import Form from 'calypso/a8c-for-agencies/components/form';
+import FormFooter from 'calypso/a8c-for-agencies/components/form/footer';
 
 type Props = {
 	onContinue: () => void;
@@ -16,11 +17,11 @@ const FinishSignupSurvey: React.FC< Props > = ( { onContinue } ) => {
 				'We have sent you an email with more details about the program and instructions for logging in. You will also receive your blueprint in the coming days; keep an eye out for it!'
 			) }
 		>
-			<div>
+			<FormFooter>
 				<Button variant="primary" onClick={ onContinue }>
 					{ translate( 'Close survey' ) }
 				</Button>
-			</div>
+			</FormFooter>
 		</Form>
 	);
 };

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, ChangeEvent } from 'react';
 import Form from 'calypso/a8c-for-agencies/components/form';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
+import FormFooter from 'calypso/a8c-for-agencies/components/form/footer';
 import { useCountriesAndStates } from 'calypso/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-countries-and-states';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
@@ -46,124 +47,116 @@ export default function PersonalizationForm( { onContinue }: Props ) {
 				title={ translate( 'Personalize your experience' ) }
 				description={ translate( "We'll tailor the product and onboarding for you." ) }
 			>
-				<div className="signup-multi-step-form__fields">
-					<FormFieldset>
-						<FormField label={ translate( 'Where is your agency located?' ) } isRequired>
-							<SearchableDropdown
-								value={ country }
-								onChange={ ( value ) => {
-									setCountry( value ?? '' );
-								} }
-								options={ countryOptions }
-								placeholder={ translate( 'Select country' ) }
-							/>
-						</FormField>
-					</FormFieldset>
+				<FormFieldset>
+					<FormField label={ translate( 'Where is your agency located?' ) } isRequired>
+						<SearchableDropdown
+							value={ country }
+							onChange={ ( value ) => {
+								setCountry( value ?? '' );
+							} }
+							options={ countryOptions }
+							placeholder={ translate( 'Select country' ) }
+						/>
+					</FormField>
+				</FormFieldset>
 
-					<FormFieldset>
-						<FormField label={ translate( 'How would you describe yourself?' ) } isRequired>
-							<FormSelect
-								id="user_type"
-								value={ userType }
-								onChange={ ( e: ChangeEvent< HTMLSelectElement > ) => {
-									setUserType( e.target.value );
-								} }
-							>
-								<option value="">{ translate( 'Select option' ) }</option>
-								<option value="agency_owner">{ translate( 'Agency owner' ) }</option>
-								<option value="developer_at_agency">
-									{ translate( 'Developer at an agency' ) }
-								</option>
-								<option value="sales_marketing_operations_at_agency">
-									{ translate( 'Sales, marketing, or operations at an agency' ) }
-								</option>
-								<option value="freelancer">{ translate( 'Freelancer' ) }</option>
-								<option value="site_owner">{ translate( 'Site owner' ) }</option>
-							</FormSelect>
-						</FormField>
-					</FormFieldset>
-
-					<FormFieldset>
-						<FormField label={ translate( 'How many sites do you manage?' ) } isRequired>
-							<FormSelect
-								id="managed_sites"
-								value={ managedSites }
-								onChange={ ( e: ChangeEvent< HTMLSelectElement > ) => {
-									setManagedSites( e.target.value );
-								} }
-							>
-								<option value="">{ translate( 'Select option' ) }</option>
-								<option value="1-5">{ translate( '1-5' ) }</option>
-								<option value="6-20">{ translate( '6-20' ) }</option>
-								<option value="21-50">{ translate( '21-50' ) }</option>
-								<option value="50-100">{ translate( '50-100' ) }</option>
-								<option value="101-500">{ translate( '101-500' ) }</option>
-								<option value="500+">{ translate( '500+' ) }</option>
-							</FormSelect>
-						</FormField>
-					</FormFieldset>
-
-					<FormFieldset>
-						<FormField label={ translate( 'What services do you offer?' ) } isRequired>
-							<MultiCheckbox
-								id="services_offered"
-								name="services_offered"
-								checked={ servicesOffered }
-								options={ [
-									{ value: 'strategy_consulting', label: translate( 'Strategy consulting' ) },
-									{
-										value: 'website_design_development',
-										label: translate( 'Website design & development' ),
-									},
-									{
-										value: 'performance_optimization',
-										label: translate( 'Performance optimization' ),
-									},
-									{
-										value: 'digital_strategy_marketing',
-										label: translate( 'Digital strategy & marketing' ),
-									},
-									{
-										value: 'maintenance_support_plans',
-										label: translate( 'Maintenance & support plans' ),
-									},
-								] }
-								onChange={ handleSetServicesOffered as any }
-							/>
-						</FormField>
-					</FormFieldset>
-
-					<FormFieldset className="signup-personalization-form__products-checkbox">
-						<FormField
-							label={ translate( 'What Automattic products do you currently offer your clients?' ) }
-							isRequired
+				<FormFieldset>
+					<FormField label={ translate( 'How would you describe yourself?' ) } isRequired>
+						<FormSelect
+							id="user_type"
+							value={ userType }
+							onChange={ ( e: ChangeEvent< HTMLSelectElement > ) => {
+								setUserType( e.target.value );
+							} }
 						>
-							<MultiCheckbox
-								id="products_offered"
-								name="products_offered"
-								checked={ productsOffered }
-								options={ [
-									{ value: 'WordPress.com', label: translate( 'WordPress.com' ) },
-									{ value: 'WooCommerce', label: translate( 'WooCommerce' ) },
-									{ value: 'Jetpack', label: translate( 'Jetpack' ) },
-									{ value: 'Pressable', label: translate( 'Pressable' ) },
-									{ value: 'WordPress VIP', label: translate( 'WordPress VIP' ) },
-								] }
-								onChange={ handleSetProductsOffered as any }
-							/>
-						</FormField>
-					</FormFieldset>
+							<option value="">{ translate( 'Select option' ) }</option>
+							<option value="agency_owner">{ translate( 'Agency owner' ) }</option>
+							<option value="developer_at_agency">{ translate( 'Developer at an agency' ) }</option>
+							<option value="sales_marketing_operations_at_agency">
+								{ translate( 'Sales, marketing, or operations at an agency' ) }
+							</option>
+							<option value="freelancer">{ translate( 'Freelancer' ) }</option>
+							<option value="site_owner">{ translate( 'Site owner' ) }</option>
+						</FormSelect>
+					</FormField>
+				</FormFieldset>
 
-					<div className="company-details-form__controls">
-						<Button
-							variant="primary"
-							onClick={ handleSubmit }
-							className="company-details-form__submit"
+				<FormFieldset>
+					<FormField label={ translate( 'How many sites do you manage?' ) } isRequired>
+						<FormSelect
+							id="managed_sites"
+							value={ managedSites }
+							onChange={ ( e: ChangeEvent< HTMLSelectElement > ) => {
+								setManagedSites( e.target.value );
+							} }
 						>
-							{ translate( 'Continue' ) }
-						</Button>
-					</div>
-				</div>
+							<option value="">{ translate( 'Select option' ) }</option>
+							<option value="1-5">{ translate( '1-5' ) }</option>
+							<option value="6-20">{ translate( '6-20' ) }</option>
+							<option value="21-50">{ translate( '21-50' ) }</option>
+							<option value="50-100">{ translate( '50-100' ) }</option>
+							<option value="101-500">{ translate( '101-500' ) }</option>
+							<option value="500+">{ translate( '500+' ) }</option>
+						</FormSelect>
+					</FormField>
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormField label={ translate( 'What services do you offer?' ) } isRequired>
+						<MultiCheckbox
+							id="services_offered"
+							name="services_offered"
+							checked={ servicesOffered }
+							options={ [
+								{ value: 'strategy_consulting', label: translate( 'Strategy consulting' ) },
+								{
+									value: 'website_design_development',
+									label: translate( 'Website design & development' ),
+								},
+								{
+									value: 'performance_optimization',
+									label: translate( 'Performance optimization' ),
+								},
+								{
+									value: 'digital_strategy_marketing',
+									label: translate( 'Digital strategy & marketing' ),
+								},
+								{
+									value: 'maintenance_support_plans',
+									label: translate( 'Maintenance & support plans' ),
+								},
+							] }
+							onChange={ handleSetServicesOffered as any }
+						/>
+					</FormField>
+				</FormFieldset>
+
+				<FormFieldset className="signup-personalization-form__products-checkbox">
+					<FormField
+						label={ translate( 'What Automattic products do you currently offer your clients?' ) }
+						isRequired
+					>
+						<MultiCheckbox
+							id="products_offered"
+							name="products_offered"
+							checked={ productsOffered }
+							options={ [
+								{ value: 'WordPress.com', label: translate( 'WordPress.com' ) },
+								{ value: 'WooCommerce', label: translate( 'WooCommerce' ) },
+								{ value: 'Jetpack', label: translate( 'Jetpack' ) },
+								{ value: 'Pressable', label: translate( 'Pressable' ) },
+								{ value: 'WordPress VIP', label: translate( 'WordPress VIP' ) },
+							] }
+							onChange={ handleSetProductsOffered as any }
+						/>
+					</FormField>
+				</FormFieldset>
+
+				<FormFooter>
+					<Button __next40pxDefaultSize variant="primary" onClick={ handleSubmit }>
+						{ translate( 'Continue' ) }
+					</Button>
+				</FormFooter>
 			</Form>
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -55,7 +55,7 @@ export default function PersonalizationForm( { onContinue }: Props ) {
 									setCountry( value ?? '' );
 								} }
 								options={ countryOptions }
-								label={ translate( 'Select country' ) }
+								placeholder={ translate( 'Select country' ) }
 							/>
 						</FormField>
 					</FormFieldset>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/style.scss
@@ -1,9 +1,8 @@
 .signup-personalization-form {
     .signup-multi-step-form__fields {
         display: flex;
+		gap: 16px;
         flex-direction: column;
-        overflow-y: auto;
-        flex: 1;
     }
 
     .signup-personalization-form__products-checkbox {
@@ -20,50 +19,14 @@
         }
     }
 
-    .form-fieldset {
-        margin: 0;
-        padding: 2px;
-    }
-
-    // Form field styles
-    .a4a-form__section-field {
-        margin-bottom: 0;
-    }
-
-    .a4a-form__section-field-label {
-        font-size: rem(14px);
-        font-weight: 600;
-        color: var(--color-neutral-80);
-        margin-bottom: 8px;
-    }
-
-    .a4a-form__section-field-required {
-        color: var(--studio-red-50);
-        margin-left: 4px;
-    }
-
-    .form-select {
-        width: 100%;
-        padding: 8px 12px;
-        border: 1px solid var(--color-neutral-10);
-        border-radius: 4px;
-        font-size: 1rem;
-        transition: border-color 0.2s ease, box-shadow 0.2s ease;
-    }
-
-    .form-select:focus {
-        border-color: var(--studio-wordpress-blue);
-        box-shadow: 0 0 0 2px var(--studio-wordpress-blue-20);
-        outline: none;
-    }
-
-    .form-select.is-error {
-        border-color: var(--studio-red-50);
-    }
-
+	.form-select,
     .searchable-dropdown {
         width: 100%;
     }
+
+	.form-fieldset {
+		margin: 0;
+	}
 
     .multi-checkbox {
         display: flex;
@@ -88,4 +51,4 @@
     .multi-checkbox .form-checkbox + span {
         margin-left: 8px;
     }
-} 
+}

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/style.scss
@@ -1,10 +1,4 @@
 .signup-personalization-form {
-    .signup-multi-step-form__fields {
-        display: flex;
-		gap: 16px;
-        flex-direction: column;
-    }
-
     .signup-personalization-form__products-checkbox {
         .multi-checkbox label {
             flex: 0 1 calc(32% - 16px); // 3 columns for products
@@ -18,15 +12,6 @@
             }
         }
     }
-
-	.form-select,
-    .searchable-dropdown {
-        width: 100%;
-    }
-
-	.form-fieldset {
-		margin: 0;
-	}
 
     .multi-checkbox {
         display: flex;

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
@@ -1,7 +1,8 @@
 .signup-multi-step-form {
 	.a4a-form {
-		padding: 48px 24px;
 		max-width: 600px;
+		margin-block-start: 56px;
+		box-sizing: border-box;
 		width: 100%;
 		gap: 16px;
 	}

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
@@ -22,4 +22,13 @@
 			max-width: 460px;
 		}
 	}
+
+	.form-select,
+    .searchable-dropdown {
+        width: 100%;
+    }
+
+	.form-fieldset {
+		margin: 0;
+	}
 }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/signup-wrapper/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/signup-wrapper/style.scss
@@ -104,7 +104,7 @@
 
   .signup-wrapper__right {
     flex: 1;
-    padding: 32px;
+    padding: 24px;
     background: inherit;
     border-radius: 4px;
     overflow-y: auto;
@@ -121,7 +121,7 @@
     &::-webkit-scrollbar-thumb {
       background-color: var(--color-neutral-10);
       border-radius: 4px;
-      
+
       &:hover {
         background-color: var(--color-neutral-20);
       }
@@ -187,7 +187,7 @@
     .signup-wrapper__right {
       &::-webkit-scrollbar-thumb {
         background-color: rgba(255, 255, 255, 0.2);
-        
+
         &:hover {
           background-color: rgba(255, 255, 255, 0.3);
         }


### PR DESCRIPTION
This PR fixes discrepancies on the Signup form v2 styling based on the original design.

**NOTE: When testing this, make sure you set your Browser's preference to light mode. The Dark mode theme will be addressed on a separate PR.**


<img width="1366" alt="Screenshot 2025-02-06 at 11 04 30 PM" src="https://github.com/user-attachments/assets/0cbcadaf-a894-471b-bc2a-150a3bb85364" />
<img width="1365" alt="Screenshot 2025-02-06 at 11 04 39 PM" src="https://github.com/user-attachments/assets/da91cc37-612b-4486-935a-446e4f3f9164" />
<img width="1366" alt="Screenshot 2025-02-06 at 11 04 48 PM" src="https://github.com/user-attachments/assets/122b8710-2766-4b83-bd8d-bfe786a47800" />
<img width="1368" alt="Screenshot 2025-02-06 at 11 05 00 PM" src="https://github.com/user-attachments/assets/cc791bee-79c0-4d3c-88b5-0f554f8a6764" />
<img width="1367" alt="Screenshot 2025-02-06 at 11 05 11 PM" src="https://github.com/user-attachments/assets/abec3eda-3b67-413e-80b4-78cdb78eb1e7" />

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1729
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1730
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1732
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1733

## Proposed Changes

* Removed some form overrides as the current Form controls already aligns with the design. This includes, form label colors, additional divs and spacing.
* Add the `FormFooter` component to standardize footer in the Form.

## Why are these changes being made?

* This is part of the new Signup form project for WC Asia preparation.

## Testing Instructions

* Use the A4A live link and go to the `/signup/wc-asia` page.
* Test that the form styling follows the new design.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
