### PR TITLE
Components: Refactor ExternalLink to FC

### DIFF
--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -46,7 +46,7 @@ export const WarningList = ( { context, translate, warnings, showContact = true 
 							/>
 							{ domainNames && displayDomainNames( domainNames ) }
 							{ supportUrl && (
-								<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">
+								<ExternalLink href={ supportUrl } target="_blank">
 									{ translate( 'Learn more.' ) }
 								</ExternalLink>
 							) }

--- a/client/blocks/jetpack-plugin-update-warning/index.tsx
+++ b/client/blocks/jetpack-plugin-update-warning/index.tsx
@@ -53,7 +53,7 @@ export const JetpackPluginUpdateWarning: FC< ExternalProps > = ( {
 		dispatch( recordTracksEvent( 'calypso_jetpack_plugin_update_warning_click' ) );
 	}, [ dispatch, setIsDismissed ] );
 
-	if ( hideWarning || isDismissed ) {
+	if ( hideWarning || isDismissed || ! pluginUpgradeUrl ) {
 		return null;
 	}
 
@@ -67,7 +67,7 @@ export const JetpackPluginUpdateWarning: FC< ExternalProps > = ( {
 						components: {
 							JetpackUpdateLink: (
 								<ExternalLink
-									href={ pluginUpgradeUrl ?? undefined }
+									href={ pluginUpgradeUrl }
 									onClick={ updatePluginClick }
 									target="_blank"
 								/>

--- a/client/blocks/jetpack-plugin-update-warning/index.tsx
+++ b/client/blocks/jetpack-plugin-update-warning/index.tsx
@@ -67,7 +67,7 @@ export const JetpackPluginUpdateWarning: FC< ExternalProps > = ( {
 						components: {
 							JetpackUpdateLink: (
 								<ExternalLink
-									href={ pluginUpgradeUrl }
+									href={ pluginUpgradeUrl ?? undefined }
 									onClick={ updatePluginClick }
 									target="_blank"
 								/>

--- a/client/blocks/reader-site-subscription/site-subscription-subheader.tsx
+++ b/client/blocks/reader-site-subscription/site-subscription-subheader.tsx
@@ -57,7 +57,7 @@ const SiteSubscriptionSubheader = ( {
 	const hostname = getHostname( url );
 	if ( hostname !== '' ) {
 		subheaderItems.push(
-			<ExternalLink key={ url } href={ url } rel="noreferrer noopener" target="_blank">
+			<ExternalLink key={ url } href={ url } target="_blank">
 				{ hostname }
 			</ExternalLink>
 		);

--- a/client/components/backup-retention-management/index.tsx
+++ b/client/components/backup-retention-management/index.tsx
@@ -334,9 +334,8 @@ const BackupRetentionManagement: FunctionComponent< OwnProps > = ( {
 												<ExternalLink
 													href="https://jetpack.com/support/backup/jetpack-vaultpress-backup-storage-and-retention/"
 													target="_blank"
-													rel="noopener noreferrer"
 													icon
-													size={ 14 }
+													iconSize={ 14 }
 												/>
 											),
 											span: <span className="highlight-days" />,

--- a/client/components/backup-retention-management/retention-option-on-cancel-purchase/index.tsx
+++ b/client/components/backup-retention-management/retention-option-on-cancel-purchase/index.tsx
@@ -113,7 +113,6 @@ const RetentionOptionOnCancelPurchase: React.FC = () => {
 										<ExternalLink
 											href="https://jetpack.com/support/backup/jetpack-vaultpress-backup-storage-and-retention/"
 											target="_blank"
-											rel="noopener noreferrer"
 											icon
 										/>
 									),

--- a/client/jetpack-cloud/sections/pricing/jpcom-footer/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-footer/index.tsx
@@ -28,9 +28,9 @@ const utmParams = {
 	utm_medium: 'automattic_referred',
 	utm_source: 'jpcom_footer',
 };
-const getTrackLinkClick = ( link: string ) => () => {
+const getTrackLinkClick = ( link: string | undefined ) => () => {
 	if ( ! link ) {
-		return undefined;
+		return;
 	}
 	recordTracksEvent( 'calypso_jetpack_footer_link_click', { link } );
 };

--- a/client/jetpack-cloud/sections/pricing/jpcom-footer/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-footer/index.tsx
@@ -29,6 +29,9 @@ const utmParams = {
 	utm_source: 'jpcom_footer',
 };
 const getTrackLinkClick = ( link: string ) => () => {
+	if ( ! link ) {
+		return undefined;
+	}
 	recordTracksEvent( 'calypso_jetpack_footer_link_click', { link } );
 };
 
@@ -343,7 +346,7 @@ const JetpackComFooter: React.FC = () => {
 													<ExternalLink
 														href={ href }
 														className="sitemap__link"
-														onClick={ trackId ? getTrackLinkClick( trackId ) : undefined }
+														onClick={ getTrackLinkClick( trackId ) }
 													>
 														{ preventWidows( label ) }
 													</ExternalLink>
@@ -361,7 +364,7 @@ const JetpackComFooter: React.FC = () => {
 											<ExternalLink
 												className="sitemap__link"
 												href={ href as string }
-												onClick={ trackId ? getTrackLinkClick( trackId ) : undefined }
+												onClick={ getTrackLinkClick( trackId ) }
 											>
 												<span className="social-properties__accessible-name">
 													{ accessibleName }

--- a/client/jetpack-cloud/sections/pricing/jpcom-footer/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-footer/index.tsx
@@ -343,7 +343,7 @@ const JetpackComFooter: React.FC = () => {
 													<ExternalLink
 														href={ href }
 														className="sitemap__link"
-														onClick={ trackId ? getTrackLinkClick( trackId ) : null }
+														onClick={ trackId ? getTrackLinkClick( trackId ) : undefined }
 													>
 														{ preventWidows( label ) }
 													</ExternalLink>
@@ -361,7 +361,7 @@ const JetpackComFooter: React.FC = () => {
 											<ExternalLink
 												className="sitemap__link"
 												href={ href as string }
-												onClick={ trackId ? getTrackLinkClick( trackId ) : null }
+												onClick={ trackId ? getTrackLinkClick( trackId ) : undefined }
 											>
 												<span className="social-properties__accessible-name">
 													{ accessibleName }

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
@@ -281,7 +281,6 @@ const SiteSubscriptionRow = ( {
 					<ExternalLink
 						className="title-url"
 						{ ...( url && { href: url } ) }
-						rel="noreferrer noopener"
 						target="_blank"
 						onClick={ () => {
 							recordSiteUrlClicked( { blog_id, feed_id, source: SOURCE_SUBSCRIPTIONS_SITE_LIST } );

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/list-item-link.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/list-item-link.tsx
@@ -41,7 +41,6 @@ function MailboxLink( { account, mailbox, readonly }: Props ) {
 				} );
 			} }
 			target="_blank"
-			rel="noopener noreferrer"
 		>
 			<span>{ emailAddress }</span>
 			<Gridicon icon="external" size={ 18 } />

--- a/client/sites/tools/deployments/deployment-creation/repository-selection-dialog.tsx
+++ b/client/sites/tools/deployments/deployment-creation/repository-selection-dialog.tsx
@@ -47,7 +47,6 @@ export const RepositorySelectionDialog = ( {
 								<ExternalLink
 									href="https://developer.wordpress.com/docs/developer-tools/github-deployments/create-github-deployment-source-files/"
 									target="_blank"
-									rel="noopener noreferrer"
 								/>
 							),
 						}

--- a/packages/components/src/external-link/index.jsx
+++ b/packages/components/src/external-link/index.jsx
@@ -24,11 +24,8 @@ import './style.scss';
  */
 function ExternalLink( {
 	className,
-	href,
-	onClick,
 	icon = false,
 	iconSize = 18,
-	target,
 	showIconFirst = false,
 	iconClassName,
 	iconComponent = null,
@@ -55,8 +52,8 @@ function ExternalLink( {
 		linkProps.rel = linkProps.rel.concat( ' noopener noreferrer' );
 	}
 
-	if ( href && shouldLocalizeUrl ) {
-		linkProps.href = localizeUrl( href );
+	if ( linkProps.href && shouldLocalizeUrl ) {
+		linkProps.href = localizeUrl( linkProps.href );
 	}
 
 	const iconEl = iconComponent || (

--- a/packages/components/src/external-link/index.jsx
+++ b/packages/components/src/external-link/index.jsx
@@ -6,6 +6,22 @@ import { ScreenReaderText, Gridicon } from '..';
 
 import './style.scss';
 
+/**
+ * External link component that optionally includes an external link icon.
+ * @param {Object} props Component props
+ * @param {string} [props.className] Additional CSS class names
+ * @param {string} [props.href] URL the link points to
+ * @param {Function} [props.onClick] Click handler
+ * @param {boolean} [props.icon] Whether to show an external link icon
+ * @param {number} [props.iconSize] Size of the icon in pixels
+ * @param {string} [props.target] Link target attribute
+ * @param {boolean} [props.showIconFirst] Whether to show icon before the text
+ * @param {string} [props.iconClassName] Additional CSS class for the icon
+ * @param {import('react').ReactNode} [props.iconComponent] Custom icon component to use instead of default
+ * @param {boolean} [props.localizeUrl] Whether to localize the URL
+ * @param {import('react').ReactNode} [props.children] Link content
+ * @returns {import('react').ReactElement} External link component
+ */
 function ExternalLink( {
 	className,
 	href,

--- a/packages/components/src/external-link/index.jsx
+++ b/packages/components/src/external-link/index.jsx
@@ -1,88 +1,78 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
-import { omit } from 'lodash';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
 import { ScreenReaderText, Gridicon } from '..';
 
 import './style.scss';
 
-class ExternalLink extends Component {
-	static defaultProps = {
-		iconSize: 18,
-		showIconFirst: false,
-		iconComponent: null,
-		localizeUrl: true,
+function ExternalLink( {
+	className,
+	href,
+	onClick,
+	icon = false,
+	iconSize = 18,
+	target,
+	showIconFirst = false,
+	iconClassName,
+	iconComponent = null,
+	localizeUrl: shouldLocalizeUrl = true,
+	children,
+	...rest
+} ) {
+	const classes = clsx( 'external-link', className, {
+		'icon-first': showIconFirst,
+		'has-icon': icon,
+	} );
+
+	const linkProps = {
+		...rest,
+		className: classes,
+		rel: 'external',
 	};
 
-	static propTypes = {
-		className: PropTypes.string,
-		href: PropTypes.string,
-		onClick: PropTypes.func,
-		icon: PropTypes.bool,
-		iconSize: PropTypes.number,
-		target: PropTypes.string,
-		showIconFirst: PropTypes.bool,
-		iconClassName: PropTypes.string,
-		iconComponent: PropTypes.object,
-		localizeUrl: PropTypes.bool,
-	};
-
-	render() {
-		const classes = clsx( 'external-link', this.props.className, {
-			'icon-first': this.props.showIconFirst,
-			'has-icon': this.props.icon,
-		} );
-
-		const props = {
-			...omit(
-				this.props,
-				'icon',
-				'iconSize',
-				'showIconFirst',
-				'iconClassName',
-				'iconComponent',
-				'localizeUrl'
-			),
-			className: classes,
-			rel: 'external',
-		};
-
-		if ( this.props.icon ) {
-			props.target = '_blank';
-		}
-
-		if ( props.target ) {
-			props.rel = props.rel.concat( ' noopener noreferrer' );
-		}
-
-		if ( props.href && props.localizeUrl ) {
-			props.href = localizeUrl( props.href );
-		}
-
-		const iconComponent = this.props.iconComponent || (
-			<Gridicon
-				className={ this.props.iconClassName }
-				icon="external"
-				size={ this.props.iconSize }
-			/>
-		);
-
-		return (
-			<a { ...props }>
-				{ this.props.icon && this.props.showIconFirst && iconComponent }
-				{ this.props.children }
-				{ this.props.icon && ! this.props.showIconFirst && iconComponent }
-				{ this.props.icon && (
-					<ScreenReaderText>
-						{ translate( '(opens in a new tab)', {
-							comment: 'accessibility label for an external link',
-						} ) }
-					</ScreenReaderText>
-				) }
-			</a>
-		);
+	if ( icon ) {
+		linkProps.target = '_blank';
 	}
+
+	if ( linkProps.target ) {
+		linkProps.rel = linkProps.rel.concat( ' noopener noreferrer' );
+	}
+
+	if ( href && shouldLocalizeUrl ) {
+		linkProps.href = localizeUrl( href );
+	}
+
+	const iconEl = iconComponent || (
+		<Gridicon className={ iconClassName } icon="external" size={ iconSize } />
+	);
+
+	return (
+		<a { ...linkProps }>
+			{ icon && showIconFirst && iconEl }
+			{ children }
+			{ icon && ! showIconFirst && iconEl }
+			{ icon && (
+				<ScreenReaderText>
+					{ translate( '(opens in a new tab)', {
+						comment: 'accessibility label for an external link',
+					} ) }
+				</ScreenReaderText>
+			) }
+		</a>
+	);
 }
+
+ExternalLink.propTypes = {
+	className: PropTypes.string,
+	href: PropTypes.string,
+	onClick: PropTypes.func,
+	icon: PropTypes.bool,
+	iconSize: PropTypes.number,
+	target: PropTypes.string,
+	showIconFirst: PropTypes.bool,
+	iconClassName: PropTypes.string,
+	iconComponent: PropTypes.object,
+	localizeUrl: PropTypes.bool,
+};
 export default ExternalLink;

--- a/packages/components/src/external-link/index.jsx
+++ b/packages/components/src/external-link/index.jsx
@@ -8,6 +8,7 @@ import './style.scss';
 
 /**
  * External link component that optionally includes an external link icon.
+ * @type {import('react').FC}
  * @param {Object} props Component props
  * @param {string} [props.className] Additional CSS class names
  * @param {string} [props.href] URL the link points to

--- a/packages/components/src/external-link/with-tracking.jsx
+++ b/packages/components/src/external-link/with-tracking.jsx
@@ -2,6 +2,25 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import PropTypes from 'prop-types';
 import ExternalLink from './index';
 
+/**
+ * External link component with tracking capabilities. Inherits all props from ExternalLink component.
+ * @param {Object} props - Component props
+ * @param {Function} [props.onClick] - Click handler
+ * @param {Function} [props.recordTracksEvent] - Custom tracking function
+ * @param {string} props.tracksEventName - Name of the tracking event
+ * @param {Object} [props.tracksEventProps] - Additional properties for the tracking event
+ * @param {string} [props.className] - Additional CSS class names
+ * @param {string} [props.href] - URL the link points to
+ * @param {boolean} [props.icon] - Whether to show an external link icon
+ * @param {number} [props.iconSize] - Size of the icon in pixels
+ * @param {string} [props.target] - Link target attribute
+ * @param {boolean} [props.showIconFirst] - Whether to show icon before the text
+ * @param {string} [props.iconClassName] - Additional CSS class for the icon
+ * @param {import('react').ReactNode} [props.iconComponent] - Custom icon component to use instead of default
+ * @param {boolean} [props.localizeUrl] - Whether to localize the URL
+ * @param {import('react').ReactNode} [props.children] - Link content
+ * @returns {import('react').ReactElement} External link component with tracking
+ */
 function ExternalLinkWithTracking( {
 	onClick,
 	recordTracksEvent: recordEvent,

--- a/packages/components/src/external-link/with-tracking.jsx
+++ b/packages/components/src/external-link/with-tracking.jsx
@@ -1,33 +1,24 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
 import ExternalLink from './index';
 
-class ExternalLinkWithTracking extends Component {
-	handleClickEvent() {
-		return () => {
-			const { onClick, tracksEventName, tracksEventProps } = this.props;
-			const trackEvent = this.props.recordTracksEvent || recordTracksEvent;
+function ExternalLinkWithTracking( {
+	onClick,
+	recordTracksEvent: recordEvent,
+	tracksEventName,
+	tracksEventProps,
+	...props
+} ) {
+	const handleClickEvent = () => {
+		const trackEvent = recordEvent || recordTracksEvent;
+		trackEvent( tracksEventName, tracksEventProps );
 
-			trackEvent( tracksEventName, tracksEventProps );
+		if ( onClick ) {
+			onClick();
+		}
+	};
 
-			if ( onClick ) {
-				onClick();
-			}
-		};
-	}
-
-	render() {
-		const {
-			onClick,
-			recordTracksEvent: recordEvent,
-			tracksEventName,
-			tracksEventProps,
-			...props
-		} = this.props;
-
-		return <ExternalLink onClick={ this.handleClickEvent() } { ...props } />;
-	}
+	return <ExternalLink onClick={ handleClickEvent } { ...props } />;
 }
 
 ExternalLinkWithTracking.propTypes = {


### PR DESCRIPTION
## Proposed Changes

Refactor `ExternalLink` and `ExternalLinkWithTracking` to functional components.

This triggered a few related refactors I wasn't planning to do initially, but here we are.

## Why are these changes being made?

Because `Component` is legacy and redundant in this case. 

Also, I was trying out how Cursor would do the refactoring, and it mostly did well, so why not as well merge it?

Still it was useful to find out some of its weak sides and what to keep an eye out for.

## Testing Instructions

* Spin up Storybook: `yarn workspace @automattic/components run storybook`
* Verify `ExternalLink` example works well
* Smoke test some external links in Calypso
* All checks should be green