### PR TITLE
Remove Is Reskinned Flag: Remove is reskinned from site selector

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -57,9 +57,6 @@ class Site extends Component {
 
 		isP2Hub: false,
 		isSiteP2: false,
-
-		isReskinned: false,
-
 		defaultIcon: null,
 	};
 
@@ -81,7 +78,6 @@ class Site extends Component {
 		compact: PropTypes.bool,
 		isP2Hub: PropTypes.bool,
 		isSiteP2: PropTypes.bool,
-		isReskinned: PropTypes.bool,
 		defaultIcon: PropTypes.node,
 	};
 
@@ -226,7 +222,6 @@ class Site extends Component {
 			'is-selected': this.props.isSelected,
 			'is-highlighted': this.props.isHighlighted,
 			'is-compact': this.props.compact,
-			'is-reskinned': this.props.isReskinned,
 			'is-trial': this.props.isTrialSite,
 			'inline-badges': inlineBadges,
 		} );

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -14,22 +14,16 @@
 	padding: 0;
 	position: relative;
 
-	&.is-reskinned {
-		.site-icon {
-			background-color: var(--color-neutral-0);
-			svg {
-				transform: scale(0.65);
-				fill: var(--color-neutral-50);
-			}
-		}
-	}
-
 	&.is-loading {
 		pointer-events: none;
 
 		.site-icon {
 			animation: pulse-light 1.8s ease-in-out infinite;
-			background-color: var(--color-neutral-10);
+			background-color: var(--color-neutral-0);
+			svg {
+				transform: scale(0.65);
+				fill: var(--color-neutral-50);
+			}
 		}
 
 		.site__title,

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -13,17 +13,27 @@
 	justify-content: space-between;
 	padding: 0;
 	position: relative;
+	.site-icon {
+		position: relative;
+		height: 30px;
+		width: 30px;
+		overflow: hidden;
+		align-self: flex-start;
+		margin-right: 8px;
+		flex: 0 0 auto;
+		background-color: var(--color-neutral-0);
+		svg {
+			transform: scale(0.65);
+			fill: var(--color-neutral-50);
+		}
+	}
 
 	&.is-loading {
 		pointer-events: none;
 
 		.site-icon {
 			animation: pulse-light 1.8s ease-in-out infinite;
-			background-color: var(--color-neutral-0);
-			svg {
-				transform: scale(0.65);
-				fill: var(--color-neutral-50);
-			}
+			background-color: var(--color-neutral-10);
 		}
 
 		.site__title,
@@ -111,17 +121,6 @@
 	}
 }
 
