### PR TITLE
AddOns: new design for the storage add-ons card

### DIFF
--- a/client/my-sites/add-ons/components/add-ons-grid.tsx
+++ b/client/my-sites/add-ons/components/add-ons-grid.tsx
@@ -1,10 +1,14 @@
+import { PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import AddOnCard from './add-ons-card';
+import StorageAddOnCard from './storage-add-ons-card';
 import type { Props as CardProps } from './add-ons-card';
 import type { AddOnMeta } from '@automattic/data-stores';
+import type { SiteId } from 'calypso/types';
 
 interface Props extends Omit< CardProps, 'addOnMeta' > {
 	addOns: ( AddOnMeta | null )[];
+	siteId?: SiteId;
 }
 
 const Container = styled.div`
@@ -18,10 +22,17 @@ const Container = styled.div`
 	}
 `;
 
-const AddOnsGrid = ( { addOns, actionPrimary, actionSecondary, highlightFeatured }: Props ) => {
+const AddOnsGrid = ( {
+	addOns,
+	actionPrimary,
+	actionSecondary,
+	highlightFeatured,
+	siteId,
+}: Props ) => {
+	const nonStorageAddOns = addOns.filter( ( addOn ) => addOn?.productSlug !== PRODUCT_1GB_SPACE );
 	return (
 		<Container>
-			{ addOns.map( ( addOn ) =>
+			{ nonStorageAddOns.map( ( addOn ) =>
 				addOn ? (
 					<AddOnCard
 						key={
@@ -34,6 +45,7 @@ const AddOnsGrid = ( { addOns, actionPrimary, actionSecondary, highlightFeatured
 					/>
 				) : null
 			) }
+			{ siteId && <StorageAddOnCard siteId={ siteId } actionPrimary={ actionPrimary } /> }
 		</Container>
 	);
 };

--- a/client/my-sites/add-ons/components/storage-add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/storage-add-ons-card.tsx
@@ -1,0 +1,269 @@
+import { AddOns, Site, StorageAddOnSlug } from '@automattic/data-stores';
+import { useGetPurchasedStorageAddOn } from '@automattic/data-stores/src/add-ons';
+import { formatCurrency } from '@automattic/format-currency';
+import styled from '@emotion/styled';
+import {
+	Card,
+	CardHeader,
+	CardBody,
+	CardFooter,
+	CustomSelectControl,
+	Button,
+} from '@wordpress/components';
+import { Icon } from '@wordpress/icons';
+import filesize from 'filesize';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import { SiteId } from 'calypso/types';
+
+export interface Props {
+	siteId: SiteId;
+	actionPrimary?: {
+		text: string;
+		handler: ( productSlug: string, quantity?: number ) => void;
+	};
+}
+
+const Container = styled.div`
+	.storage-add-ons-card {
+		width: 100%;
+		height: 100%;
+		border-radius: 5px;
+
+		> div {
+			// @wordpress/components<Card> wraps content in a first inner div
+			height: 100%;
+			width: 100%;
+			display: flex;
+			flex-direction: column;
+			box-sizing: border-box;
+			padding: 8px 0;
+		}
+	}
+
+	.storage-add-ons-card__header {
+		display: flex;
+		justify-content: flex-start;
+		gap: 0.8em;
+
+		.storage-add-ons-card__icon {
+			display: flex;
+		}
+
+		.storage-add-ons-card__name-tag {
+			display: flex;
+			align-items: center;
+			gap: 10px;
+
+			.storage-add-ons-card__name {
+				font-size: 1rem;
+				font-weight: 500;
+			}
+		}
+
+		.storage-add-ons-card__storage-used {
+			margin-inline-start: auto;
+			border-radius: 4px;
+			font-size: small;
+			background-color: var( --studio-gray-0 );
+			padding: 8px 12px;
+			font-weight: 600;
+		}
+	}
+
+	.storage-add-ons-card__body {
+		font-size: 0.875rem;
+		padding-top: 0;
+		padding-bottom: 0;
+
+		.storage-add-ons-card__storage-dropdown {
+			margin: 16px 0;
+
+			.storage-add-ons-card__storage-dropdown-option {
+				.storage-add-ons-card__storage-dropdown-option-storage {
+					font-weight: 600;
+				}
+
+				.storage-add-ons-card__storage-dropdown-option-price {
+					margin-inline-start: 4px;
+					color: #757575;
+				}
+			}
+		}
+	}
+
+	.storage-add-ons-card__footer {
+		display: flex;
+		margin-top: auto;
+
+		.storage-add-ons-card__action-button {
+			font-weight: 600;
+			text-decoration: none;
+			padding: 0;
+		}
+	}
+`;
+
+const StorageDropdownOption = ( {
+	price,
+	totalStorage,
+}: {
+	price: string | null;
+	totalStorage: number;
+} ) => {
+	const translate = useTranslate();
+
+	return (
+		<>
+			{ price ? (
+				<div className="storage-add-ons-card__storage-dropdown-option">
+					<span className="storage-add-ons-card__storage-dropdown-option-storage">
+						{ translate( '+ %(totalStorage)dGB', { args: { totalStorage } } ) }
+					</span>
+					<span className="storage-add-ons-card__storage-dropdown-option-price">
+						{ translate( '%(price)s/month, billed yearly', {
+							args: { price },
+							comment: 'The cost of a storage add on per month. Example reads as "$50/month"',
+						} ) }
+					</span>
+				</div>
+			) : null }
+		</>
+	);
+};
+
+export default function StorageAddOnCard( { siteId, actionPrimary }: Props ) {
+	const translate = useTranslate();
+	const { data: mediaStorage, isPending: isLoading } = Site.useSiteMediaStorage( {
+		siteIdOrSlug: siteId,
+	} );
+
+	const used = filesize( mediaStorage?.storageUsedBytes || 0, { round: 0 } );
+	const max = filesize( mediaStorage?.maxStorageBytes || 0, { round: 0 } );
+
+	const purchasedStorageAddOn = useGetPurchasedStorageAddOn( { siteId } );
+	const purchasedStorageAddOnQuantity = purchasedStorageAddOn?.quantity ?? 0;
+	const purchasedStorageAddOnYearlyPrice = purchasedStorageAddOn?.prices?.yearlyPrice ?? 0;
+
+	const storageAddOns = AddOns.useStorageAddOns( { siteId } );
+	const availableStorageAddOns = AddOns.useAvailableStorageAddOns( { siteId } );
+
+	const [ selectedStorageAddOnSlug, setSelectedStorageAddOnSlug ] =
+		useState< StorageAddOnSlug | null >( null );
+	const selectedStorageAddOn = storageAddOns?.find(
+		( addOn ) => addOn?.addOnSlug === selectedStorageAddOnSlug
+	);
+	const selectedStorageAddOnStorageQuantity = selectedStorageAddOn?.quantity ?? 0;
+
+	useEffect( () => {
+		if ( availableStorageAddOns.length ) {
+			setSelectedStorageAddOnSlug( availableStorageAddOns[ 0 ].addOnSlug as StorageAddOnSlug );
+		}
+	}, [ availableStorageAddOns ] );
+
+	const selectControlOptions = availableStorageAddOns?.map( ( addOn ) => {
+		const addOnStorage = addOn.quantity ?? 0;
+
+		const price =
+			addOn?.prices?.yearlyPrice && addOn?.prices?.currencyCode
+				? formatCurrency(
+						( ( addOn.prices.yearlyPrice || 0 ) - purchasedStorageAddOnYearlyPrice ) / 12,
+						addOn.prices.currencyCode,
+						{ isSmallestUnit: true }
+				  )
+				: null;
+
+		return {
+			key: addOn.addOnSlug,
+			name: (
+				<StorageDropdownOption
+					price={ price }
+					totalStorage={ addOnStorage - purchasedStorageAddOnQuantity }
+				/>
+			 ) as unknown as string,
+		};
+	} );
+
+	const selectedOptionPrice =
+		selectedStorageAddOn?.prices?.yearlyPrice && selectedStorageAddOn?.prices?.currencyCode
+			? formatCurrency(
+					( ( selectedStorageAddOn.prices.yearlyPrice || 0 ) - purchasedStorageAddOnYearlyPrice ) /
+						12,
+					selectedStorageAddOn.prices.currencyCode,
+					{ isSmallestUnit: true }
+			  )
+			: null;
+	const selectedOption = {
+		key: selectedStorageAddOnSlug,
+		name: (
+			<StorageDropdownOption
+				price={ selectedOptionPrice }
+				totalStorage={ selectedStorageAddOnStorageQuantity - purchasedStorageAddOnQuantity }
+			/>
+		 ) as unknown as string,
+	};
+
+	function handleOnChange( { selectedItem }: { selectedItem: { key: string } } ) {
+		const addOnSlug = selectedItem?.key as AddOns.StorageAddOnSlug;
+
+		if ( addOnSlug ) {
+			setSelectedStorageAddOnSlug( addOnSlug );
+		}
+	}
+
+	const onActionPrimary = () => {
+		actionPrimary?.handler(
+			availableStorageAddOns[ 0 ].productSlug,
+			selectedStorageAddOnStorageQuantity
+		);
+	};
+
+	return (
+		<Container>
+			<Card className="storage-add-ons-card">
+				<CardHeader isBorderless className="storage-add-ons-card__header">
+					<div className="storage-add-ons-card__icon">
+						{ storageAddOns?.[ 0 ]?.icon && <Icon icon={ storageAddOns[ 0 ].icon } size={ 44 } /> }
+					</div>
+					<div className="storage-add-ons-card__name-tag">
+						<div className="storage-add-ons-card__name">{ translate( 'Storage' ) }</div>
+					</div>
+					<div className="storage-add-ons-card__storage-used">
+						{ isLoading
+							? null
+							: translate( 'Using %(usedStorage)s of %(maxStorage)s', {
+									args: {
+										usedStorage: used,
+										maxStorage: max,
+									},
+									comment:
+										'Describes used vs available storage amounts (e.g., Using 20 GB of 30GB, Using 12 MB of 20GB)',
+							  } ) }
+					</div>
+				</CardHeader>
+				<CardBody className="storage-add-ons-card__body">
+					{ translate( 'Make more space for high-quality photos, videos, and other media.' ) }
+					{ selectControlOptions.length ? (
+						<div className="storage-add-ons-card__storage-dropdown">
+							<CustomSelectControl
+								__next40pxDefaultSize
+								hideLabelFromVision
+								options={ selectControlOptions || [] }
+								value={ selectedOption }
+								onChange={ handleOnChange }
+								label=""
+							/>
+						</div>
+					) : null }
+				</CardBody>
+				<CardFooter isBorderless className="storage-add-ons-card__footer">
+					{ Boolean( selectControlOptions.length ) && actionPrimary && (
+						<Button onClick={ onActionPrimary } variant="primary">
+							{ actionPrimary.text }
+						</Button>
+					) }
+				</CardFooter>
+			</Card>
+		</Container>
+	);
+}

--- a/client/my-sites/add-ons/main.tsx
+++ b/client/my-sites/add-ons/main.tsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { AddOns, Purchases } from '@automattic/data-stores';
+import { AddOns } from '@automattic/data-stores';
 import { css, Global } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -8,7 +8,6 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import Notice from 'calypso/components/notice';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
@@ -19,9 +18,14 @@ import type { ReactElement } from 'react';
 
 const globalOverrides = css`
 	.is-section-add-ons {
+		height: 100%;
 		#content.layout__content {
 			background: #fdfdfd;
+			height: 100%;
 		}
