### PR TITLE
Help Center: Update unread messages text for localization support

### DIFF
--- a/packages/help-center/src/components/help-center-launchpad.tsx
+++ b/packages/help-center/src/components/help-center-launchpad.tsx
@@ -53,7 +53,7 @@ export const HelpCenterLaunchpad = () => {
 				href={ localizeUrl( launchpadURL ) }
 				rel="noreferrer"
 				target="_top"
-				aria-label="Link to Launchpad screen"
+				aria-label={ __( 'Link to Launchpad screen', __i18n_text_domain__ ) }
 				onClick={ () => {
 					handleLaunchpadHelpLinkClick();
 				} }

--- a/packages/help-center/src/components/help-center-recent-conversations.tsx
+++ b/packages/help-center/src/components/help-center-recent-conversations.tsx
@@ -80,7 +80,7 @@ const HelpCenterRecentConversations: React.FC = () => {
 		...lastMessage,
 		...( unreadConversationsCount > 1
 			? {
-					text: 'Multiple Unread Messages',
+					text: __( 'Multiple Unread Messages', __i18n_text_domain__ ),
 					displayName: sprintf(
 						/* translators: %1$s is total number of unread messages, %2$s is the total number of chats with unread messages */
 						__( '%1$s messages from %2$s chats', __i18n_text_domain__ ),

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -135,11 +135,18 @@ function debounceSpeak( {
 	}, timeout );
 }
 
-const loadingSpeak = debounceSpeak( { message: 'Loading search results.', timeout: 1500 } );
+const loadingSpeak = debounceSpeak( {
+	message: __( 'Loading search results.', __i18n_text_domain__ ),
+	timeout: 1500,
+} );
 
-const resultsSpeak = debounceSpeak( { message: 'Search results loaded.' } );
+const resultsSpeak = debounceSpeak( {
+	message: __( 'Search results loaded.', __i18n_text_domain__ ),
+} );
 
-const errorSpeak = debounceSpeak( { message: 'No search results found.' } );
+const errorSpeak = debounceSpeak( {
+	message: __( 'No search results found.', __i18n_text_domain__ ),
+} );
 
 const filterManagePurchaseLink = ( hasPurchases: boolean, isPurchasesSection: boolean ) => {
 	if ( hasPurchases || isPurchasesSection ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Add translation for `Multiple Unread Messages` text

![CleanShot 2025-02-13 at 13 32 42@2x](https://github.com/user-attachments/assets/a9bbb855-ce09-483b-987c-42f096e4c3b9)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Add translation

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Open the Help Center
* Make sure you have multiple unread support chats
* Verify the `Multiple Unread Messages` is translated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
