### PR TITLE
Components: Use package version of `ExternalLink`

### DIFF
--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -1,5 +1,5 @@
 import path from 'path';
-import { Dialog, Gridicon, Spinner } from '@automattic/components';
+import { Dialog, Gridicon, Spinner, ExternalLink } from '@automattic/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 import ImageEditor from 'calypso/blocks/image-editor';
 import DropZone from 'calypso/components/drop-zone';
 import VerifyEmailDialog from 'calypso/components/email-verification/email-verification-dialog';
-import ExternalLink from 'calypso/components/external-link';
 import FilePicker from 'calypso/components/file-picker';
 import Gravatar from 'calypso/components/gravatar';
 import InfoPopover from 'calypso/components/info-popover';

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -1,9 +1,8 @@
-import { Card, Badge } from '@automattic/components';
+import { Card, Badge, ExternalLink } from '@automattic/components';
 import DOMPurify from 'dompurify';
 import { localize, LocalizeProps, translate } from 'i18n-calypso';
 import { Fragment } from 'react';
 import ActionPanelLink from 'calypso/components/action-panel/link';
-import ExternalLink from 'calypso/components/external-link';
 import type { DomainNames, EligibilityWarning } from 'calypso/state/automated-transfer/selectors';
 
 interface ExternalProps {

--- a/client/blocks/importer/wordpress/import-everything/import-users/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/import-users/index.tsx
@@ -1,4 +1,4 @@
-import { Gridicon } from '@automattic/components';
+import { Gridicon, ExternalLink } from '@automattic/components';
 import { useSendInvites } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { NextButton, Title, SubTitle } from '@automattic/onboarding';
@@ -7,7 +7,6 @@ import { Fragment, useEffect, useState } from '@wordpress/element';
 import { check } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
-import ExternalLink from 'calypso/components/external-link';
 import Pagination from 'calypso/components/pagination';
 import Search from 'calypso/components/search';
 import useExternalContributorsQuery from 'calypso/data/external-contributors/use-external-contributors';

--- a/client/blocks/jetpack-plugin-update-warning/index.tsx
+++ b/client/blocks/jetpack-plugin-update-warning/index.tsx
@@ -1,6 +1,6 @@
+import { ExternalLink } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FC, useCallback, useMemo, useState } from 'react';
-import ExternalLink from 'calypso/components/external-link';
 import Notice from 'calypso/components/notice';
 import { preventWidows } from 'calypso/lib/formatting';
 import version_compare from 'calypso/lib/version-compare';

--- a/client/blocks/legal-updates-banner/index.js
+++ b/client/blocks/legal-updates-banner/index.js
@@ -1,9 +1,8 @@
-import { Button, Card } from '@automattic/components';
+import { Button, Card, ExternalLink } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { connect } from 'react-redux';
-import ExternalLink from 'calypso/components/external-link';
 import { acceptTos, requestLegalData } from 'calypso/state/legal/actions';
 import { shouldDisplayTosUpdateBanner } from 'calypso/state/selectors/should-display-tos-update-banner';
 

--- a/client/blocks/qr-code-login/index.jsx
+++ b/client/blocks/qr-code-login/index.jsx
@@ -1,13 +1,12 @@
 import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
-import { Card, Gridicon } from '@automattic/components';
+import { Card, Gridicon, ExternalLink } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { QRCodeSVG } from 'qrcode.react';
 import { useEffect, useState } from 'react';
 import qrCenter from 'calypso/assets/images/qr-login/app.png';
-import ExternalLink from 'calypso/components/external-link';
 import { setStoredItem, getStoredItem } from 'calypso/lib/browser-storage';
 import { useInterval } from 'calypso/lib/interval';
 import { login } from 'calypso/lib/paths';

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -1,11 +1,10 @@
-import { Gridicon } from '@automattic/components';
+import { Gridicon, ExternalLink } from '@automattic/components';
 import clsx from 'clsx';
 import { translate, numberFormat } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import TagsList from 'calypso/blocks/reader-post-card/tags-list';
 import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
 import AutoDirection from 'calypso/components/auto-direction';
-import ExternalLink from 'calypso/components/external-link';
 import TimeSince from 'calypso/components/time-since';
 import { recordPermalinkClick } from 'calypso/reader/stats';
 import ReaderFullPostHeaderPlaceholder from './placeholders/header';

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { Gridicon, EmbedContainer } from '@automattic/components';
+import { Gridicon, EmbedContainer, ExternalLink } from '@automattic/components';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { get, startsWith, pickBy } from 'lodash';
@@ -24,7 +24,6 @@ import QueryPostLikes from 'calypso/components/data/query-post-likes';
 import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
 import QueryReaderPost from 'calypso/components/data/query-reader-post';
 import QueryReaderSite from 'calypso/components/data/query-reader-site';
