### PR TITLE
Add "why" section to format-currency README

### DIFF
--- a/packages/format-currency/README.md
+++ b/packages/format-currency/README.md
@@ -20,6 +20,20 @@ formatter.formatCurrency( /* ... */ );
 
 The formatting functions exposed by this package are actually methods on a `CurrencyFormatter` object. A default global formatter is created by the package but you can create your own formatter by using the `createFormatter` function if you want more control.
 
+## Why does this package exist?
+
+Formatting currency amounts can be surprisingly complex. Most people assume that the currency itself is the main thing that defines how to write an amount of money but it is actually more affected by locale and a number of options.
+
+Technically this package just provides a wrapper for `Intl.NumberFormat`, but it handles a lot of things automatically to make things simple and provide consistency. Here's what the functions of this package provide:
+
+- A cached number formatter for performance, keyed by currency and locale as well as any other options which must be passed to the `Intl` formatter (whether to show non-zero decimals, and whether to display a `+` sign for positive amounts).
+- The locale is set from WordPress, if available, but also falls back to the browser’s locale, and can be set explicitly if WordPress is not available (eg: for a logged-out pricing page).
+- This uses a forced latin character set to make sure we always display latin numbers for consistency.
+- We override currency codes with a hard-coded list. This is for consistency and so that some currencies seem less confusing when viewed in EN locales, since those are the default locales for many users (eg: always use `C$` for CAD instead of `CA$` or just `$` which are the CLDR standard depending on locale since `$` might imply CAD and it might imply USD).
+- We always show `US$` for USD when the user’s geolocation is not inside the US. This is important because other currencies use `$` for their currency and are surprised sometimes if they are actually charged in USD (which is the default for many users). We can’t safely display `US$` for everyone because we've found that US users are confused by that style and it decreases confidence in the product.
+- An option to format currency from the currency’s smallest unit (eg: cents in USD, yen in JPY). This is important because doing price math with floating point numbers in code produces unexpected rounding errors, so most currency amounts should be provided and manipulated as integers.
+- An optional API to return the formatted pieces of a price separately, so the consumer can decide how best to render them (eg: this is used to wrap different HTML tags around prices and currency symbols). JS already includes this feature as `Intl.NumberFormat.formatToParts()` but our API must also include the other features listed here and extra information like the position of the currency symbol (before or after the number).
+
 ## createFormatter()
 
 `createFormatter(): CurrencyFormatter`


### PR DESCRIPTION
## Proposed Changes

This PR adds a "Why" section to the `@automattic/format-currency` package to make it clear why it exists.

## Why are these changes being made?

We may merge the functionality of the `format-currency` package into the `i18n-calypso` package (see discussion here: pxLjZ-9Eg-p2#comment-21592), but it's important to maintain the features that we already provide so here I've enumerated them.

## Testing Instructions

None.