### PR TITLE
Stats Locations: add support for preserving geo mode in summary view

### DIFF
--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -13,7 +13,10 @@ import { QueryStatsParams } from 'calypso/my-sites/stats/hooks/utils';
 import StatsCardUpsell from 'calypso/my-sites/stats/stats-card-upsell';
 import StatsListCard from 'calypso/my-sites/stats/stats-list/stats-list-card';
 import StatsModulePlaceholder from 'calypso/my-sites/stats/stats-module/placeholder';
-import { trackStatsAnalyticsEvent } from 'calypso/my-sites/stats/utils';
+import {
+	getPathWithUpdatedQueryString,
+	trackStatsAnalyticsEvent,
+} from 'calypso/my-sites/stats/utils';
 import { useSelector } from 'calypso/state';
 import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
@@ -57,16 +60,25 @@ type SelectOptionType = {
 interface StatsModuleLocationsProps {
 	query: QueryStatsParams;
 	summaryUrl?: string;
+	initialGeoMode?: string;
 }
 
-const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summaryUrl } ) => {
+const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
+	query,
+	summaryUrl,
+	initialGeoMode,
+} ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const statType = STAT_TYPE_COUNTRY_VIEWS;
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const supportUrl = isOdysseyStats ? JETPACK_SUPPORT_URL_TRAFFIC : SUPPORT_URL;
 
-	const [ selectedOption, setSelectedOption ] = useState( OPTION_KEYS.COUNTRIES );
+	const urlGeoMode =
+		initialGeoMode || new URLSearchParams( window.location.search ).get( 'geoMode' );
+	const [ selectedOption, setSelectedOption ] = useState(
+		urlGeoMode && urlGeoMode in GEO_MODES ? urlGeoMode : OPTION_KEYS.COUNTRIES
+	);
 
 	const [ countryFilter, setCountryFilter ] = useState< string | null >( null );
 
@@ -274,6 +286,20 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 		return null;
 	};
 
+	const getFinalSummaryUrl = () => {
+		if ( ! summaryUrl ) {
+			return undefined;
+		}
+
+		// Add both date range and geoMode parameters to the summary URL
+		return getPathWithUpdatedQueryString(
+			{
+				geoMode: selectedOption, // This preserves the current view (countries/regions/cities)
+			},
+			summaryUrl
+		);
+	};
+
 	const moduleOverlay = getModuleOverlay();
 
 	return (
@@ -314,7 +340,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 						showMore={
 							summaryUrl
 								? {
-										url: summaryUrl,
+										url: getFinalSummaryUrl(),
 										label:
 											Array.isArray( locationData ) && locationData.length >= 10
 												? translate( 'View all', {
@@ -340,7 +366,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( { query, summary
 					footerAction={
 						summaryUrl
 							? {
-									url: summaryUrl,
+									url: getFinalSummaryUrl(),
 									label: translate( 'View more' ),
 							  }
 							: undefined

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -291,10 +291,9 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 			return undefined;
 		}
 
-		// Add both date range and geoMode parameters to the summary URL
 		return getPathWithUpdatedQueryString(
 			{
-				geoMode: selectedOption, // This preserves the current view (countries/regions/cities)
+				geoMode: selectedOption,
 			},
 			summaryUrl
 		);

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -175,7 +175,6 @@ class StatsSummary extends Component {
 				title = translate( 'Locations' );
 				path = 'locations';
 				statType = 'statsCountryViews';
-
 				summaryView = (
 					<Fragment key="countries-summary">
 						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
@@ -185,6 +184,7 @@ class StatsSummary extends Component {
 							query={ moduleQuery }
 							summary
 							listItemClassName={ listItemClassName }
+							initialGeoMode={ urlParams.get( 'geoMode' ) }
 						/>
 					</Fragment>
 				);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-roadmap/issues/2289

## Proposed Changes

* Add support for preserving geo mode in summary view
  * Add `geoMode` parameter to the summary URL to maintain the selected view (Countries/Regions/Cities)
  * Update URL handling to properly read and preserve the selected tab when navigating

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/8b58e05e-2c5a-4290-ac87-f05dd340315d" /> | <video src="https://github.com/user-attachments/assets/0a46f088-826d-4b8c-b214-d03de1179cb9" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Currently, when users navigate from the Locations module to the summary view, their selected tab (Regions/Cities) is not preserved. Instead, the view defaults back to the Countries tab, creating a disjointed user experience.

These changes:
- Preserve the user's selected view when navigating to the summary page
- Improve navigation consistency and user experience
- Reduce unnecessary clicks by maintaining the user's context

https://github.com/Automattic/jetpack-roadmap/issues/2289

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Setup
Choose one of these options:
 - Spin up a **Calypso Live Branch**
 - Test on **Odyssey** using [PCYsg-Pp7-p2](https://example-link)
   - Note: For Odyssey, append `?flags=stats/locations` to the URL

### Steps to Test
1. Navigate to the **Stats page**
2. In the Locations module:
   - Switch to either the `Regions` or `Cities` tab
   - Click `View all` or `View details` to open the summary view
3. **Expected behavior**: 
   - The summary view should maintain your selected tab (Regions/Cities)
   - It should not default back to the `Countries` tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
