### PR TITLE
Release newsletter goal launchpad tasks

### DIFF
--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { PLAN_PERSONAL } from '@automattic/calypso-products';
 import { OnboardSelect, Onboard, UserSelect, ProductsList } from '@automattic/data-stores';
 import { ONBOARDING_FLOW, clearStepPersistedState } from '@automattic/onboarding';
@@ -198,9 +197,6 @@ const onboarding: Flow = {
 			const destination = addQueryArgs( '/setup/site-setup', {
 				siteSlug: providedDependencies.siteSlug,
 				...( isGoalsAtFrontExperiment && { 'goals-at-front-experiment': true } ),
-				...( config.isEnabled( 'onboarding/newsletter-goal' ) && {
-					flags: 'onboarding/newsletter-goal',
-				} ),
 			} );
 
 			return [ destination, addQueryArgs( destination, { skippedCheckout: 1 } ) ];

--- a/config/development.json
+++ b/config/development.json
@@ -140,7 +140,6 @@
 		"onboarding/import-light": false,
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
-		"onboarding/newsletter-goal": false,
 		"onboarding/trail-map-feature-grid-copy": false,
 		"onboarding/trail-map-feature-grid-structure": false,
 		"onboarding/trail-map-feature-grid": false,

--- a/packages/data-stores/src/onboard/test/utils.ts
+++ b/packages/data-stores/src/onboard/test/utils.ts
@@ -44,23 +44,11 @@ describe( 'Test onboard utils', () => {
 		},
 		{
 			goals: [ SiteGoal.Write, SiteGoal.Newsletter ],
-			expectedIntent: SiteIntent.Write,
-			featureFlags: { 'onboarding/newsletter-goal': false },
-		},
-		{
-			goals: [ SiteGoal.Write, SiteGoal.Newsletter ],
 			expectedIntent: SiteIntent.NewsletterGoal,
-			featureFlags: { 'onboarding/newsletter-goal': true },
-		},
-		{
-			goals: [ SiteGoal.Sell, SiteGoal.Newsletter ],
-			expectedIntent: SiteIntent.Sell,
-			featureFlags: { 'onboarding/newsletter-goal': false },
 		},
 		{
 			goals: [ SiteGoal.Sell, SiteGoal.Newsletter ],
 			expectedIntent: SiteIntent.NewsletterGoal,
-			featureFlags: { 'onboarding/newsletter-goal': true },
 		},
 	] )(
 		'Should map the $goals to $expectedIntent intent ($featureFlags)',

--- a/packages/data-stores/src/onboard/utils.ts
+++ b/packages/data-stores/src/onboard/utils.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { SiteGoal, SiteIntent } from './constants';
 
 export const goalsToIntent = ( goals: SiteGoal[] ): SiteIntent => {
@@ -12,7 +11,7 @@ export const goalsToIntent = ( goals: SiteGoal[] ): SiteIntent => {
 	}
 
 	// Newsletter flow
-	if ( config.isEnabled( 'onboarding/newsletter-goal' ) && goals.includes( SiteGoal.Newsletter ) ) {
+	if ( goals.includes( SiteGoal.Newsletter ) ) {
 		return SiteIntent.NewsletterGoal;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #98305

## Proposed Changes

This change removes the feature flag for the newsletter goal from the
onboarding flow. The flag is no longer necessary as the feature we are
enabling the feature for all users.

I left the ability to mock feature flags in the `goalsToIntent()`. Seems
like it could be useful in the future.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The CfT didn't raise anything that was a blocker for the newsletter goal specifically.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the CfT instructions pdtkmj-3k2-p2 (except the `?flags=onboarding/newsletter-goal` query param will now be ignored)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
