### PR TITLE
Stats: Pull minute data for Real-time Stats chart

### DIFF
--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -1,4 +1,5 @@
 import { LineChart, ThemeProvider, jetpackTheme } from '@automattic/charts';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { Moment } from 'moment';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
@@ -6,6 +7,7 @@ import StatsEmptyState from '../../stats-empty-state';
 
 function StatsLineChart( {
 	chartData = [],
+	className,
 	height = 400,
 	moment,
 	EmptyState = StatsEmptyState,
@@ -15,6 +17,7 @@ function StatsLineChart( {
 		options: object;
 		data: Array< { date: Date; value: number } >;
 	} >;
+	className?: string;
 	height?: number;
 	moment: Moment;
 	EmptyState: typeof StatsEmptyState;
@@ -30,7 +33,7 @@ function StatsLineChart( {
 	};
 
 	return (
-		<div className="stats-line-chart">
+		<div className={ clsx( 'stats-line-chart', className ) }>
 			{ chartData?.[ 0 ].data?.length === 0 && (
 				<EmptyState
 					headingText={ translate( 'Real-time views' ) }

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -1,22 +1,11 @@
 import { LineChart, ThemeProvider, jetpackTheme } from '@automattic/charts';
 import { useTranslate } from 'i18n-calypso';
 import { Moment } from 'moment';
-import { useEffect, useState } from 'react';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import StatsEmptyState from '../../stats-empty-state';
 
-const fixtureData = [
-	{
-		label: 'Views',
-		options: {
-			stroke: '#069e08',
-		},
-		data: [] as Array< { date: Date; value: number } >,
-	},
-];
-
 function StatsLineChart( {
-	chartData = null,
+	chartData = [],
 	height = 400,
 	moment,
 	EmptyState = StatsEmptyState,
@@ -25,12 +14,12 @@ function StatsLineChart( {
 		label: string;
 		options: object;
 		data: Array< { date: Date; value: number } >;
-	} > | null;
+	} >;
 	height?: number;
 	moment: Moment;
 	EmptyState: typeof StatsEmptyState;
 } ) {
-	const [ data, setData ] = useState( () => chartData || fixtureData );
+	const translate = useTranslate();
 	const formatTime = ( value: number ) => {
 		const date = new Date( value );
 		return new Date( date ).toLocaleTimeString( moment.locale(), {
@@ -39,24 +28,10 @@ function StatsLineChart( {
 			hour12: true,
 		} );
 	};
-	const translate = useTranslate();
-
-	useEffect( () => {
-		const intervalId = setInterval( () => {
-			if ( fixtureData[ 0 ].data.length > 30 ) {
-				fixtureData[ 0 ].data.pop();
-			}
-
-			const date = new Date();
-			fixtureData[ 0 ].data.unshift( { date, value: Math.round( Math.random() * 60 ) } );
-			setData( [ ...fixtureData ] );
-		}, 60 * 1000 );
-		return () => clearInterval( intervalId );
-	}, [] );
 
 	return (
 		<div className="stats-line-chart">
-			{ data?.[ 0 ]?.data?.length === 0 && (
+			{ chartData?.[ 0 ].data?.length === 0 && (
 				<EmptyState
 					headingText={ translate( 'Real-time views' ) }
 					infoText={ translate( 'Collecting data… auto-refreshing in a minute…' ) }
@@ -64,7 +39,7 @@ function StatsLineChart( {
 			) }
 			<ThemeProvider theme={ jetpackTheme }>
 				<LineChart
-					data={ data }
+					data={ chartData }
 					withTooltips
 					withGradientFill
 					height={ height }

--- a/client/my-sites/stats/hooks/use-moment-site-zone.ts
+++ b/client/my-sites/stats/hooks/use-moment-site-zone.ts
@@ -7,7 +7,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { DATE_FORMAT } from '../constants';
 
 export const getMomentSiteZone = createSelector(
-	( state: object, siteId: number | null ) => {
+	( state: object, siteId: number | null, dateFormat = DATE_FORMAT ) => {
 		let localeSlug = i18n.getLocaleSlug();
 		if ( localeSlug === null ) {
 			localeSlug = 'en';
@@ -19,7 +19,7 @@ export const getMomentSiteZone = createSelector(
 		if ( Number.isFinite( gmtOffset ) ) {
 			// In all the components, `moment` is directly used, which defaults to the browser's local timezone.
 			// As a result, we need to convert the moment object to the site's timezone for easier comparison like `isSame`.
-			return moment( localizedMoment.utcOffset( gmtOffset ).format( DATE_FORMAT ) );
+			return moment( localizedMoment.utcOffset( gmtOffset ).format( dateFormat ) );
 		}
 
 		// Falls back to the browser's local timezone if no GMT offset is found

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -109,9 +109,15 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 		<div>
 			<AsyncLoad
 				require="calypso/my-sites/stats/components/line-chart"
+				className="stats-realtime-chart"
 				height={ 425 }
 				placeholder={ PageLoading }
-				chartData={ [ { label: 'Views', options: { stroke: '#069e08' }, data: chartData } ] }
+				chartData={ [
+					{
+						label: 'Views',
+						data: chartData,
+					},
+				] }
 			/>
 		</div>
 	);

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import wpcom from 'calypso/lib/wp';
-import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
+import { getSiteOption } from 'calypso/state/sites/selectors';
 import { parseChartData } from 'calypso/state/stats/lists/utils';
 import PageLoading from '../shared/page-loading';
 
@@ -27,16 +27,15 @@ function queryStatsVisits( siteId: number, params: QueryStatsVisitsParams ) {
 const dataUpdateIntervalInSeconds = 5;
 
 const RealtimeChart = ( { siteId }: { siteId: number } ) => {
-	const momentSiteZone = useSelector( ( state: object ) =>
-		getMomentSiteZone( state, siteId, 'YYYY-MM-DD HH' )
-	);
+	const gmtOffset = useSelector( ( state: object ) =>
+		getSiteOption( state, siteId, 'gmt_offset' )
+	) as number;
 	const [ viewsData, setViewsData ] = useState( {} as chartMinuteDataTypes );
 
 	useEffect( () => {
 		const intervalId = setInterval( () => {
-			const currentTime = moment().format( 'mm:00' );
 			// Index the chart data by YYYY-MM-DD HH:mm:00.
-			const adjustedDatetime = `${ momentSiteZone.format( 'YYYY-MM-DD HH' ) }:${ currentTime }`;
+			const adjustedDatetime = moment().utcOffset( gmtOffset ).format( 'YYYY-MM-DD HH:mm:00' );
 
 			queryStatsVisits( siteId, {
 				unit: 'hour',
@@ -57,7 +56,7 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 		}, dataUpdateIntervalInSeconds * 1000 );
 
 		return () => clearInterval( intervalId );
-	}, [ siteId, momentSiteZone ] );
+	}, [ siteId, gmtOffset ] );
 
 	// TODO: Push data and shift the array for the chart display.
 	const formatedChartData = Object.keys( viewsData ).map( ( eachMinute ) => {

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -25,8 +25,7 @@ function queryStatsVisits( siteId: number, params: QueryStatsVisitsParams ) {
 }
 // TODO: Change to 60 for production.
 const UPDATE_INTERVAL_IN_SECONDS = 5;
-// TODO: Change to 30 after resolving the date format issue on the X-axis.
-const MINUTE_DATA_LENGTH = 5;
+const MINUTE_DATA_LENGTH = 30;
 
 const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 	const gmtOffset = useSelector( ( state: object ) =>
@@ -82,6 +81,7 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 			}
 
 			return {
+				// TODO: Support simple string to display time difference rather than forcing a Date object.
 				date: new Date( eachMinute ),
 				value: diffViews,
 			};

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -1,0 +1,85 @@
+import moment from 'moment';
+import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import AsyncLoad from 'calypso/components/async-load';
+import wpcom from 'calypso/lib/wp';
+import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
+import { parseChartData } from 'calypso/state/stats/lists/utils';
+import PageLoading from '../shared/page-loading';
+
+type Unit = 'hour' | 'day' | 'week' | 'month' | 'year';
+
+interface QueryStatsVisitsParams {
+	unit: Unit;
+	date: string;
+	quantity: number;
+	stat_fields: string;
+}
+
+interface chartMinuteDataTypes {
+	[ key: string ]: {
+		views: number;
+	};
+}
+
+function queryStatsVisits( siteId: number, params: QueryStatsVisitsParams ) {
+	return wpcom.req.get( `/sites/${ siteId }/stats/visits`, params );
+}
+
+const dataUpdateIntervalInSeconds = 5;
+
+const RealtimeChart = ( { siteId }: { siteId: number } ) => {
+	const momentSiteZone = useSelector( ( state: object ) =>
+		getMomentSiteZone( state, siteId, 'YYYY-MM-DD HH' )
+	);
+	const [ chartData, setChartData ] = useState( {} as chartMinuteDataTypes );
+
+	useEffect( () => {
+		const intervalId = setInterval( () => {
+			const currentTime = moment().format( 'mm:00' );
+			// Index the chart data by YYYY-MM-DD HH:mm:00.
+			const adjustedDatetime = `${ momentSiteZone.format( 'YYYY-MM-DD HH' ) }:${ currentTime }`;
+
+			queryStatsVisits( siteId, {
+				unit: 'hour',
+				date: adjustedDatetime,
+				quantity: 1,
+				stat_fields: 'views',
+			} ).then( ( response: any ) => {
+				const result = parseChartData( response );
+				setChartData( ( prevChartData ) => {
+					return {
+						...prevChartData,
+						[ adjustedDatetime ]: {
+							views: result[ 0 ].views,
+						},
+					};
+				} );
+			} );
+		}, dataUpdateIntervalInSeconds * 1000 );
+
+		return () => clearInterval( intervalId );
+	}, [ siteId, momentSiteZone ] );
+
+	const formatedChartData = Object.keys( chartData ).map( ( key ) => {
+		return {
+			date: new Date( key ),
+			value: chartData[ key ].views,
+		};
+	} );
+
+	return (
+		<div>
+			<AsyncLoad
+				require="calypso/my-sites/stats/components/line-chart"
+				height={ 425 }
+				placeholder={ PageLoading }
+				chartData={ [
+					{ label: 'Views', options: { stroke: '#069e08' }, data: formatedChartData },
+				] }
+			/>
+		</div>
+	);
+};
+
+export default RealtimeChart;

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -17,9 +17,7 @@ interface QueryStatsVisitsParams {
 }
 
 interface chartMinuteDataTypes {
-	[ key: string ]: {
-		views: number;
-	};
+	[ key: string ]: number;
 }
 
 function queryStatsVisits( siteId: number, params: QueryStatsVisitsParams ) {
@@ -32,7 +30,7 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 	const momentSiteZone = useSelector( ( state: object ) =>
 		getMomentSiteZone( state, siteId, 'YYYY-MM-DD HH' )
 	);
-	const [ chartData, setChartData ] = useState( {} as chartMinuteDataTypes );
+	const [ viewsData, setViewsData ] = useState( {} as chartMinuteDataTypes );
 
 	useEffect( () => {
 		const intervalId = setInterval( () => {
@@ -47,13 +45,12 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 				stat_fields: 'views',
 			} ).then( ( response: any ) => {
 				const result = parseChartData( response );
-				// TODO: Handle data across hours because hourly data is not accumulated.
-				setChartData( ( prevChartData ) => {
+				const views = result[ 0 ].views || 0;
+
+				setViewsData( ( prevViewsData ) => {
 					return {
-						...prevChartData,
-						[ adjustedDatetime ]: {
-							views: result[ 0 ].views,
-						},
+						...prevViewsData,
+						[ adjustedDatetime ]: views,
 					};
 				} );
 			} );
@@ -63,10 +60,27 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 	}, [ siteId, momentSiteZone ] );
 
 	// TODO: Push data and shift the array for the chart display.
-	const formatedChartData = Object.keys( chartData ).map( ( key ) => {
+	const formatedChartData = Object.keys( viewsData ).map( ( eachMinute ) => {
+		const lastMinute = moment( eachMinute ).subtract( 1, 'minute' ).format( 'YYYY-MM-DD HH:mm:00' );
+		let diffViews: number = 0;
+
+		// First minute has no previous minute to compare to.
+		if ( viewsData[ lastMinute ] === undefined ) {
+			diffViews = 0;
+		} else if (
+			moment( lastMinute ).format( 'YYYY-MM-DD HH' ) !==
+			moment( eachMinute ).format( 'YYYY-MM-DD HH' )
+		) {
+			// If the previous minute is from a different hour, use the current minute's views.
+			diffViews = viewsData[ eachMinute ];
+		} else {
+			// Calculate the difference between the current minute and the previous minute.
+			diffViews = viewsData[ eachMinute ] - viewsData[ lastMinute ];
+		}
+
 		return {
-			date: new Date( key ),
-			value: chartData[ key ].views,
+			date: new Date( eachMinute ),
+			value: diffViews,
 		};
 	} );
 

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -47,6 +47,7 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 				stat_fields: 'views',
 			} ).then( ( response: any ) => {
 				const result = parseChartData( response );
+				// TODO: Handle data across hours because hourly data is not accumulated.
 				setChartData( ( prevChartData ) => {
 					return {
 						...prevChartData,

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -23,10 +23,10 @@ interface chartMinuteDataTypes {
 function queryStatsVisits( siteId: number, params: QueryStatsVisitsParams ) {
 	return wpcom.req.get( `/sites/${ siteId }/stats/visits`, params );
 }
-
-const dataUpdateIntervalInSeconds = 5;
+// TODO: Change to 60 for production.
+const UPDATE_INTERVAL_IN_SECONDS = 5;
 // TODO: Change to 30 after resolving the date format issue on the X-axis.
-const dataSeriesLength = 5;
+const MINUTE_DATA_LENGTH = 5;
 
 const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 	const gmtOffset = useSelector( ( state: object ) =>
@@ -55,12 +55,12 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 					};
 				} );
 			} );
-		}, dataUpdateIntervalInSeconds * 1000 );
+		}, UPDATE_INTERVAL_IN_SECONDS * 1000 );
 
 		return () => clearInterval( intervalId );
 	}, [ siteId, gmtOffset ] );
 
-	let formatedChartData = Object.keys( viewsData ).map( ( eachMinute ) => {
+	let chartData = Object.keys( viewsData ).map( ( eachMinute ) => {
 		const lastMinute = moment( eachMinute ).subtract( 1, 'minute' ).format( 'YYYY-MM-DD HH:mm:00' );
 		let diffViews: number = 0;
 
@@ -85,13 +85,13 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 	} );
 
 	// Handle array length with padding or truncating for display.
-	if ( formatedChartData.length > 0 && formatedChartData.length < dataSeriesLength ) {
-		const paddingItemsCount = dataSeriesLength - formatedChartData.length;
+	if ( chartData.length > 0 && chartData.length < MINUTE_DATA_LENGTH ) {
+		const paddingItemsCount = MINUTE_DATA_LENGTH - chartData.length;
 		for ( let i = 0; i < paddingItemsCount; i++ ) {
-			formatedChartData.unshift( formatedChartData[ 0 ] );
+			chartData.unshift( chartData[ 0 ] );
 		}
 	} else {
-		formatedChartData = formatedChartData.slice( -dataSeriesLength );
+		chartData = chartData.slice( -MINUTE_DATA_LENGTH );
 	}
 
 	return (
@@ -100,9 +100,7 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 				require="calypso/my-sites/stats/components/line-chart"
 				height={ 425 }
 				placeholder={ PageLoading }
-				chartData={ [
-					{ label: 'Views', options: { stroke: '#069e08' }, data: formatedChartData },
-				] }
+				chartData={ [ { label: 'Views', options: { stroke: '#069e08' }, data: chartData } ] }
 			/>
 		</div>
 	);

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -60,10 +60,17 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 	}, [ siteId, gmtOffset ] );
 
 	let chartData = useMemo( () => {
-		return Object.keys( viewsData ).map( ( eachMinute ) => {
+		return Object.keys( viewsData ).map( ( eachMinute, idx ) => {
 			const lastMinute = moment( eachMinute )
 				.subtract( 1, 'minute' )
 				.format( 'YYYY-MM-DD HH:mm:00' );
+
+			// Reset the data if the current minute is not continuous with the previous minute,
+			// which usually happens when the device is idle for a while.
+			if ( viewsData[ lastMinute ] === undefined && idx !== 0 ) {
+				setViewsData( {} );
+			}
+
 			let diffViews: number = 0;
 
 			// First minute has no previous minute to compare to.

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import wpcom from 'calypso/lib/wp';
@@ -60,29 +60,33 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 		return () => clearInterval( intervalId );
 	}, [ siteId, gmtOffset ] );
 
-	let chartData = Object.keys( viewsData ).map( ( eachMinute ) => {
-		const lastMinute = moment( eachMinute ).subtract( 1, 'minute' ).format( 'YYYY-MM-DD HH:mm:00' );
-		let diffViews: number = 0;
+	let chartData = useMemo( () => {
+		return Object.keys( viewsData ).map( ( eachMinute ) => {
+			const lastMinute = moment( eachMinute )
+				.subtract( 1, 'minute' )
+				.format( 'YYYY-MM-DD HH:mm:00' );
+			let diffViews: number = 0;
 
-		// First minute has no previous minute to compare to.
-		if ( viewsData[ lastMinute ] === undefined ) {
-			diffViews = 0;
-		} else if (
-			moment( lastMinute ).format( 'YYYY-MM-DD HH' ) !==
-			moment( eachMinute ).format( 'YYYY-MM-DD HH' )
-		) {
-			// If the previous minute is from a different hour, use the current minute's views.
-			diffViews = viewsData[ eachMinute ];
-		} else {
-			// Calculate the difference between the current minute and the previous minute.
-			diffViews = viewsData[ eachMinute ] - viewsData[ lastMinute ];
-		}
+			// First minute has no previous minute to compare to.
+			if ( viewsData[ lastMinute ] === undefined ) {
+				diffViews = 0;
+			} else if (
+				moment( lastMinute ).format( 'YYYY-MM-DD HH' ) !==
+				moment( eachMinute ).format( 'YYYY-MM-DD HH' )
+			) {
+				// If the previous minute is from a different hour, use the current minute's views.
+				diffViews = viewsData[ eachMinute ];
+			} else {
+				// Calculate the difference between the current minute and the previous minute.
+				diffViews = viewsData[ eachMinute ] - viewsData[ lastMinute ];
+			}
 
-		return {
-			date: new Date( eachMinute ),
-			value: diffViews,
-		};
-	} );
+			return {
+				date: new Date( eachMinute ),
+				value: diffViews,
+			};
+		} );
+	}, [ JSON.stringify( viewsData ) ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	// Handle array length with padding or truncating for display.
 	if ( chartData.length > 0 && chartData.length < MINUTE_DATA_LENGTH ) {

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -25,6 +25,8 @@ function queryStatsVisits( siteId: number, params: QueryStatsVisitsParams ) {
 }
 
 const dataUpdateIntervalInSeconds = 5;
+// TODO: Change to 30 after resolving the date format issue on the X-axis.
+const dataSeriesLength = 5;
 
 const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 	const gmtOffset = useSelector( ( state: object ) =>
@@ -58,8 +60,7 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 		return () => clearInterval( intervalId );
 	}, [ siteId, gmtOffset ] );
 
-	// TODO: Push data and shift the array for the chart display.
-	const formatedChartData = Object.keys( viewsData ).map( ( eachMinute ) => {
+	let formatedChartData = Object.keys( viewsData ).map( ( eachMinute ) => {
 		const lastMinute = moment( eachMinute ).subtract( 1, 'minute' ).format( 'YYYY-MM-DD HH:mm:00' );
 		let diffViews: number = 0;
 
@@ -82,6 +83,16 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 			value: diffViews,
 		};
 	} );
+
+	// Handle array length with padding or truncating for display.
+	if ( formatedChartData.length > 0 && formatedChartData.length < dataSeriesLength ) {
+		const paddingItemsCount = dataSeriesLength - formatedChartData.length;
+		for ( let i = 0; i < paddingItemsCount; i++ ) {
+			formatedChartData.unshift( formatedChartData[ 0 ] );
+		}
+	} else {
+		formatedChartData = formatedChartData.slice( -dataSeriesLength );
+	}
 
 	return (
 		<div>

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -62,6 +62,7 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 		return () => clearInterval( intervalId );
 	}, [ siteId, momentSiteZone ] );
 
+	// TODO: Push data and shift the array for the chart display.
 	const formatedChartData = Object.keys( chartData ).map( ( key ) => {
 		return {
 			date: new Date( key ),

--- a/client/my-sites/stats/pages/realtime/index.jsx
+++ b/client/my-sites/stats/pages/realtime/index.jsx
@@ -3,7 +3,6 @@ import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import { navItems } from 'calypso/blocks/stats-navigation/constants';
-import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
@@ -13,8 +12,8 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 import AnnualHighlightsSection from '../../sections/annual-highlights-section';
 import PageViewTracker from '../../stats-page-view-tracker';
 import statsStrings from '../../stats-strings';
-import PageLoading from '../shared/page-loading';
 import StatsModuleListing from '../shared/stats-module-listing';
+import RealtimeChart from './chart';
 
 import './style.scss';
 
@@ -57,11 +56,7 @@ function StatsRealtime() {
 				></NavigationHeader>
 				<StatsNavigation selectedItem="realtime" siteId={ siteId } slug={ siteSlug } />
 				<AnnualHighlightsSection siteId={ siteId } />
-				<AsyncLoad
-					require="calypso/my-sites/stats/components/line-chart"
-					height={ 425 }
-					placeholder={ PageLoading }
-				/>
+				<RealtimeChart siteId={ siteId } />
 				<StatsModuleListing className="stats__module-list--insights" siteId={ siteId }>
 					<StatsModuleTopPosts
 						moduleStrings={ moduleStrings.posts }

--- a/client/my-sites/stats/pages/realtime/style.scss
+++ b/client/my-sites/stats/pages/realtime/style.scss
@@ -1,4 +1,4 @@
-.stats-line-chart {
+.stats-realtime-chart {
 	position: relative;
 	margin: 32px 0;
 
@@ -15,4 +15,14 @@
 		left: 50%;
 		transform: translate(-50%, 0);
 	}
+
+	/* Style the line chart svg using the user admin color scheme */
+	path.visx-line {
+		stroke: var(--color-primary);
+	}
+
+	#area-gradient-1 > stop:first-child {
+		stop-color: var(--color-primary);
+	}
+	/* Style the line chart svg using the user admin color scheme */
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/335

## Proposed Changes

* Add `RealtimeChart` component to query hourly data and process views difference by minute for the line chart.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Pull real data for the Real-time Stats prototype.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<img width="1317" alt="截圖 2025-02-07 凌晨3 32 33" src="https://github.com/user-attachments/assets/2c0c10ac-36ef-445a-89b6-025867ac5f59" />

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Realtime tab with the feature flag `stats/real-time-tab` for a high-traffic site.
* Ensure the real-time page views chart is displayed with at most five data series and update every five seconds.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
