### PR TITLE
Components: Remove unnecessary props from `ExternalLink`

### DIFF
--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -193,14 +193,7 @@ export class EditGravatar extends Component {
 								' them from appearing on any site.{{/p}}',
 							{
 								components: {
-									ExternalLink: (
-										<ExternalLink
-											href={ gravatarLink }
-											target="_blank"
-											rel="noopener noreferrer"
-											icon
-										/>
-									),
+									ExternalLink: <ExternalLink href={ gravatarLink } target="_blank" icon />,
 									p: <p />,
 								},
 							}
@@ -280,14 +273,7 @@ export class EditGravatar extends Component {
 								' If you do not have a Gravatar account, one will be created for you when you upload your first image.{{/p}}',
 							{
 								components: {
-									ExternalLink: (
-										<ExternalLink
-											href={ gravatarLink }
-											target="_blank"
-											rel="noopener noreferrer"
-											icon
-										/>
-									),
+									ExternalLink: <ExternalLink href={ gravatarLink } target="_blank" icon />,
 									p: <p />,
 								},
 							}

--- a/client/blocks/qr-code-login/index.jsx
+++ b/client/blocks/qr-code-login/index.jsx
@@ -214,11 +214,7 @@ function QRCodeLogin( { locale, redirectToAfterLoginUrl } ) {
 			},
 			components: {
 				link: (
-					<ExternalLink
-						target="_blank"
-						icon={ false }
-						href="https://jetpack.com/app?campaign=login-qr-code"
-					/>
+					<ExternalLink target="_blank" href="https://jetpack.com/app?campaign=login-qr-code" />
 				),
 			},
 		} ),

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -67,7 +67,6 @@ const ReaderFullPostHeader = ( { post, authorProfile, layout = 'default' } ) => 
 							className="reader-full-post__header-title-link"
 							href={ post.URL }
 							target="_blank"
-							icon={ false }
 							onClick={ handlePermalinkClick }
 						>
 							{ post.title }

--- a/client/components/jetpack/backup-warnings/backup-warning-retry.jsx
+++ b/client/components/jetpack/backup-warnings/backup-warning-retry.jsx
@@ -40,7 +40,6 @@ export default function BackupWarningRetry( { siteId } ) {
 							<ExternalLink
 								href={ warningInfoLink }
 								target="_blank"
-								rel="noopener noreferrer"
 								icon={ false }
 								onClick={ () => recordTracksEvent( 'calypso_jetpack_backup_learn_why_click' ) }
 							/>

--- a/client/components/jetpack/backup-warnings/backup-warning-retry.jsx
+++ b/client/components/jetpack/backup-warnings/backup-warning-retry.jsx
@@ -40,7 +40,6 @@ export default function BackupWarningRetry( { siteId } ) {
 							<ExternalLink
 								href={ warningInfoLink }
 								target="_blank"
-								icon={ false }
 								onClick={ () => recordTracksEvent( 'calypso_jetpack_backup_learn_why_click' ) }
 							/>
 						),

--- a/client/components/jetpack/backup-warnings/backup-warnings.jsx
+++ b/client/components/jetpack/backup-warnings/backup-warnings.jsx
@@ -24,7 +24,6 @@ const getWarningInfo = ( code, category ) => {
 						<ExternalLink
 							href="https://jetpack.com/support/backup/backups-via-the-jetpack-plugin/adding-credentials-to-jetpack/#file-access-permissions"
 							target="_blank"
-							rel="noopener noreferrer"
 							icon={ false }
 						/>
 					),
@@ -39,7 +38,6 @@ const getWarningInfo = ( code, category ) => {
 						<ExternalLink
 							href="https://jetpack.com/support/backup/backups-via-the-jetpack-plugin/adding-credentials-to-jetpack/"
 							target="_blank"
-							rel="noopener noreferrer"
 							icon={ false }
 						/>
 					),
@@ -54,7 +52,6 @@ const getWarningInfo = ( code, category ) => {
 						<ExternalLink
 							href="https://jetpack.com/support/backup/backups-via-the-jetpack-plugin/#frequently-asked-questions"
 							target="_blank"
-							rel="noopener noreferrer"
 							icon={ false }
 						/>
 					),
@@ -69,7 +66,6 @@ const getWarningInfo = ( code, category ) => {
 						<ExternalLink
 							href="https://jetpack.com/blog/error-establishing-database-connection-on-wordpress/"
 							target="_blank"
-							rel="noopener noreferrer"
 							icon={ false }
 						/>
 					),

--- a/client/components/jetpack/backup-warnings/backup-warnings.jsx
+++ b/client/components/jetpack/backup-warnings/backup-warnings.jsx
@@ -24,7 +24,6 @@ const getWarningInfo = ( code, category ) => {
 						<ExternalLink
 							href="https://jetpack.com/support/backup/backups-via-the-jetpack-plugin/adding-credentials-to-jetpack/#file-access-permissions"
 							target="_blank"
-							icon={ false }
 						/>
 					),
 				},
