### PR TITLE
Enable 100 year domain flows in production

### DIFF
--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	START_WRITING_FLOW,
 	CONNECT_DOMAIN_FLOW,
@@ -140,17 +139,14 @@ const hostedSiteMigrationFlow: Record< string, () => Promise< { default: Flow } 
 		),
 };
 
-const hundredYearDomainFlow: Record< string, () => Promise< { default: Flow } > > =
-	config.isEnabled( '100-year-domain' )
-		? {
-				[ HUNDRED_YEAR_DOMAIN_FLOW ]: () =>
-					import( /* webpackChunkName: "hundred-year-domain" */ './hundred-year-domain' ),
-				[ HUNDRED_YEAR_DOMAIN_TRANSFER ]: () =>
-					import(
-						/* webpackChunkName: "hundred-year-domain-transfer" */ './hundred-year-domain-transfer'
-					),
-		  }
-		: {};
+const hundredYearDomainFlow: Record< string, () => Promise< { default: Flow } > > = {
+	[ HUNDRED_YEAR_DOMAIN_FLOW ]: () =>
+		import( /* webpackChunkName: "hundred-year-domain" */ './hundred-year-domain' ),
+	[ HUNDRED_YEAR_DOMAIN_TRANSFER ]: () =>
+		import(
+			/* webpackChunkName: "hundred-year-domain-transfer" */ './hundred-year-domain-transfer'
+		),
+};
 
 export default {
 	...availableFlows,


### PR DESCRIPTION
## Proposed Changes

Quick PR thats enable 100 year domain flows (registrations and transfers) in production.

## Why are these changes being made?
We are going to launch 100 year domains registrations and transfers.

## Testing Instructions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
