### PR TITLE
Reader: remove user profile feature flag

### DIFF
--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -17,10 +17,7 @@ import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import withDimensions from 'calypso/lib/with-dimensions';
 import { getStreamUrl } from 'calypso/reader/route';
 import { recordAction, recordGaEvent, recordPermalinkClick } from 'calypso/reader/stats';
-import {
-	getUserProfileUrl,
-	isUserProfileEnabled,
-} from 'calypso/reader/user-profile/user-profile.utils';
+import { getUserProfileUrl } from 'calypso/reader/user-profile/user-profile.utils';
 import { expandComments } from 'calypso/state/comments/actions';
 import { PLACEHOLDER_STATE, POST_COMMENT_DISPLAY_TYPES } from 'calypso/state/comments/constants';
 import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -317,7 +314,7 @@ class PostComment extends PureComponent {
 		const commentAuthorName = decodeEntities( commentAuthor.name );
 
 		let commentAuthorUrl;
-		if ( isUserProfileEnabled() && commentAuthor.wpcom_login ) {
+		if ( commentAuthor.wpcom_login ) {
 			commentAuthorUrl = getUserProfileUrl( commentAuthor.wpcom_login );
 		} else if ( commentAuthor.site_ID ) {
 			commentAuthorUrl = getStreamUrl( null, commentAuthor.site_ID );

--- a/client/blocks/comments/post-trackback.tsx
+++ b/client/blocks/comments/post-trackback.tsx
@@ -1,10 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import { get } from 'lodash';
 import TimeSince from 'calypso/components/time-since';
-import {
-	getUserProfileUrl,
-	isUserProfileEnabled,
-} from 'calypso/reader/user-profile/user-profile.utils';
+import { getUserProfileUrl } from 'calypso/reader/user-profile/user-profile.utils';
 
 import './post-comment.scss'; // yes, this is intentional. they share styles.
 
@@ -38,10 +35,9 @@ export default function PostTrackback( props: PostTrackbackProps ): JSX.Element 
 	}
 	const unescapedAuthorName = unescape( get( comment, 'author.name', '' ) );
 
-	const authorUrlLink =
-		isUserProfileEnabled() && comment.author?.wpcom_login
-			? getUserProfileUrl( comment.author.wpcom_login )
-			: comment.author?.URL;
+	const authorUrlLink = comment.author?.wpcom_login
+		? getUserProfileUrl( comment.author.wpcom_login )
+		: comment.author?.URL;
 
 	return (
 		<li className="comments__comment depth-0">

--- a/client/blocks/reader-author-link/index.tsx
+++ b/client/blocks/reader-author-link/index.tsx
@@ -2,10 +2,7 @@ import clsx from 'clsx';
 import React from 'react';
 import { isAuthorNameBlocked } from 'calypso/reader/lib/author-name-blocklist';
 import * as stats from 'calypso/reader/stats';
-import {
-	getUserProfileUrl,
-	isUserProfileEnabled,
-} from 'calypso/reader/user-profile/user-profile.utils';
+import { getUserProfileUrl } from 'calypso/reader/user-profile/user-profile.utils';
 
 import './style.scss';
 
@@ -42,10 +39,9 @@ export default function ReaderAuthorLink( props: ReaderAuthorLinkProps ) {
 		onClick?.();
 	};
 
-	const authorLinkUrl =
-		isUserProfileEnabled() && author.wpcom_login
-			? getUserProfileUrl( author.wpcom_login )
-			: props.siteUrl ?? author.URL;
+	const authorLinkUrl = author.wpcom_login
+		? getUserProfileUrl( author.wpcom_login )
+		: props.siteUrl ?? author.URL;
 
 	const authorName = author.name;
 	// If the author name is blocked, don't return anything

--- a/client/blocks/reader-avatar/index.tsx
+++ b/client/blocks/reader-avatar/index.tsx
@@ -3,10 +3,7 @@ import { Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import SiteIcon from 'calypso/blocks/site-icon';
 import Gravatar from 'calypso/components/gravatar';
-import {
-	getUserProfileUrl,
-	isUserProfileEnabled,
-} from 'calypso/reader/user-profile/user-profile.utils';
+import { getUserProfileUrl } from 'calypso/reader/user-profile/user-profile.utils';
 
 import './style.scss';
 
@@ -122,8 +119,7 @@ export default function ReaderAvatar( {
 	const siteIconElement = hasSiteIcon && (
 		<SiteIcon key="site-icon" size={ siteIconSize } site={ fakeSite } />
 	);
-	const avatarUrl =
-		isUserProfileEnabled() && author?.wpcom_login ? getUserProfileUrl( author.wpcom_login ) : null;
+	const avatarUrl = author?.wpcom_login ? getUserProfileUrl( author.wpcom_login ) : null;
 	const authorAvatar = ( hasAvatar || showPlaceholder ) && (
 		<Gravatar key="author-avatar" user={ author } size={ gravatarSize } />
 	);

--- a/client/reader/user-profile/user-profile.utils.ts
+++ b/client/reader/user-profile/user-profile.utils.ts
@@ -1,12 +1,3 @@
-import config from '@automattic/calypso-config';
-
-/**
- * Return `true` if the user profile feature is enabled.
- */
-export function isUserProfileEnabled(): boolean {
-	return config.isEnabled( 'reader/user-profile' );
-}
-
 /**
  * Return the URL of the user profile page for a given username.
  *

--- a/config/development.json
+++ b/config/development.json
@@ -165,7 +165,6 @@
 		"reader": true,
 		"reader/comment-polling": false,
 		"reader/full-errors": true,
-		"reader/user-profile": true,
 		"reader/discovery-v2": true,
 		"readymade-templates/showcase": true,
 		"redirect-fallback-browsers": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -103,7 +103,6 @@
 		"purchases/billing-history-data-view": false,
 		"purchases/new-payment-methods": true,
 		"reader": true,
-		"reader/user-profile": true,
 		"reader/discovery-v2": false,
 		"readymade-templates/showcase": false,
 		"redirect-fallback-browsers": true,

--- a/config/production.json
+++ b/config/production.json
@@ -134,7 +134,6 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": false,
-		"reader/user-profile": true,
 		"reader/discovery-v2": false,
 		"readymade-templates/showcase": false,
 		"redirect-fallback-browsers": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -131,7 +131,6 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": false,
-		"reader/user-profile": true,
 		"reader/discovery-v2": false,
 		"readymade-templates/showcase": false,
 		"redirect-fallback-browsers": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -138,7 +138,6 @@
 		"purchases/new-payment-methods": true,
 		"reader": true,
 		"reader/full-errors": true,
-		"reader/user-profile": true,
 		"reader/discovery-v2": false,
 		"readymade-templates/showcase": true,
 		"redirect-fallback-browsers": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/467

## Proposed Changes

Remove feature flags of reader user profile.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The feature flag is `true` for all environement so cleaning unnecessary code.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify user profile page is loading.
* Verify author links are working as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
