### PR TITLE
Subscribers: Change totals padding when a subscriber is selected

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -159,6 +159,10 @@ body.is-section-subscribers.is-subscribers-dataviews,
                         }
                     }
 
+                    .subscriber-totals {
+                        padding: 0 24px;
+                    }
+
                     @media ( max-width: $break-wide ) {
                         display: none;
                     }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Adjust totals padding to 24px when a subscriber is selected.

Before | After
---- | ----
![Screen Shot 2025-02-12 at 8 56 36 AM](https://github.com/user-attachments/assets/4a70e335-6ce5-4767-b562-a3ea5dced63f) | ![Screen Shot 2025-02-12 at 8 54 42 AM](https://github.com/user-attachments/assets/fd04d4cd-6602-4c12-b8cb-005115c55d19)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Alignment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /subscribers
* Click on a subscriber

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
