### PR TITLE
Add stories for all A8C logos

### DIFF
--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -71,11 +71,11 @@ export type { RenderThumbFunction } from './pricing-slider/types';
 // Logos
 export { default as ClientLogoList } from './client-logo-list';
 export { JetpackLogo } from './logos/jetpack-logo';
-export { default as CloudLogo } from './logos/cloud-logo';
-export { default as VIPLogo } from './logos/vip-logo';
-export { default as WooLogo } from './logos/woo-logo';
+export { CloudLogo } from './logos/cloud-logo';
+export { VIPLogo } from './logos/vip-logo';
+export { WooLogo } from './logos/woo-logo';
 export { WordPressLogo } from './logos/wordpress-logo';
-export { default as WooCommerceWooLogo } from './logos/woocommerce-woo-logo';
+export { WooCommerceWooLogo } from './logos/woocommerce-woo-logo';
 export { default as Swipeable } from './swipeable';
 export { default as DotPager } from './dot-pager';
 export { default as EmbedContainer } from './embed-container';

--- a/packages/components/src/logos/cloud-logo/index.tsx
+++ b/packages/components/src/logos/cloud-logo/index.tsx
@@ -1,4 +1,4 @@
-const CloudLogo = ( props: React.SVGProps< SVGSVGElement > ) => (
+export const CloudLogo = ( props: React.SVGProps< SVGSVGElement > ) => (
 	<svg xmlns="http://www.w3.org/2000/svg" width={ 31 } height={ 18 } fill="none" { ...props }>
 		<title>WP Cloud logo</title>
 		<path
@@ -37,4 +37,3 @@ const CloudLogo = ( props: React.SVGProps< SVGSVGElement > ) => (
 		/>
 	</svg>
 );
-export default CloudLogo;

--- a/packages/components/src/logos/cloud-logo/stories/index.stories.tsx
+++ b/packages/components/src/logos/cloud-logo/stories/index.stories.tsx
@@ -1,0 +1,12 @@
+import { CloudLogo } from '..';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta< typeof CloudLogo > = {
+	title: 'packages/components/Logos/CloudLogo',
+	component: CloudLogo,
+};
+export default meta;
+
+type Story = StoryObj< typeof CloudLogo >;
+
+export const Default: Story = {};

--- a/packages/components/src/logos/docs/example.tsx
+++ b/packages/components/src/logos/docs/example.tsx
@@ -1,7 +1,8 @@
-import CloudLogo from '../cloud-logo';
+import { CloudLogo } from '../cloud-logo';
 import { JetpackLogo } from '../jetpack-logo';
-import VIPLogo from '../vip-logo';
-import WooLogo from '../woo-logo';
+import { VIPLogo } from '../vip-logo';
+import { WooLogo } from '../woo-logo';
+import { WooCommerceWooLogo } from '../woocommerce-woo-logo';
 
 import './style.scss';
 export default function ProductLogoExample() {
@@ -18,6 +19,9 @@ export default function ProductLogoExample() {
 			</div>
 			<div className="logo-container">
 				<WooLogo />
+			</div>
+			<div className="logo-container">
+				<WooCommerceWooLogo />
 			</div>
 		</div>
 	);

--- a/packages/components/src/logos/vip-logo/index.tsx
+++ b/packages/components/src/logos/vip-logo/index.tsx
@@ -1,4 +1,4 @@
-const VIPLogo = ( props: React.SVGProps< SVGSVGElement > ) => (
+export const VIPLogo = ( props: React.SVGProps< SVGSVGElement > ) => (
 	<svg
 		width="38"
 		height="17"
@@ -36,4 +36,3 @@ const VIPLogo = ( props: React.SVGProps< SVGSVGElement > ) => (
 		</defs>
 	</svg>
 );
-export default VIPLogo;

--- a/packages/components/src/logos/vip-logo/stories/index.stories.tsx
+++ b/packages/components/src/logos/vip-logo/stories/index.stories.tsx
@@ -1,0 +1,12 @@
+import { VIPLogo } from '..';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta< typeof VIPLogo > = {
+	title: 'packages/components/Logos/VIPLogo',
+	component: VIPLogo,
+};
+export default meta;
+
+type Story = StoryObj< typeof VIPLogo >;
+
+export const Default: Story = {};

--- a/packages/components/src/logos/woo-logo/index.tsx
+++ b/packages/components/src/logos/woo-logo/index.tsx
@@ -1,4 +1,4 @@
-const WooLogo = ( props: React.SVGProps< SVGSVGElement > ) => (
+export const WooLogo = ( props: React.SVGProps< SVGSVGElement > ) => (
 	<svg
 		version="1.1"
 		id="Layer_1"
@@ -40,5 +40,3 @@ const WooLogo = ( props: React.SVGProps< SVGSVGElement > ) => (
 		</g>
 	</svg>
 );
-
-export default WooLogo;

--- a/packages/components/src/logos/woo-logo/stories/index.stories.tsx
+++ b/packages/components/src/logos/woo-logo/stories/index.stories.tsx
@@ -1,0 +1,12 @@
+import { WooLogo } from '..';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta< typeof WooLogo > = {
+	title: 'packages/components/Logos/WooLogo',
+	component: WooLogo,
+};
+export default meta;
+
+type Story = StoryObj< typeof WooLogo >;
+
+export const Default: Story = {};

--- a/packages/components/src/logos/woocommerce-woo-logo/index.tsx
+++ b/packages/components/src/logos/woocommerce-woo-logo/index.tsx
@@ -4,7 +4,7 @@ type WooCommerceWooLogoProps = {
 	width?: number;
 };
 
-const WooCommerceWooLogo = ( {
+export const WooCommerceWooLogo = ( {
 	className = 'woocommerce-logo',
 	height = 35,
 	width = 20,
@@ -52,5 +52,3 @@ const WooCommerceWooLogo = ( {
 		</svg>
 	);
 };
-
-export default WooCommerceWooLogo;

--- a/packages/components/src/logos/woocommerce-woo-logo/stories/index.stories.tsx
+++ b/packages/components/src/logos/woocommerce-woo-logo/stories/index.stories.tsx
@@ -1,0 +1,12 @@
+import { WooCommerceWooLogo } from '..';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta< typeof WooCommerceWooLogo > = {
+	title: 'packages/components/Logos/WooCommerceWooLogo',
+	component: WooCommerceWooLogo,
+};
+export default meta;
+
+type Story = StoryObj< typeof WooCommerceWooLogo >;
+
+export const Default: Story = {};


### PR DESCRIPTION
## Proposed Changes

Adds Storybook stories for the rest of the A8C logo components:

- WooLogo
- WooCommerceWooLogo
- VIPLogo
- CloudLogo

## Why are these changes being made?

For easier maintenance.

As we can already see, the logos have random APIs, styling, and `title` tags inside. There are also two Woo logos for some reason (not to mention a third duplicate in `client/components`). These issues need to be cleaned up and normalized separately.

## Testing Instructions

`yarn components:storybook:start` and see the Logos folder.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
