### PR TITLE
Notice: convert to functional component

### DIFF
--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -1,68 +1,42 @@
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import { removeNotice } from 'calypso/state/notices/actions';
 import { getNotices } from 'calypso/state/notices/selectors';
 import GlobalNoticesContainer from './container';
 
-export class GlobalNotices extends Component {
-	removeReduxNotice = ( noticeId, onDismissClick ) => {
-		return ( e ) => {
-			if ( onDismissClick ) {
-				onDismissClick( e );
-			}
-			this.props.removeNotice( noticeId );
-		};
+export default function GlobalNotices( { id = 'overlay-notices' } ) {
+	const dispatch = useDispatch();
+	const removeReduxNotice = ( noticeId, onDismissClick ) => ( e ) => {
+		if ( onDismissClick ) {
+			onDismissClick( e );
+		}
+		dispatch( removeNotice( noticeId ) );
 	};
 
-	render() {
-		const noticesList = this.props.storeNotices.map(
-			// We'll rest/spread props to notice so arbitrary props can be passed to `Notice`.
-			// Be sure to destructure any props that aren't for at `Notice`, e.g. `button`.
-			function ( { button, href, noticeId, onClick, onDismissClick, ...notice } ) {
-				return (
-					<Notice
-						{ ...notice }
-						key={ `notice-${ noticeId }` }
-						onDismissClick={ this.removeReduxNotice( noticeId, onDismissClick ) }
-						theme="dark"
-					>
-						{ button && (
-							<NoticeAction href={ href } onClick={ onClick }>
-								{ button }
-							</NoticeAction>
-						) }
-					</Notice>
-				);
-			},
-			this
-		);
-
-		if ( ! noticesList.length ) {
-			return null;
-		}
-
-		return <GlobalNoticesContainer id={ this.props.id }>{ noticesList }</GlobalNoticesContainer>;
+	const storeNotices = useSelector( getNotices );
+	if ( ! storeNotices.length ) {
+		return null;
 	}
 
-	static propTypes = {
-		id: PropTypes.string,
+	const noticesList = storeNotices.map(
+		// We'll rest/spread props to notice so arbitrary props can be passed to `Notice`.
+		// Be sure to destructure any props that aren't for at `Notice`, e.g. `button`.
+		( { button, href, noticeId, onClick, onDismissClick, ...notice } ) => (
+			<Notice
+				{ ...notice }
+				key={ noticeId }
+				onDismissClick={ removeReduxNotice( noticeId, onDismissClick ) }
+				theme="dark"
+			>
+				{ button && (
+					<NoticeAction href={ href } onClick={ onClick }>
+						{ button }
+					</NoticeAction>
+				) }
+			</Notice>
+		)
+	);
 
-		// Connected props
-		removeNotice: PropTypes.func.isRequired,
-		storeNotices: PropTypes.array.isRequired,
-	};
-
-	static defaultProps = {
-		id: 'overlay-notices',
-	};
+	return <GlobalNoticesContainer id={ id }>{ noticesList }</GlobalNoticesContainer>;
 }
-
-export default connect(
-	( state ) => ( {
-		storeNotices: getNotices( state ),
-	} ),
-	{ removeNotice }
-)( GlobalNotices );

--- a/client/components/global-notices/test/index.js
+++ b/client/components/global-notices/test/index.js
@@ -3,32 +3,32 @@
  */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import deepFreeze from 'deep-freeze';
-import { GlobalNotices } from '..';
+import { useSelector, useDispatch } from 'react-redux';
+import GlobalNotices from '..';
 
-const baseProps = deepFreeze( {
-	storeNotices: [],
-	removeNotice: jest.fn(),
-} );
+jest.mock( 'react-redux', () => ( {
+	useSelector: jest.fn( () => [] ),
+	useDispatch: jest.fn(),
+} ) );
 
 beforeEach( jest.clearAllMocks );
 
 describe( '<GlobalNotices />', () => {
 	test( 'should not render without notices', () => {
-		const { container } = render( <GlobalNotices { ...baseProps } /> );
+		const { container } = render( <GlobalNotices /> );
 		expect( container ).toBeEmptyDOMElement();
 	} );
 
 	test( 'should render notices with the expected structure', () => {
-		const notices = [
+		jest.mocked( useSelector ).mockReturnValue( [
 			{
 				noticeId: 'testing-notice',
 				showDismiss: true,
 				status: 'is-success',
 				text: 'A test notice',
 			},
-		];
-		const { container } = render( <GlobalNotices { ...baseProps } storeNotices={ notices } /> );
+		] );
+		const { container } = render( <GlobalNotices /> );
 		expect( container.firstChild ).toHaveClass( 'global-notices' );
 		expect( container.firstChild ).toHaveAttribute( 'id', 'overlay-notices' );
 		expect( screen.queryAllByRole( 'status' ) ).toHaveLength( 1 );
@@ -36,17 +36,15 @@ describe( '<GlobalNotices />', () => {
 	} );
 
 	test( 'should use provided id', () => {
-		const notices = [
+		jest.mocked( useSelector ).mockReturnValue( [
 			{
 				noticeId: 'testing-notice',
 				showDismiss: true,
 				status: 'is-success',
 				text: 'A test notice',
 			},
-		];
-		const { container } = render(
-			<GlobalNotices { ...baseProps } storeNotices={ notices } id="test-id" />
-		);
+		] );
+		const { container } = render( <GlobalNotices id="test-id" /> );
 		expect( container.firstChild ).toHaveAttribute( 'id', 'test-id' );
 	} );
 
@@ -60,13 +58,20 @@ describe( '<GlobalNotices />', () => {
 				text: 'A test notice',
 			},
 		];
+		jest.mocked( useSelector ).mockReturnValue( notices );
 
-		render( <GlobalNotices { ...baseProps } storeNotices={ notices } id="test-id" /> );
+		const dispatch = jest.fn();
+		jest.mocked( useDispatch ).mockReturnValue( dispatch );
+
+		render( <GlobalNotices id="test-id" /> );
 
 		await userEvent.click( screen.getByRole( 'button' ) );
 
 		expect( notices[ 0 ].onDismissClick ).toHaveBeenCalledTimes( 1 );
-		expect( baseProps.removeNotice ).toHaveBeenCalledTimes( 1 );
-		expect( baseProps.removeNotice ).toHaveBeenCalledWith( 'testing-notice' );
+		expect( dispatch ).toHaveBeenCalledTimes( 1 );
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'NOTICE_REMOVE',
+			noticeId: 'testing-notice',
+		} );
 	} );
 } );

--- a/client/components/notice/index.tsx
+++ b/client/components/notice/index.tsx
@@ -84,8 +84,10 @@ export default function Notice( {
 	}, [ onDismissClick ] );
 
 	useEffect( () => {
-		const dismissTimeout = setTimeout( onDismissClickRef.current, duration );
-		return () => clearTimeout( dismissTimeout );
+		if ( duration > 0 ) {
+			const dismissTimeout = setTimeout( onDismissClickRef.current, duration );
+			return () => clearTimeout( dismissTimeout );
+		}
 	}, [ duration ] );
 
 	const classes = clsx( 'notice', status, className, {

--- a/client/components/notice/index.tsx
+++ b/client/components/notice/index.tsx
@@ -1,7 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import clsx from 'clsx';
-import { localize } from 'i18n-calypso';
-import { Component, isValidElement, ReactNode } from 'react';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useRef, isValidElement, type ReactNode } from 'react';
 // @todo: Convert to import from `components/gridicon`
 // which makes Calypso mysteriously crash at the moment.
 //
@@ -46,132 +46,91 @@ interface NoticeProps {
 	 */
 	theme?: 'light' | 'dark';
 	text?: ReactNode;
-	translate: ( text: string ) => string;
 	children?: ReactNode;
 }
 
-export class Notice extends Component< NoticeProps > {
-	static defaultProps = {
-		className: '',
-		duration: 0,
-		icon: null,
-		isCompact: false,
-		isLoading: false,
-		onDismissClick: noop,
-		status: null,
-		text: null,
-	};
-
-	private dismissTimeout: ReturnType< typeof setTimeout > | null = null;
-
-	componentDidMount(): void {
-		if ( this.props.duration! > 0 ) {
-			this.dismissTimeout = setTimeout( this.props.onDismissClick!, this.props.duration! );
-		}
-	}
-
-	componentWillUnmount(): void {
-		if ( this.dismissTimeout ) {
-			clearTimeout( this.dismissTimeout );
-		}
-	}
-
-	componentDidUpdate(): void {
-		if ( this.dismissTimeout ) {
-			clearTimeout( this.dismissTimeout );
-		}
-
-		if ( this.props.duration! > 0 ) {
-			this.dismissTimeout = setTimeout( this.props.onDismissClick!, this.props.duration! );
-		}
-	}
-
-	getIcon(): string {
-		let icon: string;
-
-		switch ( this.props.status ) {
-			case 'is-info':
-				icon = 'info';
-				break;
-			case 'is-success':
-				icon = 'checkmark';
-				break;
-			case 'is-error':
-				icon = 'notice';
-				break;
-			case 'is-warning':
-			case 'is-transparent-info':
-				icon = 'notice';
-				break;
-			default:
-				icon = 'info';
-				break;
-		}
-
-		return icon;
-	}
-
-	render(): ReactNode {
-		const {
-			children,
-			className,
-			icon,
-			isCompact,
-			isLoading,
-			onDismissClick,
-			showDismiss = ! isCompact,
-			status,
-			text,
-			translate,
-			theme = 'dark',
-		} = this.props;
-
-		const classes = clsx( 'notice', status, className, {
-			'is-compact': isCompact,
-			'is-loading': isLoading,
-			'is-dismissable': showDismiss,
-			/**
-			 * The default scss styling of this component is of theme dark
-			 * and we only have 1 override theme which is the light theme
-			 */
-			'is-light': theme === 'light',
-		} );
-
-		let iconNeedsDrop = false;
-		let renderedIcon: ReactNode = null;
-
-		if ( icon && isValidElement( icon ) ) {
-			renderedIcon = icon;
-		} else {
-			const iconName = icon || this.getIcon();
-			renderedIcon = <Gridicon className="notice__icon" icon={ iconName as string } size={ 24 } />;
-			iconNeedsDrop = GRIDICONS_WITH_DROP.includes(
-				iconName as ( typeof GRIDICONS_WITH_DROP )[ number ]
-			);
-		}
-
-		return (
-			<div className={ classes } role="status" aria-label={ translate( 'Notice' ) }>
-				<span className="notice__icon-wrapper">
-					{ iconNeedsDrop && <span className="notice__icon-wrapper-drop" /> }
-					{ renderedIcon }
-				</span>
-				<span className="notice__content">
-					<span className="notice__text">{ text ? text : children }</span>
-				</span>
-				{ text ? children : null }
-				{ showDismiss && (
-					<button
-						className="notice__dismiss"
-						onClick={ onDismissClick }
-						aria-label={ translate( 'Dismiss' ) }
-					>
-						<Gridicon icon="cross" size={ 24 } />
-					</button>
-				) }
-			</div>
-		);
+function getIcon( status: NoticeStatus | undefined ): string {
+	switch ( status ) {
+		case 'is-success':
+			return 'checkmark';
+		case 'is-error':
+		case 'is-warning':
+		case 'is-transparent-info':
+			return 'notice';
+		case 'is-info':
+		default:
+			return 'info';
 	}
 }
 
-export default localize( Notice );
+export default function Notice( {
+	children,
+	className,
+	duration = 0,
+	icon,
+	isCompact = false,
+	isLoading = false,
+	onDismissClick = noop,
+	showDismiss = ! isCompact,
+	status,
+	text,
+	theme = 'dark',
+}: NoticeProps ) {
+	const translate = useTranslate();
+
+	const onDismissClickRef = useRef( onDismissClick );
+	useEffect( () => {
+		onDismissClickRef.current = onDismissClick;
+	}, [ onDismissClick ] );
+
+	useEffect( () => {
+		const dismissTimeout = setTimeout( onDismissClickRef.current, duration );
+		return () => clearTimeout( dismissTimeout );
+	}, [ duration ] );
+
+	const classes = clsx( 'notice', status, className, {
+		'is-compact': isCompact,
+		'is-loading': isLoading,
+		'is-dismissable': showDismiss,
+		/**
+		 * The default scss styling of this component is of theme dark
+		 * and we only have 1 override theme which is the light theme
+		 */
+		'is-light': theme === 'light',
+	} );
+
+	let iconNeedsDrop = false;
+	let renderedIcon: ReactNode = null;
+
+	if ( icon && isValidElement( icon ) ) {
+		renderedIcon = icon;
+	} else {
+		const iconName = icon || getIcon( status );
+		renderedIcon = <Gridicon className="notice__icon" icon={ iconName as string } size={ 24 } />;
+		iconNeedsDrop = GRIDICONS_WITH_DROP.includes(
+			iconName as ( typeof GRIDICONS_WITH_DROP )[ number ]
+		);
+	}
+
+	return (
+		<div className={ classes } role="status" aria-label={ translate( 'Notice' ) }>
+			<span className="notice__icon-wrapper">
+				{ iconNeedsDrop && <span className="notice__icon-wrapper-drop" /> }
+				{ renderedIcon }
+			</span>
+			<span className="notice__content">
+				<span className="notice__text">{ text ? text : children }</span>
+			</span>
+			{ text ? children : null }
+			{ showDismiss && (
+				<button
+					className="notice__dismiss"
+					onClick={ onDismissClick }
+					aria-label={ translate( 'Dismiss' ) }
+				>
+					<Gridicon icon="cross" size={ 24 } />
+				</button>
+			) }
+		</div>
+	);
+}

--- a/client/components/notice/index.tsx
+++ b/client/components/notice/index.tsx
@@ -21,8 +21,6 @@ const GRIDICONS_WITH_DROP = [
 	'spam',
 ] as const;
 
-const noop = () => {};
-
 export type NoticeStatus =
 	| 'is-error'
 	| 'is-info'
@@ -70,7 +68,7 @@ export default function Notice( {
 	icon,
 	isCompact = false,
 	isLoading = false,
-	onDismissClick = noop,
+	onDismissClick,
 	showDismiss = ! isCompact,
 	status,
 	text,
@@ -85,7 +83,7 @@ export default function Notice( {
 
 	useEffect( () => {
 		if ( duration > 0 ) {
-			const dismissTimeout = setTimeout( onDismissClickRef.current, duration );
+			const dismissTimeout = setTimeout( () => onDismissClickRef.current?.(), duration );
 			return () => clearTimeout( dismissTimeout );
 		}
 	}, [ duration ] );

--- a/client/components/notice/test/index.js
+++ b/client/components/notice/test/index.js
@@ -2,58 +2,56 @@
  * @jest-environment jsdom
  */
 import { render, screen } from '@testing-library/react';
-import { Notice } from '../index';
+import Notice from '../index';
 
 describe( 'Notice', () => {
-	const translate = ( string ) => string;
-
 	test( 'should output the component', () => {
-		render( <Notice translate={ translate } /> );
+		render( <Notice /> );
 		expect( screen.queryByRole( 'status' ) ).toHaveClass( 'notice' );
 	} );
 
 	test( 'should have dismiss button when showDismiss passed as true', () => {
-		render( <Notice showDismiss translate={ translate } /> );
+		render( <Notice showDismiss /> );
 		expect( screen.queryByRole( 'status' ) ).toHaveClass( 'is-dismissable' );
 	} );
 
 	test( 'should have dismiss button by default if isCompact is false', () => {
-		render( <Notice isCompact={ false } translate={ translate } /> );
+		render( <Notice isCompact={ false } /> );
 		expect( screen.queryByRole( 'status' ) ).toHaveClass( 'is-dismissable' );
 	} );
 
 	test( 'should have compact look when isCompact passed as true', () => {
-		render( <Notice isCompact translate={ translate } /> );
+		render( <Notice isCompact /> );
 		expect( screen.queryByRole( 'status' ) ).toHaveClass( 'is-compact' );
 	} );
 
 	test( 'should not have dismiss button by default if isCompact is true', () => {
-		render( <Notice isCompact translate={ translate } /> );
+		render( <Notice isCompact /> );
 		expect( screen.queryByRole( 'status' ) ).not.toHaveClass( 'is-dismissable' );
 	} );
 
 	test( 'should have dismiss button when showDismiss is true and isCompact is true', () => {
-		render( <Notice isCompact showDismiss translate={ translate } /> );
+		render( <Notice isCompact showDismiss /> );
 		expect( screen.queryByRole( 'status' ) ).toHaveClass( 'is-dismissable' );
 	} );
 
 	test( 'should have proper class for is-info status parameter', () => {
-		render( <Notice status="is-info" translate={ translate } /> );
+		render( <Notice status="is-info" /> );
 		expect( screen.queryByRole( 'status' ) ).toHaveClass( 'is-info' );
 	} );
 
 	test( 'should have proper class for is-success status parameter', () => {
-		render( <Notice status="is-success" translate={ translate } /> );
+		render( <Notice status="is-success" /> );
 		expect( screen.queryByRole( 'status' ) ).toHaveClass( 'is-success' );
 	} );
 
 	test( 'should have proper class for is-error status parameter', () => {
-		render( <Notice status="is-error" translate={ translate } /> );
+		render( <Notice status="is-error" /> );
 		expect( screen.queryByRole( 'status' ) ).toHaveClass( 'is-error' );
 	} );
 
 	test( 'should have proper class for is-warning status parameter', () => {
-		render( <Notice status="is-warning" translate={ translate } /> );
+		render( <Notice status="is-warning" /> );
 		expect( screen.queryByRole( 'status' ) ).toHaveClass( 'is-warning' );
 	} );
 } );

--- a/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
@@ -5,7 +5,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
-import { Notice } from 'calypso/components/notice';
+import Notice from 'calypso/components/notice';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import useSiteDomains from 'calypso/my-sites/checkout/src/hooks/use-site-domains.ts';
@@ -82,7 +82,7 @@ const DomainPendingWarning = ( { siteId, domains } ) => {
 		  );
 
 	return (
-		<Notice status="is-warning" translate={ translate } isCompact className="is-full-width">
+		<Notice status="is-warning" isCompact className="is-full-width">
 			{ message }
 		</Notice>
 	);


### PR DESCRIPTION
Inspired by review of #98345 where I noticed that `Notice` has two versions, one wrapped with `localize` (default export) and one without the wrapper (named export).

Let's convert `Notice` to a functional component, with `translate` supplied by the `useTranslate` hook.
