### PR TITLE
A4A > Marketplace: Update styles to use Core Mixins

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/style.scss
@@ -246,24 +246,15 @@ $woocommerce-purple-50: #720EEC;
 	}
 
 	.product-card__title {
-		// TODO: Replace with Heading LG
-		font-size: rem(15px);
-		font-weight: 500;
-		line-height: 1.3;
+		@include heading-large;
 	}
 
 	.product-price-with-discount__price {
-		// TODO: Replace with Heading XL
-		font-size: rem(20px);
-		font-weight: 500;
-		line-height: 1.2;
+		@include heading-x-large;
 	}
 
 	.product-price-with-discount__price-interval {
-		// TODO: Replace with Body MD
-		font-size: rem(13px);
-		font-weight: 400;
-		line-height: 1.5;
+		@include body-medium;
 	}
 
 	.product-card__pricing {
@@ -271,10 +262,7 @@ $woocommerce-purple-50: #720EEC;
 	}
 
 	.product-card__description {
-		// TODO: Replace with Body LG
-		font-size: rem(15px);
-		font-weight: 400;
-		line-height: 1.6;
+		@include body-large;
 
 		color: var(--color-neutral-80);
 		margin: 0;
@@ -283,9 +271,8 @@ $woocommerce-purple-50: #720EEC;
 	// TODO: Create a new component for
 	// this on A4A when we remove the feature flag
 	.license-lightbox-link {
-		font-size: rem(13px);
-		font-weight: 400;
-		line-height: 1.5;
+		@include body-medium;
+
 		text-decoration: none;
 		color: var(--color-primary);
 	}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-category-menu/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-category-menu/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 @import "../../variables";
 
@@ -60,7 +61,8 @@
 }
 
 .product-category-menu-title {
-	@include a4a-font-heading-lg;
+	@include heading-x-large;
+
 	color: var(--color-text-inverted);
 	z-index: 10;
 	position: relative;
@@ -71,12 +73,7 @@
 }
 
 .product-category-menu-item {
-	@include a4a-font-heading-md;
 	width: 200px;
 	height: 100px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
 	background-color: var(--color-primary-0);
-	border-radius: 4px; // eslint-disable-line wpcalypso-border-radius-theme
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .product-listing-section__content,
 .product-listing-section__header {
@@ -29,11 +30,13 @@
 }
 
 .product-listing-section__header-title {
-	@include a4a-font-heading-lg;
+	@include heading-x-large;
 }
 
 .product-listing-section__header-subtitle {
-	@include a4a-font-body-md;
+	@include body-medium;
+
+	color: var(--color-neutral-60);
 	display: none;
 
 	@include break-medium {
@@ -71,13 +74,11 @@
 }
 
 .product-listing-empty__message-heading {
-	// TODO: Replace with Heading LG
-	font-size: rem(15px);
-	font-weight: 500;
+	@include heading-large;
 }
 
 .product-listing-empty__message-description {
-	// TODO: Replace with Body MD
-	font-size: rem(13px);
+	@include body-medium;
+
 	color: var(--color-neutral-50);
 }


### PR DESCRIPTION
## Proposed Changes

* This PR updates the styles on the Marketplace to use Core mixins.

## Why are these changes being made?

* To align the user experience more closely with the Core and implement Core typography within Calypso. 

## Testing Instructions

- Open the A4A live link
- Go to Marketplace: Products > Compare it with the production and verify that it looks similar. We also updated few elements, and it is now according to the original design: pfunGA-4uw-p2

| Before | After |
|--------|--------|
| <img width="1439" alt="Screenshot 2025-02-13 at 3 03 54 PM" src="https://github.com/user-attachments/assets/2cbe345e-935d-42ed-aacf-3cf0d4f578b4" /> | <img width="1439" alt="Screenshot 2025-02-13 at 3 03 57 PM" src="https://github.com/user-attachments/assets/90dc2f0c-c95b-42d9-8524-9d1dee8d3eb1" /> |
| <img width="1439" alt="Screenshot 2025-02-13 at 3 05 24 PM" src="https://github.com/user-attachments/assets/20fc7e43-bf0c-49cb-8af5-f74d3ff08f80" /> | <img width="1439" alt="Screenshot 2025-02-13 at 3 05 30 PM" src="https://github.com/user-attachments/assets/8ebe6314-2304-4db9-a8c5-286c960263cc" /> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?