### PR TITLE
Domains: Replace `isGravatarDomain` checks by `isGravatarRestrictedDomain` checks where applicable

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/lib/fixtures.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/lib/fixtures.ts
@@ -252,6 +252,7 @@ export const defaultDomainResponse: ResponseDomain = {
 	isDnssecSupported: false,
 	isEligibleForInboundTransfer: false,
 	isGravatarDomain: false,
+	isGravatarRestrictedDomain: false,
 	isHundredYearDomain: false,
 	isIcannVerificationSuspended: false,
 	isLocked: false,

--- a/client/lib/domains/types.ts
+++ b/client/lib/domains/types.ts
@@ -100,6 +100,7 @@ export type ResponseDomain = {
 	isEligibleForInboundTransfer: boolean;
 	isIcannVerificationSuspended: boolean | null;
 	isGravatarDomain: boolean;
+	isGravatarRestrictedDomain: boolean;
 	isHundredYearDomain: boolean;
 	isLocked: boolean;
 	isMappedToAtomicSite: boolean;

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -13,7 +13,11 @@ import {
 } from 'calypso/lib/purchases';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 
-const CancelPurchaseRefundInformation = ( { purchase, isGravatarDomain, isJetpackPurchase } ) => {
+const CancelPurchaseRefundInformation = ( {
+	purchase,
+	isGravatarRestrictedDomain,
+	isJetpackPurchase,
+} ) => {
 	const { refundPeriodInDays } = purchase;
 	let text;
 
@@ -93,7 +97,7 @@ const CancelPurchaseRefundInformation = ( { purchase, isGravatarDomain, isJetpac
 			),
 		];
 
-		if ( isGravatarDomain ) {
+		if ( isGravatarRestrictedDomain ) {
 			text.push(
 				i18n.translate(
 					'This domain is provided at no cost for the first year for use with your Gravatar profile. This offer is limited to one free domain per user. If you cancel this domain, you will have to pay the standard price to register another domain for your Gravatar profile.'
@@ -145,6 +149,6 @@ export default connect( ( state, props ) => {
 	const selectedDomain = getSelectedDomain( { domains, selectedDomainName } );
 
 	return {
-		isGravatarDomain: selectedDomain?.isGravatarDomain,
+		isGravatarRestrictedDomain: selectedDomain?.isGravatarRestrictedDomain,
 	};
 } )( CancelPurchaseRefundInformation );

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -30,7 +30,7 @@ class RemoveDomainDialog extends Component {
 	};
 
 	renderDomainDeletionWarning( productName ) {
-		const { translate, slug, currentRoute, isGravatarDomain } = this.props;
+		const { translate, slug, currentRoute, isGravatarRestrictedDomain } = this.props;
 
 		return (
 			<Fragment>
@@ -39,7 +39,7 @@ class RemoveDomainDialog extends Component {
 						'Deleting a domain will make all services connected to it unreachable, including your email and website. It will also make the domain available for someone else to register.'
 					) }
 				</p>
-				{ isGravatarDomain && (
+				{ isGravatarRestrictedDomain && (
 					<p>
 						{ translate(
 							'This domain is provided at no cost for the first year for use with your Gravatar profile. This offer is limited to one free domain per user. If you cancel this domain, you will have to pay the standard price to register another domain for your Gravatar profile.'
@@ -239,7 +239,7 @@ export default connect( ( state, ownProps ) => {
 	const selectedDomainName = getName( ownProps.purchase );
 	const selectedDomain = getSelectedDomain( { domains, selectedDomainName } );
 	return {
-		isGravatarDomain: selectedDomain?.isGravatarDomain,
+		isGravatarRestrictedDomain: selectedDomain?.isGravatarRestrictedDomain,
 		hasTitanWithUs: hasTitanMailWithUs( selectedDomain ),
 		currentRoute: getCurrentRoute( state ),
 		userEmail: getCurrentUserEmail( state ),

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -186,7 +186,7 @@ const Settings = ( {
 		if (
 			! ( domain && selectedSite?.options?.is_domain_only ) ||
 			domain?.type === domainTypes.TRANSFER ||
-			domain?.isGravatarDomain
+			domain?.isGravatarRestrictedDomain
 		) {
 			return null;
 		}
@@ -324,7 +324,7 @@ const Settings = ( {
 	};
 
 	const renderNameServersSection = () => {
-		if ( ! domain || domain.type !== domainTypes.REGISTERED || domain.isGravatarDomain ) {
+		if ( ! domain || domain.type !== domainTypes.REGISTERED || domain.isGravatarRestrictedDomain ) {
 			return null;
 		}
 
@@ -772,7 +772,7 @@ const Settings = ( {
 		}
 		return (
 			<>
-				{ ! domain.isGravatarDomain && (
+				{ ! domain.isGravatarRestrictedDomain && (
 					<DomainEmailInfoCard selectedSite={ selectedSite } domain={ domain } />
 				) }
 				{ ! domain.isHundredYearDomain && (

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -374,7 +374,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 						? __( 'Transfer to another registrar' )
 						: __( 'Advanced Options' ) }
 				</CardHeading>
-				{ domain?.isGravatarDomain && (
+				{ domain?.isGravatarRestrictedDomain && (
 					<InfoNotice
 						redesigned
 						text={ __(

--- a/client/my-sites/email/email-forwards-add/index.tsx
+++ b/client/my-sites/email/email-forwards-add/index.tsx
@@ -57,7 +57,8 @@ const EmailForwardsAdd = ( {
 	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
 	const selectedDomain = getSelectedDomain( { domains, selectedDomainName } );
 	const cannotAddEmailWarningReason = getCurrentUserCannotAddEmailReason( selectedDomain );
-	const isGravatarDomain = cannotAddEmailWarningReason?.code === EMAIL_WARNING_CODE_GRAVATAR_DOMAIN;
+	const isGravatarRestrictedDomain =
+		cannotAddEmailWarningReason?.code === EMAIL_WARNING_CODE_GRAVATAR_DOMAIN;
 
 	const goToEmail = useCallback( (): void => {
 		if ( ! selectedSite ) {
@@ -80,7 +81,7 @@ const EmailForwardsAdd = ( {
 		page( getEmailManagementPath( selectedSite.slug, selectedDomainName, currentRoute ) );
 	}, [ currentRoute, selectedDomainName, selectedSite ] );
 
-	const content = isGravatarDomain ? (
+	const content = isGravatarRestrictedDomain ? (
 		<Notice showDismiss={ false } className="email-forwards-add__notice">
 			{ translate(
 				'This domain is associated with a Gravatar profile and cannot be used for email services at this time.'

--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -99,7 +99,8 @@ const EmailProvidersStackedComparison = ( {
 	const currentUserCanAddEmail = canCurrentUserAddEmail( domain );
 	const showNonOwnerMessage = ! currentUserCanAddEmail && ! isDomainInCart;
 	const cannotAddEmailWarningReason = getCurrentUserCannotAddEmailReason( domain );
-	const isGravatarDomain = cannotAddEmailWarningReason?.code === EMAIL_WARNING_CODE_GRAVATAR_DOMAIN;
+	const isGravatarRestrictedDomain =
+		cannotAddEmailWarningReason?.code === EMAIL_WARNING_CODE_GRAVATAR_DOMAIN;
 
 	const isGSuiteSupported =
 		domain && canPurchaseGSuite && ( isDomainInCart || hasGSuiteSupportedDomain( [ domain ] ) );
@@ -295,14 +296,14 @@ const EmailProvidersStackedComparison = ( {
 			{ ! isDomainInCart && domain && <EmailExistingPaidServiceNotice domain={ domain } /> }
 
 			<>
-				{ showNonOwnerMessage && ! isGravatarDomain && (
+				{ showNonOwnerMessage && ! isGravatarRestrictedDomain && (
 					<EmailNonDomainOwnerMessage
 						domain={ domain }
 						selectedSite={ selectedSite }
 						source="email-comparison"
 					/>
 				) }
-				{ isGravatarDomain && (
+				{ isGravatarRestrictedDomain && (
 					<Notice showDismiss={ false } className="email-providers-stacked-comparison__notice">
 						{ translate(
 							'This domain is associated with a Gravatar profile and cannot be used for email services at this time.'

--- a/client/state/sites/domains/schema.js
+++ b/client/state/sites/domains/schema.js
@@ -33,6 +33,7 @@ export const itemsSchema = {
 					isDnssecEnabled: { type: 'boolean' },
 					isDnssecSupported: { type: 'boolean' },
 					isGravatarDomain: { type: 'boolean' },
+					isGravatarRestrictedDomain: { type: 'boolean' },
 					isHundredYearDomain: { type: 'boolean' },
 					isPendingIcannVerification: { type: 'boolean' },
 					isPendingRenewal: { type: 'boolean' },

--- a/packages/domains-table/src/utils/types.ts
+++ b/packages/domains-table/src/utils/types.ts
@@ -99,6 +99,7 @@ export type ResponseDomain = {
 	isDnssecEnabled: boolean;
 	isDnssecSupported: boolean;
 	isGravatarDomain: boolean;
+	isGravatarRestrictedDomain: boolean;
 	isHundredYearDomain: boolean;
 	isIcannVerificationSuspended: boolean | null;
 	isLocked: boolean;

--- a/packages/launchpad/src/test/lib/fixtures.ts
+++ b/packages/launchpad/src/test/lib/fixtures.ts
@@ -252,6 +252,7 @@ export const defaultDomainResponse: any = {
 	isDnssecSupported: false,
 	isEligibleForInboundTransfer: false,
 	isGravatarDomain: false,
+	isGravatarRestrictedDomain: false,
 	isHundredsYearDomain: false,
 	isIcannVerificationSuspended: false,
 	isLocked: false,


### PR DESCRIPTION
Related to https://github.com/Automattic/nomado-issues/issues/1241

## Proposed Changes

This PR replaces some `isGravatarDomain` checks by `isGravatarRestrictedDomain` checks. 

This is the Calypso counterpart to this WPCOM PR: 172579-ghe-Automattic/wpcom.

## Why are these changes being made?

The newly introducted `usage_gravatar_restricted` domain flag is being used to check for Gravatar domains that were registered for free. The current `usage_gravatar` flag will now only be used to determine which domains were registered via Gravatar, and not to limit domain features.

This is part of the Gravatar Domains i3 project (pcYYhz-2vx-p2).

## Testing Instructions

No functionality should have changed with this PR, so you can manually test by going to the domain management page for a domain that has the `usage_gravatar_restricted` flag and ensuring these features are not accessible:
- DNS management
- Change name servers
- Transfer to other user/site
- Purchasing Professional email
- Email forwarding

You can also test with a domain that has the `usage_gravatar` flag but not the `usage_gravatar_restricted` and ensuring all these features are enabled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?