### PR TITLE
Removes the objective section from the Blaze campaign details page

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -51,10 +51,6 @@ import {
 	getCampaignStatus,
 	getCampaignStatusBadgeColor,
 } from '../../utils';
-import AwarenessIcon from '../campaign-objective-icons/AwarenessIcon';
-import EngagementIcon from '../campaign-objective-icons/EngagementIcon';
-import SalesIcon from '../campaign-objective-icons/SalesIcon';
-import TrafficIcon from '../campaign-objective-icons/TrafficIcon';
 import TargetLocations from './target-locations';
 
 interface Props {
@@ -154,8 +150,6 @@ export default function CampaignItemDetails( props: Props ) {
 		status,
 		ui_status,
 		campaign_stats,
-		objective,
-		objective_data,
 		billing_data,
 		target_urn,
 		campaign_id,
@@ -252,37 +246,6 @@ export default function CampaignItemDetails( props: Props ) {
 
 	const campaignTitleFormatted = title || __( 'Untitled' );
 	const campaignCreatedFormatted = moment.utc( created_at ).format( 'MMMM DD, YYYY' );
-
-	const objectiveIcon = ( () => {
-		switch ( objective ) {
-			case 'traffic':
-				return <span> { TrafficIcon() } </span>;
-			case 'sales':
-				return <span> { SalesIcon() } </span>;
-			case 'awareness':
-				return <span> { AwarenessIcon() } </span>;
-			case 'engagement':
-				return <span> { EngagementIcon() } </span>;
-			default:
-				return null;
-		}
-	} )();
-
-	const objectiveFormatted = ( () => {
-		if ( ! objectiveIcon || ! objective_data ) {
-			return null;
-		}
-		return (
-			<>
-				<span> { objectiveIcon } </span>
-				<span>
-					<span className="title">{ objective_data?.title }</span>
-					{ ' - ' }
-					{ objective_data?.description }
-				</span>
-			</>
-		);
-	} )();
 
 	const devicesListFormatted = devicesList ? `${ devicesList }` : __( 'All' );
 	const languagesListFormatted = languagesList
@@ -1115,17 +1078,6 @@ export default function CampaignItemDetails( props: Props ) {
 						<div className="campaign-item-details__main-stats-container">
 							<div className="campaign-item-details__secondary-stats">
 								<div className="campaign-item-details__secondary-stats-row">
-									{ objective && objectiveFormatted && (
-										<div>
-											<span className="campaign-item-details__label">
-												{ translate( 'Campaign objective' ) }
-											</span>
-											<span className="campaign-item-details__details objective">
-												{ ! isLoading ? objectiveFormatted : <FlexibleSkeleton /> }
-											</span>
-										</div>
-									) }
-
 									<div>
 										<span className="campaign-item-details__label">
 											{ translate( 'Audience' ) }


### PR DESCRIPTION
## Proposed Changes

* Removes the objective section from the Blaze campaign details page.

## Why are these changes being made?

Some time ago we added campaign objective selector to collect info about user goals. Now we collected enough information and we aren't able to wire up any functionality for this selector, so it's now creates additional step in onboarding without any benefits.

We plan to remove the objective selection on the DSP Campaign Widget, and also remove the objective section on the campaign details page.

## Testing Instructions

* Open the live preview and navigate to any campaign of yours
* Verify that you no longer see the Campaign objective seciton
![Screenshot 2025-02-11 at 4 54 19 PM](https://github.com/user-attachments/assets/8424bb3a-140a-4a88-ac6d-5aac506c9876)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
