### PR TITLE
CI: Enable Code Style file-by-file check for `.md` and `.json` files

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -574,7 +574,7 @@ object CheckCodeStyleBranch : BuildType({
 				export NODE_ENV="test"
 
 				# Find files to lint
-				TOTAL_FILES_TO_LINT=$(git diff --name-only --diff-filter=d refs/remotes/origin/trunk...HEAD | grep -E '(\.[jt]sx?|\.json|\.md)${'$'}' || true)
+				TOTAL_FILES_TO_LINT=$(git diff --name-only --diff-filter=d refs/remotes/origin/trunk...HEAD | grep -cE '(\.[jt]sx?|\.json|\.md)${'$'}' || true)
 
 				# Avoid running more than 16 parallel eslint tasks as it could OOM
 				if [ "%run_full_eslint%" = "true" ] || [ "${'$'}TOTAL_FILES_TO_LINT" -gt 16 ] || [ "${'$'}TOTAL_FILES_TO_LINT" == "0" ]; then

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -574,7 +574,7 @@ object CheckCodeStyleBranch : BuildType({
 				export NODE_ENV="test"
 
 				# Find files to lint
-				TOTAL_FILES_TO_LINT=$(git diff --name-only --diff-filter=d refs/remotes/origin/trunk...HEAD | grep -cE '\.[jt]sx?' || true)
+				TOTAL_FILES_TO_LINT=$(git diff --name-only --diff-filter=d refs/remotes/origin/trunk...HEAD | grep -E '(\.[jt]sx?|\.json|\.md)${'$'}' || true)
 
 				# Avoid running more than 16 parallel eslint tasks as it could OOM
 				if [ "%run_full_eslint%" = "true" ] || [ "${'$'}TOTAL_FILES_TO_LINT" -gt 16 ] || [ "${'$'}TOTAL_FILES_TO_LINT" == "0" ]; then
@@ -583,7 +583,7 @@ object CheckCodeStyleBranch : BuildType({
 				else
 					# To avoid `ENAMETOOLONG` errors linting files, we have to lint them one by one,
 					# instead of passing the full list of files to eslint directly.
-					for file in ${'$'}(git diff --name-only --diff-filter=d refs/remotes/origin/trunk...HEAD | grep -E '(\.[jt]sx?)${'$'}' || true); do
+					for file in ${'$'}(git diff --name-only --diff-filter=d refs/remotes/origin/trunk...HEAD | grep -E '(\.[jt]sx?|\.json|\.md)${'$'}' || true); do
 						( echo "Linting ${'$'}file"
 						yarn run eslint --format checkstyle --output-file "./checkstyle_results/eslint/${'$'}{file//\//_}.xml" "${'$'}file" ) &
 					done


### PR DESCRIPTION
## Proposed Changes

Applies a fix to the Code Style CI check so it also lints `.md` and `.json` files properly when less than or equal to 16 changed files. 

The behavior of more than 16 files is untouched, it will continue performing a full eslint on all files.

Fixes #99638. Closes #99728.

## Why are these changes being made?

To avoid introducing ESLint errors when merging new `.md` and `.json` files. See https://github.com/Automattic/wp-calypso/pull/99592#issuecomment-2653173456 for more details.

## Testing Instructions
* Follow the testing instructions in #99728.