### PR TITLE
Onboarding consistency: Goals screen

### DIFF
--- a/client/components/formatted-header/index.tsx
+++ b/client/components/formatted-header/index.tsx
@@ -14,7 +14,6 @@ interface Props extends PropsWithChildren {
 	id?: string;
 	isSecondary?: boolean;
 	screenReader?: ReactNode;
-	subHeaderAlign?: 'center';
 	subHeaderAs?: ElementType;
 	subHeaderText?: ReactNode;
 	tooltipText?: ReactNode;
@@ -32,7 +31,6 @@ const FormattedHeader: FC< Props > = ( {
 	id = '',
 	isSecondary = false,
 	screenReader = null,
-	subHeaderAlign,
 	subHeaderAs: SubHeaderAs = 'p',
 	subHeaderText,
 	tooltipText,
@@ -47,9 +45,6 @@ const FormattedHeader: FC< Props > = ( {
 	} );
 
 	const headerClasses = clsx( 'formatted-header__title', { 'wp-brand-font': brandFont } );
-	const subtitleClasses = clsx( 'formatted-header__subtitle', {
-		'is-center-align': 'center' === subHeaderAlign,
-	} );
 	const tooltip = tooltipText && (
 		<InfoPopover icon="help-outline" position="right" iconSize={ 18 } showOnHover>
 			{ tooltipText }
@@ -76,7 +71,9 @@ const FormattedHeader: FC< Props > = ( {
 				) }
 				{ screenReader && <h2 className="screen-reader-text">{ screenReader }</h2> }
 				{ formattedSubHeaderText && (
-					<SubHeaderAs className={ subtitleClasses }>{ formattedSubHeaderText }</SubHeaderAs>
+					<SubHeaderAs className="formatted-header__subtitle">
+						{ formattedSubHeaderText }
+					</SubHeaderAs>
 				) }
 			</div>
 			{ children }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -334,7 +334,6 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 				<FormattedHeader
 					id="domains-header"
 					align="center"
-					subHeaderAlign="center"
 					headerText={ getHeaderText() }
 					subHeaderText={ getSubHeaderText() }
 				/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals-capture-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals-capture-container.tsx
@@ -26,7 +26,6 @@ export const GoalsCaptureContainer: React.FC< GoalsCaptureContainerProps > = ( {
 		<StepContainer
 			{ ...otherProps }
 			isHorizontalLayout={ false }
-			className="goals__container two-columns"
 			hideBack
 			hideSkip={ false }
 			hideNext={ isMediumOrBiggerScreen }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals-capture-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals-capture-container.tsx
@@ -32,6 +32,7 @@ export const GoalsCaptureContainer: React.FC< GoalsCaptureContainerProps > = ( {
 			formattedHeader={
 				<FormattedHeader
 					id="goals-header"
+					align={ isMediumOrBiggerScreen ? 'center' : 'left' }
 					headerText={ whatAreYourGoalsText }
 					subHeaderText={ subHeaderText }
 				/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -176,7 +176,7 @@ const GoalsStep: Step = ( { navigation, flow } ) => {
 				skipLabelText={ translate( 'Skip' ) }
 				recordTracksEvent={ recordTracksEvent }
 				stepContent={
-					<>
+					<div className="select-goals">
 						<SelectGoals selectedGoals={ goals } onChange={ setGoals } />
 						{ isMediumOrBiggerScreen && (
 							<Button
@@ -207,7 +207,7 @@ const GoalsStep: Step = ( { navigation, flow } ) => {
 								</Button>
 							) }
 						</div>
-					</>
+					</div>
 				}
 			/>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -40,12 +40,13 @@
 
 	.select-goals__alternative-flows-container {
 		display: grid;
+		width: 100%;
 		grid-template-columns: max-content;
-		justify-content: center;
 		gap: 20px 8px;
 		padding-bottom: 60px + 48px; // height of sticky footer
 
 		@include break-small {
+			justify-content: center;
 			padding-bottom: 60px;
 			grid-template-columns: repeat(3, max-content);
 			gap: 16px 8px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -2,12 +2,18 @@
 @import "@wordpress/base-styles/mixins";
 @import "@automattic/typography/styles/fonts";
 
-.goals-step .step-container__skip-wrapper {
-	// I really hate this, but forcing a specificity is not much better.
-	margin-inline-start: 0 !important;
+.goals-step .step-container {
+	&__skip-wrapper {
+		// I really hate this, but forcing a specificity is not much better.
+		margin-inline-start: 0 !important;
 
-	@include break-small {
-		margin-inline-start: auto !important;
+		@include break-small {
+			margin-inline-start: auto !important;
+		}
+	}
+
+	&__header, &__content {
+		margin-inline: 16px;
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -2,62 +2,22 @@
 @import "@wordpress/base-styles/mixins";
 @import "@automattic/typography/styles/fonts";
 
-.goals__container {
-	padding: 0 20px;
+.goals-step .step-container__skip-wrapper {
+	// I really hate this, but forcing a specificity is not much better.
+	margin-inline-start: 0 !important;
 
-	&.two-columns {
-		.step-container__header {
-			margin-bottom: 16px;
-			margin-top: 20px;
-
-			.formatted-header {
-				.formatted-header__subtitle,
-				.formatted-header__title {
-					text-align: center;
-				}
-
-				.formatted-header__title {
-					text-wrap-style: pretty;
-				}
-
-				.formatted-header__subtitle {
-					margin-top: 8px;
-					text-wrap-style: balance;
-				}
-
-				margin-bottom: 24px;
-
-				@include break-small {
-					margin-top: 32px;
-					margin-bottom: 40px;
-				}
-			}
-		}
-
-		.select-goals__cards-hint {
-			font-weight: 400;
-			line-height: 24px;
-			color: #787c82;
-		}
-
-		.step-container__skip-wrapper {
-			// I really hate this, but forcing a specificity is not much better.
-			margin-inline-start: 0 !important;
-
-			@include break-small {
-				margin-inline-start: auto !important;
-			}
-		}
-
-		.step-container__content {
-			display: flex;
-			flex-direction: column;
-			align-items: center;
-			gap: 24px;
-		}
+	@include break-small {
+		margin-inline-start: auto !important;
 	}
+}
 
-	.select-goals__cards-container {
+.select-goals {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 24px;
+
+	&__cards-container {
 		font-family: Inter, $sans;
 		display: grid;
 		gap: 16px;
@@ -78,25 +38,6 @@
 		}
 	}
 
-	.select-goals__actions-container {
-		padding: 32px 0 48px;
-		display: flex;
-		flex-direction: column;
-		justify-content: flex-start;
-
-		button.is-primary {
-			width: 130px;
-			height: 44px;
-			border-radius: 4px;
-			box-shadow: 0 1px 2px rgb(0 0 0 / 5%) !important;
-		}
-
-		@include break-small {
-			// i2: justify-content: center;
-			flex-direction: row;
-		}
-	}
-
 	.select-goals__alternative-flows-container {
 		display: grid;
 		grid-template-columns: max-content;
@@ -112,11 +53,11 @@
 	}
 
 	.select-goals__next {
-		width: 160px;
+		padding: 0.5rem 3rem;
 	}
 
 	.components-button.select-goals__link.is-link { // extra specificity to override default link styles
-		color: var(--studio-gray-100);
+		color: var(--color-neutral-100);
 		font-size: $font-body-small;
 	}
 
@@ -140,64 +81,5 @@
 		@include break-small {
 			display: block;
 		}
-	}
-}
-
-.goals-link {
-	&__container {
-		position: relative;
-		padding: 0 0 32px;
-
-		@include break-small {
-			display: flex;
-			align-items: flex-start;
-			justify-content: space-between;
-			padding: 0 0 25px;
-		}
-	}
-
-	&__info-wrapper {
-		@include break-mobile {
-			display: flex;
-			align-items: flex-start;
-			width: 100%;
-		}
-	}
-
-	&__info {
-		flex: 1;
-		padding-right: 6px;
-	}
-
-	&__description {
-		font-size: $font-body-small;
-		color: #646970;
-		margin-bottom: 0;
-		margin-right: 0.2rem;
-	}
-
-	&__button {
-		margin-top: 2px;
-		padding: 0;
-		min-width: 130px;
-		border: none;
-		background: none;
-		color: #101517;
-		text-decoration: underline;
-		font-weight: 500;
-		text-align: start;
-
-		@include break-small {
-			margin-top: 0;
-			text-align: end;
-		}
-
-		&:not([disabled]):hover {
-			color: var(--color-neutral-70);
-		}
-	}
-
-	&__disabled-info svg {
-		fill: var(--color-neutral-20);
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-diy-or-difm/index.tsx
@@ -78,7 +78,6 @@ const HundredYearPlanDIYOrDIFM: Step = function HundredYearPlanDIYOrDIFM( { navi
 						brandFont
 						headerText={ translate( "Let's craft your next century" ) }
 						subHeaderText={ translate( "Join us for an exclusive strategy session where we'll:" ) }
-						subHeaderAlign="center"
 					/>
 				}
 				stepName="hundred-year-plan-setup hundred-year-plan-setup__diy-or-difm"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-setup/index.tsx
@@ -97,7 +97,6 @@ const HundredYearPlanSetup: Step = function HundredYearPlanSetup( { navigation, 
 					subHeaderText={ translate(
 						'Give your site a fitting name and description — you can always change it later.'
 					) }
-					subHeaderAlign="center"
 				/>
 			}
 			stepName="hundred-year-plan-setup"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/index.tsx
@@ -298,7 +298,6 @@ const HundredYearPlanSitePicker: Step = function HundredYearPlanSitePicker( { na
 				formattedHeader={
 					<FormattedHeader
 						align="center"
-						subHeaderAlign="center"
 						headerText={ translate( 'Select your site' ) }
 						subHeaderText={ translate(
 							'Start crafting your 100-Year legacy by appointing one of your sites.'

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-thank-you/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-thank-you/index.tsx
@@ -46,7 +46,6 @@ const HundredYearPlanThankYou: Step = function HundredYearPlanThankYou( { flow }
 								},
 							}
 						) }
-						subHeaderAlign="center"
 					/>
 				</>
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
@@ -127,9 +127,7 @@ const NewOrExistingSiteStep: Step = function NewOrExistingSiteStep( { navigation
 					intentsAlt={ [] }
 				/>
 			}
-			formattedHeader={
-				<FormattedHeader brandFont headerText={ getHeaderText() } subHeaderAlign="center" />
-			}
+			formattedHeader={ <FormattedHeader brandFont headerText={ getHeaderText() } /> }
 			justifyStepContent="center"
 			stepName="new-or-existing-site"
 			flowName={ flow }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/index.tsx
@@ -57,7 +57,6 @@ const SiteMigrationAlreadyWPCOM: FC< StepProps > = ( { stepName, flow, navigatio
 				formattedHeader={
 					<FormattedHeader
 						subHeaderAs="div"
-						subHeaderAlign="center"
 						headerText={ title }
 						subHeaderText={ subHeaderText }
 						align="center"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
@@ -108,7 +108,6 @@ const SiteMigrationApplicationPasswordsAuthorization: Step = function ( { naviga
 		<FormattedHeader
 			id="site-migration-credentials-header"
 			headerText={ translate( 'Get ready for blazing fast speeds' ) }
-			subHeaderAlign="center"
 			subHeaderText={ subHeaderText }
 			align="center"
 		/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-other-platform-detected-import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-other-platform-detected-import/index.tsx
@@ -98,7 +98,6 @@ const SiteMigrationOtherPlatform: Step = function ( { navigation } ) {
 								platformName === 'Unknown' ? descriptionWithoutPlatform : descriptionWithPlatform
 							}
 							align="center"
-							subHeaderAlign="center"
 						/>
 					)
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-started/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-started/index.tsx
@@ -79,7 +79,6 @@ const SiteMigrationStarted: Step = function () {
 						</>
 					}
 					align="center"
-					subHeaderAlign="center"
 				/>
 			}
 			hideSkip

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-support-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-support-instructions/index.tsx
@@ -102,7 +102,6 @@ export const SiteMigrationSupportInstructions: Step = ( { stepName } ) => {
 				<FormattedHeader
 					headerText={ translate( 'We’ll take it from here!' ) }
 					subHeaderText={ content }
-					subHeaderAlign="center"
 				/>
 			}
 			isHorizontalLayout={ false }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -170,7 +170,6 @@ const SiteMigrationUpgradePlan: FC< Props > = ( {
 						headerText={ headerText }
 						subHeaderText={ subHeaderText }
 						align="center"
-						subHeaderAlign="center"
 					/>
 				}
 				stepContent={ stepContent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
@@ -40,11 +40,7 @@ const SitePicker: Step = function SitePicker( { navigation, flow } ) {
 					</div>
 				}
 				formattedHeader={
-					<FormattedHeader
-						align="center"
-						subHeaderAlign="center"
-						headerText={ translate( 'Select your site' ) }
-					/>
+					<FormattedHeader align="center" headerText={ translate( 'Select your site' ) } />
 				}
 				recordTracksEvent={ recordTracksEvent }
 				flowName={ flow }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -569,7 +569,6 @@ function UnifiedPlansStep( {
 							<FormattedHeader
 								id="plans-header"
 								align="center"
-								subHeaderAlign="center"
 								headerText={ <HeaderText /> }
 								subHeaderText={ fallbackSubHeaderText }
 							/>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1433,7 +1433,6 @@ export class RenderDomainsStep extends Component {
 						<FormattedHeader
 							id="domains-header"
 							align="center"
-							subHeaderAlign="center"
 							headerText={ headerText }
 							subHeaderText={ fallbackSubHeaderText }
 						/>

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -73,7 +73,6 @@
 	.step-container__header {
 		margin-top: 32px;
 		margin-bottom: 48px;
-		margin-inline: 16px;
 		display: block;
 		justify-content: space-between;
 		align-items: center;
@@ -214,7 +213,6 @@
 	 */
 	.step-container__content {
 		margin-top: 0;
-		margin-inline: 16px;
 		display: block;
 	}
 

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -80,37 +80,24 @@
 
 		.formatted-header {
 			margin: 0;
-			flex-grow: 1;
+
+			@include break-xlarge {
+				margin-top: 88px; // 56px + 32px
+			}
 
 			.formatted-header__title {
 				@include onboarding-font-recoleta;
-				color: var(--studio-gray-100);
-				letter-spacing: 0.2px;
-				font-size: 2.15rem; /* stylelint-disable-line scales/font-sizes */
-				font-weight: 400;
-				padding: 0;
-				margin: 0;
+				color: var(--color-neutral-100);
+				font-size: 2rem;
 
 				@include break-xlarge {
 					font-size: 2.75rem;
-					margin-top: 107px;
 				}
 			}
 
 			.formatted-header__subtitle {
-				padding: 0;
-				text-align: start;
-				color: var(--studio-gray-60);
-				font-size: 1rem;
-				margin-top: 16px;
-				line-height: 24px;
-
-				&.is-center-align {
-					text-align: center;
-				}
-
-				@include break-small {
-					margin-top: 8px;
+				@include break-xlarge {
+					font-size: 1rem;
 				}
 			}
 		}

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -72,7 +72,8 @@
 	 */
 	.step-container__header {
 		margin-top: 32px;
-		margin-bottom: 32px;
+		margin-bottom: 48px;
+		margin-inline: 16px;
 		display: block;
 		justify-content: space-between;
 		align-items: center;
@@ -133,11 +134,6 @@
 					max-width: 100%;
 				}
 			}
-		}
-
-		@include break-small {
-			flex-wrap: wrap;
-			margin-top: 24px;
 		}
 	}
 
@@ -231,6 +227,7 @@
 	 */
 	.step-container__content {
 		margin-top: 0;
+		margin-inline: 16px;
 		display: block;
 	}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/98648.

## Proposed Changes

### Remove goals step content customizations

We were doing several unnecessary customizations. This PR does a bit of cleanup and conforms to the mockups.

### Remove subHeaderAlign prop from FormattedHeader

This unnecessary prop was introduced to force the subtitle to be centered, but that's already the default in FormattedHeader. Having a single `align` prop allows us to make the text left-aligned depending on the screen size.

### Align goals header and actions to the left on small screens

All Figma mockups (W9xI27S6Swvw5Ku21EbZvn-fi-9533_11274) include the header aligned to the left on small screens.

Also, the goals' action links are aligned to the left. For now, these changes are scoped to the goals step; read below.

## What's missing

The navigation bar will be addressed as a follow-up. This PR already has a big enough test scope, so let's keep it small.

I'll also create a follow-up to remove all `FormattedHeader` customizations, as most are useless. The world will be a better place from that day on.

## Testing Instructions

Please check that most of the items in the goals step match the Figma mockup and that the headings in the other steps are not broken: they don't need to be pixel perfect as I will make them look like that in the follow-up.