### PR TITLE
Subscribers: fix Add Subscribers modal icon alignment

### DIFF
--- a/packages/components/src/flow-question/style.scss
+++ b/packages/components/src/flow-question/style.scss
@@ -6,6 +6,10 @@ button.flow-question {
 	cursor: pointer;
 	text-align: left;
 
+	svg {
+		display: block;
+	}
+
 	.components-card__body {
 		padding: 22px 22px 24px;
 	}
@@ -26,7 +30,6 @@ button.flow-question {
 
 	.flow-question__icon {
 		align-self: flex-start;
-		padding: 2px 1px 0 0;
 	}
 
 	.flow-question__heading {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/wp-calypso#99465

## Proposed Changes

* Use `display: block;` on the svg icons so the browser will provide space only for the svg content, fixing the flex alignment.

| Before | After |
|-|-|
| <img width="1388" alt="image" src="https://github.com/user-attachments/assets/def734d3-3358-4319-b002-d84bd031db1d" /> | <img width="1388" alt="image" src="https://github.com/user-attachments/assets/42608f2e-a486-47db-af6f-d7e077cef691" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* By default, svg's render as `display: inline;` and so the browser will add space for things like text ascenders and descenders. This causes the wrapping element of the svg's to have a few extra pixels in height, throwing off things like flex alignment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/subcribers/<site>`
* Click on "Add Subscribers" to open the add subscribers modal
* Use the inspector to see the heights of the icons in the flow question components
* Make sure the svg's and their containing elements are exactly 24x24 pixels
* Check the alginment between the icons and the text are correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
