### PR TITLE
Remove legacy Jetpack + Woo onboarding flow and replace with Woo JPC flow

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -1034,12 +1034,7 @@ export default connect(
 			'automattic-for-agencies-client' ===
 				new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'from' ),
 		isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
-		isWooJPC:
-			// The legacy "Jetpack WooCommerce" flow is deprecated and absorbed
-			// into the Woo JPC flow
-			// TODO: move to isWooJPCFlow check
-			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ) ||
-			isWooJPCFlow( state ),
+		isWooJPC: isWooJPCFlow( state ),
 		isWCCOM: getIsWCCOM( state ),
 		isWoo: getIsWoo( state ),
 		wccomFrom: getWccomFrom( state ),

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -72,7 +72,6 @@ class Login extends Component {
 		isLinking: PropTypes.bool,
 		isJetpack: PropTypes.bool.isRequired,
 		isWhiteLogin: PropTypes.bool.isRequired,
-		isJetpackWooCommerceFlow: PropTypes.bool.isRequired,
 		isFromAkismet: PropTypes.bool,
 		isFromMigrationPlugin: PropTypes.bool,
 		isFromAutomatticForAgenciesPlugin: PropTypes.bool,
@@ -115,7 +114,6 @@ class Login extends Component {
 	static defaultProps = {
 		isJetpack: false,
 		isWhiteLogin: false,
-		isJetpackWooCommerceFlow: false,
 	};
 
 	componentDidMount() {
@@ -191,7 +189,6 @@ class Login extends Component {
 	showContinueAsUser = () => {
 		const {
 			isJetpack,
-			isJetpackWooCommerceFlow,
 			oauth2Client,
 			privateSite,
 			socialConnect,
@@ -210,7 +207,8 @@ class Login extends Component {
 			! privateSite &&
 			// Show the continue as user flow WooCommerce and Blaze Pro but not for other OAuth2 clients
 			! ( oauth2Client && ! isWCCOM && ! isBlazePro ) &&
-			! isJetpackWooCommerceFlow &&
+			// Note: do we need to replace with other flows?
+			// ! isJetpackWooCommerceFlow &&
 			! isJetpack &&
 			! fromSite &&
 			! twoFactorEnabled &&
@@ -352,7 +350,6 @@ class Login extends Component {
 			isGravPoweredClient,
 			isGravPoweredLoginPage,
 			isJetpack,
-			isJetpackWooCommerceFlow,
 			isManualRenewalImmediateLoginAttempt,
 			isP2Login,
 			isSignupExistingAccount,
@@ -617,26 +614,6 @@ class Login extends Component {
 			}
 			preHeader = null;
 			postHeader = <p className="login__header-subtitle">{ subtitle }</p>;
-		} else if ( isJetpackWooCommerceFlow ) {
-			headerText = translate( 'Log in to your WordPress.com account' );
-			preHeader = (
-				<div className="login__jetpack-logo">
-					<AsyncLoad
-						require="calypso/components/jetpack-header"
-						placeholder={ null }
-						partnerSlug={ this.props.partnerSlug }
-						isWooOnboarding
-						width={ 200 }
-					/>
-				</div>
-			);
-			postHeader = (
-				<p className="login__header-subtitle">
-					{ translate(
-						'Your account will enable you to start using the features and benefits offered by Jetpack & WooCommerce Services.'
-					) }
-				</p>
-			);
 		} else if ( isFromMigrationPlugin ) {
 			headerText = translate( 'Log in to your account' );
 		} else if ( isJetpack ) {
@@ -1059,9 +1036,12 @@ export default connect(
 			'automattic-for-agencies-client' ===
 				new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'from' ),
 		isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
-		isJetpackWooCommerceFlow:
-			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
-		isWooJPC: isWooJPCFlow( state ),
+		isWooJPC:
+			// The legacy "Jetpack WooCommerce" flow is deprecated and absorbed
+			// into the Woo JPC flow
+			// TODO: move to isWooJPCFlow check
+			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ) ||
+			isWooJPCFlow( state ),
 		isWCCOM: getIsWCCOM( state ),
 		isWoo: getIsWoo( state ),
 		wccomFrom: getWccomFrom( state ),

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -207,8 +207,6 @@ class Login extends Component {
 			! privateSite &&
 			// Show the continue as user flow WooCommerce and Blaze Pro but not for other OAuth2 clients
 			! ( oauth2Client && ! isWCCOM && ! isBlazePro ) &&
-			// Note: do we need to replace with other flows?
-			// ! isJetpackWooCommerceFlow &&
 			! isJetpack &&
 			! fromSite &&
 			! twoFactorEnabled &&

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -1161,9 +1161,7 @@ export default connect(
 			isFromAutomatticForAgenciesPlugin:
 				'automattic-for-agencies-client' === get( getCurrentQueryArguments( state ), 'from' ),
 			isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
-			isWooJPC:
-				'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ) ||
-				isWooJPCFlow( state ),
+			isWooJPC: isWooJPCFlow( state ),
 			isWoo: getIsWoo( state ),
 			redirectTo: getRedirectToOriginal( state ),
 			requestError: getRequestError( state ),

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -383,12 +383,14 @@ export class LoginForm extends Component {
 	};
 
 	recordWooCommerceLoginTracks( method ) {
-		const { isJetpackWooCommerceFlow, isWoo, wccomFrom } = this.props;
-		if ( isJetpackWooCommerceFlow ) {
-			this.props.recordTracksEvent( 'wcadmin_storeprofiler_login_jetpack_account', {
-				login_method: method,
-			} );
-		} else if ( isWoo && 'cart' === wccomFrom ) {
+		const { isWoo, wccomFrom } = this.props;
+		// Note: replace with other flow, or delete?
+		// if ( isJetpackWooCommerceFlow ) {
+		// 	this.props.recordTracksEvent( 'wcadmin_storeprofiler_login_jetpack_account', {
+		// 		login_method: method,
+		// 	} );
+		// } else
+		if ( isWoo && 'cart' === wccomFrom ) {
 			this.props.recordTracksEvent( 'wcadmin_storeprofiler_payment_login', {
 				login_method: method,
 			} );
@@ -648,6 +650,7 @@ export class LoginForm extends Component {
 			! canDoMagicLogin(
 				this.props.twoFactorAuthType,
 				this.props.oauth2Client,
+				// TODO: replace with other flow, or delete?
 				this.props.isJetpackWooCommerceFlow
 			)
 		) {
@@ -670,8 +673,9 @@ export class LoginForm extends Component {
 		if (
 			! canDoMagicLogin(
 				this.props.twoFactorAuthType,
-				this.props.oauth2Client,
-				this.props.isJetpackWooCommerceFlow
+				this.props.oauth2Client
+				// TODO: replace with other flow, or delete?
+				// this.props.isJetpackWooCommerceFlow
 			)
 		) {
 			return null;
@@ -792,7 +796,6 @@ export class LoginForm extends Component {
 			oauth2Client,
 			requestError,
 			socialAccountIsLinking: linkingSocialUser,
-			isJetpackWooCommerceFlow,
 			isP2Login,
 			isJetpack,
 			isJetpackWooDnaFlow,
@@ -878,9 +881,10 @@ export class LoginForm extends Component {
 			) : null;
 		}
 
-		if ( isJetpackWooCommerceFlow ) {
-			return this.renderWooCommerce( { socialToS } );
-		}
+		// TODO: replace with other flow, or delete?
+		// if ( isJetpackWooCommerceFlow ) {
+		// 	return this.renderWooCommerce( { socialToS } );
+		// }
 
 		if ( isJetpackWooDnaFlow ) {
 			return this.renderWooCommerce( {
@@ -1176,10 +1180,10 @@ export default connect(
 			oauth2Client: getCurrentOAuth2Client( state ),
 			isFromAutomatticForAgenciesPlugin:
 				'automattic-for-agencies-client' === get( getCurrentQueryArguments( state ), 'from' ),
-			isJetpackWooCommerceFlow:
-				'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
 			isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
-			isWooJPC: isWooJPCFlow( state ),
+			isWooJPC:
+				'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ) ||
+				isWooJPCFlow( state ),
 			isWoo: getIsWoo( state ),
 			redirectTo: getRedirectToOriginal( state ),
 			requestError: getRequestError( state ),

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -384,12 +384,6 @@ export class LoginForm extends Component {
 
 	recordWooCommerceLoginTracks( method ) {
 		const { isWoo, wccomFrom } = this.props;
-		// Note: replace with other flow, or delete?
-		// if ( isJetpackWooCommerceFlow ) {
-		// 	this.props.recordTracksEvent( 'wcadmin_storeprofiler_login_jetpack_account', {
-		// 		login_method: method,
-		// 	} );
-		// } else
 		if ( isWoo && 'cart' === wccomFrom ) {
 			this.props.recordTracksEvent( 'wcadmin_storeprofiler_payment_login', {
 				login_method: method,

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -646,14 +646,7 @@ export class LoginForm extends Component {
 	};
 
 	getMagicLoginPageLink() {
-		if (
-			! canDoMagicLogin(
-				this.props.twoFactorAuthType,
-				this.props.oauth2Client,
-				// TODO: replace with other flow, or delete?
-				this.props.isJetpackWooCommerceFlow
-			)
-		) {
+		if ( ! canDoMagicLogin( this.props.twoFactorAuthType, this.props.oauth2Client ) ) {
 			return null;
 		}
 
@@ -670,14 +663,7 @@ export class LoginForm extends Component {
 	}
 
 	getQrLoginLink() {
-		if (
-			! canDoMagicLogin(
-				this.props.twoFactorAuthType,
-				this.props.oauth2Client
-				// TODO: replace with other flow, or delete?
-				// this.props.isJetpackWooCommerceFlow
-			)
-		) {
+		if ( ! canDoMagicLogin( this.props.twoFactorAuthType, this.props.oauth2Client ) ) {
 			return null;
 		}
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -861,11 +861,6 @@ export class LoginForm extends Component {
 			) : null;
 		}
 
-		// TODO: replace with other flow, or delete?
-		// if ( isJetpackWooCommerceFlow ) {
-		// 	return this.renderWooCommerce( { socialToS } );
-		// }
-
 		if ( isJetpackWooDnaFlow ) {
 			return this.renderWooCommerce( {
 				showSocialLogin: !! accountType, // Only show the social buttons after the user entered an email.

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -6,7 +6,7 @@
 
 $breakpoint-mobile: 782px; //Mobile size.
 
-.layout:not(.is-jetpack-woocommerce-flow):not(.is-jetpack-woo-dna-flow):not(.is-wccom-oauth-flow):not(.is-woocommerce-core-profiler-flow) {
+.layout:not(.is-jetpack-woo-dna-flow):not(.is-wccom-oauth-flow):not(.is-woocommerce-core-profiler-flow) {
 	.login.is-jetpack:not(.is-automattic-for-agencies-flow) {
 		.button.is-primary {
 			background-color: var(--studio-jetpack-green-50);
@@ -56,7 +56,6 @@ $breakpoint-mobile: 782px; //Mobile size.
 	}
 }
 
-.layout.is-jetpack-woocommerce-flow,
 .layout.is-jetpack-woo-dna-flow,
 .layout.is-wccom-oauth-flow {
 	.login__jetpack-logo,

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -765,12 +765,14 @@ class SignupForm extends Component {
 	}
 
 	recordWooCommerceSignupTracks( method ) {
-		const { isJetpackWooCommerceFlow, isWoo, wccomFrom } = this.props;
-		if ( isJetpackWooCommerceFlow ) {
-			recordTracksEvent( 'wcadmin_storeprofiler_create_jetpack_account', {
-				signup_method: method,
-			} );
-		} else if ( isWoo && 'cart' === wccomFrom ) {
+		const { isWoo, wccomFrom } = this.props;
+		// TODO: replace with other flow, or delete?
+		// if ( isJetpackWooCommerceFlow ) {
+		// 	recordTracksEvent( 'wcadmin_storeprofiler_create_jetpack_account', {
+		// 		signup_method: method,
+		// 	} );
+		// } else
+		if ( isWoo && 'cart' === wccomFrom ) {
 			recordTracksEvent( 'wcadmin_storeprofiler_payment_create_account', {
 				signup_method: method,
 			} );
@@ -1191,7 +1193,9 @@ class SignupForm extends Component {
 			);
 		}
 
-		if ( this.props.isJetpackWooCommerceFlow || this.props.isJetpackWooDnaFlow ) {
+		// TODO: is it ok to merge it with JPC flow? Should we replace the check
+		// with the JPC flow, or simply remove it from the check?
+		if ( /* this.props.isJetpackWooCommerceFlow || */ this.props.isJetpackWooDnaFlow ) {
 			return (
 				<div className={ clsx( 'signup-form__woocommerce', this.props.className ) }>
 					<LoggedOutForm onSubmit={ this.handleWooCommerceSubmit } noValidate>
@@ -1380,14 +1384,17 @@ class SignupForm extends Component {
 export default connect(
 	( state, props ) => {
 		const oauth2Client = getCurrentOAuth2Client( state );
-		const isWooJPC = isWooJPCFlow( state );
+		const isWooJPC =
+			// TODO:
+			// - is it ok to merge legacy flow with JPC, or should we merge it with DNA?
+			// - move check directly to isWooJPCFlow
+			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ) ||
+			isWooJPCFlow( state );
 
 		return {
 			currentUser: getCurrentUser( state ),
 			oauth2Client,
 			sectionName: getSectionName( state ),
-			isJetpackWooCommerceFlow:
-				'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
 			isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
 			from: get( getCurrentQueryArguments( state ), 'from' ),
 			wccomFrom: getWccomFrom( state ),

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1376,10 +1376,7 @@ class SignupForm extends Component {
 export default connect(
 	( state, props ) => {
 		const oauth2Client = getCurrentOAuth2Client( state );
-		const isWooJPC =
-			// - move check directly to isWooJPCFlow
-			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ) ||
-			isWooJPCFlow( state );
+		const isWooJPC = isWooJPCFlow( state );
 
 		return {
 			currentUser: getCurrentUser( state ),

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -766,12 +766,6 @@ class SignupForm extends Component {
 
 	recordWooCommerceSignupTracks( method ) {
 		const { isWoo, wccomFrom } = this.props;
-		// TODO: replace with other flow, or delete?
-		// if ( isJetpackWooCommerceFlow ) {
-		// 	recordTracksEvent( 'wcadmin_storeprofiler_create_jetpack_account', {
-		// 		signup_method: method,
-		// 	} );
-		// } else
 		if ( isWoo && 'cart' === wccomFrom ) {
 			recordTracksEvent( 'wcadmin_storeprofiler_payment_create_account', {
 				signup_method: method,

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1187,9 +1187,7 @@ class SignupForm extends Component {
 			);
 		}
 
-		// TODO: is it ok to merge it with JPC flow? Should we replace the check
-		// with the JPC flow, or simply remove it from the check?
-		if ( /* this.props.isJetpackWooCommerceFlow || */ this.props.isJetpackWooDnaFlow ) {
+		if ( this.props.isJetpackWooDnaFlow ) {
 			return (
 				<div className={ clsx( 'signup-form__woocommerce', this.props.className ) }>
 					<LoggedOutForm onSubmit={ this.handleWooCommerceSubmit } noValidate>
@@ -1379,8 +1377,6 @@ export default connect(
 	( state, props ) => {
 		const oauth2Client = getCurrentOAuth2Client( state );
 		const isWooJPC =
-			// TODO:
-			// - is it ok to merge legacy flow with JPC, or should we merge it with DNA?
 			// - move check directly to isWooJPCFlow
 			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ) ||
 			isWooJPCFlow( state );

--- a/client/components/jetpack-header/index.jsx
+++ b/client/components/jetpack-header/index.jsx
@@ -14,7 +14,6 @@ export class JetpackHeader extends PureComponent {
 		darkColorScheme: PropTypes.bool,
 		partnerSlug: PropTypes.string,
 		isFromAutomatticForAgenciesPlugin: PropTypes.bool,
-		isWooOnboarding: PropTypes.bool,
 		isWooJPC: PropTypes.bool,
 		isWooDna: PropTypes.bool,
 		width: PropTypes.number,
@@ -26,7 +25,6 @@ export class JetpackHeader extends PureComponent {
 			partnerSlug,
 			width,
 			isFromAutomatticForAgenciesPlugin,
-			isWooOnboarding,
 			isWooJPC,
 			isWooDna,
 			translate,
@@ -34,25 +32,6 @@ export class JetpackHeader extends PureComponent {
 
 		if ( isWooJPC ) {
 			return null;
-		}
-
-		if ( isWooOnboarding ) {
-			// @todo Implement WooCommerce + partner co-branding in the future.
-			return (
-				<JetpackPartnerLogoGroup
-					width={ width || 662.5 }
-					viewBox="0 0 1270 170"
-					partnerName="WooCommerce"
-				>
-					<g transform="translate(360 25)">
-						<AsyncLoad
-							require="calypso/components/jetpack-header/woocommerce"
-							darkColorScheme={ darkColorScheme }
-							placeholder={ null }
-						/>
-					</g>
-				</JetpackPartnerLogoGroup>
-			);
 		}
 
 		if ( isWooDna ) {

--- a/client/components/social-buttons/qr-code.tsx
+++ b/client/components/social-buttons/qr-code.tsx
@@ -8,7 +8,6 @@ import { resetMagicLoginRequestForm } from 'calypso/state/login/magic-login/acti
 import { isFormDisabled } from 'calypso/state/login/selectors';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
-import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 
 type QrCodeLoginButtonProps = {
@@ -32,11 +31,6 @@ const QrCodeLoginButton = ( { loginUrl }: QrCodeLoginButtonProps ) => {
 	if ( oauth2Client && ! isWoo ) {
 		return null;
 	}
-
-	// TODO: replace with another flow, or just delete?
-	// if ( isJetpackWooCommerceFlow ) {
-	// 	return null;
-	// }
 
 	const handleClick = () => {
 		recordTracksEvent( 'calypso_login_magic_login_request_click', {

--- a/client/components/social-buttons/qr-code.tsx
+++ b/client/components/social-buttons/qr-code.tsx
@@ -18,10 +18,8 @@ type QrCodeLoginButtonProps = {
 const QrCodeLoginButton = ( { loginUrl }: QrCodeLoginButtonProps ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const { isDisabled, isJetpackWooCommerceFlow, oauth2Client, isWoo } = useSelector( ( select ) => {
+	const { isDisabled, oauth2Client, isWoo } = useSelector( ( select ) => {
 		return {
-			isJetpackWooCommerceFlow:
-				'woocommerce-onboarding' === getCurrentQueryArguments( select )?.from,
 			oauth2Client: getCurrentOAuth2Client( select ) as { id: string },
 			locale: getCurrentLocaleSlug( select ),
 			isWoo: getIsWoo( select ),
@@ -35,9 +33,10 @@ const QrCodeLoginButton = ( { loginUrl }: QrCodeLoginButtonProps ) => {
 		return null;
 	}
 
-	if ( isJetpackWooCommerceFlow ) {
-		return null;
-	}
+	// TODO: replace with another flow, or just delete?
+	// if ( isJetpackWooCommerceFlow ) {
+	// 	return null;
+	// }
 
 	const handleClick = () => {
 		recordTracksEvent( 'calypso_login_magic_login_request_click', {

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -174,9 +174,6 @@ class Document extends Component {
 								className={ clsx( 'layout', {
 									[ 'is-group-' + sectionGroup ]: sectionGroup,
 									[ 'is-section-' + sectionName ]: sectionName,
-									// TODO: clean up classname in styles too
-									// Should we replace it with another flow, or can we just delete?
-									// 'is-jetpack-woocommerce-flow': isJetpackWooCommerceFlow,
 									'is-jetpack-woo-dna-flow': isJetpackWooDnaFlow,
 								} ) }
 							>

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -96,9 +96,6 @@ class Document extends Component {
 				? `var localeFromRoute = ${ jsonStringifyForHtml( params.lang ?? '' ) };\n`
 				: '' );
 
-		const isJetpackWooCommerceFlow =
-			'jetpack-connect' === sectionName && 'woocommerce-onboarding' === requestFrom;
-
 		const isJetpackWooDnaFlow = 'jetpack-connect' === sectionName && isWooDna;
 
 		const theme = config( 'theme' );
@@ -177,7 +174,9 @@ class Document extends Component {
 								className={ clsx( 'layout', {
 									[ 'is-group-' + sectionGroup ]: sectionGroup,
 									[ 'is-section-' + sectionName ]: sectionName,
-									'is-jetpack-woocommerce-flow': isJetpackWooCommerceFlow,
+									// TODO: clean up classname in styles too
+									// Should we replace it with another flow, or can we just delete?
+									// 'is-jetpack-woocommerce-flow': isJetpackWooCommerceFlow,
 									'is-jetpack-woo-dna-flow': isJetpackWooDnaFlow,
 								} ) }
 							>

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -60,7 +60,6 @@ class Document extends Component {
 			query,
 			reactQueryDevtoolsHelper,
 			renderedLayout,
-			requestFrom,
 			sectionGroup,
 			sectionName,
 			storeSandboxHelper,

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -19,7 +19,6 @@ import { authQueryPropTypes } from './utils';
 export class AuthFormHeader extends Component {
 	static propTypes = {
 		authQuery: authQueryPropTypes.isRequired,
-		isWooOnboarding: PropTypes.bool,
 		isWooJPC: PropTypes.bool,
 		isWpcomMigration: PropTypes.bool,
 		wooDnaConfig: PropTypes.object,
@@ -57,7 +56,6 @@ export class AuthFormHeader extends Component {
 		const {
 			translate,
 			partnerSlug,
-			isWooOnboarding,
 			isWooJPC,
 			wooDnaConfig,
 			isWpcomMigration,
@@ -95,15 +93,6 @@ export class AuthFormHeader extends Component {
 		}
 
 		const currentState = this.getState();
-
-		if ( isWooOnboarding ) {
-			switch ( currentState ) {
-				case 'logged-out':
-					return translate( 'Create a Jetpack account' );
-				default:
-					return translate( 'Connecting your store' );
-			}
-		}
 
 		if ( isWooJPC ) {
 			switch ( currentState ) {
@@ -150,24 +139,12 @@ export class AuthFormHeader extends Component {
 	getSubHeaderText() {
 		const {
 			translate,
-			isWooOnboarding,
 			isWooJPC,
 			wooDnaConfig,
 			isWpcomMigration,
 			isFromAutomatticForAgenciesPlugin,
 		} = this.props;
 		const currentState = this.getState();
-
-		if ( isWooOnboarding ) {
-			switch ( currentState ) {
-				case 'logged-out':
-					return translate(
-						'Your account will enable you to start using the features and benefits offered by Jetpack & WooCommerce Services.'
-					);
-				default:
-					return translate( "Once connected we'll continue setting up your store" );
-			}
-		}
 
 		if ( isWooJPC ) {
 			const pluginName = getPluginTitle( this.props.authQuery?.plugin_name, translate );

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -453,7 +453,14 @@ export class JetpackAuthorize extends Component {
 
 	isWooJPC( props = this.props ) {
 		const { from } = props.authQuery;
-		return 'woocommerce-core-profiler' === from || this.props.isWooJPC;
+		return (
+			// TODO: the two extra `from` checks shouldn't be necessary,
+			// as they should be embedded in the isWooJPCFlow. But the unit
+			// tests don't use the connected component
+			'woocommerce-core-profiler' === from ||
+			'woocommerce-onboarding' === from ||
+			this.props.isWooJPC
+		);
 	}
 
 	getWooDnaConfig( props = this.props ) {

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -443,7 +443,8 @@ export class JetpackAuthorize extends Component {
 			[
 				'woocommerce-services-auto-authorize',
 				'woocommerce-setup-wizard',
-				// Are we ok to leave this here?
+				// Legacy flow not in use anymore. Keeping around just to
+				// support redirects correctly.
 				'woocommerce-onboarding',
 				'woocommerce-core-profiler',
 			].includes( from ) || this.getWooDnaConfig( props ).isWooDnaFlow()

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -453,12 +453,7 @@ export class JetpackAuthorize extends Component {
 
 	isWooJPC( props = this.props ) {
 		const { from } = props.authQuery;
-		return (
-			// TODO: can we reuse existing logic?
-			'woocommerce-onboarding' === from ||
-			'woocommerce-core-profiler' === from ||
-			this.props.isWooJPC
-		);
+		return 'woocommerce-core-profiler' === from || this.props.isWooJPC;
 	}
 
 	getWooDnaConfig( props = this.props ) {

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -443,20 +443,26 @@ export class JetpackAuthorize extends Component {
 			[
 				'woocommerce-services-auto-authorize',
 				'woocommerce-setup-wizard',
+				// Are we ok to leave this here?
 				'woocommerce-onboarding',
 				'woocommerce-core-profiler',
 			].includes( from ) || this.getWooDnaConfig( props ).isWooDnaFlow()
 		);
 	};
 
-	isWooOnboarding( props = this.props ) {
-		const { from } = props.authQuery;
-		return 'woocommerce-onboarding' === from;
-	}
+	// isWooOnboarding( props = this.props ) {
+	// 	const { from } = props.authQuery;
+	// 	return 'woocommerce-onboarding' === from;
+	// }
 
 	isWooJPC( props = this.props ) {
 		const { from } = props.authQuery;
-		return 'woocommerce-core-profiler' === from || this.props.isWooJPC;
+		return (
+			// TODO: can we reuse existing logic?
+			'woocommerce-onboarding' === from ||
+			'woocommerce-core-profiler' === from ||
+			this.props.isWooJPC
+		);
 	}
 
 	getWooDnaConfig( props = this.props ) {
@@ -503,10 +509,6 @@ export class JetpackAuthorize extends Component {
 
 		const { recordTracksEvent } = this.props;
 		switch ( true ) {
-			case this.isWooOnboarding():
-				recordTracksEvent( 'wcadmin_storeprofiler_connect_store', { use_account: true } );
-				window.location.href = e.target.href;
-				break;
 			case this.isWooJPC():
 				// Logout user before redirecting to login page.
 				try {
@@ -537,12 +539,13 @@ export class JetpackAuthorize extends Component {
 
 	handleSignOut = () => {
 		const { recordTracksEvent } = this.props;
-		const { from } = this.props.authQuery;
+		// const { from } = this.props.authQuery;
 		recordTracksEvent( 'calypso_jpc_signout_click' );
 
-		if ( 'woocommerce-onboarding' === from ) {
-			recordTracksEvent( 'wcadmin_storeprofiler_connect_store', { create_jetpack: true } );
-		}
+		// Replace with another flow, keep, or delete?
+		// if ( 'woocommerce-onboarding' === from ) {
+		// 	recordTracksEvent( 'wcadmin_storeprofiler_connect_store', { create_jetpack: true } );
+		// }
 
 		this.props.redirectToLogout( window.location.href );
 	};
@@ -1224,7 +1227,6 @@ export class JetpackAuthorize extends Component {
 
 		return (
 			<MainWrapper
-				isWooOnboarding={ this.isWooOnboarding() }
 				isWooJPC={ this.isWooJPC() }
 				isWpcomMigration={ this.isFromMigrationPlugin() }
 				isFromAutomatticForAgenciesPlugin={ this.isFromAutomatticForAgenciesPlugin() }
@@ -1247,7 +1249,6 @@ export class JetpackAuthorize extends Component {
 						/>
 						<AuthFormHeader
 							authQuery={ this.props.authQuery }
-							isWooOnboarding={ this.isWooOnboarding() }
 							isWooJPC={ this.isWooJPC() }
 							isWpcomMigration={ this.isFromMigrationPlugin() }
 							isFromAutomatticForAgenciesPlugin={ this.isFromAutomatticForAgenciesPlugin() }

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -451,11 +451,6 @@ export class JetpackAuthorize extends Component {
 		);
 	};
 
-	// isWooOnboarding( props = this.props ) {
-	// 	const { from } = props.authQuery;
-	// 	return 'woocommerce-onboarding' === from;
-	// }
-
 	isWooJPC( props = this.props ) {
 		const { from } = props.authQuery;
 		return (

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -540,13 +540,7 @@ export class JetpackAuthorize extends Component {
 
 	handleSignOut = () => {
 		const { recordTracksEvent } = this.props;
-		// const { from } = this.props.authQuery;
 		recordTracksEvent( 'calypso_jpc_signout_click' );
-
-		// Replace with another flow, keep, or delete?
-		// if ( 'woocommerce-onboarding' === from ) {
-		// 	recordTracksEvent( 'wcadmin_storeprofiler_connect_store', { create_jetpack: true } );
-		// }
 
 		this.props.redirectToLogout( window.location.href );
 	};
@@ -598,9 +592,11 @@ export class JetpackAuthorize extends Component {
 
 		recordTracksEvent( 'calypso_jpc_approve_click' );
 
-		if ( 'woocommerce-onboarding' === from ) {
-			recordTracksEvent( 'wcadmin_storeprofiler_connect_store', { use_account: true } );
-		}
+		// Should we keep this around, since we otherwise removed other instances
+		// where we fired this tracks event?
+		// if ( 'woocommerce-onboarding' === from ) {
+		// 	recordTracksEvent( 'wcadmin_storeprofiler_connect_store', { use_account: true } );
+		// }
 
 		if ( 'woocommerce-core-profiler' === from ) {
 			recordTracksEvent( 'calypso_jpc_wc_coreprofiler_connect', { use_account: true } );

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -1021,7 +1021,7 @@ export class JetpackAuthorize extends Component {
 								siteName={ decodeEntities( authQuery.blogname ) }
 								companyName={ this.getCompanyName() }
 								from={ authQuery.from }
-								isWooJPC={ this.props.isWooJPC }
+								isWooJPC={ this.isWooJPC() }
 							/>
 							{ this.renderStateAction() }
 						</div>

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -455,8 +455,8 @@ export class JetpackAuthorize extends Component {
 		const { from } = props.authQuery;
 		return (
 			// TODO: the two extra `from` checks shouldn't be necessary,
-			// as they should be embedded in the isWooJPCFlow. But the unit
-			// tests don't use the connected component
+			// as they are part of the isWooJPCFlow check. But the unit tests
+			// don't use the connected component and would otherwise fail.
 			'woocommerce-core-profiler' === from ||
 			'woocommerce-onboarding' === from ||
 			this.props.isWooJPC
@@ -588,12 +588,6 @@ export class JetpackAuthorize extends Component {
 		}
 
 		recordTracksEvent( 'calypso_jpc_approve_click' );
-
-		// Should we keep this around, since we otherwise removed other instances
-		// where we fired this tracks event?
-		// if ( 'woocommerce-onboarding' === from ) {
-		// 	recordTracksEvent( 'wcadmin_storeprofiler_connect_store', { use_account: true } );
-		// }
 
 		if ( 'woocommerce-core-profiler' === from ) {
 			recordTracksEvent( 'calypso_jpc_wc_coreprofiler_connect', { use_account: true } );

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -12,7 +12,6 @@ import { retrieveMobileRedirect } from './persistence-utils';
 export class JetpackConnectMainWrapper extends PureComponent {
 	static propTypes = {
 		isWide: PropTypes.bool,
-		isWooOnboarding: PropTypes.bool,
 		isWooJPC: PropTypes.bool,
 		isWpcomMigration: PropTypes.bool,
 		wooDnaConfig: PropTypes.object,
@@ -23,7 +22,6 @@ export class JetpackConnectMainWrapper extends PureComponent {
 
 	static defaultProps = {
 		isWide: false,
-		isWooOnboarding: false,
 		isWooJPC: false,
 		wooDnaConfig: null,
 	};
@@ -31,7 +29,6 @@ export class JetpackConnectMainWrapper extends PureComponent {
 	render() {
 		const {
 			isWide,
-			isWooOnboarding,
 			isWooJPC,
 			isWpcomMigration,
 			isFromAutomatticForAgenciesPlugin,
@@ -47,14 +44,15 @@ export class JetpackConnectMainWrapper extends PureComponent {
 
 		const wrapperClassName = clsx( 'jetpack-connect__main', {
 			'is-wide': isWide,
-			'is-woocommerce': isWooOnboarding || isWooDna || isWooJPC,
+			'is-woocommerce': isWooDna || isWooJPC,
 			'is-woocommerce-core-profiler-flow': isWooJPC,
 			'is-mobile-app-flow': !! retrieveMobileRedirect(),
 			'is-wpcom-migration': isWpcomMigration,
 			'is-automattic-for-agencies-flow': isFromAutomatticForAgenciesPlugin,
 		} );
 
-		const width = isWooOnboarding || isWooDna ? 200 : undefined;
+		// Note: legacy flow here was "merged" with DNA
+		const width = isWooDna ? 200 : undefined;
 		const darkColorScheme = false;
 
 		return (
@@ -68,7 +66,6 @@ export class JetpackConnectMainWrapper extends PureComponent {
 						<JetpackHeader
 							partnerSlug={ partnerSlug }
 							isFromAutomatticForAgenciesPlugin={ isFromAutomatticForAgenciesPlugin }
-							isWooOnboarding={ isWooOnboarding }
 							isWooJPC={ isWooJPC }
 							isWooDna={ isWooDna }
 							width={ width }

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -124,14 +124,19 @@ export class JetpackSignup extends Component {
 		this.props.resetAuthAccountType();
 	};
 
-	isWooOnboarding() {
-		const { authQuery } = this.props;
-		return 'woocommerce-onboarding' === authQuery.from;
-	}
+	// isWooOnboarding() {
+	// 	const { authQuery } = this.props;
+	// 	return 'woocommerce-onboarding' === authQuery.from;
+	// }
 
 	isWooJPC( props = this.props ) {
 		const { from } = props.authQuery;
-		return 'woocommerce-core-profiler' === from || this.props.isWooJPC;
+		// TODO: can we reuse existing logic?
+		return (
+			'woocommerce-onboarding' === from ||
+			'woocommerce-core-profiler' === from ||
+			this.props.isWooJPC
+		);
 	}
 
 	getWooDnaConfig() {
@@ -504,7 +509,6 @@ export class JetpackSignup extends Component {
 
 		return (
 			<MainWrapper
-				isWooOnboarding={ this.isWooOnboarding() }
 				isWooJPC={ this.isWooJPC() }
 				isFromAutomatticForAgenciesPlugin={ this.isFromAutomatticForAgenciesPlugin() }
 			>
@@ -512,7 +516,6 @@ export class JetpackSignup extends Component {
 					{ this.renderLocaleSuggestions() }
 					<AuthFormHeader
 						authQuery={ this.props.authQuery }
-						isWooOnboarding={ this.isWooOnboarding() }
 						isWooJPC={ this.isWooJPC() }
 						isFromAutomatticForAgenciesPlugin={ this.isFromAutomatticForAgenciesPlugin() }
 						disableSiteCard={ isWooJPC }

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -124,19 +124,9 @@ export class JetpackSignup extends Component {
 		this.props.resetAuthAccountType();
 	};
 
-	// isWooOnboarding() {
-	// 	const { authQuery } = this.props;
-	// 	return 'woocommerce-onboarding' === authQuery.from;
-	// }
-
 	isWooJPC( props = this.props ) {
 		const { from } = props.authQuery;
-		// TODO: can we reuse existing logic?
-		return (
-			'woocommerce-onboarding' === from ||
-			'woocommerce-core-profiler' === from ||
-			this.props.isWooJPC
-		);
+		return 'woocommerce-core-profiler' === from || this.props.isWooJPC;
 	}
 
 	getWooDnaConfig() {

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -497,14 +497,14 @@ export class JetpackSignup extends Component {
 
 		return (
 			<MainWrapper
-				isWooJPC={ this.isWooJPC() }
+				isWooJPC={ isWooJPC }
 				isFromAutomatticForAgenciesPlugin={ this.isFromAutomatticForAgenciesPlugin() }
 			>
 				<div className="jetpack-connect__authorize-form">
 					{ this.renderLocaleSuggestions() }
 					<AuthFormHeader
 						authQuery={ this.props.authQuery }
-						isWooJPC={ this.isWooJPC() }
+						isWooJPC={ isWooJPC }
 						isFromAutomatticForAgenciesPlugin={ this.isFromAutomatticForAgenciesPlugin() }
 						disableSiteCard={ isWooJPC }
 					/>

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -166,9 +166,7 @@ export class JetpackSignup extends Component {
 					extra: {
 						...userData.extra,
 						jpc: true,
-						source: this.props.isWooJPC
-							? 'woo-passwordless-jpc' + '-' + this.props.authQuery.from
-							: '',
+						source: this.isWooJPC() ? 'woo-passwordless-jpc' + '-' + this.props.authQuery.from : '',
 					},
 				} )
 				.then( this.handleUserCreationSuccess, this.handleUserCreationError )

--- a/client/jetpack-connect/store-header.tsx
+++ b/client/jetpack-connect/store-header.tsx
@@ -28,7 +28,6 @@ export default function StoreHeader() {
 			<div className={ headerClass }>
 				<JetpackHeader
 					partnerSlug={ partnerSlug }
-					isWooOnboarding={ false }
 					isWooDna={ false }
 					isWooJPC={ false }
 					darkColorScheme

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -5,11 +5,10 @@
 $colophon-height: 50px;
 
 .jetpack-connect__main:not(.is-woocommerce):not(.is-wpcom-migration):not(.is-automattic-for-agencies-flow),
-.layout.is-section-jetpack-connect:not(.is-jetpack-mobile-flow):not(.is-jetpack-woocommerce-flow):not(.is-jetpack-woo-dna-flow):not(.is-wpcom-migration):not(.is-woocommerce-core-profiler-flow):not(.is-automattic-for-agencies-flow) {
+.layout.is-section-jetpack-connect:not(.is-jetpack-mobile-flow):not(.is-jetpack-woo-dna-flow):not(.is-wpcom-migration):not(.is-woocommerce-core-profiler-flow):not(.is-automattic-for-agencies-flow) {
 	@include jetpack-connect-colors();
 }
 
-.layout.is-jetpack-woocommerce-flow,
 .layout.is-jetpack-woo-dna-flow {
 	@include woocommerce-colors();
 }
@@ -850,7 +849,6 @@ $colophon-height: 50px;
 	}
 
 	/** WooCommerce Onboarding Styles **/
-	&.is-jetpack-woocommerce-flow,
 	&.is-jetpack-woo-dna-flow {
 		background-color: var(--color-woocommerce-onboarding-background);
 
@@ -1430,12 +1428,10 @@ $colophon-height: 50px;
 
 body.is-section-jetpack-connect {
 	background-color: var(--color-surface);
-	.layout {
-		&.is-jetpack-woocommerce-flow,
-		&.is-jetpack-woo-dna-flow {
-			.wpcom-site__logo {
-				display: none;
-			}
+
+	.layout.is-jetpack-woo-dna-flow {
+		.wpcom-site__logo {
+			display: none;
 		}
 	}
 }

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -178,8 +178,7 @@ describe( 'JetpackAuthorize', () => {
 			expect( isWooRedirect( props ) ).toBe( true );
 		} );
 
-		// Should we change the test name, since this flow is not as "new"?
-		test( 'should return true for new woo onboarding', () => {
+		test( 'should return true for legacy woo onboarding', () => {
 			const props = { authQuery: { from: 'woocommerce-onboarding' } };
 			expect( isWooRedirect( props ) ).toBe( true );
 		} );

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -178,6 +178,7 @@ describe( 'JetpackAuthorize', () => {
 			expect( isWooRedirect( props ) ).toBe( true );
 		} );
 
+		// Should we change the test name, since this flow is not as "new"?
 		test( 'should return true for new woo onboarding', () => {
 			const props = { authQuery: { from: 'woocommerce-onboarding' } };
 			expect( isWooRedirect( props ) ).toBe( true );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -445,11 +445,7 @@ export default withCurrentRoute(
 			( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
 			currentRoute.startsWith( '/checkout/jetpack' );
 		const isWooJPC =
-			[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
-			// TODO:
-			// - confirm that it's ok to merge with JPC (and not DNA)
-			// - move to isWooJPCFlow function
-			( 'woocommerce-onboarding' === currentQuery?.from || isWooJPCFlow( state ) );
+			[ 'jetpack-connect', 'login' ].includes( sectionName ) && isWooJPCFlow( state );
 		const isBlazePro = getIsBlazePro( state );
 		const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
 		const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -297,7 +297,8 @@ class Layout extends Component {
 			'is-jetpack-login': this.props.isJetpackLogin,
 			'is-jetpack-site': this.props.isJetpack,
 			'is-jetpack-mobile-flow': this.props.isJetpackMobileFlow,
-			'is-jetpack-woocommerce-flow': this.props.isJetpackWooCommerceFlow,
+			// Can we just delete, or do we need to replace it with another flow?
+			// 'is-jetpack-woocommerce-flow': this.props.isJetpackWooCommerceFlow,
 			'is-jetpack-woo-dna-flow': this.props.isJetpackWooDnaFlow,
 			'is-woocommerce-core-profiler-flow': this.props.isWooJPC,
 			'is-automattic-for-agencies-flow': this.props.isFromAutomatticForAgenciesPlugin,
@@ -446,7 +447,11 @@ export default withCurrentRoute(
 			( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
 			currentRoute.startsWith( '/checkout/jetpack' );
 		const isWooJPC =
-			[ 'jetpack-connect', 'login' ].includes( sectionName ) && isWooJPCFlow( state );
+			[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
+			// TODO:
+			// - confirm that it's ok to merge with JPC (and not DNA)
+			// - move to isWooJPCFlow function
+			( 'woocommerce-onboarding' === currentQuery?.from || isWooJPCFlow( state ) );
 		const isBlazePro = getIsBlazePro( state );
 		const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
 		const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(
@@ -480,9 +485,6 @@ export default withCurrentRoute(
 			isJetpackCloud() ||
 			isA8CForAgencies();
 		const isJetpackMobileFlow = 'jetpack-connect' === sectionName && !! retrieveMobileRedirect();
-		const isJetpackWooCommerceFlow =
-			[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
-			'woocommerce-onboarding' === currentQuery?.from;
 		const isJetpackWooDnaFlow =
 			[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
 			wooDnaConfig( currentQuery ).isWooDnaFlow();
@@ -507,7 +509,7 @@ export default withCurrentRoute(
 			sidebarIsHidden,
 			isJetpack,
 			isJetpackLogin,
-			isJetpackWooCommerceFlow,
+			// isJetpackWooCommerceFlow,
 			isJetpackWooDnaFlow,
 			isJetpackMobileFlow,
 			isWooJPC,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -297,8 +297,6 @@ class Layout extends Component {
 			'is-jetpack-login': this.props.isJetpackLogin,
 			'is-jetpack-site': this.props.isJetpack,
 			'is-jetpack-mobile-flow': this.props.isJetpackMobileFlow,
-			// Can we just delete, or do we need to replace it with another flow?
-			// 'is-jetpack-woocommerce-flow': this.props.isJetpackWooCommerceFlow,
 			'is-jetpack-woo-dna-flow': this.props.isJetpackWooDnaFlow,
 			'is-woocommerce-core-profiler-flow': this.props.isWooJPC,
 			'is-automattic-for-agencies-flow': this.props.isFromAutomatticForAgenciesPlugin,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -503,7 +503,6 @@ export default withCurrentRoute(
 			sidebarIsHidden,
 			isJetpack,
 			isJetpackLogin,
-			// isJetpackWooCommerceFlow,
 			isJetpackWooDnaFlow,
 			isJetpackMobileFlow,
 			isWooJPC,

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -131,8 +131,6 @@ const LayoutLoggedOut = ( {
 		'is-jetpack-site': isJetpackCheckout,
 		'is-white-login': isWhiteLogin,
 		'is-popup': isPopup,
-		// Ok to remove, or should it be replace with another flow?
-		// 'is-jetpack-woocommerce-flow': isJetpackWooCommerceFlow,
 		'is-jetpack-woo-dna-flow': isJetpackWooDnaFlow,
 		'is-p2-login': isP2Login,
 		'is-gravatar': isGravatar,

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -342,12 +342,7 @@ export default withCurrentRoute(
 				! isWooOAuth2Client( oauth2Client ) &&
 				! isBlazeProOAuth2Client( oauth2Client ) &&
 				[ 'signup', 'jetpack-connect' ].includes( sectionName );
-			// const isJetpackWooCommerceFlow = 'woocommerce-onboarding' === currentQuery?.from;
-			// TODO:
-			// - should we also add the section check like in the other file?
-			// - merge with JPC or DNA?
-			// - move to isWooJPCFlow
-			const isWooJPC = 'woocommerce-onboarding' === currentQuery?.from || isWooJPCFlow( state );
+			const isWooJPC = isWooJPCFlow( state );
 			const wccomFrom = getWccomFrom( state );
 			const masterbarIsHidden =
 				! ( currentSection || currentRoute ) ||

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -55,7 +55,6 @@ const LayoutLoggedOut = ( {
 	isJetpackLogin,
 	isWhiteLogin,
 	isPopup,
-	isJetpackWooCommerceFlow,
 	isJetpackWooDnaFlow,
 	isP2Login,
 	isGravatar,
@@ -132,7 +131,8 @@ const LayoutLoggedOut = ( {
 		'is-jetpack-site': isJetpackCheckout,
 		'is-white-login': isWhiteLogin,
 		'is-popup': isPopup,
-		'is-jetpack-woocommerce-flow': isJetpackWooCommerceFlow,
+		// Ok to remove, or should it be replace with another flow?
+		// 'is-jetpack-woocommerce-flow': isJetpackWooCommerceFlow,
 		'is-jetpack-woo-dna-flow': isJetpackWooDnaFlow,
 		'is-p2-login': isP2Login,
 		'is-gravatar': isGravatar,
@@ -344,8 +344,12 @@ export default withCurrentRoute(
 				! isWooOAuth2Client( oauth2Client ) &&
 				! isBlazeProOAuth2Client( oauth2Client ) &&
 				[ 'signup', 'jetpack-connect' ].includes( sectionName );
-			const isJetpackWooCommerceFlow = 'woocommerce-onboarding' === currentQuery?.from;
-			const isWooJPC = isWooJPCFlow( state );
+			// const isJetpackWooCommerceFlow = 'woocommerce-onboarding' === currentQuery?.from;
+			// TODO:
+			// - should we also add the section check like in the other file?
+			// - merge with JPC or DNA?
+			// - move to isWooJPCFlow
+			const isWooJPC = 'woocommerce-onboarding' === currentQuery?.from || isWooJPCFlow( state );
 			const wccomFrom = getWccomFrom( state );
 			const masterbarIsHidden =
 				! ( currentSection || currentRoute ) ||
@@ -360,7 +364,6 @@ export default withCurrentRoute(
 				isJetpackLogin,
 				isWhiteLogin,
 				isPopup,
-				isJetpackWooCommerceFlow,
 				isJetpackWooDnaFlow,
 				isP2Login,
 				isGravatar,

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -203,11 +203,6 @@ export const canDoMagicLogin = ( twoFactorAuthType, oauth2Client ) => {
 		return false;
 	}
 
-	// TODO: replace with other flow, or delete?
-	// if ( isJetpackWooCommerceFlow ) {
-	// 	return false;
-	// }
-
 	return true;
 };
 

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -203,9 +203,10 @@ export const canDoMagicLogin = ( twoFactorAuthType, oauth2Client, isJetpackWooCo
 		return false;
 	}
 
-	if ( isJetpackWooCommerceFlow ) {
-		return false;
-	}
+	// TODO: replace with other flow, or delete?
+	// if ( isJetpackWooCommerceFlow ) {
+	// 	return false;
+	// }
 
 	return true;
 };

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -188,7 +188,7 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 	return signupUrl;
 }
 
-export const canDoMagicLogin = ( twoFactorAuthType, oauth2Client, isJetpackWooCommerceFlow ) => {
+export const canDoMagicLogin = ( twoFactorAuthType, oauth2Client ) => {
 	if ( ! config.isEnabled( `login/magic-login` ) || twoFactorAuthType ) {
 		return false;
 	}

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -212,8 +212,9 @@ export class LoginLinks extends Component {
 			! canDoMagicLogin(
 				this.props.twoFactorAuthType,
 				this.props.oauth2Client,
-				this.props.wccomFrom,
-				this.props.isJetpackWooCommerceFlow
+				this.props.wccomFrom
+				// Replace with other flow, or delete?
+				// this.props.isJetpackWooCommerceFlow
 			)
 		) {
 			return null;
@@ -261,9 +262,10 @@ export class LoginLinks extends Component {
 			return null;
 		}
 
-		if ( this.props.isJetpackWooCommerceFlow ) {
-			return null;
-		}
+		// Replace with other flow, or delete?
+		// if ( this.props.isJetpackWooCommerceFlow ) {
+		// 	return null;
+		// }
 
 		const loginUrl = login( {
 			locale: this.props.locale,
@@ -298,7 +300,6 @@ export default connect(
 		currentRoute: getCurrentRoute( state ),
 		isLoggedIn: Boolean( getCurrentUserId( state ) ),
 		query: getCurrentQueryArguments( state ),
-		isJetpackWooCommerceFlow: 'woocommerce-onboarding' === getCurrentQueryArguments( state ).from,
 		wccomFrom: getWccomFrom( state ),
 	} ),
 	{

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -25,7 +25,6 @@ import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { resetMagicLoginRequestForm } from 'calypso/state/login/magic-login/actions';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 
 export class LoginLinks extends Component {
 	static propTypes = {
@@ -208,15 +207,7 @@ export class LoginLinks extends Component {
 	}
 
 	renderMagicLoginLink() {
-		if (
-			! canDoMagicLogin(
-				this.props.twoFactorAuthType,
-				this.props.oauth2Client,
-				this.props.wccomFrom
-				// Replace with other flow, or delete?
-				// this.props.isJetpackWooCommerceFlow
-			)
-		) {
+		if ( ! canDoMagicLogin( this.props.twoFactorAuthType, this.props.oauth2Client ) ) {
 			return null;
 		}
 
@@ -300,7 +291,6 @@ export default connect(
 		currentRoute: getCurrentRoute( state ),
 		isLoggedIn: Boolean( getCurrentUserId( state ) ),
 		query: getCurrentQueryArguments( state ),
-		wccomFrom: getWccomFrom( state ),
 	} ),
 	{
 		recordTracksEvent,

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -253,11 +253,6 @@ export class LoginLinks extends Component {
 			return null;
 		}
 
-		// Replace with other flow, or delete?
-		// if ( this.props.isJetpackWooCommerceFlow ) {
-		// 	return null;
-		// }
-
 		const loginUrl = login( {
 			locale: this.props.locale,
 			twoFactorAuthType: 'qr',

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -153,11 +153,10 @@ $image-height: 47px;
 	}
 }
 
-.layout.is-jetpack-login:not(.is-jetpack-woocommerce-flow):not(.is-wccom-oauth-flow):not(.is-woocommerce-core-profiler-flow) {
+.layout.is-jetpack-login:not(.is-wccom-oauth-flow):not(.is-woocommerce-core-profiler-flow) {
 	@include jetpack-connect-colors();
 }
 
-.layout.is-jetpack-woocommerce-flow,
 .layout.is-wccom-oauth-flow,
 .layout.is-jetpack-woo-dna-flow {
 	@include woocommerce-colors();
@@ -196,7 +195,6 @@ $image-height: 47px;
 	}
 }
 
-.layout.is-jetpack-woocommerce-flow,
 .layout.is-wccom-oauth-flow {
 	background-color: var(--color-woocommerce-onboarding-background);
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -176,7 +176,6 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 		user: false,
 		env: calypsoEnv,
 		sanitize: sanitize,
-		requestFrom: request.query.from,
 		isWooDna: wooDnaConfig( request.query ).isWooDnaFlow(),
 		badge: false,
 		lang: config( 'i18n_default_locale_slug' ),

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -406,11 +406,6 @@ const assertDefaultContext = ( { url, entry } ) => {
 		expect( request.context.sanitize ).toEqual( app.getMocks().sanitize );
 	} );
 
-	it( 'sets requestFrom', async () => {
-		const { request } = await app.run( { request: { query: { from: 'from' } } } );
-		expect( request.context.requestFrom ).toEqual( 'from' );
-	} );
-
 	it( 'sets lang to the default', async () => {
 		const { request } = await app.run();
 		expect( request.context.lang ).toEqual( 'en' );

--- a/client/state/selectors/is-woo-jpc-flow.ts
+++ b/client/state/selectors/is-woo-jpc-flow.ts
@@ -4,7 +4,14 @@ import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-
 import { isWooCommerceCoreProfilerFlow } from './is-woocommerce-core-profiler-flow';
 import type { AppState } from 'calypso/types';
 
-const isWooCommercePaymentsOnboardingFlow = ( state: AppState ): boolean => {
+// The legacy Jetpack Woo Onboarding flow is not in use anymore,
+// and is now absorbed into the Woo JPC Onboarding flow.
+// See https://github.com/Automattic/wp-calypso/pull/99558 for more details.
+const isLegacyJetpackWooOnboardingFlow = ( state: AppState ) => {
+	return 'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' );
+};
+
+const isWooCommercePaymentsOnboardingFlow = ( state: AppState ) => {
 	const from =
 		get( getInitialQueryArguments( state ), 'from' ) === 'woocommerce-payments' ||
 		get( getCurrentQueryArguments( state ), 'from' ) === 'woocommerce-payments';
@@ -42,7 +49,11 @@ const isWooCommercePaymentsOnboardingFlow = ( state: AppState ): boolean => {
  * @returns {?boolean}        Whether the user should see the new passwordless Jetpack connection or not
  */
 export const isWooJPCFlow = ( state: AppState ): boolean => {
-	return isWooCommerceCoreProfilerFlow( state ) || isWooCommercePaymentsOnboardingFlow( state );
+	return (
+		isLegacyJetpackWooOnboardingFlow( state ) ||
+		isWooCommerceCoreProfilerFlow( state ) ||
+		isWooCommercePaymentsOnboardingFlow( state )
+	);
 };
 
 export default isWooJPCFlow;

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -27,9 +27,7 @@ const EVENT_NAME_EXCEPTIONS = [
 	'a8c_cookie_banner_view',
 	'a8c_ccpa_optout',
 	// WooCommerce Onboarding / Connection Flow.
-	'wcadmin_storeprofiler_create_jetpack_account',
 	'wcadmin_storeprofiler_connect_store',
-	'wcadmin_storeprofiler_login_jetpack_account',
 	'wcadmin_storeprofiler_payment_login',
 	'wcadmin_storeprofiler_payment_create_account',
 	// Checkout

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -27,7 +27,6 @@ const EVENT_NAME_EXCEPTIONS = [
 	'a8c_cookie_banner_view',
 	'a8c_ccpa_optout',
 	// WooCommerce Onboarding / Connection Flow.
-	'wcadmin_storeprofiler_connect_store',
 	'wcadmin_storeprofiler_payment_login',
 	'wcadmin_storeprofiler_payment_create_account',
 	// Checkout


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up to #99266

## Proposed Changes

- Remove the legacy Jetpack + Woo onboarding flow. The flow is apparently not in use anymore, as confirmed by @chihsuan  and @ilyasfoo in https://github.com/Automattic/wp-calypso/pull/99266#issuecomment-2642159957
- the old flow (represented in code generally by the `isJetpackWooCommerceFlow` and `isWooOnboarding` variables, and associated to the `from='woocommerce-onboarding'` query string) is removed and "merged" into the Woo JPC flow
- The PR follows the general steps proposed in p1738776609659759-slack-C01SFMVEYAK
- The following tracks events are not being fired anymore:
  - `wcadmin_storeprofiler_create_jetpack_account`
  - `wcadmin_storeprofiler_login_jetpack_account`
  - `wcadmin_storeprofiler_connect_store`
- Related styles are also being removed


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Removing unneeded code keeps our codebase tidy

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check how the legacy, JPC and Woo DNA onboarding flows behave on trunk:
  - To test the old legacy flow (ie. jetpack woo onboarding) on trunk, visit [this link](https://wordpress.com/log-in/jetpack?redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000%2Fjetpack%2Fconnect%2Fauthorize%3Fclient_id%3D219799967%26redirect_uri%3Dhttps%253A%252F%252Fdull-wasp.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fhandler%253Djetpack-connection-webhooks%2526action%253Dauthorize%2526_wpnonce%253D3f81798d85%2526redirect%253Dhttps%25253A%25252F%25252Fdull-wasp.jurassic.ninja%25252Fwp-admin%25252Fadmin.php%25253Fpage%25253Dwc-admin%26state%3D1%26scope%3Dadministrator%253Ae0a0df66fa6e6d2b7c0969d37fa165d4%26user_email%3Dchi-hsuan.huang%2540automattic.com%26user_login%3Dchihsuanhuang%26jp_version%3D12.1.1%26secret%3DuDAtkilHDeWP4lnJewWTAH5Gv7EQVJxt%26blogname%3DDull%2BWasp%26site_url%3Dhttps%253A%252F%252Fdull-wasp.jurassic.ninja%26home_url%3Dhttps%253A%252F%252Fdull-wasp.jurassic.ninja%26site_icon%26site_lang%3Den_US%26site_created%3D2023-06-05%2B07%253A02%253A54%26allow_site_connection%3D1%26locale%3Den%26_ui%3D42367338%26_ut%3Dwpcom%253Auser_id%26calypso_env%3Dproduction%26_as%3Dwp-cli%26from%3Dwoocommerce-onboarding%26purchase_nonce%3Di5V9KqSt%26_wp_nonce%3De48c9f86a6%26redirect_after_auth%3Dhttps%253A%252F%252Fdull-wasp.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin%26site%3Dhttps%253A%252F%252Fdull-wasp.jurassic.ninja&from=woocommerce-onboarding)
  - To test the new onboarding flow (ie. Woo JPC) on trunk, visit [this link](https://wordpress.com/log-in/jetpack?redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000%2Fjetpack%2Fconnect%2Fauthorize%3Fclient_id%3D219799967%26redirect_uri%3Dhttps%253A%252F%252Fdull-wasp.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fhandler%253Djetpack-connection-webhooks%2526action%253Dauthorize%2526_wpnonce%253D3f81798d85%2526redirect%253Dhttps%25253A%25252F%25252Fdull-wasp.jurassic.ninja%25252Fwp-admin%25252Fadmin.php%25253Fpage%25253Dwc-admin%26state%3D1%26scope%3Dadministrator%253Ae0a0df66fa6e6d2b7c0969d37fa165d4%26user_email%3Dchi-hsuan.huang%2540automattic.com%26user_login%3Dchihsuanhuang%26jp_version%3D12.1.1%26secret%3DuDAtkilHDeWP4lnJewWTAH5Gv7EQVJxt%26blogname%3DDull%2BWasp%26site_url%3Dhttps%253A%252F%252Fdull-wasp.jurassic.ninja%26home_url%3Dhttps%253A%252F%252Fdull-wasp.jurassic.ninja%26site_icon%26site_lang%3Den_US%26site_created%3D2023-06-05%2B07%253A02%253A54%26allow_site_connection%3D1%26locale%3Den%26_ui%3D42367338%26_ut%3Dwpcom%253Auser_id%26calypso_env%3Dproduction%26_as%3Dwp-cli%26from%3Dwoocommerce-onboarding%26purchase_nonce%3Di5V9KqSt%26_wp_nonce%3De48c9f86a6%26redirect_after_auth%3Dhttps%253A%252F%252Fdull-wasp.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-admin%26site%3Dhttps%253A%252F%252Fdull-wasp.jurassic.ninja&from=woocommerce-core-profiler)
  - To test the Woo DNA flow on `trunk`, visit [this link](https://wordpress.com/jetpack/connect/authorize?client_id=239804800&redirect_uri=https%3A%2F%2Fcarp-of-turtles.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fhandler%3Djetpack-connection-webhooks%26action%3Dauthorize%26_wpnonce%3Dfa2483e781%26redirect%3Dhttps%253A%252F%252Fcarp-of-turtles.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Dwc-settings%2526tab%253Dshipping%2526section%253Dwoocommerce-services-settings&state=1&scope=administrator%3A1234&user_email=user%40email.com&user_login=user&jp_version=14.2-a.1&secret=na&blogname=Carp+Of+Turtles&site_url=https%3A%2F%2Fcarp-of-turtles.jurassic.ninja&home_url=https%3A%2F%2Fcarp-of-turtles.jurassic.ninja&site_icon&site_lang=en_US&site_created=2024-12-11+04%3A19%3A54&allow_site_connection=1&calypso_env&source&_as=wp-cli&from=woocommerce-services&_ui=189375772&_ut=wpcom%3Auser_id&purchase_nonce=qUjMAC7v&woodna_service_name=WooCommerce+Shipping+%26+Tax&woodna_help_url=https%3A%2F%2Fwoocommerce.com%2Fdocument%2Fwoocommerce-shipping-and-tax%2F&_wp_nonce=1e563eb72b&redirect_after_auth=https%3A%2F%2Fcarp-of-turtles.jurassic.ninja%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-settings%26tab%3Dshipping%26section%3Dwoocommerce-services-settings&site=https%3A%2F%2Fcarp-of-turtles.jurassic.ninja)
  - Note: the main difference between those two links is in the last `from=` query parameter: `woocommerce-onboarding` for the legacy onboarding flow, `woocommerce-core-profiler` for the Woo JPC flow
2. Make sure that, on this PR, the same URL used for the legacy jetpack woo onboarding flow navigates to the Woo JPC flow
3. Make sure that the Woo DNA flow is unaffected by the changes in this PR and works like on `trunk`
4. Make sure that the flow described in [this comment](https://github.com/Automattic/wp-calypso/pull/99558#pullrequestreview-2611405968) also works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?