### PR TITLE
Prevent confetti animation to display twice after purchase

### DIFF
--- a/client/components/thank-you-v2/index.tsx
+++ b/client/components/thank-you-v2/index.tsx
@@ -1,8 +1,11 @@
 import { ConfettiAnimation } from '@automattic/components';
 import { TranslateResult } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
 import ThankYouFooter, { ThankYouFooterDetailProps } from './footer';
 import ThankYouHeader from './header';
 import ThankYouUpsell, { ThankYouUpsellProps } from './upsell';
+
+const CONFETTI_ANIMATION_DELAY_MS = 2500;
 
 import './style.scss';
 
@@ -29,9 +32,18 @@ export default function ThankYouV2( props: ThankYouV2Props ) {
 		showSuccessAnimation = true,
 	} = props;
 
+	const [ shouldShowAnimation, setShouldShowAnimation ] = useState( false );
+
+	useEffect( () => {
+		if ( showSuccessAnimation ) {
+			setShouldShowAnimation( true );
+			setTimeout( () => setShouldShowAnimation( false ), CONFETTI_ANIMATION_DELAY_MS );
+		}
+	}, [] );
+
 	return (
 		<div className="thank-you">
-			{ showSuccessAnimation && <ConfettiAnimation delay={ 1000 } /> }
+			{ shouldShowAnimation && <ConfettiAnimation delay={ 1000 } /> }
 
 			<ThankYouHeader title={ title } subtitle={ subtitle } buttons={ headerButtons } />
 

--- a/client/components/thank-you-v2/index.tsx
+++ b/client/components/thank-you-v2/index.tsx
@@ -5,8 +5,6 @@ import ThankYouFooter, { ThankYouFooterDetailProps } from './footer';
 import ThankYouHeader from './header';
 import ThankYouUpsell, { ThankYouUpsellProps } from './upsell';
 
-const CONFETTI_ANIMATION_DELAY_MS = 2500;
-
 import './style.scss';
 
 interface ThankYouV2Props {
@@ -37,9 +35,8 @@ export default function ThankYouV2( props: ThankYouV2Props ) {
 	useEffect( () => {
 		if ( showSuccessAnimation ) {
 			setShouldShowAnimation( true );
-			setTimeout( () => setShouldShowAnimation( false ), CONFETTI_ANIMATION_DELAY_MS );
 		}
-	}, [] );
+	}, [ showSuccessAnimation ] );
 
 	return (
 		<div className="thank-you">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5230

## Proposed Changes

* Adds a state to prevent the animation from being displayed twice in quick succession

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* After a plan purchase, the thank you page was showing the confetti animation twice.
![confetti_issue](https://github.com/user-attachments/assets/9ce9f675-252e-4c1a-b725-dacbb6d5e1cc)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to a site on Free plan (for example)
* Upgrade your plan (to Personal)
* Confirm the confetti animation is only displayed once

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
