### PR TITLE
A4A: adds 'Dark' mode support on the new Signup form.

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/style.scss
@@ -1,6 +1,10 @@
 .choice-blueprint__text {
 	@include a4a-font-body-lg;
     color: var(--color-neutral-60);
+
+	@media (prefers-color-scheme: dark) {
+			color: var(--color-text-inverted);
+	}
 }
 
 .choice-blueprint__button {

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/style.scss
@@ -18,6 +18,11 @@
 	a {
 		text-decoration: underline;
 	}
+
+
+	@media (prefers-color-scheme: dark) {
+		color: var(--color-text-inverted);
+	}
 }
 
 .signup-multi-step-form__name-fields {

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
@@ -31,4 +31,21 @@
 	.form-fieldset {
 		margin: 0;
 	}
+
+	.a4a-form__section-field-label,
+	.a4a-form__section-field-required {
+		@include a4a-font-heading-sm($font-size: rem(14px));
+	}
+
+	@media (prefers-color-scheme: dark) {
+		.a4a-form__heading .a4a-form__heading-title,
+		.a4a-form__heading .a4a-form__heading-description,
+		.a4a-form__section-field-label,
+		.a4a-form__section-field-required,
+		.signup-personalization-form .multi-checkbox label,
+		.form-radio__label {
+			color: var(--color-text-inverted);
+		}
+	}
 }
+

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
@@ -43,8 +43,36 @@
 		.a4a-form__section-field-label,
 		.a4a-form__section-field-required,
 		.signup-personalization-form .multi-checkbox label,
-		.form-radio__label {
+		.form-phone-input label,
+		.form-radio__label,
+		.components-form-token-field__suggestion {
 			color: var(--color-text-inverted);
+		}
+
+		input[type="text"].form-text-input,
+		input[type="url"].form-text-input,
+		input[type="password"].form-text-input,
+		input[type="email"].form-text-input,
+		input[type="tel"].form-text-input,
+		input[type="number"].form-text-input,
+		input[type="search"].form-text-input,
+		.components-form-token-field__input,
+		.form-select,
+		.form-checkbox,
+		.form-radio,
+		.form-textarea,
+		.components-button.is-secondary {
+			background-color: #022836;
+			border-color: #E6F5FF1A;
+			color: var(--color-text-inverted);
+			&::placeholder {
+				color: #E6F5FF99;
+			}
+		}
+
+		.form-checkbox:checked,
+		.form-radio:checked::before {
+			background-color: var(--color-text-inverted);
 		}
 	}
 }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/signup-wrapper/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/signup-wrapper/style.scss
@@ -44,7 +44,7 @@
     }
   }
 
