### PR TITLE
i18n: Update `numberFormat` calls with compact notation to use `numberFormatCompact` method

### DIFF
--- a/apps/odyssey-stats/src/widget/modules.tsx
+++ b/apps/odyssey-stats/src/widget/modules.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/components';
 import { protect, akismet } from '@automattic/components/src/icons';
 import clsx from 'clsx';
-import { useTranslate, numberFormat } from 'i18n-calypso';
+import { useTranslate, numberFormatCompact } from 'i18n-calypso';
 import { useState, FunctionComponent } from 'react';
 import wpcom from 'calypso/lib/wp';
 import useModuleDataQuery from '../hooks/use-module-data-query';
@@ -64,14 +64,7 @@ const ModuleCard: FunctionComponent< ModuleCardProps > = ( {
 				<>
 					{ ( ! isError || ! canManageModule ) && (
 						<div className="stats-widget-module__value">
-							<span>
-								{ numberFormat( value, {
-									numberFormatOptions: {
-										notation: 'compact',
-										maximumFractionDigits: 1,
-									},
-								} ) }
-							</span>
+							<span>{ numberFormatCompact( value ) }</span>
 						</div>
 					) }
 					{ isError && canManageModule && (

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -1,5 +1,5 @@
 import { external } from '@wordpress/icons';
-import { useTranslate, numberFormat } from 'i18n-calypso';
+import { useTranslate, numberFormatCompact } from 'i18n-calypso';
 import { useState, useCallback, useEffect, useMemo } from 'react';
 import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
 import useProductAndPlans from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans';
@@ -218,9 +218,7 @@ export default function PressablePlanSection( {
 							),
 							translate( '{{b}}%(count)s visits{{/b}} per month*', {
 								args: {
-									count: numberFormat( selectedPlanInfo?.visits ?? 0, {
-										numberFormatOptions: { notation: 'compact' },
-									} ),
+									count: numberFormatCompact( selectedPlanInfo?.visits ?? 0 ),
 								},
 								components: {
 									b: <b />,

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-slider-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/lib/get-slider-options.ts
@@ -1,4 +1,4 @@
-import { numberFormat } from 'i18n-calypso';
+import { numberFormatCompact } from 'i18n-calypso';
 import { FILTER_TYPE_INSTALL, FILTER_TYPE_STORAGE, FILTER_TYPE_VISITS } from '../constants';
 import { FilterType } from '../types';
 import { PressablePlan } from './get-pressable-plan';
@@ -19,9 +19,7 @@ export default function getSliderOptions(
 			if ( type === FILTER_TYPE_INSTALL ) {
 				label = `${ plan.install }`;
 			} else if ( type === FILTER_TYPE_VISITS ) {
-				label = `${ numberFormat( plan.visits, {
-					numberFormatOptions: { notation: 'compact', maximumFractionDigits: 1 },
-				} ) }`;
+				label = `${ numberFormatCompact( plan.visits ) }`;
 			} else if ( type === FILTER_TYPE_STORAGE ) {
 				label = `${ plan.storage }${ compact ? '' : 'GB' }`;
 			}

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -1,7 +1,7 @@
 import { Button, Tooltip } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { Icon, external } from '@wordpress/icons';
-import { useTranslate, numberFormat } from 'i18n-calypso';
+import { useTranslate, numberFormat, numberFormatCompact } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
 import { CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
 import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
@@ -129,11 +129,7 @@ export default function PlanSelectionDetails( {
 								: translate( 'Custom WordPress installs' ),
 							translate( '{{b}}%(count)s{{/b}} visits per month*', {
 								args: {
-									count: info
-										? numberFormat( info.visits, {
-												numberFormatOptions: { notation: 'compact' },
-										  } )
-										: customString,
+									count: info ? numberFormatCompact( info.visits ) : customString,
 								},
 								components: { b: <b /> },
 								comment: '%(count)s is the number of visits per month.',

--- a/client/blocks/author-compact-profile/index.tsx
+++ b/client/blocks/author-compact-profile/index.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { useTranslate, numberFormat } from 'i18n-calypso';
+import { useTranslate, numberFormatCompact } from 'i18n-calypso';
 import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
@@ -91,12 +91,7 @@ export default function AuthorCompactProfile( props: AuthorCompactProfileProps )
 						{ translate( '%(followCount)s subscriber', '%(followCount)s subscribers', {
 							count: followCount,
 							args: {
-								followCount: numberFormat( followCount, {
-									numberFormatOptions: {
-										notation: 'compact',
-										maximumFractionDigits: 1,
-									},
-								} ),
+								followCount: numberFormatCompact( followCount ),
 							},
 						} ) }
 					</div>

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -1,6 +1,6 @@
 import { Gridicon, ExternalLink } from '@automattic/components';
 import clsx from 'clsx';
-import { translate, numberFormat } from 'i18n-calypso';
+import { translate, numberFormatCompact } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import TagsList from 'calypso/blocks/reader-post-card/tags-list';
 import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
@@ -94,9 +94,7 @@ const ReaderFullPostHeader = ( { post, authorProfile, layout = 'default' } ) => 
 								{ translate( '%(followCount)s subscriber', '%(followCount)s subscribers', {
 									count: followCount,
 									args: {
-										followCount: numberFormat( followCount, {
-											numberFormatOptions: { notation: 'compact', maximumFractionDigits: 1 },
-										} ),
+										followCount: numberFormatCompact( followCount ),
 									},
 								} ) }
 							</span>

--- a/client/components/post-stats-card/index.tsx
+++ b/client/components/post-stats-card/index.tsx
@@ -3,7 +3,7 @@ import { Card, Button } from '@automattic/components';
 import { eye } from '@automattic/components/src/icons';
 import { Icon, commentContent, starEmpty } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useTranslate, numberFormat } from 'i18n-calypso';
+import { useTranslate, numberFormatCompact } from 'i18n-calypso';
 import { useMemo } from 'react';
 import './style.scss';
 
@@ -79,14 +79,7 @@ export default function PostStatsCard( {
 					<div className="post-stats-card__count-header">{ translate( 'Views' ) }</div>
 					<div className="post-stats-card__count-value">
 						<span>
-							{ ! isLoading && viewCount !== null
-								? numberFormat( viewCount, {
-										numberFormatOptions: {
-											notation: 'compact',
-											maximumFractionDigits: 1,
-										},
-								  } )
-								: '-' }
+							{ ! isLoading && viewCount !== null ? numberFormatCompact( viewCount ) : '-' }
 						</span>
 					</div>
 				</div>
@@ -95,14 +88,7 @@ export default function PostStatsCard( {
 					<div className="post-stats-card__count-header">{ translate( 'Likes' ) }</div>
 					<div className="post-stats-card__count-value">
 						<span>
-							{ ! isLoading && likeCount !== null
-								? numberFormat( likeCount, {
-										numberFormatOptions: {
-											notation: 'compact',
-											maximumFractionDigits: 1,
-										},
-								  } )
-								: '-' }
+							{ ! isLoading && likeCount !== null ? numberFormatCompact( likeCount ) : '-' }
 						</span>
 					</div>
 				</div>
@@ -111,14 +97,7 @@ export default function PostStatsCard( {
 					<div className="post-stats-card__count-header">{ translate( 'Comments' ) }</div>
 					<div className="post-stats-card__count-value">
 						<span>
-							{ ! isLoading && commentCount !== null
-								? numberFormat( commentCount, {
-										numberFormatOptions: {
-											notation: 'compact',
-											maximumFractionDigits: 1,
-										},
-								  } )
-								: '-' }
+							{ ! isLoading && commentCount !== null ? numberFormatCompact( commentCount ) : '-' }
 						</span>
 					</div>
 				</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/insights-stats.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/insights-stats.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/components';
 import { Icon, arrowUp, arrowDown, external } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useTranslate, numberFormat } from 'i18n-calypso';
+import { useTranslate, numberFormatCompact } from 'i18n-calypso';
 import ExpandedCard from './expanded-card';
 import type { SiteStats } from '../types';
 
@@ -62,14 +62,7 @@ export default function InsightsStats( { stats, siteUrlWithScheme, trackEvent }:
 				<div className="site-expanded-content__card-content">
 					<div className="site-expanded-content__card-content-column">
 						<div className="site-expanded-content__card-content-score">
-							<span>
-								{ numberFormat( data.visitors, {
-									numberFormatOptions: {
-										notation: 'compact',
-										maximumFractionDigits: 1,
-									},
-								} ) }
-							</span>
+							<span>{ numberFormatCompact( data.visitors ) }</span>
 							{ getTrendContent( data.visitorsTrend, data.visitorsChange ) }
 						</div>
 						<div className="site-expanded-content__card-content-score-title">
@@ -78,14 +71,7 @@ export default function InsightsStats( { stats, siteUrlWithScheme, trackEvent }:
 					</div>
 					<div className="site-expanded-content__card-content-column">
 						<div className="site-expanded-content__card-content-score">
-							<span>
-								{ numberFormat( data.views, {
-									numberFormatOptions: {
-										notation: 'compact',
-										maximumFractionDigits: 1,
-									},
-								} ) }
-							</span>
+							<span>{ numberFormatCompact( data.views ) }</span>
 							{ getTrendContent( data.viewsTrend, data.viewsChange ) }
 						</div>
 						<div className="site-expanded-content__card-content-score-title">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-stats-column.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-stats-column.tsx
@@ -1,7 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import { Icon, arrowUp, arrowDown } from '@wordpress/icons';
 import clsx from 'clsx';
-import { translate, numberFormat } from 'i18n-calypso';
+import { translate, numberFormatCompact } from 'i18n-calypso';
 import { useCallback, useContext } from 'react';
 import { DATAVIEWS_LIST } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
@@ -67,11 +67,7 @@ export default function SiteStatsColumn( { site, stats, siteError }: Props ) {
 				>
 					{ trendIcon }
 					<div className="sites-overview__stats">
-						<span className="shortened-number">
-							{ numberFormat( totalViews, {
-								numberFormatOptions: { notation: 'compact', maximumFractionDigits: 1 },
-							} ) }
-						</span>
+						<span className="shortened-number">{ numberFormatCompact( totalViews ) }</span>
 					</div>
 				</button>
 			);
@@ -109,14 +105,7 @@ export default function SiteStatsColumn( { site, stats, siteError }: Props ) {
 			{ trendIcon }
 
 			<div className="sites-overview__stats">
-				<span>
-					{ numberFormat( totalViews, {
-						numberFormatOptions: {
-							notation: 'compact',
-							maximumFractionDigits: 1,
-						},
-					} ) }
-				</span>
+				<span>{ numberFormatCompact( totalViews ) }</span>
 			</div>
 		</span>
 	);

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -1,5 +1,5 @@
 import { Badge, Button } from '@automattic/components';
-import { useTranslate, numberFormat } from 'i18n-calypso';
+import { useTranslate, numberFormatCompact } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import {
@@ -132,9 +132,7 @@ const PluginDetailsHeader = ( {
 							{ translate( 'Active installations' ) }
 						</div>
 						<div className="plugin-details-header__info-value">
-							{ numberFormat( plugin.active_installs, {
-								numberFormatOptions: { notation: 'compact' },
-							} ) }
+							{ numberFormatCompact( plugin.active_installs ) }
 						</div>
 					</div>
 				) }

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -4,7 +4,7 @@ import {
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { useTranslate, numberFormat } from 'i18n-calypso';
+import { useTranslate, numberFormatCompact } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import './style.scss';
@@ -160,7 +160,7 @@ const PluginDetailsSidebar = ( {
 						{ translate( 'Active installations' ) }
 					</div>
 					<div className="plugin-details-sidebar__active-installs-value value">
-						{ numberFormat( active_installs, { numberFormatOptions: { notation: 'compact' } } ) }
+						{ numberFormatCompact( active_installs ) }
 					</div>
 				</div>
 			) }

--- a/client/my-sites/stats/sections/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/sections/all-time-highlights-section/index.tsx
@@ -6,7 +6,7 @@ import {
 import { eye } from '@automattic/components/src/icons';
 import { Icon, people, postContent, starEmpty, commentContent } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useTranslate, numberFormat } from 'i18n-calypso';
+import { useTranslate, numberFormat, numberFormatCompact } from 'i18n-calypso';
 import React, { useMemo } from 'react';
 import QueryPosts from 'calypso/components/data/query-posts';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
@@ -148,16 +148,7 @@ export default function AllTimeHighlightsSection( {
 				{
 					id: 'views',
 					header: translate( 'Views' ),
-					content: (
-						<span>
-							{ numberFormat( viewsBestDayTotal, {
-								numberFormatOptions: {
-									notation: 'compact',
-									maximumFractionDigits: 1,
-								},
-							} ) }
-						</span>
-					),
+					content: <span>{ numberFormatCompact( viewsBestDayTotal ) }</span>,
 					footer: translate( '%(percent)s of views', {
 						args: { percent: formatPercentage( bestViewsEverPercent, true ) },
 						context: 'Stats: Percentage of views',

--- a/client/my-sites/stats/stats-email-top-row/top-card.jsx
+++ b/client/my-sites/stats/stats-email-top-row/top-card.jsx
@@ -1,5 +1,5 @@
 import { Card, Spinner } from '@automattic/components';
-import { useTranslate, numberFormat } from 'i18n-calypso';
+import { useTranslate, numberFormatCompact } from 'i18n-calypso';
 
 /* This is a very stripped down version of HighlightCard
  * HighlightCard doesn't support non-numeric values
@@ -25,12 +25,7 @@ const TopCardValue = ( { value, isLoading } ) => {
 
 	return (
 		<span className="highlight-card-count-value" title={ String( value ) }>
-			{ numberFormat( value, {
-				numberFormatOptions: {
-					notation: 'compact',
-					maximumFractionDigits: 1,
-				},
-			} ) }
+			{ numberFormatCompact( value ) }
 		</span>
 	);
 };

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -1,5 +1,5 @@
 import formatCurrency from '@automattic/format-currency';
-import { useTranslate, numberFormat } from 'i18n-calypso';
+import { useTranslate, numberFormatCompact } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { EXTENSION_THRESHOLD_IN_MILLION } from 'calypso/my-sites/stats/hooks/use-available-upgrade-tiers';
@@ -42,17 +42,7 @@ function getStepsForTiers( tiers: StatsPlanTierUI[], currencyCode: string ) {
 
 		// Return the new step with string values.
 		return {
-			lhValue:
-				typeof tier.views === 'number'
-					? String(
-							numberFormat( tier.views, {
-								numberFormatOptions: {
-									notation: 'compact',
-									maximumFractionDigits: 1,
-								},
-							} )
-					  )
-					: '-',
+			lhValue: typeof tier.views === 'number' ? numberFormatCompact( tier.views ) : '-',
 			rhValue: price,
 			originalPrice: tier.price,
 			upgradePrice: tierUpgradePricePerMonth

--- a/client/my-sites/stats/stats-tabs/tab.jsx
+++ b/client/my-sites/stats/stats-tabs/tab.jsx
@@ -2,7 +2,7 @@ import { TooltipContent } from '@automattic/components/src/highlight-cards/count
 import { TrendComparison } from '@automattic/components/src/highlight-cards/count-comparison-card';
 import Popover from '@automattic/components/src/popover';
 import clsx from 'clsx';
-import { localize } from 'i18n-calypso';
+import { localize, numberFormatCompact } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
 
@@ -66,7 +66,6 @@ class StatsTabsTab extends Component {
 			previousValue,
 			value,
 			hasPreviousData,
-			numberFormat,
 		} = this.props;
 
 		const tabClass = clsx( 'stats-tab', className, {
@@ -100,12 +99,7 @@ class StatsTabsTab extends Component {
 					{ hasPreviousData && (
 						<div className="stats-tabs__highlight">
 							<span className="stats-tabs__highlight-value" ref={ this.tooltipRef }>
-								{ numberFormat( value, {
-									numberFormatOptions: {
-										notation: 'compact',
-										maximumFractionDigits: 1,
-									},
-								} ) }
+								{ numberFormatCompact( value ) }
 							</span>
 							<TrendComparison count={ value } previousCount={ previousValue } />
 							<Popover

--- a/client/my-sites/stats/stats-views/months.jsx
+++ b/client/my-sites/stats/stats-views/months.jsx
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { Popover } from '@automattic/components';
-import { localize, numberFormat } from 'i18n-calypso';
+import { localize, numberFormat, numberFormatCompact } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { createRef, createElement, PureComponent } from 'react';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
@@ -131,10 +131,7 @@ const StatsViewsMonths = ( props ) => {
 				totals.months[ month ] += value;
 				totals.yearsCount[ year ] += 1;
 				totals.monthsCount[ month ] += 1;
-				displayValue = numberFormat( value, {
-					decimals: 1,
-					numberFormatOptions: { notation: 'compact' },
-				} );
+				displayValue = numberFormatCompact( value );
 			}
 
 			totalValue += value;

--- a/client/my-sites/subscribers/components/subscriber-stats-card/subscriber-stats-card.tsx
+++ b/client/my-sites/subscribers/components/subscriber-stats-card/subscriber-stats-card.tsx
@@ -1,5 +1,5 @@
 import { Card, Spinner } from '@automattic/components';
-import { numberFormat } from 'i18n-calypso';
+import { numberFormatCompact } from 'i18n-calypso';
 import { ReactNode } from 'react';
 import InfoPopover from 'calypso/components/info-popover';
 import '@automattic/components/src/highlight-cards/style.scss';
@@ -42,14 +42,7 @@ const SubscriberStatsCardValue = ( {
 			className="highlight-card-count-value subscriber-stats-card__value"
 			title={ String( value ) }
 		>
-			{ typeof value === 'number'
-				? numberFormat( value, {
-						numberFormatOptions: {
-							notation: 'compact',
-							maximumFractionDigits: 1,
-						},
-				  } )
-				: '-' }
+			{ typeof value === 'number' ? numberFormatCompact( value ) : '-' }
 		</span>
 	);
 };

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import { addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
-import { useTranslate, numberFormat } from 'i18n-calypso';
+import { useTranslate, numberFormatCompact } from 'i18n-calypso';
 import moment from 'moment';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import TagLink from 'calypso/blocks/reader-post-card/tag-link';
@@ -85,17 +85,13 @@ const ReaderTagSidebar = ( {
 				<div className="reader-tag-sidebar-stats">
 					<div className="reader-tag-sidebar-stats__item">
 						<span className="reader-tag-sidebar-stats__count">
-							{ numberFormat( tagStats?.data?.total_posts, {
-								numberFormatOptions: { notation: 'compact' },
-							} ) }
+							{ numberFormatCompact( tagStats?.data?.total_posts ) }
 						</span>
 						<span className="reader-tag-sidebar-stats__title">{ translate( 'Posts' ) }</span>
 					</div>
 					<div className="reader-tag-sidebar-stats__item">
 						<span className="reader-tag-sidebar-stats__count">
-							{ numberFormat( tagStats?.data?.total_sites, {
-								numberFormatOptions: { notation: 'compact' },
-							} ) }
+							{ numberFormatCompact( tagStats?.data?.total_sites ) }
 						</span>
 						<span className="reader-tag-sidebar-stats__title">{ translate( 'Sites' ) }</span>
 					</div>

--- a/client/reader/stream/site-feed-sidebar/index.jsx
+++ b/client/reader/stream/site-feed-sidebar/index.jsx
@@ -1,4 +1,4 @@
-import { useTranslate, numberFormat } from 'i18n-calypso';
+import { useTranslate, numberFormatCompact } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import ReaderFeedHeaderFollow from 'calypso/blocks/reader-feed-header/follow';
 import TagLink from 'calypso/blocks/reader-post-card/tag-link';
@@ -45,7 +45,7 @@ const FeedStreamSidebar = ( {
 					{ postCount && (
 						<div className="reader-tag-sidebar-stats__item">
 							<span className="reader-tag-sidebar-stats__count">
-								{ numberFormat( postCount, { numberFormatOptions: { notation: 'compact' } } ) }
+								{ numberFormatCompact( postCount ) }
 							</span>
 							<span className="reader-tag-sidebar-stats__title">
 								{ translate( 'Post', 'Posts', { count: postCount } ) }
@@ -55,9 +55,7 @@ const FeedStreamSidebar = ( {
 					{ followerCount && (
 						<div className="reader-tag-sidebar-stats__item">
 							<span className="reader-tag-sidebar-stats__count">
-								{ numberFormat( followerCount, {
-									numberFormatOptions: { notation: 'compact', maximumFractionDigits: 1 },
-								} ) }
+								{ numberFormatCompact( followerCount ) }
 							</span>
 							<span className="reader-tag-sidebar-stats__title">
 								{ translate( 'Subscriber', 'Subscribers', { count: followerCount } ) }

--- a/client/reader/tags/trending-tags.tsx
+++ b/client/reader/tags/trending-tags.tsx
@@ -1,5 +1,5 @@
 import { addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
-import { numberFormat } from 'i18n-calypso';
+import { numberFormatCompact } from 'i18n-calypso';
 import titlecase from 'to-title-case';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { TagResult } from './controller';
@@ -27,9 +27,7 @@ const TagRow = ( props: TagRowProps ) => {
 		<div className="trending-tags__column" key={ props.slug }>
 			<a href={ path } onClick={ trackTagClick.bind( null, props.slug ) }>
 				<span className="trending-tags__title">{ titlecase( props.title ) }</span>
-				<span className="trending-tags__count">
-					{ numberFormat( props.count, { numberFormatOptions: { notation: 'compact' } } ) }
-				</span>
+				<span className="trending-tags__count">{ numberFormatCompact( props.count ) }</span>
 			</a>
 		</div>
 	);

--- a/packages/components/src/count/index.jsx
+++ b/packages/components/src/count/index.jsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { localize, numberFormat } from 'i18n-calypso';
+import { localize, numberFormat, numberFormatCompact } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 
 import './style.scss';
@@ -18,9 +18,7 @@ export const Count = ( {
 
 	return (
 		<span ref={ forwardRef } className={ clsx( 'count', { 'is-primary': primary } ) } { ...props }>
-			{ compact
-				? numberFormat( count, { numberFormatOptions: { notation: 'compact' } } )
-				: effectiveNumberFormat( count ) }
+			{ compact ? numberFormatCompact( count ) : effectiveNumberFormat( count ) }
 		</span>
 	);
 };

--- a/packages/components/src/highlight-cards/mobile-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/mobile-highlight-cards.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@wordpress/icons';
-import { numberFormat } from 'i18n-calypso';
+import { numberFormatCompact } from 'i18n-calypso';
 import { TrendComparison } from './count-comparison-card';
 import './style.scss';
 
@@ -51,14 +51,7 @@ function MobileHighlightCard( {
 					preformattedValue
 				) : (
 					<span className="shortened-number">
-						{ count !== null
-							? numberFormat( count, {
-									numberFormatOptions: {
-										notation: 'compact',
-										maximumFractionDigits: 1,
-									},
-							  } )
-							: '-' }
+						{ count !== null ? numberFormatCompact( count ) : '-' }
 					</span>
 				) }
 			</span>

--- a/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx
+++ b/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx
@@ -1,7 +1,7 @@
 import { decodeEntities } from '@wordpress/html-entities';
 import { Icon, chevronDown, chevronUp, tag, file } from '@wordpress/icons';
 import clsx from 'clsx';
-import { numberFormat } from 'i18n-calypso';
+import { numberFormat, numberFormatCompact } from 'i18n-calypso';
 import React, { Fragment, useState } from 'react';
 import type { HorizontalBarListItemProps } from './types';
 
@@ -105,16 +105,7 @@ const HorizontalBarListItem = ( {
 
 	const renderValue = () => {
 		if ( useShortNumber ) {
-			return (
-				<span>
-					{ numberFormat( value, {
-						numberFormatOptions: {
-							notation: 'compact',
-							maximumFractionDigits: 1,
-						},
-					} ) }
-				</span>
-			);
+			return <span>{ numberFormatCompact( value ) }</span>;
 		}
 
 		if ( formatValue ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/i18n-issues/issues/941

## Proposed Changes

Follow-up on https://github.com/Automattic/wp-calypso/pull/99538 to update calls to `numberFormat` with compact notation to go through `numberFormatCompact` instead.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/941

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

A lot of code is affected, but testing a few cases should suffice.

1. Code review in case anything stands out
2. A few cases listed below. Test between EN & EL/DE locales.

#### `/stats/insights/:site` "Most popular day" stats

<img width="800" alt="Screenshot 2025-02-05 at 10 41 01 AM" src="https://github.com/user-attachments/assets/fc17df06-76cc-47c9-b32d-1b92c82fc1cd" />

#### `/stats/insights/:site` "Latest post"

<img width="398" alt="Screenshot 2025-02-05 at 11 32 38 AM" src="https://github.com/user-attachments/assets/febaf29f-7518-4e64-b37f-0e45c3a6dc25" />

#### `/subscribers/:site` - individual stats

Click on a subscriber to view individual subscriber stats. May have to enable it through the `?flags=individual-subscriber-stats`

<img width="800" alt="Screenshot 2025-02-05 at 11 49 59 AM" src="https://github.com/user-attachments/assets/cce3ecae-78e2-4606-a154-fee5fe7cd22a" />

#### `/devdocs` Blocks. Confirm `AuthorCompactProfile` renders subscribers count without decimals

<img width="400" alt="Screenshot 2025-01-31 at 6 43 23 PM" src="https://github.com/user-attachments/assets/afda1961-4027-4cf2-9148-71891a4987de" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
