### PR TITLE
Update the main Launch site CTA behavior in the Focused Launchpad

### DIFF
--- a/client/my-sites/customer-home/components/full-screen-launchpad.scss
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.scss
@@ -20,6 +20,10 @@
 		}
 	}
 
+	.launchpad__checklist-wrapper {
+		margin-bottom: 24px;
+	}
+
 	.checklist-item__task {
         padding: 2px;
         border: 1px solid var(--studio-gray-5);
@@ -95,20 +99,17 @@
 	.launchpad-site-launch {
 		font-size: 1rem;
 		padding: 1.5rem;
-		margin-top: 24px;
 	}
 
 	.launchpad-actions {
 		display: flex;
 		flex-direction: column;
-		gap: 16px;
+		gap: 12px;
 		margin: auto;
 		align-items: center;
 		
 		.launchpad-site-launch {
 			order: 0;
 		}
-		
 	}
-	
 }

--- a/client/my-sites/customer-home/components/full-screen-launchpad.scss
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.scss
@@ -3,6 +3,7 @@
 	max-width: 536px;
 	margin: auto;
 	box-shadow: none;
+	padding-bottom: 10px;
 
 	.customer-home__launchpad-header{
 		display: flex;
@@ -87,6 +88,7 @@
 		}
 
 		&:last-child {
+			display: none;
 			border: 0;
 			
 			button {
@@ -112,6 +114,14 @@
 
 			svg {
 				display: none;
+			}
+		}
+	}
+
+	&.all-tasks-completed {
+		.checklist-item__task {
+			&:last-child {
+				display: block;
 			}
 		}
 	}

--- a/client/my-sites/customer-home/components/full-screen-launchpad.scss
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.scss
@@ -89,40 +89,26 @@
 
 		&:last-child {
 			display: none;
-			border: 0;
-			
-			button {
-				border-radius: 4px;
-				font-size: .875rem;
-				font-weight: 500;
-				background-color: var(--color-accent);
-				color: var(--color-text-inverted);
-				max-width: 260px;
-				margin: auto;
-				margin-top: 24px;
-
-				&:hover,
-				&:focus {
-					background-color: var(--color-accent-60);
-				}
-			}
-
-			.checklist-item__text{
-				text-align: center;
-				color: var(--color-text-inverted);
-			}
-
-			svg {
-				display: none;
-			}
 		}
 	}
 
-	&.all-tasks-completed {
-		.checklist-item__task {
-			&:last-child {
-				display: block;
-			}
-		}
+	.launchpad-site-launch {
+		font-size: 1rem;
+		padding: 1.5rem;
+		margin-top: 24px;
 	}
+
+	.launchpad-actions {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+		margin: auto;
+		align-items: center;
+		
+		.launchpad-site-launch {
+			order: 0;
+		}
+		
+	}
+	
 }

--- a/client/my-sites/customer-home/components/full-screen-launchpad.scss
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.scss
@@ -29,7 +29,7 @@
             border-bottom: none;
         }
 