-import ExternalLink from 'calypso/components/external-link';
 import PostExcerpt from 'calypso/components/post-excerpt';
 import {
 	RelatedPostsFromSameSite,

--- a/client/blocks/reader-full-post/unavailable.jsx
+++ b/client/blocks/reader-full-post/unavailable.jsx
@@ -1,11 +1,11 @@
 import config from '@automattic/calypso-config';
+import { ExternalLink } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Fragment } from 'react';
 import BackButton from 'calypso/components/back-button';
 import DocumentHead from 'calypso/components/data/document-head';
-import ExternalLink from 'calypso/components/external-link';
 import ReaderMain from 'calypso/reader/components/reader-main';
 
 const noop = () => {};

--- a/client/blocks/reader-site-subscription/site-subscription-subheader.tsx
+++ b/client/blocks/reader-site-subscription/site-subscription-subheader.tsx
@@ -1,8 +1,8 @@
+import { ExternalLink } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { numberFormat, useTranslate } from 'i18n-calypso';
 import React from 'react';
-import ExternalLink from 'calypso/components/external-link';
 import { useRecordViewFeedButtonClicked } from 'calypso/landing/subscriptions/tracks';
 import { getFeedUrl } from 'calypso/reader/route';
 

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from '@automattic/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose, isEmpty, get } from 'lodash';
@@ -7,7 +8,6 @@ import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import ReaderSiteNotificationSettings from 'calypso/blocks/reader-site-notification-settings';
 import ReaderSubscriptionListItemPlaceholder from 'calypso/blocks/reader-subscription-list-item/placeholder';
 import ReaderSuggestedFollowsDialog from 'calypso/blocks/reader-suggested-follows/dialog';
-import ExternalLink from 'calypso/components/external-link';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import FollowButton from 'calypso/reader/follow-button';
 import {

--- a/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-feed-item.tsx
+++ b/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-feed-item.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button, ExternalLink } from '@automattic/components';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -7,7 +7,6 @@ import { filterURLForDisplay } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
 import { SiteIcon } from 'calypso/blocks/site-icon';
-import ExternalLink from 'calypso/components/external-link';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { useResendEmailVerification } from '../../landing/stepper/hooks/use-resend-email-verification';

--- a/client/components/backup-retention-management/index.tsx
+++ b/client/components/backup-retention-management/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, Spinner } from '@automattic/components';
+import { Button, Card, Spinner, ExternalLink } from '@automattic/components';
 import { useEffect, useState, useCallback } from '@wordpress/element';
 import { removeQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
@@ -7,7 +7,6 @@ import { useStorageText } from 'calypso/components/backup-storage-space/hooks';
 import { UpsellPrice } from 'calypso/components/backup-storage-space/usage-warning/upsell';
 import useUpsellInfo from 'calypso/components/backup-storage-space/usage-warning/use-upsell-slug';
 import QuerySiteProducts from 'calypso/components/data/query-site-products';
-import ExternalLink from 'calypso/components/external-link';
 import { addQueryArgs } from 'calypso/lib/route';
 import { buildCheckoutURL } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import { useDispatch, useSelector } from 'calypso/state';

--- a/client/components/backup-retention-management/retention-option-on-cancel-purchase/index.tsx
+++ b/client/components/backup-retention-management/retention-option-on-cancel-purchase/index.tsx
@@ -1,10 +1,9 @@
 import { camelOrSnakeSlug } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { Button, Card } from '@automattic/components';
+import { Button, Card, ExternalLink } from '@automattic/components';
 import { useEffect, useState, useCallback } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { productHasBackups } from 'calypso/blocks/jetpack-benefits/feature-checks';
-import ExternalLink from 'calypso/components/external-link';
 import HasRetentionCapabilitiesSwitch from 'calypso/jetpack-cloud/sections/settings/has-retention-capabilities-switch';
 import { settingsPath } from 'calypso/lib/jetpack/paths';
 import { useDispatch, useSelector } from 'calypso/state';

--- a/client/components/environment-badge/index.jsx
+++ b/client/components/environment-badge/index.jsx
@@ -1,6 +1,5 @@
-import { Gridicon } from '@automattic/components';
+import { Gridicon, ExternalLink } from '@automattic/components';
 import { node, string } from 'prop-types';
-import ExternalLink from 'calypso/components/external-link';
 
 import './style.scss';
 

--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -1,7 +1,0 @@
-import { ExternalLink } from '@automattic/components';
-
-// We're in the process of migrating to @automattic/components. Because of this, we're using this wrapper
-// component to point references to the old ExternalLink component to the new one in @automattic/components.
-// This allows us to transition in smaller pieces and without risking updates to the old Calypso component in the interim.
-
-export default ExternalLink;

--- a/client/components/external-link/with-tracking.jsx
+++ b/client/components/external-link/with-tracking.jsx
@@ -1,7 +1,0 @@
-import { ExternalLinkWithTracking } from '@automattic/components';
-
-// We're in the process of migrating to @automattic/components. Because of this, we're using this wrapper
-// component to point references to the old ExternalLink component to the new one in @automattic/components.
-// This allows us to transition in smaller pieces and without risking updates to the old Calypso component in the interim.
-
-export default ExternalLinkWithTracking;

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -1,4 +1,4 @@
-import { Gridicon } from '@automattic/components';
+import { Gridicon, ExternalLink } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { dispatch as dataStoreDispatch } from '@wordpress/data';
@@ -7,7 +7,6 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import ExternalLink from 'calypso/components/external-link';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './style.scss';

--- a/client/components/jetpack/backup-warnings/backup-warning-retry.jsx
+++ b/client/components/jetpack/backup-warnings/backup-warning-retry.jsx
@@ -1,9 +1,8 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Gridicon } from '@automattic/components';
+import { Gridicon, ExternalLink } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import ExternalLink from 'calypso/components/external-link';
 import Button from 'calypso/components/forms/form-button';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import { rewindBackupSite } from 'calypso/state/activity-log/actions';

