### PR TITLE
A4A: Add Jetpack required banner to Plugins section

### DIFF
--- a/client/a8c-for-agencies/sections/plugins/plugins-jetpack-banner.tsx
+++ b/client/a8c-for-agencies/sections/plugins/plugins-jetpack-banner.tsx
@@ -1,0 +1,23 @@
+import { JetpackLogo } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import Banner from 'calypso/components/banner';
+
+export default function A4APluginsJetpackBanner() {
+	const translate = useTranslate();
+
+	return (
+		<div className="a4a-plugins-jetpack-banner-container">
+			<Banner
+				title={ translate( 'Jetpack Required for Plugin Management' ) }
+				description={ translate(
+					'To update plugins, Jetpack must be activated on each site. Your Pressable plan includes Jetpack Complete for free. Activate it to access plugin management in this dashboard.'
+				) }
+				icon={ <JetpackLogo size={ 16 } /> }
+				className="plugins__jetpack-banner"
+				dismissPreferenceName="a4a-plugins-jetpack-banner"
+				disableCircle
+				jetpack
+			/>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/plugins/plugins-jetpack-banner.tsx
+++ b/client/a8c-for-agencies/sections/plugins/plugins-jetpack-banner.tsx
@@ -10,7 +10,7 @@ export default function A4APluginsJetpackBanner() {
 			<Banner
 				title={ translate( 'Jetpack Required for Plugin Management' ) }
 				description={ translate(
-					'To update plugins, Jetpack must be activated on each site. Your Pressable plan includes Jetpack Complete for free. Activate it to access plugin management in this dashboard.'
+					'To manage plugins, Jetpack must be activated on each site. Your Pressable plan includes Jetpack Complete for free. Activate it to access plugin management in this dashboard.'
 				) }
 				icon={ <JetpackLogo size={ 16 } /> }
 				className="plugins__jetpack-banner"

--- a/client/my-sites/plugins/plugins-dashboard/index.tsx
+++ b/client/my-sites/plugins/plugins-dashboard/index.tsx
@@ -4,6 +4,7 @@ import pagejs from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import A4APluginsJetpackBanner from 'calypso/a8c-for-agencies/sections/plugins/plugins-jetpack-banner';
 import QueryJetpackSitesFeatures from 'calypso/components/data/query-jetpack-sites-features';
 import QueryPlugins from 'calypso/components/data/query-plugins';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -52,7 +53,6 @@ import { PluginComponentProps } from '../plugin-management-v2/types';
 import PluginsListDataViews from '../plugins-list/plugins-list-dataviews';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { Plugin } from 'calypso/state/plugins/installed/types';
-
 import './style.scss';
 
 interface PluginActionCallback {
@@ -344,6 +344,7 @@ const PluginsDashboard = ( {
 			<QueryProductsList />
 			<LayoutColumn className="sites-overview" wide>
 				<LayoutTop withNavigation={ false }>
+					{ isA8CForAgencies() && <A4APluginsJetpackBanner /> }
 					<LayoutHeader>
 						<Title>{ translate( 'Manage Plugins' ) }</Title>
 						{ ! pluginSlug && (


### PR DESCRIPTION
<img width="1376" alt="Screenshot 2025-02-07 at 19 34 42" src="https://github.com/user-attachments/assets/68753e8d-c420-4550-a077-f61a2f424830" />

Adds a banner informing users that Jetpack is required to manage plugins through the Plugin Management section.

## Testing Instructions

* Open the live link
* Go to the Plugins section and confirm you see the banner as displayed above.
* Confirm that you can dismiss it.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
