### PR TITLE
Fix alignment for hundred year plan

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/index.tsx
@@ -39,7 +39,7 @@ const HundredYearPlanDIYOrDIFM: Step = function HundredYearPlanDIYOrDIFM( { navi
 			<HundredYearPlanStepWrapper
 				stepContent={
 					<>
-						<div>
+						<div className="hundred-year-plan__benefits-wrapper">
 							<ul className="hundred-year-plan__benefits">
 								<li>
 									<Icon size={ 18 } icon={ check } />{ ' ' }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/styles.scss
@@ -8,6 +8,12 @@
 			margin-top: 0;	
 		}
 	}
+	
+	.hundred-year-plan__benefits-wrapper {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	}
 
 	.hundred-year-plan__benefits {
 		margin: 0 0.5rem 2.5rem 0.5rem;
@@ -74,11 +80,11 @@
 
 	.calendly-popup {
 		height: 100%;
-
 	}
 	.calendly-popup-content {
 		height: 100%;
 	}
+	
 	.calendly-popup-close {
 		position: absolute;
 		top: 1.5rem;


### PR DESCRIPTION
## Proposed Changes

This PR fixes the alignment on the hundred year plan page. cc @ianstewart 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The left aligned content block looks out of balance against the rest of the content being centre aligned.

**Before**

<img width="1832" alt="image" src="https://github.com/user-attachments/assets/f9162db6-31ba-4ca3-bd4b-24643aceca70" />

**After**

<img width="1832" alt="image" src="https://github.com/user-attachments/assets/d12bc628-80f9-4d63-a247-ede76383e598" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit `/setup/hundred-year-plan/diy-or-difm`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
