### PR TITLE
Remove free domain notice from checkout summary for 100 year plan

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -22,6 +22,7 @@ import {
 	WPCOM_FEATURES_ATOMIC,
 	isWooExpressPlan,
 	isSenseiProduct,
+	PLAN_100_YEARS,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
@@ -711,12 +712,14 @@ function CheckoutSummaryPlanFeatures( props: {
 
 	const showPricingGridFeatures = ! hasRenewalInCart;
 
+	const isHundredYearPlan = PLAN_100_YEARS === planInCart?.product_slug;
+
 	const planFeatures = getPlanFeatures(
 		planInCart,
 		translate,
 		hasDomainsInCart,
 		hasRenewalInCart,
-		nextDomainIsFree,
+		nextDomainIsFree && ! isHundredYearPlan,
 		showPricingGridFeatures
 	);
 


### PR DESCRIPTION
## Proposed Changes

This PR removes "Free domain for one year" feature in checkout summary, for 100 year plan.


## Why are these changes being made?
For 100 year plans, the domain is free for 100 years. In this first iteration, we are just removing the notice. 


## Testing Instructions
Apply this PR, go through the 100 year plan flow and remove the domain from the cart. Verify that the notice is not visibile in the cart summary,

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
