### PR TITLE
Hundred Year Plan Site Picker:Add the siteId and siteUrl parameters to the Help Center url

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/index.tsx
@@ -124,12 +124,14 @@ const ConfirmationModal = ( {
 	isFetching,
 	siteTitle,
 	siteDomain,
+	siteId,
 	onConfirm,
 	closeModal,
 }: {
 	isFetching: boolean;
 	siteTitle?: string;
 	siteDomain?: string;
+	siteId?: number;
 	onConfirm: () => void;
 	closeModal: () => void;
 } ) => {
@@ -138,12 +140,15 @@ const ConfirmationModal = ( {
 
 	const { setShowHelpCenter, setNavigateToRoute } = useDataStoreDispatch( HelpCenter.register() );
 
+	const userFieldMessage =
+		'Automated message: This is a user looking to purchase the 100-Year Plan and is currently in the site picker step: https://wordpress.com/setup/hundred-year-plan/site-picker';
+	const helpCenterUrl = `/odie?provider=zendesk&userFieldMessage=${ encodeURIComponent(
+		userFieldMessage
+	) }&siteUrl=${ siteDomain }&siteId=${ siteId }`;
+
 	const openHelpCenter = () => {
 		recordTracksEvent( 'calypso_hundred_year_plan_help_click' );
-		setNavigateToRoute(
-			'/odie?provider=zendesk&userFieldMessage=' +
-				encodeURIComponent( 'This is a user looking to purchase the 100-Year Plan' )
-		);
+		setNavigateToRoute( helpCenterUrl );
 		setShowHelpCenter( true );
 		closeModal();
 	};
@@ -309,6 +314,7 @@ const HundredYearPlanSitePicker: Step = function HundredYearPlanSitePicker( { na
 					closeModal={ closeModal }
 					siteTitle={ siteTitle }
 					siteDomain={ siteDomain?.domain }
+					siteId={ site?.ID }
 				/>
 			) }
 		</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow up to: https://github.com/Automattic/wp-calypso/pull/99100

## Proposed Changes

This PR adds more context to the HelpCenter URL passing the:

- Site URL
- Site ID

And it also improves the message to provide more context for HEs

The Help Center URL is updated as soon as the site is selected. This information is sent once the user clicks on "Contact Us".
![CleanShot 2025-02-07 at 14 52 35@2x](https://github.com/user-attachments/assets/881b046a-8365-4b70-bd15-2f954c4b8d12)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To provide more context for the Zendesk workflows. Related Slack convo: p1738772868088709-slack-C07D72S1135

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Access `/setup/hundred-year-plan/site-picker` 
- You can console log the `helpCenterUrl`, and you'll get something similar to: `/odie?provider=zendesk&userFieldMessage=This%20is%20a%20user%20looking%20to%20purchase%20the%20100-Year%20Plan&siteUrl=atrumtest03.wordpress.com&siteId=163266266`
- Confirm the siteUrl and siteId match the selected site in the picker UI.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?