### PR TITLE
Stats: Display chart with stable 30-minute series data

### DIFF
--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -64,7 +64,7 @@ function StatsLineChart( {
 					options={ {
 						yScale: {
 							type: 'linear',
-							domain: [ 0, maxViews ],
+							zero: true,
 						},
 						axis: {
 							x: {

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -7,6 +7,8 @@ import StatsEmptyState from '../../stats-empty-state';
 
 function StatsLineChart( {
 	chartData = [],
+	maxViews = 1,
+	formatTimeTick,
 	className,
 	height = 400,
 	moment,
@@ -17,24 +19,35 @@ function StatsLineChart( {
 		options: object;
 		data: Array< { date: Date; value: number } >;
 	} >;
+	maxViews?: number;
+	formatTimeTick?: ( value: number ) => string;
 	className?: string;
 	height?: number;
 	moment: Moment;
 	EmptyState: typeof StatsEmptyState;
 } ) {
 	const translate = useTranslate();
-	const formatTime = ( value: number ) => {
-		const date = new Date( value );
-		return new Date( date ).toLocaleTimeString( moment.locale(), {
-			hour: '2-digit',
-			minute: '2-digit',
-			hour12: true,
-		} );
+
+	const formatTime = formatTimeTick
+		? formatTimeTick
+		: ( value: number ) => {
+				const date = new Date( value );
+				return new Date( date ).toLocaleTimeString( moment.locale(), {
+					hour: '2-digit',
+					minute: '2-digit',
+					hour12: true,
+				} );
+		  };
+
+	const formatViews = ( value: number ) => {
+		return value.toFixed( 0 ).toString();
 	};
+
+	const dataSeries = chartData?.[ 0 ].data || [];
 
 	return (
 		<div className={ clsx( 'stats-line-chart', className ) }>
-			{ chartData?.[ 0 ].data?.length === 0 && (
+			{ dataSeries.length === 0 && (
 				<EmptyState
 					headingText={ translate( 'Real-time views' ) }
 					infoText={ translate( 'Collecting data… auto-refreshing in a minute…' ) }
@@ -48,7 +61,22 @@ function StatsLineChart( {
 					height={ height }
 					/** naturalCurve sometime goes off the grid :( */
 					margin={ { left: 15, top: 20, bottom: 20 } }
-					options={ { axis: { x: { tickFormat: formatTime }, y: { orientation: 'right' } } } }
+					options={ {
+						yScale: {
+							type: 'linear',
+							domain: [ 0, maxViews ],
+						},
+						axis: {
+							x: {
+								tickFormat: formatTime,
+							},
+							y: {
+								orientation: 'right',
+								tickFormat: formatViews,
+								numTicks: maxViews > 4 ? 4 : 1,
+							},
+						},
+					} }
 				/>
 			</ThemeProvider>
 		</div>

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import wpcom from 'calypso/lib/wp';
+import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { parseChartData } from 'calypso/state/stats/lists/utils';
 import PageLoading from '../shared/page-loading';
@@ -31,51 +32,66 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 	const gmtOffset = useSelector( ( state: object ) =>
 		getSiteOption( state, siteId, 'gmt_offset' )
 	) as number;
+	const momentSiteZone = useSelector( ( state: object ) => getMomentSiteZone( state, siteId ) );
 	const [ viewsData, setViewsData ] = useState( {} as chartMinuteDataTypes );
+	const [ initialViewsCount, setInitialViewsCount ] = useState< number | undefined >( undefined );
 
 	useEffect( () => {
 		const intervalId = setInterval( () => {
-			// Index the chart data by YYYY-MM-DD HH:mm:00.
-			const adjustedDatetime = moment().utcOffset( gmtOffset ).format( 'YYYY-MM-DD HH:mm:00' );
+			// Query the chart data by offset YYYY-MM-DD HH:mm:00.
+			const adjustedDatetimeForQuery = moment()
+				.utcOffset( gmtOffset )
+				.format( 'YYYY-MM-DD HH:mm:00' );
+			// Index the chart data by local YYYY-MM-DD HH:mm:00 to compare with local time in X-axis tickFormat.
+			const localDatetimeKey = moment().format( 'YYYY-MM-DD HH:mm:00' );
 
 			queryStatsVisits( siteId, {
 				unit: 'hour',
-				date: adjustedDatetime,
+				date: adjustedDatetimeForQuery,
 				quantity: 1,
 				stat_fields: 'views',
 			} ).then( ( response: any ) => {
 				const result = parseChartData( response );
 				const views = result[ 0 ].views || 0;
 
+				if ( initialViewsCount === undefined ) {
+					setInitialViewsCount( views );
+				}
+
 				setViewsData( ( prevViewsData ) => {
 					return {
 						...prevViewsData,
-						[ adjustedDatetime ]: views,
+						[ localDatetimeKey ]: views,
 					};
 				} );
 			} );
 		}, UPDATE_INTERVAL_IN_SECONDS * 1000 );
 
 		return () => clearInterval( intervalId );
-	}, [ siteId, gmtOffset ] );
+	}, [ siteId, gmtOffset, initialViewsCount ] );
 
-	let chartData = useMemo( () => {
-		return Object.keys( viewsData ).map( ( eachMinute, idx ) => {
+	const { chartData, maxViews } = useMemo( () => {
+		const allDatetimeKeys = [];
+		// Display all the minutes in the last 30 minutes.
+		for ( let i = 0; i <= MINUTE_DATA_LENGTH; i++ ) {
+			const datetime = moment().subtract( i, 'minute' ).format( 'YYYY-MM-DD HH:mm:00' );
+			allDatetimeKeys.unshift( datetime );
+		}
+
+		let maxViews = 1;
+		const data = allDatetimeKeys.map( ( eachMinute ) => {
 			const lastMinute = moment( eachMinute )
 				.subtract( 1, 'minute' )
 				.format( 'YYYY-MM-DD HH:mm:00' );
 
-			// Reset the data if the current minute is not continuous with the previous minute,
-			// which usually happens when the device is idle for a while.
-			if ( viewsData[ lastMinute ] === undefined && idx !== 0 ) {
-				setViewsData( {} );
-			}
-
 			let diffViews: number = 0;
 
-			// First minute has no previous minute to compare to.
-			if ( viewsData[ lastMinute ] === undefined ) {
+			if ( viewsData[ eachMinute ] === undefined ) {
+				// No queried minute data yet.
 				diffViews = 0;
+			} else if ( viewsData[ lastMinute ] === undefined ) {
+				// The first queried minute data.
+				diffViews = viewsData[ eachMinute ] - ( initialViewsCount || 0 );
 			} else if (
 				moment( lastMinute ).format( 'YYYY-MM-DD HH' ) !==
 				moment( eachMinute ).format( 'YYYY-MM-DD HH' )
@@ -87,23 +103,33 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 				diffViews = viewsData[ eachMinute ] - viewsData[ lastMinute ];
 			}
 
+			if ( diffViews > maxViews ) {
+				maxViews = diffViews;
+			}
+
 			return {
-				// TODO: Support simple string to display time difference rather than forcing a Date object.
 				date: new Date( eachMinute ),
 				value: diffViews,
 			};
 		} );
+
+		return {
+			chartData: data,
+			maxViews,
+		};
 	}, [ JSON.stringify( viewsData ) ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
-	// Handle array length with padding or truncating for display.
-	if ( chartData.length > 0 && chartData.length < MINUTE_DATA_LENGTH ) {
-		const paddingItemsCount = MINUTE_DATA_LENGTH - chartData.length;
-		for ( let i = 0; i < paddingItemsCount; i++ ) {
-			chartData.unshift( chartData[ 0 ] );
-		}
-	} else {
-		chartData = chartData.slice( -MINUTE_DATA_LENGTH );
-	}
+	// Format the time in minute difference from now.
+	const formatTimeTick = ( value: number ) => {
+		const date = new Date( value );
+		const datetime = date.getTime();
+
+		const now = new Date();
+		const nowDatetime = now.getTime();
+		const diffMinutes = Math.floor( ( nowDatetime - datetime ) / 1000 / 60 );
+
+		return `-${ diffMinutes }m`;
+	};
 
 	return (
 		<div>
@@ -112,12 +138,15 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 				className="stats-realtime-chart"
 				height={ 425 }
 				placeholder={ PageLoading }
+				moment={ momentSiteZone }
 				chartData={ [
 					{
 						label: 'Views',
 						data: chartData,
 					},
 				] }
+				maxViews={ maxViews }
+				formatTimeTick={ formatTimeTick }
 			/>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/99419

## Proposed Changes

* Generate a 30-minute data series as the stable display.
* Adjust the `tickFormat` for the X-axis to display `-0m` ~ `-30m` labels.
* Add `yScale.domain` to align `0` to the bottom of the Y-axis when no views are fetched.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* A follow-up to tweak the real-time chart with data and options.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Realtime tab with the feature flag: `stats/real-time-tab`.
* Ensure the chart displays all 30 minutes of data with the correct view differences.

<img width="1314" alt="截圖 2025-02-11 凌晨1 30 23" src="https://github.com/user-attachments/assets/0eb34ea5-74e2-4dd8-8f2b-c6ec5fd3724b" />

<img width="1312" alt="截圖 2025-02-11 凌晨1 41 21" src="https://github.com/user-attachments/assets/72081413-ed53-4107-b790-2c9812e9262a" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
