### PR TITLE
Fixed notice hover state to be compatible with removed IsReskinned flag

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -282,7 +282,7 @@ a.notice__action {
 	}
 
 	&:hover {
-		color: var(--color-text-inverted);
+		color: var(--studio-gray-80);
 	}
 
 	.gridicon {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up of https://github.com/Automattic/wp-calypso/pull/99112
Related to the Focused Launchpad: pet6gk-1T7-p2

## Proposed Changes

* We're updating the hover state color for buttons inside Notices:

**Before**:

https://github.com/user-attachments/assets/347701f5-3dc5-4cea-802a-1ee0cf7fb9ec 

**After**:

https://github.com/user-attachments/assets/c17d1489-e9f6-4a1a-882f-5b2be244b764 


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is a follow-up of [removed IsSkinned](https://github.com/Automattic/wp-calypso/pull/99112). The background color now is light compared to the old dark one, so the hover effect needs to be updated.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [/setup/onboarding](http://calypso.localhost:3000/setup/onboarding)
* Complete the onboarding process
* When in the launchpad, replace the URL to the /home page adding the extra flag parameter: `flags=home/launchpad-first`
* Edit the page's title
* Check if the new style is correct

Or follow the video:

https://github.com/user-attachments/assets/6d1e4b97-bad7-49b2-89e4-0ad6e20b8165




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?