### PR TITLE
Remove: WordPress upload media mocks and alias.

### DIFF
--- a/apps/blaze-dashboard/webpack.config.js
+++ b/apps/blaze-dashboard/webpack.config.js
@@ -116,9 +116,6 @@ module.exports = {
 		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
 		mainFields: [ 'browser', 'calypso:src', 'module', 'main' ],
 		conditionNames: [ 'calypso:src', 'import', 'module', 'require' ],
-		alias: {
-			'@wordpress/upload-media': false,
-		},
 	},
 	node: false,
 	plugins: [

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -110,9 +110,6 @@ module.exports = {
 		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
 		mainFields: [ 'browser', 'calypso:src', 'module', 'main' ],
 		conditionNames: [ 'calypso:src', 'import', 'module', 'require' ],
-		alias: {
-			'@wordpress/upload-media': false,
-		},
 	},
 	node: false,
 	plugins: [

--- a/client/__mocks__/upload-media.js
+++ b/client/__mocks__/upload-media.js
@@ -1,4 +1,0 @@
-module.exports = {
-	// Add mock implementations if necessary
-	uploadMedia: () => {},
-};

--- a/client/webpack.config.desktop.js
+++ b/client/webpack.config.desktop.js
@@ -93,7 +93,6 @@ module.exports = {
 			// Alias calypso to ./client. This allows for smaller bundles, as it ensures that
 			// importing `./client/file.js` is the same thing than importing `calypso/file.js`
 			calypso: __dirname,
-			'@wordpress/upload-media': false,
 		},
 	},
 	plugins: [

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -288,7 +288,6 @@ const webpackConfig = {
 			calypso: __dirname,
 
 			util: findPackage( 'util/' ), //Trailing `/` stops node from resolving it to the built-in module
-			'@wordpress/upload-media': false,
 		} ),
 		fallback: {
 			stream: require.resolve( 'stream-browserify' ),

--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -135,7 +135,6 @@ const webpackConfig = {
 		conditionNames: [ 'calypso:src', 'import', 'module', 'require' ],
 		alias: {
 			'@automattic/calypso-config': 'calypso/server/config',
-			'@wordpress/upload-media': false,
 		},
 	},
 	node: {

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -121,9 +121,6 @@ function getWebpackConfig(
 			fallback: {
 				stream: require.resolve( 'stream-browserify' ),
 			},
-			alias: {
-				'@wordpress/upload-media': false,
-			},
 		},
 		node: false,
 		plugins: [

--- a/packages/page-pattern-modal/jest.config.js
+++ b/packages/page-pattern-modal/jest.config.js
@@ -4,7 +4,4 @@ module.exports = {
 		configData: {},
 	},
 	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
-	moduleNameMapper: {
-		'^@wordpress/upload-media$': '<rootDir>/src/__mocks__/index.js',
-	},
 };

--- a/packages/page-pattern-modal/src/__mocks__/index.js
+++ b/packages/page-pattern-modal/src/__mocks__/index.js
@@ -1,4 +1,0 @@
-module.exports = {
-	// Add mock implementations if necessary
-	uploadMedia: () => {},
-};

--- a/test/client/jest.config.js
+++ b/test/client/jest.config.js
@@ -10,7 +10,6 @@ module.exports = {
 	moduleNameMapper: {
 		'^@automattic/calypso-config$': '<rootDir>/server/config/index.js',
 		'react-markdown': '<rootDir>/node_modules/react-markdown/react-markdown.min.js',
-		'^@wordpress/upload-media$': '<rootDir>/__mocks__/upload-media.js',
 	},
 	transformIgnorePatterns: [
 		'node_modules[\\/\\\\](?!.*\\.(?:gif|jpg|jpeg|png|svg|scss|sass|css)$)',


### PR DESCRIPTION
The @wordpress/upload-media alias and mocks were added as a temporary solution because core was not properly bundling the package. But this issue was fixed upstream and meanwhile, the package versions we are using on calypso already contain the fix so these mocks are not needed.



## Testing Instructions
Verify the CI is green.
