### PR TITLE
A4A > Licenses: Fix the creation of a site flow for WPCOM hosting for the unassigned licenses. 

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -3,8 +3,10 @@ import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState, useEffect } from 'react';
 import {
+	A4A_MARKETPLACE_ASSIGN_LICENSE_LINK,
 	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
 	A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
+	A4A_SITES_LINK_NEEDS_SETUP,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import {
 	isPressableHostingProduct,
@@ -59,6 +61,10 @@ export default function LicenseDetailsActions( {
 
 	const debugUrl = siteUrl ? `https://jptools.wordpress.com/debug/?url=${ siteUrl }` : null;
 	const downloadUrl = useLicenseDownloadUrlMutation( licenseKey );
+
+	const redirectUrl = isWPCOMHostingLicense
+		? A4A_SITES_LINK_NEEDS_SETUP
+		: addQueryArgs( { key: licenseKey }, A4A_MARKETPLACE_ASSIGN_LICENSE_LINK );
 
 	const openRevokeDialog = useCallback( () => {
 		setRevokeDialog( true );
@@ -149,13 +155,8 @@ export default function LicenseDetailsActions( {
 				) }
 
 			{ licenseState === LicenseState.Detached && licenseType === LicenseType.Partner && (
-				<Button
-					compact
-					primary
-					className="license-details__assign-button"
-					href={ addQueryArgs( { key: licenseKey }, '/marketplace/assign-license' ) }
-				>
-					{ translate( 'Assign License' ) }
+				<Button compact primary className="license-details__assign-button" href={ redirectUrl }>
+					{ isWPCOMHostingLicense ? translate( 'Create site' ) : translate( 'Assign license' ) }
 				</Button>
 			) }
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1769

## Proposed Changes

This PR fixes the creation of a site flow for WPCOM hosting for the unassigned licenses. 

## Why are these changes being made?

* To fix the create site flow for WPCOM hosting

## Testing Instructions

* Open the A4A live link
* Go to Licenses: Unassigned > Open the detailed view for any WPCOM hosting license (Issue a new one if you don't have one) > Verify that the button now shows `Create site` instead of `Assign License` > Click the button and verify that you are redirected to the Needs Setup page.
* Do the same for a regular license and verify that you can correctly assign a license to a site. 

<img width="1392" alt="Screenshot 2025-02-12 at 3 50 02 PM" src="https://github.com/user-attachments/assets/a9f1b304-7cb2-46b2-8c63-0d7df539fc91" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
