### PR TITLE
Signup: Fix the query parameter won't be updated when you switch between different signup flows

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -127,9 +127,8 @@ export default {
 	},
 
 	saveInitialContext( context, next ) {
-		if ( ! initialContext ) {
-			initialContext = Object.assign( {}, context );
-		}
+		// Merge the context as some properties are available only on the initial.
+		initialContext = Object.assign( {}, initialContext ?? {}, context );
 
 		next();
 	},

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -127,8 +127,16 @@ export default {
 	},
 
 	saveInitialContext( context, next ) {
-		// Merge the context as some properties are available only on the initial.
-		initialContext = Object.assign( {}, initialContext ?? {}, context );
+		const userLoggedIn = isUserLoggedIn( context.store.getState() );
+		if ( ! initialContext ) {
+			initialContext = Object.assign( {}, context );
+		} else if (
+			getFlowName( initialContext.params, userLoggedIn ) !==
+			getFlowName( context.params, userLoggedIn )
+		) {
+			// Update the `initialContext` when the flow changes.
+			initialContext = Object.assign( {}, initialContext, context );
+		}
 
 		next();
 	},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99628

## Proposed Changes

* Merge the context instead of just saving the initial one as some properties are available only on the initial.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

It seems this issue cannot be reproduce on local 🤔

* Go to /themes on Incognito mode
* Select a theme
* Click the `Pick this design` button
* Press the browser back button
* Go to Plugins from the Navbar
* Select a paid
* Click the `Get started` button
* Ensure you won't see WSDO screen and everything works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
