### PR TITLE
A4A: Filter out sites without full Jetpack installed from Plugins dashboard

### DIFF
--- a/client/my-sites/plugins/plugins-dashboard/index.tsx
+++ b/client/my-sites/plugins/plugins-dashboard/index.tsx
@@ -42,6 +42,7 @@ import {
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 import { getAllPlugins as getAllWporgPlugins } from 'calypso/state/plugins/wporg/selectors';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import getSelectedOrAllSitesWithJetpackPlugin from 'calypso/state/selectors/get-selected-or-all-sites-with-jetpack-plugin';
 import getSites from 'calypso/state/selectors/get-sites';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
 import { PluginActionName, PluginActions, Site } from '../hooks/types';
@@ -107,7 +108,9 @@ const PluginsDashboard = ( {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const isJetpackCloudOrA8CForAgencies = isJetpackCloud() || isA8CForAgencies();
-	const allSites = useSelector( ( state ) => getSites( state ) );
+	const allSites = useSelector( ( state ) =>
+		isA8CForAgencies() ? getSelectedOrAllSitesWithJetpackPlugin( state ) : getSites( state )
+	);
 	const siteIds = siteObjectsToSiteIds( allSites ) ?? [];
 	const wporgPlugins = useSelector( ( state ) => getAllWporgPlugins( state ) );
 	const isLoading = useSelector(

--- a/client/my-sites/plugins/plugins-dashboard/index.tsx
+++ b/client/my-sites/plugins/plugins-dashboard/index.tsx
@@ -42,7 +42,7 @@ import {
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 import { getAllPlugins as getAllWporgPlugins } from 'calypso/state/plugins/wporg/selectors';
 import { getProductsList } from 'calypso/state/products-list/selectors';
-import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
+import getSites from 'calypso/state/selectors/get-sites';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
 import { PluginActionName, PluginActions, Site } from '../hooks/types';
 import { withShowPluginActionDialog } from '../hooks/use-show-plugin-action-dialog';
@@ -107,7 +107,7 @@ const PluginsDashboard = ( {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const isJetpackCloudOrA8CForAgencies = isJetpackCloud() || isA8CForAgencies();
-	const allSites = useSelector( ( state ) => getSelectedOrAllSitesWithPlugins( state ) );
+	const allSites = useSelector( ( state ) => getSites( state ) );
 	const siteIds = siteObjectsToSiteIds( allSites ) ?? [];
 	const wporgPlugins = useSelector( ( state ) => getAllWporgPlugins( state ) );
 	const isLoading = useSelector(

--- a/client/my-sites/plugins/plugins-dashboard/index.tsx
+++ b/client/my-sites/plugins/plugins-dashboard/index.tsx
@@ -42,7 +42,7 @@ import {
 import { removePluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 import { getAllPlugins as getAllWporgPlugins } from 'calypso/state/plugins/wporg/selectors';
 import { getProductsList } from 'calypso/state/products-list/selectors';
-import getSites from 'calypso/state/selectors/get-sites';
+import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
 import { PluginActionName, PluginActions, Site } from '../hooks/types';
 import { withShowPluginActionDialog } from '../hooks/use-show-plugin-action-dialog';
@@ -107,7 +107,7 @@ const PluginsDashboard = ( {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const isJetpackCloudOrA8CForAgencies = isJetpackCloud() || isA8CForAgencies();
-	const allSites = useSelector( ( state ) => getSites( state ) );
+	const allSites = useSelector( ( state ) => getSelectedOrAllSitesWithPlugins( state ) );
 	const siteIds = siteObjectsToSiteIds( allSites ) ?? [];
 	const wporgPlugins = useSelector( ( state ) => getAllWporgPlugins( state ) );
 	const isLoading = useSelector(

--- a/client/state/selectors/get-selected-or-all-sites-with-jetpack-plugin.js
+++ b/client/state/selectors/get-selected-or-all-sites-with-jetpack-plugin.js
@@ -1,0 +1,26 @@
+import { createSelector } from '@automattic/state-utils';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import isJetpackConnectionPluginActive from 'calypso/state/sites/selectors/is-jetpack-connection-plugin-active';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+import 'calypso/state/ui/init';
+
+/**
+ * Return an array with the selected site or all sites able to have plugins
+ * @param {Object} state  Global state tree
+ * @returns {Array}        Array of Sites objects with the result
+ */
+
+export default createSelector(
+	( state ) =>
+		getSelectedOrAllSites( state ).filter(
+			( site ) =>
+				isJetpackSite( state, site.ID ) &&
+				canCurrentUser( state, site.ID, 'manage_options' ) &&
+				( site.visible || getSelectedSiteId( state ) ) &&
+				isJetpackConnectionPluginActive( state, site.ID, 'jetpack' )
+		),
+	( state ) => [ state.ui.selectedSiteId, state.sites.items, state.currentUser.capabilities ]
+);

--- a/client/state/selectors/get-selected-or-all-sites-with-plugins.js
+++ b/client/state/selectors/get-selected-or-all-sites-with-plugins.js
@@ -2,6 +2,7 @@ import { createSelector } from '@automattic/state-utils';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import isJetpackConnectionPluginActive from 'calypso/state/sites/selectors/is-jetpack-connection-plugin-active';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import 'calypso/state/ui/init';
@@ -18,7 +19,8 @@ export default createSelector(
 			( site ) =>
 				isJetpackSite( state, site.ID ) &&
 				canCurrentUser( state, site.ID, 'manage_options' ) &&
-				( site.visible || getSelectedSiteId( state ) )
+				( site.visible || getSelectedSiteId( state ) ) &&
+				isJetpackConnectionPluginActive( state, site.ID, 'jetpack' )
 		),
 	( state ) => [ state.ui.selectedSiteId, state.sites.items, state.currentUser.capabilities ]
 );

--- a/client/state/selectors/get-selected-or-all-sites-with-plugins.js
+++ b/client/state/selectors/get-selected-or-all-sites-with-plugins.js
@@ -2,7 +2,6 @@ import { createSelector } from '@automattic/state-utils';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getSelectedOrAllSites from 'calypso/state/selectors/get-selected-or-all-sites';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import isJetpackConnectionPluginActive from 'calypso/state/sites/selectors/is-jetpack-connection-plugin-active';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import 'calypso/state/ui/init';
@@ -19,8 +18,7 @@ export default createSelector(
 			( site ) =>
 				isJetpackSite( state, site.ID ) &&
 				canCurrentUser( state, site.ID, 'manage_options' ) &&
-				( site.visible || getSelectedSiteId( state ) ) &&
-				isJetpackConnectionPluginActive( state, site.ID, 'jetpack' )
+				( site.visible || getSelectedSiteId( state ) )
 		),
 	( state ) => [ state.ui.selectedSiteId, state.sites.items, state.currentUser.capabilities ]
 );


### PR DESCRIPTION
Removes sites without full Jetpack from the Plugins dashboard as most plugin actions won't work without the Jetpack JSON API.

## Proposed Changes

* Adds a new selector to filter out sites that don’t have Jetpack fully installed.
* Applies the new selector conditionally for A4A users.

## Testing Instructions

* Open the live link for A4A
* Login as `a4ademo`
* Go to `/plugins/manage/sites/woocommerce`
* Confirm you see "Installed on 6 sites"
* Without the new selector it should display "

<img width="334" alt="Screenshot 2025-02-11 at 23 24 34" src="https://github.com/user-attachments/assets/2aec661d-93f1-4b11-b056-2b1203f00f7e" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
