### PR TITLE
Stats: Convert class component to function for Subscribers module

### DIFF
--- a/client/my-sites/stats/pages/subscribers/index.tsx
+++ b/client/my-sites/stats/pages/subscribers/index.tsx
@@ -132,7 +132,6 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 							) }
 							<StatsModuleListing className={ className } siteId={ siteId }>
 								<Followers
-									path="followers"
 									className={ clsx(
 										{
 											'stats__flexible-grid-item--half': supportsEmailStats,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

In order to use hooks in https://github.com/Automattic/wp-calypso/pull/99573

## Proposed Changes

Convert StatModuleFollowers to function component assisted by AI. Changes include:

- Replaced the class component with a functional component using arrow function syntax
- Removed the Component import and class definition
- Converted the state to hooks (though in this case there was no local state that needed preservation)
- Replaced Redux connect with useSelector and useDispatch hooks
- Converted calculateOffset class method to a memoized function using useCallback
- Removed the localize HOC and replaced it with useTranslate hook
- Moved all the Redux selectors to use useSelector hook
- Removed the connectComponent and flowRight exports
- Preserved all the existing functionality while making the code more modern and maintainable

The component should work exactly the same way as before, but with a more modern implementation using hooks. The Redux state management is now handled through hooks instead of the connect HOC, making the code cleaner and easier to understand.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Simply component and prepare for refactoring to use a new endpoint

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `http://calypso.localhost:3000/stats/subscribers/you-site.com`
* Ensure the Subscribers module still work as it did
* Ensure code looks okay

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