-// Adjusts the SiteIcon component for use
-// within a Site item
-.site .site-icon {
-	position: relative;
-	height: 30px;
-	width: 30px;
-	overflow: hidden;
-	align-self: flex-start;
-	margin-right: 8px;
-	flex: 0 0 auto;
-}
 
 // The group of site title and domain
 .site__info {

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { getUrlParts, getUrlFromParts, determineUrlType, format } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
-import SearchRestyled from '@automattic/search';
+import Search from '@automattic/search';
 import clsx from 'clsx';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
@@ -12,7 +12,6 @@ import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import AllSites from 'calypso/blocks/all-sites';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
-import Search from 'calypso/components/search';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import { addQueryArgs } from 'calypso/lib/url';
 import allSitesMenu from 'calypso/my-sites/sidebar/static-data/all-sites-menu';
@@ -59,7 +58,6 @@ export class SiteSelector extends Component {
 		visibleSites: PropTypes.arrayOf( PropTypes.object ),
 		allSitesPath: PropTypes.string,
 		navigateToSite: PropTypes.func.isRequired,
-		isReskinned: PropTypes.bool,
 		showManageSitesButton: PropTypes.bool,
 		showHiddenSites: PropTypes.bool,
 		maxResults: PropTypes.number,
@@ -402,7 +400,7 @@ export class SiteSelector extends Component {
 				onMouseEnter={ this.onSiteHover }
 				isHighlighted={ this.isHighlighted }
 				isSelected={ this.isSelected }
-				isReskinned={ this.props.isReskinned }
+				isReskinned
 			/>
 		);
 	}
@@ -426,8 +424,6 @@ export class SiteSelector extends Component {
 
 		const sites = this.sitesToBeRendered();
 
-		const SearchComponent = this.props.isReskinned ? SearchRestyled : Search;
-
 		return (
 			<div
 				ref={ this.props.forwardRef }
@@ -435,7 +431,7 @@ export class SiteSelector extends Component {
 				onMouseMove={ this.onMouseMove }
 				onMouseLeave={ this.onMouseLeave }
 			>
-				<SearchComponent
+				<Search
 					onSearch={ this.onSearch }
 					placeholder={ this.props.searchPlaceholder }
 					// eslint-disable-next-line jsx-a11y/no-autofocus
@@ -443,7 +439,7 @@ export class SiteSelector extends Component {
 					disabled={ ! this.props.hasLoadedSites }
 					onSearchClose={ this.props.onClose }
 					onKeyDown={ this.onKeyDown }
-					isReskinned={ this.props.isReskinned }
+					isReskinned
 				/>
 				<div className="site-selector__sites" ref={ this.setSiteSelectorRef }>
 					{ this.renderAllSites() }

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -400,7 +400,6 @@ export class SiteSelector extends Component {
 				onMouseEnter={ this.onSiteHover }
 				isHighlighted={ this.isHighlighted }
 				isSelected={ this.isSelected }
-				isReskinned
 			/>
 		);
 	}

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -438,7 +438,6 @@ export class SiteSelector extends Component {
 					disabled={ ! this.props.hasLoadedSites }
 					onSearchClose={ this.props.onClose }
 					onKeyDown={ this.onKeyDown }
-					isReskinned
 				/>
 				<div className="site-selector__sites" ref={ this.setSiteSelectorRef }>
 					{ this.renderAllSites() }

--- a/client/components/site-selector/sites-list.tsx
+++ b/client/components/site-selector/sites-list.tsx
@@ -17,7 +17,6 @@ interface SitesListProps extends SitesSortingPreferenceProps {
 	maxResults?: number;
 	searchTerm: string;
 	addToVisibleSites( siteId: number ): void;
-	isReskinned?: boolean;
 	sites: SiteDetailsWithTitle[];
 	onSelect( event: React.MouseEvent, siteId: number ): void;
 	indicator: boolean;
@@ -33,7 +32,6 @@ const SitesList = ( {
 	maxResults,
 	sitesSorting,
 	addToVisibleSites,
-	isReskinned,
 	sites: originalSites,
 	onSelect,
 	indicator,
@@ -69,7 +67,6 @@ const SitesList = ( {
 									onMouseEnter={ onMouseEnter }
 									isHighlighted={ isHighlighted( site.ID ) }
 									isSelected={ isSelected( site ) }
-									isReskinned={ isReskinned }
 								/>
 							);
 						} ) }

--- a/client/components/theme-site-selector-modal/index.jsx
+++ b/client/components/theme-site-selector-modal/index.jsx
@@ -46,7 +46,7 @@ export default function ThemeSiteSelectorModal( { isOpen, navigateOnClose = true
 			<div className="theme-site-selector-modal__content">
 				{ hasNonVisibleSites && <p>{ translate( 'Some unsupported sites are hidden.' ) }</p> }
 				{ /* eslint-disable-next-line jsx-a11y/no-autofocus */ }
-				<SiteSelector autoFocus onSiteSelect={ onSiteSelect } isReskinned />
+				<SiteSelector autoFocus onSiteSelect={ onSiteSelect } />
 			</div>
 		</Modal>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/styles.scss
@@ -42,7 +42,6 @@
 				}
 
 				.site-selector__sites {
-					border-top: none;
 
 					@include breakpoint-deprecated( "<660px" ) {
 						max-height: none;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/styles.scss
@@ -42,7 +42,6 @@
 				}
 
 				.site-selector__sites {
-
 					@include breakpoint-deprecated( "<660px" ) {
 						max-height: none;
 					}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/styles.scss
@@ -51,8 +51,6 @@
 				}
 
 				.site-selector__sites {
-					border-top: none;
-
 					@include breakpoint-deprecated( "<660px" ) {
 						max-height: none;
 					}

--- a/client/me/notification-settings/blogs-settings/index.jsx
+++ b/client/me/notification-settings/blogs-settings/index.jsx
@@ -106,7 +106,6 @@ class BlogsSettings extends Component {
 						onSearch={ ( searchTerm ) => {
 							this.setState( { searchTerm } );
 						} }
-						isReskinned
 						placeholder={ this.props.translate( 'Search by name or domain…' ) }
 						disableAutocorrect
 						defaultValue=""

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/style.scss
@@ -49,7 +49,4 @@
 		}
 	}
 
-	.site-selector.is-large .site-selector__sites {
-		border-top: none;
-	}
 }

--- a/client/my-sites/promote-post-i2/components/search-bar/index.tsx
+++ b/client/my-sites/promote-post-i2/components/search-bar/index.tsx
@@ -316,7 +316,6 @@ export default function SearchBar( props: Props ) {
 				placeholder={ translate( 'Search…' ) }
 				delaySearch
 				delayTimeout={ 500 }
-				isReskinned
 				onSearch={ ( inputValue: string ) => {
 					if ( inputValue !== null ) {
 						onChangeSearch( inputValue );

--- a/client/signup/steps/site-picker/index.jsx
+++ b/client/signup/steps/site-picker/index.jsx
@@ -26,11 +26,7 @@ class SitePicker extends Component {
 	renderScreen() {
 		return (
 			<Card className="site-picker__wrapper">
-				<SiteSelector
-					filter={ this.filterSites }
-					onSiteSelect={ this.handleSiteSelect }
-					isReskinned
-				/>
+				<SiteSelector filter={ this.filterSites } onSiteSelect={ this.handleSiteSelect } />
 			</Card>
 		);
 	}

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -155,7 +155,6 @@ export const SitesContentControls = ( {
 			<SitesSearch
 				searchIcon={ <SearchIcon /> }
 				onSearch={ handleSearch }
-				isReskinned
 				placeholder={ __( 'Search by name or domain…' ) }
 				disableAutocorrect
 				defaultValue={ initialSearch }

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -64,7 +64,7 @@
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
 		"prepack": "yarn run clean && yarn run build",
 		"storybook": "sb dev"
 	}

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -64,7 +64,7 @@
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"storybook": "sb dev"
 	}

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -78,6 +78,7 @@ type Props = {
 	value?: string;
 	searchMode?: 'when-typing' | 'on-enter';
 	searchIcon?: ReactNode;
+	submitOnOpenIconClick?: boolean;
 };
 
 //This is fix for IE11. Does not work on Edge.

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -2,7 +2,7 @@
 
 import { Button, Spinner } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { close, search, Icon } from '@wordpress/icons';
+import { close, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { debounce } from 'lodash';
@@ -58,7 +58,6 @@ type Props = {
 	displayOpenAndCloseIcons?: boolean;
 	fitsContainer?: boolean;
 	hideClose?: boolean;
-	isReskinned?: boolean;
 	hideOpenIcon?: boolean;
 	inputLabel?: string;
 	openIconSide?: 'left' | 'right';
@@ -79,7 +78,6 @@ type Props = {
 	value?: string;
 	searchMode?: 'when-typing' | 'on-enter';
 	searchIcon?: ReactNode;
-	submitOnOpenIconClick?: boolean;
 };
 
 //This is fix for IE11. Does not work on Edge.
@@ -147,10 +145,7 @@ const InnerSearch = (
 		minLength,
 		maxLength,
 		hideClose = false,
-		isReskinned = false,
 		searchMode = 'when-typing',
-		searchIcon,
-		submitOnOpenIconClick = false,
 	}: Props,
 	forwardedRef: Ref< ImperativeHandle >
 ) => {
@@ -225,15 +220,6 @@ const InnerSearch = (
 		onSearchChange?.( keyword );
 	}, [ keyword ] );
 
-	const openSearch = ( event: KeyboardOrMouseEvent ) => {
-		event.preventDefault();
-
-		setKeyword( '' );
-		setIsOpen( true );
-
-		recordEvent?.( 'Clicked Open Search' );
-	};
-
 	const closeSearch = ( event: KeyboardOrMouseEvent ) => {
 		event.preventDefault();
 
@@ -280,7 +266,6 @@ const InnerSearch = (
 	}, [ isOpen ] );
 
 	const closeListener = keyListener( closeSearch );
-	const openListener = keyListener( openSearch );
 
 	const scrollOverlay = () => {
 		window.requestAnimationFrame( () => {
@@ -395,7 +380,7 @@ const InnerSearch = (
 		return null;
 	};
 
-	const renderReskinSearchIcon = () => {
+	const renderOpenIcon = () => {
 		const searchIcon = (
 			<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<path
@@ -410,46 +395,10 @@ const InnerSearch = (
 				/>
 			</svg>
 		);
-
-		return <Icon icon={ searchIcon } size={ 32 } className="search-component__icon-search" />;
-	};
-
-	const renderOpenIcon = () => {
-		const enableOpenIcon = pinned && ! isOpen;
-
 		if ( searchIcon ) {
 			return searchIcon;
 		}
-
-		if ( isReskinned ) {
-			return renderReskinSearchIcon();
-		}
-
-		const onClick = ( props: React.MouseEvent< HTMLButtonElement > ) => {
-			if ( submitOnOpenIconClick ) {
-				handleSubmit();
-			}
-
-			if ( enableOpenIcon ) {
-				return openSearch( props );
-			}
-
-			return () => searchInput.current?.focus();
-		};
-
-		return (
-			<Button
-				className="search-component__icon-navigation"
-				ref={ openIcon }
-				onClick={ onClick }
-				tabIndex={ enableOpenIcon ? 0 : undefined }
-				onKeyDown={ enableOpenIcon ? openListener : undefined }
-				aria-controls={ 'search-component-' + instanceId }
-				aria-label={ __( 'Open Search', __i18n_text_domain__ ) }
-			>
-				{ ! hideOpenIcon && <Icon icon={ search } className="search-component__open-icon" /> }
-			</Button>
-		);
+		return <Icon icon={ searchIcon } size={ 32 } className="search-component__icon-search" />;
 	};
 
 	const renderCloseButton = () => {

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -146,6 +146,8 @@ const InnerSearch = (
 		maxLength,
 		hideClose = false,
 		searchMode = 'when-typing',
+		searchIcon,
+		submitOnOpenIconClick = false,
 	}: Props,
 	forwardedRef: Ref< ImperativeHandle >
 ) => {
@@ -220,6 +222,15 @@ const InnerSearch = (
 		onSearchChange?.( keyword );
 	}, [ keyword ] );
 
+	const openSearch = ( event: KeyboardOrMouseEvent ) => {
+		event.preventDefault();
+
+		setKeyword( '' );
+		setIsOpen( true );
+
+		recordEvent?.( 'Clicked Open Search' );
+	};
+
 	const closeSearch = ( event: KeyboardOrMouseEvent ) => {
 		event.preventDefault();
 
@@ -266,6 +277,7 @@ const InnerSearch = (
 	}, [ isOpen ] );
 
 	const closeListener = keyListener( closeSearch );
+	const openListener = keyListener( openSearch );
 
 	const scrollOverlay = () => {
 		window.requestAnimationFrame( () => {
@@ -381,24 +393,61 @@ const InnerSearch = (
 	};
 
 	const renderOpenIcon = () => {
-		const searchIcon = (
-			<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-				<path
-					fillRule="evenodd"
-					clipRule="evenodd"
-					d="M13.8269 19.8984L8.49362 24.5651L7.50586 23.4362L12.8392 18.7695L13.8269 19.8984Z"
-				/>
-				<path
-					fillRule="evenodd"
-					clipRule="evenodd"
-					d="M17.9994 21.1667C21.221 21.1667 23.8327 18.555 23.8327 15.3333C23.8327 12.1117 21.221 9.5 17.9994 9.5C14.7777 9.5 12.166 12.1117 12.166 15.3333C12.166 18.555 14.7777 21.1667 17.9994 21.1667ZM17.9994 22.6667C22.0494 22.6667 25.3327 19.3834 25.3327 15.3333C25.3327 11.2832 22.0494 8 17.9994 8C13.9493 8 10.666 11.2832 10.666 15.3333C10.666 19.3834 13.9493 22.6667 17.9994 22.6667Z"
-				/>
-			</svg>
+		const enableOpenIcon = pinned && ! isOpen;
+
+		const defaultSearchIcon = (
+			<div className="search-component__left-icon-container">
+				<svg
+					viewBox="0 0 32 32"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+					className="search-component__icon-search"
+				>
+					<path
+						fillRule="evenodd"
+						clipRule="evenodd"
+						d="M13.8269 19.8984L8.49362 24.5651L7.50586 23.4362L12.8392 18.7695L13.8269 19.8984Z"
+					/>
+					<path
+						fillRule="evenodd"
+						clipRule="evenodd"
+						d="M17.9994 21.1667C21.221 21.1667 23.8327 18.555 23.8327 15.3333C23.8327 12.1117 21.221 9.5 17.9994 9.5C14.7777 9.5 12.166 12.1117 12.166 15.3333C12.166 18.555 14.7777 21.1667 17.9994 21.1667ZM17.9994 22.6667C22.0494 22.6667 25.3327 19.3834 25.3327 15.3333C25.3327 11.2832 22.0494 8 17.9994 8C13.9493 8 10.666 11.2832 10.666 15.3333C10.666 19.3834 13.9493 22.6667 17.9994 22.6667Z"
+					/>
+				</svg>
+			</div>
 		);
+
 		if ( searchIcon ) {
 			return searchIcon;
 		}
-		return <Icon icon={ searchIcon } size={ 32 } className="search-component__icon-search" />;
+
+		const onClick = ( props: React.MouseEvent< HTMLButtonElement > ) => {
+			if ( submitOnOpenIconClick ) {
+				handleSubmit();
+			}
+
+			if ( enableOpenIcon ) {
+				return openSearch( props );
+			}
+
+			return () => searchInput.current?.focus();
+		};
+
+		return (
+			<Button
+				className="search-component__icon-navigation"
+				ref={ openIcon }
+				onClick={ onClick }
+				tabIndex={ enableOpenIcon ? 0 : undefined }
+				onKeyDown={ enableOpenIcon ? openListener : undefined }
+				aria-controls={ 'search-component-' + instanceId }
+				aria-label={ __( 'Open Search', __i18n_text_domain__ ) }
+			>
+				{ ! hideOpenIcon && (
+					<Icon icon={ defaultSearchIcon } className="search-component__open-icon" />
+				) }
+			</Button>
+		);
 	};
 
 	const renderCloseButton = () => {

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -2,7 +2,7 @@
 
 import { Button, Spinner } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { close, Icon } from '@wordpress/icons';
+import { close, search, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { debounce } from 'lodash';
@@ -395,29 +395,6 @@ const InnerSearch = (
 
 	const renderOpenIcon = () => {
 		const enableOpenIcon = pinned && ! isOpen;
-
-		const defaultSearchIcon = (
-			<div className="search-component__left-icon-container">
-				<svg
-					viewBox="0 0 32 32"
-					fill="none"
-					xmlns="http://www.w3.org/2000/svg"
-					className="search-component__icon-search"
-				>
-					<path
-						fillRule="evenodd"
-						clipRule="evenodd"
-						d="M13.8269 19.8984L8.49362 24.5651L7.50586 23.4362L12.8392 18.7695L13.8269 19.8984Z"
-					/>
-					<path
-						fillRule="evenodd"
-						clipRule="evenodd"
-						d="M17.9994 21.1667C21.221 21.1667 23.8327 18.555 23.8327 15.3333C23.8327 12.1117 21.221 9.5 17.9994 9.5C14.7777 9.5 12.166 12.1117 12.166 15.3333C12.166 18.555 14.7777 21.1667 17.9994 21.1667ZM17.9994 22.6667C22.0494 22.6667 25.3327 19.3834 25.3327 15.3333C25.3327 11.2832 22.0494 8 17.9994 8C13.9493 8 10.666 11.2832 10.666 15.3333C10.666 19.3834 13.9493 22.6667 17.9994 22.6667Z"
-					/>
-				</svg>
-			</div>
-		);
-
 		if ( searchIcon ) {
 			return searchIcon;
 		}
@@ -444,9 +421,7 @@ const InnerSearch = (
 				aria-controls={ 'search-component-' + instanceId }
 				aria-label={ __( 'Open Search', __i18n_text_domain__ ) }
 			>
-				{ ! hideOpenIcon && (
-					<Icon icon={ defaultSearchIcon } className="search-component__open-icon" />
-				) }
+				{ ! hideOpenIcon && <Icon icon={ search } className="search-component__open-icon" /> }
 			</Button>
 		);
 	};

--- a/packages/search/src/style.scss
+++ b/packages/search/src/style.scss
@@ -12,7 +12,6 @@ $input-z-index: 20;
 .search-component {
 	border-radius: 2px;
 	display: flex;
-	flex: 1 1 auto;
 	width: 60px;
 	height: 51px;
 	position: relative;
@@ -21,8 +20,14 @@ $input-z-index: 20;
 	z-index: 1;
 	transition: all 0.15s ease-in-out;
 
+	.search-component__left-icon-container {
+		min-width: 32px;
+		svg {
+			fill: var( --color-neutral-10 );
+		}
+	}
+
 	input.search-component__input[type="search"] {
-		width: 0;
 		flex: 1 1 auto;
 		z-index: $input-z-index;
 		top: 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to: https://github.com/Automattic/wp-calypso/issues/95419
- Discussion: pdvytD-Yw-p2

## Proposed Changes

* Removes the is reskinned flag from the `SiteSelector` and the  `@automattic/search` components
* The non reskinned version styling will be completely removed
* The styling change is a minor cosmetic fixes specially around borders 
* Most routes will see the modern site selector component however any localized overrides will not change

<img width="1704" alt="image" src="https://github.com/user-attachments/assets/58986462-d739-4b7c-a68e-b0794c7a31fe" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Purge isReskinned flag from the codebase

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Go to the following routes and check the site selector component (some might have to click a button to trigger the display of the site selector). Make sure the look and feels look unbroken and smooth.

* Theme site spicker: `/theme/twentytwentyfive`
* Site selection search: `/setup/hundred-year-plan/site-picker`
* DIFM Site Picker: `/start/do-it-for-me/difm-site-picker`
* Start writing site picker: `/setup/start-writing/site-picker`
* Design first site picker: `/setup/design-first/site-picker`
* Notification settings site selector: `/me/notifications`


Do the same with the search box in the following locations
* Language picker search box: `/me/account` 
* Help search box: `/help`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?