### PR TITLE
A4A: Remove truncated logic on product card description.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-badges/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-badges/style.scss
@@ -2,4 +2,5 @@
 	display: flex;
 	gap: 8px;
 	margin-block-start: 8px;
+	flex-wrap: wrap;
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/index.tsx
@@ -13,6 +13,7 @@ import { LICENSE_INFO_MODAL_ID } from 'calypso/jetpack-cloud/sections/partner-po
 import getProductShortTitle from 'calypso/jetpack-cloud/sections/partner-portal/lib/get-product-short-title';
 import LicenseLightbox from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox';
 import LicenseLightboxLink from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox-link';
+import { preventWidows } from 'calypso/lib/formatting';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from '../../../../../state/partner-portal/types';
 import ProductBadges from '../product-badges';
@@ -82,16 +83,6 @@ export default function ProductCard( props: Props ) {
 			}
 		}
 	}, [] );
-
-	const truncateDescription = ( description: any ) => {
-		if ( description.length <= 84 ) {
-			return description;
-		}
-
-		const lastSpace = description.slice( 0, 82 ).lastIndexOf( ' ' );
-
-		return description.slice( 0, lastSpace > 0 ? lastSpace : 83 ) + '…';
-	};
 
 	const { description: productDescription } = useProductDescription( product.slug );
 
@@ -209,7 +200,7 @@ export default function ProductCard( props: Props ) {
 								</div>
 
 								<div className="product-card__description">
-									{ truncateDescription( productDescription ) }
+									{ preventWidows( productDescription ) }
 								</div>
 							</div>
 						</div>

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/style.scss
@@ -4,6 +4,7 @@
 .product-card {
 	display: flex;
 	justify-content: stretch;
+	min-height: 270px;
 	&.disabled {
 		opacity: 0.5;
 


### PR DESCRIPTION
At present, we are aggressively truncating product card descriptions even though there is ample space. We have decided to eliminate the truncation logic and display the full description instead.

| Before | After |
|--------|--------|
| <img width="1333" alt="Screenshot 2025-02-13 at 7 24 59 PM" src="https://github.com/user-attachments/assets/90798404-8b3d-476c-8a5a-f345a7608e0f" /> | <img width="1330" alt="Screenshot 2025-02-13 at 7 25 12 PM" src="https://github.com/user-attachments/assets/cc7b9fb2-2c7c-4b5c-8501-070d69e3afd3" /> | 

Context: p1739443680703539-slack-C06JY8QL0TU

## Proposed Changes

* Eliminate truncation logic in product cards.  
* Establish a minimum height for all product cards to ensure uniformity in height.

## Why are these changes being made?

* This makes the products page more informative without the need of extra clicks to provide complete product description.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace/products` page.
* Confirm that the product cards show complete description without truncated text.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?