### PR TITLE
Remove Is Reskinned Flag: Remove isReskinned from all signup flows

### DIFF
--- a/client/components/emails/email-signup-titan-card/index.jsx
+++ b/client/components/emails/email-signup-titan-card/index.jsx
@@ -63,7 +63,6 @@ class EmailSignupTitanCard extends Component {
 			addButtonTitle,
 			extraClasses,
 			hideSkip = false,
-			isReskinned,
 			onAddButtonClick,
 			onSkipButtonClick,
 			showChevron,
@@ -73,39 +72,28 @@ class EmailSignupTitanCard extends Component {
 		const domainItem = signupDependencies.domainItem?.meta;
 		const classes = clsx( 'email-suggestion', extraClasses );
 
-		const wrapDivActionContainer = ( contentElement ) =>
-			isReskinned ? (
-				<div className="email-signup-titan-card__suggestion-action-container">
-					{ contentElement }
-				</div>
-			) : (
-				contentElement
-			);
-
 		return (
 			<>
 				<QueryProductsList />
 				<Card className={ classes } compact>
 					{ this.renderEmailSuggestion( domainItem ) }
-					{ wrapDivActionContainer(
-						<>
-							{ ! hideSkip && (
-								<Button
-									className="email-signup-titan-card__suggestion-action"
-									onClick={ onSkipButtonClick }
-								>
-									{ skipButtonTitle }
-								</Button>
-							) }
+					<div className="email-signup-titan-card__suggestion-action-container">
+						{ ! hideSkip && (
 							<Button
 								className="email-signup-titan-card__suggestion-action"
-								primary
-								onClick={ onAddButtonClick }
+								onClick={ onSkipButtonClick }
 							>
-								{ addButtonTitle }
+								{ skipButtonTitle }
 							</Button>
-						</>
-					) }
+						) }
+						<Button
+							className="email-signup-titan-card__suggestion-action"
+							primary
+							onClick={ onAddButtonClick }
+						>
+							{ addButtonTitle }
+						</Button>
+					</div>
 					{ showChevron && (
 						<Gridicon
 							className="email-signup-titan-card__suggestion-chevron"

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -10,7 +10,6 @@ import flows from 'calypso/signup/config/flows';
 import NavigationLink from 'calypso/signup/navigation-link';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
-import { isReskinnedFlow } from '../is-flow';
 import './style.scss';
 
 function PresalesChat() {
@@ -69,7 +68,7 @@ class StepWrapper extends Component {
 				rel={ this.props.isExternalBackUrl ? 'external' : '' }
 				labelText={ this.props.backLabelText }
 				allowBackFirstStep={ this.props.allowBackFirstStep || !! this.props.backUrl }
-				backIcon={ isReskinnedFlow( this.props.flowName ) ? 'chevron-left' : undefined }
+				backIcon="chevron-left"
 				queryParams={ this.props.queryParams }
 			/>
 		);
@@ -211,11 +210,9 @@ class StepWrapper extends Component {
 		} );
 		const enablePresales = flows.getFlow( flowName, this.props.userLoggedIn )?.enablePresales;
 
-		let sticky = false;
+		let sticky = null;
 		if ( isSticky !== undefined ) {
 			sticky = isSticky;
-		} else {
-			sticky = isReskinnedFlow( flowName ) ? null : false;
 		}
 
 		return (

--- a/client/signup/steps/site-options/index.tsx
+++ b/client/signup/steps/site-options/index.tsx
@@ -14,7 +14,6 @@ import './index.scss';
 
 interface Props {
 	goToNextStep: () => void;
-	isReskinned: boolean;
 	signupDependencies: any;
 	stepName: string;
 	flowName: string;

--- a/client/signup/steps/site-picker/index.jsx
+++ b/client/signup/steps/site-picker/index.jsx
@@ -29,7 +29,7 @@ class SitePicker extends Component {
 				<SiteSelector
 					filter={ this.filterSites }
 					onSiteSelect={ this.handleSiteSelect }
-					isReskinned={ this.props.isReskinned }
+					isReskinned
 				/>
 			</Card>
 		);

--- a/client/signup/steps/woocommerce-install/confirm/index.tsx
+++ b/client/signup/steps/woocommerce-install/confirm/index.tsx
@@ -29,7 +29,7 @@ const WarningsOrHoldsSection = styled.div`
 `;
 
 export default function Confirm( props: WooCommerceInstallProps ) {
-	const { goToNextStep, isReskinned } = props;
+	const { goToNextStep } = props;
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 
@@ -151,14 +151,14 @@ export default function Confirm( props: WooCommerceInstallProps ) {
 			headerText={ __( 'One final step' ) }
 			fallbackHeaderText={ __( 'One final step' ) }
 			subHeaderText={ __(
-				'We’ve highlighted a few important details you should review before we create your store. '
+				'We’ve highlighted a few important details you should review before we create your store.'
 			) }
 			fallbackSubHeaderText={ __(
-				'We’ve highlighted a few important details you should review before we create your store. '
+				'We’ve highlighted a few important details you should review before we create your store.'
 			) }
-			align={ isReskinned ? 'left' : 'center' }
+			align="left"
 			stepContent={ getContent() }
-			isWideLayout={ isReskinned }
+			isWideLayout
 			{ ...props }
 		/>
 	);

--- a/client/signup/steps/woocommerce-install/step-business-info/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-business-info/index.tsx
@@ -18,7 +18,7 @@ import type { WooCommerceInstallProps } from '..';
 import './style.scss';
 
 export default function StepBusinessInfo( props: WooCommerceInstallProps ) {
-	const { goToNextStep, isReskinned } = props;
+	const { goToNextStep } = props;
 	const { __ } = useI18n();
 
 	const dispatch = useDispatch();
@@ -115,9 +115,9 @@ export default function StepBusinessInfo( props: WooCommerceInstallProps ) {
 							options={ [
 								{ value: '', label: '' },
 								{ value: '0', label: __( "I don't have any products yet." ) },
-								{ value: '1-10', label: __( '1-10' ) },
-								{ value: '11-100', label: __( '11-101' ) },
-								{ value: '101-1000', label: __( '101-1000' ) },
+								{ value: '1-10', label: __( '1–10' ) },
+								{ value: '11-100', label: __( '11–101' ) },
+								{ value: '101-1000', label: __( '101–1000' ) },
 								{ value: '1000+', label: __( '1000+' ) },
 							] }
 							onChange={ updateProductCount }
@@ -242,9 +242,9 @@ export default function StepBusinessInfo( props: WooCommerceInstallProps ) {
 			fallbackHeaderText={ __( 'Tell us a bit about your business' ) }
 			subHeaderText={ __( 'We will guide you to get started based on your responses.' ) }
 			fallbackSubHeaderText={ __( 'We will guide you to get started based on your responses.' ) }
-			align={ isReskinned ? 'left' : 'center' }
+			align="left"
 			stepContent={ getContent() }
-			isWideLayout={ isReskinned }
+			isWideLayout
 			{ ...props }
 		/>
 	);

--- a/client/signup/steps/woocommerce-install/step-store-address/index.tsx
+++ b/client/signup/steps/woocommerce-install/step-store-address/index.tsx
@@ -39,7 +39,7 @@ const CityZipRow = styled.div`
 `;
 
 export default function StepStoreAddress( props: WooCommerceStoreAddressProps ) {
-	const { goToNextStep, isReskinned, signupDependencies } = props;
+	const { goToNextStep, signupDependencies } = props;
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 
@@ -223,9 +223,9 @@ export default function StepStoreAddress( props: WooCommerceStoreAddressProps ) 
 			fallbackSubHeaderText={ __(
 				'This will be used as your default business address. You can change it later if you need to.'
 			) }
-			align={ isReskinned ? 'left' : 'center' }
+			align="left"
 			stepContent={ getContent() }
-			isWideLayout={ isReskinned }
+			isWideLayout
 			{ ...props }
 		/>
 	);

--- a/client/signup/steps/woocommerce-install/transfer/index.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/index.tsx
@@ -76,7 +76,7 @@ export default function Transfer( props: WooCommerceInstallProps ) {
 			hideNext
 			hideSkip
 			hideFormattedHeader
-			isWideLayout={ props.isReskinned }
+			isWideLayout
 			stepContent={
 				<>
 					{ isAtomic && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to: https://github.com/Automattic/wp-calypso/issues/95419

## Proposed Changes

* Cleanups all the flags from the signup framework since all of the flows are now on the re-skinned theme

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Purge the isReskinned flag from the codebase

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* There should be no visible changes to any signup flows since this simply a code cleanup of variables

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
