### PR TITLE
Stats: add link to post title

### DIFF
--- a/client/components/post-stats-card/index.tsx
+++ b/client/components/post-stats-card/index.tsx
@@ -60,7 +60,7 @@ export default function PostStatsCard( {
 		<Card className={ classes }>
 			<h4 className="post-stats-card__heading">{ heading }</h4>
 			<div className="post-stats-card__post-info">
-				<TitleTag className="post-stats-card__post-title" href={ titleLink }>
+				<TitleTag className="post-stats-card__post-title" href={ titleLink } target="_blank">
 					{ post?.title }
 				</TitleTag>
 				{ ( isLoading || post?.date ) && (

--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -28,6 +28,7 @@ type Post = {
 	like_count: number | null;
 	post_thumbnail: PostThumbnail | null;
 	comment_count: number | null;
+	url: string | null;
 };
 
 const POST_STATS_CARD_TITLE_LIMIT = 48;
@@ -51,6 +52,7 @@ export default function PostDetailHighlightsSection( {
 		post_thumbnail: post?.post_thumbnail?.URL || null,
 		title: truncateWithLimit( getProcessedText( post?.title ), POST_STATS_CARD_TITLE_LIMIT ),
 	};
+
 	const { supportsEmailStats } = useSelector( ( state ) =>
 		getEnvStatsFeatureSupportChecks( state, siteId )
 	);
@@ -99,6 +101,7 @@ export default function PostDetailHighlightsSection( {
 							viewCount={ viewCount }
 							commentCount={ post?.comment_count || 0 }
 							locale={ userLocale }
+							titleLink={ post?.url || undefined }
 						/>
 
 						<Card className="highlight-card">

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -169,6 +169,7 @@ class StatsPostDetail extends Component {
 
 		// Prepare post details to PostStatsCard from post or postFallback.
 		const passedPost = this.getPost();
+		passedPost.url = previewUrl;
 
 		const postType = passedPost && passedPost.type !== null ? passedPost.type : 'post';
 		let actionLabel;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/jetpack-roadmap#2235.

## Proposed Changes

* Make the post title an actual link in the individual post page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Automattic/jetpack-roadmap#1818.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to the Stats page of a website, like `/stats/day/secretly-accurate-flyingfish.jurassic.ninja`
- Scroll down to the `Posts & pages` card and select a post.
- In the individual post page, ensure the post title is now a clickable link:

<img alt="image" src="https://github.com/user-attachments/assets/38c8d4f9-ebd8-4dfa-a443-85122516ae16" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
