### PR TITLE
Block meta tracking in California

### DIFF
--- a/client/lib/analytics/tracker-buckets.ts
+++ b/client/lib/analytics/tracker-buckets.ts
@@ -5,6 +5,7 @@ import {
 	isUrlExcludedForPerformance,
 	mayWeTrackUserGpcInCcpaRegion,
 	mayWeSessionTrack,
+	getExceptions,
 } from 'calypso/lib/analytics/utils';
 import { isE2ETest } from 'calypso/lib/e2e';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -39,7 +40,7 @@ const allAdTrackers = [
 
 const sessionAdTrackers = [ 'hotjar', 'logrocket' ];
 
-type AdTracker = ( typeof allAdTrackers )[ number ];
+export type AdTracker = ( typeof allAdTrackers )[ number ];
 
 export enum Bucket {
 	ESSENTIAL = 'essential',
@@ -136,6 +137,12 @@ export const mayWeTrackByBucket = ( bucket: Bucket ) => {
 };
 
 export const mayWeInitTracker = ( tracker: AdTracker ) => {
+	const exceptions = getExceptions();
+
+	if ( exceptions[ tracker ] ) {
+		return false;
+	}
+
 	const bucket = AdTrackersBuckets[ tracker ];
 	return null !== bucket && mayWeTrackByBucket( bucket );
 };

--- a/client/lib/analytics/utils/get-exceptions.ts
+++ b/client/lib/analytics/utils/get-exceptions.ts
@@ -1,7 +1,7 @@
 import cookie from 'cookie';
 import type { AdTracker } from '../tracker-buckets';
 
-const getExceptions = (): Record< AdTracker, boolean > => {
+const getExceptions = (): Partial< Record< AdTracker, boolean > > => {
 	const cookies = cookie.parse( document.cookie );
 	const region = ( cookies.region || '' ).toLowerCase();
 	const countryCode = ( cookies.country_code || '' ).toLowerCase();

--- a/client/lib/analytics/utils/get-exceptions.ts
+++ b/client/lib/analytics/utils/get-exceptions.ts
@@ -1,0 +1,18 @@
+import cookie from 'cookie';
+import type { AdTracker } from '../tracker-buckets';
+
+const getExceptions = (): Record< AdTracker, boolean > => {
+	const cookies = cookie.parse( document.cookie );
+	const region = ( cookies.region || '' ).toLowerCase();
+	const countryCode = ( cookies.country_code || '' ).toLowerCase();
+
+	if ( ! region || ! countryCode ) {
+		return {};
+	}
+
+	return {
+		facebook: region === 'california' && countryCode === 'us',
+	};
+};
+
+export default getExceptions;

--- a/client/lib/analytics/utils/index.ts
+++ b/client/lib/analytics/utils/index.ts
@@ -15,3 +15,4 @@ export { default as shouldSeeCookieBanner } from './should-see-cookie-banner';
 export { mayWeTrackUserGpcInCcpaRegion, isGpcFlagSetOptOut } from './is-gpc-flag-set';
 export { default as useDoNotSell } from './use-do-not-sell';
 export { default as mayWeSessionTrack } from './may-we-session-track';
+export { default as getExceptions } from './get-exceptions';


### PR DESCRIPTION
## Proposed Changes

* Add an exceptions function that handles blocking certain trackers under certain circumstances
* Add facebook to exceptions if region is California and country_code is US

## Why are these changes being made?

Discussion here: p1723479368879969-slack-C02EUU03J2K

## Testing Instructions

1. Open the Calypso blue live link and go to `/me/purchases?flags=ad-tracking`
2. Make sure you have all Ad blockers disabled for the live link
3. If you live in California, update your `region` or `country_code` cookie to something other than California and US
4. Open the page inspector and search `fbevents` and ensure the Pixel tracking script is in the DOM
![image](https://github.com/user-attachments/assets/78b730fe-0333-410d-b8fe-6e1da088f395)
5. Now update your `region` to `California` and `country_code` to `US` and ensure the script is no longer loaded

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?