### PR TITLE
Site Migration: Fix the copy when importing a site

### DIFF
--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -38,8 +38,8 @@ export default function ListStep( props: Props ) {
 	const { siteSlug, submit, getFinalImporterUrl, onNavBack } = props;
 	const backToFlow = urlQueryParams.get( 'backToFlow' );
 	const fromSite = urlQueryParams.get( 'from' );
-	const title = props.title || __( 'Import content from another platform' );
-	const subTitle = props.subTitle || __( 'Select the platform where your content lives' );
+	const title = props.title || __( 'Import content from another platform or file' );
+	const subTitle = props.subTitle || __( "Select the platform you're coming from" );
 
 	// We need to remove the wix importer from the primary importers list.
 	const primaryListOptions: ImporterOption[] = getImportersAsImporterOption( 'primary' ).filter(

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -184,7 +184,7 @@ export class StartImportFlow {
 	 */
 	async validateImporterListPage(): Promise< void > {
 		await this.page
-			.locator( selectors.startBuildingHeader( 'Import content from another platform' ) )
+			.locator( selectors.startBuildingHeader( 'Import content from another platform or file' ) )
 			.waitFor();
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #98101

## Proposed Changes

* Fix the title and the subtitle on the Import step to make it clear we receive a file
  * Updated the title to: Import content from another platform or file
  * Subtitle to: Select the platform you're coming from 

<img width="1512" alt="Captura de Tela 2025-02-09 às 11 57 49" src="https://github.com/user-attachments/assets/daca66f5-ec97-4dfe-9a2a-5866653b2e2d" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As per this comment paYJgx-5HR-p2#comment-5662, it wasn't clear that we import the sites using an archive file.

> The import process is unclear because the initial screen doesn’t explicitly mention importing an archive file. Instead, it focuses on “importing from a current platform,” which could confuse users who possess an archive (but may not know what it does). The flow assumes a direct site-to-site migration.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link below.
* Go through the migration flow until you reach the "Let’s find your site" step.
* On the "Let’s find your site" step, click on the "pick your current platform from a list" link below the continue button.
* You should see the Import List step with the new Copy.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?