### PR TITLE
Fix language on 100-year plan + domain thank you page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -1,6 +1,7 @@
 import { PLAN_100_YEARS, getPlan, domainProductSlugs } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -69,6 +70,13 @@ const Content = styled.div< { isMobile: boolean } >`
 	text-align: center;
 	.hundred-year-plan-thank-you__thank-you-text-container {
 		margin: 24px ${ ( { isMobile } ) => ( isMobile ? '0' : '80px' ) };
+	}
+	.hundred-year-plan-thank-you__thank-you-link {
+		color: var( --studio-gray-5 );
+		text-decoration: underline;
+		&:hover {
+			text-decoration: none;
+		}
 	}
 `;
 
@@ -223,19 +231,33 @@ export default function HundredYearThankYou( {
 			planTitle: getPlan( PLAN_100_YEARS )?.getTitle() || '',
 		},
 	} );
-	const helpAndSupportDescription =
-		productSlug === PLAN_100_YEARS
-			? translate(
-					'Our Premier Support team will be in touch by email shortly to schedule a welcome session and walk you through your exclusive benefits. We’re looking forward to supporting you every step of the way.'
-			  )
-			: translate(
-					'Our Premier Support team will be in touch by email shortly and can answer any questions you have. We’re looking forward to supporting you every step of the way.'
-			  );
+	const helpAndSupportDescription = translate(
+		'Our Premier Support team will be in touch by email shortly to schedule a welcome session and walk you through your exclusive benefits. We’re looking forward to supporting you every step of the way.'
+	);
+	const domainHelpAndSupportDescription = translate(
+		'If you have any questions please take a look at {{faqLink}}our guide{{/faqLink}}, or feel free to reach out to our Premier Support team. We’re looking forward to working with you every step of the way.',
+		{
+			components: {
+				faqLink: (
+					<a
+						href={ localizeUrl( 'https://wordpress.com/support/plan-features/100-year-plan/' ) }
+						target="_blank"
+						className="hundred-year-plan-thank-you__thank-you-link"
+						rel="noopener noreferrer"
+					/>
+				),
+			},
+		}
+	);
 
 	const description =
-		productSlug === PLAN_100_YEARS
-			? `${ hundredYearPlanDescription } ${ helpAndSupportDescription }`
-			: `${ domainSpecificDescription } ${ helpAndSupportDescription }`;
+		productSlug === PLAN_100_YEARS ? (
+			`${ hundredYearPlanDescription } ${ helpAndSupportDescription }`
+		) : (
+			<>
+				{ domainSpecificDescription } { domainHelpAndSupportDescription }
+			</>
+		);
 
 	return (
 		<>

--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -18,7 +18,6 @@ import { getSiteId, getSiteOptions, isRequestingSite } from 'calypso/state/sites
 import { hideMasterbar } from 'calypso/state/ui/actions';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
-const HOUR_IN_MS = 1000 * 60;
 const VideoContainer = styled.div< { isMobile: boolean } >`
 	overflow: hidden;
 	position: relative;
@@ -133,10 +132,6 @@ const CustomizedWordPressLogo = styled( WordPressLogo )`
 	fill: var( --studio-white );
 `;
 
-function isSiteCreatedWithinLastHour( createdTime: string ): boolean {
-	return Date.now() - new Date( createdTime ).getTime() < HOUR_IN_MS;
-}
-
 export default function HundredYearThankYou( {
 	siteSlug,
 	receiptId,
@@ -196,16 +191,11 @@ export default function HundredYearThankYou( {
 		isReceiptLoading ||
 		isLoadingDomains ||
 		( productSlug !== PLAN_100_YEARS && ! isDomainDataLoaded );
-	const hundredYearPlanCta =
-		siteCreatedTimeStamp && isSiteCreatedWithinLastHour( siteCreatedTimeStamp ) ? (
-			<StyledLightButton onClick={ () => page( `/setup/site-setup/goals?siteSlug=${ siteSlug }` ) }>
-				{ translate( 'Start building' ) }
-			</StyledLightButton>
-		) : (
-			<StyledLightButton onClick={ () => page( ` /home/${ siteSlug }` ) }>
-				{ translate( 'Manage your site' ) }
-			</StyledLightButton>
-		);
+	const hundredYearPlanCta = (
+		<StyledLightButton onClick={ () => page( ` /home/${ siteSlug }` ) }>
+			{ translate( 'Manage your site' ) }
+		</StyledLightButton>
+	);
 	const hundredYearDomainCta = (
 		<StyledLightButton
 			onClick={ () =>
@@ -216,8 +206,6 @@ export default function HundredYearThankYou( {
 		</StyledLightButton>
 	);
 	const cta = productSlug === PLAN_100_YEARS ? hundredYearPlanCta : hundredYearDomainCta;
-
-	const messageTarget = targetDomain?.domain || siteSlug;
 	const domainSpecificDescription =
 		productSlug === domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION
 			? translate( 'Your 100-Year Domain %(domain)s has been registered.', {
@@ -230,18 +218,19 @@ export default function HundredYearThankYou( {
 						domain: targetDomain?.domain || siteSlug,
 					},
 			  } );
-	const hundredYearPlanDescription = translate(
-		'The %(planTitle)s for %(messageTarget)s is active.',
-		{
-			args: {
-				messageTarget,
-				planTitle: getPlan( PLAN_100_YEARS )?.getTitle() || '',
-			},
-		}
-	);
-	const helpAndSupportDescription = translate(
-		'Our Premier Support team will be in touch by email shortly to schedule a welcome session and walk you through your exclusive benefits. We’re looking forward to supporting you every step of the way.'
-	);
+	const hundredYearPlanDescription = translate( 'Your %(planTitle)s is now active.', {
+		args: {
+			planTitle: getPlan( PLAN_100_YEARS )?.getTitle() || '',
+		},
+	} );
+	const helpAndSupportDescription =
+		productSlug === PLAN_100_YEARS
+			? translate(
+					'Our Premier Support team will be in touch by email shortly to schedule a welcome session and walk you through your exclusive benefits. We’re looking forward to supporting you every step of the way.'
+			  )
+			: translate(
+					'Our Premier Support team will be in touch by email shortly and can answer any questions you have. We’re looking forward to supporting you every step of the way.'
+			  );
 
 	const description =
 		productSlug === PLAN_100_YEARS


### PR DESCRIPTION
## Proposed Changes

This PR fixes makes some copy changes to the 100 year plan + domain screens. It also updates the CTA button to always go to the site management screen.

**Before**
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/2fb5a39e-d1ce-43f6-a21d-f5ba95a6c0f2" />

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/a450ea30-be03-4667-9bba-c4c854f65a2b" />

**After**
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/958a1256-80a7-44a9-a1d7-58c1ff685d25" />


<img width="1840" alt="image" src="https://github.com/user-attachments/assets/4a3c93dc-53ab-41a9-826b-5936f6e70d2d" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Register a domain from `/setup/hundred-year-domain/domains`
* Create a site from `/setup/hundred-year-plan/diy-or-difm`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
