### PR TITLE
Subscribers: Update search placeholder

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -393,7 +393,11 @@ const SubscriberDataViews = ( {
 						defaultLayouts={ selectedSubscriber ? { list: {} } : { table: {} } }
 						actions={ actions }
 						search
-						searchLabel={ translate( 'Search by name, username or email…' ) }
+						searchLabel={
+							isEnglishLocale || hasTranslation( 'Search subscribers…' )
+								? translate( 'Search subscribers…' )
+								: translate( 'Search by name, username or email…' )
+						}
 					/>
 				) }
 			</section>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99467

## Proposed Changes

* Update the search placeholder to be shorter (not cut off by the width of the field).

Before | After
---- | ----
![Screen Shot 2025-02-07 at 2 55 22 PM](https://github.com/user-attachments/assets/11876396-8300-41cb-af89-b2a22e4eea0d) | ![Screen Shot 2025-02-07 at 2 55 13 PM](https://github.com/user-attachments/assets/98c455e6-6117-410b-8744-80d69445ad26)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Raised in https://github.com/Automattic/wp-calypso/issues/99467

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /subscribers/{site url}
* Check that the placeholder fits in the search field.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
