### PR TITLE
Backup: allow users to restore from same backup point multiple times

### DIFF
--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { Button, Card, Gridicon } from '@automattic/components';
 import { ExternalLink } from '@wordpress/components';
+import { usePrevious } from '@wordpress/compose';
 import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useCallback, useState } from 'react';
@@ -94,6 +95,12 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 	const inProgressRewindStatus = useSelector( ( state ) =>
 		getInProgressRewindStatus( state, siteId, rewindId )
 	);
+
+	// Keep track of the previous restore status so we can detect when it transitions
+	// from 'queued'/'running' to 'finished' during this session (rather than being
+	// 'finished' from a past session).
+	const previousRestoreStatus = usePrevious( inProgressRewindStatus );
+
 	const { message, percent, currentEntry, status } = useSelector(
 		( state ) => getRestoreProgress( state, siteId ) || ( {} as RestoreProgress )
 	);
@@ -471,7 +478,27 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 	const isFinished = isRestoreDone && showFinishedScreen;
 
 	useEffect( () => {
-		if ( isRestoreDone && userHasRequestedRestore && ! showFinishedScreen ) {
+		// If the server says the restore is 'queued' or 'running', it means a
+		// restore is in progress. Even if the user just refreshed the page, we
+		// want to mark userHasRequestedRestore = true so that when it finishes,
+		// we'll know it actually completed during this session (and can show
+		// the Finished screen).
+		if (
+			inProgressRewindStatus &&
+			[ 'queued', 'running' ].includes( inProgressRewindStatus ) &&
+			! userHasRequestedRestore
+		) {
+			setUserHasRequestedRestore( true );
+		}
+	}, [ inProgressRewindStatus, userHasRequestedRestore ] );
+
+	useEffect( () => {
+		if (
+			isRestoreDone &&
+			userHasRequestedRestore &&
+			[ 'queued', 'running' ].includes( previousRestoreStatus as string ) &&
+			! showFinishedScreen
+		) {
 			dispatch(
 				recordTracksEvent( 'calypso_jetpack_backup_restore_completed', {
 					has_credentials: hasCredentials,
@@ -494,6 +521,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 		inProgressRewindStatus,
 		isRestoreDone,
 		isRestoreInProgress,
+		previousRestoreStatus,
 		restoreInitiated,
 		showFinishedScreen,
 		userHasRequestedRestore,
@@ -516,6 +544,9 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 		} else if ( isInProgress ) {
 			return renderInProgress();
 		} else if ( isRestoreDone && ! showFinishedScreen ) {
+			// The API may still say "finished" from a *previous* restore with the same rewindId.
+			// If our local showFinishedScreen flag is false, we treat this as a "new" visit
+			// and show the confirm screen instead of the finished screen.
 			return renderConfirm();
 		} else if ( isFinished ) {
 			return renderFinished();

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -88,6 +88,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 	const [ restoreInitiated, setRestoreInitiated ] = useState( false );
 	const [ restoreFailed, setRestoreFailed ] = useState( false );
 	const [ showConfirm, setShowConfirm ] = useState( false );
+	const [ showFinishedScreen, setShowFinishedScreen ] = useState( false );
 
 	const rewindState = useSelector( ( state ) => getRewindState( state, siteId ) ) as RewindState;
 	const inProgressRewindStatus = useSelector( ( state ) =>
@@ -117,7 +118,6 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 
 	useEffect( () => {
 		const preflightPassed = isPreflightEnabled && preflightStatus === PreflightTestStatus.SUCCESS;
-
 		if ( userHasRequestedRestore && ! isRestoreInProgress && ! restoreInitiated ) {
 			if ( credentialsAreValid || preflightPassed ) {
 				setRestoreInitiated( true );
@@ -467,10 +467,11 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 		( ! inProgressRewindStatus && userHasRequestedRestore ) ||
 		( inProgressRewindStatus && [ 'queued', 'running' ].includes( inProgressRewindStatus ) ) ||
 		( userHasRequestedRestore && inProgressRewindStatus === 'failed' && ! restoreFailed );
-	const isFinished = inProgressRewindStatus !== null && inProgressRewindStatus === 'finished';
+	const isRestoreDone = inProgressRewindStatus === 'finished';
+	const isFinished = isRestoreDone && showFinishedScreen;
 
 	useEffect( () => {
-		if ( isFinished ) {
+		if ( isRestoreDone && userHasRequestedRestore && ! showFinishedScreen ) {
 			dispatch(
 				recordTracksEvent( 'calypso_jetpack_backup_restore_completed', {
 					has_credentials: hasCredentials,
@@ -479,6 +480,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			setRestoreInitiated( false );
 			setUserHasRequestedRestore( false );
 			setRestoreFailed( false );
+			setShowFinishedScreen( true );
 		}
 
 		if ( ! isRestoreInProgress && restoreInitiated && inProgressRewindStatus === 'failed' ) {
@@ -490,9 +492,10 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 		dispatch,
 		hasCredentials,
 		inProgressRewindStatus,
-		isFinished,
+		isRestoreDone,
 		isRestoreInProgress,
 		restoreInitiated,
+		showFinishedScreen,
 		userHasRequestedRestore,
 	] );
 
@@ -512,6 +515,8 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			);
 		} else if ( isInProgress ) {
 			return renderInProgress();
+		} else if ( isRestoreDone && ! showFinishedScreen ) {
+			return renderConfirm();
 		} else if ( isFinished ) {
 			return renderFinished();
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/92536

## Proposed Changes

- Introduce local `showFinishedScreen` flag to differentiate between a finished restore in the current session versus a past session.
- In `useEffect`, set `userHasRequestedRestore` to `true` whenever the server reports a restore is in progress (`"queued"` or `"running"`). This prevents losing track of an ongoing restore after a page refresh.
- Only show the “finished” screen if we detect a transition from `"queued"/"running"` to `"finished"` **during** this session (via `userHasRequestedRestore` and `previousRestoreStatus`).
- If the server still reports `"finished"` but our local state indicates we never started the restore this session, we show the “confirm” screen instead. This allows multiple restores from the same backup point.

## Why are these changes being made?

- Currently, if a restore has already finished, returning to the restore page (or refreshing) always shows the “finished” screen and prevents new restore attempts from the same backup point.
- Some users need to restore multiple times (testing, rollback, etc.). These changes ensure that a restore which finished in a *previous* session doesn’t block the user from attempting another restore from the same backup point.
- If the user refreshes mid-restore, the UI now consistently shows “in-progress” rather than reverting to the confirm or error screen.

## Testing Instructions
* Spin up a Jetpack Cloud live branch
* Pick a site with VaultPress Backup plan

1. **New Restore Flow**  
   - Select a backup point and click **Restore now**.  
   - The UI should transition to the “Currently restoring…” screen (`inProgress`) and eventually show a “finished” screen.  
   - Verify that the “finished” screen only appears when the restore completes within this session.

2. **Refresh Mid-Restore**  
   - Start a restore (wait until the status is “running”), then refresh the page.  
   - Confirm that it still shows the progress screen and eventually transitions to the “finished” screen.

3. **Multiple Restores on the Same Backup Point**  
   - After a restore finishes, refresh or navigate away.  
   - Return to the same backup point/rewind ID and confirm that you see the “confirm” screen (not “finished”).  
   - Click “Restore now” again; it should proceed normally.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
