### PR TITLE
Checkout: Hide 'is for business use' checkbox if already set on payment method

### DIFF
--- a/client/lib/checkout/payment-methods.tsx
+++ b/client/lib/checkout/payment-methods.tsx
@@ -104,6 +104,7 @@ export interface StoredPaymentMethodTaxLocation {
 	organization?: string;
 	address?: string;
 	city?: string;
+	is_for_business?: boolean;
 }
 
 export const isPaymentAgreement = (

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -106,6 +106,7 @@ import type {
 	ResponseCart,
 } from '@automattic/shopping-cart';
 import type { CountryListItem } from '@automattic/wpcom-checkout';
+import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 import type { PropsWithChildren, ReactNode } from 'react';
 
 const debug = debugFactory( 'calypso:wp-checkout' );
@@ -338,6 +339,7 @@ export default function CheckoutMainContent( {
 	showErrorMessageBriefly,
 	siteId,
 	siteUrl,
+	storedCards,
 	isRemovingProductFromCart,
 	areThereErrors,
 	isInitialCartLoading,
@@ -359,6 +361,7 @@ export default function CheckoutMainContent( {
 	showErrorMessageBriefly: ( error: string ) => void;
 	siteId: number | undefined;
 	siteUrl: string | undefined;
+	storedCards: StoredPaymentMethod[];
 	isRemovingProductFromCart: boolean;
 	areThereErrors: boolean;
 	isInitialCartLoading: boolean;
@@ -790,6 +793,7 @@ export default function CheckoutMainContent( {
 						is100YearPlanTermsAccepted={ is100YearPlanTermsAccepted }
 						setIs100YearPlanTermsAccepted={ setIs100YearPlanTermsAccepted }
 						isSubmitted={ isSubmitted }
+						storedCards={ storedCards }
 					/>
 					<CheckoutFormSubmit
 						validateForm={ validateForm }
@@ -985,12 +989,14 @@ function CheckoutTermsAndCheckboxes( {
 	is100YearPlanTermsAccepted,
 	setIs100YearPlanTermsAccepted,
 	isSubmitted,
+	storedCards,
 }: {
 	is3PDAccountConsentAccepted: boolean;
 	setIs3PDAccountConsentAccepted: ( isAccepted: boolean ) => void;
 	is100YearPlanTermsAccepted: boolean;
 	setIs100YearPlanTermsAccepted: ( isAccepted: boolean ) => void;
 	isSubmitted: boolean;
+	storedCards: StoredPaymentMethod[];
 } ) {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
@@ -1003,7 +1009,7 @@ function CheckoutTermsAndCheckboxes( {
 	return (
 		<CheckoutTermsAndCheckboxesWrapper>
 			<BeforeSubmitCheckoutHeader />
-			<IsForBusinessCheckbox />
+			<IsForBusinessCheckbox storedCards={ storedCards } />
 			{ hasMarketplaceProduct && (
 				<AcceptTermsOfServiceCheckbox
 					isAccepted={ is3PDAccountConsentAccepted }

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -794,6 +794,7 @@ export default function CheckoutMain( {
 					isLoggedOutCart={ !! isLoggedOutCart }
 					onPageLoadError={ onPageLoadError }
 					paymentMethods={ paymentMethods }
+					storedCards={ storedCards }
 					removeProductFromCart={ removeProductFromCartAndMaybeRedirect }
 					showErrorMessageBriefly={ showErrorMessageBriefly }
 					siteId={ updatedSiteId }

--- a/client/my-sites/checkout/src/components/is-for-business-checkbox.tsx
+++ b/client/my-sites/checkout/src/components/is-for-business-checkbox.tsx
@@ -1,10 +1,12 @@
-import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
+import { usePaymentMethodId, FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { useShoppingCart, convertTaxLocationToLocationUpdate } from '@automattic/shopping-cart';
 import { hasCheckoutVersion, styled } from '@automattic/wpcom-checkout';
 import { CheckboxControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 import useCartKey from '../../use-cart-key';
+import { logStashEvent } from '../lib/analytics';
 const CheckboxWrapper = styled.div`
 	margin-top: 16px;
 
@@ -17,12 +19,29 @@ const CheckboxWrapper = styled.div`
 		color: ${ ( props ) => props.theme.colors.primary };
 	}
 `;
-export function IsForBusinessCheckbox() {
+export function IsForBusinessCheckbox( { storedCards }: { storedCards: StoredPaymentMethod[] } ) {
 	const translate = useTranslate();
 	const { formStatus } = useFormStatus();
 
 	const cartKey = useCartKey();
 	const { responseCart, updateLocation, isLoading, isPendingUpdate } = useShoppingCart( cartKey );
+	const [ paymentMethodId ] = usePaymentMethodId();
+
+	function isValidFormattedString( str: unknown ): str is `${ string }-${ number }` {
+		if ( typeof str !== 'string' ) {
+			throw new TypeError(
+				`Invalid input: Expected a formatted string - e.g. "existingCard-1234567", but received ${ typeof str } (${ String(
+					str
+				) })`
+			);
+		}
+		if ( ! /^[a-zA-Z]+-\d+$/.test( str ) ) {
+			throw new Error(
+				`Invalid format: Expected a formatted string - e.g. "existingCard-1234567", but received "${ str }"`
+			);
+		}
+		return true;
+	}
 
 	const isUnitedStateWithBusinessOption = ( () => {
 		if ( responseCart.tax.location.country_code !== 'US' ) {
@@ -40,10 +59,37 @@ export function IsForBusinessCheckbox() {
 		return false;
 	} )();
 
+	const isForBusinessUseSetOnActivePaymentMethod = ( () => {
+		// Get stored payment methods
+		// Get selected payment method in payment step
+		try {
+			if ( isValidFormattedString( paymentMethodId ) ) {
+				// Compare selected card id against storedCards ids, get selectedPaymentMethod object
+
+				if ( storedCards.length ) {
+					const selectedPaymentMethodObj = storedCards.find(
+						( payment ) => payment.stored_details_id === paymentMethodId.split( '-' )[ 1 ]
+					);
+
+					return !! selectedPaymentMethodObj?.tax_location?.is_for_business;
+				}
+			}
+		} catch ( error ) {
+			logStashEvent( 'checkout_add_product_analytics_error', {
+				error: String( error ),
+			} );
+			return false;
+		}
+	} )();
+
 	const isChecked = responseCart.tax.location.is_for_business ?? false;
 	const isDisabled = formStatus !== FormStatus.READY || isLoading || isPendingUpdate;
 
-	if ( ! isUnitedStateWithBusinessOption || ! hasCheckoutVersion( 'business-use-tax' ) ) {
+	if (
+		! isUnitedStateWithBusinessOption ||
+		! hasCheckoutVersion( 'business-use-tax' ) ||
+		isForBusinessUseSetOnActivePaymentMethod
+	) {
 		return null;
 	}
 


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is now closed, see https://github.com/Automattic/wp-calypso/pull/99833

This is a WIP.

Currently, this PR adds logic to <IsForBusinessCheckbox /> that gets the currently active (selected) stored payment method object from the `/me/payment-method` network request that is loaded in <CheckoutMain />. 

This is done so that we can check if `tax.location.is_for_business` is already set for the payment method. If it is, we can then hide the checkbox so it isn't unset accidentally. The only way to change this value for a payment method _should_ be by deleting the method and adding it again during a different checkout transaction (at this time).

If it is not set, then the normal logic is applied and the checkbox is shown for OH and CT postal codes.

> [!IMPORTANT]
> Since checking the checkbox sends a post request to the shopping cart endpoint and sets the tax_location value for `is_for_business` in the shopping cart, I need to find a way to ensure this value is _unset_ or at least set to `true` for any payment method that already has the value set for its stored payment method. I'm not yet sure what to do here, but maybe @sirbrillig has some insight here

Related to 170802-ghe-Automattic/wpcom


## Testing Instructions

* Hiding the checkbox works in Checkout if you have an existing payment method with is_for_business set.