--- a/client/components/jetpack/backup-warnings/backup-warnings.jsx
+++ b/client/components/jetpack/backup-warnings/backup-warnings.jsx
@@ -1,8 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Gridicon } from '@automattic/components';
+import { Gridicon, ExternalLink } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import ExternalLink from 'calypso/components/external-link';
 import BackupWarningHeader from 'calypso/components/jetpack/backup-warnings/backup-warning-header';
 import BackupWarningListHeader from 'calypso/components/jetpack/backup-warnings/backup-warning-list-header';
 import LogItem from 'calypso/components/jetpack/log-item';

--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -1,9 +1,9 @@
 import config from '@automattic/calypso-config';
+import { ExternalLink } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { default as ActivityCard, useToggleContent } from 'calypso/components/activity-card';
 import { default as Toolbar } from 'calypso/components/activity-card/toolbar';
-import ExternalLink from 'calypso/components/external-link';
 import BackupWarningRetry from 'calypso/components/jetpack/backup-warnings/backup-warning-retry';
 import NextScheduledBackup from 'calypso/components/jetpack/daily-backup-status/status-card/parts/next-scheduled-backup';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';

--- a/client/components/jetpack/daily-backup-status/status-card/backup-support-links.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-support-links.jsx
@@ -1,5 +1,5 @@
+import { ExternalLink } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import ExternalLink from 'calypso/components/external-link';
 import contactSupportUrl from 'calypso/lib/jetpack/contact-support-url';
 
 const BackupSupportLinks = ( { siteUrl } ) => {

--- a/client/components/jetpack/jetpack-disconnected-wpcom/index.tsx
+++ b/client/components/jetpack/jetpack-disconnected-wpcom/index.tsx
@@ -1,10 +1,9 @@
-import { Button } from '@automattic/components';
+import { Button, ExternalLink } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { JETPACK_SUPPORT_CONNECTION_ISSUES } from '@automattic/urls';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import JetpackDisconnected from 'calypso/assets/images/jetpack/disconnected.svg';
-import ExternalLink from 'calypso/components/external-link';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import { preventWidows } from 'calypso/lib/formatting';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';

--- a/client/components/jetpack/jetpack-disconnected/index.tsx
+++ b/client/components/jetpack/jetpack-disconnected/index.tsx
@@ -1,9 +1,9 @@
+import { ExternalLink } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { JETPACK_SUPPORT_CONNECTION_ISSUES } from '@automattic/urls';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import JetpackDisconnectedSVG from 'calypso/assets/images/jetpack/disconnected-gray.svg';
-import ExternalLink from 'calypso/components/external-link';
 import Upsell from 'calypso/components/jetpack/upsell';
 import { preventWidows } from 'calypso/lib/formatting';
 import { useSelector, useDispatch } from 'calypso/state';

--- a/client/components/jetpack/server-credentials-wizard-dialog/index.tsx
+++ b/client/components/jetpack/server-credentials-wizard-dialog/index.tsx
@@ -1,8 +1,7 @@
-import { Dialog, Gridicon } from '@automattic/components';
+import { Dialog, Gridicon, ExternalLink } from '@automattic/components';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import ExternalLink from 'calypso/components/external-link';
 import ServerCredentialsForm from 'calypso/components/jetpack/server-credentials-form';
 import { useSelector } from 'calypso/state';
 import getJetpackCredentials from 'calypso/state/selectors/get-jetpack-credentials';

--- a/client/components/jetpack/threat-item/index.tsx
+++ b/client/components/jetpack/threat-item/index.tsx
@@ -1,8 +1,7 @@
-import { Button } from '@automattic/components';
+import { Button, ExternalLinkWithTracking } from '@automattic/components';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import * as React from 'react';
-import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 import {
 	getThreatPayloadDescription,
 	getThreatFix,

--- a/client/components/link-card/index.tsx
+++ b/client/components/link-card/index.tsx
@@ -1,6 +1,6 @@
+import { ExternalLink } from '@automattic/components';
 import styled from '@emotion/styled';
 import { ReactNode } from 'react';
-import ExternalLink from 'calypso/components/external-link';
 
 import './style.scss';
 

--- a/client/components/popover-menu/item.jsx
+++ b/client/components/popover-menu/item.jsx
@@ -1,9 +1,8 @@
-import { Gridicon } from '@automattic/components';
+import { Gridicon, ExternalLink } from '@automattic/components';
 import clsx from 'clsx';
 import { omit } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import ExternalLink from 'calypso/components/external-link';
 
 const noop = () => {};
 

--- a/client/components/support-info/index.jsx
+++ b/client/components/support-info/index.jsx
@@ -1,6 +1,6 @@
+import { ExternalLink } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import ExternalLink from 'calypso/components/external-link';
 import InfoPopover from 'calypso/components/info-popover';
 
 import './style.scss';

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
@@ -1,10 +1,9 @@
-import { Button } from '@automattic/components';
+import { Button, ExternalLink } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useContext, useEffect, useMemo } from 'react';
 import { A4A_MARKETPLACE_CHECKOUT_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { getSelectedFilters } from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard/get-selected-filters';
 import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
-import ExternalLink from 'calypso/components/external-link';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';

--- a/client/jetpack-cloud/sections/pricing/jpcom-footer/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-footer/index.tsx
@@ -1,9 +1,8 @@
-import { Gridicon } from '@automattic/components';
+import { Gridicon, ExternalLink } from '@automattic/components';
 import { localizeUrl, useLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState, useCallback } from 'react';
 import DoNotSellDialogContainer from 'calypso/blocks/do-not-sell-dialog';
-import ExternalLink from 'calypso/components/external-link';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import SocialLogo from 'calypso/components/social-logo';
 import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/bundle.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/bundle.tsx
@@ -1,6 +1,6 @@
+import { ExternalLink } from '@automattic/components';
 import { useLocale, localizeUrl } from '@automattic/i18n-utils';
 import { Fragment } from 'react';
-import ExternalLink from 'calypso/components/external-link';
 import AntispamIcon from '../icons/jetpack-bundle-icon-antispam';
 import BackupIcon from '../icons/jetpack-bundle-icon-backup';
 import BoostIcon from '../icons/jetpack-bundle-icon-boost';

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/main-menu-item.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/main-menu-item.tsx
@@ -1,8 +1,7 @@
-import { Gridicon } from '@automattic/components';
+import { Gridicon, ExternalLink } from '@automattic/components';
 import { useLocale, localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useRef } from 'react';
-import ExternalLink from 'calypso/components/external-link';
 import { isMobile, sortByMenuOrder, onLinkClick, closeOnFocusOut, isValidLink } from '../utils';
 import BundlesSection from './bundles-section';
 import type { MenuItem } from 'calypso/data/jetpack/use-jetpack-masterbar-data-query';

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -1,9 +1,9 @@
+import { ExternalLink } from '@automattic/components';
 import { useLocale, localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useEffect, useState, useRef } from 'react';
 import * as React from 'react';
-import ExternalLink from 'calypso/components/external-link';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import JetpackSaleBanner from 'calypso/jetpack-cloud/sections/pricing/sale-banner';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';

--- a/client/jetpack-cloud/sections/settings/main.jsx
+++ b/client/jetpack-cloud/sections/settings/main.jsx
@@ -1,4 +1,4 @@
-import { Card, FoldableCard } from '@automattic/components';
+import { Card, FoldableCard, ExternalLink } from '@automattic/components';
 import { localize, useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -8,7 +8,6 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackScan from 'calypso/components/data/query-jetpack-scan';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import QuerySiteCredentials from 'calypso/components/data/query-site-credentials';
-import ExternalLink from 'calypso/components/external-link';
 import ServerCredentialsForm from 'calypso/components/jetpack/server-credentials-form';
 import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-contact-info/index.tsx
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Gridicon } from '@automattic/components';
+import { Gridicon, ExternalLink } from '@automattic/components';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { camelToSnakeCase, mapRecordKeysRecursively, snakeToCamelCase } from '@automattic/js-utils';
 import { useTranslate } from 'i18n-calypso';
@@ -7,7 +7,6 @@ import { useDispatch } from 'react-redux';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import ContactDetailsFormFields from 'calypso/components/domains/contact-details-form-fields';
 import TwoColumnsLayout from 'calypso/components/domains/layout/two-columns-layout';
-import ExternalLink from 'calypso/components/external-link';
 import FormattedHeader from 'calypso/components/formatted-header';
 import {
 	useDomainTransferReceive,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/faqs.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/faqs.tsx
@@ -1,6 +1,6 @@
+import { ExternalLinkWithTracking } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
-import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 import FoldableFAQ from 'calypso/components/foldable-faq';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
@@ -1,4 +1,4 @@
-import { Gridicon } from '@automattic/components';
+import { Gridicon, ExternalLink } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { __experimentalHStack as HStack } from '@wordpress/components';
@@ -6,7 +6,6 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { SiteIcon } from 'calypso/blocks/site-icon';
-import ExternalLink from 'calypso/components/external-link';
 import InfoPopover from 'calypso/components/info-popover';
 import TimeSince from 'calypso/components/time-since';
 import {

--- a/client/layout/guided-tours/config-elements/link.js
+++ b/client/layout/guided-tours/config-elements/link.js
@@ -1,5 +1,5 @@
+import { ExternalLink } from '@automattic/components';
 import { Component } from 'react';
-import ExternalLink from 'calypso/components/external-link';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 
 class Link extends Component {

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -1,14 +1,13 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
-import { Gridicon } from '@automattic/components';
+import { Gridicon, ExternalLink } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
-import ExternalLink from 'calypso/components/external-link';
 import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
 import { isDomainConnectAuthorizePath } from 'calypso/lib/domains/utils';
 import { canDoMagicLogin, getLoginLinkPageUrl } from 'calypso/lib/login';

--- a/client/me/concierge/book/calendar-step.js
+++ b/client/me/concierge/book/calendar-step.js
@@ -1,9 +1,8 @@
-import { CompactCard } from '@automattic/components';
+import { CompactCard, ExternalLinkWithTracking } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';

--- a/client/me/concierge/shared/no-available-times.js
+++ b/client/me/concierge/shared/no-available-times.js
@@ -1,8 +1,7 @@
-import { Card } from '@automattic/components';
+import { Card, ExternalLinkWithTracking } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import PrimaryHeader from './primary-header';
 

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -1,8 +1,7 @@
-import { Card } from '@automattic/components';
+import { Card, ExternalLink } from '@automattic/components';
 import { CONCIERGE_SUPPORT } from '@automattic/urls';
 import { localize } from 'i18n-calypso';
 import { Component, Fragment } from 'react';
-import ExternalLink from 'calypso/components/external-link';
 import FormattedHeader from 'calypso/components/formatted-header';
 import ClosureNotice from '../shared/closure-notice';
 

--- a/client/me/site-blocks/list-item.jsx
+++ b/client/me/site-blocks/list-item.jsx
@@ -1,8 +1,7 @@
-import { Button } from '@automattic/components';
+import { Button, ExternalLink } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import ExternalLink from 'calypso/components/external-link';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { unblockSite } from 'calypso/state/reader/site-blocks/actions';
 import { getSite } from 'calypso/state/reader/sites/selectors';

--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -4,7 +4,7 @@ import {
 	PLAN_PERSONAL,
 	WPCOM_FEATURES_FULL_ACTIVITY_LOG,
 } from '@automattic/calypso-products';
-import { Button, Gridicon } from '@automattic/components';
+import { Button, Gridicon, ExternalLink } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -12,7 +12,6 @@ import activityImage from 'calypso/assets/images/illustrations/site-activity.svg
 import DismissibleCard from 'calypso/blocks/dismissible-card';
 import CardHeading from 'calypso/components/card-heading';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
-import ExternalLink from 'calypso/components/external-link';
 import { preventWidows } from 'calypso/lib/formatting';
 import { PRODUCT_UPSELLS_BY_FEATURE } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';

--- a/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
@@ -1,6 +1,5 @@
-import { Button, Card, FormLabel, Gridicon } from '@automattic/components';
+import { Button, Card, FormLabel, Gridicon, ExternalLink } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
-import ExternalLink from 'calypso/components/external-link';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import ActivityIcon from '../activity-log-item/activity-icon';
 

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-activation-instructions.tsx
@@ -1,7 +1,6 @@
-import { Button } from '@automattic/components';
+import { Button, ExternalLink } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import ExternalLink from 'calypso/components/external-link';
 import JetpackInstructionList from './jetpack-instruction-list';
 
 const JetpackActivationInstructions: React.FC = () => {

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
@@ -1,7 +1,6 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button, Gridicon, ExternalLink } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useCallback } from 'react';
-import ExternalLink from 'calypso/components/external-link';
 import { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';

--- a/client/my-sites/checkout/upsell-nudge/quickstart-sessions-retirement/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/quickstart-sessions-retirement/index.jsx
@@ -1,9 +1,8 @@
-import { CompactCard, Button } from '@automattic/components';
+import { CompactCard, Button, ExternalLink } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { SUPPORT_ROOT } from '@automattic/urls';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
-import ExternalLink from 'calypso/components/external-link';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import {
 	CONCIERGE_QUICKSTART_SESSION,

--- a/client/my-sites/comment/comment-permalink.jsx
+++ b/client/my-sites/comment/comment-permalink.jsx
@@ -1,9 +1,8 @@
-import { Card } from '@automattic/components';
+import { Card, ExternalLink } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import ExternalLink from 'calypso/components/external-link';
 import SectionHeader from 'calypso/components/section-header';
 import { getSiteComment } from 'calypso/state/comments/selectors';
 

--- a/client/my-sites/comments/comment/comment-author-more-info.jsx
+++ b/client/my-sites/comments/comment/comment-author-more-info.jsx
@@ -1,10 +1,9 @@
-import { Button, Popover, Gridicon } from '@automattic/components';
+import { Button, Popover, Gridicon, ExternalLink } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import ExternalLink from 'calypso/components/external-link';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { urlToDomainAndPath } from 'calypso/lib/url';
 import {

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -1,10 +1,9 @@
-import { Gridicon, Tooltip } from '@automattic/components';
+import { Gridicon, Tooltip, ExternalLink } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import ExternalLink from 'calypso/components/external-link';
 import Gravatar from 'calypso/components/gravatar';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { decodeEntities } from 'calypso/lib/formatting';

--- a/client/my-sites/customer-home/cards/education/educational-content/index.jsx
+++ b/client/my-sites/customer-home/cards/education/educational-content/index.jsx
@@ -1,8 +1,7 @@
-import { Gridicon, MaterialIcon } from '@automattic/components';
+import { Gridicon, MaterialIcon, ExternalLink } from '@automattic/components';
 import { isDesktop } from '@automattic/viewport';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import ExternalLink from 'calypso/components/external-link';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 

--- a/client/my-sites/customer-home/cards/tasks/revive-auto-reverted-atomic/index.tsx
+++ b/client/my-sites/customer-home/cards/tasks/revive-auto-reverted-atomic/index.tsx
@@ -1,7 +1,7 @@
+import { ExternalLinkWithTracking } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import disconnectedIllustration from 'calypso/assets/images/customer-home/disconnected-dark.svg';
-import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 import {
 	TASK_REACTIVATE_ATOMIC_TRANSFER,
 	TASK_REACTIVATE_EXPIRED_PLAN,

--- a/client/my-sites/domains/components/mapping-instructions/index.jsx
+++ b/client/my-sites/domains/components/mapping-instructions/index.jsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from '@automattic/components';
 import {
 	MAP_DOMAIN_CHANGE_NAME_SERVERS,
 	MAP_EXISTING_DOMAIN_UPDATE_A_RECORDS,
@@ -6,7 +7,6 @@ import {
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
-import ExternalLink from 'calypso/components/external-link';
 import FoldableFAQ from 'calypso/components/foldable-faq';
 import { Notice } from 'calypso/components/notice';
 import { isSubdomain } from 'calypso/lib/domains';

--- a/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/add-dns-record.jsx
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { ExternalLink } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { DNS_RECORDS_ADD, DNS_RECORDS_EDITING_OR_DELETING } from '@automattic/urls';
 import { localize } from 'i18n-calypso';
@@ -6,7 +7,6 @@ import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import QueryDomainDns from 'calypso/components/data/query-domain-dns';
-import ExternalLink from 'calypso/components/external-link';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
@@ -1,5 +1,5 @@
 import page, { type Context } from '@automattic/calypso-router';
-import { Button, Gridicon } from '@automattic/components';
+import { Button, Gridicon, ExternalLink } from '@automattic/components';
 import {
 	useAllDomainsQuery,
 	useDomainsBulkActionsMutation,
@@ -16,7 +16,6 @@ import { useSelector } from 'react-redux';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import QueryWhois from 'calypso/components/data/query-whois';
 import TwoColumnsLayout from 'calypso/components/domains/layout/two-columns-layout';
-import ExternalLink from 'calypso/components/external-link';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain } from 'calypso/lib/domains';

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
@@ -1,11 +1,10 @@
 import page from '@automattic/calypso-router';
-import { Card } from '@automattic/components';
+import { Card, ExternalLink } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import TwoColumnsLayout from 'calypso/components/domains/layout/two-columns-layout';
-import ExternalLink from 'calypso/components/external-link';
 import Main from 'calypso/components/main';
 import useDomainTransferRequestQuery from 'calypso/data/domains/transfers/use-domain-transfer-request-query';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-record-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-record-header.tsx
@@ -1,8 +1,8 @@
+import { ExternalLink } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { SiteExcerptData } from '@automattic/sites';
 import { translate } from 'i18n-calypso';
 import React, { useMemo } from 'react';
-import ExternalLink from 'calypso/components/external-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { domainManagementAllOverview, domainManagementDns } from 'calypso/my-sites/domains/paths';
 import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';

--- a/client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-records-header.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/headers/dns-records-header.tsx
@@ -1,8 +1,8 @@
+import { ExternalLink } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { SiteExcerptData } from '@automattic/sites';
 import { translate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import ExternalLink from 'calypso/components/external-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { domainManagementAllOverview } from 'calypso/my-sites/domains/paths';
 import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';

--- a/client/my-sites/earn/components/commission-fees.tsx
+++ b/client/my-sites/earn/components/commission-fees.tsx
@@ -1,5 +1,5 @@
+import { ExternalLink } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import ExternalLink from 'calypso/components/external-link';
 import { preventWidows } from 'calypso/lib/formatting';
 import { useSelector } from 'calypso/state';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes/list-item-link.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes/list-item-link.tsx
@@ -1,5 +1,4 @@
-import { Gridicon } from '@automattic/components';
-import ExternalLink from 'calypso/components/external-link';
+import { Gridicon, ExternalLink } from '@automattic/components';
 import { getEmailAddress, isEmailForwardAccount, isTitanMailAccount } from 'calypso/lib/emails';
 import { getGmailUrl } from 'calypso/lib/gsuite';
 import { getTitanEmailUrl, useTitanAppsUrlPrefix } from 'calypso/lib/titan';

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { Button, Card, Gridicon } from '@automattic/components';
+import { Button, Card, Gridicon, ExternalLink } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -11,7 +11,6 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
 import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
 import QuerySiteKeyrings from 'calypso/components/data/query-site-keyrings';
-import ExternalLink from 'calypso/components/external-link';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';

--- a/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
@@ -1,10 +1,9 @@
-import { Spinner } from '@automattic/components';
+import { Spinner, ExternalLink } from '@automattic/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import ExternalLink from 'calypso/components/external-link';
 import { loadmShotsPreview } from 'calypso/lib/mshots';
 import ErrorPane from 'calypso/my-sites/importer/error-pane';
 import ImporterActionButton from 'calypso/my-sites/importer/importer-action-buttons/action-button';

--- a/client/my-sites/plans-features-main/components/plan-faq.jsx
+++ b/client/my-sites/plans-features-main/components/plan-faq.jsx
@@ -5,13 +5,12 @@ import {
 	PLAN_ECOMMERCE,
 	getPlan,
 } from '@automattic/calypso-products';
-import { ExternalLink } from '@automattic/components';
+import { ExternalLink, ExternalLinkWithTracking } from '@automattic/components';
 import { localizeUrl, useHasEnTranslation } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
-import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 import FoldableFAQComponent from 'calypso/components/foldable-faq';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 

--- a/client/my-sites/plans/jetpack-plans/product-card/product-tooltip.ts
+++ b/client/my-sites/plans/jetpack-plans/product-card/product-tooltip.ts
@@ -4,10 +4,10 @@ import {
 	PRODUCT_WPCOM_SEARCH_MONTHLY,
 	getPriceTierForUnits,
 } from '@automattic/calypso-products';
+import { ExternalLink } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { translate, TranslateResult } from 'i18n-calypso';
 import { createElement } from 'react';
-import ExternalLink from 'calypso/components/external-link';
 import { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
 import type { PriceTierEntry } from '@automattic/calypso-products';
 

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -1,8 +1,8 @@
+import { ExternalLink } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import ExternalLink from 'calypso/components/external-link';
 import { DISABLE_AUTOUPDATE_PLUGIN, ENABLE_AUTOUPDATE_PLUGIN } from 'calypso/lib/plugins/constants';
 import { getSiteFileModDisableReason, isMainNetworkSite } from 'calypso/lib/site/utils';
 import PluginAction from 'calypso/my-sites/plugins/plugin-action/plugin-action';

--- a/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
@@ -1,8 +1,7 @@
-import { FoldableCard } from '@automattic/components';
+import { FoldableCard, ExternalLink } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import styled from '@emotion/styled';
 import { Fragment } from 'react';
-import ExternalLink from 'calypso/components/external-link';
 
 const Container = styled( FoldableCard )`
 	display: flex;

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -6,14 +6,13 @@ import {
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { Button, Gridicon } from '@automattic/components';
+import { Button, Gridicon, ExternalLink } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component, useRef } from 'react';
 import { connect } from 'react-redux';
-import ExternalLink from 'calypso/components/external-link';
 import InfoPopover from 'calypso/components/info-popover';
 import {
 	marketplacePlanToAdd,

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -2,13 +2,13 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 
+import { ExternalLink } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { Icon, trash } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import ExternalLink from 'calypso/components/external-link';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -1,9 +1,9 @@
+import { ExternalLink } from '@automattic/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { filter, find } from 'lodash';
 import { createRef, Component } from 'react';
 import titleCase from 'to-title-case';
-import ExternalLink from 'calypso/components/external-link';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';

--- a/client/my-sites/post-type-list/post-item/index.jsx
+++ b/client/my-sites/post-type-list/post-item/index.jsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from '@automattic/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -5,7 +6,6 @@ import { Component } from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import PostShare from 'calypso/blocks/post-share';
-import ExternalLink from 'calypso/components/external-link';
 import PostRelativeTimeStatus from 'calypso/my-sites/post-relative-time-status';
 import { preloadEditor } from 'calypso/sections-preloaders';
 import { bumpStat } from 'calypso/state/analytics/actions';

--- a/client/my-sites/promote-post-i2/components/payment-links/index.tsx
+++ b/client/my-sites/promote-post-i2/components/payment-links/index.tsx
@@ -1,7 +1,6 @@
-import { Gridicon } from '@automattic/components';
+import { Gridicon, ExternalLink } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
-import ExternalLink from 'calypso/components/external-link';
 import { OrderInfo } from 'calypso/data/promote-post/use-promote-post-billing-summary-query';
 import { formatNumber } from 'calypso/my-sites/promote-post-i2/utils';
 

--- a/client/my-sites/site-indicator/index.jsx
+++ b/client/my-sites/site-indicator/index.jsx
@@ -1,4 +1,4 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button, Gridicon, ExternalLink } from '@automattic/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -6,7 +6,6 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import Animate from 'calypso/components/animate';
 import QuerySiteConnectionStatus from 'calypso/components/data/query-site-connection-status';
-import ExternalLink from 'calypso/components/external-link';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import isJetpackConnectionUnhealthy from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-unhealthy';

--- a/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
@@ -6,6 +6,7 @@ import {
 	FormInputValidation as FormTextValidation,
 	FormLabel,
 	Button,
+	ExternalLink,
 } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
@@ -14,7 +15,6 @@ import { useEffect } from 'react';
 import googleIllustration from 'calypso/assets/images/illustrations/google-analytics-logo.svg';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
-import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';

--- a/client/my-sites/site-settings/date-time-format/time-format-option.jsx
+++ b/client/my-sites/site-settings/date-time-format/time-format-option.jsx
@@ -1,7 +1,6 @@
-import { FormLabel } from '@automattic/components';
+import { FormLabel, ExternalLink } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
-import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';

--- a/client/my-sites/site-settings/form-analytics-stores.jsx
+++ b/client/my-sites/site-settings/form-analytics-stores.jsx
@@ -1,8 +1,8 @@
+import { ExternalLink } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
-import ExternalLink from 'calypso/components/external-link';
 import FormLegend from 'calypso/components/forms/form-legend';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -1,11 +1,10 @@
-import { Button, FormInputValidation } from '@automattic/components';
+import { Button, FormInputValidation, ExternalLink } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get, omit } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
-import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormInput from 'calypso/components/forms/form-text-input-with-affixes';
 import InlineSupportLink from 'calypso/components/inline-support-link';

--- a/client/my-sites/site-settings/sitemaps.jsx
+++ b/client/my-sites/site-settings/sitemaps.jsx
@@ -1,10 +1,10 @@
+import { ExternalLink } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryJetpackConnection from 'calypso/components/data/query-jetpack-connection';
-import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { PanelCard, PanelCardHeading } from 'calypso/components/panel';

--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -4,13 +4,18 @@ import {
 	WPCOM_FEATURES_ANTISPAM,
 	isJetpackAntiSpam,
 } from '@automattic/calypso-products';
-import { FormInputValidation, FormLabel, Gridicon, FoldableCard } from '@automattic/components';
+import {
+	FormInputValidation,
+	FormLabel,
+	Gridicon,
+	FoldableCard,
+	ExternalLink,
+} from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { includes, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
-import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';

--- a/client/my-sites/store/components/woocommerce-colophon/index.js
+++ b/client/my-sites/store/components/woocommerce-colophon/index.js
@@ -1,7 +1,7 @@
+import { ExternalLink } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import ExternalLink from 'calypso/components/external-link';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import WooCommerceLogo from '../woocommerce-logo';
 

--- a/client/signup/steps/clone-destination/index.jsx
+++ b/client/signup/steps/clone-destination/index.jsx
@@ -1,11 +1,10 @@
-import { Card, Button, FormInputValidation, FormLabel } from '@automattic/components';
+import { Card, Button, FormInputValidation, FormLabel, ExternalLink } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import ExternalLink from 'calypso/components/external-link';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';

--- a/client/sites/marketing/connections/service.jsx
+++ b/client/sites/marketing/connections/service.jsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { Badge, FoldableCard } from '@automattic/components';
+import { Badge, FoldableCard, ExternalLink } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import requestExternalAccess from '@automattic/request-external-access';
 import clsx from 'clsx';
@@ -8,7 +8,6 @@ import { isEqual, find, some, get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, cloneElement } from 'react';
 import { connect } from 'react-redux';
-import ExternalLink from 'calypso/components/external-link';
 import Notice from 'calypso/components/notice';
 import SocialLogo from 'calypso/components/social-logo';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';

--- a/client/sites/marketing/sharing/components/buttons-block-appearance.jsx
+++ b/client/sites/marketing/sharing/components/buttons-block-appearance.jsx
@@ -1,6 +1,6 @@
+import { ExternalLink } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
-import ExternalLink from 'calypso/components/external-link';
 import { PanelCard } from 'calypso/components/panel';
 import { useSelector } from 'calypso/state';
 import { getSiteAdminUrl } from 'calypso/state/sites/selectors';

--- a/client/sites/tools/sftp-ssh/sftp-form.tsx
+++ b/client/sites/tools/sftp-ssh/sftp-form.tsx
@@ -1,11 +1,10 @@
 import { FEATURE_SFTP, FEATURE_SSH } from '@automattic/calypso-products';
-import { Button, FormLabel, Spinner } from '@automattic/components';
+import { Button, FormLabel, Spinner, ExternalLink } from '@automattic/components';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
-import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useCompleteLaunchpadTasksWithNotice } from 'calypso/launchpad/hooks/use-complete-launchpad-tasks-with-notice';


### PR DESCRIPTION
## Proposed Changes

This PR updates the codebase to use `ExternalLink` from the `@automattic/components` package instead of its wrapper in `client/components`.

## Why are these changes being made?

Just cleaning up. This is a follow-up to https://github.com/Automattic/wp-calypso/pull/99544#pullrequestreview-2608288600.

## Testing Instructions

* Verify changes make sense.
* Verify all checks pass.