### PR TITLE
Domain-To-Plan Credit: Add notice banner to site details

### DIFF
--- a/client/sites/overview/components/hosting-overview.tsx
+++ b/client/sites/overview/components/hosting-overview.tsx
@@ -1,3 +1,4 @@
+import { Notice } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -30,6 +31,16 @@ const HostingOverview: FC = () => {
 
 	return (
 		<div className="hosting-overview">
+			<Notice
+				className="hosting-overview__domain-to-plan-credit-notice"
+				status="info"
+				onRemove={ () => {} }
+			>
+				{ translate(
+					// TODO: Retrieve value of credit to programmatically insert into this message.
+					'You have $X in upgrade credits for a price reduction in your plan upgrade.'
+				) }
+			</Notice>
 			<NavigationHeader
 				className="hosting-overview__navigation-header"
 				title={ translate( 'Overview' ) }

--- a/client/sites/overview/components/style.scss
+++ b/client/sites/overview/components/style.scss
@@ -130,6 +130,13 @@ $blueberry-color: #3858e9;
 
 }
 
+// TODO: Determine if this is the appropriate convention for CSS grids
+.hosting-overview__domain-to-plan-credit-notice {
+	grid-column: 1 / -1;
+	grid-row: 1;
+	background-color: reset;
+}
+
 .hosting-overview__navigation-header {
 	grid-column: 1 / -1;
 	grid-row: 1;

--- a/packages/plans-grid-next/src/components/shared/storage/components/storage-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/storage-dropdown.tsx
@@ -93,43 +93,39 @@ const StorageDropdown = ( {
 		( select ) => select( WpcomPlansUI.store ).getSelectedStorageOptionForPlan( planSlug, siteId ),
 		[ planSlug, siteId ]
 	);
-	const defaultStorageOption = useDefaultStorageOption( { planSlug } );
+	const defaultStorageOptionSlug = useDefaultStorageOption( { planSlug } );
 	const availableStorageAddOns = AddOns.useAvailableStorageAddOns( { siteId } );
 	const planStorage = usePlanStorage( planSlug );
 
 	useEffect( () => {
 		if ( ! selectedStorageOptionForPlan ) {
-			defaultStorageOption &&
+			defaultStorageOptionSlug &&
 				setSelectedStorageOptionForPlan( {
-					addOnSlug: defaultStorageOption,
+					addOnSlug: defaultStorageOptionSlug,
 					planSlug,
 					siteId,
 				} );
 		}
 	}, [
-		defaultStorageOption,
+		defaultStorageOptionSlug,
 		planSlug,
 		selectedStorageOptionForPlan,
 		setSelectedStorageOptionForPlan,
 		siteId,
 	] );
 
-	const defaultStorageItem = useMemo(
-		() => ( {
-			key: defaultStorageOption || '',
-			name: (
-				<StorageDropdownOption price="" totalStorage={ planStorage } />
-			 ) as unknown as string,
-		} ),
-		[ defaultStorageOption, planStorage ]
-	);
+	const selectControlOptions = useMemo( () => {
+		// Get the default storage add-on meta or the storage included with the plan
+		const defaultStorageAddOnMeta = getSelectedStorageAddOn(
+			storageAddOns,
+			defaultStorageOptionSlug || ''
+		) || { addOnSlug: defaultStorageOptionSlug, prices: null, quantity: 0 };
 
-	const selectControlOptions = [ defaultStorageItem ].concat(
-		availableStorageAddOns?.map( ( addOn ) => {
-			const addOnStorage = addOn.quantity ?? 0;
+		return [ defaultStorageAddOnMeta, ...availableStorageAddOns ]?.map( ( addOn ) => {
+			const addOnStorage = addOn?.quantity ?? 0;
 
 			return {
-				key: addOn.addOnSlug,
+				key: addOn?.addOnSlug || '',
 				name: (
 					<StorageDropdownOption
 						price={ addOn?.prices?.formattedMonthlyPrice }
@@ -137,8 +133,8 @@ const StorageDropdown = ( {
 					/>
 				 ) as unknown as string,
 			};
-		} )
-	);
+		} );
+	}, [ availableStorageAddOns, defaultStorageOptionSlug, planStorage, storageAddOns ] );
 
 	const selectedStorageAddOn = getSelectedStorageAddOn(
 		storageAddOns,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3690

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
