### PR TITLE
Dashboard: Fix inconsistent heading margins for top-level screens

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -368,6 +368,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				header.navigation-header {
 					padding-inline: 16px;
 					padding-bottom: 0;
+					padding-top: 24px;
 				}
 			}
 			@media only screen and ( min-width: 601px ) and ( max-width: 781px ) {

--- a/client/my-sites/plugins/plugins-navigation-header/style.scss
+++ b/client/my-sites/plugins/plugins-navigation-header/style.scss
@@ -26,9 +26,15 @@
 		}
 	}
 
+	.formatted-header {
+		display: flex;
+		align-items: center;
+		min-height: 40px;
+	}
+
 	.formatted-header__title {
 		font-size: 1.5rem;
-		line-height: 1.2;
+		line-height: 1.25;
 	}
 }
 

--- a/client/my-sites/plugins/search-categories/style.scss
+++ b/client/my-sites/plugins/search-categories/style.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-$search-categories-padding-top: 40px;
+$search-categories-padding-top: 16px;
 
 .search-categories {
 	display: flex;

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -69,7 +69,7 @@
 			display: flex;
 			flex-direction: column;
 			flex-grow: 1;
-			margin-top: 40px;
+			margin-top: 16px;
 			min-height: 0;
 			@media (max-width: $break-small) {
 				margin-top: 10px;
@@ -588,8 +588,8 @@
 			box-sizing: content-box;
 
 			.is-global-sidebar-visible & {
-				padding-top: 40px;
-				margin-top: -40px;
+				padding-top: 16px;
+				margin-top: -16px;
 				&.is-sticky {
 					height: auto;
 				}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/94950
Related to https://github.com/Automattic/wp-calypso/pull/99415

## Proposed Changes

* This makes the /domains/manage, /plugins, and /themes heading margins more consistent with /sites.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Keeping consistency is key.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open /sites, /domains/manage, /themes, and /plugins in separate tabs.
* Make sure the heading margins are consistent.

<img width="1495" alt="image" src="https://github.com/user-attachments/assets/e655bc5f-3d5d-4370-964c-c3c28ab21d4c" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
