### PR TITLE
Stats: scope UTM builder modal style overrides

### DIFF
--- a/client/my-sites/stats/stats-module-utm-builder/style.scss
+++ b/client/my-sites/stats/stats-module-utm-builder/style.scss
@@ -19,15 +19,15 @@ $modal-content-padding: 32px;
 			max-height: 85%;
 		}
 	}
-}
 
-.components-modal__header {
-	font-family: $font-recoleta;
-
-	// Overwrite the modal's class
-	h1.components-modal__header-heading {
-		font-size: 32px; // stylelint-disable-line declaration-property-unit-allowed-list
-		line-height: 39px;
+	.components-modal__header {
+		font-family: $font-recoleta;
+	
+		// Overwrite the modal's class
+		h1.components-modal__header-heading {
+			font-size: 32px; // stylelint-disable-line declaration-property-unit-allowed-list
+			line-height: 39px;
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#99456](https://github.com/Automattic/wp-calypso/issues/99465)

## Proposed Changes

* Scope style overrides to common components so they don't leak into other instances

**Before**

https://github.com/user-attachments/assets/28edaa88-5aea-4bfb-a95d-c41de439f61f

**After**

https://github.com/user-attachments/assets/f3a336e1-bf3c-4574-b2d7-1fbbb4f5f922



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Some modal heading CSS overrides in the stats module was being preloaded when hovering over the WP link. This caused the overrides to change the styles of the Add Subscribers modal on `/subscribers/{SITE}`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/subscribers/{SITE_HOST}` (or Users -> Subscribers in the sidebar) on the Calypso live link
* Click the Add Subscribers button to launch the modal. Styles should look as expected.
* Close the modal and hover the WP logo link (this preloads some styles).
* Open the Add Subscribers modal again. Styles should not have changed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
