### PR TITLE
Launchpad requests goals-first cumulative experience

### DIFF
--- a/client/data/experiment/use-goals-first-cumulative-experience.ts
+++ b/client/data/experiment/use-goals-first-cumulative-experience.ts
@@ -1,0 +1,47 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { ONBOARDING_FLOW } from '@automattic/onboarding';
+import { useMemo } from 'react';
+import { getFlowFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
+import { useExperiment } from 'calypso/lib/explat';
+import { useSelector } from 'calypso/state';
+import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
+import type { AppState } from 'calypso/types';
+
+export const EXPERIMENT_NAME = 'calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131';
+
+/**
+ * Check whether the user should have the cumulative improvements to the "goals first" onboarding experience.
+ *
+ * Returns [ isLoading, isCumulativeExperience ]
+ */
+export function useGoalsFirstCumulativeExperience(): [ boolean, boolean ] {
+	const flow = useMemo( () => getFlowFromURL(), [] );
+
+	const inOnboardingFlow = flow === ONBOARDING_FLOW;
+
+	const selectedSite = useSelector( ( state: AppState ) => getSelectedSite( state ) );
+	const isSelectedSiteEligible =
+		selectedSite?.options?.site_creation_flow === ONBOARDING_FLOW &&
+		( selectedSite.options.created_at ?? '' ) > '2025-02-03T10:22:45+00:00'; // If created_at is null then this expression is false
+
+	const [ isLoading, experimentAssignment ] = useExperiment( EXPERIMENT_NAME, {
+		isEligible:
+			( inOnboardingFlow || isSelectedSiteEligible ) &&
+			! isEnabled( 'onboarding/force-goals-first' ),
+	} );
+
+	if ( isEnabled( 'onboarding/force-goals-first' ) ) {
+		return [ false, true ];
+	}
+
+	/**
+	 * If the user is not eligible, we'll treat them as if they were in the
+	 * holdout/control group so we can provide the existing experience.
+	 *
+	 * This fallback is necessary because experimentAssignment returns null when the user
+	 * is not eligible, and we're using this hook within steps that are used by other flows.
+	 */
+	const variationName = experimentAssignment?.variationName ?? 'control';
+
+	return [ isLoading, variationName === 'treatment_cumulative' ];
+}

--- a/client/landing/stepper/declarative-flow/helpers/use-goals-first-experiment.ts
+++ b/client/landing/stepper/declarative-flow/helpers/use-goals-first-experiment.ts
@@ -9,9 +9,9 @@ export const EXPERIMENT_NAME = 'calypso_signup_onboarding_goals_first_flow_holdo
 /**
  * Check whether the user should have the "goals first" onboarding experience.
  *
- * Returns [ isLoading, isGoalsAtFrontExperiment, variationName ]
+ * Returns [ isLoading, isGoalsAtFrontExperiment ]
  */
-export function useGoalsFirstExperiment(): [ boolean, boolean, string ] {
+export function useGoalsFirstExperiment(): [ boolean, boolean ] {
 	const flow = useMemo( () => getFlowFromURL(), [] );
 
 	const [ isLoading, experimentAssignment ] = useExperiment( EXPERIMENT_NAME, {
@@ -19,7 +19,7 @@ export function useGoalsFirstExperiment(): [ boolean, boolean, string ] {
 	} );
 
 	if ( isEnabled( 'onboarding/force-goals-first' ) ) {
-		return [ false, true, 'control' ];
+		return [ false, true ];
 	}
 
 	/**
@@ -37,5 +37,5 @@ export function useGoalsFirstExperiment(): [ boolean, boolean, string ] {
 		variationName
 	);
 
-	return [ isLoading, isGoalsAtFrontExperiment, variationName ];
+	return [ isLoading, isGoalsAtFrontExperiment ];
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -5,6 +5,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
+import { useGoalsFirstCumulativeExperience } from 'calypso/data/experiment/use-goals-first-cumulative-experience';
 import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
 import { isGoalsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-big-sky-eligible';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
@@ -58,8 +59,8 @@ const GoalsStep: Step = ( { navigation, flow } ) => {
 	const { setGoals, setIntent, resetIntent } = useDispatch( ONBOARD_STORE );
 	const refParameter = getQueryArgs()?.ref as string;
 
-	const [ , isGoalsAtFrontExperiment, variationName ] = useGoalsFirstExperiment();
-	const isIntentNewsletterGoalEnabled = variationName === 'treatment_cumulative';
+	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
+	const [ , isIntentNewsletterGoalEnabled ] = useGoalsFirstCumulativeExperience();
 
 	useEffect( () => {
 		resetIntent();

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -5,6 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import { type FC } from 'react';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { useGoalsFirstCumulativeExperience } from 'calypso/data/experiment/use-goals-first-cumulative-experience';
 import { useLaunchpad } from './use-launchpad';
 
 import './style.scss';
@@ -18,7 +19,7 @@ const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( {
 	checklistSlug,
 	onSiteLaunched,
 }: CustomerHomeLaunchpadProps ) => {
-	const launchpadContext = 'customer-home';
+	const launchpadContext = useLaunchpadContext();
 	const translate = useTranslate();
 
 	const {
@@ -92,5 +93,14 @@ const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( {
 		</div>
 	);
 };
+
+function useLaunchpadContext() {
+	const [ isLoading, isCumulative ] = useGoalsFirstCumulativeExperience();
+	if ( isLoading ) {
+		return null;
+	}
+
+	return isCumulative ? 'customer-home-treatment-cumulative' : 'customer-home';
+}
 
 export default CustomerHomeLaunchpad;

--- a/client/my-sites/customer-home/cards/launchpad/use-launchpad.ts
+++ b/client/my-sites/customer-home/cards/launchpad/use-launchpad.ts
@@ -12,7 +12,7 @@ import type { AppState } from 'calypso/types';
 
 interface UseLaunchpadProps {
 	checklistSlug: string;
-	launchpadContext: string;
+	launchpadContext: string | null;
 }
 
 export function useLaunchpad( { checklistSlug, launchpadContext }: UseLaunchpadProps ) {
@@ -25,7 +25,11 @@ export function useLaunchpad( { checklistSlug, launchpadContext }: UseLaunchpadP
 	const {
 		data: { checklist, is_dismissed: isDismissed, is_dismissible: isDismissible, title },
 		refetch,
-	} = useSortedLaunchpadTasks( siteSlug, checklistSlug, launchpadContext );
+	} = useSortedLaunchpadTasks(
+		launchpadContext ? siteSlug : null, // Prevents launchpad data from loading until launchpadContext is loaded
+		checklistSlug,
+		launchpadContext ?? ''
+	);
 
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
@@ -7,7 +7,7 @@ import {
 } from '@automattic/calypso-products';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
-import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
+import { useGoalsFirstCumulativeExperience } from 'calypso/data/experiment/use-goals-first-cumulative-experience';
 import PlanItem from './plan-item';
 import { RowWithBorder } from '.';
 
@@ -29,8 +29,7 @@ export default function SuggestedPlanSection( {
 }: Props ) {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
-	const [ , , variationName ] = useGoalsFirstExperiment();
-	const shouldUseNewCopy = variationName === 'treatment_cumulative';
+	const [ , shouldUseNewCopy ] = useGoalsFirstCumulativeExperience();
 
 	const suggestedPlans = [
 		{

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -138,6 +138,7 @@ export const useLaunchpad = (
 			is_dismissible: false,
 			title: null,
 		},
+		enabled: Boolean( siteSlug ),
 	} );
 };
 

--- a/packages/launchpad/src/launchpad.tsx
+++ b/packages/launchpad/src/launchpad.tsx
@@ -17,7 +17,7 @@ export const SITE_STORE = Site.register( { client_id: '', client_secret: '' } );
 type LaunchpadProps = {
 	siteSlug: string | null;
 	checklistSlug: string;
-	launchpadContext: string;
+	launchpadContext: string | null;
 	onSiteLaunched?: () => void;
 	onTaskClick?: EventHandlers[ 'onTaskClick' ];
 	onPostFilterTasks?: ( tasks: Task[] ) => Task[];
@@ -35,7 +35,11 @@ const Launchpad = ( {
 }: LaunchpadProps ) => {
 	const {
 		data: { checklist },
-	} = useSortedLaunchpadTasks( siteSlug, checklistSlug, launchpadContext );
+	} = useSortedLaunchpadTasks(
+		launchpadContext ? siteSlug : null, // Prevents launchpad data from loading until launchpadContext is loaded
+		checklistSlug,
+		launchpadContext ?? ''
+	);
 
 	const tasklistCompleted = checklist?.every( ( task: Task ) => task.completed ) || false;
 
@@ -73,6 +77,10 @@ const Launchpad = ( {
 	const launchpadOptions = {
 		onSuccess: sortLaunchpadTasksByCompletionStatus,
 	};
+
+	if ( ! launchpadContext ) {
+		return null;
+	}
 
 	return (
 		<>

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -31,7 +31,7 @@ export type LaunchpadChecklist = Task[];
 
 export type LaunchpadTracksData = {
 	checklistSlug: string;
-	launchpadContext: string;
+	launchpadContext: string | null;
 	recordTracksEvent: ( event: string, properties: Record< string, unknown > ) => void;
 	tasklistCompleted: boolean;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98877

## Proposed Changes

- Splits the "cumulative_treatment" code out of `useGoalsFirstExperiment()` and into another hook
- Use the site's creation flow and date to help determine whether a site/user is eligible for the cumulative improvements
- `useLaunchpad()` only makes request if it has a valid `siteSlug`
- Customer Home's launchpad waits for experiment assignment to load before requesting launchpad data
- Customer Home now now sends `launchpad_context=customer-home-treatment-cumulative` if the user is in that experiment cohort

## Why are we making these changes?

This change refactors the `launchpadContext` code so it can be aware of whether the user should see cumulative improvements to the goals-first flow.

The new hook `useGoalsFirstCumulativeExperience` is introduced to determine if the user should see the cumulative improvements. This replaces the use of `useGoalsFirstExperiment()` for determining whether the user is in the cumulative group or not. The new hook also supports working outside of the stepper framework, since some cumulative improvements will be outside of the stepper.

This change is related to https://github.com/Automattic/wp-calypso/issues/98877 because we need to make changes to the backend logic of the launchpad, however Jetpack doesn't know enough to know whether the user should see the cumulative improvements or not. The first use of `useGoalsFirstCumulativeExperience()` is to set `launchpad_context=customer-home-treatment-cumulative` so we can make those server side changes. See https://github.com/Automattic/jetpack/pull/41326.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use 22180-explat-experiment to assign yourself to a cohort
* Go through `/setup/onboarding`, confirming you still see the correct onboarding experience for your cohort
* Confirm requests for launchpad data send the correct `launchpad_context` query param for the cohort you've selected
* Optionally test with https://github.com/Automattic/jetpack/pull/41326, to ensure only the cumulative cohort sees improvements to the verify email task (i.e. the verify email task is only hidden for existing users when those existing users are in the cumulative cohort )

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?