### PR TITLE
Subscribers: Add tooltip and true / false filter options

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -65,6 +65,11 @@ body.is-section-subscribers.is-subscribers-dataviews,
                 border-radius: 0;
                 cursor: pointer;
             }
+
+            .subscriber-data-views__tooltip-text {
+                border-bottom: 1px dotted var(--studio-gray-60);
+                cursor: pointer;
+            }
         
             &__list {
                 flex: 1 1 auto;

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -1,8 +1,10 @@
 import { Gravatar } from '@automattic/components';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { Tooltip } from '@wordpress/components';
 import { DataViews, type View, type Action, Operator } from '@wordpress/dataviews';
 import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
+import { hasTranslation } from '@wordpress/i18n';
 import { translate } from 'i18n-calypso';
 import TimeSince from 'calypso/components/time-since';
 import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
@@ -66,6 +68,22 @@ const SubscriberDataViews = ( {
 	onGiftSubscription,
 }: SubscriberDataViewsProps ) => {
 	const isMobile = useBreakpoint( '<660px' );
+	const isEnglishLocale = useIsEnglishLocale();
+
+	const renderEmailSubscriberStatus = ( isEmailSubscriber: boolean ) => {
+		if ( isEmailSubscriber ) {
+			return translate( 'Yes' );
+		}
+		if ( isEnglishLocale || hasTranslation( 'Reader only subscriber' ) ) {
+			return (
+				<Tooltip text={ translate( 'Reader only subscriber' ) }>
+					<span className="subscriber-data-views__tooltip-text">{ translate( 'No' ) }</span>
+				</Tooltip>
+			);
+		}
+		return translate( 'No' );
+	};
+
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const [ filterOption, setFilterOption ] = useState( SubscribersFilterBy.All );
 	const [ selectedSubscriber, setSelectedSubscriber ] = useState< Subscriber | null >( null );
@@ -210,15 +228,7 @@ const SubscriberDataViews = ( {
 				label: translate( 'Email subscriber' ),
 				getValue: ( { item }: { item: Subscriber } ) => ( item.is_email_subscriber ? 'yes' : 'no' ),
 				render: ( { item }: { item: Subscriber } ) => (
-					<div>
-						{ item.is_email_subscriber ? (
-							translate( 'Yes' )
-						) : (
-							<Tooltip text={ translate( 'Reader only subscriber' ) }>
-								<span className="subscriber-data-views__tooltip-text">{ translate( 'No' ) }</span>
-							</Tooltip>
-						) }
-					</div>
+					<div>{ renderEmailSubscriberStatus( item.is_email_subscriber ) }</div>
 				),
 				elements: [
 					{ label: translate( 'True' ), value: SubscribersFilterBy.EmailSubscriber },
@@ -242,7 +252,7 @@ const SubscriberDataViews = ( {
 				enableSorting: true,
 			},
 		],
-		[]
+		[ isEnglishLocale ]
 	);
 
 	const actions = useMemo< Action< Subscriber >[] >( () => {

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -70,20 +70,6 @@ const SubscriberDataViews = ( {
 	const isMobile = useBreakpoint( '<660px' );
 	const isEnglishLocale = useIsEnglishLocale();
 
-	const renderEmailSubscriberStatus = ( isEmailSubscriber: boolean ) => {
-		if ( isEmailSubscriber ) {
-			return translate( 'Yes' );
-		}
-		if ( isEnglishLocale || hasTranslation( 'Reader only subscriber' ) ) {
-			return (
-				<Tooltip text={ translate( 'Reader only subscriber' ) }>
-					<span className="subscriber-data-views__tooltip-text">{ translate( 'No' ) }</span>
-				</Tooltip>
-			);
-		}
-		return translate( 'No' );
-	};
-
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const [ filterOption, setFilterOption ] = useState( SubscribersFilterBy.All );
 	const [ selectedSubscriber, setSelectedSubscriber ] = useState< Subscriber | null >( null );
@@ -227,9 +213,18 @@ const SubscriberDataViews = ( {
 				id: 'is_email_subscriber',
 				label: translate( 'Email subscriber' ),
 				getValue: ( { item }: { item: Subscriber } ) => ( item.is_email_subscriber ? 'yes' : 'no' ),
-				render: ( { item }: { item: Subscriber } ) => (
-					<div>{ renderEmailSubscriberStatus( item.is_email_subscriber ) }</div>
-				),
+				render: ( { item }: { item: Subscriber } ) => {
+					const noTooltip =
+						isEnglishLocale || hasTranslation( 'Reader only subscriber' ) ? (
+							<Tooltip text={ translate( 'Reader only subscriber' ) }>
+								<span className="subscriber-data-views__tooltip-text">{ translate( 'No' ) }</span>
+							</Tooltip>
+						) : (
+							translate( 'No' )
+						);
+
+					return <div>{ item.is_email_subscriber ? translate( 'Yes' ) : noTooltip }</div>;
+				},
 				elements: [
 					{ label: translate( 'True' ), value: SubscribersFilterBy.EmailSubscriber },
 					{

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -1,5 +1,6 @@
 import { Gravatar } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
+import { Tooltip } from '@wordpress/components';
 import { DataViews, type View, type Action, Operator } from '@wordpress/dataviews';
 import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { translate } from 'i18n-calypso';
@@ -209,12 +210,20 @@ const SubscriberDataViews = ( {
 				label: translate( 'Email subscriber' ),
 				getValue: ( { item }: { item: Subscriber } ) => ( item.is_email_subscriber ? 'yes' : 'no' ),
 				render: ( { item }: { item: Subscriber } ) => (
-					<div>{ item.is_email_subscriber ? 'Yes' : 'No' }</div>
+					<div>
+						{ item.is_email_subscriber ? (
+							'Yes'
+						) : (
+							<Tooltip text={ translate( 'Reader only subscriber' ) }>
+								<span className="subscriber-data-views__tooltip-text">No</span>
+							</Tooltip>
+						) }
+					</div>
 				),
 				elements: [
-					{ label: translate( 'Subscribed' ), value: SubscribersFilterBy.EmailSubscriber },
+					{ label: translate( 'True' ), value: SubscribersFilterBy.EmailSubscriber },
 					{
-						label: translate( 'Not subscribed' ),
+						label: translate( 'False' ),
 						value: SubscribersFilterBy.ReaderSubscriber,
 					},
 				],

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -212,10 +212,10 @@ const SubscriberDataViews = ( {
 				render: ( { item }: { item: Subscriber } ) => (
 					<div>
 						{ item.is_email_subscriber ? (
-							'Yes'
+							translate( 'Yes' )
 						) : (
 							<Tooltip text={ translate( 'Reader only subscriber' ) }>
-								<span className="subscriber-data-views__tooltip-text">No</span>
+								<span className="subscriber-data-views__tooltip-text">{ translate( 'No' ) }</span>
 							</Tooltip>
 						) }
 					</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add "Reader only subscriber" tooltip to No in the email subscriber column on /subscribers.
<img width="718" alt="Screen Shot 2025-02-06 at 12 16 38 PM" src="https://github.com/user-attachments/assets/45455a8c-88bc-47d0-808c-628b77258561" />

* Change the email subscriber filter options to True / False.

<img width="483" alt="Screen Shot 2025-02-06 at 12 16 27 PM" src="https://github.com/user-attachments/assets/0de09614-aefd-4141-b593-6fdc3b9de369" />
<img width="484" alt="Screen Shot 2025-02-06 at 12 17 26 PM" src="https://github.com/user-attachments/assets/b413f5c7-a4d2-4ab9-b120-e1ff56025886" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pe7F0s-2ul-p2#comment-3392

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /subscribers/{site url} for a site that has at least one non-email subscriber (you can unsubscribe from emails in /reader/subscriptions).
* Check that you can hover over "No" in the email subscriber column and see "Reader only subscriber."
* Check that you can filter by Email subscriber > True / False.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?