### PR TITLE
A4A: create new signup mutation and pass signup form data

### DIFF
--- a/client/a8c-for-agencies/sections/signup/hooks/use-create-signup-mutation.ts
+++ b/client/a8c-for-agencies/sections/signup/hooks/use-create-signup-mutation.ts
@@ -1,0 +1,46 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { APIError, Agency } from 'calypso/state/a8c-for-agencies/types';
+import { AgencyDetailsSignupPayload } from '../types';
+
+function createSignup( details: AgencyDetailsSignupPayload ): Promise< Agency > {
+	return wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: '/agency/signup',
+		body: {
+			first_name: details.firstName,
+			last_name: details.lastName,
+			email: details.email,
+			agency_name: details.agencyName,
+			agency_url: details.agencyUrl,
+			number_sites: details.managedSites,
+			user_type: details.userType,
+			services_offered: details.servicesOffered,
+			products_offered: details.productsOffered,
+			address_line1: details.line1,
+			address_line2: details.line2,
+			address_city: details.city,
+			address_country: details.country,
+			address_state: details.state,
+			address_postal_code: details.postalCode,
+			phone_number: details.phoneNumber ?? '',
+			referral_status: details.referer,
+			top_partnering_goal: details.topPartneringGoal,
+			top_yearly_goal: details.topYearlyGoal,
+			work_with_clients:
+				details.workWithClients === 'other'
+					? details.workWithClientsOther
+					: details.workWithClients,
+			approach_and_challenges: details.approachAndChallenges,
+		},
+	} );
+}
+
+export default function useCreateSignupMutation< TContext = unknown >(
+	options?: UseMutationOptions< Agency, APIError, AgencyDetailsSignupPayload, TContext >
+): UseMutationResult< Agency, APIError, AgencyDetailsSignupPayload, TContext > {
+	return useMutation< Agency, APIError, AgencyDetailsSignupPayload, TContext >( {
+		...options,
+		mutationFn: createSignup,
+	} );
+}

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
@@ -8,18 +8,12 @@ import FormRadio from 'calypso/components/forms/form-radio';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import { preventWidows } from 'calypso/lib/formatting';
+import { AgencyDetailsSignupPayload } from '../../../../types';
 
 import './style.scss';
 
 type Props = {
-	onContinue: () => void;
-};
-
-type FormData = {
-	topGoal: string;
-	mainGoal2025: string;
-	workModel: string;
-	specificApproach: string;
+	onContinue: ( data: Partial< AgencyDetailsSignupPayload > ) => void;
 };
 
 const BlueprintFormRadio = ( {
@@ -50,16 +44,17 @@ const BlueprintFormRadio = ( {
 
 const BlueprintForm: React.FC< Props > = ( { onContinue } ) => {
 	const translate = useTranslate();
-	const [ formData, setFormData ] = useState< FormData >( {
-		topGoal: '',
-		mainGoal2025: '',
-		workModel: '',
-		specificApproach: '',
+	const [ formData, setFormData ] = useState< Partial< AgencyDetailsSignupPayload > >( {
+		topPartneringGoal: '',
+		topYearlyGoal: '',
+		workWithClients: '',
+		workWithClientsOther: '',
+		approachAndChallenges: '',
 	} );
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
-		onContinue();
+		onContinue( formData );
 	};
 
 	const topGoalOptions = [
@@ -125,8 +120,8 @@ const BlueprintForm: React.FC< Props > = ( { onContinue } ) => {
 						<BlueprintFormRadio
 							key={ `goal-option-${ option.value }` }
 							label={ option.label }
-							checked={ formData.topGoal === option.value }
-							onChange={ () => setFormData( { ...formData, topGoal: option.value } ) }
+							checked={ formData.topPartneringGoal === option.value }
+							onChange={ () => setFormData( { ...formData, topPartneringGoal: option.value } ) }
 						/>
 					) ) }
 				</div>
@@ -141,8 +136,8 @@ const BlueprintForm: React.FC< Props > = ( { onContinue } ) => {
 						<BlueprintFormRadio
 							key={ `main-goal-2025-option-${ option.value }` }
 							label={ option.label }
-							checked={ formData.mainGoal2025 === option.value }
-							onChange={ () => setFormData( { ...formData, mainGoal2025: option.value } ) }
+							checked={ formData.topYearlyGoal === option.value }
+							onChange={ () => setFormData( { ...formData, topYearlyGoal: option.value } ) }
 						/>
 					) ) }
 				</div>
@@ -159,17 +154,16 @@ const BlueprintForm: React.FC< Props > = ( { onContinue } ) => {
 						<BlueprintFormRadio
 							key={ `work-model-option-${ option.value }` }
 							label={ option.label }
-							checked={ formData.workModel === option.value }
-							onChange={ () => setFormData( { ...formData, workModel: option.value } ) }
+							checked={ formData.workWithClients === option.value }
+							onChange={ () => setFormData( { ...formData, workWithClients: option.value } ) }
 						/>
 					) ) }
-					{ formData.workModel === 'other' && (
+					{ formData.workWithClients === 'other' && (
 						<FormTextInput
-							value={ formData.specificApproach }
-							onChange={ () => {
-								// TODO: form data
-								return;
-							} }
+							value={ formData.workWithClientsOther }
+							onChange={ ( e: React.ChangeEvent< HTMLInputElement > ) =>
+								setFormData( { ...formData, workWithClientsOther: e.target.value } )
+							}
 							placeholder={ translate( 'Add your explanation' ) }
 						/>
 					) }
@@ -182,9 +176,9 @@ const BlueprintForm: React.FC< Props > = ( { onContinue } ) => {
 				) }
 			>
 				<FormTextarea
-					value={ formData.specificApproach }
+					value={ formData.approachAndChallenges }
 					onChange={ ( e: React.ChangeEvent< HTMLTextAreaElement > ) =>
-						setFormData( { ...formData, specificApproach: e.target.value } )
+						setFormData( { ...formData, approachAndChallenges: e.target.value } )
 					}
 					placeholder={ translate( 'Add your approach' ) }
 				/>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import Form from 'calypso/a8c-for-agencies/components/form';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
 import FormFooter from 'calypso/a8c-for-agencies/components/form/footer';
+import { AgencyDetailsSignupPayload } from 'calypso/a8c-for-agencies/sections/signup/types';
 import QuerySmsCountries from 'calypso/components/data/query-countries/sms';
 import FormPhoneInput from 'calypso/components/forms/form-phone-input';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -13,17 +14,8 @@ import { preventWidows } from 'calypso/lib/formatting';
 
 import './style.scss';
 
-type FormData = {
-	firstName: string;
-	lastName: string;
-	email: string;
-	agencyName: string;
-	businessUrl: string;
-	phoneNumber: string;
-};
-
 type Props = {
-	onContinue: () => void;
+	onContinue: ( data: Partial< AgencyDetailsSignupPayload > ) => void;
 };
 
 const SignupContactForm = ( { onContinue }: Props ) => {
@@ -32,12 +24,12 @@ const SignupContactForm = ( { onContinue }: Props ) => {
 	const countriesList = useGetSupportedSMSCountries();
 	const noCountryList = countriesList.length === 0;
 
-	const [ formData, setFormData ] = useState< FormData >( {
+	const [ formData, setFormData ] = useState< Partial< AgencyDetailsSignupPayload > >( {
 		firstName: '',
 		lastName: '',
 		email: '',
 		agencyName: '',
-		businessUrl: '',
+		agencyUrl: '',
 		phoneNumber: '',
 	} );
 
@@ -49,7 +41,8 @@ const SignupContactForm = ( { onContinue }: Props ) => {
 	};
 
 	const handleInputChange =
-		( field: keyof FormData ) => ( event: React.ChangeEvent< HTMLInputElement > ) => {
+		( field: keyof AgencyDetailsSignupPayload ) =>
+		( event: React.ChangeEvent< HTMLInputElement > ) => {
 			setFormData( ( prev ) => ( {
 				...prev,
 				[ field ]: event.target.value,
@@ -58,7 +51,7 @@ const SignupContactForm = ( { onContinue }: Props ) => {
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
-		onContinue();
+		onContinue( formData );
 	};
 
 	return (
@@ -112,9 +105,9 @@ const SignupContactForm = ( { onContinue }: Props ) => {
 
 			<FormField label={ translate( 'Business URL' ) } isRequired>
 				<FormTextInput
-					name="businessUrl"
-					value={ formData.businessUrl }
-					onChange={ handleInputChange( 'businessUrl' ) }
+					name="agencyUrl"
+					value={ formData.agencyUrl }
+					onChange={ handleInputChange( 'agencyUrl' ) }
 					placeholder={ translate( 'Business URL' ) }
 				/>
 			</FormField>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
@@ -1,16 +1,26 @@
+import { APIError } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useCallback, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { AgencyDetailsSignupPayload } from 'calypso/a8c-for-agencies/sections/signup/types';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import useCreateSignupMutation from '../../../hooks/use-create-signup-mutation';
 import StepProgress from '../step-progress';
 import BlueprintForm from './blueprint-form';
 import ChoiceBlueprint from './choice-blueprint';
 import SignupContactForm from './contact-form';
 import FinishSignupSurvey from './finish-signup-survey';
 import PersonalizationForm from './personalization';
+
 import './style.scss';
 
 const MultiStepForm = () => {
 	const translate = useTranslate();
 	const [ currentStep, setCurrentStep ] = useState( 1 );
+	const dispatch = useDispatch();
+	const notificationId = 'a4a-agency-signup-form';
+
+	const [ formData, setFormData ] = useState< Partial< AgencyDetailsSignupPayload > >( {} );
 
 	const steps = [
 		{ label: translate( 'Sign up' ), isActive: currentStep === 1, isComplete: currentStep > 1 },
@@ -26,29 +36,56 @@ const MultiStepForm = () => {
 		},
 	];
 
+	const createSignup = useCreateSignupMutation( {
+		onSuccess: () => {
+			dispatch( successNotice( 'Signup successful', { id: notificationId } ) );
+		},
+		onError: ( error: APIError ) => {
+			dispatch( errorNotice( error?.message, { id: notificationId } ) );
+		},
+	} );
+
+	useEffect( () => {
+		if ( currentStep === 5 ) {
+			createSignup.mutate( formData as AgencyDetailsSignupPayload );
+		}
+	}, [ currentStep, formData, createSignup ] );
+
+	const updateDataAndContinue = useCallback(
+		( data: Partial< AgencyDetailsSignupPayload >, nextStep: number ) => {
+			setFormData( { ...formData, ...data } );
+
+			setCurrentStep( nextStep );
+		},
+		[ formData ]
+	);
+
+	const clearDataAndRefresh = () => {
+		setFormData( {} );
+		setCurrentStep( 1 );
+	};
+
 	const currentForm = useMemo( () => {
 		switch ( currentStep ) {
 			case 1:
-				return <SignupContactForm onContinue={ () => setCurrentStep( 2 ) } />;
+				return <SignupContactForm onContinue={ ( data ) => updateDataAndContinue( data, 2 ) } />;
 			case 2:
-				return <PersonalizationForm onContinue={ () => setCurrentStep( 3 ) } />;
+				return <PersonalizationForm onContinue={ ( data ) => updateDataAndContinue( data, 3 ) } />;
 			case 3:
 				return (
 					<ChoiceBlueprint
-						onContinue={ () => setCurrentStep( 4 ) }
-						onSkip={ () => setCurrentStep( 5 ) }
+						onContinue={ () => updateDataAndContinue( {}, 4 ) }
+						onSkip={ () => updateDataAndContinue( {}, 5 ) }
 					/>
 				);
 			case 4:
-				return <BlueprintForm onContinue={ () => setCurrentStep( 5 ) } />;
+				return <BlueprintForm onContinue={ ( data ) => updateDataAndContinue( data, 5 ) } />;
 			case 5:
-				return <FinishSignupSurvey onContinue={ () => setCurrentStep( 6 ) } />;
-			case 6:
-				return <h1>Thank you!</h1>;
+				return <FinishSignupSurvey onContinue={ clearDataAndRefresh } />;
 			default:
 				return null;
 		}
-	}, [ currentStep ] );
+	}, [ currentStep, updateDataAndContinue ] );
 
 	return (
 		<div className="signup-multi-step-form">

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
@@ -1,6 +1,6 @@
 import { APIError } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useState, useCallback, useEffect } from 'react';
+import { useMemo, useState, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { AgencyDetailsSignupPayload } from 'calypso/a8c-for-agencies/sections/signup/types';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -45,19 +45,16 @@ const MultiStepForm = () => {
 		},
 	} );
 
-	useEffect( () => {
-		if ( currentStep === 5 ) {
-			createSignup.mutate( formData as AgencyDetailsSignupPayload );
-		}
-	}, [ currentStep, formData, createSignup ] );
-
 	const updateDataAndContinue = useCallback(
 		( data: Partial< AgencyDetailsSignupPayload >, nextStep: number ) => {
-			setFormData( { ...formData, ...data } );
-
+			const newFormData = { ...formData, ...data };
+			setFormData( newFormData );
 			setCurrentStep( nextStep );
+			if ( nextStep === 5 ) {
+				createSignup.mutate( newFormData as AgencyDetailsSignupPayload );
+			}
 		},
-		[ formData ]
+		[ formData, createSignup ]
 	);
 
 	const clearDataAndRefresh = () => {

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -1,7 +1,7 @@
 import { SearchableDropdown } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState, ChangeEvent } from 'react';
+import { useState, ChangeEvent, useMemo } from 'react';
 import Form from 'calypso/a8c-for-agencies/components/form';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
 import FormFooter from 'calypso/a8c-for-agencies/components/form/footer';
@@ -51,25 +51,27 @@ export default function PersonalizationForm( { onContinue }: Props ) {
 		} ) );
 	};
 
-	const getServicesOfferedOptions = () => {
-		return [
+	const servicesOfferedOptions = useMemo(
+		() => [
 			{ value: 'strategy_consulting', label: translate( 'Strategy consulting' ) },
 			{ value: 'website_design_development', label: translate( 'Website design & development' ) },
 			{ value: 'performance_optimization', label: translate( 'Performance optimization' ) },
 			{ value: 'digital_strategy_marketing', label: translate( 'Digital strategy & marketing' ) },
 			{ value: 'maintenance_support_plans', label: translate( 'Maintenance & support plans' ) },
-		];
-	};
+		],
+		[ translate ]
+	);
 
-	const getProductsOfferedOptions = () => {
-		return [
+	const productsOfferedOptions = useMemo(
+		() => [
 			{ value: 'WordPress.com', label: translate( 'WordPress.com' ) },
 			{ value: 'WooCommerce', label: translate( 'WooCommerce' ) },
 			{ value: 'Jetpack', label: translate( 'Jetpack' ) },
 			{ value: 'Pressable', label: translate( 'Pressable' ) },
 			{ value: 'WordPress VIP', label: translate( 'WordPress VIP' ) },
-		];
-	};
+		],
+		[ translate ]
+	);
 
 	const handleSetCountry = ( value?: string | null ) => {
 		if ( ! value ) {
@@ -148,7 +150,7 @@ export default function PersonalizationForm( { onContinue }: Props ) {
 							id="services_offered"
 							name="services_offered"
 							checked={ formData.servicesOffered }
-							options={ getServicesOfferedOptions() }
+							options={ servicesOfferedOptions }
 							onChange={ handleSetServicesOffered as any }
 						/>
 					</FormField>
@@ -163,7 +165,7 @@ export default function PersonalizationForm( { onContinue }: Props ) {
 							id="products_offered"
 							name="products_offered"
 							checked={ formData.productsOffered }
-							options={ getProductsOfferedOptions() }
+							options={ productsOfferedOptions }
 							onChange={ handleSetProductsOffered as any }
 						/>
 					</FormField>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -6,6 +6,7 @@ import Form from 'calypso/a8c-for-agencies/components/form';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
 import FormFooter from 'calypso/a8c-for-agencies/components/form/footer';
 import { useCountriesAndStates } from 'calypso/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-countries-and-states';
+import { AgencyDetailsSignupPayload } from 'calypso/a8c-for-agencies/sections/signup/types';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
 import MultiCheckbox from 'calypso/components/forms/multi-checkbox';
@@ -13,31 +14,77 @@ import MultiCheckbox from 'calypso/components/forms/multi-checkbox';
 import './style.scss';
 
 interface Props {
-	onContinue: () => void;
+	onContinue: ( data: Partial< AgencyDetailsSignupPayload > ) => void;
 }
 
 export default function PersonalizationForm( { onContinue }: Props ) {
 	const translate = useTranslate();
 	const { countryOptions } = useCountriesAndStates();
 
-	const [ country, setCountry ] = useState( '' );
-	const [ userType, setUserType ] = useState( '' );
-	const [ managedSites, setManagedSites ] = useState( '' );
-	const [ servicesOffered, setServicesOffered ] = useState< string[] >( [] );
-	const [ productsOffered, setProductsOffered ] = useState< string[] >( [] );
+	const [ formData, setFormData ] = useState< Partial< AgencyDetailsSignupPayload > >( {
+		country: '',
+		userType: '',
+		managedSites: '',
+		servicesOffered: [],
+		productsOffered: [],
+	} );
+
+	const handleInputChange =
+		( field: keyof AgencyDetailsSignupPayload ) => ( event: ChangeEvent< HTMLSelectElement > ) => {
+			setFormData( ( prev ) => ( {
+				...prev,
+				[ field ]: event.target.value,
+			} ) );
+		};
 
 	const handleSetServicesOffered = ( services: { value: string[] } ) => {
-		setServicesOffered( services.value );
+		setFormData( ( prev ) => ( {
+			...prev,
+			servicesOffered: services.value,
+		} ) );
 	};
 
 	const handleSetProductsOffered = ( products: { value: string[] } ) => {
-		setProductsOffered( products.value );
+		setFormData( ( prev ) => ( {
+			...prev,
+			productsOffered: products.value,
+		} ) );
+	};
+
+	const getServicesOfferedOptions = () => {
+		return [
+			{ value: 'strategy_consulting', label: translate( 'Strategy consulting' ) },
+			{ value: 'website_design_development', label: translate( 'Website design & development' ) },
+			{ value: 'performance_optimization', label: translate( 'Performance optimization' ) },
+			{ value: 'digital_strategy_marketing', label: translate( 'Digital strategy & marketing' ) },
+			{ value: 'maintenance_support_plans', label: translate( 'Maintenance & support plans' ) },
+		];
+	};
+
+	const getProductsOfferedOptions = () => {
+		return [
+			{ value: 'WordPress.com', label: translate( 'WordPress.com' ) },
+			{ value: 'WooCommerce', label: translate( 'WooCommerce' ) },
+			{ value: 'Jetpack', label: translate( 'Jetpack' ) },
+			{ value: 'Pressable', label: translate( 'Pressable' ) },
+			{ value: 'WordPress VIP', label: translate( 'WordPress VIP' ) },
+		];
+	};
+
+	const handleSetCountry = ( value?: string | null ) => {
+		if ( ! value ) {
+			return;
+		}
+
+		setFormData( ( prev ) => ( {
+			...prev,
+			country: value,
+		} ) );
 	};
 
 	const handleSubmit = async ( e: React.FormEvent ) => {
 		e.preventDefault();
-
-		onContinue();
+		onContinue( formData );
 	};
 
 	return (
@@ -50,10 +97,8 @@ export default function PersonalizationForm( { onContinue }: Props ) {
 				<FormFieldset>
 					<FormField label={ translate( 'Where is your agency located?' ) } isRequired>
 						<SearchableDropdown
-							value={ country }
-							onChange={ ( value ) => {
-								setCountry( value ?? '' );
-							} }
+							value={ formData.country }
+							onChange={ handleSetCountry }
 							options={ countryOptions }
 							placeholder={ translate( 'Select country' ) }
 						/>
@@ -64,10 +109,8 @@ export default function PersonalizationForm( { onContinue }: Props ) {
 					<FormField label={ translate( 'How would you describe yourself?' ) } isRequired>
 						<FormSelect
 							id="user_type"
-							value={ userType }
-							onChange={ ( e: ChangeEvent< HTMLSelectElement > ) => {
-								setUserType( e.target.value );
-							} }
+							value={ formData.userType }
+							onChange={ handleInputChange( 'userType' ) }
 						>
 							<option value="">{ translate( 'Select option' ) }</option>
 							<option value="agency_owner">{ translate( 'Agency owner' ) }</option>
@@ -85,10 +128,8 @@ export default function PersonalizationForm( { onContinue }: Props ) {
 					<FormField label={ translate( 'How many sites do you manage?' ) } isRequired>
 						<FormSelect
 							id="managed_sites"
-							value={ managedSites }
-							onChange={ ( e: ChangeEvent< HTMLSelectElement > ) => {
-								setManagedSites( e.target.value );
-							} }
+							value={ formData.managedSites }
+							onChange={ handleInputChange( 'managedSites' ) }
 						>
 							<option value="">{ translate( 'Select option' ) }</option>
 							<option value="1-5">{ translate( '1-5' ) }</option>
@@ -106,26 +147,8 @@ export default function PersonalizationForm( { onContinue }: Props ) {
 						<MultiCheckbox
 							id="services_offered"
 							name="services_offered"
-							checked={ servicesOffered }
-							options={ [
-								{ value: 'strategy_consulting', label: translate( 'Strategy consulting' ) },
-								{
-									value: 'website_design_development',
-									label: translate( 'Website design & development' ),
-								},
-								{
-									value: 'performance_optimization',
-									label: translate( 'Performance optimization' ),
-								},
-								{
-									value: 'digital_strategy_marketing',
-									label: translate( 'Digital strategy & marketing' ),
-								},
-								{
-									value: 'maintenance_support_plans',
-									label: translate( 'Maintenance & support plans' ),
-								},
-							] }
+							checked={ formData.servicesOffered }
+							options={ getServicesOfferedOptions() }
 							onChange={ handleSetServicesOffered as any }
 						/>
 					</FormField>
@@ -139,14 +162,8 @@ export default function PersonalizationForm( { onContinue }: Props ) {
 						<MultiCheckbox
 							id="products_offered"
 							name="products_offered"
-							checked={ productsOffered }
-							options={ [
-								{ value: 'WordPress.com', label: translate( 'WordPress.com' ) },
-								{ value: 'WooCommerce', label: translate( 'WooCommerce' ) },
-								{ value: 'Jetpack', label: translate( 'Jetpack' ) },
-								{ value: 'Pressable', label: translate( 'Pressable' ) },
-								{ value: 'WordPress VIP', label: translate( 'WordPress VIP' ) },
-							] }
+							checked={ formData.productsOffered }
+							options={ getProductsOfferedOptions() }
 							onChange={ handleSetProductsOffered as any }
 						/>
 					</FormField>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/signup-wrapper/sidebar-image.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/signup-wrapper/sidebar-image.tsx
@@ -13,7 +13,7 @@ const SignupSidebarImage = ( { className }: Props ) => {
 			className={ className }
 			xmlns="http://www.w3.org/2000/svg"
 		>
-			<g clip-path="url(#clip0_8498_167)">
+			<g clipPath="url(#clip0_8498_167)">
 				<path
 					d="M125.275 96C61.952 151.947 -14.2017 300.396 48.294 316.872C166.434 348.016 277.997 154.178 335.94 200.515C425.78 272.36 34.5 431 225 750.5"
 					stroke="#98DBFF"

--- a/client/a8c-for-agencies/sections/signup/types.ts
+++ b/client/a8c-for-agencies/sections/signup/types.ts
@@ -1,0 +1,25 @@
+export interface AgencyDetailsSignupPayload {
+	firstName: string;
+	lastName: string;
+	agencyName: string;
+	agencyUrl: string;
+	managedSites?: string;
+	userType: string;
+	servicesOffered: string[];
+	productsOffered: string[];
+	email: string;
+	city: string;
+	line1: string;
+	line2: string;
+	country: string;
+	postalCode: string;
+	phoneNumber?: string;
+	state: string;
+	referer?: string | null;
+	tos?: 'consented';
+	topPartneringGoal?: string;
+	topYearlyGoal?: string;
+	workWithClients?: string;
+	workWithClientsOther?: string;
+	approachAndChallenges?: string;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1738

## Proposed Changes

- This PR handles FormData updates on every page and sends `/signup` request when the form is finished.

Note: this PR doesn't handle validation and it will be done in a separate task.

<img width="481" alt="Screenshot 2025-02-07 at 3 28 02 PM" src="https://github.com/user-attachments/assets/217ed19b-e142-4435-be57-a3d01d6ba4f7" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link below navigate to `/signup/wc-asia`
- Open dev tools
- Fill in the form
- On the last step, check network tab and validate the parameters.
- This PR can also be tested with backend draft: 172607-ghe-Automattic/wpcom

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?