### PR TITLE
Site: Removing coming soon badge

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -13,17 +13,11 @@ import SiteIndicator from 'calypso/my-sites/site-indicator';
 import SitesMigrationTrialBadge from 'calypso/sites-dashboard/components/sites-migration-trial-badge';
 import SitesStagingBadge from 'calypso/sites-dashboard/components/sites-staging-badge';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { isTrialSite } from 'calypso/state/sites/plans/selectors';
-import {
-	getSite,
-	getSiteSlug,
-	isSitePreviewable,
-	getSiteOption,
-} from 'calypso/state/sites/selectors';
+import { getSite, getSiteSlug, isSitePreviewable } from 'calypso/state/sites/selectors';
 
 import './style.scss';
 
@@ -300,9 +294,6 @@ function mapStateToProps( state, ownProps ) {
 		isSiteP2: isSiteWPForTeams( state, siteId ),
 		isP2Hub: isSiteP2Hub( state, siteId ),
 		isTrialSite: isTrialSite( state, siteId ),
-		isAtomicAndEditingToolkitDeactivated:
-			isAtomicSite( state, siteId ) &&
-			getSiteOption( state, siteId, 'editing_toolkit_is_active' ) === false,
 	};
 }
 

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -149,15 +149,7 @@ class Site extends Component {
 	};
 
 	renderSiteBadges() {
-		const { isSiteUnlaunched, site, translate, isAtomicAndEditingToolkitDeactivated } = this.props;
-
-		// We show public coming soon badge only when the site is not private.
-		// Check for `! site.is_private` to ensure two Coming Soon badges don't appear while we introduce public coming soon.
-		const shouldShowPublicComingSoonSiteBadge =
-			! site.is_private &&
-			this.props.site.is_coming_soon &&
-			! isAtomicAndEditingToolkitDeactivated &&
-			! this.props.isTrialSite;
+		const { isSiteUnlaunched, site, translate } = this.props;
 
 		// Cover the coming Soon v1 cases for sites still unlaunched and/or in Coming Soon private by default.
 		// isPrivateAndUnlaunched means it is an unlaunched coming soon v1 site
@@ -191,11 +183,6 @@ class Site extends Component {
 				{ site.options && site.options.is_difm_lite_in_progress && (
 					<span className="site__badge site__badge-domain-only">
 						{ translate( 'Express Service' ) }
-					</span>
-				) }
-				{ shouldShowPublicComingSoonSiteBadge && (
-					<span className="site__badge site__badge-coming-soon">
-						{ translate( 'Coming Soon' ) }
 					</span>
 				) }
 				{ site.options && site.options.is_redirect && (


### PR DESCRIPTION
Related to #98900

## Proposed Changes

* This PR explores removing the "coming soon" badge like suggested by the issue above. 

## Testing Instructions

* Create a new simple site
* Notice there's no "coming soon" badge when the site is unlaunched in the sidebar.
