### PR TITLE
Upsell Audit: Clean-up business plan upgrade upsell screen references

### DIFF
--- a/client/lib/route/path.ts
+++ b/client/lib/route/path.ts
@@ -45,11 +45,6 @@ export function getSiteFragment( path: URLString ): SiteSlug | SiteId | false {
 	) {
 		searchPositions = [ 3, pieces.length - 2, pieces.length - 1 ];
 	}
-	// In other paths the site fragment is in the second position.
-	// e.g. /checkout/example.wordpress.com/offer-plan-upgrade/business-monthly/75806534
-	else if ( basePath.includes( '/offer-plan-upgrade/' ) && basePath.startsWith( '/checkout/' ) ) {
-		searchPositions = [ 2 ];
-	}
 	// For this specific path, the site fragment is in the last index position.
 	// e.g /checkout/offer-professional-email/new-domain.com/example.wordpress.com (last)
 	else if (

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -157,11 +157,6 @@ describe( 'route', function () {
 			test( 'should return the correct site fragment during upsell', function () {
 				expect(
 					route.getSiteFragment(
-						'/checkout/example.wordpress.com/offer-plan-upgrade/business-monthly/75806534'
-					)
-				).toEqual( 'example.wordpress.com' );
-				expect(
-					route.getSiteFragment(
 						'/checkout/offer-professional-email/new-domain.com/75806534/example.wordpress.com'
 					)
 				).toEqual( 'example.wordpress.com' );

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -41,7 +41,6 @@ import HundredYearThankYou from './checkout-thank-you/hundred-year-thank-you';
 import JetpackCheckoutThankYou from './checkout-thank-you/jetpack-checkout-thank-you';
 import CheckoutPending from './checkout-thank-you/pending';
 import UpsellNudge, {
-	BUSINESS_PLAN_UPGRADE_UPSELL,
 	CONCIERGE_SUPPORT_SESSION,
 	CONCIERGE_QUICKSTART_SESSION,
 	PROFESSIONAL_EMAIL_UPSELL,
@@ -366,24 +365,9 @@ export function upsellNudge( context, next ) {
 	} else if ( context.path.match( /(add|offer)-support-session/ ) ) {
 		upsellType = CONCIERGE_SUPPORT_SESSION;
 		upgradeItem = 'concierge-session';
-	} else if ( context.path.includes( 'offer-plan-upgrade' ) ) {
-		upgradeItem = context.params.upgradeItem;
-
-		switch ( upgradeItem ) {
-			case 'business':
-			case 'business-2-years':
-			case 'business-3-years':
-			case 'business-monthly':
-				upsellType = BUSINESS_PLAN_UPGRADE_UPSELL;
-				break;
-			default:
-				upsellType = BUSINESS_PLAN_UPGRADE_UPSELL;
-		}
 	} else if ( context.path.includes( 'offer-professional-email' ) ) {
 		upsellType = PROFESSIONAL_EMAIL_UPSELL;
 		upgradeItem = context.params.domain;
-	} else {
-		upsellType = BUSINESS_PLAN_UPGRADE_UPSELL;
 	}
 
 	setSectionMiddleware( { name: upsellType } )( context );

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -365,14 +365,5 @@ export default function () {
 	// Visiting /checkout without a plan or product should be redirected to /plans
 	page( '/checkout', '/plans' );
 
-	page(
-		'/checkout/:site/offer-plan-upgrade/:upgradeItem/:receiptId?',
-		redirectLoggedOut,
-		siteSelection,
-		upsellNudge,
-		makeLayout,
-		clientRender
-	);
-
 	page( '/checkout*', redirectLoggedOut );
 }

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -52,7 +52,6 @@ const noop = () => {};
  */
 export const CONCIERGE_QUICKSTART_SESSION = 'concierge-quickstart-session';
 export const CONCIERGE_SUPPORT_SESSION = 'concierge-support-session';
-export const BUSINESS_PLAN_UPGRADE_UPSELL = 'business-plan-upgrade-upsell';
 export const PROFESSIONAL_EMAIL_UPSELL = 'professional-email-upsell';
 
 export interface UpsellNudgeManualProps {
@@ -108,7 +107,7 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 				? upgradeItem
 				: parseInt( String( selectedSiteId ), 10 );
 
-		if ( upsellType === BUSINESS_PLAN_UPGRADE_UPSELL ) {
+		if ( ! upsellType ) {
 			this.redirectToThankYouPageUrl();
 			return null;
 		}


### PR DESCRIPTION
## Proposed Changes

As a follow-up of https://github.com/Automattic/wp-calypso/pull/99622, this PR removes dead code.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Clean-up.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Upgrade a site to the Premium plan and ensure that you're not taken to the Business plan upsell screen but to the congrats screen instead.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
