### PR TITLE
Reader - fix 0 at bottom of loading following stream.

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -726,6 +726,7 @@ class ReaderStream extends Component {
 		);
 
 		const TopLevel = this.props.isMain ? ReaderMain : 'div';
+
 		return (
 			<TopLevel className={ baseClassnames }>
 				<div ref={ this.overlayRef } className="stream__init-overlay" />
@@ -735,7 +736,7 @@ class ReaderStream extends Component {
 				{ this.props.children }
 				{ showingStream && items.length ? this.props.intro?.() : null }
 				{ body }
-				{ showingStream && items.length && ! isRequesting && (
+				{ showingStream && !! items.length && ! isRequesting && (
 					<>
 						<ListEnd />
 						{ streamKey.startsWith( 'following' ) && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/99427

## Proposed Changes

* converts `items.length` in the rendering logic check to be a boolean value, so it doesn't drop a 0 in the page.

BEFORE
![Screenshot 2025-02-06 at 2 37 32 PM](https://github.com/user-attachments/assets/132f6e6b-74ee-4199-bc98-614eeb578e1e)

AFTER
![Screenshot 2025-02-06 at 2 33 23 PM](https://github.com/user-attachments/assets/1932a67f-9bd0-4259-99c5-7c671ef0c752)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It was dropping a 0 in the page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the /reader feed and verify there is no longer a 0 at the bottom.
* You can use devtools to throttle network speed if needed, or you can adjust the [forcePlaceholders value in the code](https://github.com/Automattic/wp-calypso/blob/a62ca2e49c39909e12a74a7db61c4b59ab2f9388/client/reader/stream/index.jsx#L626)
* Visit the bottom of your recent stream (or select an individual site under recent, but there must be some posts), and verify the footer still shows up after scrolling to the bottom of the feed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
