### PR TITLE
Stats Locations: prevent redundant country-views API calls

### DIFF
--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -303,7 +303,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 
 	return (
 		<>
-			{ ! shouldGateStatsModule && siteId && statType && (
+			{ ! shouldGate && ! supportsLocationsStatsFeature && geoMode === 'country' && (
 				<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
 			) }
 			{ isRequestingData && ! shouldGate && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-roadmap/issues/2287

## Proposed Changes
- Update the condition for when the legacy country-views API is queried to only trigger when the new Locations feature is not supported and we're in country view mode

## Why are these changes being made?
Currently, we're querying the legacy country-views API even when the new Locations module is enabled, resulting in redundant API calls. Since the new Locations API is fetched using the `useLocationViewsQuery` hook, we only need the legacy API when the new feature is not supported.

This change optimizes the module by preventing unnecessary API requests, improving performance and reducing server load.

## Testing Instructions

> [!NOTE]
> The main goal of the tests is to ensure we are not calling the legacy country-views API if the site has Jetpack 14.2 or higher and the stats/locations feature flag is enabled.

### Setup
- Test on **Odyssey** using [PCYsg-Pp7-p2](https://example-link) (option 2)
  - Note: For Odyssey, append `?flags=stats/locations` to the URL

### Steps to Test

1. Using a site with **Jetpack 14.2 or higher**:
   - Navigate to the Stats page
   - Verify the countries list loads correctly
   - Check network requests — confirm there are **no calls** to the legacy country-views API
   - Switch between Countries/Regions/Cities tabs
     - Verify data loads correctly
     - Confirm there are still no calls to the legacy API

2. Using a site with **Jetpack 14.1 or lower**:
   - Navigate to the Stats page
   - Verify the countries list loads correctly
   - Check network requests — confirm you see a call to the legacy country-views API
   - Switch to Regions or Cities tabs
     - Verify you see the Jetpack upgrade prompt
     - Confirm no additional calls to the legacy API are made

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
