### PR TITLE
Allowing personal plans to be eligible for AI site builder

### DIFF
--- a/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts
+++ b/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { isBusinessPlan, isPremiumPlan } from '@automattic/calypso-products';
+import { isBusinessPlan, isPremiumPlan, isPersonalPlan } from '@automattic/calypso-products';
 import { Onboard } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
 import userAgent from 'calypso/lib/user-agent';
@@ -32,7 +32,10 @@ export function useIsBigSkyEligible() {
 	);
 
 	const isEligibleGoals = isGoalsBigSkyEligible( goals );
-	const isEligiblePlan = isPremiumPlan( product_slug ) || isBusinessPlan( product_slug );
+	const isEligiblePlan =
+		isPremiumPlan( product_slug ) ||
+		isBusinessPlan( product_slug ) ||
+		isPersonalPlan( product_slug );
 	const [ isLoadingBigsky, isBigSkyBeforePlansExperiment ] = useBigSkyBeforePlans();
 
 	if ( isLoadingBigsky ) {


### PR DESCRIPTION
## Proposed Changes

* This PR allows the AI site builder to run for personal sites after the onboarding flow.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This PR is a bugfix, see: p5j4vm-57y-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To reproduce the original issue on WPCOM
* Follow instructions here to make sure you are in the proper groups: pdtkmj-3kX-p2
* Test in an incognito window to get a new account with no existing session or cookies
* Navigate to wordpress.com/setup/onboarding
* Select the "publish a blog" goal
* Select "Build with AI" on the next screen
* When you create an account, be sure to not use an a8c email
* Choose any domain
* Select the personal plan on the plan selection screen
* Go through checkout
* After checkout, you will not get the AI site builder

---

* Now, test the same flow outlined above using the calypso live link provided in this PR. Note that you should turn off the proxy for this test.
* Confirm that you do get the AI site builder at the end of the flow when following the steps above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?