### PR TITLE
Adds the site's goals to the launchpad tracks events

### DIFF
--- a/packages/launchpad/src/use-tracking/index.tsx
+++ b/packages/launchpad/src/use-tracking/index.tsx
@@ -29,6 +29,7 @@ export const useTracking = ( params: Params ) => {
 	const isCheckListCompleted = completedSteps.length === tasks.length;
 	const isSiteAvailable = !! site;
 	const hasNoTask = tasks.length === 0;
+	const goals = site?.options?.site_goals?.join( ',' );
 
 	// We skip the view events until we have fetched the site details to avoid sending incomplete data
 	const shoulSkipTracking = hasNoTask || ! isSiteAvailable;
@@ -49,6 +50,7 @@ export const useTracking = ( params: Params ) => {
 			context: context,
 			site_intent: siteIntent,
 			flow,
+			goals,
 		} );
 
 		tasks.forEach( ( task: Task ) => {
@@ -60,6 +62,7 @@ export const useTracking = ( params: Params ) => {
 				order: task.order,
 				site_intent: siteIntent,
 				flow,
+				goals,
 			} );
 		} );
 		// Array of tasks requires deep comparison
@@ -78,6 +81,7 @@ export const useTracking = ( params: Params ) => {
 			task_id: task.id,
 			flow,
 			order: task.order,
+			goals,
 		} );
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98623

## Proposed Changes

* Add goals prop to `_task_view`, `_tasklist_viewed`, and `_task_clicked` launchpad tracks events
* Stringifies the goals list using commas, just like we do in the goals screen tracks events

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This makes the performance of goals and tasks easier for the data team to analyse.

p1738900386353329/1738879562.278169-slack-C04H4NY6STW

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create new sites with various goal combinations
  * Use a goal selection that lands in My Home (like Newsletter)
  * Use a goal selection that lands in the fullscreen launchpad
  * Use an empty goals selection
* Confirm the `_tasklist_viewed`, `_task_view`, and `_task_clicked` events are sent with goals props

Note that the "task completed" event is recorded on the backend, so not part of this PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?