### PR TITLE
WIP: Refactor getFinalImporterUrl to use the object pattern.

### DIFF
--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -8,6 +8,7 @@ import {
 	type ImporterConfigPriority,
 } from 'calypso/lib/importer/importer-config';
 import ImporterLogo from 'calypso/my-sites/importer/importer-logo';
+import type { GetFinalImporterUrlParams } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/helper';
 import type { ImporterPlatform } from 'calypso/lib/importer/types';
 import './style.scss';
 
@@ -23,12 +24,7 @@ interface Props {
 	title?: string;
 	subTitle?: string;
 	submit?: ( dependencies: Record< string, unknown > ) => void;
-	getFinalImporterUrl: (
-		siteSlug: string,
-		fromSite: string,
-		platform: ImporterPlatform,
-		backToFlow?: string
-	) => string;
+	getFinalImporterUrl: ( params: GetFinalImporterUrlParams ) => string;
 	onNavBack?: () => void;
 }
 

--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -47,12 +47,12 @@ export default function ListStep( props: Props ) {
 	);
 
 	const onImporterSelect = ( platform: ImporterPlatform ): void => {
-		const importerUrl = getFinalImporterUrl(
-			siteSlug ?? '',
-			fromSite ?? '',
+		const importerUrl = getFinalImporterUrl( {
+			targetSlug: siteSlug ?? '',
+			fromSite: fromSite ?? '',
 			platform,
-			backToFlow ?? undefined
-		);
+			backToFlow: backToFlow ?? undefined,
+		} );
 		submit?.( { platform, url: importerUrl } );
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/index.tsx
@@ -36,7 +36,11 @@ const ImportReadyPreview: Step = function ImportStep( props ) {
 			return;
 		}
 
-		const url = getFinalImporterUrl( siteSlug as string, urlData.url, urlData.platform );
+		const url = getFinalImporterUrl( {
+			targetSlug: siteSlug as string,
+			fromSite: urlData.url,
+			platform: urlData.platform,
+		} );
 		navigation.submit?.( { url } );
 	}, [ urlData, siteSlug, navigation ] );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready/index.tsx
@@ -26,7 +26,11 @@ const ImportReady: Step = function ImportStep( props ) {
 	 ↓ Methods
 	 */
 	const goToImporterPage = () => {
-		const url = getFinalImporterUrl( siteSlug as string, urlData.url, urlData.platform );
+		const url = getFinalImporterUrl( {
+			targetSlug: siteSlug as string,
+			fromSite: urlData.url,
+			platform: urlData.platform,
+		} );
 
 		navigation.submit?.( { url, platform: urlData.platform } );
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -11,13 +11,17 @@ import { getImporterEngines } from 'calypso/lib/importer/importer-config';
 import { ImporterPlatform } from 'calypso/lib/importer/types';
 import { BASE_ROUTE } from './config';
 
-export function getFinalImporterUrl(
-	targetSlug: string,
-	fromSite: string,
-	platform: ImporterPlatform,
-	backToFlow?: string,
-	customizedActionGoToFlow?: string
-) {
+interface GetFinalImporterUrlParams {
+	targetSlug: string;
+	fromSite: string;
+	platform: ImporterPlatform;
+	backToFlow?: string;
+	customizedActionGoToFlow?: string;
+}
+
+export function getFinalImporterUrl( params: GetFinalImporterUrlParams ) {
+	const { targetSlug, fromSite, platform, backToFlow, customizedActionGoToFlow } = params;
+
 	let importerUrl;
 	const encodedFromSite = encodeURIComponent( fromSite );
 	const productImporters = getImporterEngines();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -11,7 +11,7 @@ import { getImporterEngines } from 'calypso/lib/importer/importer-config';
 import { ImporterPlatform } from 'calypso/lib/importer/types';
 import { BASE_ROUTE } from './config';
 
-interface GetFinalImporterUrlParams {
+export interface GetFinalImporterUrlParams {
 	targetSlug: string;
 	fromSite: string;
 	platform: ImporterPlatform;

--- a/client/landing/stepper/declarative-flow/migration/helpers/index.ts
+++ b/client/landing/stepper/declarative-flow/migration/helpers/index.ts
@@ -38,7 +38,12 @@ export const goToImporter = ( {
 	from,
 	ref,
 }: GoToImporterParams ) => {
-	const path = getFinalImporterUrl( siteSlug, from || '', platform, backToFlow );
+	const path = getFinalImporterUrl( {
+		targetSlug: siteSlug,
+		fromSite: from || '',
+		platform,
+		backToFlow,
+	} );
 
 	if ( isWpAdminImporter( path ) ) {
 		return goTo( path, replaceHistory );


### PR DESCRIPTION
Related to #99443

## Proposed Changes

Refactor `getFinalImporterUrl` to accept an object instead of individual arguments for better scalability and readability.

## Why are these changes being made?
In #99443, I proposed adding a function that fixes navigation between onboarding views. One of these onboarding views, uses this function to navigate the user. In order for the fix in #99443 to work with that composite flow, we also need to apply that change in `getFinalImporterUrl`. 

However, there are currently 4 possible arguments that can be passed into `getFinalImporterUrl`. Passing a fifth argument, which would be needed (need the URL params) throws a linter error. 


For #99443, I would add the following change:

```diff
diff --git a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
index bd163047af..201068f772 100644
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -17,10 +17,12 @@ interface GetFinalImporterUrlParams {
        platform: ImporterPlatform;
        backToFlow?: string;
        customizedActionGoToFlow?: string;
+       urlQueryParams?: URLSearchParams;
 }
 
 export function getFinalImporterUrl( params: GetFinalImporterUrlParams ) {
-       const { targetSlug, fromSite, platform, backToFlow, customizedActionGoToFlow } = params;
+       const { targetSlug, fromSite, platform, backToFlow, customizedActionGoToFlow, urlQueryParams } =
+               params;
 
        let importerUrl;
        const encodedFromSite = encodeURIComponent( fromSite );
@@ -45,9 +47,12 @@ export function getFinalImporterUrl( params: GetFinalImporterUrlParams ) {
        }
 
        if ( backToFlow ) {
-               importerUrl = addQueryArgs( importerUrl, {
-                       backToFlow,
-               } );
+               importerUrl = addQueryArgs(
+                       persistQueryParams( importerUrl, urlQueryParams ?? new URLSearchParams() ),
+                       {
+                               backToFlow,
+                       }
+               );
        }
 
        if ( customizedActionGoToFlow ) {
```


## Testing Instructions
TODO

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
