### PR TITLE
Enable newsletter goal based on experiment assignment

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -58,7 +58,8 @@ const GoalsStep: Step = ( { navigation, flow } ) => {
 	const { setGoals, setIntent, resetIntent } = useDispatch( ONBOARD_STORE );
 	const refParameter = getQueryArgs()?.ref as string;
 
-	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
+	const [ , isGoalsAtFrontExperiment, variationName ] = useGoalsFirstExperiment();
+	const isIntentNewsletterGoalEnabled = variationName === 'treatment_cumulative';
 
 	useEffect( () => {
 		resetIntent();
@@ -111,7 +112,7 @@ const GoalsStep: Step = ( { navigation, flow } ) => {
 	const getStepSubmissionHandler =
 		( action: string, eventProps: Record< string, unknown > = {} ) =>
 		() => {
-			const intent = goalsToIntent( goals );
+			const intent = goalsToIntent( goals, isIntentNewsletterGoalEnabled );
 			setIntent( intent );
 
 			recordGoalsSelectTracksEvent( goals, intent );

--- a/client/landing/stepper/declarative-flow/site-setup-wg-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-wg-flow.ts
@@ -31,7 +31,7 @@ const siteSetupWithoutGoalsFlow: FlowV1 = {
 		const { site } = useSiteData();
 
 		useEffect( () => {
-			setIntent( goalsToIntent( site?.options?.site_goals ?? [] ) );
+			setIntent( goalsToIntent( site?.options?.site_goals ?? [], false ) );
 			setGoals( site?.options?.site_goals ?? [] );
 		}, [ site, setIntent, setGoals ] );
 

--- a/packages/data-stores/src/onboard/test/utils.ts
+++ b/packages/data-stores/src/onboard/test/utils.ts
@@ -39,24 +39,32 @@ describe( 'Test onboard utils', () => {
 			expectedIntent: SiteIntent.Write,
 		},
 		{
-			goals: [ SiteGoal.Write, SiteGoal.Engagement ],
+			goals: [ SiteGoal.Write, SiteGoal.Newsletter ],
 			expectedIntent: SiteIntent.Write,
+			isIntentNewsletterGoalsEnabled: false,
 		},
 		{
 			goals: [ SiteGoal.Write, SiteGoal.Newsletter ],
 			expectedIntent: SiteIntent.NewsletterGoal,
+			isIntentNewsletterGoalsEnabled: true,
+		},
+		{
+			goals: [ SiteGoal.Sell, SiteGoal.Newsletter ],
+			expectedIntent: SiteIntent.Sell,
+			isIntentNewsletterGoalsEnabled: false,
 		},
 		{
 			goals: [ SiteGoal.Sell, SiteGoal.Newsletter ],
 			expectedIntent: SiteIntent.NewsletterGoal,
+			isIntentNewsletterGoalsEnabled: true,
 		},
 	] )(
 		'Should map the $goals to $expectedIntent intent ($featureFlags)',
-		( { goals, expectedIntent, featureFlags = {} } ) => {
+		( { goals, expectedIntent, featureFlags = {}, isIntentNewsletterGoalsEnabled = false } ) => {
 			( config.isEnabled as jest.Mock ).mockImplementation( ( flag ) =>
 				Boolean( featureFlags[ flag ] )
 			);
-			expect( goalsToIntent( goals ) ).toBe( expectedIntent );
+			expect( goalsToIntent( goals, isIntentNewsletterGoalsEnabled ) ).toBe( expectedIntent );
 		}
 	);
 } );

--- a/packages/data-stores/src/onboard/utils.ts
+++ b/packages/data-stores/src/onboard/utils.ts
@@ -1,6 +1,9 @@
 import { SiteGoal, SiteIntent } from './constants';
 
-export const goalsToIntent = ( goals: SiteGoal[] ): SiteIntent => {
+export const goalsToIntent = (
+	goals: SiteGoal[],
+	isIntentNewsletterGoalEnabled: boolean
+): SiteIntent => {
 	// When DIFM and Import goals are selected together, DIFM Intent will have the priority and will be set.
 	if ( goals.includes( SiteGoal.DIFM ) ) {
 		return SiteIntent.DIFM;
@@ -11,7 +14,7 @@ export const goalsToIntent = ( goals: SiteGoal[] ): SiteIntent => {
 	}
 
 	// Newsletter flow
-	if ( goals.includes( SiteGoal.Newsletter ) ) {
+	if ( isIntentNewsletterGoalEnabled && goals.includes( SiteGoal.Newsletter ) ) {
 		return SiteIntent.NewsletterGoal;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98305

## Proposed Changes

This change ensures that the newsletter goal is only used if the
user is in the cumulative treatment group.

This changes the logic in #99445 which released the behaviour to all
users.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The release should have always been only to the cumulative group.
p1739142831953399-slack-C04H4NY6STW

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow the CfT instructions pdtkmj-3k2-p2 (except the `?flags=onboarding/newsletter-goal` query param will now be ignored, use 22180-explat-experiment experiment assignment instead)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?