### PR TITLE
Fix next step not showing when changing site name for sites with build intent

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -33,9 +33,9 @@ import {
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
-// Maps a field in the settings form to a checklist task slug
+// Maps a field in the settings form to a checklist task slug(s)
 const FIELDS_TO_LAUNCHPAD_TASKS = {
-	blogname: 'site_title',
+	blogname: [ 'site_title', 'setup_general' ],
 	'subscription_options.welcome': 'customize_welcome_message',
 };
 
@@ -111,9 +111,13 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 		displaySuccessNotice( noticeSettings ) {
 			const launchpadTasksToComplete = [];
 
-			Object.entries( FIELDS_TO_LAUNCHPAD_TASKS ).forEach( ( [ field, taskSlug ] ) => {
+			Object.entries( FIELDS_TO_LAUNCHPAD_TASKS ).forEach( ( [ field, taskSlugs ] ) => {
 				if ( get( this.state.modifiedFields, field ) ) {
-					launchpadTasksToComplete.push( taskSlug );
+					if ( Array.isArray( taskSlugs ) ) {
+						taskSlugs.forEach( ( taskSlug ) => launchpadTasksToComplete.push( taskSlug ) );
+					} else {
+						launchpadTasksToComplete.push( taskSlugs );
+					}
 				}
 			} );
 

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -113,11 +113,8 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 
 			Object.entries( FIELDS_TO_LAUNCHPAD_TASKS ).forEach( ( [ field, taskSlugs ] ) => {
 				if ( get( this.state.modifiedFields, field ) ) {
-					if ( Array.isArray( taskSlugs ) ) {
-						taskSlugs.forEach( ( taskSlug ) => launchpadTasksToComplete.push( taskSlug ) );
-					} else {
-						launchpadTasksToComplete.push( taskSlugs );
-					}
+					const slugs = Array.isArray( taskSlugs ) ? taskSlugs : [ taskSlugs ];
+					launchpadTasksToComplete.push( ...slugs );
 				}
 			} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Task-related: https://github.com/Automattic/wp-calypso/issues/98245
PT: pet6gk-1T7-p2

## Proposed Changes

* Check that `setup_general` task when is available when changing site name and show `Next steps` snacbar

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding` create a site with build intent
* In My Home, choose the `Give site a name` task
* Give your site a name and verify the snackbar shows with the `next step` cta

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?