### PR TITLE
Big Sky: Identify post-checkout BigSky setup using query parameter instead of feature flag

### DIFF
--- a/client/landing/stepper/declarative-flow/helpers/use-bigsky-before-plans-experiment.ts
+++ b/client/landing/stepper/declarative-flow/helpers/use-bigsky-before-plans-experiment.ts
@@ -15,9 +15,9 @@ export const EXPERIMENT_NAME = 'calypso_signup_onboarding_goals_first_bigsky_202
  */
 export function useBigSkyBeforePlans(): [ boolean, boolean ] {
 	const flow = useMemo( () => getFlowFromURL(), [] );
-	const forceBigSkyBeforePlan =
+	const forceBigSkyEligibility =
 		useRef(
-			new URLSearchParams( window.location.search ).get( 'forceBigSkyBeforePlan' ) === 'true'
+			new URLSearchParams( window.location.search ).get( 'isBigSkyBeforePlansFlow' ) === 'true'
 		).current || configApi.isEnabled( 'onboarding/force-big-sky-before-plan' );
 
 	const [ isLoadingGoalsFirst, isGoalsFirstExperiment ] = useGoalsFirstExperiment();
@@ -27,10 +27,10 @@ export function useBigSkyBeforePlans(): [ boolean, boolean ] {
 			! isLoadingGoalsFirst &&
 			isGoalsFirstExperiment &&
 			flow === ONBOARDING_FLOW &&
-			! forceBigSkyBeforePlan,
+			! forceBigSkyEligibility,
 	} );
 
