### PR TITLE
A4A > Partner Directory: Fix access control

### DIFF
--- a/client/a8c-for-agencies/controller.tsx
+++ b/client/a8c-for-agencies/controller.tsx
@@ -39,7 +39,8 @@ const handleMultiUserSupport = ( agency: Agency, pathname: string, next: () => v
 export const requireAccessContext: Callback = ( context, next ) => {
 	const state = context.store.getState();
 	const agency = getActiveAgency( state );
-	const { pathname, search, hash } = window.location;
+	const { search, hash } = window.location;
+	const pathname = context.pathname;
 
 	if ( agency ) {
 		// If multi-user support is enabled, we need to check if the user has access to the current path
@@ -61,7 +62,8 @@ export const requireClientAccessContext: Callback = ( context, next ) => {
 		return;
 	}
 
-	const { pathname, search, hash } = window.location;
+	const { search, hash } = window.location;
+	const pathname = context.pathname;
 	const args = getQueryArgs( window.location.href );
 	page.redirect(
 		addQueryArgs( A4A_CLIENT_LANDING_LINK, { ...args, return: pathname + search + hash } )
@@ -71,7 +73,7 @@ export const requireClientAccessContext: Callback = ( context, next ) => {
 export const requireTierAccessContext: Callback = ( context, next ) => {
 	const state = context.store.getState();
 	const agency = getActiveAgency( state );
-	const { pathname } = window.location;
+	const pathname = context.pathname;
 
 	if ( isEnabled( 'a8c-for-agencies-agency-tier' ) && ! isPathAllowedForTier( pathname, agency ) ) {
 		context.primary = <TierPermissionError section={ context.section.name } />;


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1757

## Proposed Changes

This PR fixes an issue with access control that is caused by a stale pathname. We are fixing this issue by using `context.pathname` that comes directly from the `page` router and represents the actual route being processed instead of `window.locations.pathname` that reflects the browser's URL bar, which might not update immediately during navigation.

## Why are these changes being made?

* To fix the access control issue on Partner Directory. 

## Testing Instructions

* Open the A4A live link
* Go to the Overview page > Go to Partner Directory, notice the page loads as expected > Go to Overview page again > Go to Partner Directory and verify that the page loads as expected. You can reproduce this bug by following the same steps in production. You can notice in the screen recording below that the path is not updating according to the current route.


**Before**

https://github.com/user-attachments/assets/631fc342-b02c-4ece-847c-07c09ff54ab6 

**After**

https://github.com/user-attachments/assets/677fcedb-9072-44f5-ba88-835d8fed00b0

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
