### PR TITLE
Use framenavigated to detect redirection in woo signup test

### DIFF
--- a/test/e2e/specs/onboarding/signup__woo-email.ts
+++ b/test/e2e/specs/onboarding/signup__woo-email.ts
@@ -55,7 +55,8 @@ describe(
 			} );
 
 			it( 'Activate account', async function () {
-				await page.goto( activationLink, { waitUntil: 'networkidle', timeout: 25000 } );
+				const activationPage = await browser.newPage();
+				await activationPage.goto( activationLink, { waitUntil: 'networkidle', timeout: 25000 } );
 			} );
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See p4TIVU-b2h-p2

## Proposed Changes

- Looking at the logs, most failed tests seem to be caused by timeouts while waiting for the WooCommerce.com redirection. Since we only need to verify that the redirection occurs, we don’t need to wait for the entire page to load. This PR uses framenavigated to detect the redirection, avoiding unnecessary wait time.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix flasky woo signup test.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check the code and make sure it makes sense.
* Run the test.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?