-		a, button {
+		a {
 			padding: 20px 24px;
 			margin: 0;
 			border-bottom: none;
@@ -53,8 +53,7 @@
             border-bottom: 1px solid var(--studio-gray-5);
 			border-radius: 4px;
 
-			a,
-			button {
+			a {
 				margin: 0 0 -1px 0;
 				padding: 28px 24px;
 				border-radius: 2px;
@@ -73,20 +72,47 @@
 		&:first-child {
             border-radius: 4px 4px 0 0;
 
-            a,
-            button {
+            a {
                 border-radius: 2px 2px 0 0;
             }
         }
 
-		&:last-child {
+		&:nth-last-child(2) {
 			border-radius: 0 0 4px 4px;
             border-bottom: 1px solid var(--studio-gray-5);
             
-            a,
-            button {
+            a {
                 border-radius: 0 0 2px 2px;
             }
+		}
+
+		&:last-child {
+			border: 0;
+			
+			button {
+				border-radius: 4px;
+				font-size: .875rem;
+				font-weight: 500;
+				background-color: var(--color-accent);
+				color: var(--color-text-inverted);
+				max-width: 260px;
+				margin: auto;
+				margin-top: 24px;
+
+				&:hover,
+				&:focus {
+					background-color: var(--color-accent-60);
+				}
+			}
+
+			.checklist-item__text{
+				text-align: center;
+				color: var(--color-text-inverted);
+			}
+
+			svg {
+				display: none;
+			}
 		}
 	}
 }

--- a/client/my-sites/customer-home/components/full-screen-launchpad.scss
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.scss
@@ -34,7 +34,7 @@
             border-bottom: none;
         }
 
-		a {
+		a, button {
 			padding: 20px 24px;
 			margin: 0;
 			border-bottom: none;
@@ -58,7 +58,7 @@
             border-bottom: 1px solid var(--studio-gray-5);
 			border-radius: 4px;
 
-			a {
+			a, button {
 				margin: 0 0 -1px 0;
 				padding: 28px 24px;
 				border-radius: 2px;
@@ -77,7 +77,7 @@
 		&:first-child {
             border-radius: 4px 4px 0 0;
 
-            a {
+            a, button {
                 border-radius: 2px 2px 0 0;
             }
         }
@@ -85,8 +85,8 @@
 		&:nth-last-child(2) {
 			border-radius: 0 0 4px 4px;
             border-bottom: 1px solid var(--studio-gray-5);
-            
-            a {
+
+            a, button {
                 border-radius: 0 0 2px 2px;
             }
 		}

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -83,6 +83,7 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ): JSX
 	}
 
 	const launchSiteTask = checklist?.find( ( task: Task ) => task.isLaunchTask );
+	const isLaunchSiteTaskComplete = launchSiteTask?.completed;
 
 	const isAllTasksCompleted =
 		hasChecklist &&
@@ -101,7 +102,7 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ): JSX
 						size={ 40 }
 						enableDesktopScaling
 						numberOfSteps={ numberOfSteps - ( launchSiteTask ? 1 : 0 ) }
-						currentStep={ completedSteps }
+						currentStep={ completedSteps - ( isLaunchSiteTaskComplete ? 1 : 0 ) }
 					/>
 					<h2>{ ! isAllTasksCompleted ? __( "Let's get started!" ) : __( "You're all set!" ) }</h2>
 					<span>{ ! isAllTasksCompleted && launchpadTitle }</span>

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -63,12 +63,17 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ): JSX
 		return null;
 	}
 
-	const isAllTasksCompleted = hasChecklist && numberOfSteps > 0 && completedSteps === numberOfSteps;
+	const isAllTasksCompleted =
+		hasChecklist && numberOfSteps > 0 && completedSteps >= numberOfSteps - 1; // -1 because the last task is the "Launch your site" button
 
 	return (
 		<div css={ { display: 'flex', flexDirection: 'column', alignItems: 'center' } }>
 			<div className="is-launchpad-first" css={ { width: '100%' } }>
-				<div className="customer-home-launchpad customer-home__card is-small-hero">
+				<div
+					className={ `customer-home-launchpad customer-home__card is-small-hero ${
+						isAllTasksCompleted ? 'all-tasks-completed' : ''
+					}` }
+				>
 					<div className="customer-home__launchpad-header">
 						<CircularProgressBar
 							size={ 40 }
@@ -91,9 +96,7 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ): JSX
 					/>
 				</div>
 			</div>
-			<Button onClick={ onSkipLaunchpad } variant={ isAllTasksCompleted ? 'primary' : undefined }>
-				{ isAllTasksCompleted ? __( 'Explore dashboard' ) : __( 'Skip to dashboard' ) }
-			</Button>
+			<Button onClick={ onSkipLaunchpad }>{ __( 'Skip to dashboard' ) }</Button>
 		</div>
 	);
 };

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -44,15 +44,18 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ): JSX
 		setIsLaunching( true );
 		launchSiteApi(
 			async () => {
-				await updateLaunchpadSettings( siteId, {
-					checklist_statuses: { site_launched: true },
-				} );
+				try {
+					await updateLaunchpadSettings( siteId, {
+						checklist_statuses: { site_launched: true },
+					} );
 
-				await refetch?.();
-				await layout?.refetch();
-				await dispatch( requestSite( siteId ) );
-				onClose();
-				setIsLaunching( false );
+					await refetch?.();
+					await layout?.refetch();
+					await dispatch( requestSite( siteId ) );
+					onClose();
+				} finally {
+					setIsLaunching( false );
+				}
 			},
 			{ siteSlug }
 		);

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -81,9 +81,7 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ): JSX
 		return null;
 	}
 
-	const launchSiteTask = checklist?.find( ( task: Task ) =>
-		[ 'site_launched', 'blog_launched', 'link_in_bio_launched' ].includes( task.id )
-	);
+	const launchSiteTask = checklist?.find( ( task: Task ) => task.isLaunchTask );
 
 	const isAllTasksCompleted =
 		hasChecklist &&

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -111,7 +111,7 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ): JSX
 					highlightNextAction
 				/>
 				<div className="launchpad-actions">
