### PR TITLE
Revert "Reader: `reader` and `account` flows set Reader as the user's default landing page (Take 2)"

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -1,8 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { HOSTING_LP_FLOW, ONBOARDING_FLOW, ONBOARDING_GUIDED_FLOW } from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
-import { savePreference } from 'calypso/state/preferences/actions';
-import { READER_AS_LANDING_PAGE_PREFERENCE } from 'calypso/state/sites/selectors/has-reader-as-landing-page';
 
 const noop = () => {};
 
@@ -92,14 +90,6 @@ export function generateFlows( {
 			providesDependenciesInQuery: [ 'toStepper' ],
 			optionalDependenciesInQuery: [ 'toStepper' ],
 			hideProgressIndicator: true,
-			postCompleteCallback: async ( { dispatch } ) => {
-				dispatch(
-					savePreference( READER_AS_LANDING_PAGE_PREFERENCE, {
-						useReaderAsLandingPage: true,
-						updatedAt: Date.now(),
-					} )
-				);
-			},
 		},
 		{
 			name: 'business',
@@ -382,14 +372,6 @@ export function generateFlows( {
 			lastModified: '2025-01-28',
 			showRecaptcha: true,
 			hideProgressIndicator: true,
-			postCompleteCallback: async ( { dispatch } ) => {
-				dispatch(
-					savePreference( READER_AS_LANDING_PAGE_PREFERENCE, {
-						useReaderAsLandingPage: true,
-						updatedAt: Date.now(),
-					} )
-				);
-			},
 		},
 		{
 			name: 'crowdsignal',

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -384,11 +384,7 @@ class Signup extends Component {
 
 		if ( flow.postCompleteCallback ) {
 			const siteId = dependencies && dependencies.siteId;
-			await flow.postCompleteCallback( {
-				siteId,
-				flowName: this.props.flowName,
-				dispatch: this.props.dispatch,
-			} );
+			await flow.postCompleteCallback( { siteId, flowName: this.props.flowName } );
 		}
 	};
 
@@ -624,7 +620,7 @@ class Signup extends Component {
 			dependencies.oauth2_client_id && ! progress?.[ 'oauth2-user' ]?.service; // service is set for social signup (e.g. Google, Apple)
 		// If the user is not logged in, we need to log them in first.
 		// And if it's regular oauth client signup, we perform the oauth login because the WPCC user creation code automatically logs the user in.
-		// There's no need to turn the bearer token into a cookie. If we log user in again, it will cause an activation error.
+		// There’s no need to turn the bearer token into a cookie. If we log user in again, it will cause an activation error.
 		// However, we need to skip this to perform a regular login for social sign in.
 		if ( ! userIsLoggedIn && ( config.isEnabled( 'oauth' ) || isRegularOauth2ClientSignup ) ) {
 			debug( `Handling oauth login` );
@@ -994,10 +990,9 @@ export default connect(
 			hostingFlow,
 		};
 	},
-	( dispatch ) => ( {
-		dispatch,
+	{
 		submitSignupStep,
 		removeStep,
 		addStep,
-	} )
+	}
 )( Signup );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#99565