### PR TITLE
Reader User Profile: Make Read More link open in a separate tab

### DIFF
--- a/client/reader/user-profile/components/user-profile-header/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/index.tsx
@@ -80,7 +80,12 @@ const UserProfileHeader = ( { user }: UserProfileHeaderProps ): JSX.Element => {
 								{ isClamped && user.profile_URL && (
 									<>
 										<div className="user-profile-header__bio-desc-fader"></div>
-										<a className="user-profile-header__bio-desc-link" href={ user.profile_URL }>
+										<a
+											className="user-profile-header__bio-desc-link"
+											href={ user.profile_URL }
+											target="_blank"
+											rel="noopener noreferrer"
+										>
 											{ translate( 'Read More' ) }{ ' ' }
 											<Icon width={ 18 } height={ 18 } icon={ external } />
 										</a>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/99281
(This change was supposed to go in that PR, but I inadvertently didn't push the last commit)

## Proposed Changes

This makes sure the Read More link opens in a separate tab.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

1. It's an out of app flow, so we should make it open externally
2. The icon we are showing generally represents external links that should be opened in a new tab.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit the profile at `/read/users/robertbpugh` — ensure the Read More link opens in a separate tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
