### PR TITLE
Remove Is Reskinned Flag: Completely cleanup domains of the isReskinned flag

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -115,16 +115,12 @@ export class DomainProductPrice extends Component {
 
 		return (
 			<div className={ className }>
+				{ this.props.isMappingProduct
+					? null
+					: this.props.translate( '%(cost)s/year', {
+							args: { cost: this.props.price },
+					  } ) }
 				<div className="domain-product-price__free-text">{ message }</div>
-				<div className="domain-product-price__price">
-					<del>
-						{ this.props.isMappingProduct
-							? null
-							: this.props.translate( '%(cost)s/year', {
-									args: { cost: this.props.price },
-							  } ) }
-					</del>
-				</div>
 			</div>
 		);
 	}

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -115,12 +115,12 @@ export class DomainProductPrice extends Component {
 
 		return (
 			<div className={ className }>
+				<div className="domain-product-price__free-text">{ message }</div>
 				{ this.props.isMappingProduct
 					? null
 					: this.props.translate( '%(cost)s/year', {
 							args: { cost: this.props.price },
 					  } ) }
-				<div className="domain-product-price__free-text">{ message }</div>
 			</div>
 		);
 	}

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -116,11 +116,15 @@ export class DomainProductPrice extends Component {
 		return (
 			<div className={ className }>
 				<div className="domain-product-price__free-text">{ message }</div>
-				{ this.props.isMappingProduct
-					? null
-					: this.props.translate( '%(cost)s/year', {
-							args: { cost: this.props.price },
-					  } ) }
+				<div className="domain-product-price__price">
+					<del>
+						{ this.props.isMappingProduct
+							? null
+							: this.props.translate( '%(cost)s/year', {
+									args: { cost: this.props.price },
+							  } ) }
+					</del>
+				</div>
 			</div>
 		);
 	}

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -68,7 +68,7 @@ class DomainRegistrationSuggestion extends Component {
 		productCost: PropTypes.string,
 		renewCost: PropTypes.string,
 		productSaleCost: PropTypes.string,
-		isReskinned: PropTypes.bool,
+		hideMatchReasons: PropTypes.bool,
 		domainAndPlanUpsellFlow: PropTypes.bool,
 		products: PropTypes.object,
 	};
