### PR TITLE
Stepper: Add initial createSite hook

### DIFF
--- a/client/landing/stepper/hooks/use-create-site-hook.ts
+++ b/client/landing/stepper/hooks/use-create-site-hook.ts
@@ -1,0 +1,164 @@
+import config from '@automattic/calypso-config';
+import { getLanguage } from '@automattic/i18n-utils';
+import { getNewSiteParams, processItemCart } from '@automattic/onboarding/src/cart';
+import { useMutation } from '@tanstack/react-query';
+import { getLocaleSlug } from 'i18n-calypso';
+import wpcomRequest from 'wpcom-proxy-request';
+import { useSelector } from 'calypso/state';
+import { getCurrentUserName, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { useFlowState } from '../declarative-flow/internals/state-manager/store';
+import { getFlowFromURL } from '../utils/get-flow-from-url';
+import type { DomainSuggestion, NewSiteSuccessResponse, Site } from '@automattic/data-stores';
+import type { SiteGoal } from '@automattic/data-stores/src/onboard';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+
+type Params = {
+	flowName: string;
+	userIsLoggedIn: boolean;
+	isPurchasingDomainItem: boolean;
+	themeSlugWithRepo: string;
+	siteVisibility: Site.Visibility;
+	siteTitle: string;
+	siteAccentColor: string;
+	useThemeHeadstart: boolean;
+	username: string;
+	domainCartItems: MinimalRequestCartProduct[];
+	partnerBundle?: string | null;
+	storedSiteUrl?: string;
+	domainItem?: DomainSuggestion;
+	sourceSlug?: string;
+	siteIntent?: string;
+	siteGoals?: SiteGoal[];
+	planCartItems?: MinimalRequestCartProduct[] | null;
+};
+
+export const createSite = async ( {
+	flowName,
+	userIsLoggedIn,
+	isPurchasingDomainItem,
+	themeSlugWithRepo,
+	siteVisibility,
+	siteTitle,
+	siteAccentColor,
+	useThemeHeadstart,
+	username,
+	domainCartItems,
+	partnerBundle = null,
+	storedSiteUrl,
+	domainItem,
+	sourceSlug,
+	siteIntent,
+	planCartItems,
+}: Params ) => {
+	const siteUrl = storedSiteUrl || domainItem?.domain_name;
+	const isFreeThemePreselected = themeSlugWithRepo.startsWith( 'pub' );
+
+	const newSiteParams = getNewSiteParams( {
+		flowToCheck: flowName,
+		isPurchasingDomainItem,
+		themeSlugWithRepo,
+		siteUrl,
+		siteTitle,
+		siteAccentColor,
+		useThemeHeadstart,
+		siteVisibility,
+		username,
+		sourceSlug,
+		siteIntent,
+		partnerBundle,
+	} );
+
+	const locale = getLocaleSlug();
+
+	const siteCreationResponse: NewSiteSuccessResponse = await wpcomRequest( {
+		path: '/sites/new',
+		apiVersion: '1.1',
+		method: 'POST',
+		body: {
+			...newSiteParams,
+			locale,
+			lang_id: getLanguage( locale as string )?.value,
+			client_id: config( 'wpcom_signup_id' ),
+			client_secret: config( 'wpcom_signup_key' ),
+			options: newSiteParams.options,
+		},
+	} );
+
+	const parsedBlogURL = new URL( siteCreationResponse?.blog_details.url );
+	const siteSlug = parsedBlogURL.hostname;
+	const siteId = siteCreationResponse?.blog_details.blogid;
+	const siteDetails = {
+		siteId,
+		siteSlug,
+		domainItem,
+		siteCreated: true,
+		goToCheckout: Boolean( planCartItems?.length ),
+	};
+
+	if ( domainCartItems.length ) {
+		for ( const domainCartItem of domainCartItems ) {
+			await processItemCart(
+				siteSlug,
+				isFreeThemePreselected,
+				themeSlugWithRepo,
+				flowName,
+				userIsLoggedIn,
+				domainCartItem
+			);
+		}
+	}
+
+	return siteDetails;
+};
+
+export const useCreateSite = () => {
+	const flowName = getFlowFromURL();
+	const userIsLoggedIn = useSelector( isUserLoggedIn );
+	const { get } = useFlowState();
+	const domains = get( 'domains' );
+	const username = useSelector( getCurrentUserName );
+	const planCartItems = get( 'plans' )?.cartItems;
+	const siteTitle = get( 'newsletterSetup' )?.siteTitle as string;
+
+	/**
+	 * Support singular and multiple domain cart items.
+	 */
+	const mergedDomainCartItems = Array.isArray( domains?.domainCart )
+		? domains?.domainCart.slice( 0 )
+		: [];
+
+	if ( domains?.domainItem ) {
+		mergedDomainCartItems.push( domains?.domainItem );
+	}
+
+	return useMutation( {
+		mutationFn: ( {
+			theme,
+			siteIntent,
+		}: {
+			theme: string;
+			siteIntent: string;
+			siteGoals?: SiteGoal[];
+		} ) =>
+			createSite( {
+				flowName,
+				userIsLoggedIn,
+				isPurchasingDomainItem: false,
+				themeSlugWithRepo: theme,
+				siteVisibility: 1,
+				siteTitle,
+				// We removed the color option during newsletter onboarding.
+				// But backend still expects/needs a value, so supplying the default.
+				// Ideally should remove this and update code downstream to handle this.
+				siteAccentColor: '#113AF5',
+				useThemeHeadstart: true,
+				username,
+				domainCartItems: mergedDomainCartItems,
+				partnerBundle: null,
+				storedSiteUrl: domains?.siteUrl,
+				domainItem: domains?.domainItem,
+				siteIntent,
+				planCartItems,
+			} ),
+	} ).mutateAsync;
+};

--- a/client/landing/stepper/utils/get-flow-from-url.ts
+++ b/client/landing/stepper/utils/get-flow-from-url.ts
@@ -4,7 +4,8 @@ export const getFlowFromURL = () => {
 	const fromPath = matchPath( { path: '/setup/:flow/*' }, window.location.pathname )?.params?.flow;
 	// backward support the old Stepper URL structure (?flow=something)
 	const fromQuery = new URLSearchParams( window.location.search ).get( 'flow' );
-	return fromPath || fromQuery;
+	// Need to update this to make sure we always get the flow from the URL and its not an empty string
+	return fromPath || fromQuery || '';
 };
 
 export const getStepFromURL = () => {

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -374,7 +374,7 @@ export async function setThemeOnSite(
 	}
 }
 
-async function processItemCart(
+export async function processItemCart(
 	siteSlug: string,
 	isFreeThemePreselected: boolean,
 	themeSlugWithRepo: string,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Adds the initial version of the use-create-site hook to be used and tested with the `example` flow for state management changes

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This will be used will tested with the new state management in a follow up.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Testing is not needed since this is not used yet.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