-  .signup-wrapper-testimonial {
+  .signup-wrapper__testimonial {
     color: var(--color-text);
     padding: 24px;
     background: var(--color-surface);
@@ -53,50 +53,50 @@
     position: relative;
     top: -1rem;
 
-    .signup-wrapper-testimonial-text {
+    .signup-wrapper__testimonial-text {
       font-size: 1rem;
       line-height: 1.5;
       margin-bottom: 24px;
       color: var(--color-text);
     }
 
-    .signup-wrapper-testimonial-author {
+    .signup-wrapper__testimonial-author {
       display: flex;
       align-items: center;
       gap: 12px;
     }
 
-    .signup-wrapper-testimonial-avatar {
+    .signup-wrapper__testimonial-avatar {
       width: 48px;
       height: 48px;
       border-radius: 50%;
       background: var(--color-neutral-5);
     }
 
-    .signup-wrapper-testimonial-info {
+    .signup-wrapper__testimonial-info {
       display: flex;
       flex-direction: column;
       gap: 4px;
     }
 
-    .signup-wrapper-testimonial-name {
+    .signup-wrapper__testimonial-name {
       font-weight: 600;
       font-size: 1rem;
       color: var(--color-text);
     }
 
-    .signup-wrapper-testimonial-title {
+    .signup-wrapper__testimonial-title {
       font-weight: 600;
       font-size: 1rem;
       color: var(--color-text);
     }
 
-    .signup-wrapper-testimonial-url {
+    .signup-wrapper__testimonial-url {
       font-size: 0.875rem;
       color: var(--color-text-subtle);
       text-decoration: underline;
 
-      .signup-wrapper-testimonial-url:visited {
+      .signup-wrapper__testimonial-url:visited {
         color: var(--color-text-subtle);
       }
     }
@@ -153,29 +153,29 @@
       }
     }
 
-    .signup-wrapper-testimonial {
+    .signup-wrapper__testimonial {
       color: var(--color-surface);
       background: #02506E;
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
       backdrop-filter: blur(8px);
 
-      .signup-wrapper-testimonial-text {
+      .signup-wrapper__testimonial-text {
         color: var(--color-neutral-0);
       }
 
-      .signup-wrapper-testimonial-avatar {
+      .signup-wrapper__testimonial-avatar {
         background: var(--color-neutral-50);
       }
 
-      .signup-wrapper-testimonial-name {
+      .signup-wrapper__testimonial-name {
         color: var(--color-surface);
       }
 
-      .signup-wrapper-testimonial-title {
+      .signup-wrapper__testimonial-title {
         color: var(--color-surface);
       }
 
-      .signup-wrapper-testimonial-url {
+      .signup-wrapper__testimonial-url {
         color: var(--color-surface);
 
         &:visited {

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/step-progress/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/step-progress/style.scss
@@ -1,6 +1,5 @@
 .step-progress {
 	width: 100%;
-	background: var(--studio-white);
 
 	.step-progress__steps {
 		max-width: 600px;
@@ -32,6 +31,10 @@
 		.step-progress__step-label {
 			color: var(--color-neutral-80);
 			font-weight: 600;
+
+			@media (prefers-color-scheme: dark) {
+				color: var(--color-text-inverted);
+			}
 		}
 	}
 
@@ -43,16 +46,28 @@
 		.step-progress__step-label {
 			color: var(--color-neutral-80);
 			font-weight: 600;
+
+			@media (prefers-color-scheme: dark) {
+				color: var(--color-text-inverted);
+			}
 		}
 	}
 
 	.step-progress__step:not(.is-active):not(.is-complete) {
 		.step-progress__step-indicator {
 			background-color: var(--color-neutral-5);
+
+			@media (prefers-color-scheme: dark) {
+				opacity: 0.2;
+			}
 		}
 
 		.step-progress__step-label {
 			color: var(--color-neutral-40);
+
+			@media (prefers-color-scheme: dark) {
+				color: var(--color-text-inverted);
+			}
 		}
 	}
 
@@ -70,4 +85,5 @@
 		order: -1;
 		margin-bottom: 4px;
 	}
-} 
+}
+

--- a/packages/components/src/logos/wordpress-logo/README.md
+++ b/packages/components/src/logos/wordpress-logo/README.md
@@ -16,10 +16,10 @@ export default function MyComponent() {
 
 The following props can be passed to the WordPressLogo component:
 
-| PROPERTY | TYPE     | REQUIRED | DEFAULT | DESCRIPTION                                     |
-| -------- | -------- | -------- | ------- | ----------------------------------------------- |
-| **size** | _number_ | no       | `72`    | The width and height of the spinner, in pixels. |
-| **className** | _string_ | no       | `'wordpress-logo'`    | The CSS class name applied to the SVG element. |
+| PROPERTY      | TYPE     | REQUIRED | DEFAULT            | DESCRIPTION                                     |
+| ------------- | -------- | -------- | ------------------ | ----------------------------------------------- |
+| **size**      | _number_ | no       | `72`               | The width and height of the spinner, in pixels. |
+| **className** | _string_ | no       | `'wordpress-logo'` | The CSS class name applied to the SVG element.  |
 
 Note that passing a class name through the `className` prop will override the default class,
 rather than merging them together. We plan to fix this behavior.


### PR DESCRIPTION
This PR adds 'Dark' mode support on the new Signup form.

https://github.com/user-attachments/assets/baead8e4-544e-469c-b3dd-7c39faf49103


Depends on https://github.com/Automattic/wp-calypso/pull/99414
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1740

## Proposed Changes

* Add 'Dark' preference CSS rules.

## Why are these changes being made?

This is part of the new Signup form project for WC Asia preparation.

## Testing Instructions

* Set your browser preference to 'Dark' mode.
* Use the A4A live link and go to the /signup/wc-asia page.
* Test that the form 'Dark' mode styling follows the design

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