-					{ launchSiteTask && (
+					{ launchSiteTask && isAllTasksCompleted && (
 						<Button onClick={ onSkipLaunchpad } className="launchpad-site-launch" variant="primary">
 							{ launchSiteTask?.title }
 						</Button>

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -1,6 +1,7 @@
 import { CircularProgressBar, ConfettiAnimation } from '@automattic/components';
-import { updateLaunchpadSettings } from '@automattic/data-stores';
-import { Launchpad } from '@automattic/launchpad';
+import { updateLaunchpadSettings, useSortedLaunchpadTasks } from '@automattic/data-stores';
+import { wpcomRequest } from '@automattic/data-stores/src/wpcom-request-controls';
+import { Launchpad, Task } from '@automattic/launchpad';
 import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
@@ -38,6 +39,14 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ): JSX
 	} );
 
 	const onSiteLaunched = async () => {
+		onClose();
+
+		await wpcomRequest( {
+			path: `/sites/${ siteSlug }/launch`,
+			apiVersion: '1.1',
+			method: 'post',
+		} );
+
 		await updateLaunchpadSettings( siteId, {
 			checklist_statuses: { site_launched: true },
 		} );
@@ -59,44 +68,57 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ): JSX
 		dispatch( requestSite( siteId ) );
 	};
 
+	const {
+		data: { checklist },
+	} = useSortedLaunchpadTasks( siteSlug, checklistSlug, launchpadContext );
+
 	if ( isDismissed ) {
 		return null;
 	}
 
+	const launchSiteTask = checklist?.find( ( task: Task ) =>
+		[ 'site_launched', 'blog_launched', 'link_in_bio_launched' ].includes( task.id )
+	);
+
 	const isAllTasksCompleted =
-		hasChecklist && numberOfSteps > 0 && completedSteps >= numberOfSteps - 1; // -1 because the last task is the "Launch your site" button
+		hasChecklist &&
+		numberOfSteps > 0 &&
+		completedSteps >= numberOfSteps - ( launchSiteTask ? 1 : 0 );
 
 	return (
-		<div css={ { display: 'flex', flexDirection: 'column', alignItems: 'center' } }>
-			<div className="is-launchpad-first" css={ { width: '100%' } }>
-				<div
-					className={ `customer-home-launchpad customer-home__card is-small-hero ${
-						isAllTasksCompleted ? 'all-tasks-completed' : ''
-					}` }
-				>
-					<div className="customer-home__launchpad-header">
-						<CircularProgressBar
-							size={ 40 }
-							enableDesktopScaling
-							numberOfSteps={ numberOfSteps }
-							currentStep={ completedSteps }
-						/>
-						<h2>
-							{ ! isAllTasksCompleted ? __( "Let's get started!" ) : __( "You're all set!" ) }
-						</h2>
-						<span>{ ! isAllTasksCompleted && launchpadTitle }</span>
-					</div>
-					{ isAllTasksCompleted && <ConfettiAnimation /> }
-					<Launchpad
-						siteSlug={ siteSlug }
-						checklistSlug={ checklistSlug }
-						launchpadContext={ launchpadContext }
-						onSiteLaunched={ onSiteLaunched }
-						highlightNextAction
+		<div className="is-launchpad-first" css={ { width: '100%' } }>
+			<div
+				className={ `customer-home-launchpad customer-home__card is-small-hero ${
+					isAllTasksCompleted ? 'all-tasks-completed' : ''
+				}` }
+			>
+				<div className="customer-home__launchpad-header">
+					<CircularProgressBar
+						size={ 40 }
+						enableDesktopScaling
+						numberOfSteps={ numberOfSteps - ( launchSiteTask ? 1 : 0 ) }
+						currentStep={ completedSteps }
 					/>
+					<h2>{ ! isAllTasksCompleted ? __( "Let's get started!" ) : __( "You're all set!" ) }</h2>
+					<span>{ ! isAllTasksCompleted && launchpadTitle }</span>
+				</div>
+				{ isAllTasksCompleted && <ConfettiAnimation /> }
+				<Launchpad
+					siteSlug={ siteSlug }
+					checklistSlug={ checklistSlug }
+					launchpadContext={ launchpadContext }
+					onSiteLaunched={ onSiteLaunched }
+					highlightNextAction
+				/>
+				<div className="launchpad-actions">
+					{ launchSiteTask && (
+						<Button onClick={ onSkipLaunchpad } className="launchpad-site-launch" variant="primary">
+							{ launchSiteTask?.title }
+						</Button>
+					) }
+					<Button onClick={ onSkipLaunchpad }>{ __( 'Skip to dashboard' ) }</Button>
 				</div>
 			</div>
-			<Button onClick={ onSkipLaunchpad }>{ __( 'Skip to dashboard' ) }</Button>
 		</div>
 	);
 };

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -1,12 +1,13 @@
 import { CircularProgressBar, ConfettiAnimation } from '@automattic/components';
 import { updateLaunchpadSettings, useSortedLaunchpadTasks } from '@automattic/data-stores';
