### PR TITLE
Stats: fix Love Jetpack notice background

### DIFF
--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -148,8 +148,8 @@ const DoYouLoveJetpackStatsNotice = ( {
 
 	return (
 		<div
-			className={ `inner-notice-container has-odyssey-stats-bg-color ${
-				! isOdysseyStats && 'inner-notice-container--calypso'
+			className={ `inner-notice-container ${
+				! isOdysseyStats ? 'inner-notice-container--calypso' : ''
 			}` }
 		>
 			<NoticeBanner


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/jetpack#41230.

## Proposed Changes

Based on [Eder's suggestion][1], the fix is to remove the background color instead of fixing the bottom padding.

Also took the opportunity to fix the `isOdysseyStats` check, as it was outputting a `false` class when the condition was not evaluated to `true`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Automattic/jetpack-roadmap#1818

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- An easy way to test this is on an Odyssey (self-hosted) site that has no Jetpack plan.
  - It's possible to do that by spinning up a Jurassic Ninja site, unchecking the option to provide a Jetpack license and installing the Jetpack plugin.
- Navigate to `Jetpack -> Stats`.
- Check the `Do you love Jetpack Stats?` notice background.

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/2c0a295e-8a0a-40d5-9a16-9ec0918363a1) | ![image](https://github.com/user-attachments/assets/27320d74-871a-4980-b060-4d363fd0b227) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

[1]: https://github.com/Automattic/jetpack/issues/41230#issuecomment-2613597298