### PR TITLE
Site settings: adjust site tools links alignment

### DIFF
--- a/client/sites/settings/site/style.scss
+++ b/client/sites/settings/site/style.scss
@@ -2,4 +2,8 @@
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
+	align-items: stretch;
+	.site-tools__link {
+		margin: 0;
+	}
 }


### PR DESCRIPTION

## Proposed Changes

This CSS ensures that the site tools links align neatly and stretch to the container width rather than centred and floating.

## Why are these changes being made?

### Before

<img width="849" alt="Screenshot 2025-02-07 at 12 43 09 pm" src="https://github.com/user-attachments/assets/04ab7ce5-a9e3-4c5d-ab43-45892d39b330" />


### After

<img width="819" alt="Screenshot 2025-02-07 at 1 19 57 pm" src="https://github.com/user-attachments/assets/d426f5fb-2863-404f-a59b-203b6e41ca7b" />


## Testing Instructions

1. Head over to`/sites/settings/site/[YOUR_SITE]`
2. Check that the "Change your site address" links and others below are aligned and stretch to the content width.
3. Check narrow viewport widths (mobile) and in Safari, Firefox etc

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
