### PR TITLE
A4A: Plugins section misc styling tweaks

### DIFF
--- a/client/a8c-for-agencies/sections/plugins/index.tsx
+++ b/client/a8c-for-agencies/sections/plugins/index.tsx
@@ -4,6 +4,8 @@ import { makeLayout, render as clientRender } from 'calypso/controller';
 import { renderPluginsDashboard } from 'calypso/my-sites/plugins/controller';
 import { pluginsContext, pluginManagementContext, pluginDetailsContext } from './controller';
 
+import './style.scss';
+
 export default function () {
 	page( '/plugins', requireAccessContext, pluginsContext, makeLayout, clientRender );
 

--- a/client/a8c-for-agencies/sections/plugins/plugins-jetpack-banner.tsx
+++ b/client/a8c-for-agencies/sections/plugins/plugins-jetpack-banner.tsx
@@ -1,20 +1,31 @@
 import { JetpackLogo } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import Banner from 'calypso/components/banner';
+import { useSelector } from 'calypso/state';
+import { getPreference } from 'calypso/state/preferences/selectors';
+
+const JETPACK_BANNER_DISMISS_PREFERENCE = 'a4a-plugins-jetpack-banner';
 
 export default function A4APluginsJetpackBanner() {
 	const translate = useTranslate();
+	const isDismissed = useSelector( ( state ) =>
+		getPreference( state, 'dismissible-card-' + JETPACK_BANNER_DISMISS_PREFERENCE )
+	);
+
+	if ( isDismissed ) {
+		return null;
+	}
 
 	return (
 		<div className="a4a-plugins-jetpack-banner-container">
 			<Banner
 				title={ translate( 'Jetpack Required for Plugin Management' ) }
 				description={ translate(
-					'To manage plugins, Jetpack must be activated on each site. Your Pressable plan includes Jetpack Complete for free. Activate it to access plugin management in this dashboard.'
+					'To update plugins, Jetpack must be activated on each site. Your Pressable plan includes Jetpack Complete for free. Activate it to access plugin management in this dashboard.'
 				) }
 				icon={ <JetpackLogo size={ 16 } /> }
 				className="plugins__jetpack-banner"
-				dismissPreferenceName="a4a-plugins-jetpack-banner"
+				dismissPreferenceName={ JETPACK_BANNER_DISMISS_PREFERENCE }
 				disableCircle
 				jetpack
 			/>

--- a/client/a8c-for-agencies/sections/plugins/plugins-jetpack-banner.tsx
+++ b/client/a8c-for-agencies/sections/plugins/plugins-jetpack-banner.tsx
@@ -21,7 +21,7 @@ export default function A4APluginsJetpackBanner() {
 			<Banner
 				title={ translate( 'Jetpack Required for Plugin Management' ) }
 				description={ translate(
-					'To update plugins, Jetpack must be activated on each site. Your Pressable plan includes Jetpack Complete for free. Activate it to access plugin management in this dashboard.'
+					'To manage plugins, Jetpack must be activated on each site. Your Pressable plan includes Jetpack Complete for free. Activate it to access plugin management in this dashboard.'
 				) }
 				icon={ <JetpackLogo size={ 16 } /> }
 				className="plugins__jetpack-banner"

--- a/client/a8c-for-agencies/sections/plugins/style.scss
+++ b/client/a8c-for-agencies/sections/plugins/style.scss
@@ -1,0 +1,11 @@
+.is-section-a8c-for-agencies-plugins {
+	.wpcom-site {
+		.main.hosting-dashboard-layout.sites-dashboard.sites-dashboard__layout:not(.preview-hidden) {
+			.hosting-dashboard-layout-column__container {
+				.hosting-dashboard-layout__top-wrapper {
+					display: block;
+				}
+			}
+		}
+	}
+}

--- a/client/my-sites/plugins/plugins-dashboard/index.tsx
+++ b/client/my-sites/plugins/plugins-dashboard/index.tsx
@@ -345,7 +345,7 @@ const PluginsDashboard = ( {
 			<QueryProductsList />
 			<LayoutColumn className="sites-overview" wide>
 				<LayoutTop withNavigation={ false }>
-					{ isA8CForAgencies() && <A4APluginsJetpackBanner /> }
+					{ isA8CForAgencies() && ! pluginSlug && <A4APluginsJetpackBanner /> }
 					<LayoutHeader>
 						<Title>{ translate( 'Manage Plugins' ) }</Title>
 						{ ! pluginSlug && (


### PR DESCRIPTION
## Proposed Changes

* Hide Jetpack banner wrapper when dismissed.
* Ensure the Jetpack banner doesn’t appear when the plugin details pane is open.
* Fix "Manage Plugins" text alignment when the plugin details pane is open.

## Testing Instructions

* Open the live link.
* Go to `/plugins/manage/sites`.
* If the Jetpack required banner isn’t visible, clear the `dismissible-card-a4a-plugins-jetpack-banner` preference.
* Click on a plugin and confirm that the banner does not appear (see screenshot).
* Verify that the "Manage Plugins" button is aligned to the left when the plugin details pane is open (see screenshot).

| Before | After |
|--------|--------|
| <img width="843" alt="Screenshot 2025-02-12 at 12 30 42" src="https://github.com/user-attachments/assets/045dc607-4044-4ed9-83fb-e32e2a543958" />  | <img width="698" alt="Screenshot 2025-02-12 at 12 31 54" src="https://github.com/user-attachments/assets/d83d53d9-fcc7-4f8c-b8e2-80017b9b78a6" /> |
| <img width="782" alt="Screenshot 2025-02-12 at 12 31 25" src="https://github.com/user-attachments/assets/650dc0c0-880e-4e81-bd8a-0dd84671216b" /> | <img width="698" alt="Screenshot 2025-02-12 at 12 31 54" src="https://github.com/user-attachments/assets/c3488ad6-5f70-454c-9e22-ecb167a50d0e" /> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
