### PR TITLE
Help Center: Change document title when chat is opened

### DIFF
--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -9,6 +9,7 @@ import {
 	useAutoScroll,
 	useCreateZendeskConversation,
 	useZendeskMessageListener,
+	useUpdateDocumentTitle,
 } from '../../hooks';
 import { getOdieInitialMessage } from '../../utils';
 import { ViewMostRecentOpenConversationNotice } from '../odie-notice/view-most-recent-conversation-notice';
@@ -59,6 +60,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 
 	useZendeskMessageListener();
 	useAutoScroll( messagesContainerRef );
+	useUpdateDocumentTitle();
 
 	useEffect( () => {
 		if ( isForwardingToZendesk || hasForwardedToZendesk ) {

--- a/packages/odie-client/src/hooks/index.ts
+++ b/packages/odie-client/src/hooks/index.ts
@@ -5,3 +5,4 @@ export { useCreateZendeskConversation } from './use-create-zendesk-conversation'
 export { useGetCombinedChat } from './use-get-combined-chat';
 export { useOdieUserTracking } from './use-odie-user-tracking';
 export { useSendZendeskMessage } from './use-send-zendesk-message';
+export { useUpdateDocumentTitle } from './use-update-document-title';

--- a/packages/odie-client/src/hooks/use-update-document-title.ts
+++ b/packages/odie-client/src/hooks/use-update-document-title.ts
@@ -1,0 +1,19 @@
+import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useOdieAssistantContext } from '../context';
+
+export const useUpdateDocumentTitle = () => {
+	const { chat } = useOdieAssistantContext();
+
+	useEffect( () => {
+		const title = document.title;
+
+		if ( chat.provider === 'zendesk' ) {
+			document.title = __( 'Chat with support - WordPress.com' );
+		}
+
+		return () => {
+			document.title = title;
+		};
+	}, [ chat.provider ] );
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9817

## Proposed Changes

* Change document title when opening zd chat

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To help user find open chats easier

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use PR link or build the PR
* Open a ZD conversation
* The document title should update
* When navigating back, the document title should be restored