+	}
+	.layout__primary {
+		height: 100%;
 	}
 `;
 
@@ -32,6 +36,7 @@ const globalOverrides = css`
 const mobileBreakpoint = 660;
 
 const ContainerMain = styled.div`
+	height: 100%;
 	.add-ons__main {
 		.add-ons__formatted-header {
 			text-align: center;
@@ -57,40 +62,6 @@ const ContainerMain = styled.div`
 	}
 `;
 
-export const StorageAddonsNotice = () => {
-	const translate = useTranslate();
-	const selectedSite = useSelector( getSelectedSite ) ?? null;
-	const availableStorageAddOns = AddOns.useAvailableStorageAddOns( { siteId: selectedSite?.ID } );
-	const storageAddOnPurchases = Purchases.useSitePurchasesByProductSlug( {
-		siteId: selectedSite?.ID,
-		productSlug: availableStorageAddOns?.[ 0 ]?.productSlug,
-	} );
-
-	// No storage add-ons available for purchase, so no need to show the notice
-	if ( ! availableStorageAddOns.length ) {
-		return null;
-	}
-
-	// No storage add-ons purchased, so no need to show the notice
-	if ( ! storageAddOnPurchases || ! Object.values( storageAddOnPurchases ).length ) {
-		return null;
-	}
-
-	return (
-		<Notice showDismiss={ false }>
-			{ translate(
-				'Purchasing a storage add-on will replace your current %(currentExtraStorage)sGB extra storage (not add to it).',
-				{
-					args: {
-						currentExtraStorage:
-							Object.values( storageAddOnPurchases )[ 0 ].purchaseRenewalQuantity || '0',
-					},
-				}
-			) }
-		</Notice>
-	);
-};
-
 const ContentWithHeader = ( props: { children: ReactElement } ) => {
 	const translate = useTranslate();
 
@@ -104,7 +75,6 @@ const ContentWithHeader = ( props: { children: ReactElement } ) => {
 						'Expand the functionality of your WordPress.com site by enabling any of the following features.'
 					) }
 				/>
-				<StorageAddonsNotice />
 				<div className="add-ons__main-content">{ props.children }</div>
 			</Main>
 		</ContainerMain>
@@ -158,7 +128,7 @@ const AddOnsMain = () => {
 	};
 
 	return (
-		<div>
+		<>
 			<Global styles={ globalOverrides } />
 			<QuerySitePurchases siteId={ selectedSite?.ID } />
 			<PageViewTracker path="/add-ons/:site" title="Add-Ons" />
@@ -167,10 +137,11 @@ const AddOnsMain = () => {
 					actionPrimary={ { text: translate( 'Buy add-on' ), handler: handleActionPrimary } }
 					actionSecondary={ { text: translate( 'Manage add-on' ), handler: handleActionSelected } }
 					addOns={ addOns }
+					siteId={ selectedSite?.ID }
 					highlightFeatured
 				/>
 			</ContentWithHeader>
-		</div>
+		</>
 	);
 };
 

--- a/packages/data-stores/src/add-ons/add-ons-list.ts
+++ b/packages/data-stores/src/add-ons/add-ons-list.ts
@@ -22,85 +22,85 @@ import spaceUpgradeIcon from './icons/space-upgrade';
 import unlimitedThemesIcon from './icons/unlimited-themes';
 import type { AddOnMeta, AddOnSlug } from './types';
 
-export const getAddOnsList = (): AddOnMeta[] => {
-	const defaultAddOns: AddOnMeta[] = [
-		{
-			addOnSlug: ADD_ON_UNLIMITED_THEMES,
-			productSlug: PRODUCT_WPCOM_UNLIMITED_THEMES,
-			featureSlugs: [ WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED ] as string[],
-			icon: unlimitedThemesIcon,
-			featured: true,
-		},
-		{
-			addOnSlug: ADD_ON_CUSTOM_DESIGN,
-			productSlug: PRODUCT_WPCOM_CUSTOM_DESIGN,
-			featureSlugs: [ WPCOM_FEATURES_CUSTOM_DESIGN ] as string[],
-			icon: customDesignIcon,
-		},
-		{
-			addOnSlug: ADD_ON_50GB_STORAGE,
-			productSlug: PRODUCT_1GB_SPACE,
-			featureSlugs: null,
-			icon: spaceUpgradeIcon,
-			quantity: 50,
-			name: i18n.translate( '50 GB Storage' ),
-			description: i18n.translate(
-				'Make more space for high-quality photos, videos, and other media. '
-			),
-		},
-		{
-			addOnSlug: ADD_ON_100GB_STORAGE,
-			productSlug: PRODUCT_1GB_SPACE,
-			featureSlugs: null,
-			icon: spaceUpgradeIcon,
-			quantity: 100,
-			name: i18n.translate( '100 GB Storage' ),
-			description: i18n.translate(
-				'Take your site to the next level. Store all your media in one place without worrying about running out of space.'
-			),
-		},
-		{
-			addOnSlug: ADD_ON_150GB_STORAGE,
-			productSlug: PRODUCT_1GB_SPACE,
-			featureSlugs: null,
-			icon: spaceUpgradeIcon,
-			quantity: 150,
-			name: i18n.translate( '%d GB Storage', { args: [ 150 ] } ),
-		},
-		{
-			addOnSlug: ADD_ON_200GB_STORAGE,
-			productSlug: PRODUCT_1GB_SPACE,
-			featureSlugs: null,
-			icon: spaceUpgradeIcon,
-			quantity: 200,
-			name: i18n.translate( '%d GB Storage', { args: [ 200 ] } ),
-		},
-		{
-			addOnSlug: ADD_ON_250GB_STORAGE,
-			productSlug: PRODUCT_1GB_SPACE,
-			featureSlugs: null,
-			icon: spaceUpgradeIcon,
-			quantity: 250,
-			name: i18n.translate( '%d GB Storage', { args: [ 250 ] } ),
-		},
-		{
-			addOnSlug: ADD_ON_300GB_STORAGE,
-			productSlug: PRODUCT_1GB_SPACE,
-			featureSlugs: null,
-			icon: spaceUpgradeIcon,
-			quantity: 300,
-			name: i18n.translate( '%d GB Storage', { args: [ 300 ] } ),
-		},
-		{
-			addOnSlug: ADD_ON_350GB_STORAGE,
-			productSlug: PRODUCT_1GB_SPACE,
-			featureSlugs: null,
-			icon: spaceUpgradeIcon,
-			quantity: 350,
-			name: i18n.translate( '%d GB Storage', { args: [ 350 ] } ),
-		},
-	];
+const defaultAddOns: AddOnMeta[] = [
+	{
+		addOnSlug: ADD_ON_UNLIMITED_THEMES,
+		productSlug: PRODUCT_WPCOM_UNLIMITED_THEMES,
+		featureSlugs: [ WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED ] as string[],
+		icon: unlimitedThemesIcon,
+		featured: true,
+	},
+	{
+		addOnSlug: ADD_ON_CUSTOM_DESIGN,
+		productSlug: PRODUCT_WPCOM_CUSTOM_DESIGN,
+		featureSlugs: [ WPCOM_FEATURES_CUSTOM_DESIGN ] as string[],
+		icon: customDesignIcon,
+	},
+	{
+		addOnSlug: ADD_ON_50GB_STORAGE,
+		productSlug: PRODUCT_1GB_SPACE,
+		featureSlugs: null,
+		icon: spaceUpgradeIcon,
+		quantity: 50,
+		name: i18n.translate( '50 GB Storage' ),
+		description: i18n.translate(
+			'Make more space for high-quality photos, videos, and other media. '
+		),
+	},
+	{
+		addOnSlug: ADD_ON_100GB_STORAGE,
+		productSlug: PRODUCT_1GB_SPACE,
+		featureSlugs: null,
+		icon: spaceUpgradeIcon,
+		quantity: 100,
+		name: i18n.translate( '100 GB Storage' ),
+		description: i18n.translate(
+			'Take your site to the next level. Store all your media in one place without worrying about running out of space.'
+		),
+	},
+	{
+		addOnSlug: ADD_ON_150GB_STORAGE,
+		productSlug: PRODUCT_1GB_SPACE,
+		featureSlugs: null,
+		icon: spaceUpgradeIcon,
+		quantity: 150,
+		name: i18n.translate( '%d GB Storage', { args: [ 150 ] } ),
+	},
+	{
+		addOnSlug: ADD_ON_200GB_STORAGE,
+		productSlug: PRODUCT_1GB_SPACE,
+		featureSlugs: null,
+		icon: spaceUpgradeIcon,
+		quantity: 200,
+		name: i18n.translate( '%d GB Storage', { args: [ 200 ] } ),
+	},
+	{
+		addOnSlug: ADD_ON_250GB_STORAGE,
+		productSlug: PRODUCT_1GB_SPACE,
+		featureSlugs: null,
+		icon: spaceUpgradeIcon,
+		quantity: 250,
+		name: i18n.translate( '%d GB Storage', { args: [ 250 ] } ),
+	},
+	{
+		addOnSlug: ADD_ON_300GB_STORAGE,
+		productSlug: PRODUCT_1GB_SPACE,
+		featureSlugs: null,
+		icon: spaceUpgradeIcon,
+		quantity: 300,
+		name: i18n.translate( '%d GB Storage', { args: [ 300 ] } ),
+	},
+	{
+		addOnSlug: ADD_ON_350GB_STORAGE,
+		productSlug: PRODUCT_1GB_SPACE,
+		featureSlugs: null,
+		icon: spaceUpgradeIcon,
+		quantity: 350,
+		name: i18n.translate( '%d GB Storage', { args: [ 350 ] } ),
+	},
+];
 
+export const getAddOnsList = (): AddOnMeta[] => {
 	return defaultAddOns;
 };
 

--- a/packages/data-stores/src/add-ons/hooks/use-available-storage-add-ons.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-available-storage-add-ons.ts
@@ -42,7 +42,7 @@ const useAvailableStorageAddOns = ( { siteId }: Props ): AddOnMeta[] => {
 		return nonNullAddOns.filter( ( addOn ) =>
 			isStorageQuantityAvailable( addOn?.quantity ?? 0, siteMediaStorageData )
 		);
-	}, [ siteMediaStorage, storageAddOns ] );
+	}, [ siteMediaStorage.data, storageAddOns ] );
 };
 
 export default useAvailableStorageAddOns;

--- a/packages/data-stores/src/add-ons/hooks/use-get-purchased-storage-add-on.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-get-purchased-storage-add-on.ts
@@ -1,0 +1,24 @@
+import { PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
+import * as Purchases from '../../purchases';
+import useStorageAddOns from './use-storage-add-ons';
+import type { AddOnMeta } from '../..';
+
+export default function useGetPurchasedStorageAddOn( {
+	siteId,
+}: {
+	siteId?: number | null;
+} ): AddOnMeta | null {
+	const storageAddOns = useStorageAddOns( { siteId } );
+	const matchingPurchases = Purchases.useSitePurchasesByProductSlug( {
+		siteId,
+		productSlug: PRODUCT_1GB_SPACE,
+	} );
+
+	if ( ! matchingPurchases ) {
+		return null;
+	}
+
+	const purchase: Purchases.Purchase = Object.values( matchingPurchases )[ 0 ];
+	const storageAddOnQuantity = purchase.purchaseRenewalQuantity;
+	return storageAddOns.find( ( addOn ) => addOn?.quantity === storageAddOnQuantity ) ?? null;
+}

--- a/packages/data-stores/src/add-ons/index.ts
+++ b/packages/data-stores/src/add-ons/index.ts
@@ -8,6 +8,7 @@ export {
 	default as useStorageAddOnAvailability,
 	StorageAddOnAvailability,
 } from './hooks/use-storage-add-on-availability';
+export { default as useGetPurchasedStorageAddOn } from './hooks/use-get-purchased-storage-add-on';
 export * from './constants';
 
 /** Types */

--- a/packages/data-stores/src/add-ons/mocks.ts
+++ b/packages/data-stores/src/add-ons/mocks.ts
@@ -17,6 +17,7 @@ const STORAGE_ADD_ONS_MOCK: AddOnMeta[] = [
 			yearlyPrice: 120,
 			formattedMonthlyPrice: 'USD10',
 			formattedYearlyPrice: 'USD120',
+			currencyCode: 'USD',
 		},
 		description: 'Make more space for high-quality photos, videos, and other media. ',
 		featured: false,

--- a/packages/data-stores/src/add-ons/types.ts
+++ b/packages/data-stores/src/add-ons/types.ts
@@ -18,6 +18,7 @@ export interface AddOnMeta {
 		yearlyPrice: number;
 		formattedMonthlyPrice: string;
 		formattedYearlyPrice: string;
+		currencyCode: string;
 	} | null;
 	quantity?: number; // used for determining checkout costs for quantity based products
 	checkoutLink?: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/3677
Fixes https://github.com/Automattic/wp-calypso/issues/95416

## Proposed Changes

* Updates the design for the storage add-on on the AddOns page. All storage add-on cards are replaced with a single storage card with a dropdown to allow users to select the desired storage. The dropdown values represent additional storage to be added.
* Also fixes the issue described in https://github.com/Automattic/wp-calypso/issues/95416, by memoizing some arrays. More details are in the code comments.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* p58i-jlJ-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/add-ons/<site slug>`.
* Confirm that a single storage add-ons card is present and it matches the design (3De4YM0tRV3Qs691ui6QAW-fi-7996_5289)
<img width="533" alt="image" src="https://github.com/user-attachments/assets/af5e561b-9036-4966-9fea-58dd13291330" />

* Opening the dropdown should show add-on values up to a maximum of 350GB.
<img width="563" alt="image" src="https://github.com/user-attachments/assets/93b9b7e4-bea0-4eee-bdb3-1eabb97ef0ef" />

* Select any add-on from the list. **Note the price mentioned - this should be the same as the price shown on the checkout** page. (Monthly price * 12). Click on the "Buy add-on" button.
* In the following examples, the 200GB add-on has been purchased.
* Go back to `/add-ons/<site slug>`.
* Confirm that the space used is `203GB`. (200GB + 53GB platform default) (The site is on a Business plan)
* Confirm that the dropdown values only contain add-ons till 150GB. (Since the maximum storage possible is 400GB).
* <img width="769" alt="image" src="https://github.com/user-attachments/assets/1b50c496-40b0-49b0-aa18-80752ef150c3" />

* The dropdown and CTA should not be shown if the maximum storage has been purchased.
<img width="568" alt="image" src="https://github.com/user-attachments/assets/c9f823d3-1912-4e7b-ab9d-888fbd4ea47a" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?