### PR TITLE
Help Center: Add Recent chats button to ellipsis menu

### DIFF
--- a/packages/help-center/src/components/help-center-header.scss
+++ b/packages/help-center/src/components/help-center-header.scss
@@ -103,6 +103,12 @@
 		padding: 0 4px;
 	}
 
+	button:disabled {
+		svg {
+			fill: var(--wp-components-color-gray-600, #949494);
+		}
+	}
+
 	button {
 		display: flex;
 		align-items: center;
@@ -117,12 +123,6 @@
 		div {
 			margin-bottom: 2px;
 			font-size: 0.875rem;
-		}
-
-		:disabled {
-			svg {
-				fill: var( --wp-components-color-gray-600, #949494 );
-			}
 		}
 
 		&:not( :disabled ) {

--- a/packages/help-center/src/components/help-center-header.scss
+++ b/packages/help-center/src/components/help-center-header.scss
@@ -119,14 +119,22 @@
 			font-size: 0.875rem;
 		}
 
-		&:hover, &:focus {
-			background-color: $help-center-blue;
-			color: var(--studio-white);
-
+		:disabled {
 			svg {
-				fill: var(--studio-white);
+				fill: var( --wp-components-color-gray-600, #949494 );
 			}
+		}
 
+		&:not( :disabled ) {
+			&:hover,
+			&:focus {
+				background-color: $help-center-blue;
+				color: var( --studio-white );
+
+				svg {
+					fill: var( --studio-white );
+				}
+			}
 		}
 	}
 

--- a/packages/help-center/src/components/help-center-header.scss
+++ b/packages/help-center/src/components/help-center-header.scss
@@ -103,18 +103,6 @@
 		padding: 0 4px;
 	}
 
-	.conversation-menu__clear-conversation {
-		&:hover, &:focus {
-			background-color: $help-center-blue;
-			color: var(--studio-white);
-
-			svg {
-				fill: var(--studio-white);
-			}
-
-		}
-	}
-
 	button {
 		display: flex;
 		align-items: center;
@@ -129,6 +117,16 @@
 		div {
 			margin-bottom: 2px;
 			font-size: 0.875rem;
+		}
+
+		&:hover, &:focus {
+			background-color: $help-center-blue;
+			color: var(--studio-white);
+
+			svg {
+				fill: var(--studio-white);
+			}
+
 		}
 	}
 

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -112,23 +112,21 @@ const ChatEllipsisMenu = () => {
 			trackEventProps={ { source: 'help_center' } }
 		>
 			<div className="conversation-menu__wrapper">
-				<button className="conversation-menu__clear-conversation" onClick={ clearChat }>
+				<button onClick={ clearChat }>
 					<Icon icon={ comment } />
 					<div>{ __( 'New conversation', __i18n_text_domain__ ) }</div>
 				</button>
-				{ totalNumberOfConversations > 0 && (
-					<button className="conversation-menu__view-chats" onClick={ handleViewChats }>
-						<Icon icon={ scheduled } />
-						<div>
-							{ _n(
-								'View recent chat',
-								'View recent chats',
-								totalNumberOfConversations,
-								__i18n_text_domain__
-							) }
-						</div>
-					</button>
-				) }
+				<Button onClick={ handleViewChats } disabled={ totalNumberOfConversations === 0 }>
+					<Icon icon={ scheduled } />
+					<div>
+						{ _n(
+							'View recent chat',
+							'View recent chats',
+							totalNumberOfConversations,
+							__i18n_text_domain__
+						) }
+					</div>
+				</Button>
 				<button onClick={ toggleSoundNotifications }>
 					<ToggleControl
 						className="conversation-menu__notification-toggle"

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -7,15 +7,7 @@ import { CardHeader, Button, Flex, ToggleControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useMemo, useCallback, useEffect, useState } from '@wordpress/element';
 import { _n } from '@wordpress/i18n';
-import {
-	closeSmall,
-	chevronUp,
-	lineSolid,
-	commentContent,
-	page,
-	Icon,
-	comment,
-} from '@wordpress/icons';
+import { closeSmall, chevronUp, lineSolid, scheduled, page, Icon, comment } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { Route, Routes, useLocation, useSearchParams, useNavigate } from 'react-router-dom';
@@ -117,7 +109,7 @@ const ChatEllipsisMenu = () => {
 				</button>
 				{ totalNumberOfConversations > 0 && (
 					<button className="conversation-menu__view-chats" onClick={ handleViewChats }>
-						<Icon icon={ commentContent } />
+						<Icon icon={ scheduled } />
 						<div>
 							{ _n(
 								'View recent chat',
@@ -129,17 +121,15 @@ const ChatEllipsisMenu = () => {
 					</button>
 				) }
 				<button onClick={ toggleSoundNotifications }>
-					<div>
-						<ToggleControl
-							className="conversation-menu__notification-toggle"
-							label={ __( 'Notification sound', __i18n_text_domain__ ) }
-							checked={ areSoundNotificationsEnabled }
-							onChange={ ( newValue ) => {
-								setAreSoundNotificationsEnabled( newValue );
-							} }
-							__nextHasNoMarginBottom
-						/>
-					</div>
+					<ToggleControl
+						className="conversation-menu__notification-toggle"
+						label={ __( 'Notification sound', __i18n_text_domain__ ) }
+						checked={ areSoundNotificationsEnabled }
+						onChange={ ( newValue ) => {
+							setAreSoundNotificationsEnabled( newValue );
+						} }
+						__nextHasNoMarginBottom
+					/>
 				</button>
 			</div>
 		</EllipsisMenu>

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -114,7 +114,7 @@ const ChatEllipsisMenu = () => {
 			<div className="conversation-menu__wrapper">
 				<button onClick={ clearChat }>
 					<Icon icon={ comment } />
-					<div>{ __( 'New conversation', __i18n_text_domain__ ) }</div>
+					<div>{ __( 'New chat', __i18n_text_domain__ ) }</div>
 				</button>
 				<Button onClick={ handleViewChats } disabled={ totalNumberOfConversations === 0 }>
 					<Icon icon={ scheduled } />

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -1,10 +1,12 @@
 /* eslint-disable no-restricted-imports */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { EllipsisMenu } from '@automattic/odie-client';
+import { useGetMostRecentOpenConversation } from '@automattic/odie-client/src/hooks/use-get-most-recent-open-conversation';
 import { clearHelpCenterZendeskConversationStarted } from '@automattic/odie-client/src/utils/storage-utils';
 import { CardHeader, Button, Flex, ToggleControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useMemo, useCallback, useEffect, useState } from '@wordpress/element';
+import { _n } from '@wordpress/i18n';
 import {
 	closeSmall,
 	chevronUp,
@@ -16,7 +18,7 @@ import {
 } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
-import { Route, Routes, useLocation, useSearchParams } from 'react-router-dom';
+import { Route, Routes, useLocation, useSearchParams, useNavigate } from 'react-router-dom';
 import { usePostByUrl } from '../hooks';
 import { useResetSupportInteraction } from '../hooks/use-reset-support-interaction';
 import { DragIcon } from '../icons';
@@ -73,6 +75,8 @@ const SupportModeTitle = () => {
 const ChatEllipsisMenu = () => {
 	const { __ } = useI18n();
 	const resetSupportInteraction = useResetSupportInteraction();
+	const navigate = useNavigate();
+	const { totalNumberOfConversations } = useGetMostRecentOpenConversation();
 	const { areSoundNotificationsEnabled } = useSelect( ( select ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
 		return {
@@ -85,6 +89,14 @@ const ChatEllipsisMenu = () => {
 		await resetSupportInteraction();
 		clearHelpCenterZendeskConversationStarted();
 		recordTracksEvent( 'calypso_inlinehelp_clear_conversation' );
+	};
+
+	const handleViewChats = () => {
+		recordTracksEvent( 'calypso_inlinehelp_view_open_chats_menu', {
+			total_number_of_conversations: totalNumberOfConversations,
+		} );
+
+		navigate( '/chat-history' );
 	};
 
 	const toggleSoundNotifications = ( event: React.MouseEvent< HTMLButtonElement > ) => {
@@ -103,6 +115,19 @@ const ChatEllipsisMenu = () => {
 					<Icon icon={ comment } />
 					<div>{ __( 'New conversation', __i18n_text_domain__ ) }</div>
 				</button>
+				{ totalNumberOfConversations > 0 && (
+					<button className="conversation-menu__view-chats" onClick={ handleViewChats }>
+						<Icon icon={ commentContent } />
+						<div>
+							{ _n(
+								'View recent chat',
+								'View recent chats',
+								totalNumberOfConversations,
+								__i18n_text_domain__
+							) }
+						</div>
+					</button>
+				) }
 				<button onClick={ toggleSoundNotifications }>
 					<div>
 						<ToggleControl

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -7,7 +7,16 @@ import { CardHeader, Button, Flex, ToggleControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useMemo, useCallback, useEffect, useState } from '@wordpress/element';
 import { _n } from '@wordpress/i18n';
-import { closeSmall, chevronUp, lineSolid, scheduled, page, Icon, comment } from '@wordpress/icons';
+import {
+	closeSmall,
+	chevronUp,
+	lineSolid,
+	scheduled,
+	page,
+	Icon,
+	comment,
+	commentContent,
+} from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { Route, Routes, useLocation, useSearchParams, useNavigate } from 'react-router-dom';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/10450

## Proposed Changes

![image](https://github.com/user-attachments/assets/72f424c8-a53b-4783-9b98-996f13141d76)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To help users find their open chats

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Live Link
* Open chat
* Click on 3 dots
