### PR TITLE
added tsp data in campaign details page

### DIFF
--- a/client/data/promote-post/use-promote-post-campaigns-query.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query.ts
@@ -55,6 +55,7 @@ export type CampaignResponse = {
 					blog_name: string;
 					type: string;
 					blog_url: string;
+					reply_text?: string;
 				}[];
 			};
 		};

--- a/client/data/promote-post/use-promote-post-campaigns-query.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query.ts
@@ -43,6 +43,21 @@ export type CampaignResponse = {
 		conversion_rate?: number;
 		conversion_value?: Record< string, number >;
 		conversion_last_currency_found?: string;
+		likes_total: number;
+		replies_total: number;
+		tsp?: {
+			impressions_total: number;
+			clicks_total: number;
+			permalink: string;
+			replies?: {
+				total_notes: number;
+				notes: {
+					blog_name: string;
+					type: string;
+					blog_url: string;
+				}[];
+			};
+		};
 	};
 	billing_data: {
 		payment_method: string;

--- a/client/data/promote-post/use-promote-post-campaigns-query.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query.ts
@@ -43,12 +43,12 @@ export type CampaignResponse = {
 		conversion_rate?: number;
 		conversion_value?: Record< string, number >;
 		conversion_last_currency_found?: string;
-		likes_total: number;
-		replies_total: number;
 		tsp?: {
 			impressions_total: number;
 			clicks_total: number;
 			permalink: string;
+			likes_total: number;
+			replies_total: number;
 			replies?: {
 				total_notes: number;
 				notes: {

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -181,14 +181,15 @@ export default function CampaignItemDetails( props: Props ) {
 		conversion_rate,
 		conversion_last_currency_found,
 		tsp,
-		likes_total,
-		replies_total,
 	} = campaign_stats || {};
 
 	const {
 		impressions_total: tsp_impressions_total,
-		clicks_total: tsp_clicks_total,
+		// uncomment this line when we check that clicks are tracked through smart
+		// clicks_total: tsp_clicks_total,
 		replies,
+		likes_total,
+		replies_total,
 		permalink,
 	} = tsp || {};
 
@@ -260,8 +261,9 @@ export default function CampaignItemDetails( props: Props ) {
 		tsp_impressions_total && tsp_impressions_total > 0
 			? formatNumber( tsp_impressions_total )
 			: '-';
-	const tspClicksFormatted =
-		tsp_clicks_total && tsp_clicks_total > 0 ? formatNumber( tsp_clicks_total ) : '-';
+	// uncomment this line when we check that clicks are tracked through smart
+	// const tspClicksFormatted =
+	// 	tsp_clicks_total && tsp_clicks_total > 0 ? formatNumber( tsp_clicks_total ) : '-';
 	const weeklyBudget = budget_cents ? ( budget_cents / 100 ) * 7 : 0;
 	const weeklySpend =
 		total_budget_used && billing_data ? Math.max( 0, total_budget_used - billing_data?.total ) : 0;
@@ -1059,16 +1061,17 @@ export default function CampaignItemDetails( props: Props ) {
 														</span>
 													</span>
 												</div>
-												<div>
-													<span className="campaign-item-details__label">
-														{ translate( 'Site visits from Tumblr Post' ) }
-													</span>
-													<span className="campaign-item-details__text">
-														<span className="wp-brand-font">
-															{ ! isLoading ? tspClicksFormatted : <FlexibleSkeleton /> }
-														</span>
-													</span>
-												</div>
+												{ /* commenting this until we figure out if this is working properly*/ }
+												{ /*<div>*/ }
+												{ /*	<span className="campaign-item-details__label">*/ }
+												{ /*		{ translate( 'Site visits from Tumblr Post' ) }*/ }
+												{ /*	</span>*/ }
+												{ /*	<span className="campaign-item-details__text">*/ }
+												{ /*		<span className="wp-brand-font">*/ }
+												{ /*			{ ! isLoading ? tspClicksFormatted : <FlexibleSkeleton /> }*/ }
+												{ /*		</span>*/ }
+												{ /*	</span>*/ }
+												{ /*</div>*/ }
 											</div>
 											<div className="campaign-item-details__main-stats-row ">
 												<div>

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -8,7 +8,7 @@ import { __, _n, _x, sprintf } from '@wordpress/i18n';
 import { chevronDown, chevronLeft, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment/moment';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import InfoPopover from 'calypso/components/info-popover';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
@@ -133,6 +133,7 @@ export default function CampaignItemDetails( props: Props ) {
 	const paymentBlocked = data?.paymentsBlocked ?? false;
 
 	const [ showReportErrorDialog, setShowReportErrorDialog ] = useState( false );
+	const [ showAllReplies, setShowAllReplies ] = useState( false );
 
 	const getEffectiveEndDate = () => {
 		const endDate = campaign?.end_date ? new Date( campaign.end_date ) : null;
@@ -179,7 +180,19 @@ export default function CampaignItemDetails( props: Props ) {
 		conversion_value,
 		conversion_rate,
 		conversion_last_currency_found,
+		tsp,
+		likes_total,
+		replies_total,
 	} = campaign_stats || {};
+
+	const {
+		impressions_total: tsp_impressions_total,
+		clicks_total: tsp_clicks_total,
+		replies,
+		permalink,
+	} = tsp || {};
+
+	const displayedReplies = showAllReplies ? replies?.notes : replies?.notes.slice( 0, 3 );
 
 	// check if delivery outperformed
 	const calculateOutperformPercentage = ( estimates: string, total: number ): number => {
@@ -241,6 +254,14 @@ export default function CampaignItemDetails( props: Props ) {
 			: '-';
 	const ctrFormatted = clickthrough_rate ? `${ clickthrough_rate.toFixed( 2 ) }%` : '-';
 	const clicksFormatted = clicks_total && clicks_total > 0 ? formatNumber( clicks_total ) : '-';
+	const likesFormatted = likes_total && likes_total > 0 ? formatNumber( likes_total ) : '-';
+	const repliesFormatted = replies_total && replies_total > 0 ? formatNumber( replies_total ) : '-';
+	const tspImpressionsFormatted =
+		tsp_impressions_total && tsp_impressions_total > 0
+			? formatNumber( tsp_impressions_total )
+			: '-';
+	const tspClicksFormatted =
+		tsp_clicks_total && tsp_clicks_total > 0 ? formatNumber( tsp_clicks_total ) : '-';
 	const weeklyBudget = budget_cents ? ( budget_cents / 100 ) * 7 : 0;
 	const weeklySpend =
 		total_budget_used && billing_data ? Math.max( 0, total_budget_used - billing_data?.total ) : 0;
@@ -827,9 +848,14 @@ export default function CampaignItemDetails( props: Props ) {
 										</div>
 									) }
 									<div className="campaign-item-details__main-stats-row ">
+										<div className="campaign-item-details__main-stats-title">
+											<span className="campaign-item-details__title">
+												{ translate( 'Ad Performance' ) }
+											</span>
+										</div>
 										<div>
 											<span className="campaign-item-details__label">
-												{ translate( 'Clicks' ) }
+												{ translate( 'Visitors' ) }
 											</span>
 											<span className="campaign-item-details__text">
 												<span className="wp-brand-font">
@@ -958,7 +984,7 @@ export default function CampaignItemDetails( props: Props ) {
 															controls={ [
 																{
 																	onClick: () => setChartSource( ChartSourceOptions.Clicks ),
-																	title: __( 'Clicks' ),
+																	title: __( 'Visitors' ),
 																	isDisabled: chartSource === ChartSourceOptions.Clicks,
 																},
 																{
@@ -970,7 +996,7 @@ export default function CampaignItemDetails( props: Props ) {
 															icon={ chevronDown }
 															text={
 																chartSource === ChartSourceOptions.Clicks
-																	? __( 'Clicks' )
+																	? __( 'Visitors' )
 																	: __( 'Impressions' )
 															}
 															label={ chartSource }
@@ -990,7 +1016,7 @@ export default function CampaignItemDetails( props: Props ) {
 														<div className="campaign-item-page__locaton-charts">
 															<span className="campaign-item-details__label">
 																{ chartSource === ChartSourceOptions.Clicks
-																	? __( 'Clicks by location' )
+																	? __( 'Visitors by location' )
 																	: __( 'Impressions by location' ) }
 															</span>
 															<div>
@@ -1004,6 +1030,90 @@ export default function CampaignItemDetails( props: Props ) {
 													</div>
 												</div>
 											) }
+										</>
+									) }
+									{ areStatsEnabled && tsp && (
+										<>
+											<div className="campaign-item-details__main-stats-row ">
+												<div className="campaign-item-details__main-stats-title">
+													<span className="campaign-item-details__title">
+														{ translate( 'Social Engagement' ) }
+													</span>
+													<a
+														href={ permalink }
+														target="_blank"
+														rel="noreferrer"
+														className="campaign-item-details__tsp-permalink"
+													>
+														<span>{ translate( 'Open ad preview' ) }</span>
+														<Gridicon icon="external" size={ 16 } />
+													</a>
+												</div>
+												<div>
+													<span className="campaign-item-details__label">
+														{ translate( 'Tumblr Post views' ) }
+													</span>
+													<span className="campaign-item-details__text">
+														<span className="wp-brand-font">
+															{ ! isLoading ? tspImpressionsFormatted : <FlexibleSkeleton /> }
+														</span>
+													</span>
+												</div>
+												<div>
+													<span className="campaign-item-details__label">
+														{ translate( 'Site visits from Tumblr Post' ) }
+													</span>
+													<span className="campaign-item-details__text">
+														<span className="wp-brand-font">
+															{ ! isLoading ? tspClicksFormatted : <FlexibleSkeleton /> }
+														</span>
+													</span>
+												</div>
+											</div>
+											<div className="campaign-item-details__main-stats-row ">
+												<div>
+													<span className="campaign-item-details__label">
+														{ translate( 'Replies' ) }
+													</span>
+													<span className="campaign-item-details__text">
+														<span className="wp-brand-font">
+															{ ! isLoading ? repliesFormatted : <FlexibleSkeleton /> }
+														</span>
+													</span>
+												</div>
+												<div>
+													<span className="campaign-item-details__label">
+														{ translate( 'Likes' ) }
+													</span>
+													<span className="campaign-item-details__text">
+														<span className="wp-brand-font">
+															{ ! isLoading ? likesFormatted : <FlexibleSkeleton /> }
+														</span>
+													</span>
+												</div>
+												{ displayedReplies && replies && replies?.total_notes > 0 && (
+													<div className="campaign-items-details__tsp-replies">
+														{ displayedReplies.map( ( note, index ) => (
+															<div key={ index } className="campaign-items-details__tsp-reply">
+																<a href={ note.blog_url } target="_blank" rel="noopener noreferrer">
+																	@{ note.blog_name }
+																</a>
+																<br />
+																{ note.type === 'like' && translate( 'Liked this' ) }
+																{ note.type === 'reblog' && translate( 'Reblogged this' ) }
+															</div>
+														) ) }
+														{ replies && replies?.total_notes > 3 && (
+															<button
+																className="campaign-items-details__replies-show-more-button"
+																onClick={ () => setShowAllReplies( ! showAllReplies ) }
+															>
+																{ showAllReplies ? __( 'Show Less' ) : __( 'Show More' ) }
+															</button>
+														) }
+													</div>
+												) }
+											</div>
 										</>
 									) }
 								</div>

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -185,7 +185,7 @@ export default function CampaignItemDetails( props: Props ) {
 
 	const {
 		impressions_total: tsp_impressions_total,
-		// uncomment this line when we check that clicks are tracked through smart
+		// todo uncomment this line when we check that clicks are tracked through smart
 		// clicks_total: tsp_clicks_total,
 		replies,
 		likes_total,
@@ -261,7 +261,7 @@ export default function CampaignItemDetails( props: Props ) {
 		tsp_impressions_total && tsp_impressions_total > 0
 			? formatNumber( tsp_impressions_total )
 			: '-';
-	// uncomment this line when we check that clicks are tracked through smart
+	// todo uncomment this line when we check that clicks are tracked through smart
 	// const tspClicksFormatted =
 	// 	tsp_clicks_total && tsp_clicks_total > 0 ? formatNumber( tsp_clicks_total ) : '-';
 	const weeklyBudget = budget_cents ? ( budget_cents / 100 ) * 7 : 0;
@@ -1061,7 +1061,7 @@ export default function CampaignItemDetails( props: Props ) {
 														</span>
 													</span>
 												</div>
-												{ /* commenting this until we figure out if this is working properly*/ }
+												{ /* todo commenting this until we figure out if this is working properly*/ }
 												{ /*<div>*/ }
 												{ /*	<span className="campaign-item-details__label">*/ }
 												{ /*		{ translate( 'Site visits from Tumblr Post' ) }*/ }
@@ -1104,6 +1104,7 @@ export default function CampaignItemDetails( props: Props ) {
 																<br />
 																{ note.type === 'like' && translate( 'Liked this' ) }
 																{ note.type === 'reblog' && translate( 'Reblogged this' ) }
+																{ note.type === 'reply' && ( note?.reply_text || '-' ) }
 															</div>
 														) ) }
 														{ replies && replies?.total_notes > 3 && (

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -855,7 +855,7 @@ export default function CampaignItemDetails( props: Props ) {
 										</div>
 										<div>
 											<span className="campaign-item-details__label">
-												{ translate( 'Visitors' ) }
+												{ translate( 'Clicks' ) }
 											</span>
 											<span className="campaign-item-details__text">
 												<span className="wp-brand-font">
@@ -984,7 +984,7 @@ export default function CampaignItemDetails( props: Props ) {
 															controls={ [
 																{
 																	onClick: () => setChartSource( ChartSourceOptions.Clicks ),
-																	title: __( 'Visitors' ),
+																	title: __( 'Clicks' ),
 																	isDisabled: chartSource === ChartSourceOptions.Clicks,
 																},
 																{
@@ -996,7 +996,7 @@ export default function CampaignItemDetails( props: Props ) {
 															icon={ chevronDown }
 															text={
 																chartSource === ChartSourceOptions.Clicks
-																	? __( 'Visitors' )
+																	? __( 'Clicks' )
 																	: __( 'Impressions' )
 															}
 															label={ chartSource }
@@ -1016,7 +1016,7 @@ export default function CampaignItemDetails( props: Props ) {
 														<div className="campaign-item-page__locaton-charts">
 															<span className="campaign-item-details__label">
 																{ chartSource === ChartSourceOptions.Clicks
-																	? __( 'Visitors by location' )
+																	? __( 'Clicks by location' )
 																	: __( 'Impressions by location' ) }
 															</span>
 															<div>
@@ -1032,7 +1032,7 @@ export default function CampaignItemDetails( props: Props ) {
 											) }
 										</>
 									) }
-									{ areStatsEnabled && tsp && (
+									{ tsp && (
 										<>
 											<div className="campaign-item-details__main-stats-row ">
 												<div className="campaign-item-details__main-stats-title">

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -296,10 +296,21 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 				grid-template-columns: repeat(2, 1fr);
 			}
 
-			> div {
-				display: flex;
+			> div:not(.campaign-item-details__main-stats-title) {
 				flex-direction: column;
 				padding: 16px;
+			}
+
+			.campaign-item-details__main-stats-title {
+				grid-column: 1 / -1;
+				padding: 16px 16px 10px 16px;
+				display: flex;
+				justify-content: space-between;
+			}
+			.campaign-item-details__title{
+				font-size: 1rem;
+				font-weight: 500;
+				color: var(--studio-gray-100);
 			}
 
 			.campaign-item-details__label {
@@ -311,6 +322,45 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 				display: inline-block;
 				vertical-align: bottom;
 				margin-left: 4px;
+			}
+
+
+			.campaign-item-details__tsp-permalink {
+				display: flex;
+				align-items: center;
+				justify-content: center;
+			}
+			.campaign-items-details__tsp-replies {
+				grid-column: 1 / -1;
+				padding: 16px;
+				display: flex;
+				gap: 4px;
+				flex-direction: column;
+				align-items: flex-start;
+			}
+
+			.campaign-items-details__tsp-reply {
+				padding: 8px;
+				background-color: var(--studio-gray-0);
+				margin-bottom: 4px;
+				display: inline-flex;
+				flex: 0 0 auto;
+				max-width: 100%;
+				flex-direction: column;
+				border-radius: 4px;
+				line-height: 0.85;
+
+				a {
+					font-weight: 500;
+					color: var(--studio-gray-100)
+				}
+			}
+			.campaign-items-details__replies-show-more-button {
+				color: var(--color-accent);
+				font-weight: 500;
+				margin-top: 12px;
+				text-align: left;
+				cursor: pointer;
 			}
 		}
 		.campaign-item-details__graph-stats-row {


### PR DESCRIPTION
Related to #

3002-gh-tumblr/a8c-dsp

## Proposed Changes

We are adding data for the TSP blaze ad in the campaign details page

/advertising/campaigns/:campaign_id/:blog_url

the changes should look like the below SS

<img width="774" alt="Screenshot 2025-02-12 at 12 42 54 PM" src="https://github.com/user-attachments/assets/3b16fef0-0762-4f1d-94c3-402e45eb033d" />

below I am highlighting the new changes


<img width="774" alt="Screenshot 2025-02-12 at 12 42 54 PM-2" src="https://github.com/user-attachments/assets/567975da-d9a5-4aa8-94ae-c5469176281d" />

we changed some minor user displaying strings (from clicks to visitors)

and we are adding the new section that is bringing tsp related data and metrics



## Testing Instructions

if DSP PR 3141 is not yet merged, checkout this branch to your local DSP repo

1. create a Blaze campaign with TSP . (you can fake some clicks, impressions and replies in your local db)

2. bridge calypso to your DSP server and go the campaign details page

3. you should also try to have some likes, reblogs etc in your permalink so that you can see the replies (as shown above) - try to have more than 3 so you also get the show more  button and check the functionality

4 check that the permalink works 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
