### PR TITLE
Improve Ads settings error message when PayPal address is missing.

### DIFF
--- a/client/state/data-layer/wpcom/wordads/settings/index.js
+++ b/client/state/data-layer/wpcom/wordads/settings/index.js
@@ -124,9 +124,11 @@ export const handleSaveFailure = ( {
 	updateWordadsSettings( siteId, previousSettings ),
 	errorNotice(
 		error === 'invalid_paypal'
-			? translate( 'Please enter a valid PayPal email address.' )
+			? translate(
+					'Your account needs a valid PayPal email to receive earnings. Enter one below, then try saving again.'
+			  )
 			: translate( 'An unexpected error occurred. Please try again later.' ),
-		{ id: `wordads-notice-error-${ siteId }`, duration: 5000 }
+		{ id: `wordads-notice-error-${ siteId }`, duration: 10000 }
 	),
 ];
 


### PR DESCRIPTION
Related to: #41383

Addresses: #99689

## Proposed Changes

Update missing Paypal address message when saving ads settings and increase its setTimeout.

**Current**
> Please enter a valid PayPal email address.

**Proposed**
> Your account needs a valid PayPal email to receive earnings. Enter one below, then try saving again.

## Why are these changes being made?

When you turn on WordAds, we don't ask for a PayPal account even though it's needed to save settings. Ideally, we don't need a PayPal address to save settings. 

This change updates the language to explain more why the PayPal address is needed and where to find it. It also increases the duration of the message to 10s. 

We should improve the configuration flow, but for now, I think this helps users in the meantime.

## Screenshots

| Header | Header |
|--------|--------|
| <img width="1271" alt="Screenshot 2025-02-13 at 12 09 56 PM" src="https://github.com/user-attachments/assets/0f142d90-9a8f-48a5-91fe-aa2b82bf40a9" /> | <img width="1274" alt="Screenshot 2025-02-13 at 12 09 05 PM" src="https://github.com/user-attachments/assets/5ee10437-c452-48f4-9c09-a87b2a5247b0" /> |

## Testing Instructions
With Premium Plan or greater, domain and a public site:
 
* Turn on [WordAds](https://wordpress.com/support/wordads-and-earn/#applying-for-word-ads)
* Save a setting
* Expect to see the error message
* Enter an address in the Paypal 
* Expect the setting to have saved

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
