### PR TITLE
Users: dedupe user count

### DIFF
--- a/client/data/users/use-users-query.js
+++ b/client/data/users/use-users-query.js
@@ -32,10 +32,15 @@ const useUsersQuery = ( siteId, fetchOptions = {}, queryOptions = {} ) => {
 			return allPages.length * n;
 		},
 		select: ( data ) => {
+			/* @TODO:
+			 * `uniqueBy` is necessary, because the API can return duplicates.
+			 * This is most commonly seen where a user has both a "regular" user role
+			 * such as Administrator and Editor, and has also been added as a "Viewer" .
+			 */
+			const users = uniqueBy( extractPages( data.pages ), compareUnique );
 			return {
-				/* @TODO: `uniqueBy` is necessary, because the API can return duplicates */
 				users: uniqueBy( extractPages( data.pages ), compareUnique ),
-				total: data.pages[ 0 ].found,
+				total: users?.length ?? data.pages[ 0 ].found,
 				...data,
 			};
 		},


### PR DESCRIPTION

## Proposed Changes

This commit uses the length of the deduped users rather than the undeduped length in the users query. It ensures that the count is correctly displayed on the Users page.

### Before

<img width="765" alt="Screenshot 2025-02-07 at 12 06 46 pm" src="https://github.com/user-attachments/assets/c04dea7b-4a38-459e-a1e4-e10368e6598c" />


### After
<img width="810" alt="Screenshot 2025-02-07 at 12 12 30 pm" src="https://github.com/user-attachments/assets/9aaa0564-12f7-4569-9914-9c4f47ce3f18" />



## Why are these changes being made?

The list of users is already deduped, but the count is not. This creates a mismatch between the number of users returned in the list and the count.

I suspect it was an oversight in https://github.com/Automattic/wp-calypso/pull/50712/files#diff-d3b37aa7f029b8f881e02a9ea0d701be351599baeab1900624a99512954a6cceR43

I think the deduping should happen at the source: Related endpoint changes: https://github.com/Automattic/jetpack/pull/28317#issuecomment-2658129481

## Testing Instructions

1. Fire up this branch and head over to `/people/team/[YOUR_SITE]`
2. Invite a new user, e.g., Editor. Accept that invite. 
3. Refresh `/people/team/[YOUR_SITE]` and check that the "You have n team members" contains the correct count.
4. Now invite a Viewer. Accept. 
5. Refresh `/people/team/[YOUR_SITE]` and check that the "You have n team members" contains the correct count. (Invites are not counted)
6. Now invite that same Viewer from `4` again but give them a role of Editor or Author. Accept that invite.
7. Refresh `/people/team/[YOUR_SITE]` and check that the "You have n team members" contains the correct count.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
