### PR TITLE
Design Picker: Support to activate free/personal/premium themes on atomic sites

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -12,7 +12,6 @@ import {
 	updateLaunchpadSettings,
 	useStarterDesignBySlug,
 	useStarterDesignsQuery,
-	getThemeIdFromStylesheet,
 } from '@automattic/data-stores';
 import {
 	UnifiedDesignPicker,
@@ -49,7 +48,7 @@ import {
 } from 'calypso/components/theme-tier/constants';
 import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
 import { ThemeUpgradeModal as UpgradeModal } from 'calypso/components/theme-upgrade-modal';
-import { ActiveTheme, useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
+import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
 import { useIsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-big-sky-eligible';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useExperiment } from 'calypso/lib/explat';
@@ -65,7 +64,6 @@ import { hasPurchasedDomain } from 'calypso/state/purchases/selectors/has-purcha
 import { useSiteGlobalStylesOnPersonal } from 'calypso/state/sites/hooks/use-site-global-styles-on-personal';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
-import { setActiveTheme, activateOrInstallThenActivate } from 'calypso/state/themes/actions';
 import { useIsThemeAllowedOnSite } from 'calypso/state/themes/hooks/use-is-theme-allowed-on-site';
 import {
 	isMarketplaceThemeSubscribed as getIsMarketplaceThemeSubscribed,
@@ -74,6 +72,7 @@ import {
 } from 'calypso/state/themes/selectors';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 import { getPreferredBillingCycleProductSlug } from 'calypso/state/themes/theme-utils';
+import { useActivateDesign } from '../../../../hooks/use-activate-design';
 import { useIsPluginBundleEligible } from '../../../../hooks/use-is-plugin-bundle-eligible';
 import { useQuery } from '../../../../hooks/use-query';
 import { useSiteData } from '../../../../hooks/use-site-data';
@@ -104,8 +103,6 @@ import type {
 } from '@automattic/data-stores';
 import type { Design, StyleVariation } from '@automattic/design-picker';
 import type { GlobalStylesObject } from '@automattic/global-styles';
-import type { AnyAction } from 'redux';
-import type { ThunkAction } from 'redux-thunk';
 import './style.scss';
 
 const SiteIntent = Onboard.SiteIntent;
@@ -200,6 +197,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	);
 
 	const { setDesignOnSite, assembleSite } = useDispatch( SITE_STORE );
+	const activateDesign = useActivateDesign( {} );
 
 	// ********** Logic for fetching designs
 	const selectStarterDesigns = ( allDesigns: StarterDesigns ) => {
@@ -654,32 +652,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					( design ) => design.slug === _selectedDesign?.slug
 				);
 
-				setPendingAction( () => {
-					if ( _selectedDesign?.is_virtual ) {
-						const themeId = getThemeIdFromStylesheet( _selectedDesign.recipe?.stylesheet ?? '' );
-						return Promise.resolve()
-							.then( () =>
-								reduxDispatch(
-									activateOrInstallThenActivate( themeId ?? '', site?.ID ?? 0, {
-										source: 'assembler',
-									} ) as ThunkAction< PromiseLike< string >, any, any, AnyAction >
-								)
-							)
-							.then( ( activeThemeStylesheet: string ) =>
-								assembleSite( siteSlugOrId, activeThemeStylesheet, {
-									homeHtml: _selectedDesign.recipe?.pattern_html,
-									headerHtml: _selectedDesign.recipe?.header_html,
-									footerHtml: _selectedDesign.recipe?.footer_html,
-									siteSetupOption: 'assembler-virtual-theme',
-								} )
-							);
-					}
-
-					return setDesignOnSite( siteSlugOrId, _selectedDesign, {
+				setPendingAction( async () => {
+					await activateDesign( _selectedDesign, {
 						styleVariation: selectedStyleVariation || _selectedDesign?.style_variations?.[ 0 ],
 						globalStyles,
-					} ).then( ( theme: ActiveTheme ) => {
-						return reduxDispatch( setActiveTheme( site?.ID || -1, theme ) );
 					} );
 				} );
 
@@ -703,6 +679,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			}
 		},
 		[
+			activateDesign,
 			assembleSite,
 			categorization.selections,
 			designs,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -197,7 +197,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	);
 
 	const { setDesignOnSite, assembleSite } = useDispatch( SITE_STORE );
-	const activateDesign = useActivateDesign( {} );
+	const activateDesign = useActivateDesign();
 
 	// ********** Logic for fetching designs
 	const selectStarterDesigns = ( allDesigns: StarterDesigns ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
@@ -17,7 +17,7 @@ const ErrorStep: Step = function ErrorStep( { navigation } ) {
 	const { goBack, goNext } = navigation;
 	const { __ } = useI18n();
 	const siteDomains = useSiteDomains();
-	const siteSetupError = useSiteSetupError();
+	const { error, message } = useSiteSetupError();
 
 	let domain = '';
 
@@ -25,20 +25,15 @@ const ErrorStep: Step = function ErrorStep( { navigation } ) {
 		domain = siteDomains[ 0 ].domain;
 	}
 
-	const messageCopy = () => {
-		return __(
-			'It looks like something went wrong while setting up your site. Please contact support so that we can help you out.'
-		);
-	};
-
-	const headerText = siteSetupError?.error || __( "We've hit a snag" );
-	const bodyText = siteSetupError?.message || messageCopy();
-
 	const getContent = () => {
+		const errorMessage = [ error, message ].filter( Boolean ).join( ': ' );
 		return (
-			<WarningsOrHoldsSection>
-				<SupportCard domain={ domain } />
-			</WarningsOrHoldsSection>
+			<>
+				{ !! errorMessage && <p className="error-step__message">{ errorMessage }</p> }
+				<WarningsOrHoldsSection>
+					<SupportCard domain={ domain } />
+				</WarningsOrHoldsSection>
+			</>
 		);
 	};
 
@@ -50,8 +45,16 @@ const ErrorStep: Step = function ErrorStep( { navigation } ) {
 			isHorizontalLayout={ false }
 			formattedHeader={
 				<>
-					<FormattedHeader id="step-error-header" headerText={ headerText } align="left" />
-					<p>{ bodyText }</p>
+					<FormattedHeader
+						id="step-error-header"
+						headerText={ __( "We've hit a snag" ) }
+						align="left"
+					/>
+					<p>
+						{ __(
+							'It looks like something went wrong while setting up your site. Please contact support so that we can help you out.'
+						) }
+					</p>
 				</>
 			}
 			stepContent={ getContent() }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/style.scss
@@ -13,6 +13,13 @@ $design-button-primary-hover-color: var(--color-primary-60);
 	}
 }
 
+.error-step__message {
+	padding: 12px;
+	border-radius: 4px;
+	color: var(--color-error-50);;
+	background-color: var(--color-error-5);
+}
+
 .error-step__button {
 	background: $design-button-primary-color;
 	border-color: $design-button-primary-color;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/style.scss
@@ -16,7 +16,7 @@ $design-button-primary-hover-color: var(--color-primary-60);
 .error-step__message {
 	padding: 12px;
 	border-radius: 4px;
-	color: var(--color-error-50);;
+	color: var(--color-error-50);
 	background-color: var(--color-error-5);
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
@@ -61,7 +61,7 @@ const LaunchBigSky: Step = function () {
 
 		// Set the Assembler theme on the site.
 		if ( ! assemblerThemeActive ) {
-			setDesignOnSite( selectedSiteSlug, getAssemblerDesign() );
+			setDesignOnSite( selectedSiteSlug, getAssemblerDesign(), { enableThemeSetup: true } );
 		}
 
 		// Create a new home page if one is not set yet.

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -114,7 +114,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 					// including the values that were updated during the action() running.
 					setDestinationState( destination );
 					setHasActionSuccessfullyRun( true );
-				} catch ( e ) {
+				} catch ( e: any ) {
 					// eslint-disable-next-line no-console
 					console.error( 'ProcessingStep failed:', e );
 					captureFlowException( e );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -10,14 +10,14 @@ import {
 	HUNDRED_YEAR_DOMAIN_TRANSFER,
 	isAnyHostingFlow,
 } from '@automattic/onboarding';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState, useRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { StepperLoader } from 'calypso/landing/stepper/declarative-flow/internals/components';
 import availableFlows from 'calypso/landing/stepper/declarative-flow/registered-flows';
 import { useRecordSignupComplete } from 'calypso/landing/stepper/hooks/use-record-signup-complete';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordSignupProcessingScreen } from 'calypso/lib/analytics/signup';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useInterval } from 'calypso/lib/interval';
@@ -98,7 +98,11 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 
 	const captureFlowException = useCaptureFlowException( props.flow, 'ProcessingStep' );
 
+	const { setSiteSetupError, clearSiteSetupError } = useDispatch( SITE_STORE );
+
 	useEffect( () => {
+		clearSiteSetupError();
+
 		( async () => {
 			if ( typeof action === 'function' ) {
 				try {
@@ -114,6 +118,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 					// eslint-disable-next-line no-console
 					console.error( 'ProcessingStep failed:', e );
 					captureFlowException( e );
+					setSiteSetupError( e.error || e.code, e.message );
 					submit?.( {}, ProcessingResult.FAILURE );
 				}
 			} else {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -126,6 +126,7 @@ export default function PlansStepAdaptor( props: StepProps ) {
 			setPendingAction( async () => {
 				return setDesignOnSite( site?.ID, defaultDesign, {
 					styleVariation: defaultDesign?.style_variations?.[ 0 ],
+					enableThemeSetup: true,
 				} ).then( async ( theme: ActiveTheme ) => {
 					await updateLaunchpadSettings( site?.ID || '', {
 						checklist_statuses: { design_completed: false },

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -129,7 +129,9 @@ const pluginBundleFlow: FlowV1 = {
 						setGoalsOnSite( siteSlug, goals ),
 					];
 					if ( intent === SiteIntent.Write && ! selectedDesign && ! isAtomic ) {
-						pendingActions.push( setDesignOnSite( siteSlug, WRITE_INTENT_DEFAULT_DESIGN ) );
+						pendingActions.push(
+							setDesignOnSite( siteSlug, WRITE_INTENT_DEFAULT_DESIGN, { enableThemeSetup: true } )
+						);
 					}
 
 					Promise.all( pendingActions ).then( () => window.location.assign( to ) );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,8 +1,4 @@
-import {
-	Onboard,
-	updateLaunchpadSettings,
-	getThemeIdFromStylesheet,
-} from '@automattic/data-stores';
+import { Onboard, updateLaunchpadSettings } from '@automattic/data-stores';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
@@ -15,9 +11,9 @@ import { addQueryArgs } from 'calypso/lib/route';
 import { useDispatch as reduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getInitialQueryArguments } from 'calypso/state/selectors/get-initial-query-arguments';
-import { setActiveTheme, activateOrInstallThenActivate } from 'calypso/state/themes/actions';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { WRITE_INTENT_DEFAULT_DESIGN } from '../constants';
+import { useActivateDesign } from '../hooks/use-activate-design';
 import { useIsPluginBundleEligible } from '../hooks/use-is-plugin-bundle-eligible';
 import { useSiteData } from '../hooks/use-site-data';
 import { useCanUserManageOptions } from '../hooks/use-user-can-manage-options';
@@ -34,9 +30,6 @@ import {
 	ProvidedDependencies,
 } from './internals/types';
 import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-stores';
-import type { ActiveTheme } from 'calypso/data/themes/use-active-theme-query';
-import type { AnyAction } from 'redux';
-import type { ThunkAction } from 'redux-thunk';
 
 const SiteIntent = Onboard.SiteIntent;
 
@@ -199,7 +192,9 @@ const siteSetupFlow: FlowV1 = {
 					const pendingActions = [];
 
 					if ( siteIntent === SiteIntent.Write && ! selectedDesign && ! isAtomic ) {
-						pendingActions.push( setDesignOnSite( siteSlug, WRITE_INTENT_DEFAULT_DESIGN ) );
+						pendingActions.push(
+							setDesignOnSite( siteSlug, WRITE_INTENT_DEFAULT_DESIGN, { enableThemeSetup: true } )
+						);
 					}
 
 					// Update Launchpad option based on site intent
@@ -668,7 +663,6 @@ const siteSetupFlow: FlowV1 = {
 		const isGoalsAtFrontExperiment = useGoalsAtFrontExperimentQueryParam();
 		const { siteSlugOrId, siteId } = useSiteData();
 		const { setPendingAction } = useDispatch( ONBOARD_STORE );
-		const { setDesignOnSite, assembleSite } = useDispatch( SITE_STORE );
 		const { selectedDesign, selectedStyleVariation, selectedGlobalStyles } = useSelect(
 			( select ) => {
 				const { getSelectedDesign, getSelectedStyleVariation, getSelectedGlobalStyles } = select(
@@ -687,6 +681,8 @@ const siteSetupFlow: FlowV1 = {
 
 		const skippedCheckout = useQuery().get( 'skippedCheckout' );
 
+		const activateDesign = useActivateDesign();
+
 		useEffect( () => {
 			if ( ! isGoalsAtFrontExperiment || ! siteSlugOrId || ! siteId ) {
 				return;
@@ -697,60 +693,29 @@ const siteSetupFlow: FlowV1 = {
 					return;
 				}
 
-				// Complete the "Select a design" task only when there is a selected design.
+				try {
+					await activateDesign();
+				} catch ( error ) {
+					// We attempt to set the design on the site anyway even when the checkout is skipped.
+					// That's because the user might have selected a free design, and there's no reason
+					// we shouldn't set that design on the site when the checkout is skipped.
+					// If the ThemeNotPurchasedError is thrown we know that they actually selected a
+					// paid theme and we're unable to apply it.
+					if ( error.name !== 'ThemeNotPurchasedError' || skippedCheckout !== '1' ) {
+						throw error;
+					}
+				}
+
 				const design_completed = selectedDesign?.default ? false : true;
 				await updateLaunchpadSettings( siteSlugOrId, {
 					checklist_statuses: { design_completed },
 				} );
-
-				if ( selectedDesign?.is_virtual ) {
-					const themeId = getThemeIdFromStylesheet( selectedDesign.recipe?.stylesheet ?? '' );
-					return Promise.resolve()
-						.then( () =>
-							dispatch(
-								activateOrInstallThenActivate( themeId ?? '', siteId, {
-									source: 'assembler',
-								} ) as ThunkAction< PromiseLike< string >, any, any, AnyAction >
-							)
-						)
-						.then( ( activeThemeStylesheet: string ) =>
-							assembleSite( siteSlugOrId, activeThemeStylesheet, {
-								homeHtml: selectedDesign.recipe?.pattern_html,
-								headerHtml: selectedDesign.recipe?.header_html,
-								footerHtml: selectedDesign.recipe?.footer_html,
-								siteSetupOption: 'assembler-virtual-theme',
-							} )
-						);
-				}
-
-				return setDesignOnSite( siteSlugOrId, selectedDesign, {
-					styleVariation: selectedStyleVariation,
-					globalStyles: selectedGlobalStyles,
-				} )
-					.then( async ( theme: ActiveTheme ) => {
-						const design_completed = selectedDesign?.default ? false : true;
-						await updateLaunchpadSettings( siteSlugOrId, {
-							checklist_statuses: { design_completed },
-						} );
-						return dispatch( setActiveTheme( siteId, theme ) );
-					} )
-					.catch( ( error: Error ) => {
-						// We attempt to set the design on the site anyway even when the checkout is skipped.
-						// That's because the user might have selected a free design, and there's no reason
-						// we shouldn't set that design on the site when the checkout is skipped.
-						// If the ThemeNotPurchasedError is thrown we know that they actually selected a
-						// paid theme and we're unable to apply it.
-						if ( error.name === 'ThemeNotPurchasedError' && skippedCheckout === '1' ) {
-							return;
-						}
-						throw error;
-					} );
 			} );
 		}, [
 			isGoalsAtFrontExperiment,
 			siteSlugOrId,
 			siteId,
-			setDesignOnSite,
+			activateDesign,
 			selectedDesign,
 			setPendingAction,
 			dispatch,

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -694,8 +694,11 @@ const siteSetupFlow: FlowV1 = {
 				}
 
 				try {
-					await activateDesign();
-				} catch ( error ) {
+					await activateDesign( selectedDesign, {
+						styleVariation: selectedStyleVariation,
+						globalStyles: selectedGlobalStyles,
+					} );
+				} catch ( error: any ) {
 					// We attempt to set the design on the site anyway even when the checkout is skipped.
 					// That's because the user might have selected a free design, and there's no reason
 					// we shouldn't set that design on the site when the checkout is skipped.

--- a/client/landing/stepper/hooks/use-activate-design.ts
+++ b/client/landing/stepper/hooks/use-activate-design.ts
@@ -1,0 +1,72 @@
+import { getThemeIdFromStylesheet } from '@automattic/data-stores';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useCallback } from 'react';
+import { SITE_STORE } from 'calypso/landing/stepper/stores';
+import { useDispatch as useReduxDispatch } from 'calypso/state';
+import { setActiveTheme, activateOrInstallThenActivate } from 'calypso/state/themes/actions';
+import { useSiteData } from './use-site-data';
+import type { SiteSelect } from '@automattic/data-stores';
+import type { Design, DesignOptions } from '@automattic/design-picker';
+import type { AnyAction } from 'redux';
+import type { ThunkAction } from 'redux-thunk';
+
+export const useActivateDesign = () => {
+	const reduxDispatch = useReduxDispatch();
+	const { site } = useSiteData();
+	const isJetpack = useSelect(
+		( select ) => site?.ID && ( select( SITE_STORE ) as SiteSelect ).isJetpackSite( site?.ID ),
+		[ site?.ID ]
+	);
+
+	const { installTheme, setDesignOnSite, assembleSite } = useDispatch( SITE_STORE );
+
+	const activateDesign = useCallback(
+		async ( design: Design, designOptions: DesignOptions ) => {
+			const themeId = getThemeIdFromStylesheet( design.recipe?.stylesheet ?? '' ) ?? '';
+			if ( design?.is_virtual ) {
+				const activeThemeStylesheet = await reduxDispatch(
+					activateOrInstallThenActivate( themeId, site?.ID ?? 0, {
+						source: 'assembler',
+					} ) as ThunkAction< PromiseLike< string >, any, any, AnyAction >
+				);
+				await assembleSite( site.ID, activeThemeStylesheet, {
+					homeHtml: design.recipe?.pattern_html,
+					headerHtml: design.recipe?.header_html,
+					footerHtml: design.recipe?.footer_html,
+					siteSetupOption: 'assembler-virtual-theme',
+				} );
+				return;
+			}
+
+			// Try to install the theme on Jetpack sites.
+			if ( isJetpack ) {
+				try {
+					await installTheme( site.ID, themeId );
+				} catch ( error ) {
+					if ( error.error !== 'theme_already_installed' ) {
+						throw error;
+					}
+				}
+			}
+
+			const activeTheme = await setDesignOnSite( site.ID, design, {
+				enableThemeSetup: ! isJetpack,
+				...designOptions,
+			} );
+
+			await reduxDispatch( setActiveTheme( site?.ID || -1, activeTheme ) );
+		},
+		[
+			site,
+			getThemeIdFromStylesheet,
+			reduxDispatch,
+			activateOrInstallThenActivate,
+			assembleSite,
+			installTheme,
+			setDesignOnSite,
+			setActiveTheme,
+		]
+	);
+
+	return activateDesign;
+};

--- a/client/landing/stepper/hooks/use-activate-design.ts
+++ b/client/landing/stepper/hooks/use-activate-design.ts
@@ -29,7 +29,7 @@ export const useActivateDesign = () => {
 						source: 'assembler',
 					} ) as ThunkAction< PromiseLike< string >, any, any, AnyAction >
 				);
-				await assembleSite( site.ID, activeThemeStylesheet, {
+				await assembleSite( site?.ID, activeThemeStylesheet, {
 					homeHtml: design.recipe?.pattern_html,
 					headerHtml: design.recipe?.header_html,
 					footerHtml: design.recipe?.footer_html,
@@ -41,15 +41,15 @@ export const useActivateDesign = () => {
 			// Try to install the theme on Jetpack sites.
 			if ( isJetpack ) {
 				try {
-					await installTheme( site.ID, themeId );
-				} catch ( error ) {
+					await installTheme( site?.ID, themeId );
+				} catch ( error: any ) {
 					if ( error.error !== 'theme_already_installed' ) {
 						throw error;
 					}
 				}
 			}
 
-			const activeTheme = await setDesignOnSite( site.ID, design, {
+			const activeTheme = await setDesignOnSite( site?.ID, design, {
 				enableThemeSetup: ! isJetpack,
 				...designOptions,
 			} );

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -582,10 +582,16 @@ describe( 'Site Actions', () => {
 
 		it( 'should call theme-setup api', () => {
 			const { setDesignOnSite } = createActions( mockedClientCredentials );
-			const generator = setDesignOnSite( siteSlug, {
-				...mockedDesign,
-				slug: 'arbutus',
-			} );
+			const generator = setDesignOnSite(
+				siteSlug,
+				{
+					...mockedDesign,
+					slug: 'arbutus',
+				},
+				{
+					enableThemeSetup: true,
+				}
+			);
 
 			// First iteration: WP_COM_REQUEST to /sites/${ siteSlug }/themes/mine is fired
 			expect( generator.next().value ).toEqual(
@@ -595,7 +601,7 @@ describe( 'Site Actions', () => {
 			);
 
 			// Second iteration: WP_COM_REQUEST to /sites/${ siteSlug }/theme-setup is fired
-			expect( generator.next().value ).toEqual( createMockedThemeSetupApiRequest() );
+			expect( generator.next( {} ).value ).toEqual( createMockedThemeSetupApiRequest() );
 
 			// Second iteration: Complete the cycle
 			expect( generator.next().done ).toEqual( true );

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -536,6 +536,7 @@ export interface LaunchPadCheckListTasksStatuses {
 }
 
 export interface ActiveTheme {
+	id: string;
 	stylesheet: string;
 	_links: {
 		'wp:user-global-styles': { href: string }[];

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -97,6 +97,8 @@ export interface Design {
 export interface DesignOptions {
 	styleVariation?: StyleVariation;
 	globalStyles?: GlobalStylesObject;
+	/** Potentially runs Headstart. */
+	enableThemeSetup?: boolean;
 }
 
 export interface DesignPreviewOptions {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98818

## Proposed Changes

* Support to activate free/personal/premium themes on atomic sites by
  * Try to install the theme on any Jetpack site to resolve the `theme_not_found` issue
  * Use the `id` of the theme if the `stylesheet` is not available. It happens on the atomic site since the `stylesheet` won't be included on the response of the `/themes/mine` endpoint
* Display the error message on the error step
  <img src="https://github.com/user-attachments/assets/002ff14c-babc-4b61-9a25-c7b6cd27cd30" width="300" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create an atomic site
* After the atomic transfer, go to the site setup flow by `/setup/site-setup?siteSlug=<your_site>`
* Select any goal on the Goal
* Select a free/personal/premium theme on the Design Picker
* Ensure the selected theme can be activated successfully

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
