### PR TITLE
Show Launch site button only if allowed

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -42,6 +42,7 @@ import {
 	getSiteHomeUrl,
 	getSite,
 } from 'calypso/state/sites/selectors';
+import canCurrentUserManageSiteOptions from 'calypso/state/sites/selectors/can-current-user-manage-site-options';
 import canCurrentUserUseCustomerHome from 'calypso/state/sites/selectors/can-current-user-use-customer-home';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { activateNextLayoutFocus, setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
@@ -415,9 +416,9 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderLaunchButton() {
-		const { isUnlaunchedSite, siteId, translate } = this.props;
+		const { isUnlaunchedSite, siteId, translate, isManageSiteOptionsEnabled } = this.props;
 
-		if ( ! isUnlaunchedSite ) {
+		if ( ! isUnlaunchedSite || ! isManageSiteOptionsEnabled ) {
 			return null;
 		}
 
@@ -653,6 +654,7 @@ export default connect(
 
 		return {
 			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
+			isManageSiteOptionsEnabled: canCurrentUserManageSiteOptions( state, siteId ),
 			isNotificationsShowing: isNotificationsOpen( state ),
 			isEcommerce: isEcommercePlan( sitePlanSlug ),
 			siteId: siteId,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/99313

## Proposed Changes

Do not allow a user to launch a site if not enough permissions.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the home of a site you are not admin of
* You should not see the Launch site button