-import { wpcomRequest } from '@automattic/data-stores/src/wpcom-request-controls';
 import { Launchpad, Task } from '@automattic/launchpad';
 import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
+import { launchSiteApi } from 'calypso/lib/signup/step-actions';
 import { useDispatch } from 'calypso/state';
 import { requestSite } from 'calypso/state/sites/actions';
 import { getSite } from 'calypso/state/sites/selectors';
@@ -18,6 +19,7 @@ import './full-screen-launchpad.scss';
 export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ): JSX.Element | null => {
 	const dispatch = useDispatch();
 	const { __ } = useI18n();
+	const [ isLaunching, setIsLaunching ] = useState( false );
 	const siteId = useSelector( getSelectedSiteId ) || 0;
 	const site = useSelector( ( state: AppState ) => getSite( state, siteId ) );
 	const checklistSlug = site?.options?.site_intent ?? '';
@@ -39,21 +41,21 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ): JSX
 	} );
 
 	const onSiteLaunched = async () => {
-		onClose();
+		setIsLaunching( true );
+		launchSiteApi(
+			async () => {
+				await updateLaunchpadSettings( siteId, {
+					checklist_statuses: { site_launched: true },
+				} );
 
-		await wpcomRequest( {
-			path: `/sites/${ siteSlug }/launch`,
-			apiVersion: '1.1',
-			method: 'post',
-		} );
-
-		await updateLaunchpadSettings( siteId, {
-			checklist_statuses: { site_launched: true },
-		} );
-
-		await refetch?.();
-		layout?.refetch();
-		dispatch( requestSite( siteId ) );
+				await refetch?.();
+				await layout?.refetch();
+				await dispatch( requestSite( siteId ) );
+				onClose();
+				setIsLaunching( false );
+			},
+			{ siteSlug }
+		);
 	};
 
 	const onSkipLaunchpad = async () => {
@@ -112,11 +114,19 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ): JSX
 				/>
 				<div className="launchpad-actions">
 					{ launchSiteTask && isAllTasksCompleted && (
-						<Button onClick={ onSkipLaunchpad } className="launchpad-site-launch" variant="primary">
+						<Button
+							onClick={ onSiteLaunched }
+							className="launchpad-site-launch"
+							variant="primary"
+							isBusy={ isLaunching }
+							disabled={ isLaunching }
+						>
 							{ launchSiteTask?.title }
 						</Button>
 					) }
-					<Button onClick={ onSkipLaunchpad }>{ __( 'Skip to dashboard' ) }</Button>
+					<Button onClick={ onSkipLaunchpad } disabled={ isLaunching }>
+						{ __( 'Skip to dashboard' ) }
+					</Button>
 				</div>
 			</div>
 		</div>

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -3,6 +3,7 @@ import { updateLaunchpadSettings, useSortedLaunchpadTasks } from '@automattic/da
 import { Launchpad, Task } from '@automattic/launchpad';
 import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import clsx from 'clsx';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
@@ -91,9 +92,9 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ): JSX
 	return (
 		<div className="is-launchpad-first" css={ { width: '100%' } }>
 			<div
-				className={ `customer-home-launchpad customer-home__card is-small-hero ${
-					isAllTasksCompleted ? 'all-tasks-completed' : ''
-				}` }
+				className={ clsx( `customer-home-launchpad customer-home__card is-small-hero`, {
+					'all-tasks-completed': isAllTasksCompleted,
+				} ) }
 			>
 				<div className="customer-home__launchpad-header">
 					<CircularProgressBar


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99560

## Proposed Changes

- Only show the Launch CTA after all tasks are completed
- Show it as a separate CTA, as the old Launchpad does
- When launching the site, enable a loading state in the button

https://github.com/user-attachments/assets/38b3a112-4e15-46a9-9189-f713724c8956


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a new site at /setup/onboarding (can be on prod)
* After you land at the Launchpad, copy your site URL and replace in this URL: http://calypso.localhost:3000/home/{myDomain}?flags=home/launchpad-first
* Note that we don't show the launch button yet
* Complete all tasks and check if you see the main CTA
* Launch the site and ensure the button is responsible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
