### PR TITLE
A4A: Signup - Add form validation for contact and personalization forms

### DIFF
--- a/client/a8c-for-agencies/components/form/hoc/with-error-handling/index.tsx
+++ b/client/a8c-for-agencies/components/form/hoc/with-error-handling/index.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, useCallback, useMemo, useState } from 'react';
+import { ComponentType, useCallback, useMemo, useState, useEffect } from 'react';
 import { FieldTypes } from './types';
 
 type Validator< T > = ( field: T ) => string | null;
@@ -20,6 +20,11 @@ function withErrorHandling< T, F extends FieldTypes >(
 		if ( !! props.error && props.error !== newProps.error ) {
 			setError( props.error );
 		}
+
+		// This is a workaround to ensure that the error is updated when the parent component updates the error.
+		useEffect( () => {
+			setError( props.error );
+		}, [ props.error ] );
 
 		const validate = useCallback( () => {
 			if ( ! checks ) {

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/hooks/use-contact-form-validation.ts
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/hooks/use-contact-form-validation.ts
@@ -1,0 +1,81 @@
+import emailValidator from 'email-validator';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useState } from 'react';
+import { isSiteActive } from 'calypso/a8c-for-agencies/components/form/utils';
+import { AgencyDetailsSignupPayload } from 'calypso/a8c-for-agencies/sections/signup/types';
+import { preventWidows } from 'calypso/lib/formatting';
+
+export const CAPTURE_URL_RGX =
+	/^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([-.][a-z0-9]+)*\.[a-z]{2,63}(:[0-9]{1,5})?(\/.*)?$/i;
+const CAPTURE_SOCIAL_URL_RGX =
+	/^(https?:\/\/)?(www\.)?(facebook\.com|linkedin\.com|instagram\.com)(\/.*)?$/i;
+
+type ValidationState = {
+	firstName?: string;
+	lastName?: string;
+	agencyName?: string;
+	agencyUrl?: string;
+	email?: string;
+};
+
+const useContactFormValidation = () => {
+	const translate = useTranslate();
+	const [ validationError, setValidationError ] = useState< ValidationState >( {} );
+	const [ isValidating, setIsValidating ] = useState( false );
+
+	const updateValidationError = ( newState: ValidationState ) => {
+		return setValidationError( ( prev ) => ( { ...prev, ...newState } ) );
+	};
+
+	const validate = useCallback(
+		async ( payload: Partial< AgencyDetailsSignupPayload > ) => {
+			const newValidationError: ValidationState = {};
+			setIsValidating( true );
+			if ( payload.firstName === '' ) {
+				newValidationError.firstName = translate( `First name can't be empty` );
+			}
+			if ( payload.lastName === '' ) {
+				newValidationError.lastName = translate( `Last name can't be empty` );
+			}
+
+			if ( payload.agencyName === '' ) {
+				newValidationError.agencyName = translate( `Agency name can't be empty` );
+			}
+
+			if ( payload.email === '' || typeof payload.email !== 'string' ) {
+				newValidationError.email = translate( `Email address can't be empty` );
+			} else if ( ! emailValidator.validate( payload.email ) ) {
+				newValidationError.email = translate( `Please provide correct email address` );
+			}
+
+			if ( payload.agencyUrl === '' || typeof payload.agencyUrl !== 'string' ) {
+				newValidationError.agencyUrl = translate( `Agency URL can't be empty` );
+			} else if ( ! CAPTURE_URL_RGX.test( payload.agencyUrl ) ) {
+				newValidationError.agencyUrl = translate( `Please enter a valid URL` );
+			} else if (
+				CAPTURE_SOCIAL_URL_RGX.test( payload.agencyUrl ) ||
+				! ( await isSiteActive( payload.agencyUrl ) )
+			) {
+				newValidationError.agencyUrl = preventWidows(
+					translate(
+						"Please enter a valid site URL for your business. If you're experiencing issues contact us at partnerships@automattic.com"
+					)
+				);
+			}
+
+			setIsValidating( false );
+
+			if ( Object.keys( newValidationError ).length > 0 ) {
+				setValidationError( newValidationError );
+				return newValidationError;
+			}
+
+			return null;
+		},
+		[ setValidationError, translate ]
+	);
+
+	return { validate, validationError, updateValidationError, isValidating };
+};
+
+export default useContactFormValidation;

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/hooks/use-contact-form-validation.ts
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/hooks/use-contact-form-validation.ts
@@ -3,10 +3,9 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import { isSiteActive } from 'calypso/a8c-for-agencies/components/form/utils';
 import { AgencyDetailsSignupPayload } from 'calypso/a8c-for-agencies/sections/signup/types';
+import { CAPTURE_URL_RGX } from 'calypso/blocks/import/util';
 import { preventWidows } from 'calypso/lib/formatting';
 
-export const CAPTURE_URL_RGX =
-	/^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([-.][a-z0-9]+)*\.[a-z]{2,63}(:[0-9]{1,5})?(\/.*)?$/i;
 const CAPTURE_SOCIAL_URL_RGX =
 	/^(https?:\/\/)?(www\.)?(facebook\.com|linkedin\.com|instagram\.com)(\/.*)?$/i;
 
@@ -31,24 +30,24 @@ const useContactFormValidation = () => {
 		async ( payload: Partial< AgencyDetailsSignupPayload > ) => {
 			const newValidationError: ValidationState = {};
 			setIsValidating( true );
-			if ( payload.firstName === '' ) {
+			if ( payload.firstName?.trim() === '' ) {
 				newValidationError.firstName = translate( `First name can't be empty` );
 			}
-			if ( payload.lastName === '' ) {
+			if ( payload.lastName?.trim() === '' ) {
 				newValidationError.lastName = translate( `Last name can't be empty` );
 			}
 
-			if ( payload.agencyName === '' ) {
+			if ( payload.agencyName?.trim() === '' ) {
 				newValidationError.agencyName = translate( `Agency name can't be empty` );
 			}
 
-			if ( payload.email === '' || typeof payload.email !== 'string' ) {
+			if ( payload.email?.trim() === '' || typeof payload.email !== 'string' ) {
 				newValidationError.email = translate( `Email address can't be empty` );
 			} else if ( ! emailValidator.validate( payload.email ) ) {
 				newValidationError.email = translate( `Please provide correct email address` );
 			}
 
-			if ( payload.agencyUrl === '' || typeof payload.agencyUrl !== 'string' ) {
+			if ( payload.agencyUrl?.trim() === '' || typeof payload.agencyUrl !== 'string' ) {
 				newValidationError.agencyUrl = translate( `Agency URL can't be empty` );
 			} else if ( ! CAPTURE_URL_RGX.test( payload.agencyUrl ) ) {
 				newValidationError.agencyUrl = translate( `Please enter a valid URL` );

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/hooks/use-personalization-form-validation.ts
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/hooks/use-personalization-form-validation.ts
@@ -1,0 +1,38 @@
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useState } from 'react';
+import { AgencyDetailsSignupPayload } from 'calypso/a8c-for-agencies/sections/signup/types';
+
+type ValidationState = {
+	country?: string;
+};
+
+const usePersonalizationFormValidation = () => {
+	const translate = useTranslate();
+	const [ validationError, setValidationError ] = useState< ValidationState >( {} );
+
+	const updateValidationError = ( newState: ValidationState ) => {
+		return setValidationError( ( prev ) => ( { ...prev, ...newState } ) );
+	};
+
+	const validate = useCallback(
+		async ( payload: Partial< AgencyDetailsSignupPayload > ) => {
+			const newValidationError: ValidationState = {};
+
+			if ( payload.country === '' ) {
+				newValidationError.country = translate( `Please select your country` );
+			}
+
+			if ( Object.keys( newValidationError ).length > 0 ) {
+				setValidationError( newValidationError );
+				return newValidationError;
+			}
+
+			return null;
+		},
+		[ setValidationError, translate ]
+	);
+
+	return { validate, validationError, updateValidationError };
+};
+
+export default usePersonalizationFormValidation;

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -10,6 +10,7 @@ import { AgencyDetailsSignupPayload } from 'calypso/a8c-for-agencies/sections/si
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
 import MultiCheckbox from 'calypso/components/forms/multi-checkbox';
+import usePersonalizationFormValidation from './hooks/use-personalization-form-validation';
 
 import './style.scss';
 
@@ -20,11 +21,12 @@ interface Props {
 export default function PersonalizationForm( { onContinue }: Props ) {
 	const translate = useTranslate();
 	const { countryOptions } = useCountriesAndStates();
+	const { validate, validationError, updateValidationError } = usePersonalizationFormValidation();
 
 	const [ formData, setFormData ] = useState< Partial< AgencyDetailsSignupPayload > >( {
 		country: '',
-		userType: '',
-		managedSites: '',
+		userType: 'agency_owner',
+		managedSites: '1-5',
 		servicesOffered: [],
 		productsOffered: [],
 	} );
@@ -82,10 +84,15 @@ export default function PersonalizationForm( { onContinue }: Props ) {
 			...prev,
 			country: value,
 		} ) );
+		updateValidationError( { country: undefined } );
 	};
 
 	const handleSubmit = async ( e: React.FormEvent ) => {
 		e.preventDefault();
+		const error = await validate( formData );
+		if ( error ) {
+			return;
+		}
 		onContinue( formData );
 	};
 
@@ -97,7 +104,11 @@ export default function PersonalizationForm( { onContinue }: Props ) {
 				description={ translate( "We'll tailor the product and onboarding for you." ) }
 			>
 				<FormFieldset>
-					<FormField label={ translate( 'Where is your agency located?' ) } isRequired>
+					<FormField
+						error={ validationError.country }
+						label={ translate( 'Where is your agency located?' ) }
+						isRequired
+					>
 						<SearchableDropdown
 							value={ formData.country }
 							onChange={ handleSetCountry }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -125,7 +125,6 @@ export default function PersonalizationForm( { onContinue }: Props ) {
 							value={ formData.userType }
 							onChange={ handleInputChange( 'userType' ) }
 						>
-							<option value="">{ translate( 'Select option' ) }</option>
 							<option value="agency_owner">{ translate( 'Agency owner' ) }</option>
 							<option value="developer_at_agency">{ translate( 'Developer at an agency' ) }</option>
 							<option value="sales_marketing_operations_at_agency">
@@ -144,7 +143,6 @@ export default function PersonalizationForm( { onContinue }: Props ) {
 							value={ formData.managedSites }
 							onChange={ handleInputChange( 'managedSites' ) }
 						>
-							<option value="">{ translate( 'Select option' ) }</option>
 							<option value="1-5">{ translate( '1-5' ) }</option>
 							<option value="6-20">{ translate( '6-20' ) }</option>
 							<option value="21-50">{ translate( '21-50' ) }</option>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR adds validation based on how we validate fields in current `/signup` form.

- Implement form validation hooks for contact and personalization forms
- Add error handling and validation for form fields
- Ensure proper error display and user feedback during signup process

<img width="804" alt="Screenshot 2025-02-11 at 1 47 45 PM" src="https://github.com/user-attachments/assets/406f40dd-c730-4c82-8b49-71d8d58db088" />

<img width="749" alt="Screenshot 2025-02-11 at 1 48 09 PM" src="https://github.com/user-attachments/assets/1a7ed6a8-49e3-4571-9eed-386e85c91a90" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link below navigate to `/signup/wc-asia` and test the form for validation

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
