### PR TITLE
A4A: handle auth when redirected to signup finish

### DIFF
--- a/client/a8c-for-agencies/sections/signup/primary/agency-signup-finish/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/primary/agency-signup-finish/index.tsx
@@ -18,7 +18,9 @@ import { getSignupDataFromRequestParameters } from '../../lib/signup-data-from-r
 import {
 	clearSignupDataFromLocalStorage,
 	getSignupDataFromLocalStorage,
+	saveSignupDataToLocalStorage,
 } from '../../lib/signup-data-to-local-storage';
+import { useHandleWPCOMRedirect } from '../../signup-form/hooks/use-handle-wpcom-redirect';
 
 import './style.scss';
 
@@ -29,6 +31,7 @@ export default function AgencySignupFinish() {
 	const agency = useSelector( getActiveAgency );
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const handleWPCOMRedirect = useHandleWPCOMRedirect();
 
 	const createAgency = useCreateAgencyMutation( {
 		onSuccess: () => {
@@ -50,9 +53,16 @@ export default function AgencySignupFinish() {
 
 	useEffect( () => {
 		function createAgencyHandler() {
-			// Added to prevent typescript errors and for additional safety
-			if ( ! userLoggedIn || ! signupData ) {
+			// If the signup data is not present, redirect to the signup page.
+			if ( ! signupData ) {
 				page.redirect( A4A_SIGNUP_LINK );
+				return;
+			}
+
+			// If the user is not logged in, save the signup data to local storage and redirect to the WPCOM login page.
+			if ( ! userLoggedIn ) {
+				saveSignupDataToLocalStorage( signupData );
+				handleWPCOMRedirect( signupData );
 				return;
 			}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1736

## Proposed Changes

A small follow-up for https://github.com/Automattic/wp-calypso/pull/99515. After getting to `signup/finish` page we need to authenticate our app. This is handled with existing logic.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Clone this branch locally and run a8c-for-agencies
- In incognito window, navigate to `agencies.automattic.com`
- You will be redirected to wpcom asked to create new account. Create one.
- After, you asked to Authorize. **Don't do it**
- Instead, open url `http://agencies.localhost:3000/` with signup finish data like this: `/signup/finish?address_line1=asdas&address_line2=asdad&address_state=&address_postal_code=&first_name=Test%20A&last_name=L%203&email=andrii.lysenko%2Btest.signup.8%40automattic.com&agency_name=Test%203&agency_url=http%3A%2F%2Fautomattic.com&number_sites=1-5&user_type=agency_owner&services_offered%5B0%5D=website_design_development&products_offered%5B0%5D=Jetpack&address_city=asda&address_country=AL&phone_number=&referral_status=&client_id=95932` . You should get redirected again to Auth page. This time approve it.
- After, agency should be corrected normally.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
