### PR TITLE
RDV: Redirect from /media to upload.php for experiment users

### DIFF
--- a/client/my-sites/media/index.js
+++ b/client/my-sites/media/index.js
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import { makeLayout, render as clientRender, redirectIfDuplicatedView } from 'calypso/controller';
 import { getSiteFragment } from 'calypso/lib/route';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import mediaController from './controller';
@@ -10,6 +10,7 @@ export default function () {
 	page(
 		'/media/:filter(this-post|images|documents|videos|audio)?/:domain',
 		siteSelection,
+		redirectIfDuplicatedView( 'upload.php' ),
 		navigation,
 		mediaController.media,
 		makeLayout,


### PR DESCRIPTION
## Proposed Changes

This PR redirects users under the holdout experiment from `/media/:siteSlug` page to the classic `upload.php`.

## Why are these changes being made?

pbxlJb-6P2-p2

## Testing Instructions

1. IMPORTANT: Apply also the following Jetpack PR: https://github.com/Automattic/jetpack/pull/41720
2. Prepare site with Default admin interface view
3. Prepare a non-a8c user with `control` holdout experiment variation (you can use the escape hatch p7DVsv-m73-p2)
4. Log in as that user
5. Go to `/media`, verify that it loads Calypso as normal.
6. Force that user to `treatment` variation (maybe resetting the escape hatch mechanism above)
7. Wait ~ a minute to ensure the cache is expired
8. Go to `/media`
9. Verify that it redirects to `upload.php` with the following notice

<img width="883" alt="image" src="https://github.com/user-attachments/assets/b2794181-d2d4-4d40-95b0-31a65965eb11" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?