### PR TITLE
Stats: use subscribers_by_user_type for email/wpcom subs

### DIFF
--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -5,7 +5,10 @@ import { parseAvatar } from 'calypso/state/stats/lists/utils';
 import getDefaultQueryParams from './default-query-params';
 
 const MAX_SUBSCRIBERS_TO_RETURN = 10;
-const isJetpackApi = config.isEnabled( 'is_running_in_jetpack' );
+const isJetpackApi = config.isEnabled( 'is_running_in_jetpack_site' );
+const sortByDateDesc = ( a: { date_subscribed: string }, b: { date_subscribed: string } ) => {
+	return new Date( b.date_subscribed ).getTime() - new Date( a.date_subscribed ).getTime();
+};
 
 const querySubscribersTotals = ( siteId: number | null, filterAdmin?: boolean ): Promise< any > => {
 	return wpcom.req
@@ -117,8 +120,6 @@ export function useSubscribersTotalsWithoutAdminQueries( siteId: number | null )
 }
 
 function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boolean ) {
-	const isJetpackApi = config.isEnabled( 'is_running_in_jetpack' );
-
 	const results = useQueries( {
 		queries: [
 			{
@@ -152,13 +153,13 @@ function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boole
 		],
 	} );
 
-	if ( ! isJetpackApi ) {
-		// Use `subscribers_by_user_type` endpoint in Calypso Stats.
+	if ( isJetpackApi ) {
+		// `subscribers_by_user_type` endpoint is not available for Odyssey Stats yet.
 		return {
 			data: {
-				total_email: results[ 3 ]?.data?.total,
-				total_wpcom: results[ 2 ]?.data?.total,
-				total: results[ 1 ].data?.email_subscribers,
+				total_email: results[ 0 ]?.data?.total_email,
+				total_wpcom: results[ 0 ]?.data?.total_wpcom,
+				total: results[ 0 ]?.data?.total,
 				paid_subscribers: results[ 1 ]?.data?.paid_subscribers,
 				free_subscribers:
 					results[ 1 ]?.data?.email_subscribers !== undefined &&
@@ -166,31 +167,20 @@ function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boole
 						? results[ 1 ].data.email_subscribers - results[ 1 ].data.paid_subscribers
 						: null,
 				social_followers: results[ 1 ]?.data?.social_followers,
-				is_owner_subscribing: results[ 2 ]?.data?.is_owner_subscribing,
-				// Merge email and wpcom subscribers and sort by date_subscribed, and only shows the most recent 10 subscribers.
-				subscribers:
-					[
-						...( results[ 3 ]?.data?.subscribers ?? [] ),
-						...( results[ 2 ]?.data?.subscribers ?? [] ),
-					]
-						.sort( ( a, b ) => {
-							return (
-								new Date( b.date_subscribed ).getTime() - new Date( a.date_subscribed ).getTime()
-							);
-						} )
-						.slice( 0, MAX_SUBSCRIBERS_TO_RETURN ) ?? [],
+				is_owner_subscribing: results[ 0 ]?.data?.is_owner_subscribing,
+				subscribers: ( results[ 0 ]?.data?.subscribers ?? [] ).sort( sortByDateDesc ),
 			},
-			isLoading: results.some( ( result ) => result.isLoading ),
+			isLoading: results.some( ( result ) => result.isPending ),
 			isError: results.some( ( result ) => result.isError ),
 		};
 	}
 
-	// `subscribers_by_user_type` endpoint is not available for Odyssey Stats yet.
+	// Use `subscribers_by_user_type` endpoint in Calypso Stats.
 	return {
 		data: {
-			total_email: results[ 0 ]?.data?.total_email,
-			total_wpcom: results[ 0 ]?.data?.total_wpcom,
-			total: results[ 0 ]?.data?.total,
+			total_email: results[ 3 ]?.data?.total,
+			total_wpcom: results[ 2 ]?.data?.total,
+			total: results[ 1 ].data?.email_subscribers,
 			paid_subscribers: results[ 1 ]?.data?.paid_subscribers,
 			free_subscribers:
 				results[ 1 ]?.data?.email_subscribers !== undefined &&
@@ -198,8 +188,15 @@ function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boole
 					? results[ 1 ].data.email_subscribers - results[ 1 ].data.paid_subscribers
 					: null,
 			social_followers: results[ 1 ]?.data?.social_followers,
-			is_owner_subscribing: results[ 0 ]?.data?.is_owner_subscribing,
-			subscribers: results[ 0 ]?.data?.subscribers,
+			is_owner_subscribing: results[ 2 ]?.data?.is_owner_subscribing,
+			// Merge email and wpcom subscribers and sort by date_subscribed, and only shows the most recent 10 subscribers.
+			subscribers:
+				[
+					...( results[ 3 ]?.data?.subscribers ?? [] ),
+					...( results[ 2 ]?.data?.subscribers ?? [] ),
+				]
+					.sort( sortByDateDesc )
+					.slice( 0, MAX_SUBSCRIBERS_TO_RETURN ) ?? [],
 		},
 		isLoading: results.some( ( result ) => result.isLoading ),
 		isError: results.some( ( result ) => result.isError ),

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -44,7 +44,7 @@ const selectSubscribers = ( payload: {
 		display_name: string;
 		avatar: string;
 		url: string;
-		follow_data: { params: object };
+		follow_data: { params: object }; //Empty object atm
 	}[];
 } ) => {
 	return {

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -2,18 +2,25 @@ import { useQueries } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import getDefaultQueryParams from './default-query-params';
 
-const querySubscribersTotals = ( siteId: number | null, filterAdmin?: boolean ): Promise< any > => {
-	return wpcom.req.get(
-		{
-			path: `/sites/${ siteId }/stats/followers`,
-		},
-		{
-			type: 'all',
-			filter_admin: filterAdmin ? true : false,
-			// Only one-page results adjust visible subscribers with deleted accounts to align with the subscriber list.
-			max: 10,
-		}
-	);
+const querySubscribersTotals = (
+	siteId: number | null,
+	user_type: 'email' | 'wpcom',
+	filterAdmin?: boolean
+): Promise< any > => {
+	return wpcom.req
+		.get(
+			{
+				apiNamespace: 'wpcom/v2',
+				path: `/sites/${ siteId }/subscribers_by_user_type`,
+			},
+			{
+				per_page: 10,
+				page: 1,
+				user_type,
+				filterAdmin,
+			}
+		)
+		.catch( () => ( {} ) );
 };
 
 const queryMore = ( siteId: number | null ): Promise< any > => {
@@ -61,8 +68,8 @@ function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boole
 		queries: [
 			{
 				...getDefaultQueryParams(),
-				queryKey: [ 'stats', 'totals', 'subscribers', siteId, filterAdmin ],
-				queryFn: () => querySubscribersTotals( siteId, filterAdmin ),
+				queryKey: [ 'stats', 'totals', 'subscribers', 'email', siteId, filterAdmin ],
+				queryFn: () => querySubscribersTotals( siteId, 'email', filterAdmin ),
 				select: selectSubscribers,
 				staleTime: 1000 * 60 * 5, // 5 minutes
 			},
@@ -73,14 +80,21 @@ function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boole
 				select: selectPaidSubscribers,
 				staleTime: 1000 * 60 * 5, // 5 minutes
 			},
+			{
+				...getDefaultQueryParams(),
+				queryKey: [ 'stats', 'totals', 'subscribers', 'wpcom', siteId, filterAdmin ],
+				queryFn: () => querySubscribersTotals( siteId, 'wpcom', filterAdmin ),
+				select: selectSubscribers,
+				staleTime: 1000 * 60 * 5, // 5 minutes
+			},
 		],
 	} );
 
 	return {
 		data: {
-			total_email: queries[ 0 ]?.data?.total_email,
-			total_wpcom: queries[ 0 ]?.data?.total_wpcom,
-			total: queries[ 0 ]?.data?.total,
+			total_email: queries[ 0 ]?.data?.total,
+			total_wpcom: queries[ 2 ]?.data?.total,
+			total: queries[ 1 ].data?.email_subscribers,
 			paid_subscribers: queries[ 1 ]?.data?.paid_subscribers,
 			free_subscribers:
 				queries[ 1 ]?.data?.email_subscribers !== undefined &&
@@ -88,7 +102,7 @@ function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boole
 					? queries[ 1 ].data.email_subscribers - queries[ 1 ].data.paid_subscribers
 					: null,
 			social_followers: queries[ 1 ]?.data?.social_followers,
-			is_owner_subscribing: queries[ 0 ]?.data?.is_owner_subscribing,
+			is_owner_subscribing: false,
 		},
 		isLoading: queries.some( ( result ) => result.isLoading ),
 		isError: queries.some( ( result ) => result.isError ),

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -1,6 +1,9 @@
 import { useQueries } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
+import { parseAvatar } from 'calypso/state/stats/lists/utils';
 import getDefaultQueryParams from './default-query-params';
+
+const MAX_SUBSCRIBERS_TO_RETURN = 10;
 
 const querySubscribersTotals = (
 	siteId: number | null,
@@ -17,7 +20,8 @@ const querySubscribersTotals = (
 				per_page: 10,
 				page: 1,
 				user_type,
-				filterAdmin,
+				filter_admin: filterAdmin, //not used.
+				sort: 'date_subscribed',
 			}
 		)
 		.catch( () => ( {} ) );
@@ -35,12 +39,38 @@ const selectSubscribers = ( payload: {
 	total_email: number;
 	total_wpcom: number;
 	is_owner_subscribing: boolean;
+	subscribers: {
+		date_subscribed: string;
+		display_name: string;
+		avatar: string;
+		url: string;
+		follow_data: { params: object };
+	}[];
 } ) => {
 	return {
 		total: payload.total,
 		total_email: payload.total_email,
 		total_wpcom: payload.total_wpcom,
 		is_owner_subscribing: payload.is_owner_subscribing,
+		subscribers: payload.subscribers?.map( ( item ) => {
+			return {
+				label: item.display_name,
+				iconClassName: 'avatar-user',
+				icon: parseAvatar( item.avatar ),
+				link: item.url,
+				value: {
+					type: 'relative-date',
+					value: item.date_subscribed,
+				},
+				actions: [
+					{
+						type: 'follow',
+						data: item.follow_data ? item.follow_data.params : false,
+					},
+				],
+				date_subscribed: item.date_subscribed,
+			};
+		} ),
 	};
 };
 
@@ -103,6 +133,17 @@ function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boole
 					: null,
 			social_followers: queries[ 1 ]?.data?.social_followers,
 			is_owner_subscribing: false,
+			subscribers:
+				[
+					...( queries[ 0 ]?.data?.subscribers ?? [] ),
+					...( queries[ 2 ]?.data?.subscribers ?? [] ),
+				]
+					.sort( ( a, b ) => {
+						return (
+							new Date( b.date_subscribed ).getTime() - new Date( a.date_subscribed ).getTime()
+						);
+					} )
+					.slice( 0, MAX_SUBSCRIBERS_TO_RETURN ) ?? [],
 		},
 		isLoading: queries.some( ( result ) => result.isLoading ),
 		isError: queries.some( ( result ) => result.isError ),

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -11,6 +11,10 @@ const sortByDateDesc = ( a: { date_subscribed: string }, b: { date_subscribed: s
 };
 
 const querySubscribersTotals = ( siteId: number | null, filterAdmin?: boolean ): Promise< any > => {
+	// Skip the query for en.blog.wordpress.com as it's blocked.
+	if ( siteId === 3584907 ) {
+		return {} as any;
+	}
 	return wpcom.req.get(
 		{
 			path: `/sites/${ siteId }/stats/followers`,

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -132,7 +132,8 @@ function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boole
 					? queries[ 1 ].data.email_subscribers - queries[ 1 ].data.paid_subscribers
 					: null,
 			social_followers: queries[ 1 ]?.data?.social_followers,
-			is_owner_subscribing: false,
+			is_owner_subscribing: queries[ 0 ]?.data?.is_owner_subscribing,
+			// Merge email and wpcom subscribers and sort by date_subscribed, and only shows the most recent 10 subscribers.
 			subscribers:
 				[
 					...( queries[ 0 ]?.data?.subscribers ?? [] ),

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -1,15 +1,37 @@
+import config from '@automattic/calypso-config';
 import { useQueries } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { parseAvatar } from 'calypso/state/stats/lists/utils';
 import getDefaultQueryParams from './default-query-params';
 
 const MAX_SUBSCRIBERS_TO_RETURN = 10;
+const isJetpackApi = config.isEnabled( 'is_running_in_jetpack' );
 
-const querySubscribersTotals = (
+const querySubscribersTotals = ( siteId: number | null, filterAdmin?: boolean ): Promise< any > => {
+	return wpcom.req
+		.get(
+			{
+				path: `/sites/${ siteId }/stats/followers`,
+			},
+			{
+				type: 'all',
+				filter_admin: filterAdmin ? true : false,
+				// Only one-page results adjust visible subscribers with deleted accounts to align with the subscriber list.
+				max: MAX_SUBSCRIBERS_TO_RETURN,
+			}
+		)
+		.catch( () => ( {} ) );
+};
+
+const querySubscribersTotalByType = (
 	siteId: number | null,
 	user_type: 'email' | 'wpcom',
 	filterAdmin?: boolean
 ): Promise< any > => {
+	// Return early to avoid 404.
+	if ( isJetpackApi ) {
+		return {} as any;
+	}
 	return wpcom.req
 		.get(
 			{
@@ -40,6 +62,7 @@ const selectSubscribers = ( payload: {
 	total_wpcom: number;
 	is_owner_subscribing: boolean;
 	subscribers: {
+		label?: string;
 		date_subscribed: string;
 		display_name: string;
 		avatar: string;
@@ -54,7 +77,7 @@ const selectSubscribers = ( payload: {
 		is_owner_subscribing: payload.is_owner_subscribing,
 		subscribers: payload.subscribers?.map( ( item ) => {
 			return {
-				label: item.display_name,
+				label: item.label ?? item.display_name,
 				iconClassName: 'avatar-user',
 				icon: parseAvatar( item.avatar ),
 				link: item.url,
@@ -94,12 +117,14 @@ export function useSubscribersTotalsWithoutAdminQueries( siteId: number | null )
 }
 
 function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boolean ) {
-	const queries = useQueries( {
+	const isJetpackApi = config.isEnabled( 'is_running_in_jetpack' );
+
+	const results = useQueries( {
 		queries: [
 			{
 				...getDefaultQueryParams(),
-				queryKey: [ 'stats', 'totals', 'subscribers', 'email', siteId, filterAdmin ],
-				queryFn: () => querySubscribersTotals( siteId, 'email', filterAdmin ),
+				queryKey: [ 'stats', 'totals', 'subscribers', 'all', siteId, filterAdmin ],
+				queryFn: () => querySubscribersTotals( siteId, filterAdmin ),
 				select: selectSubscribers,
 				staleTime: 1000 * 60 * 5, // 5 minutes
 			},
@@ -113,41 +138,71 @@ function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boole
 			{
 				...getDefaultQueryParams(),
 				queryKey: [ 'stats', 'totals', 'subscribers', 'wpcom', siteId, filterAdmin ],
-				queryFn: () => querySubscribersTotals( siteId, 'wpcom', filterAdmin ),
+				queryFn: () => querySubscribersTotalByType( siteId, 'wpcom', filterAdmin ),
+				select: selectSubscribers,
+				staleTime: 1000 * 60 * 5, // 5 minutes
+			},
+			{
+				...getDefaultQueryParams(),
+				queryKey: [ 'stats', 'totals', 'subscribers', 'email', siteId, filterAdmin ],
+				queryFn: () => querySubscribersTotalByType( siteId, 'email', filterAdmin ),
 				select: selectSubscribers,
 				staleTime: 1000 * 60 * 5, // 5 minutes
 			},
 		],
 	} );
 
+	if ( ! isJetpackApi ) {
+		// Use `subscribers_by_user_type` endpoint in Calypso Stats.
+		return {
+			data: {
+				total_email: results[ 3 ]?.data?.total,
+				total_wpcom: results[ 2 ]?.data?.total,
+				total: results[ 1 ].data?.email_subscribers,
+				paid_subscribers: results[ 1 ]?.data?.paid_subscribers,
+				free_subscribers:
+					results[ 1 ]?.data?.email_subscribers !== undefined &&
+					results[ 1 ]?.data?.paid_subscribers !== undefined
+						? results[ 1 ].data.email_subscribers - results[ 1 ].data.paid_subscribers
+						: null,
+				social_followers: results[ 1 ]?.data?.social_followers,
+				is_owner_subscribing: results[ 2 ]?.data?.is_owner_subscribing,
+				// Merge email and wpcom subscribers and sort by date_subscribed, and only shows the most recent 10 subscribers.
+				subscribers:
+					[
+						...( results[ 3 ]?.data?.subscribers ?? [] ),
+						...( results[ 2 ]?.data?.subscribers ?? [] ),
+					]
+						.sort( ( a, b ) => {
+							return (
+								new Date( b.date_subscribed ).getTime() - new Date( a.date_subscribed ).getTime()
+							);
+						} )
+						.slice( 0, MAX_SUBSCRIBERS_TO_RETURN ) ?? [],
+			},
+			isLoading: results.some( ( result ) => result.isLoading ),
+			isError: results.some( ( result ) => result.isError ),
+		};
+	}
+
+	// `subscribers_by_user_type` endpoint is not available for Odyssey Stats yet.
 	return {
 		data: {
-			total_email: queries[ 0 ]?.data?.total,
-			total_wpcom: queries[ 2 ]?.data?.total,
-			total: queries[ 1 ].data?.email_subscribers,
-			paid_subscribers: queries[ 1 ]?.data?.paid_subscribers,
+			total_email: results[ 0 ]?.data?.total_email,
+			total_wpcom: results[ 0 ]?.data?.total_wpcom,
+			total: results[ 0 ]?.data?.total,
+			paid_subscribers: results[ 1 ]?.data?.paid_subscribers,
 			free_subscribers:
-				queries[ 1 ]?.data?.email_subscribers !== undefined &&
-				queries[ 1 ]?.data?.paid_subscribers !== undefined
-					? queries[ 1 ].data.email_subscribers - queries[ 1 ].data.paid_subscribers
+				results[ 1 ]?.data?.email_subscribers !== undefined &&
+				results[ 1 ]?.data?.paid_subscribers !== undefined
+					? results[ 1 ].data.email_subscribers - results[ 1 ].data.paid_subscribers
 					: null,
-			social_followers: queries[ 1 ]?.data?.social_followers,
-			is_owner_subscribing: queries[ 2 ]?.data?.is_owner_subscribing,
-			// Merge email and wpcom subscribers and sort by date_subscribed, and only shows the most recent 10 subscribers.
-			subscribers:
-				[
-					...( queries[ 0 ]?.data?.subscribers ?? [] ),
-					...( queries[ 2 ]?.data?.subscribers ?? [] ),
-				]
-					.sort( ( a, b ) => {
-						return (
-							new Date( b.date_subscribed ).getTime() - new Date( a.date_subscribed ).getTime()
-						);
-					} )
-					.slice( 0, MAX_SUBSCRIBERS_TO_RETURN ) ?? [],
+			social_followers: results[ 1 ]?.data?.social_followers,
+			is_owner_subscribing: results[ 0 ]?.data?.is_owner_subscribing,
+			subscribers: results[ 0 ]?.data?.subscribers,
 		},
-		isLoading: queries.some( ( result ) => result.isLoading ),
-		isError: queries.some( ( result ) => result.isError ),
+		isLoading: results.some( ( result ) => result.isLoading ),
+		isError: results.some( ( result ) => result.isError ),
 	};
 }
 

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -42,7 +42,7 @@ const querySubscribersTotalByType = (
 				path: `/sites/${ siteId }/subscribers_by_user_type`,
 			},
 			{
-				per_page: 10,
+				per_page: MAX_SUBSCRIBERS_TO_RETURN,
 				page: 1,
 				user_type,
 				filter_admin: filterAdmin, //not used.

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -132,7 +132,7 @@ function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boole
 					? queries[ 1 ].data.email_subscribers - queries[ 1 ].data.paid_subscribers
 					: null,
 			social_followers: queries[ 1 ]?.data?.social_followers,
-			is_owner_subscribing: queries[ 0 ]?.data?.is_owner_subscribing,
+			is_owner_subscribing: queries[ 2 ]?.data?.is_owner_subscribing,
 			// Merge email and wpcom subscribers and sort by date_subscribed, and only shows the most recent 10 subscribers.
 			subscribers:
 				[

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -196,7 +196,7 @@ function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boole
 					...( results[ 2 ]?.data?.subscribers ?? [] ),
 				]
 					.sort( sortByDateDesc )
-					.slice( 0, MAX_SUBSCRIBERS_TO_RETURN ) ?? [],
+					.slice( 0, MAX_SUBSCRIBERS_TO_RETURN ),
 		},
 		isLoading: results.some( ( result ) => result.isLoading ),
 		isError: results.some( ( result ) => result.isError ),

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -11,19 +11,17 @@ const sortByDateDesc = ( a: { date_subscribed: string }, b: { date_subscribed: s
 };
 
 const querySubscribersTotals = ( siteId: number | null, filterAdmin?: boolean ): Promise< any > => {
-	return wpcom.req
-		.get(
-			{
-				path: `/sites/${ siteId }/stats/followers`,
-			},
-			{
-				type: 'all',
-				filter_admin: filterAdmin ? true : false,
-				// Only one-page results adjust visible subscribers with deleted accounts to align with the subscriber list.
-				max: MAX_SUBSCRIBERS_TO_RETURN,
-			}
-		)
-		.catch( () => ( {} ) );
+	return wpcom.req.get(
+		{
+			path: `/sites/${ siteId }/stats/followers`,
+		},
+		{
+			type: 'all',
+			filter_admin: filterAdmin ? true : false,
+			// Only one-page results adjust visible subscribers with deleted accounts to align with the subscriber list.
+			max: MAX_SUBSCRIBERS_TO_RETURN,
+		}
+	);
 };
 
 const querySubscribersTotalByType = (
@@ -35,21 +33,19 @@ const querySubscribersTotalByType = (
 	if ( isJetpackApi ) {
 		return {} as any;
 	}
-	return wpcom.req
-		.get(
-			{
-				apiNamespace: 'wpcom/v2',
-				path: `/sites/${ siteId }/subscribers_by_user_type`,
-			},
-			{
-				per_page: MAX_SUBSCRIBERS_TO_RETURN,
-				page: 1,
-				user_type,
-				filter_admin: filterAdmin, //not used.
-				sort: 'date_subscribed',
-			}
-		)
-		.catch( () => ( {} ) );
+	return wpcom.req.get(
+		{
+			apiNamespace: 'wpcom/v2',
+			path: `/sites/${ siteId }/subscribers_by_user_type`,
+		},
+		{
+			per_page: MAX_SUBSCRIBERS_TO_RETURN,
+			page: 1,
+			user_type,
+			filter_admin: filterAdmin, //not used.
+			sort: 'date_subscribed',
+		}
+	);
 };
 
 const queryMore = ( siteId: number | null ): Promise< any > => {
@@ -190,13 +186,12 @@ function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boole
 			social_followers: results[ 1 ]?.data?.social_followers,
 			is_owner_subscribing: results[ 2 ]?.data?.is_owner_subscribing,
 			// Merge email and wpcom subscribers and sort by date_subscribed, and only shows the most recent 10 subscribers.
-			subscribers:
-				[
-					...( results[ 3 ]?.data?.subscribers ?? [] ),
-					...( results[ 2 ]?.data?.subscribers ?? [] ),
-				]
-					.sort( sortByDateDesc )
-					.slice( 0, MAX_SUBSCRIBERS_TO_RETURN ),
+			subscribers: [
+				...( results[ 3 ]?.data?.subscribers ?? [] ),
+				...( results[ 2 ]?.data?.subscribers ?? [] ),
+			]
+				.sort( sortByDateDesc )
+				.slice( 0, MAX_SUBSCRIBERS_TO_RETURN ),
 		},
 		isLoading: results.some( ( result ) => result.isLoading ),
 		isError: results.some( ( result ) => result.isError ),

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -2,26 +2,17 @@ import { isEnabled } from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { get } from 'lodash';
-import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getSiteSlug, isAdminInterfaceWPAdmin, isJetpackSite } from 'calypso/state/sites/selectors';
-import {
-	isRequestingSiteStatsForQuery,
-	getSiteStatsNormalizedData,
-	hasSiteStatsQueryFailed,
-} from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { SUBSCRIBERS_SUPPORT_URL } from '../const';
+import useSubscribersTotalsQueries from '../hooks/use-subscribers-totals-query';
 import ErrorPanel from '../stats-error';
 import StatsListCard from '../stats-list/stats-list-card';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 
 import './style.scss';
-
-const MAX_FOLLOWERS_TO_SHOW = 10;
 
 const StatModuleFollowers = ( { className } ) => {
 	const translate = useTranslate();
@@ -33,62 +24,32 @@ const StatModuleFollowers = ( { className } ) => {
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const isAdminInterface = useSelector( ( state ) => isAdminInterfaceWPAdmin( state, siteId ) );
 
-	// Query objects
-	const emailQuery = { type: 'email', max: 10 };
-	const wpcomQuery = { type: 'wpcom', max: 10 };
+	const { data: subTotals, isLoading, isError: hasError } = useSubscribersTotalsQueries( siteId );
 
-	// Stats data and loading states
-	const requestingEmailFollowers = useSelector( ( state ) =>
-		isRequestingSiteStatsForQuery( state, siteId, 'statsFollowers', emailQuery )
-	);
-	const emailData = useSelector( ( state ) =>
-		getSiteStatsNormalizedData( state, siteId, 'statsFollowers', emailQuery )
-	);
-	const hasEmailQueryFailed = useSelector( ( state ) =>
-		hasSiteStatsQueryFailed( state, siteId, 'statsFollowers', emailQuery )
-	);
-	const requestingWpcomFollowers = useSelector( ( state ) =>
-		isRequestingSiteStatsForQuery( state, siteId, 'statsFollowers', wpcomQuery )
-	);
-	const wpcomData = useSelector( ( state ) =>
-		getSiteStatsNormalizedData( state, siteId, 'statsFollowers', wpcomQuery )
-	);
-	const hasWpcomQueryFailed = useSelector( ( state ) =>
-		hasSiteStatsQueryFailed( state, siteId, 'statsFollowers', wpcomQuery )
-	);
+	const calculateOffset = ( pastValue ) => {
+		const now = new Date();
+		const value = new Date( pastValue );
+		const difference = now.getTime() - value.getTime();
 
-	const calculateOffset = useCallback(
-		( pastValue ) => {
-			const now = new Date();
-			const value = new Date( pastValue );
-			const difference = now.getTime() - value.getTime();
+		const seconds = Math.floor( difference / 1000 );
+		const minutes = Math.floor( seconds / 60 );
+		const hours = Math.floor( minutes / 60 );
+		const days = Math.floor( hours / 24 );
 
-			const seconds = Math.floor( difference / 1000 );
-			const minutes = Math.floor( seconds / 60 );
-			const hours = Math.floor( minutes / 60 );
-			const days = Math.floor( hours / 24 );
+		let result = '';
 
-			let result = '';
+		if ( days > 0 ) {
+			result = translate( '%d days', { args: days } );
+		} else if ( hours > 0 ) {
+			result = translate( '%d hours', { args: hours } );
+		} else if ( minutes > 0 ) {
+			result = translate( '%d minutes', { args: minutes } );
+		}
 
-			if ( days > 0 ) {
-				result = translate( '%d days', { args: days } );
-			} else if ( hours > 0 ) {
-				result = translate( '%d hours', { args: hours } );
-			} else if ( minutes > 0 ) {
-				result = translate( '%d minutes', { args: minutes } );
-			}
+		return result;
+	};
 
-			return result;
-		},
-		[ translate ]
-	);
-
-	const isLoading = requestingWpcomFollowers || requestingEmailFollowers;
-	const hasEmailFollowers = !! get( emailData, 'subscribers', [] ).length;
-	const hasWpcomFollowers = !! get( wpcomData, 'subscribers', [] ).length;
-	const noData = ! hasWpcomFollowers && ! hasEmailFollowers;
-	const hasError = hasEmailQueryFailed || hasWpcomQueryFailed;
-
+	const noData = ! subTotals.subscribers.length;
 	const summaryPageSlug = siteSlug || '';
 	const useJetpackCloudLinks =
 		isAtomic || isJetpack || ( isEnabled( 'jetpack/manage-simple-sites' ) && isAdminInterface );
@@ -96,65 +57,50 @@ const StatModuleFollowers = ( { className } ) => {
 		? `https://cloud.jetpack.com/subscribers/${ summaryPageSlug }`
 		: `https://wordpress.com/subscribers/${ summaryPageSlug }`;
 
-	// Combine data sets, sort by recency, and limit to 10
-	const data = [ ...( wpcomData?.subscribers ?? [] ), ...( emailData?.subscribers ?? [] ) ]
-		.sort( ( a, b ) => {
-			return new Date( b.value?.value || 0 ) - new Date( a.value?.value || 0 );
-		} )
-		.slice( 0, MAX_FOLLOWERS_TO_SHOW );
-
 	return (
-		<>
-			{ siteId && (
-				<QuerySiteStats statType="statsFollowers" siteId={ siteId } query={ wpcomQuery } />
-			) }
-			{ siteId && (
-				<QuerySiteStats statType="statsFollowers" siteId={ siteId } query={ emailQuery } />
-			) }
-			<StatsListCard
-				moduleType="followers"
-				data={ data.map( ( dataPoint ) => ( {
-					...dataPoint,
-					value: calculateOffset( dataPoint.value?.value ),
-				} ) ) }
-				usePlainCard
-				hasNoBackground
-				title={ translate( 'Subscribers' ) }
-				emptyMessage={ translate(
-					'Once you get a few, {{link}}your subscribers{{/link}} will appear here.',
-					{
-						comment: '{{link}} links to support documentation.',
-						components: {
-							link: (
-								<a
-									target="_blank"
-									rel="noreferrer"
-									href={ localizeUrl( `${ SUBSCRIBERS_SUPPORT_URL }#subscriber-stats` ) }
-								/>
-							),
-						},
-						context: 'Stats: Info box label when the Subscribers module is empty',
-					}
-				) }
-				mainItemLabel={ translate( 'Subscriber' ) }
-				metricLabel={ translate( 'Since' ) }
-				splitHeader
-				showMore={ {
-					url: subscriberManagementUrl,
-					label: translate( 'Manage subscribers' ),
-				} }
-				error={
-					noData &&
-					! hasError &&
-					! isLoading && (
-						<ErrorPanel className="is-empty-message" message={ translate( 'No subscribers' ) } />
-					)
+		<StatsListCard
+			moduleType="followers"
+			data={ subTotals.subscribers.map( ( dataPoint ) => ( {
+				...dataPoint,
+				value: calculateOffset( dataPoint.value?.value ),
+			} ) ) }
+			usePlainCard
+			hasNoBackground
+			title={ translate( 'Subscribers' ) }
+			emptyMessage={ translate(
+				'Once you get a few, {{link}}your subscribers{{/link}} will appear here.',
+				{
+					comment: '{{link}} links to support documentation.',
+					components: {
+						link: (
+							<a
+								target="_blank"
+								rel="noreferrer"
+								href={ localizeUrl( `${ SUBSCRIBERS_SUPPORT_URL }#subscriber-stats` ) }
+							/>
+						),
+					},
+					context: 'Stats: Info box label when the Subscribers module is empty',
 				}
-				loader={ isLoading && <StatsModulePlaceholder isLoading={ isLoading } /> }
-				className={ clsx( 'stats__modernised-followers', className ) }
-				showLeftIcon
-			/>
-		</>
+			) }
+			mainItemLabel={ translate( 'Subscriber' ) }
+			metricLabel={ translate( 'Since' ) }
+			splitHeader
+			showMore={ {
+				url: subscriberManagementUrl,
+				label: translate( 'Manage subscribers' ),
+			} }
+			error={
+				noData &&
+				! hasError &&
+				! isLoading && (
+					<ErrorPanel className="is-empty-message" message={ translate( 'No subscribers' ) } />
+				)
+			}
+			loader={ isLoading && <StatsModulePlaceholder isLoading={ isLoading } /> }
+			className={ clsx( 'stats__modernised-followers', className ) }
+			showLeftIcon
+		/>
 	);
 };
 

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -32,7 +32,7 @@ const StatModuleFollowers = ( { className } ) => {
 		const difference = now.getTime() - value.getTime();
 
 		const seconds = Math.floor( difference / 1000 );
-		const minutes = Math.floor( seconds / 60 );
+		const minutes = Math.ceil( seconds / 60 );
 		const hours = Math.floor( minutes / 60 );
 		const days = Math.floor( hours / 24 );
 

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -2,6 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getSiteSlug, isAdminInterfaceWPAdmin, isJetpackSite } from 'calypso/state/sites/selectors';
@@ -26,28 +27,31 @@ const StatModuleFollowers = ( { className } ) => {
 
 	const { data: subTotals, isLoading, isError: hasError } = useSubscribersTotalsQueries( siteId );
 
-	const calculateOffset = ( pastValue ) => {
-		const now = new Date();
-		const value = new Date( pastValue );
-		const difference = now.getTime() - value.getTime();
+	const calculateOffset = useCallback(
+		( pastValue ) => {
+			const now = new Date();
+			const value = new Date( pastValue );
+			const difference = now.getTime() - value.getTime();
 
-		const seconds = Math.floor( difference / 1000 );
-		const minutes = Math.ceil( seconds / 60 );
-		const hours = Math.floor( minutes / 60 );
-		const days = Math.floor( hours / 24 );
+			const seconds = Math.floor( difference / 1000 );
+			const minutes = Math.ceil( seconds / 60 );
+			const hours = Math.floor( minutes / 60 );
+			const days = Math.floor( hours / 24 );
 
-		let result = '';
+			let result = '';
 
-		if ( days > 0 ) {
-			result = translate( '%d days', { args: days } );
-		} else if ( hours > 0 ) {
-			result = translate( '%d hours', { args: hours } );
-		} else if ( minutes > 0 ) {
-			result = translate( '%d minutes', { args: minutes } );
-		}
+			if ( days > 0 ) {
+				result = translate( '%d days', { args: days } );
+			} else if ( hours > 0 ) {
+				result = translate( '%d hours', { args: hours } );
+			} else if ( minutes > 0 ) {
+				result = translate( '%d minutes', { args: minutes } );
+			}
 
-		return result;
-	};
+			return result;
+		},
+		[ translate ]
+	);
 
 	const noData = ! subTotals.subscribers.length;
 	const summaryPageSlug = siteSlug || '';

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -74,7 +74,7 @@ export function isAutoRefreshAllowedForQuery( query ) {
  * @param   {string} avatarUrl Raw avatar URL
  * @returns {string}           Parsed URL
  */
-function parseAvatar( avatarUrl ) {
+export function parseAvatar( avatarUrl ) {
 	if ( ! avatarUrl ) {
 		return null;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related PR: https://github.com/Automattic/wp-calypso/pull/99575

## Proposed Changes

* Use alternative `subscribers_by_user_type` endpoint in Subscribers Stats so that dotcom blog could be enabled

This is a temporary solution to enable the page, and should be revisited to optimise the performance of the original endpoint.

- `stats/followers` is still used in Odyssey Stats unchanged as the above endpoint doesn't exist in Jetpack.

More information: 
- pMz3w-lh9-p2
- peRNfl-1be-p2
- peRNfl-1at-p2

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Support dotcom blog marketing blog

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live Branch on `/stats/subscribers/day/en.blog.wordpress.com`
* Ensure the page loads without errors
* Switch to another website
* Ensure the page loads without errors (the subscribe action would be missing tho)
* Build locally for Odyssey Stats
* Open `/wp-admin/admin.php?page=stats#!/stats/subscribers/jasper1.au.ngrok.io?page=stats`
* Ensure it works just like it did

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?