### PR TITLE
Update email forward list and DNS records table headers to match styles of DataViews of site management

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-records-list-item.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list-item.jsx
@@ -41,7 +41,7 @@ function DnsRecordsListItem( { type, name, value, actions, disabled, isHeader, r
 		>
 			<div className="dns-records-list-item">
 				<div className="dns-records-list-item__data dns-records-list-item__type">
-					<strong>{ type }</strong>
+					{ isHeader ? <span>{ type }</span> : <strong>{ type }</strong> }
 				</div>
 				<div className="dns-records-list-item__data dns-records-list-item__name">
 					<span>{ name }</span>

--- a/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/style.scss
@@ -246,6 +246,15 @@
 		.hosting-dashboard-layout-column__container {
 			height: 100%;
 		}
+
+		thead.email-forward-list__row th,
+		.dns-records-list-item__wrapper.is-header .dns-records-list-item__data {
+			font-weight: 500;
+			text-transform: uppercase;
+			/* stylelint-disable-next-line scales/font-sizes */
+			font-size: .6875rem;
+			font-style: normal;
+		}
 	}
 
 	.domain__main-placeholder {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99340 and https://github.com/Automattic/wp-calypso/issues/99341

## Proposed Changes

* Change header font style of Email forward list
* Change header font style of DNS records list

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Domain management revamp + calypso untangling

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /domains/manage and click on a domain to open it in flyout. Open the domain which has some forward emails
* Go to Emails tab. The fonts in the table header should match the font and size in /sites
* Go to domain overview tab
* Open the DNS record management list
* Make sure the header of the table there matches /sites too

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
