### PR TITLE
Subscribers: Show categories on subscribers details

### DIFF
--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -207,7 +207,7 @@ const SubscribersPage = ( {
 					{ isEnabled( 'subscribers-dataviews' ) ? (
 						// Your new dataviews component
 						<SubscriberDataViews
-							siteId={ selectedSite?.ID }
+							siteId={ selectedSite?.ID ?? null }
 							onGiftSubscription={ onGiftSubscription }
 							isUnverified={ isUnverified }
 							isStagingSite={ isStagingSite }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add categories back to subscriber details.

Before:

<img width="1145" alt="Screen Shot 2025-02-07 at 11 20 11 AM" src="https://github.com/user-attachments/assets/af76e830-4158-4e13-94f9-65d59919fe1d" />

After:

<img width="1149" alt="Screen Shot 2025-02-07 at 11 20 38 AM" src="https://github.com/user-attachments/assets/aac29e73-a5d6-48d1-a8ce-c7b135772a99" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* They were removed, but shouldn't have been.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable categories at settings/newsletter, and enable at least one newsletter category.
* Go to /subscribers/
* Add a subscriber to one or more categories.
* Click on that subscriber and verify that you see the categories in the subscriber details.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