@@ -38,7 +37,6 @@ const getWarningInfo = ( code, category ) => {
 						<ExternalLink
 							href="https://jetpack.com/support/backup/backups-via-the-jetpack-plugin/adding-credentials-to-jetpack/"
 							target="_blank"
-							icon={ false }
 						/>
 					),
 				},
@@ -52,7 +50,6 @@ const getWarningInfo = ( code, category ) => {
 						<ExternalLink
 							href="https://jetpack.com/support/backup/backups-via-the-jetpack-plugin/#frequently-asked-questions"
 							target="_blank"
-							icon={ false }
 						/>
 					),
 				},
@@ -66,7 +63,6 @@ const getWarningInfo = ( code, category ) => {
 						<ExternalLink
 							href="https://jetpack.com/blog/error-establishing-database-connection-on-wordpress/"
 							target="_blank"
-							icon={ false }
 						/>
 					),
 				},

--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -111,14 +111,7 @@ const BackupSuccessful = ( {
 									'For more information {{ExternalLink}}visit our documentation page{{/ExternalLink}}.',
 								{
 									components: {
-										ExternalLink: (
-											<ExternalLink
-												href={ multiSiteInfoLink }
-												target="_blank"
-												rel="noopener noreferrer"
-												icon
-											/>
-										),
+										ExternalLink: <ExternalLink href={ multiSiteInfoLink } target="_blank" icon />,
 									},
 								}
 							)

--- a/client/components/jetpack/daily-backup-status/status-card/backup-support-links.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-support-links.jsx
@@ -15,21 +15,17 @@ const BackupSupportLinks = ( { siteUrl } ) => {
 			</div>
 			<div className="backup-support-links__links">
 				<div>
-					<ExternalLink href={ troubleshootingLink } target="_blank" rel="noopener noreferrer">
+					<ExternalLink href={ troubleshootingLink } target="_blank">
 						{ translate( 'Troubleshooting tips' ) }
 					</ExternalLink>
 				</div>
 				<div>
-					<ExternalLink href={ fixConnectionIssuesLink } target="_blank" rel="noopener noreferrer">
+					<ExternalLink href={ fixConnectionIssuesLink } target="_blank">
 						{ translate( 'How to fix connection issues' ) }
 					</ExternalLink>
 				</div>
 				<div>
-					<ExternalLink
-						href={ contactSupportUrl( siteUrl ) }
-						target="_blank"
-						rel="noopener noreferrer"
-					>
+					<ExternalLink href={ contactSupportUrl( siteUrl ) } target="_blank">
 						{ translate( 'Contact Jetpack support' ) }
 					</ExternalLink>
 				</div>

--- a/client/components/jetpack/threat-description/index.tsx
+++ b/client/components/jetpack/threat-description/index.tsx
@@ -102,7 +102,7 @@ class ThreatDescription extends PureComponent< Props > {
 				{ source &&
 					this.renderTextOrNode(
 						<p className="threat-description__section-text">
-							<ExternalLink href={ source } rel="noopener noreferrer">
+							<ExternalLink href={ source }>
 								{ translate( 'Learn more about this vulnerability' ) }
 							</ExternalLink>
 						</p>

--- a/client/components/jetpack/threat-item/index.tsx
+++ b/client/components/jetpack/threat-item/index.tsx
@@ -210,7 +210,6 @@ const ThreatItem: React.FC< Props > = ( {
 						className="button is-primary threat-item__codeable-button"
 						href="https://codeable.io/partners/jetpack-scan/"
 						target="_blank"
-						rel="noopener noreferrer"
 						tracksEventName="calypso_jetpack_scan_threat_codeable_estimate"
 					>
 						{ translate( 'Get a free estimate' ) }

--- a/client/components/support-info/index.jsx
+++ b/client/components/support-info/index.jsx
@@ -40,14 +40,14 @@ function SupportInfo( {
 				{ link || filteredPrivacyLink ? ' ' : null }
 				{ link && (
 					<span className="support-info__learn-more">
-						<ExternalLink href={ link } target="_blank" rel="noopener noreferrer">
+						<ExternalLink href={ link } target="_blank">
 							{ translate( 'Learn more' ) }
 						</ExternalLink>
 					</span>
 				) }
 				{ filteredPrivacyLink && (
 					<span className="support-info__privacy">
-						<ExternalLink href={ filteredPrivacyLink } target="_blank" rel="noopener noreferrer">
+						<ExternalLink href={ filteredPrivacyLink } target="_blank">
 							{ translate( 'Privacy Information' ) }
 						</ExternalLink>
 					</span>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -206,14 +206,12 @@ function ContactInfo( {
 					'https://wordpress.com/support/domains/domain-registrations-and-privacy/#privacy-protection'
 				) }
 				target="_blank"
-				icon={ false }
 			/>
 		);
 		const icannLink = (
 			<ExternalLink
 				href="https://www.icann.org/resources/pages/contact-verification-2013-05-03-en"
 				target="_blank"
-				icon={ false }
 			/>
 		);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/faqs.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/faqs.tsx
@@ -156,7 +156,6 @@ const DomainTransferFAQ: FC = () => {
 									components: {
 										ExternalLinkWithTracking: (
 											<ExternalLinkWithTracking
-												icon={ false }
 												href="https://wordpress.com/help"
 												tracksEventName="domain_transfer_faq_support_link_click"
 											/>

--- a/client/me/concierge/book/calendar-step.js
+++ b/client/me/concierge/book/calendar-step.js
@@ -94,7 +94,6 @@ class CalendarStep extends Component {
 										u: <u />,
 										externalLink: (
 											<ExternalLinkWithTracking
-												icon={ false }
 												href="/webinars"
 												target="_blank"
 												tracksEventName="calypso_concierge_book_view_webinars"

--- a/client/me/concierge/shared/no-available-times.js
+++ b/client/me/concierge/shared/no-available-times.js
@@ -27,7 +27,6 @@ class NoAvailableTimes extends Component {
 								components: {
 									externalLink1: (
 										<ExternalLinkWithTracking
-											icon={ false }
 											href="/webinars"
 											tracksEventName="calypso_concierge_book_view_webinars"
 										/>
@@ -42,14 +41,12 @@ class NoAvailableTimes extends Component {
 								components: {
 									externalLink1: (
 										<ExternalLinkWithTracking
-											icon={ false }
 											href="/webinars"
 											tracksEventName="calypso_concierge_book_view_webinars"
 										/>
 									),
 									externalLink2: (
 										<ExternalLinkWithTracking
-											icon={ false }
 											href="/help/contact"
 											tracksEventName="calypso_concierge_book_contact_us"
 										/>

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -30,12 +30,7 @@ class PrimaryHeader extends Component {
 							'Use the tool below to book your in-depth support session.'
 						) }
 					/>
-					<ExternalLink
-						className="shared__info-link"
-						icon={ false }
-						href={ CONCIERGE_SUPPORT }
-						target="_blank"
-					>
+					<ExternalLink className="shared__info-link" href={ CONCIERGE_SUPPORT } target="_blank">
 						{ translate( 'Learn more' ) }
 					</ExternalLink>
 				</Card>

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -58,7 +58,6 @@ class AddDnsRecord extends Component {
 						: localizeUrl( DNS_RECORDS_ADD )
 				}
 				target="_blank"
-				icon={ false }
 			/>
 		);
 

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
@@ -293,14 +293,12 @@ export default function BulkEditContactInfoPage( {
 					'https://wordpress.com/support/domains/domain-registrations-and-privacy/#privacy-protection'
 				) }
 				target="_blank"
-				icon={ false }
 			/>
 		);
 		const icannLink = (
 			<ExternalLink
 				href="https://www.icann.org/resources/pages/contact-verification-2013-05-03-en"
 				target="_blank"
-				icon={ false }
 			/>
 		);
 

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
@@ -103,14 +103,12 @@ const EditContactInfoPage = ( {
 					'https://wordpress.com/support/domains/domain-registrations-and-privacy/#privacy-protection'
 				) }
 				target="_blank"
-				icon={ false }
 			/>
 		);
 		const icannLink = (
 			<ExternalLink
 				href="https://www.icann.org/resources/pages/contact-verification-2013-05-03-en"
 				target="_blank"
-				icon={ false }
 			/>
 		);
 

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -187,7 +187,6 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 											<ExternalLink
 												href="https://www.google.com/business/"
 												target="_blank"
-												rel="noopener noreferrer"
 												icon
 												onClick={ this.trackGoogleMyBusinessClick }
 											/>

--- a/client/my-sites/pages/virtual-page/index.tsx
+++ b/client/my-sites/pages/virtual-page/index.tsx
@@ -34,7 +34,6 @@ const HomepagePopover = ( { isAdmin, template }: HomepagePopoverProps ) => {
 	const learnMoreLink = (
 		<ExternalLink
 			href={ localizeUrl( 'https://wordpress.com/support/templates/#template-hierarchy' ) }
-			rel="noopener noreferrer"
 			children={ null }
 		/>
 	);

--- a/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
@@ -198,7 +198,6 @@ const GoogleAnalyticsJetpackForm = ( {
 										icon
 										href="https://support.google.com/analytics/answer/2763052"
 										target="_blank"
-										rel="noopener noreferrer"
 									>
 										{ translate( 'Learn more' ) }
 									</ExternalLink>

--- a/client/my-sites/site-settings/form-analytics-stores.jsx
+++ b/client/my-sites/site-settings/form-analytics-stores.jsx
@@ -13,7 +13,7 @@ class FormAnalyticsStores extends Component {
 
 	renderExplanation = ( setting ) => {
 		const link = setting.link ? (
-			<ExternalLink icon href={ setting.link.url } target="_blank" rel="noopener noreferrer">
+			<ExternalLink icon href={ setting.link.url } target="_blank">
 				{ setting.link.label }
 			</ExternalLink>
 		) : null;

--- a/client/my-sites/store/components/woocommerce-colophon/index.js
+++ b/client/my-sites/store/components/woocommerce-colophon/index.js
@@ -15,7 +15,7 @@ class WooCommerceColophon extends Component {
 	render() {
 		return (
 			<div className="woocommerce-colophon">
-				<ExternalLink icon={ false } onClick={ this.onClick } href="https://woocommerce.com">
+				<ExternalLink onClick={ this.onClick } href="https://woocommerce.com">
 					{ this.props.translate( 'Powered by {{WooCommerceLogo /}}', {
 						components: {
 							WooCommerceLogo: <WooCommerceLogo height={ 32 } width={ 120 } />,


### PR DESCRIPTION
## Proposed Changes

This PR removes the `rel="noopener noreferrer"` and `icon={ false }`.

## Why are these changes being made?

Just cleaning up. This is a follow-up to https://github.com/Automattic/wp-calypso/pull/99544#pullrequestreview-2608288600.

## Testing Instructions

* Verify changes make sense. They're a bit repetitive.
* Verify all checks pass.