### PR TITLE
A4A: Fix update plugin version button spacing

### DIFF
--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -100,11 +100,8 @@ export default function UpdatePlugin( { plugin, selectedSite, className, updateP
 					className="update-plugin__new-version"
 					compact
 				>
-					{ translate( '{{span}}Update to {{/span}}%s', {
-						components: {
-							span: <span />,
-						},
-						args: updatedVersions[ 0 ],
+					{ translate( 'Update to %(version)s', {
+						args: { version: updatedVersions[ 0 ] },
 					} ) }
 				</Button>
 			</div>


### PR DESCRIPTION
Fixes a display issue in the update to version button. Note the missing space before the version number.

| Before | After |
| -------- | ------- |
| <img width="202" alt="Screenshot 2025-02-10 at 13 08 01" src="https://github.com/user-attachments/assets/8b8fcd30-2894-4df5-bfcc-5e387ab6c426" /> | <img width="200" alt="Screenshot 2025-02-10 at 13 08 34" src="https://github.com/user-attachments/assets/c9ce9806-e7ae-4711-9815-d691545573dc" /> |

## Testing Instructions

* Open the live link
* Go to `/plugins/manage/sites/woocommerce-payments`
* Check if the text spacing in the button matches the screenshot above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
