### PR TITLE
Domain-To-Plan Credit: Add notice banner to site details

### DIFF
--- a/client/components/domain-to-plan-credit-message/index.tsx
+++ b/client/components/domain-to-plan-credit-message/index.tsx
@@ -1,0 +1,35 @@
+import { formatCurrency } from '@automattic/format-currency';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useTranslate } from 'i18n-calypso';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import { useSelector } from 'calypso/state';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+
+type Props = {
+	amount: number;
+};
+
+const DomainToPlanCreditMessage = ( { amount }: Props ) => {
+	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+	const translate = useTranslate();
+	const upgradeCreditDocsUrl = localizeUrl(
+		'https://wordpress.com/support/manage-purchases/upgrade-your-plan/#upgrade-credit'
+	);
+
+	return translate(
+		'You have {{b}}%(amountInCurrency)s{{/b}} in {{a}}upgrade credits{{/a}} available from your current domain. This credit will be applied to the pricing below at checkout if you purchase a plan today!',
+		{
+			args: {
+				amountInCurrency: formatCurrency( amount, currencyCode ?? '', {
+					isSmallestUnit: true,
+				} ),
+			},
+			components: {
+				b: <strong />,
+				a: <InlineSupportLink supportLink={ upgradeCreditDocsUrl } />,
+			},
+		}
+	);
+};
+
+export default DomainToPlanCreditMessage;

--- a/client/my-sites/plans-features-main/components/plan-notice-domain-to-plan-credit.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice-domain-to-plan-credit.tsx
@@ -1,14 +1,8 @@
-import { formatCurrency } from '@automattic/format-currency';
-import { localizeUrl } from '@automattic/i18n-utils';
-import { useTranslate } from 'i18n-calypso';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
-import InlineSupportLink from 'calypso/components/inline-support-link';
+import DomainToPlanCreditMessage from 'calypso/components/domain-to-plan-credit-message';
 import Notice from 'calypso/components/notice';
 import { useDomainToPlanCreditsApplicable } from 'calypso/my-sites/plans-features-main/hooks/use-domain-to-plan-credits-applicable';