@@ -393,10 +393,6 @@ class DomainRegistrationSuggestion extends Component {
 	}
 
 	renderMatchReason() {
-		if ( this.props.isReskinned ) {
-			return null;
-		}
-
 		const {
 			suggestion: { domain_name: domain },
 			isFeatured,
@@ -430,7 +426,7 @@ class DomainRegistrationSuggestion extends Component {
 			productSaleCost,
 			premiumDomain,
 			showStrikedOutPrice,
-			isReskinned,
+			hideMatchReasons,
 		} = this.props;
 
 		const isUnavailableDomain = this.isUnavailableDomain( domain );
@@ -454,11 +450,11 @@ class DomainRegistrationSuggestion extends Component {
 				{ ...this.getButtonProps() }
 				isFeatured={ isFeatured }
 				showStrikedOutPrice={ showStrikedOutPrice }
-				isReskinned={ isReskinned }
+				hideMatchReasons={ hideMatchReasons }
 			>
 				{ this.renderBadges() }
 				{ this.renderDomain() }
-				{ this.renderMatchReason() }
+				{ ! hideMatchReasons && this.renderMatchReason() }
 			</DomainSuggestion>
 		);
 	}

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -395,11 +395,10 @@ class DomainRegistrationSuggestion extends Component {
 	renderMatchReason() {
 		const {
 			suggestion: { domain_name: domain },
-			isFeatured,
 		} = this.props;
 
-		if ( ! isFeatured || ! Array.isArray( this.props.suggestion.match_reasons ) ) {
-			return null;
+		if ( ! Array.isArray( this.props.suggestion.match_reasons ) ) {
+			return <div className="domain-registration-suggestion__match-reasons"></div>;
 		}
 
 		const matchReasons = parseMatchReasons( domain, this.props.suggestion.match_reasons );
@@ -454,7 +453,7 @@ class DomainRegistrationSuggestion extends Component {
 			>
 				{ this.renderBadges() }
 				{ this.renderDomain() }
-				{ ! hideMatchReasons && this.renderMatchReason() }
+				{ ! hideMatchReasons && isFeatured && this.renderMatchReason() }
 			</DomainSuggestion>
 		);
 	}

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -42,6 +42,7 @@ class DomainSearchResults extends Component {
 		mappingSuggestionLabel: PropTypes.string,
 		offerUnavailableOption: PropTypes.bool,
 		showAlreadyOwnADomain: PropTypes.bool,
+		showDomainTransferSuggestion: PropTypes.bool,
 		onClickResult: PropTypes.func.isRequired,
 		onAddMapping: PropTypes.func,
 		onAddTransfer: PropTypes.func,
@@ -367,7 +368,7 @@ class DomainSearchResults extends Component {
 			if (
 				this.props.offerUnavailableOption &&
 				this.props.siteDesignType !== DESIGN_TYPE_STORE &&
-				! this.props.isReskinned
+				this.props.showDomainTransferSuggestion
 			) {
 				unavailableOffer = (
 					<DomainTransferSuggestion

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -318,7 +318,7 @@ class DomainSearchResults extends Component {
 					selectedSite={ this.props.selectedSite }
 					pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 					unavailableDomains={ this.props.unavailableDomains }
-					isReskinned={ this.props.isReskinned }
+					hideMatchReasons={ this.props.hideMatchReasons }
 					domainAndPlanUpsellFlow={ this.props.domainAndPlanUpsellFlow }
 					products={ this.props.useProvidedProductsList ? this.props.products : undefined }
 					isCartPendingUpdateDomain={ this.props.isCartPendingUpdateDomain }
@@ -354,7 +354,7 @@ class DomainSearchResults extends Component {
 						premiumDomain={ this.props.premiumDomains[ suggestion.domain_name ] }
 						pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 						unavailableDomains={ this.props.unavailableDomains }
-						isReskinned={ this.props.isReskinned }
+						hideMatchReasons={ this.props.hideMatchReasons }
 						domainAndPlanUpsellFlow={ this.props.domainAndPlanUpsellFlow }
 						products={ this.props.useProvidedProductsList ? this.props.products : undefined }
 						isCartPendingUpdateDomain={ this.props.isCartPendingUpdateDomain }
@@ -390,13 +390,12 @@ class DomainSearchResults extends Component {
 
 		return (
 			<div className="domain-search-results__domain-suggestions">
-				{ ! this.props.isReskinned && this.props.children }
 				{ suggestionCount }
 				{ featuredSuggestionElement }
 				{ suggestionElements }
 				{ unavailableOffer }
 				{ this.props.showSkipButton && domainSkipSuggestion }
-				{ this.props.isReskinned && this.props.children }
+				{ this.props.children }
 			</div>
 		);
 	}

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -36,7 +36,6 @@ class DomainSuggestion extends Component {
 			salePrice,
 			isSignupStep,
 			showStrikedOutPrice,
-			isReskinned,
 		} = this.props;
 
 		if ( hidePrice ) {
@@ -55,13 +54,12 @@ class DomainSuggestion extends Component {
 				rule={ priceRule }
 				isSignupStep={ isSignupStep }
 				showStrikedOutPrice={ showStrikedOutPrice }
-				isReskinned={ isReskinned }
 			/>
 		);
 	}
 
 	render() {
-		const { children, extraClasses, isAdded, isFeatured, showStrikedOutPrice, isReskinned } =
+		const { children, extraClasses, isAdded, isFeatured, showStrikedOutPrice, hideMatchReasons } =
 			this.props;
 		const classes = clsx(
 			'domain-suggestion',
@@ -87,8 +85,8 @@ class DomainSuggestion extends Component {
 				<div className={ contentClassName }>
 					{ domainContent }
 					{ matchReason }
-					{ ( isReskinned || ! isFeatured ) && this.renderPrice() }
-					{ ! isReskinned && isFeatured && (
+					{ ( hideMatchReasons || ! isFeatured ) && this.renderPrice() }
+					{ ! hideMatchReasons && isFeatured && (
 						<div className="domain-suggestion__price-container">{ this.renderPrice() }</div>
 					) }
 					<div className="domain-suggestion__action-container">

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -122,7 +122,7 @@ export class FeaturedDomainSuggestions extends Component {
 						premiumDomain={ this.props.premiumDomains[ suggestion.domain_name ] }
 						fetchAlgo={ this.getFetchAlgorithm( suggestion ) }
 						buttonStyles={ { primary: true } }
-						isReskinned={ this.props.isReskinned }
+						hideMatchReasons={ this.props.hideMatchReasons }
 						products={ this.props.products ?? undefined }
 						isCartPendingUpdateDomain={ this.props.isCartPendingUpdateDomain }
 						{ ...childProps }

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -79,6 +79,7 @@
 		flex-grow: 1;
 		margin-top: 0;
 		flex-wrap: wrap;
+		min-height: 95px;
 		.domain-registration-suggestion__title-info {
 			width: 100%;
 		}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1694,7 +1694,7 @@ class RegisterDomainStep extends Component {
 				unavailableDomains={ this.state.unavailableDomains }
 				onSkip={ this.props.onSkip }
 				showSkipButton={ this.props.showSkipButton }
-				isReskinned={ this.props.isReskinned }
+				hideMatchReasons={ this.props.isReskinned }
 				domainAndPlanUpsellFlow={ this.props.domainAndPlanUpsellFlow }
 				useProvidedProductsList={ this.props.useProvidedProductsList }
 				isCartPendingUpdateDomain={ this.props.isCartPendingUpdateDomain }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -126,7 +126,10 @@ class RegisterDomainStep extends Component {
 		deemphasiseTlds: PropTypes.array,
 		recordFiltersSubmit: PropTypes.func.isRequired,
 		recordFiltersReset: PropTypes.func.isRequired,
-		isReskinned: PropTypes.bool,
+		/**
+		 * A flag signalling if the step is being used in the onboarding flow
+		 */
+		isOnboarding: PropTypes.bool,
 		showSkipButton: PropTypes.bool,
 		onSkip: PropTypes.func,
 		promoTlds: PropTypes.array,
@@ -537,7 +540,7 @@ class RegisterDomainStep extends Component {
 			! Array.isArray( this.state.searchResults ) &&
 			! this.state.loadingResults &&
 			! this.props.showExampleSuggestions;
-		const showFilters = ! isRenderingInitialSuggestions || this.props.isReskinned;
+		const showFilters = ! isRenderingInitialSuggestions || this.props.isOnboarding;
 
 		const showTldFilter =
 			( Array.isArray( this.state.availableTlds ) && this.state.availableTlds.length > 0 ) ||
@@ -622,7 +625,7 @@ class RegisterDomainStep extends Component {
 			onSearch: this.onSearch,
 			onSearchChange: this.onSearchChange,
 			ref: this.bindSearchCardReference,
-			isReskinned: this.props.isReskinned,
+			isOnboarding: this.props.isOnboarding,
 			childrenBeforeCloseButton:
 				this.props.isDomainAndPlanPackageFlow && this.renderSearchFilters(),
 		};
@@ -1524,10 +1527,10 @@ class RegisterDomainStep extends Component {
 	}
 
 	renderExampleSuggestions() {
-		const { isReskinned, domainsWithPlansOnly, offerUnavailableOption, products, path } =
+		const { isOnboarding, domainsWithPlansOnly, offerUnavailableOption, products, path } =
 			this.props;
 
-		if ( isReskinned ) {
+		if ( isOnboarding ) {
 			return this.renderBestNamesPrompt();
 		}
 
@@ -1694,7 +1697,8 @@ class RegisterDomainStep extends Component {
 				unavailableDomains={ this.state.unavailableDomains }
 				onSkip={ this.props.onSkip }
 				showSkipButton={ this.props.showSkipButton }
-				hideMatchReasons={ this.props.isReskinned }
+				hideMatchReasons={ this.props.isOnboarding }
+				showDomainTransferSuggestion={ this.props.isOnboarding }
 				domainAndPlanUpsellFlow={ this.props.domainAndPlanUpsellFlow }
 				useProvidedProductsList={ this.props.useProvidedProductsList }
 				isCartPendingUpdateDomain={ this.props.isCartPendingUpdateDomain }
@@ -1702,7 +1706,7 @@ class RegisterDomainStep extends Component {
 				temporaryCart={ this.props.temporaryCart }
 				domainRemovalQueue={ this.props.domainRemovalQueue }
 			>
-				{ ! this.props.isReskinned &&
+				{ ! this.props.isOnboarding &&
 					hasResults &&
 					isFreeDomainExplainerVisible &&
 					this.renderFreeDomainExplainer() }
@@ -1711,7 +1715,7 @@ class RegisterDomainStep extends Component {
 	}
 
 	renderSideContent() {
-		return this.props.isReskinned && ! this.state.loadingResults && this.props.reskinSideContent;
+		return this.props.isOnboarding && ! this.state.loadingResults && this.props.reskinSideContent;
 	}
 
 	getFetchAlgo() {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -251,7 +251,7 @@ export function DomainFormControl( {
 					includeWordPressDotCom={ includeWordPressDotCom ?? true }
 					initialState={ initialState }
 					isPlanSelectionAvailableInFlow={ isPlanSelectionAvailableLaterInFlow }
-					isReskinned
+					isOnboarding
 					reskinSideContent={ getSideContent() }
 					isSignupStep
 					key="domainForm"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -202,14 +202,6 @@ export function DomainFormControl( {
 		);
 	};
 
-	const isReskinnedSupportedFlow = () => {
-		if ( ! flow ) {
-			return false;
-		}
-
-		return isDomainUpsellFlow( flow ) || isSiteAssemblerFlow( flow );
-	};
-
 	const renderDomainForm = () => {
 		let initialState: DomainForm = {};
 		if ( domainForm ) {
@@ -289,7 +281,7 @@ export function DomainFormControl( {
 		content = renderDomainForm();
 	}
 
-	if ( isReskinnedSupportedFlow() && ! showUseYourDomain ) {
+	if ( ( isDomainUpsellFlow( flow ) || isSiteAssemblerFlow( flow ) ) && ! showUseYourDomain ) {
 		sideContent = getSideContent();
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
@@ -62,7 +62,6 @@ const RenderDomainsStepConnect = connect(
 			flowName: flow,
 			path: window.location.pathname,
 			positionInFlow: 1,
-			isReskinned: true,
 			stepSectionName,
 			signupDependencies: step,
 		};

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1080,7 +1080,7 @@ export class RenderDomainsStep extends Component {
 				forceHideFreeDomainExplainerAndStrikeoutUi={
 					this.props.forceHideFreeDomainExplainerAndStrikeoutUi
 				}
-				isReskinned={ this.props.isReskinned }
+				isOnboarding={ this.props.isReskinned }
 				reskinSideContent={ this.getSideContent() }
 				isInLaunchFlow={ 'launch-site' === this.props.flowName }
 				promptText={

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -44,7 +44,6 @@ import {
 } from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
-import { getSitePropertyDefaults } from 'calypso/lib/signup/site-properties';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
@@ -103,7 +102,6 @@ export class RenderDomainsStep extends Component {
 		stepName: PropTypes.string.isRequired,
 		stepSectionName: PropTypes.string,
 		selectedSite: PropTypes.object,
-		isReskinned: PropTypes.bool,
 		recordTracksEvent: PropTypes.func,
 	};
 
@@ -1080,7 +1078,7 @@ export class RenderDomainsStep extends Component {
 				forceHideFreeDomainExplainerAndStrikeoutUi={
 					this.props.forceHideFreeDomainExplainerAndStrikeoutUi
 				}
-				isOnboarding={ this.props.isReskinned }
+				isOnboarding
 				reskinSideContent={ this.getSideContent() }
 				isInLaunchFlow={ 'launch-site' === this.props.flowName }
 				promptText={
@@ -1153,7 +1151,7 @@ export class RenderDomainsStep extends Component {
 	isHostingFlow = () => isHostingSignupFlow( this.props.flowName );
 
 	getSubHeaderText() {
-		const { flowName, isAllDomains, stepSectionName, isReskinned, translate } = this.props;
+		const { flowName, isAllDomains, stepSectionName, translate } = this.props;
 
 		if ( isAllDomains ) {
 			return translate( 'Find the domain that defines you' );
@@ -1183,12 +1181,8 @@ export class RenderDomainsStep extends Component {
 			return translate( 'Find and claim one or more domain names' );
 		}
 
-		if ( isReskinned ) {
-			return (
-				! stepSectionName &&
-				'domain-transfer' !== flowName &&
-				translate( 'Enter some descriptive keywords to get started' )
-			);
+		if ( ! stepSectionName && 'domain-transfer' !== flowName ) {
+			return translate( 'Enter some descriptive keywords to get started' );
 		}
 
 		return 'transfer' === this.props.stepSectionName || 'mapping' === this.props.stepSectionName
@@ -1197,8 +1191,7 @@ export class RenderDomainsStep extends Component {
 	}
 
 	getHeaderText() {
-		const { headerText, isAllDomains, isReskinned, stepSectionName, translate, flowName } =
-			this.props;
+		const { headerText, isAllDomains, stepSectionName, translate, flowName } = this.props;
 
 		if ( stepSectionName === 'use-your-domain' || 'domain-transfer' === flowName ) {
 			return '';
@@ -1212,14 +1205,10 @@ export class RenderDomainsStep extends Component {
 			return translate( 'Your next big idea starts here' );
 		}
 
-		if ( isReskinned ) {
-			if ( shouldUseMultipleDomainsInCart( flowName ) ) {
-				return ! stepSectionName && translate( 'Choose your domains' );
-			}
-			return ! stepSectionName && translate( 'Choose a domain' );
+		if ( shouldUseMultipleDomainsInCart( flowName ) ) {
+			return ! stepSectionName && translate( 'Choose your domains' );
 		}
-
-		return getSitePropertyDefaults( 'signUpFlowDomainsStepHeader' );
+		return ! stepSectionName && translate( 'Choose a domain' );
 	}
 
 	getAnalyticsSection() {
@@ -1238,7 +1227,7 @@ export class RenderDomainsStep extends Component {
 			content = this.domainForm();
 		}
 
-		if ( ! this.props.stepSectionName && this.props.isReskinned ) {
+		if ( ! this.props.stepSectionName ) {
 			sideContent = this.getSideContent();
 		}
 
@@ -1325,7 +1314,6 @@ export class RenderDomainsStep extends Component {
 			stepSectionName,
 			isAllDomains,
 			translate,
-			isReskinned,
 			userSiteCount,
 			previousStepName,
 			useStepperWrapper,
@@ -1473,7 +1461,7 @@ export class RenderDomainsStep extends Component {
 				hideSkip
 				goToNextStep={ this.handleSkip }
 				align="center"
-				isWideLayout={ isReskinned }
+				isWideLayout
 			/>
 		);
 	}

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -15,10 +15,6 @@ import StepWrapper from 'calypso/signup/step-wrapper';
 import { isUserLoggedIn, getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getAvailableProductsList } from 'calypso/state/products-list/selectors';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-import SiteOrDomainChoice from './choice';
-import DomainImage from './domain-image';
-import ExistingSiteImage from './existing-site-image';
-import NewSiteImage from './new-site-image';
 
 import './style.scss';
 
@@ -58,7 +54,7 @@ class SiteOrDomain extends Component {
 	}
 
 	getChoices() {
-		const { translate, isReskinned, isLoggedIn, siteCount } = this.props;
+		const { translate, isLoggedIn, siteCount } = this.props;
 
 		const domainName = this.getDomainName();
 		let buyADomainTitle = translate( 'Just buy a domain', 'Just buy domains', {
@@ -72,22 +68,40 @@ class SiteOrDomain extends Component {
 		const choices = [];
 
 		const buyADomainDescription = translate( 'Add a site later.' );
-		if ( isReskinned ) {
+		choices.push( {
+			key: 'domain',
+			title: buyADomainTitle,
+			description: buyADomainDescription,
+			icon: null,
+			titleIcon: globe,
+			value: 'domain',
+			actionText: <Gridicon icon="chevron-right" size={ 18 } />,
+			allItemClickable: true,
+		} );
+		choices.push( {
+			key: 'page',
+			title: translate( 'New site' ),
+			description: translate(
+				'Customize and launch your site.{{br/}}{{strong}}Free domain for the first year on annual plans.{{/strong}}',
+				{
+					components: {
+						strong: <strong />,
+						br: <br />,
+					},
+				}
+			),
+			icon: null,
+			titleIcon: addCard,
+			value: 'page',
+			actionText: <Gridicon icon="chevron-right" size={ 18 } />,
+			allItemClickable: true,
+		} );
+		if ( isLoggedIn && siteCount > 0 ) {
 			choices.push( {
-				key: 'domain',
-				title: buyADomainTitle,
-				description: buyADomainDescription,
-				icon: null,
-				titleIcon: globe,
-				value: 'domain',
-				actionText: <Gridicon icon="chevron-right" size={ 18 } />,
-				allItemClickable: true,
-			} );
-			choices.push( {
-				key: 'page',
-				title: translate( 'New site' ),
+				key: 'existing-site',
+				title: translate( 'Existing WordPress.com site' ),
 				description: translate(
-					'Customize and launch your site.{{br/}}{{strong}}Free domain for the first year on annual plans.{{/strong}}',
+					'Use the domain with a site you already started.{{br/}}{{strong}}Free domain for the first year on annual plans.{{/strong}}',
 					{
 						components: {
 							strong: <strong />,
@@ -96,55 +110,10 @@ class SiteOrDomain extends Component {
 					}
 				),
 				icon: null,
-				titleIcon: addCard,
-				value: 'page',
+				titleIcon: layout,
+				value: 'existing-site',
 				actionText: <Gridicon icon="chevron-right" size={ 18 } />,
 				allItemClickable: true,
-			} );
-			if ( isLoggedIn && siteCount > 0 ) {
-				choices.push( {
-					key: 'existing-site',
-					title: translate( 'Existing WordPress.com site' ),
-					description: translate(
-						'Use the domain with a site you already started.{{br/}}{{strong}}Free domain for the first year on annual plans.{{/strong}}',
-						{
-							components: {
-								strong: <strong />,
-								br: <br />,
-							},
-						}
-					),
-					icon: null,
-					titleIcon: layout,
-					value: 'existing-site',
-					actionText: <Gridicon icon="chevron-right" size={ 18 } />,
-					allItemClickable: true,
-				} );
-			}
-		} else {
-			choices.push( {
-				type: 'page',
-				label: translate( 'New site' ),
-				image: <NewSiteImage />,
-				description: translate(
-					'Choose a theme, customize, and launch your site. A free domain for one year is included with all annual plans.'
-				),
-			} );
-			if ( isLoggedIn && siteCount > 0 ) {
-				choices.push( {
-					type: 'existing-site',
-					label: translate( 'Existing WordPress.com site' ),
-					image: <ExistingSiteImage />,
-					description: translate(
-						'Use with a site you already started. A free domain for one year is included with all annual plans.'
-					),
-				} );
-			}
-			choices.push( {
-				type: 'domain',
-				label: buyADomainTitle,
-				image: <DomainImage />,
-				description: buyADomainDescription,
 			} );
 		}
 
@@ -152,30 +121,13 @@ class SiteOrDomain extends Component {
 	}
 
 	renderChoices() {
-		const { isReskinned } = this.props;
-
 		return (
 			<div className="site-or-domain__choices">
-				{ isReskinned ? (
-					<>
-						<SelectItems
-							items={ this.getChoices() }
-							onSelect={ this.handleClickChoice }
-							preventWidows={ preventWidows }
-						/>
-					</>
-				) : (
-					<>
-						{ this.getChoices().map( ( choice, index ) => (
-							<SiteOrDomainChoice
-								choice={ choice }
-								handleClickChoice={ this.handleClickChoice }
-								isPlaceholder={ ! this.props.productsLoaded }
-								key={ `site-or-domain-choice-${ index }` }
-							/>
-						) ) }
-					</>
-				) }
+				<SelectItems
+					items={ this.getChoices() }
+					onSelect={ this.handleClickChoice }
+					preventWidows={ preventWidows }
+				/>
 			</div>
 		);
 	}
@@ -249,7 +201,7 @@ class SiteOrDomain extends Component {
 	};
 
 	render() {
-		const { translate, productsLoaded, isReskinned } = this.props;
+		const { translate, productsLoaded } = this.props;
 		const domainName = this.getDomainName();
 
 		if ( productsLoaded && ! domainName ) {
@@ -277,10 +229,8 @@ class SiteOrDomain extends Component {
 		const additionalProps = {};
 		let headerText = this.props.getHeaderText( this.getDomainCart() );
 
-		if ( isReskinned ) {
-			additionalProps.isHorizontalLayout = false;
-			additionalProps.align = 'center';
-		}
+		additionalProps.isHorizontalLayout = false;
+		additionalProps.align = 'center';
 
 		if ( this.isLeanDomainSearch() ) {
 			additionalProps.className = 'lean-domain-search';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: https://github.com/Automattic/wp-calypso/issues/95419

## Proposed Changes

* Renames the `isReskinned` flag used for hiding domain match reasons to `hideMatchReasons `
* Renames the `isReskinned` flag used for the different layout used in Onboarding flows as `isOnboarding`
* Renames the `isReskinned` flag used for the flag related to showing domain transfer suggestions to `showDomainTransferSuggestion`
* Minor bugfix for when there are no match reasons

| Broken margin bottom near `Free for ...` | Fixed |
| - | - |
| <img width="500" alt="image" src="https://github.com/user-attachments/assets/1797837a-e237-4409-8eb9-443e237ab240" /> | <img width="500" alt="image" src="https://github.com/user-attachments/assets/4ddb4336-efc7-4f65-b05d-74c1278e525e" /> |
## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Codebase cleanup from invasive flag

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check `/setup/onboarding/domains` make sure the domains page mimicks production
* Go to the domains add page and make sure `/domains/add` it mimicks production
* On domains add page search for a term which shows no match results (Test) and make sure the layout is fixed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
