### PR TITLE
Components: use `useTranslate` hook in `ExternalLink`

### DIFF
--- a/packages/components/src/external-link/index.jsx
+++ b/packages/components/src/external-link/index.jsx
@@ -1,6 +1,6 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { ScreenReaderText, Gridicon } from '..';
 
@@ -34,6 +34,7 @@ function ExternalLink( {
 	children,
 	...rest
 } ) {
+	const translate = useTranslate();
 	const classes = clsx( 'external-link', className, {
 		'icon-first': showIconFirst,
 		'has-icon': icon,


### PR DESCRIPTION
## Proposed Changes

Use `useTranslate()` hook in `ExternalLink` instead of using the non-reactive `translate()` import.

## Why are these changes being made?

Using the reactive version makes more sense. Follow-up to https://github.com/Automattic/wp-calypso/pull/99544#discussion_r1952286353

## Testing Instructions

* Verify all checks are green.
* Smoke test external links.