### PR TITLE
Update hundred year domain manage link

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -209,7 +209,7 @@ export default function HundredYearThankYou( {
 	const hundredYearDomainCta = (
 		<StyledLightButton
 			onClick={ () =>
-				page( ` /domains/manage/all/${ targetDomain?.name }/edit/${ targetDomain?.name }` )
+				page( ` /domains/manage/all/overview/${ targetDomain?.name }/${ targetDomain?.name }` )
 			}
 		>
 			{ translate( 'Manage your domain' ) }


### PR DESCRIPTION
## Proposed Changes

This PR updates the link to manage your 100-year domain so that it takes you to the new domain management experience:
<img width="1723" alt="image" src="https://github.com/user-attachments/assets/87e1dc94-a8aa-4d7e-9c10-b96f8b81fbd2" />

**Before**
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/eaa13eee-ad26-4446-893d-7e44283498fa" />

**After**
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/ef867098-b4f8-48c0-adab-8e8c0e956022" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/setup/hundred-year-domain/domains`
* Buy the domain
* Click on manage your domain

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
