### PR TITLE
Release focused launchpad to wpcalypso - with tests fix

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -52,7 +52,7 @@
 		"global-styles/on-personal-plan": true,
 		"help": true,
 		"help/gpt-response": true,
-		"home/launchpad-first": false,
+		"home/launchpad-first": true,
 		"home/layout-dev": true,
 		"hosting/datacenter-picker": true,
 		"hosting-server-settings-enhancements": true,

--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -195,7 +195,10 @@ describe(
 				// Stepper has a quirk where it redirects twice. Playwright hooks to the first one and thinks it was aborted.
 				await fixme_retry( () => page.waitForURL( /launchpad/ ) );
 
-				await page.getByRole( 'button', { name: 'Skip for now' } ).click();
+				// Try to find the skip button with a more specific selector
+				const skipButton = page.getByRole( 'button', { name: /skip (for now|to dashboard)/i } );
+				await skipButton.waitFor( { state: 'visible', timeout: 10000 } );
+				await skipButton.click();
 			} );
 
 			it( 'See Home', async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Context: p1738781315185299/1737519094.618889-slack-C04H4NY6STW
PT: pet6gk-1T7-p2

## Proposed Changes

We want to allow designers to test the Focused Launchpad in My home on wpcalypso so they can test the whole flow with the proper redirects it does

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Just adding the `?flags=home/launchpad-first` doesn't allow us testing everything because /site-creating/processing removes it and the /home redirect also removes it redirecting the user back to /build/launchpad instead of keeping them at the focused launchpad.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Just ensure we're editing the correct file to release the changes to wpcalypso, instead of staging or even prod.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?