### PR TITLE
Redirect to /settings/general if the RDV experiment is DISABLED

### DIFF
--- a/client/my-sites/site-settings/settings-controller.js
+++ b/client/my-sites/site-settings/settings-controller.js
@@ -88,7 +88,7 @@ export async function redirectGeneralSettingsIfDuplicatedViewsEnabled( context, 
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSelectedSiteSlug( state );
 
-	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( context.store.getState() );
+	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( state );
 	const hasClassicAdminInterfaceStyle =
 		getSiteOption( state, siteId, 'wpcom_admin_interface' ) === 'wp-admin';
 	if ( isUntangled && hasClassicAdminInterfaceStyle ) {
@@ -96,6 +96,22 @@ export async function redirectGeneralSettingsIfDuplicatedViewsEnabled( context, 
 	}
 
 	redirectIfDuplicatedView( 'options-general.php' )( context, next );
+}
+
+/**
+ * Redirect to /settings/general if the Remove Duplicate Views experiment is DISABLED
+ * since /sites/settings/site/:site looks broken for those users.
+ */
+export async function redirectSiteSettingsIfDuplicatedViewsDisabled( context, next ) {
+	const state = context.store.getState();
+	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( state );
+	const siteSlug = getSelectedSiteSlug( state );
+
+	if ( ! isUntangled ) {
+		return page.redirect( `/settings/general/${ siteSlug }` );
+	}
+
+	next();
 }
 
 export async function siteSettings( context, next ) {

--- a/client/sites/settings/index.tsx
+++ b/client/sites/settings/index.tsx
@@ -5,6 +5,7 @@ import {
 	redirectIfCurrentUserCannot,
 } from 'calypso/controller';
 import { siteSelection, navigation, sites } from 'calypso/my-sites/controller';
+import { redirectSiteSettingsIfDuplicatedViewsDisabled } from 'calypso/my-sites/site-settings/settings-controller';
 import {
 	SETTINGS_SITE,
 	SETTINGS_ADMINISTRATION,
@@ -36,6 +37,7 @@ export default function () {
 		siteSelection,
 		navigation,
 		redirectIfCurrentUserCannot( 'manage_options' ),
+		redirectSiteSettingsIfDuplicatedViewsDisabled,
 		siteSettings,
 		siteDashboard( SETTINGS_SITE ),
 		makeLayout,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1739023467265609-slack-C07H21B2W59, https://github.com/Automattic/wp-calypso/pull/99388, https://github.com/Automattic/wp-calypso/pull/98875/, https://github.com/Automattic/dotcom-forge/issues/10387

## Proposed Changes

This PR changes to redirect from `/sites/settings/site` to `/settings/general` if the Remove Duplicated Views (RDV) experiment is DISABLED. This prevents RDV `control` users from encountering the broken Settings tab. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

p1739170725703829/1739159536.734729-slack-CRWCHQGUB

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. **Ensure you have access to the RDV experiment flags.**  
   - Toggle the RDV experiment between `treatment` and `control` via 22167-explat-experiment 
2. **Verify behavior for users in the `treatment` group (RDV enabled):**  
   - **Default Interface sites:**  
     - Navigating to `/settings/general` should redirect to `options-general.php`.  
     - Navigating to `/sites/settings/site` should stay at `/sites/settings/site`.  
   - **Classic Interface sites:**  
     - Navigating to `/settings/general` should redirect to `/sites/settings/site`.  
     - Navigating to `/sites/settings/site` should stay at `/sites/settings/site`. (extra context in https://github.com/Automattic/wp-calypso/pull/98875's "Redirection logic" and https://github.com/Automattic/wp-calypso/issues/99391
3. **Verify behavior for users in the `control` group (RDV disabled):**  
   - **Default Interface sites:**  
     - 🆕 Navigating to `/sites/settings/site` should redirect to `/settings/general`.  
     - Navigating to `/settings/general` should stay at `/settings/general`.  
   - **Classic Interface sites:**  
     - 🆕 Navigating to `/sites/settings/site` should redirect to `/settings/general`.  
     - Navigating to `/settings/general` should stay at `/settings/general`.  

<details><summary>Additional Regression Tests:</summary>
<p>

### **Treatment Group (RDV Enabled)**
- **Default Interface Sites:**
  - **Calypso:**
    - New **Settings** tab appears in the Hosting Dashboard.
    - Navigating to **Settings > General** redirects to `options-general.php`.
  - **wp-admin:**
    - `options-general.php` contains a link to `/sites/settings/site` (**WordPress.com Site Settings**).
    - `options-reading.php` contains a link to `/sites/settings/site` (**Site Visibility**).
- **Classic Interface Sites:**
  - **Same behavior as Default Interface Sites.**

### **Control Group (RDV Disabled)**
- **Default Interface Sites:**
  - **Calypso:**
    - Old **Server Settings** tab appears in the Hosting Dashboard.
    - Navigating to **Settings > General** should be at `/settings/general`.
  - **wp-admin:**
    - `options-general.php` should **not** contain a link to `/sites/settings/site` (**WordPress.com Site Settings**).
    - `options-reading.php` should **not** contain a link to `/sites/settings/site` (**Site Visibility**).
- **Classic Interface Sites:**
  - **Calypso:**
    - Old **Server Settings** tab appears in the Hosting Dashboard.
    - Navigating to **Settings > General** should be at `/settings/general` (**Hosting > Site Settings**).
  - **wp-admin:**
    - **Same behavior as Default Interface Sites.**

</p>
</details>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?