### PR TITLE
Desktop app: Enable the new oauth login flow

### DIFF
--- a/desktop/app/lib/config/index.js
+++ b/desktop/app/lib/config/index.js
@@ -10,7 +10,7 @@ config.author = pkg.author;
 config.protocol = 'wpdesktop';
 
 config.loginURL = function () {
-	return this.baseURL() + 'log-in';
+	return this.baseURL() + 'log-in/desktop';
 };
 
 config.baseURL = function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89736 #72754 #55611

## Proposed Changes

In #98345 we introduced a new OAuth login flow for the desktop app, but kept it disabled. This PR enables that flow.

In this new flow, logging into the Desktop app happens in the user's external browser, instead of directly in the app. So, instead of the Desktop app showing calypso's login screen, it shows just a button that when clicked opens calypso's login screen in the user's browser.

The user than goes through the normal login flow in their browser, and is redirected back to the app when authenticated.

https://github.com/user-attachments/assets/a10585a1-b8b4-4292-88b5-8f6fdd333498

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Currently, the desktop app is unusable for users who, for example, have passkeys. There are also other cases where login in the desktop app is broken, see linked issues above. Doing the login externally instead of directly in the desktop app would fix all authentication-related issues.

Prior analysis on this has been done in p1717608504988349-slack-C029GN3KD and pdKhl6-49R-p2. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
