### PR TITLE
Stats: Subscribers data transformation improvements

### DIFF
--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -15,6 +15,7 @@ function StatsLineChart( {
 	EmptyState = StatsEmptyState,
 	zeroBaseline = true,
 	xAxisNumTicks,
+	fixedDomain = false,
 }: {
 	chartData: Array< {
 		label: string;
@@ -29,6 +30,7 @@ function StatsLineChart( {
 	EmptyState: typeof StatsEmptyState;
 	zeroBaseline?: boolean;
 	xAxisNumTicks?: number;
+	fixedDomain?: boolean;
 } ) {
 	const translate = useTranslate();
 
@@ -68,7 +70,7 @@ function StatsLineChart( {
 					options={ {
 						yScale: {
 							type: 'linear',
-							domain: [ 0, maxViews ],
+							...( fixedDomain && { domain: [ 0, maxViews ] } ),
 							zero: zeroBaseline,
 						},
 						axis: {

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -14,6 +14,7 @@ function StatsLineChart( {
 	moment,
 	EmptyState = StatsEmptyState,
 	zeroBaseline = true,
+	xAxisNumTicks,
 }: {
 	chartData: Array< {
 		label: string;
@@ -27,6 +28,7 @@ function StatsLineChart( {
 	moment: Moment;
 	EmptyState: typeof StatsEmptyState;
 	zeroBaseline?: boolean;
+	xAxisNumTicks?: number;
 } ) {
 	const translate = useTranslate();
 
@@ -72,7 +74,7 @@ function StatsLineChart( {
 						axis: {
 							x: {
 								tickFormat: formatTime,
-								numTicks: className === 'stats-realtime-chart' ? undefined : dataSeries.length,
+								numTicks: xAxisNumTicks ?? dataSeries.length,
 							},
 							y: {
 								orientation: 'right',

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -72,7 +72,7 @@ function StatsLineChart( {
 						axis: {
 							x: {
 								tickFormat: formatTime,
-								numTicks: className === 'stats-realtime-chart' ? undefined : 5,
+								numTicks: className === 'stats-realtime-chart' ? undefined : dataSeries.length,
 							},
 							y: {
 								orientation: 'right',

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -13,6 +13,7 @@ function StatsLineChart( {
 	height = 400,
 	moment,
 	EmptyState = StatsEmptyState,
+	zeroBaseline = true,
 }: {
 	chartData: Array< {
 		label: string;
@@ -25,6 +26,7 @@ function StatsLineChart( {
 	height?: number;
 	moment: Moment;
 	EmptyState: typeof StatsEmptyState;
+	zeroBaseline?: boolean;
 } ) {
 	const translate = useTranslate();
 
@@ -65,10 +67,12 @@ function StatsLineChart( {
 						yScale: {
 							type: 'linear',
 							domain: [ 0, maxViews ],
+							zero: zeroBaseline,
 						},
 						axis: {
 							x: {
 								tickFormat: formatTime,
+								numTicks: className === 'stats-realtime-chart' ? undefined : 5,
 							},
 							y: {
 								orientation: 'right',

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -38,6 +38,7 @@ function StatsLineChart( {
 					hour12: true,
 				} );
 		  };
+
 	const formatViews = ( value: number ) => {
 		return value.toFixed( 0 ).toString();
 	};

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -32,12 +32,12 @@ function StatsLineChart( {
 		? formatTimeTick
 		: ( value: number ) => {
 				const date = new Date( value );
-				return date.toLocaleDateString( moment.locale(), {
-					month: 'short',
-					day: 'numeric',
+				return new Date( date ).toLocaleTimeString( moment.locale(), {
+					hour: '2-digit',
+					minute: '2-digit',
+					hour12: true,
 				} );
 		  };
-
 	const formatViews = ( value: number ) => {
 		return value.toFixed( 0 ).toString();
 	};

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -32,10 +32,9 @@ function StatsLineChart( {
 		? formatTimeTick
 		: ( value: number ) => {
 				const date = new Date( value );
-				return new Date( date ).toLocaleTimeString( moment.locale(), {
-					hour: '2-digit',
-					minute: '2-digit',
-					hour12: true,
+				return date.toLocaleDateString( moment.locale(), {
+					month: 'short',
+					day: 'numeric',
 				} );
 		  };
 

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -78,7 +78,7 @@ export default function SubscribersChartSection( {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const isChartLibraryEnabled = config.isEnabled( 'stats/chart-library' );
 	const quantityDefault: QuantityDefaultType = {
-		day: 14,
+		day: 30,
 		week: 12,
 		month: 6,
 		year: 3,

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -127,33 +127,6 @@ export default function SubscribersChartSection( {
 	const hasAddedPaidSubscriptionProduct = products && products.length > 0;
 	const chartData = transformData( data?.data || [], hasAddedPaidSubscriptionProduct );
 
-	// Adds a data transform function specific to the line chart component
-	function transformDataForLineChart( data: SubscribersData[] ) {
-		// Create a copy of the data array to avoid mutating the original
-		const sortedData = [ ...data ]
-			// Sort in chronological order (oldest to newest)
-			.sort( ( a, b ) => new Date( a.period ).getTime() - new Date( b.period ).getTime() );
-
-		return [
-			{
-				label: 'Subscribers',
-				options: {
-					stroke: '#069e08',
-				},
-				data: sortedData.map( ( point ) => {
-					const date = new Date( point.period );
-					// Lock date to midnight for all values to better align with ticks
-					date.setHours( 0, 0, 0, 0 );
-
-					return {
-						date,
-						value: point.subscribers ?? 0,
-					};
-				} ),
-			},
-		];
-	}
-
 	// adds in a tick formatting function to pass to the linechart component
 	// this can be modified to add more date formats (eg. month, year, etc.)
 	const formatTimeTick = ( value: number ) => {
@@ -215,7 +188,19 @@ export default function SubscribersChartSection( {
 					{ isChartLibraryEnabled ? (
 						<AsyncLoad
 							require="calypso/my-sites/stats/components/line-chart"
-							chartData={ transformDataForLineChart( data?.data || [] ) }
+							chartData={ [
+								{
+									label: 'Subscribers',
+									options: {
+										stroke: '#069e08',
+									},
+									data:
+										data?.data?.map( ( point ) => ( {
+											date: new Date( point.period ),
+											value: point.subscribers ?? 0,
+										} ) ) || [],
+								},
+							] }
 							height={ 300 }
 							formatTimeTick={ formatTimeTick }
 						/>

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -181,20 +181,11 @@ export default function SubscribersChartSection( {
 							chartData={ [
 								{
 									label: 'Subscribers',
-									options: {
-										stroke: '#069e08',
-									},
-									data: data?.data?.map( ( point ) => ( {
-										date: new Date( point.period ),
-										value: point.subscribers || 0,
-									} ) ) || [
-										// Fallback dummy data if no real data available
-										{ date: new Date( '2024-01-01' ), value: 10 },
-										{ date: new Date( '2024-01-08' ), value: 15 },
-										{ date: new Date( '2024-01-15' ), value: 12 },
-										{ date: new Date( '2024-01-22' ), value: 18 },
-										{ date: new Date( '2024-01-29' ), value: 20 },
-									],
+									data:
+										data?.data?.map( ( point ) => ( {
+											date: new Date( point.period ),
+											value: point.subscribers || 0,
+										} ) ) || [],
 								},
 							] }
 							height={ 300 }

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -128,25 +128,30 @@ export default function SubscribersChartSection( {
 	const chartData = transformData( data?.data || [], hasAddedPaidSubscriptionProduct );
 
 	// Adds a data transform function specific to the line chart component
-	function transformDataForLineChart( data: SubscribersData[] ): Array< {
-		label: string;
-		options: object;
-		data: Array< { date: Date; value: number } >;
-	} > {
-		const series = [
+	function transformDataForLineChart( data: SubscribersData[] ) {
+		// Create a copy of the data array to avoid mutating the original
+		const sortedData = [ ...data ]
+			// Sort in chronological order (oldest to newest)
+			.sort( ( a, b ) => new Date( a.period ).getTime() - new Date( b.period ).getTime() );
+
+		return [
 			{
 				label: 'Subscribers',
 				options: {
 					stroke: '#069e08',
 				},
-				data: data.map( ( point ) => ( {
-					date: new Date( point.period ),
-					value: point.subscribers ?? 0,
-				} ) ),
+				data: sortedData.map( ( point ) => {
+					const date = new Date( point.period );
+					// Lock date to midnight for all values to better align with ticks
+					date.setHours( 0, 0, 0, 0 );
+
+					return {
+						date,
+						value: point.subscribers ?? 0,
+					};
+				} ),
 			},
 		];
-
-		return series;
 	}
 
 	// adds in a tick formatting function to pass to the linechart component

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -213,14 +213,6 @@ export default function SubscribersChartSection( {
 							chartData={ transformDataForLineChart( data?.data || [] ) }
 							height={ 300 }
 							formatTimeTick={ formatTimeTick }
-							maxViews={ Math.max(
-								...( data?.data || [] ).map( ( point ) =>
-									Math.max(
-										point.subscribers || 0,
-										hasAddedPaidSubscriptionProduct ? point.subscribers_paid || 0 : 0
-									)
-								)
-							) }
 						/>
 					) : (
 						<UplotChart

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -127,6 +127,36 @@ export default function SubscribersChartSection( {
 	const hasAddedPaidSubscriptionProduct = products && products.length > 0;
 	const chartData = transformData( data?.data || [], hasAddedPaidSubscriptionProduct );
 
+	// Adds a data transform function specific to the line chart component
+	function transformDataForLineChart( data: SubscribersData[] ): Array< {
+		label: string;
+		options: object;
+		data: Array< { date: Date; value: number } >;
+	} > {
+		const series = [
+			{
+				label: 'Subscribers',
+				options: {},
+				data: data.map( ( point ) => ( {
+					date: new Date( point.period ),
+					value: point.subscribers ?? 0,
+				} ) ),
+			},
+		];
+
+		return series;
+	}
+
+	// adds in a tick formatting function to pass to the linechart component
+	// this can be modified to add more date formats (eg. month, year, etc.)
+	const formatTimeTick = ( value: number ) => {
+		const date = new Date( value );
+		return date.toLocaleDateString( undefined, {
+			month: 'short',
+			day: 'numeric',
+		} );
+	};
+
 	const subscribers = {
 		label: 'Subscribers',
 		path: `/stats/subscribers/`,
@@ -178,17 +208,17 @@ export default function SubscribersChartSection( {
 					{ isChartLibraryEnabled ? (
 						<AsyncLoad
 							require="calypso/my-sites/stats/components/line-chart"
-							chartData={ [
-								{
-									label: 'Subscribers',
-									data:
-										data?.data?.map( ( point ) => ( {
-											date: new Date( point.period ),
-											value: point.subscribers || 0,
-										} ) ) || [],
-								},
-							] }
+							chartData={ transformDataForLineChart( data?.data || [] ) }
 							height={ 300 }
+							formatTimeTick={ formatTimeTick }
+							maxViews={ Math.max(
+								...( data?.data || [] ).map( ( point ) =>
+									Math.max(
+										point.subscribers || 0,
+										hasAddedPaidSubscriptionProduct ? point.subscribers_paid || 0 : 0
+									)
+								)
+							) }
 						/>
 					) : (
 						<UplotChart

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -186,30 +186,50 @@ export default function SubscribersChartSection( {
 				<>
 					<div className="subscribers-section-legend" ref={ legendRef }></div>
 					{ isChartLibraryEnabled ? (
-						<AsyncLoad
-							require="calypso/my-sites/stats/components/line-chart"
-							chartData={ [
+						( () => {
+							// Create Date objects and validate them
+							const transformedData =
+								data?.data
+									?.map( ( point ) => {
+										const dateObj = new Date( point.period );
+										if ( isNaN( dateObj.getTime() ) ) {
+											return null;
+										}
+
+										// Freeze the object to prevent mutations and ensure immutability
+										return Object.freeze( {
+											date: dateObj,
+											value: point.subscribers ?? 0,
+										} );
+										// Filter out any null values from invalid dates, fallback to empty array if data is undefined
+									} )
+									.filter( Boolean ) || [];
+
+							// Freeze the entire chart data structure to maintain immutability throughout
+							const chartData = Object.freeze( [
 								{
 									label: 'Subscribers',
-									options: {
-										stroke: '#069e08',
-									},
-									data:
-										data?.data?.map( ( point ) => ( {
-											date: new Date( point.period ),
-											value: point.subscribers ?? 0,
-										} ) ) || [],
+									options: { stroke: '#069e08' },
+									data: transformedData,
 								},
-							] }
-							height={ 300 }
-							formatTimeTick={ formatTimeTick }
-						/>
+							] );
+
+							return (
+								<AsyncLoad
+									require="calypso/my-sites/stats/components/line-chart"
+									chartData={ chartData }
+									height={ 300 }
+									formatTimeTick={ formatTimeTick }
+									EmptyState={ () => null }
+									zeroBaseline={ false }
+								/>
+							);
+						} )()
 					) : (
 						<UplotChart
-							data={ chartData }
+							data={ transformData( data?.data || [], hasAddedPaidSubscriptionProduct ) }
 							legendContainer={ legendRef }
 							period={ period }
-							// Use variable --studio-jetpack-green for chart colors on Odyssey Stats.
 							mainColor={ isOdysseyStats ? '#069e08' : undefined }
 							fillColorFrom={ isOdysseyStats ? 'rgba(6, 158, 8, 0.4)' : undefined }
 							fillColorTo={ isOdysseyStats ? 'rgba(6, 158, 8, 0)' : undefined }

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -38,7 +38,7 @@ interface QuantityDefaultType {
 export type PeriodType = 'day' | 'week' | 'month' | 'year';
 
 // New Subscriber Stats
-function transformData(
+function transformUplotData(
 	data: SubscribersData[],
 	hasAddedPaidSubscriptionProduct: boolean
 ): uPlot.AlignedData {
@@ -65,6 +65,27 @@ function transformData(
 
 	return [ x, y1 ];
 }
+
+type ChartDataPoint = {
+	date: Date;
+	value: number;
+};
+
+const transformLineChartData = ( data: SubscribersData[] ): ChartDataPoint[] => {
+	return ( data
+		?.map( ( point ) => {
+			const dateObj = new Date( point.period );
+			if ( isNaN( dateObj.getTime() ) ) {
+				return null;
+			}
+
+			return {
+				date: dateObj,
+				value: point.subscribers ?? 0,
+			};
+		} )
+		.filter( Boolean ) || [] ) as ChartDataPoint[]; // Type assertion to ensure null values are filtered out
+};
 
 export default function SubscribersChartSection( {
 	siteId,
@@ -125,7 +146,16 @@ export default function SubscribersChartSection( {
 	const isChartLoading = isLoading || isPaidSubscriptionProductsLoading;
 
 	const hasAddedPaidSubscriptionProduct = products && products.length > 0;
-	const chartData = transformData( data?.data || [], hasAddedPaidSubscriptionProduct );
+
+	// Prepare data for both chart libraries
+	const uplotData = transformUplotData( data?.data || [], hasAddedPaidSubscriptionProduct );
+	const lineChartData = [
+		{
+			label: 'Subscribers',
+			options: { stroke: '#069e08' },
+			data: transformLineChartData( data?.data || [] ),
+		},
+	];
 
 	// adds in a tick formatting function to pass to the linechart component
 	// this can be modified to add more date formats (eg. month, year, etc.)
@@ -176,56 +206,27 @@ export default function SubscribersChartSection( {
 				</div>
 			</div>
 			{ isChartLoading && <StatsModulePlaceholder className="is-chart" isLoading /> }
-			{ ! isChartLoading && chartData.length === 0 && (
+			{ ! isChartLoading && uplotData.length === 0 && (
 				<p className="subscribers-section__no-data">
 					{ translate( 'No data available for the specified period.' ) }
 				</p>
 			) }
 			{ errorMessage && <div>Error: { errorMessage }</div> }
-			{ ! isChartLoading && chartData.length !== 0 && (
+			{ ! isChartLoading && uplotData.length !== 0 && (
 				<>
 					<div className="subscribers-section-legend" ref={ legendRef }></div>
 					{ isChartLibraryEnabled ? (
-						( () => {
-							// Create Date objects and validate them
-							const transformedData =
-								data?.data
-									?.map( ( point ) => {
-										const dateObj = new Date( point.period );
-										if ( isNaN( dateObj.getTime() ) ) {
-											return null;
-										}
-
-										return {
-											date: dateObj,
-											value: point.subscribers ?? 0,
-										};
-										// Filter out any null values from invalid dates, fallback to empty array if data is undefined
-									} )
-									.filter( Boolean ) || [];
-
-							const chartData = [
-								{
-									label: 'Subscribers',
-									options: { stroke: '#069e08' },
-									data: transformedData,
-								},
-							];
-
-							return (
-								<AsyncLoad
-									require="calypso/my-sites/stats/components/line-chart"
-									chartData={ chartData }
-									height={ 300 }
-									formatTimeTick={ formatTimeTick }
-									EmptyState={ () => null }
-									zeroBaseline={ false }
-								/>
-							);
-						} )()
+						<AsyncLoad
+							require="calypso/my-sites/stats/components/line-chart"
+							chartData={ lineChartData }
+							height={ 300 }
+							formatTimeTick={ formatTimeTick }
+							EmptyState={ () => null }
+							zeroBaseline={ false }
+						/>
 					) : (
 						<UplotChart
-							data={ transformData( data?.data || [], hasAddedPaidSubscriptionProduct ) }
+							data={ uplotData }
 							legendContainer={ legendRef }
 							period={ period }
 							mainColor={ isOdysseyStats ? '#069e08' : undefined }

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -136,7 +136,9 @@ export default function SubscribersChartSection( {
 		const series = [
 			{
 				label: 'Subscribers',
-				options: {},
+				options: {
+					stroke: '#069e08',
+				},
 				data: data.map( ( point ) => ( {
 					date: new Date( point.period ),
 					value: point.subscribers ?? 0,

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -78,7 +78,7 @@ export default function SubscribersChartSection( {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const isChartLibraryEnabled = config.isEnabled( 'stats/chart-library' );
 	const quantityDefault: QuantityDefaultType = {
-		day: 30,
+		day: 14,
 		week: 12,
 		month: 6,
 		year: 3,
@@ -196,23 +196,21 @@ export default function SubscribersChartSection( {
 											return null;
 										}
 
-										// Freeze the object to prevent mutations and ensure immutability
-										return Object.freeze( {
+										return {
 											date: dateObj,
 											value: point.subscribers ?? 0,
-										} );
+										};
 										// Filter out any null values from invalid dates, fallback to empty array if data is undefined
 									} )
 									.filter( Boolean ) || [];
 
-							// Freeze the entire chart data structure to maintain immutability throughout
-							const chartData = Object.freeze( [
+							const chartData = [
 								{
 									label: 'Subscribers',
 									options: { stroke: '#069e08' },
 									data: transformedData,
 								},
-							] );
+							];
 
 							return (
 								<AsyncLoad


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR updates the subscribers page line chart with the correct data source
* It is only visible behind the feature flag
* This is still a work in progress. Some things that need updated:
 - It currently does not display well for weekly view
 - It needs more tuning on the axes ticks
 - It needs a theme/colour update
 
* This is a followon PR from https://github.com/Automattic/wp-calypso/pull/99332/


## Testing Instructions

* Open Calypso live branch
* Navigate to `/stats/subscribers/{URL}i?flags=stats/chart-library`
* Check everything appears as normal
* Append feature flag `flags=stats/chart-library`
* Check the chart looks good, and that this hasn't broken realtime stats at all

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
