### PR TITLE
Help Center auto-open: Failover to proxied status when all fails

### DIFF
--- a/packages/data-stores/src/help-center/index.ts
+++ b/packages/data-stores/src/help-center/index.ts
@@ -11,6 +11,14 @@ export type { State };
 
 let isRegistered = false;
 
+declare global {
+	interface Window {
+		helpCenterData?: {
+			isProxied: boolean;
+		};
+	}
+}
+
 // All end-to-end tests use a custom user agent containing this string.
 const E2E_USER_AGENT = 'wp-e2e-tests';
 
@@ -26,7 +34,9 @@ export const isSupportSession = () => {
 			!! document.querySelector( '#wp-admin-bar-support-session-details' ) ||
 			!! document.querySelector( '#a8c-support-session-overlay' ) ||
 			// Atomic
-			document.body.classList.contains( 'support-session' )
+			document.body.classList.contains( 'support-session' ) ||
+			// Our failover last hope, don't re-open when proxied.
+			window.helpCenterData?.isProxied
 		);
 	}
 	return false;


### PR DESCRIPTION
I tried multiple ways to detect whether someone is in a support session to not auto-open the Help Center, all checks have failed in some instance or another (we have Calypso, wp-admin, wp-admin Atomic, Gutenberg iframed, Gutenberg Simple, and Gutenberg Atomic). I finally now switched to not open the HC when the user is proxied as a final failover value.

Fixes https://github.com/Automattic/wp-calypso/issues/99073

## Why are these changes being made?
To prevent getting in the way of HEs during support sessions.

## Testing Instructions

It's a bit tricky to test this.

- Sandbox widgets.wp.com
- In apps/help-center run `yarn dev --sync`.
- **Chrome window 1**: Login as a normal user, feel free to use mine `sdfsdlfhsdjf` via SSP and https://wordpress.com/wp-login.php?no_calypso.
- Open the Help Center. 
- **Chrome window 2**: Go to the user's RC.
- Switch to user (make sure to do so in an A8C chrome instance).
- The HC should not open.
- Go to the editor of Atomic site https://dsfdsfdsfdsfsfds.wpcomstaging.com/wp-admin/post-new.php
- It shouldn't open.
- Go to the editor of Simple site: http://somesimpleusersimplesite.wordpress.com/wp-admin/post-new.php
- HC shouldn't open.