-import { useSelector } from 'calypso/state';
-import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import type { PlanSlug } from '@automattic/calypso-products';
-
 type Props = {
 	className?: string;
 	onDismissClick?: () => void;
@@ -22,12 +16,7 @@ const PlanNoticeDomainToPlanCredit = ( {
 	siteId,
 	visiblePlans,
 }: Props ) => {
-	const translate = useTranslate();
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const domainToPlanCreditsApplicable = useDomainToPlanCreditsApplicable( siteId, visiblePlans );
-	const upgradeCreditDocsUrl = localizeUrl(
-		'https://wordpress.com/support/manage-purchases/upgrade-your-plan/#upgrade-credit'
-	);
 	const showNotice =
 		visiblePlans &&
 		visiblePlans.length > 0 &&
@@ -46,24 +35,7 @@ const PlanNoticeDomainToPlanCredit = ( {
 					status="is-success"
 					isReskinned
 				>
-					{ translate(
-						'You have {{b}}%(amountInCurrency)s{{/b}} in {{a}}upgrade credits{{/a}} available from your current domain. This credit will be applied to the pricing below at checkout if you purchase a plan today!',
-						{
-							args: {
-								amountInCurrency: formatCurrency(
-									domainToPlanCreditsApplicable,
-									currencyCode ?? '',
-									{
-										isSmallestUnit: true,
-									}
-								),
-							},
-							components: {
-								b: <strong />,
-								a: <InlineSupportLink supportLink={ upgradeCreditDocsUrl } />,
-							},
-						}
-					) }
+					<DomainToPlanCreditMessage amount={ domainToPlanCreditsApplicable } />
 				</Notice>
 			) }
 		</>

--- a/client/sites/overview/components/hosting-overview.tsx
+++ b/client/sites/overview/components/hosting-overview.tsx
@@ -1,4 +1,4 @@
-import { Notice } from '@wordpress/components';
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -8,6 +8,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ActiveDomainsCard from './active-domains-card';
 import MigrationOverview from './migration-overview';
 import PlanCard from './plan-card';
+import PlanCreditNotice from './plan-credit-notice';
 import QuickActionsCard from './quick-actions-card';
 import SiteBackupCard from './site-backup-card';
 import SupportCard from './support-card';
@@ -31,16 +32,7 @@ const HostingOverview: FC = () => {
 
 	return (
 		<div className="hosting-overview">
-			<Notice
-				className="hosting-overview__domain-to-plan-credit-notice"
-				status="info"
-				onRemove={ () => {} }
-			>
-				{ translate(
-					// TODO: Retrieve value of credit to programmatically insert into this message.
-					'You have $X in upgrade credits for a price reduction in your plan upgrade.'
-				) }
-			</Notice>
+			{ isEnabled( 'domain-to-plan-credit' ) && <PlanCreditNotice /> }
 			<NavigationHeader
 				className="hosting-overview__navigation-header"
 				title={ translate( 'Overview' ) }

--- a/client/sites/overview/components/hosting-overview.tsx
+++ b/client/sites/overview/components/hosting-overview.tsx
@@ -1,3 +1,4 @@
+import { Notice } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -30,6 +31,16 @@ const HostingOverview: FC = () => {
 
 	return (
 		<div className="hosting-overview">
+			<Notice
+				className="hosting-overview__domain-to-plan-credit-notice"
+				status="info"
+				onRemove={ () => {} }
+			>
+				{ translate(
+					// TODO: Retrieve value of credit to programmatically insert into this message.
+					'You have $X in upgrade credits for a price reduction in your plan upgrade.'
+				) }
+			</Notice>
 			<NavigationHeader
 				className="hosting-overview__navigation-header"
 				title={ translate( 'Overview' ) }

--- a/client/sites/overview/components/plan-credit-notice.tsx
+++ b/client/sites/overview/components/plan-credit-notice.tsx
@@ -1,0 +1,42 @@
+import { useSitePlans } from '@automattic/data-stores/src/plans';
+import { Notice } from '@wordpress/components';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import DomainToPlanCreditMessage from 'calypso/components/domain-to-plan-credit-message';
+import { useDomainToPlanCreditsApplicable } from 'calypso/my-sites/plans-features-main/hooks/use-domain-to-plan-credits-applicable';
+import { useSelector } from 'calypso/state';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import type { PlanSlug } from '@automattic/calypso-products';
+
+const PlanCreditNotice = () => {
+	const site = useSelector( getSelectedSite );
+	const { ID: siteId } = site || {};
+	const { data: sitePlans } = useSitePlans( { siteId, coupon: undefined } );
+	const domainToPlanCreditsApplicable = useDomainToPlanCreditsApplicable(
+		siteId,
+		Object.keys( sitePlans || {} ) as PlanSlug[]
+	);
+	const showNotice = domainToPlanCreditsApplicable !== null && domainToPlanCreditsApplicable > 0;
+
+	if ( ! siteId ) {
+		return null;
+	}
+
+	return (
+		<>
+			<QuerySitePlans siteId={ siteId } />
+			<QuerySitePurchases siteId={ siteId } />
+			{ showNotice && (
+				<Notice
+					className="hosting-overview__domain-to-plan-credit-notice"
+					status="info"
+					onRemove={ () => {} }
+				>
+					<DomainToPlanCreditMessage amount={ domainToPlanCreditsApplicable } />
+				</Notice>
+			) }
+		</>
+	);
+};
+
+export default PlanCreditNotice;

--- a/client/sites/overview/components/plan-credit-notice.tsx
+++ b/client/sites/overview/components/plan-credit-notice.tsx
@@ -29,6 +29,7 @@ const PlanCreditNotice = () => {
 			{ showNotice && (
 				<Notice
 					className="hosting-overview__domain-to-plan-credit-notice"
+					isDismissible={ false }
 					status="info"
 					onRemove={ () => {} }
 				>

--- a/client/sites/overview/components/style.scss
+++ b/client/sites/overview/components/style.scss
@@ -130,6 +130,13 @@ $blueberry-color: #3858e9;
 
 }
 
+// TODO: Determine if this is the appropriate convention for CSS grids
+.hosting-overview__domain-to-plan-credit-notice {
+	grid-column: 1 / -1;
+	grid-row: 1;
+	background-color: reset;
+}
+
 .hosting-overview__navigation-header {
 	grid-column: 1 / -1;
 	grid-row: 1;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3690

## Proposed changes

Display a domain-to-plan credit notice in the site details view:

![CleanShot 2025-02-13 at 14 20 41@2x](https://github.com/user-attachments/assets/b992df38-6877-491a-9984-161b520d9ee3)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Encourage customers to upgrade to a paid plan by reminding them about available credit.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit `/overview/:blog` for a domain-only site
2. Verify that the credit notice is not displayed
3. Enable the feature flag: `?flags=domain-to-plan-credit`
4. Reload the page
5. Verify that the credit notice is displayed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
