### PR TITLE
Hide DNS records summary if nameserver is external

### DIFF
--- a/client/my-sites/domains/domain-management/settings/dns/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/dns/index.tsx
@@ -18,6 +18,7 @@ const DnsDetails = ( {
 	selectedDomainName,
 	currentRoute,
 	selectedSite,
+	showDetails,
 }: DnsDetailsProps ) => {
 	const showPlaceholder = ! dns.hasLoadedFromServer;
 	const translate = useTranslate();
@@ -52,6 +53,7 @@ const DnsDetails = ( {
 
 	const renderDomains = () => {
 		let domainConnectRecordIsEnabled = false;
+		const showDNSSummary = ! showDetails === false;
 
 		const domains = dns.records.map( ( dnsRecord, index ) => {
 			const isRootRecord = dnsRecord.name === `${ selectedDomainName }.`;
@@ -77,8 +79,8 @@ const DnsDetails = ( {
 
 		return (
 			<>
-				{ domains }
-				{ domainConnectRecordIsEnabled && getDomainConnectDnsRecord() }
+				{ showDNSSummary && domains }
+				{ showDNSSummary && domainConnectRecordIsEnabled && getDomainConnectDnsRecord() }
 				<Button
 					className="dns-card__button"
 					href={ domainManagementDns( selectedSite.slug, selectedDomainName, currentRoute ) }

--- a/client/my-sites/domains/domain-management/settings/dns/types.ts
+++ b/client/my-sites/domains/domain-management/settings/dns/types.ts
@@ -7,6 +7,7 @@ export type DnsDetailsProps = {
 	selectedDomainName: string;
 	selectedSite: SiteDetails;
 	currentRoute: string;
+	showDetails?: boolean;
 };
 
 export type DnsRecordItemProps = {

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -439,6 +439,8 @@ const Settings = ( {
 			return null;
 		}
 
+		const showDnsRecordsSummary = areAllWpcomNameServers();
+
 		const selectedDomain = domains.find( ( domain ) => selectedDomainName === domain.name );
 		if ( ! selectedDomain ) {
 			return null;
@@ -460,6 +462,7 @@ const Settings = ( {
 								selectedDomainName={ selectedDomainName }
 								selectedSite={ selectedSite }
 								currentRoute={ currentRoute }
+								showDetails={ showDnsRecordsSummary }
 							/>
 						</>
 					) : (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9794

## Proposed Changes

* When Name Servers are external, hide the DNS records to remove confusion

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* From walkthrough

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a domain from /domains/manage
* Set the nameservers of that domain to so something other than on WPCOM, like Cloudflare
* Now open the DNS Records accordion
* Make sure you don't see the details anymore, however you should still be able to see the manage button
* Make sure that nothing has changed for the domains with WPCOM nameservers

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
