### PR TITLE
[Odie] Refetch Interval for query receiging the Zendesk status

### DIFF
--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -66,12 +66,7 @@ export const UserMessage = ( {
 	};
 
 	const renderExtraContactOptions = () => {
-		const currentMessageIndex = chat.messages.findIndex(
-			( msg ) => msg.message_id === message.message_id
-		);
-		const isLastMessage = currentMessageIndex === chat.messages.length - 1;
-
-		return isLastMessage && <GetSupport onClickAdditionalEvent={ handleContactSupportClick } />;
+		return <GetSupport onClickAdditionalEvent={ handleContactSupportClick } />;
 	};
 
 	const isMessageShowingDisclaimer =

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -66,7 +66,11 @@ export const UserMessage = ( {
 	};
 
 	const renderExtraContactOptions = () => {
-		return <GetSupport onClickAdditionalEvent={ handleContactSupportClick } />;
+		return (
+			chat.provider === 'odie' && (
+				<GetSupport onClickAdditionalEvent={ handleContactSupportClick } />
+			)
+		);
 	};
 
 	const isMessageShowingDisclaimer =

--- a/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
@@ -1,22 +1,19 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState, useEffect } from 'react';
 
 async function fetchZendeskConfig(): Promise< boolean > {
 	const config = await fetch( 'https://wpcom.zendesk.com/embeddable/config' );
 	const validResponse = config.ok && config.status === 200;
 
-	if ( ! validResponse ) {
-		recordTracksEvent( 'calypso_helpcenter_zendesk_config_error', {
-			status: config.status,
-			statusText: config.statusText,
-		} );
-	}
-
 	return validResponse;
 }
 
 export function useCanConnectToZendeskMessaging( enabled = true ) {
-	return useQuery( {
+	const queryClient = useQueryClient();
+	const [ shouldRefetch, setShouldRefetch ] = useState( false );
+
+	const query = useQuery< boolean, Error >( {
 		queryKey: [ 'canConnectToZendesk' ],
 		queryFn: fetchZendeskConfig,
 		staleTime: Infinity,
@@ -24,10 +21,30 @@ export function useCanConnectToZendeskMessaging( enabled = true ) {
 		refetchOnMount: false,
 		retryOnMount: false,
 		refetchOnWindowFocus: false,
-		refetchInterval: 180000,
+		refetchInterval: shouldRefetch ? 60000 : false,
 		meta: {
 			persist: false,
 		},
 		enabled,
 	} );
+
+	useEffect( () => {
+		if ( query.isSuccess ) {
+			setShouldRefetch( false );
+		} else {
+			setShouldRefetch( true );
+			queryClient.invalidateQueries( { queryKey: [ 'canConnectToZendesk' ] } );
+		}
+	}, [ query.isSuccess, queryClient ] );
+
+	useEffect( () => {
+		if ( ! query.data ) {
+			recordTracksEvent( 'calypso_helpcenter_zendesk_config_error', {
+				status: query.status,
+				statusText: query.error?.message,
+			} );
+		}
+	}, [ query.data, query.error?.message, query.status ] );
+
+	return query;
 }

--- a/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useState, useEffect } from 'react';
+import { useState, useEffect } from '@wordpress/element';
 
 async function fetchZendeskConfig(): Promise< boolean > {
 	const config = await fetch( 'https://wpcom.zendesk.com/embeddable/config' );

--- a/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
@@ -1,18 +1,30 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useQuery } from '@tanstack/react-query';
+
+async function fetchZendeskConfig(): Promise< boolean > {
+	const config = await fetch( 'https://wpcom.zendesk.com/embeddable/config' );
+	const validResponse = config.ok && config.status === 200;
+
+	if ( ! validResponse ) {
+		recordTracksEvent( 'calypso_helpcenter_zendesk_config_error', {
+			status: config.status,
+			statusText: config.statusText,
+		} );
+	}
+
+	return validResponse;
+}
 
 export function useCanConnectToZendeskMessaging( enabled = true ) {
 	return useQuery( {
 		queryKey: [ 'canConnectToZendesk' ],
-		queryFn: async () => {
-			const config = await fetch( 'https://wpcom.zendesk.com/embeddable/config' );
-
-			return config.ok;
-		},
+		queryFn: fetchZendeskConfig,
 		staleTime: Infinity,
 		retry: false,
 		refetchOnMount: false,
 		retryOnMount: false,
 		refetchOnWindowFocus: false,
+		refetchInterval: 180000,
 		meta: {
 			persist: false,
 		},


### PR DESCRIPTION
## Proposed Changes

Refetch Zendesk config every minute if the last reponse failed.

## Why are these changes being made?
We've seen cases where the button to scalate to Zendesk is not shown. Due to conflating Third Part Cookies with failures in the fetch from the Zendesk API.

## Testing Instructions

1. It's nice to install a chrome extension that can block fetch's to certain endpoints. For that you might install [ModResponse](https://chromewebstore.google.com/detail/modresponse-mock-and-repl/bbjcdpjihbfmkgikdkplcalfebgcjjpm?pli=1)
2. Add the endpoint https://wpcom.zendesk.com/embeddable/config to be blocked (eg, response status 500)
3. Go to the calypso live link now and assert that when opening the Help Center there is a notice in the header indicating an error with cookies.
4. Now, unblock the endpoint and without refreshing, just wait for the Notice to dissapear. This notice has the same visiblity as the buttons to escalate.
5. Check that every time the config endpoint failed, registered an Track Event 'calypso_helpcenter_zendesk_config_error'
6. Assert also that once the endpoint works, you can escalate with Odie to Zendesk, and when you get the buttons to contact user support, if you send a new message, the buttons don't dissapear.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
