### PR TITLE
Revert: Change default notice style to dark

### DIFF
--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -27,7 +27,7 @@ export class GlobalNotices extends Component {
 						{ ...notice }
 						key={ `notice-${ noticeId }` }
 						onDismissClick={ this.removeReduxNotice( noticeId, onDismissClick ) }
-						theme="light"
+						theme="dark"
 					>
 						{ button && (
 							<NoticeAction href={ href } onClick={ onClick }>

--- a/client/components/global-notices/test/__snapshots__/index.js.snap
+++ b/client/components/global-notices/test/__snapshots__/index.js.snap
@@ -8,7 +8,7 @@ exports[`<GlobalNotices /> should render notices with the expected structure 1`]
   >
     <div
       aria-label="Notice"
-      class="notice is-success is-dismissable is-light"
+      class="notice is-success is-dismissable"
       role="status"
     >
       <span


### PR DESCRIPTION
Related to #

## Proposed Changes

* Changes the default notice style to dark

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Discussion: p1739002922765779-slack-C9EJ7KSGH
