### PR TITLE
fix reader recent submenu selection state

### DIFF
--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -54,6 +54,7 @@ const ReaderSidebarRecent = ( {
 	);
 	const recordReaderTracksEvent = useRecordReaderTracksEvent();
 	const dispatch = useDispatch();
+	const isRecentStream = RECENT_PATH_REGEX.test( path );
 
 	let sitesToShow = showAllSites ? sites : sites.slice( 0, SITE_DISPLAY_CUTOFF );
 	// const totalUnseenCount = sites.reduce( ( total, site ) => total + site.unseen_count, 0 );
@@ -75,7 +76,7 @@ const ReaderSidebarRecent = ( {
 
 	const selectSite = ( feedId: number | null ) => {
 		dispatch( selectSidebarRecentSite( { feedId } ) );
-		if ( ! RECENT_PATH_REGEX.test( path ) ) {
+		if ( ! isRecentStream ) {
 			page( '/reader' );
 		}
 
@@ -99,7 +100,7 @@ const ReaderSidebarRecent = ( {
 			customIcon={ <ReaderFollowingIcon viewBox="-3 0 24 24" /> }
 			disableFlyout
 			className={ clsx( 'reader-sidebar-recent', className, {
-				'sidebar__menu--selected': ! isOpen && RECENT_PATH_REGEX.test( path ),
+				'sidebar__menu--selected': ! isOpen && isRecentStream,
 			} ) }
 			count={ undefined }
 			icon={ null }
@@ -111,7 +112,8 @@ const ReaderSidebarRecent = ( {
 					className={ clsx(
 						'reader-sidebar-recent__item reader-sidebar-recent__item--without-icon',
 						{
-							'reader-sidebar-recent__item--selected': selectedSiteFeedId === null,
+							'reader-sidebar-recent__item--selected':
+								isRecentStream && selectedSiteFeedId === null,
 						}
 					) }
 					onClick={ () => selectSite( null ) }
@@ -124,7 +126,8 @@ const ReaderSidebarRecent = ( {
 				<li key={ site.ID }>
 					<button
 						className={ clsx( 'reader-sidebar-recent__item', {
-							'reader-sidebar-recent__item--selected': site.feed_ID === selectedSiteFeedId,
+							'reader-sidebar-recent__item--selected':
+								isRecentStream && site.feed_ID === selectedSiteFeedId,
 						} ) }
 						onClick={ () => selectSite( site.feed_ID ) }
 					>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/99725
 
## Proposed Changes

Fixes the reader recent submenu item selection state to not show active when we are viewing other streams than recent.

Updates the reader-recent-sidebar component to:
* Consolidates existing checks for `RECENT_PATH_REGEX.test( path )` as a variable `isRecentStream`.
* Adds `isRecentStream` as a condition on selection state for the "All" and site submenu options.


BEFORE
![recent-selection-before](https://github.com/user-attachments/assets/17dde9b0-3037-4b70-b796-5544e72069d6)



AFTER
![recent-selection-after](https://github.com/user-attachments/assets/33ff4b28-af83-4c46-9bb2-12efdbc21aa1)




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Confusing that it shows selected when its not the selected stream.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the reader recent stream, verify "All" loads bold.
* In the sidebar click another stream like discover or likes. Verify "All" under recent is no longer bold.
* Do the same for selecting a specific site stream under recent. Verify once navigating to a non-recent stream the item is no longer marked as selected/bold.
* Smoke test surrounding functionality.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
