### PR TITLE
A4A: Enable Plugins Management section in staging & production

### DIFF
--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -47,7 +47,7 @@
 		"a8c-for-agencies-auth": true,
 		"a8c-for-agencies-landing": true,
 		"a8c-for-agencies-overview": true,
-		"a8c-for-agencies-plugins": false,
+		"a8c-for-agencies-plugins": true,
 		"a8c-for-agencies-sites": true,
 		"a8c-for-agencies-marketplace": true,
 		"a8c-for-agencies-purchases": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -50,7 +50,7 @@
 		"a8c-for-agencies-auth": true,
 		"a8c-for-agencies-landing": true,
 		"a8c-for-agencies-overview": true,
-		"a8c-for-agencies-plugins": false,
+		"a8c-for-agencies-plugins": true,
 		"a8c-for-agencies-sites": true,
 		"a8c-for-agencies-marketplace": true,
 		"a8c-for-agencies-purchases": true,


### PR DESCRIPTION
## Proposed Changes

* Enable Agency Plugin Management section flag on staging & production.

## Why are these changes being made?

* To enable Plugin Management on staging & production.

## Testing Instructions

* Make sure the section flag is set to true in production and staging env (`a8c-for-agencies-production.json`, `a8c-for-agencies-stage.json`)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