-	if ( forceBigSkyBeforePlan ) {
+	if ( forceBigSkyEligibility ) {
 		setPlansListExperiment( EXPERIMENT_NAME, 'treatment' );
 		return [ false, true ];
 	}

--- a/client/landing/stepper/declarative-flow/helpers/use-bigsky-before-plans-experiment.ts
+++ b/client/landing/stepper/declarative-flow/helpers/use-bigsky-before-plans-experiment.ts
@@ -1,7 +1,6 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { setPlansListExperiment } from '@automattic/calypso-products';
 import { ONBOARDING_FLOW } from '@automattic/onboarding';
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { useExperiment } from 'calypso/lib/explat';
 import { getFlowFromURL } from '../../utils/get-flow-from-url';
 import { useGoalsFirstExperiment } from './use-goals-first-experiment';
@@ -15,6 +14,9 @@ export const EXPERIMENT_NAME = 'calypso_signup_onboarding_goals_first_bigsky_202
  */
 export function useBigSkyBeforePlans(): [ boolean, boolean ] {
 	const flow = useMemo( () => getFlowFromURL(), [] );
+	const forceBigSkyBeforePlan = useRef(
+		new URLSearchParams( window.location.search ).get( 'forceBigSkyBeforePlan' ) === 'true'
+	).current;
 	const [ isLoadingGoalsFirst, isGoalsFirstExperiment ] = useGoalsFirstExperiment();
 
 	const [ isLoading, experimentAssignment ] = useExperiment( EXPERIMENT_NAME, {
@@ -22,10 +24,10 @@ export function useBigSkyBeforePlans(): [ boolean, boolean ] {
 			! isLoadingGoalsFirst &&
 			isGoalsFirstExperiment &&
 			flow === ONBOARDING_FLOW &&
-			! isEnabled( 'onboarding/force-big-sky-before-plan' ),
+			! forceBigSkyBeforePlan,
 	} );
 
-	if ( isEnabled( 'onboarding/force-big-sky-before-plan' ) ) {
+	if ( forceBigSkyBeforePlan ) {
 		setPlansListExperiment( EXPERIMENT_NAME, 'treatment' );
 		return [ false, true ];
 	}

--- a/client/landing/stepper/declarative-flow/helpers/use-bigsky-before-plans-experiment.ts
+++ b/client/landing/stepper/declarative-flow/helpers/use-bigsky-before-plans-experiment.ts
@@ -1,3 +1,4 @@
+import configApi from '@automattic/calypso-config';
 import { setPlansListExperiment } from '@automattic/calypso-products';
 import { ONBOARDING_FLOW } from '@automattic/onboarding';
 import { useMemo, useRef } from 'react';
@@ -14,9 +15,11 @@ export const EXPERIMENT_NAME = 'calypso_signup_onboarding_goals_first_bigsky_202
  */
 export function useBigSkyBeforePlans(): [ boolean, boolean ] {
 	const flow = useMemo( () => getFlowFromURL(), [] );
-	const forceBigSkyBeforePlan = useRef(
-		new URLSearchParams( window.location.search ).get( 'forceBigSkyBeforePlan' ) === 'true'
-	).current;
+	const forceBigSkyBeforePlan =
+		useRef(
+			new URLSearchParams( window.location.search ).get( 'forceBigSkyBeforePlan' ) === 'true'
+		).current || configApi.isEnabled( 'onboarding/force-big-sky-before-plan' );
+
 	const [ isLoadingGoalsFirst, isGoalsFirstExperiment ] = useGoalsFirstExperiment();
 
 	const [ isLoading, experimentAssignment ] = useExperiment( EXPERIMENT_NAME, {

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -182,14 +182,14 @@ const onboarding: Flow = {
 			if ( createWithBigSky && isBigSkyBeforePlansExperiment && isGoalsAtFrontExperiment ) {
 				const destination = addQueryArgs( '/setup/site-setup/launch-big-sky', {
 					siteSlug: providedDependencies.siteSlug,
-					flags: 'onboarding/force-big-sky-before-plan',
+					forceBigSkyBeforePlan: true,
 				} );
 
 				return [
 					destination,
 					addQueryArgs( '/setup/onboarding/plans', {
 						skippedCheckout: 1,
-						flags: 'onboarding/force-big-sky-before-plan',
+						forceBigSkyBeforePlan: true,
 					} ),
 				];
 			}

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -182,14 +182,14 @@ const onboarding: Flow = {
 			if ( createWithBigSky && isBigSkyBeforePlansExperiment && isGoalsAtFrontExperiment ) {
 				const destination = addQueryArgs( '/setup/site-setup/launch-big-sky', {
 					siteSlug: providedDependencies.siteSlug,
-					forceBigSkyBeforePlan: true,
+					isBigSkyBeforePlansFlow: true,
 				} );
 
 				return [
 					destination,
 					addQueryArgs( '/setup/onboarding/plans', {
 						skippedCheckout: 1,
-						forceBigSkyBeforePlan: true,
+						isBigSkyBeforePlansFlow: true,
 					} ),
 				];
 			}

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -119,6 +119,7 @@
 		"onboarding/trail-map-feature-grid-structure": false,
 		"onboarding/trail-map-feature-grid": false,
 		"onboarding/user-on-stepper-hosting": true,
+		"onboarding/force-big-sky-before-plan": true,
 		"onboarding/force-goals-first": true,
 		"p2/p2-plus": true,
 		"p2-enabled": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -119,7 +119,6 @@
 		"onboarding/trail-map-feature-grid-structure": false,
 		"onboarding/trail-map-feature-grid": false,
 		"onboarding/user-on-stepper-hosting": true,
-		"onboarding/force-big-sky-before-plan": true,
 		"onboarding/force-goals-first": true,
 		"p2/p2-plus": true,
 		"p2-enabled": false,


### PR DESCRIPTION
## Proposed Changes

p1739402209821199/1739392492.597779-slack-C04H4NY6STW

## Why are these changes being made?

Feature flags that are disabled in production cannot be enabled on-the-fly, for example using the `?flags=` query parameter. That caused the BigSky forced assignment after checkout to fail since the feature flag check was always returning `false`.

Moving to a regular query parameter instead of `flags` fixed the issue.