### PR TITLE
A4A: Standardize side-scrolling experience.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-carousel/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-carousel/index.tsx
@@ -24,6 +24,8 @@ export default function A4ACarousel( { children, className }: Props ) {
 
 	const offsetStep = containerWidth;
 
+	const requiresNavigation = contentWidth > containerWidth;
+
 	const moveLeft = useCallback( () => {
 		setOffsetX( Math.min( offsetX + offsetStep, 0 ) );
 	}, [ offsetStep, offsetX ] );
@@ -66,7 +68,11 @@ export default function A4ACarousel( { children, className }: Props ) {
 	};
 
 	return (
-		<div className={ clsx( 'a4a-carousel-wrapper', className ) }>
+		<div
+			className={ clsx( 'a4a-carousel-wrapper', className, {
+				'is-with-navigation': requiresNavigation,
+			} ) }
+		>
 			<div
 				className={ clsx( 'a4a-carousel', { 'is-touch-active': !! touchStart } ) }
 				ref={ containerRef }
@@ -74,22 +80,24 @@ export default function A4ACarousel( { children, className }: Props ) {
 				onTouchMove={ onTouchMove }
 				onTouchEnd={ onTouchEnd }
 			>
-				<div className="a4a-carousel__navigation">
-					<Button
-						className="a4a-carousel__navigation-button"
-						onClick={ moveLeft }
-						disabled={ offsetX === 0 }
-					>
-						<Icon icon={ chevronLeft } size={ 20 } />
-					</Button>
-					<Button
-						className="a4a-carousel__navigation-button"
-						onClick={ moveRight }
-						disabled={ offsetX === -maxOffset }
-					>
-						<Icon icon={ chevronRight } size={ 20 } />
-					</Button>
-				</div>
+				{ requiresNavigation && (
+					<div className="a4a-carousel__navigation">
+						<Button
+							className="a4a-carousel__navigation-button"
+							onClick={ moveLeft }
+							disabled={ offsetX === 0 }
+						>
+							<Icon icon={ chevronLeft } size={ 20 } />
+						</Button>
+						<Button
+							className="a4a-carousel__navigation-button"
+							onClick={ moveRight }
+							disabled={ offsetX === -maxOffset }
+						>
+							<Icon icon={ chevronRight } size={ 20 } />
+						</Button>
+					</div>
+				) }
 				<div
 					className="a4a-carousel__content"
 					style={ { transform: `translateX(${ offsetX }px)` } }

--- a/client/a8c-for-agencies/components/a4a-carousel/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-carousel/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@wordpress/components';
 import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import './style.scss';
 
@@ -17,8 +17,8 @@ export default function A4ACarousel( { children, className }: Props ) {
 	const contentRef = useRef< HTMLDivElement >( null );
 	const containerRef = useRef< HTMLDivElement >( null );
 
-	const containerWidth = containerRef.current?.clientWidth ?? 0;
-	const contentWidth = contentRef.current?.clientWidth ?? 0;
+	const [ containerWidth, setContainerWidth ] = useState( 0 );
+	const [ contentWidth, setContentWidth ] = useState( 0 );
 
 	const maxOffset = Math.max( 0, contentWidth - containerWidth );
 
@@ -27,45 +27,74 @@ export default function A4ACarousel( { children, className }: Props ) {
 	const requiresNavigation = contentWidth > containerWidth;
 
 	const moveLeft = useCallback( () => {
-		setOffsetX( Math.min( offsetX + offsetStep, 0 ) );
-	}, [ offsetStep, offsetX ] );
-
-	const moveRight = useCallback( () => {
-		setOffsetX( Math.max( offsetX - offsetStep, -maxOffset ) );
-	}, [ offsetX, offsetStep, maxOffset ] );
-
-	const onTouchStart = ( e: React.TouchEvent ) => {
-		setTouchStart( e.targetTouches[ 0 ].clientX );
-	};
-
-	const onTouchMove = ( e: React.TouchEvent ) => {
-		if ( ! touchStart ) {
+		if ( ! requiresNavigation ) {
 			return;
 		}
 
-		const currentTouch = e.targetTouches[ 0 ].clientX;
-		const distance = touchStart - currentTouch;
+		setOffsetX( Math.min( offsetX + offsetStep, 0 ) );
+	}, [ offsetStep, offsetX, requiresNavigation ] );
 
-		// If distance is greater than threshold, snap to next/previous
-		const snapThreshold = containerWidth * 0.2; // 20% of container width
-		if ( Math.abs( distance ) > snapThreshold ) {
-			const newOffset =
-				distance > 0
-					? Math.max( offsetX - offsetStep, -maxOffset )
-					: Math.min( offsetX + offsetStep, 0 );
-			setOffsetX( newOffset );
-		} else {
-			// Otherwise do smooth tracking
-			const newOffset = Math.max( Math.min( offsetX - distance, 0 ), -maxOffset );
-			setOffsetX( newOffset );
+	const moveRight = useCallback( () => {
+		if ( ! requiresNavigation ) {
+			return;
 		}
 
-		setTouchStart( currentTouch );
-	};
+		setOffsetX( Math.max( offsetX - offsetStep, -maxOffset ) );
+	}, [ requiresNavigation, offsetX, offsetStep, maxOffset ] );
 
-	const onTouchEnd = () => {
+	const onTouchStart = useCallback(
+		( e: React.TouchEvent ) => {
+			if ( ! requiresNavigation ) {
+				return;
+			}
+
+			setTouchStart( e.targetTouches[ 0 ].clientX );
+		},
+		[ requiresNavigation ]
+	);
+
+	const onTouchMove = useCallback(
+		( e: React.TouchEvent ) => {
+			e.stopPropagation();
+
+			if ( ! requiresNavigation ) {
+				return;
+			}
+
+			if ( ! touchStart ) {
+				return;
+			}
+
+			const currentTouch = e.targetTouches[ 0 ].clientX;
+			const distance = touchStart - currentTouch;
+
+			// If distance is greater than threshold, snap to next/previous
+			const snapThreshold = containerWidth * 0.2; // 20% of container width
+			if ( Math.abs( distance ) > snapThreshold ) {
+				const newOffset =
+					distance > 0
+						? Math.max( offsetX - offsetStep, -maxOffset )
+						: Math.min( offsetX + offsetStep, 0 );
+				setOffsetX( newOffset );
+			} else {
+				// Otherwise do smooth tracking
+				const newOffset = Math.max( Math.min( offsetX - distance, 0 ), -maxOffset );
+				setOffsetX( newOffset );
+			}
+
+			setTouchStart( currentTouch );
+		},
+		[ requiresNavigation, touchStart, containerWidth, offsetX, offsetStep, maxOffset ]
+	);
+
+	const onTouchEnd = useCallback( () => {
 		setTouchStart( null );
-	};
+	}, [] );
+
+	useEffect( () => {
+		setContainerWidth( containerRef.current?.clientWidth ?? 0 );
+		setContentWidth( contentRef.current?.clientWidth ?? 0 );
+	}, [ containerRef, contentRef ] );
 
 	return (
 		<div

--- a/client/a8c-for-agencies/components/page-section/style.scss
+++ b/client/a8c-for-agencies/components/page-section/style.scss
@@ -54,9 +54,15 @@
 
 .page-section__header-description {
 	@include a4a-font-body-md;
+	max-width: 600px;
 	margin: 0;
 
 	@include break-medium {
 		@include a4a-font-body-lg;
+	}
+
+
+	@include break-large {
+		margin-inline-end: 64px;
 	}
 }

--- a/client/a8c-for-agencies/components/page-section/style.scss
+++ b/client/a8c-for-agencies/components/page-section/style.scss
@@ -54,15 +54,9 @@
 
 .page-section__header-description {
 	@include a4a-font-body-md;
-	max-width: 600px;
 	margin: 0;
 
 	@include break-medium {
 		@include a4a-font-body-lg;
-	}
-
-
-	@include break-large {
-		margin-inline-end: 64px;
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-features-section-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-features-section-v2/index.tsx
@@ -1,5 +1,6 @@
 import { Card } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
+import A4ACarousel from 'calypso/a8c-for-agencies/components/a4a-carousel';
 import PageSection, { PageSectionProps } from 'calypso/a8c-for-agencies/components/page-section';
 import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
 
@@ -51,18 +52,20 @@ export default function HostingFeaturesSectionV2( {
 			background={ background }
 			description={ description }
 		>
-			<div className="hosting-features-section-v2__cards">
-				{ features.map( ( feature, index ) => {
-					return (
-						<FeatureCard
-							key={ `feature-card-${ index }` }
-							icon={ feature.icon }
-							title={ feature.title }
-							items={ feature.items }
-						/>
-					);
-				} ) }
-			</div>
+			<A4ACarousel>
+				<div className="hosting-features-section-v2__cards">
+					{ features.map( ( feature, index ) => {
+						return (
+							<FeatureCard
+								key={ `feature-card-${ index }` }
+								icon={ feature.icon }
+								title={ feature.title }
+								items={ feature.items }
+							/>
+						);
+					} ) }
+				</div>
+			</A4ACarousel>
 		</PageSection>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-features-section-v2/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-features-section-v2/style.scss
@@ -2,6 +2,8 @@
 @import "@wordpress/base-styles/mixins";
 
 .hosting-features-section-v2 {
+	overflow: hidden;
+
 	.a4a-carousel__navigation {
 		display: none;
 

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-features-section-v2/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-features-section-v2/style.scss
@@ -2,8 +2,26 @@
 @import "@wordpress/base-styles/mixins";
 
 .hosting-features-section-v2 {
-	.a4a-carousel-wrapper {
-		margin-block-start: -64px;
+	.a4a-carousel__navigation {
+		display: none;
+
+		@include break-large {
+			display: flex;
+		}
+	}
+
+	.a4a-carousel-wrapper.is-with-navigation {
+		@include break-large {
+			margin-block-start: -64px;
+		}
+	}
+
+	.a4a-carousel__content {
+		width: 100%;
+
+		@include break-large {
+			width: max-content;
+		}
 	}
 
 	.a4a-carousel__navigation-button {
@@ -14,6 +32,8 @@
 .hosting-features-section-v2__cards {
 	display: grid;
 	gap: 16px;
+	grid-template-columns: 1fr;
+	min-width: 100%;
 
 	@include break-large {
 		grid-template-columns: repeat(4, 350px);

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-features-section-v2/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-features-section-v2/style.scss
@@ -1,6 +1,16 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+.hosting-features-section-v2 {
+	.a4a-carousel-wrapper {
+		margin-block-start: -64px;
+	}
+
+	.a4a-carousel__navigation-button {
+		border: 1px solid var(--color-neutral-50);
+	}
+}
+
 .hosting-features-section-v2__cards {
 	display: grid;
 	gap: 16px;

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/index.tsx
@@ -1,6 +1,7 @@
 import { Card } from '@wordpress/components';
 import { Icon, copy, key, code, plus } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import A4ACarousel from 'calypso/a8c-for-agencies/components/a4a-carousel';
 import PageSection from 'calypso/a8c-for-agencies/components/page-section';
 import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
 
@@ -37,70 +38,72 @@ export default function MigrationsHostingFeatures() {
 				'WordPress.com and Pressable are powered by WP Cloud, the only cloud platform optimized for WordPress.'
 			) }
 		>
-			<div className="migrations-hosting-features__cards">
-				<FeatureCard
-					icon={ copy }
-					title={ translate( 'Performance' ) }
-					items={ [
-						translate( 'Global edge caching' ),
-						translate( 'Global CDN with 28+ locations' ),
-						translate( 'High-frequency CPUs' ),
-						translate( 'High-burst capacity' ),
-						translate( 'Automated datacenter failover' ),
-						translate( 'Extremely fast DNS with SSL' ),
-						translate( '10 PHP workers w/ auto-scaling' ),
-						translate( 'Uptime monitoring' ),
-					] }
-				/>
+			<A4ACarousel>
+				<div className="migrations-hosting-features__cards">
+					<FeatureCard
+						icon={ copy }
+						title={ translate( 'Performance' ) }
+						items={ [
+							translate( 'Global edge caching' ),
+							translate( 'Global CDN with 28+ locations' ),
+							translate( 'High-frequency CPUs' ),
+							translate( 'High-burst capacity' ),
+							translate( 'Automated datacenter failover' ),
+							translate( 'Extremely fast DNS with SSL' ),
+							translate( '10 PHP workers w/ auto-scaling' ),
+							translate( 'Uptime monitoring' ),
+						] }
+					/>
 
-				<FeatureCard
-					icon={ key }
-					title={ translate( 'Security' ) }
-					items={ [
-						translate( 'Real-time backups' ),
-						translate( 'Global CDN with 28+ locations' ),
-						translate( 'DDOS protection and mitigation' ),
-						translate( 'Brute-force protection' ),
-						translate( 'Malware detection & removal' ),
-						translate( 'Spam protection with Akismet' ),
-						translate( 'Web application firewall (WAF)' ),
-						translate( 'One-click restores' ),
-						translate( 'Automated WordPress updates' ),
-						translate( 'Isolated site infrastructure' ),
-					] }
-				/>
+					<FeatureCard
+						icon={ key }
+						title={ translate( 'Security' ) }
+						items={ [
+							translate( 'Real-time backups' ),
+							translate( 'Global CDN with 28+ locations' ),
+							translate( 'DDOS protection and mitigation' ),
+							translate( 'Brute-force protection' ),
+							translate( 'Malware detection & removal' ),
+							translate( 'Spam protection with Akismet' ),
+							translate( 'Web application firewall (WAF)' ),
+							translate( 'One-click restores' ),
+							translate( 'Automated WordPress updates' ),
+							translate( 'Isolated site infrastructure' ),
+						] }
+					/>
 
-				<FeatureCard
-					icon={ code }
-					title={ translate( 'Dev Tools' ) }
-					items={ [
-						translate( 'Local development environment' ),
-						translate( 'Free staging site' ),
-						translate( 'WP-CLI access' ),
-						translate( 'SSH/SFTP access' ),
-						translate( 'GitHub deployments' ),
-						translate( 'Plugin auto-updates' ),
-						translate( 'Centralized site management' ),
-						translate( 'Domain management' ),
-						translate( 'Site activity log' ),
-					] }
-				/>
+					<FeatureCard
+						icon={ code }
+						title={ translate( 'Dev Tools' ) }
+						items={ [
+							translate( 'Local development environment' ),
+							translate( 'Free staging site' ),
+							translate( 'WP-CLI access' ),
+							translate( 'SSH/SFTP access' ),
+							translate( 'GitHub deployments' ),
+							translate( 'Plugin auto-updates' ),
+							translate( 'Centralized site management' ),
+							translate( 'Domain management' ),
+							translate( 'Site activity log' ),
+						] }
+					/>
 
-				<FeatureCard
-					icon={ plus }
-					title={ translate( 'And More!' ) }
-					items={ [
-						translate( '24/7 priority expert support' ),
-						translate( 'Free managed migrations' ),
-						translate( 'Install plugins and themes' ),
-						translate( 'In-depth site analytics dashboard' ),
-						translate( 'Elastic-powered search' ),
-						translate( '4K, unbranded VideoPress player' ),
-						translate( 'Free domain for one year' ),
-						translate( 'Smart redirects' ),
-					] }
-				/>
-			</div>
+					<FeatureCard
+						icon={ plus }
+						title={ translate( 'And More!' ) }
+						items={ [
+							translate( '24/7 priority expert support' ),
+							translate( 'Free managed migrations' ),
+							translate( 'Install plugins and themes' ),
+							translate( 'In-depth site analytics dashboard' ),
+							translate( 'Elastic-powered search' ),
+							translate( '4K, unbranded VideoPress player' ),
+							translate( 'Free domain for one year' ),
+							translate( 'Smart redirects' ),
+						] }
+					/>
+				</div>
+			</A4ACarousel>
 		</PageSection>
 	);
 }

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/index.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import A4ACarousel from 'calypso/a8c-for-agencies/components/a4a-carousel';
 import PageSection from 'calypso/a8c-for-agencies/components/page-section';
 import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
+import { preventWidows } from 'calypso/lib/formatting';
 
 import './style.scss';
 
@@ -34,8 +35,10 @@ export default function MigrationsHostingFeatures() {
 		<PageSection
 			className="migrations-hosting-features"
 			heading={ translate( 'Best-in-class WordPress hosting' ) }
-			description={ translate(
-				'WordPress.com and Pressable are powered by WP Cloud, the only cloud platform optimized for WordPress.'
+			description={ preventWidows(
+				translate(
+					'WordPress.com and Pressable are powered by WP Cloud, the only cloud platform optimized for WordPress.'
+				)
 			) }
 		>
 			<A4ACarousel>

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/style.scss
@@ -1,6 +1,34 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+.migrations-hosting-features {
+	.a4a-carousel__navigation {
+		display: none;
+
+		@include break-large {
+			display: flex;
+		}
+	}
+
+	.a4a-carousel-wrapper.is-with-navigation {
+		@include break-large {
+			margin-block-start: -32px;
+		}
+	}
+
+	.a4a-carousel__content {
+		width: 100%;
+
+		@include break-large {
+			width: max-content;
+		}
+	}
+
+	.a4a-carousel__navigation-button {
+		border: 1px solid var(--color-neutral-50);
+	}
+}
+
 .migrations-hosting-features__cards {
 	display: grid;
 	gap: 16px;

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/style.scss
@@ -2,6 +2,8 @@
 @import "@wordpress/base-styles/mixins";
 
 .migrations-hosting-features {
+	overflow: hidden;
+
 	.a4a-carousel__navigation {
 		display: none;
 

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/style.scss
@@ -15,9 +15,14 @@
 	.page-section__header-description {
 		@include a4a-font-heading-md;
 		color: var(--color-neutral-70);
+		max-width: 600px;
 
 		@include break-medium {
 			@include a4a-font-heading-xl;
+		}
+
+		@include break-large {
+			padding-inline-end: 64px;
 		}
 	}
 }


### PR DESCRIPTION
To enhance the consistency of our side-scrolling experience in the A4A portal, we should utilize the carousel component. Two components in the Marketplace feature this side-scrolling, and this needs to be updated.

| Before | After |
|--------|--------|
| <img width="1431" alt="Screenshot 2025-02-12 at 8 06 11 PM" src="https://github.com/user-attachments/assets/4e7c70f5-fbd5-42dd-bf2b-cb96c509502c" /> | <img width="1440" alt="Screenshot 2025-02-12 at 8 05 58 PM" src="https://github.com/user-attachments/assets/ef46f153-5d9d-44a8-b672-fd621e246aa5" /> | 

Context: pfunGA-4oo-p2#comment-7390

## Proposed Changes

* Update the HostingFeaturesV2 component to wrap its content with the A4A carousel to inherit the behavior.
* Fix a few issues with the A4A carousel navigation states.

## Why are these changes being made?

* This is a minor consistency improvement within the A4A portal.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace/hosting/pressable` page.
* Scroll down to the "Included with every Pressible site" section.
* Confirm that you see the carousel working. See screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?