### PR TITLE
Remove temporary fix for notice hover state to be compatible with removed IsReskinned flag

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -282,7 +282,7 @@ a.notice__action {
 	}
 
 	&:hover {
-		color: var(--studio-gray-80);
+		color: var(--color-text-inverted);
 	}
 
 	.gridicon {


### PR DESCRIPTION
Now that the issue is solved and we're using the gray Notice again, let's revert the temporary fix on prod.

Reverts Automattic/wp-calypso#99542

On prod:

https://github.com/user-attachments/assets/3952ebbb-104c-4ed4-8fd1-f2bb8188347b


Fix:

https://github.com/user-attachments/assets/7f197711-1751-4442-8179-62347936fa36



