### PR TITLE
Remove the active theme badge and select the default variation for designSetup

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -676,7 +676,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					}
 
 					return setDesignOnSite( siteSlugOrId, _selectedDesign, {
-						styleVariation: selectedStyleVariation,
+						styleVariation: selectedStyleVariation || _selectedDesign?.style_variations?.[ 0 ],
 						globalStyles,
 					} ).then( ( theme: ActiveTheme ) => {
 						return reduxDispatch( setActiveTheme( site?.ID || -1, theme ) );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -990,7 +990,11 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				getOptionsMenu={ isUpdatedBadgeDesign ? getBadge : undefined }
 				oldHighResImageLoading={ oldHighResImageLoading }
 				siteActiveTheme={ siteActiveTheme?.[ 0 ]?.stylesheet ?? null }
-				showActiveThemeBadge={ intent !== SiteIntent.Build && ! isSiteSetupFlow( flow ) }
+				showActiveThemeBadge={
+					intent !== SiteIntent.Build &&
+					! isSiteSetupFlow( flow ) &&
+					intent !== SiteIntent.UpdateDesign
+				}
 				isMultiFilterEnabled
 				isBigSkyEligible={ isBigSkyEligible }
 			/>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/95578

## Proposed Changes

[Current behavior](https://github.com/Automattic/wp-calypso/issues/95578#issuecomment-2467133462)

> The variation selection bug: If the default variation is already selected, you have to explicitly click the default variation again before it will correctly clear the existing style variation

This PR matches the UI behavior by passing the default style variation if the user doesn't explicitly select another style variation.

## Before

![before](https://github.com/user-attachments/assets/7981908a-9d2f-47a5-afd4-b59b1b4b758c)

So the flow would be:
1. Select Twenty Twenty-Five with a style variation, no need to purchase 
2. In the launchpad, go back and pick some other design (as the Active theme selection won't let you click)
3. Select Twenty Twenty-Five theme again but don't click on the style variations and click on continue

You'll notice the style variation is still the previous one selected.

https://github.com/user-attachments/assets/ea5f5e2b-1969-4ff2-8ed8-15baabb5c149


## After

https://github.com/user-attachments/assets/1d53afec-fb43-4199-ae18-227025fd81ed



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To match the behavior with what the UI shows to not cause confusion.
* To prevent the user from not able to click on the same theme to change the variation

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]  
> The Active theme selection making the theme unclickable is not part of what this PR wants to address

* Go through /setup/onboarding, don't select any goals
* In the launchpad, go back to pick a design step
* Select Twenty Twenty-Five with a style variation, no need to purchase
* In the launchpad, go back and pick Twenty Twenty-Five theme again but don't click on the style variations and click on continue
* You should see the style has switched to the Twenty Twenty-Five default theme



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
