### PR TITLE
Improved Launchpad style according to feedback

### DIFF
--- a/client/my-sites/customer-home/components/full-screen-launchpad.scss
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.scss
@@ -1,4 +1,3 @@
-
 .is-launchpad-first .customer-home-launchpad {
 	max-width: 536px;
 	margin: auto;
@@ -11,12 +10,13 @@
 		align-items: center;
 
 		h2 {
-			margin-top: 24px;
+			margin-top: 1rem;
 			font-size: 2rem;
+			font-weight: 500;
 		}
 
 		span {
-			margin: 4px 0 24px 0;
+			margin-bottom: 1.5rem;
 		}
 	}
 

--- a/packages/launchpad/src/checklist-item/index.tsx
+++ b/packages/launchpad/src/checklist-item/index.tsx
@@ -1,6 +1,7 @@
-import { Badge, Gridicon } from '@automattic/components';
-import { Button } from '@wordpress/components';
+import { Badge } from '@automattic/components';
+import { Button, Icon } from '@wordpress/components';
 import { __, isRTL } from '@wordpress/i18n';
+import { check, chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
 import type { Task, Expandable } from '../types';
 import type { FC, Key } from 'react';
@@ -86,11 +87,11 @@ const ChecklistItem: FC< Props > = ( {
 					{ completed && (
 						// show checkmark for completed tasks regardless if they are disabled or kept active
 						<div className="checklist-item__checkmark-container">
-							<Gridicon
+							<Icon
+								icon={ check }
 								aria-label={ __( 'Task complete', 'launchpad' ) }
 								className="checklist-item__checkmark"
-								icon="checkmark"
-								size={ 18 }
+								size={ 25 }
 							/>
 						</div>
 					) }
@@ -102,11 +103,11 @@ const ChecklistItem: FC< Props > = ( {
 						</span>
 					) }
 					{ shouldDisplayChevron && (
-						<Gridicon
+						<Icon
 							aria-label={ __( 'Task enabled', 'launchpad' ) }
 							className="checklist-item__chevron"
-							icon={ `chevron-${ isRTL() ? 'left' : 'right' }` }
-							size={ 18 }
+							icon={ isRTL() ? chevronLeft : chevronRight }
+							size={ 25 }
 						/>
 					) }
 					{ subtitle && <p className="checklist-item__subtext">{ subtitle }</p> }

--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -114,7 +114,7 @@
 	display: flex;
 	margin-left: 1px;
 	margin-bottom: -2px;
-	
+
 	.checklist-item__checkmark {
 		vertical-align: text-bottom;
 	}
@@ -190,7 +190,7 @@
 
 	.checklist-item__chevron,
 	.checklist-item__checkmark {
-		fill: var(--studio-green-50);
+		fill: var(--color-success);
 	}
 	.checklist-item__counter {
 		color: var(--color-neutral-40);

--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -111,11 +111,10 @@
 
 .checklist-item__checkmark-container {
 	margin-right: 7px;
-	width: 20px;
 	display: flex;
 	margin-left: 1px;
 	margin-bottom: -2px;
-
+	
 	.checklist-item__checkmark {
 		vertical-align: text-bottom;
 	}
@@ -191,7 +190,7 @@
 
 	.checklist-item__chevron,
 	.checklist-item__checkmark {
-		fill: var(--color-neutral-40);
+		fill: var(--studio-green-50);
 	}
 	.checklist-item__counter {
 		color: var(--color-neutral-40);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99559

## Proposed Changes

* We're improving font spacing and weight
* Replacing Icons for Core's icons

| Before | After |
|--------|--------|
| <img width="591" alt="image" src="https://github.com/user-attachments/assets/660c3a17-7216-44ba-9dbc-8c0acfda0b82" /> | <img width="586" alt="image" src="https://github.com/user-attachments/assets/05504b54-bb25-4e65-ae03-f300b3cbfac8" /> |


Even though we're moving away from it, it's important to note that, with this change, we also changed the current Launchpad icons:

| Before | After |
|--------|--------|
| <img width="371" alt="image" src="https://github.com/user-attachments/assets/65a36449-11c7-4d37-adb6-d9d4ef709954" /> | <img width="373" alt="image" src="https://github.com/user-attachments/assets/f8ea1a2a-3cac-443e-9ffc-a81d36c992ff" /> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the /setup/onboarding and test the Focused Launchpad using the home's flag: http://calypso.localhost:3000/home/{siteSlug}?flags=home/launchpad-first
* Make sure the design feedback (p1739186479857679/1738962296.911579-slack-C04H4NY6STW) was implemented as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?