### PR TITLE
Social: Fix connections layout issues

### DIFF
--- a/client/sites/marketing/connections/service-examples.scss
+++ b/client/sites/marketing/connections/service-examples.scss
@@ -55,3 +55,31 @@
 .connections__sharing-service-tip {
 	margin: 1rem 0;
 }
+
+.sharing-service-examples {
+	display: grid;
+	grid-auto-columns: minmax(0, 1fr);
+	grid-auto-flow: column;
+	margin-top: 0.4rem;
+
+	@media (max-width: 660px) {
+		grid-auto-flow: row;
+		grid-gap: 2rem;
+		height: auto;
+		min-height: unset;
+	}
+
+	img {
+		max-height: 520px;
+		max-width: 100%;
+	}
+
+	>div {
+		padding: 0.4rem;
+
+		&:has(img) {
+			margin-inline-start: auto;
+			margin-inline-end: auto;
+		}
+	}
+}

--- a/client/sites/marketing/connections/service-examples.scss
+++ b/client/sites/marketing/connections/service-examples.scss
@@ -75,8 +75,6 @@
 	}
 
 	>div {
-		padding: 0.4rem;
-
 		&:has(img) {
 			margin-inline-start: auto;
 			margin-inline-end: auto;

--- a/client/sites/marketing/connections/service.jsx
+++ b/client/sites/marketing/connections/service.jsx
@@ -666,14 +666,15 @@ export class SharingService extends Component {
 							'is-placeholder': this.props.isFetching,
 						} ) }
 					>
-						<ServiceExamples
-							service={ this.props.service }
-							action={ this.performAction }
-							connectAnother={ this.connectAnother }
-							isConnecting={ this.state.isConnecting }
-							connections={ connections }
-						/>
-
+						{ 'not-connected' === connectionStatus && (
+							<ServiceExamples
+								service={ this.props.service }
+								action={ this.performAction }
+								connectAnother={ this.connectAnother }
+								isConnecting={ this.state.isConnecting }
+								connections={ connections }
+							/>
+						) }
 						{ this.isGooglePhotosMigration( connectionStatus ) && <GooglePhotosMigration /> }
 
 						{ ! this.isMailchimpService( connectionStatus ) && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-reach/issues/737

## Proposed Changes

* Hid examples for already connected services -- c4df7923df7e2796165f5dcaf463934db13acfaf
* Added back missing css to have grid -- 5d07ad1d4e0621cec3bdedd2ae3b46874a87847a

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check the connections management page `/marketing/connections/<site_url>`
* For connected accounts you should not see the examples.
* Examples should break into 2 columns on large screens, and 1 on small ones

![CleanShot 2025-02-06 at 16 50 27 png](https://github.com/user-attachments/assets/940e89da-9e9f-4e61-b6d9-a69f3e3286e0)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
