### PR TITLE
Launchpad My Home: Show celebration confetti when user competes all tasks

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/use-launchpad.ts
+++ b/client/my-sites/customer-home/cards/launchpad/use-launchpad.ts
@@ -24,6 +24,7 @@ export function useLaunchpad( { checklistSlug, launchpadContext }: UseLaunchpadP
 
 	const {
 		data: { checklist, is_dismissed: isDismissed, is_dismissible: isDismissible, title },
+		refetch,
 	} = useSortedLaunchpadTasks( siteSlug, checklistSlug, launchpadContext );
 
 	const numberOfSteps = checklist?.length || 0;
@@ -49,5 +50,6 @@ export function useLaunchpad( { checklistSlug, launchpadContext }: UseLaunchpadP
 		launchpadTitle,
 		temporaryDismiss,
 		permanentDismiss,
+		refetch,
 	};
 }


### PR DESCRIPTION
…pleted

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/99160

## Proposed Changes

* Remove the celebration modal and show the confetti animation directly when tasks are completed
* Refetch tasks when user launches the site

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site from `/setup/onboarding`, use `flags=home/launchpad-first` to enable the feature
* Complete all tasks and ensure the celebration confetti is shown
* Verify the subtitle is removed when completed
* Verify the title is now `You are all set!`
* Verify the CTA become `Explore dashboard`


https://github.com/user-attachments/assets/00010ed0-b522-49fa-bc6c-2208e23d6c16



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
