### PR TITLE
Storybook: Show Controls panel first

### DIFF
--- a/packages/calypso-storybook/src/index.js
+++ b/packages/calypso-storybook/src/index.js
@@ -39,8 +39,8 @@ module.exports = function storybookDefaultConfig( {
 		staticDirs,
 		stories: stories && stories.length ? stories : [ '../src/**/*.stories.{js,jsx,ts,tsx}' ],
 		addons: [
-			'@storybook/addon-actions',
 			'@storybook/addon-controls',
+			'@storybook/addon-actions',
 			'@storybook/addon-docs',
 			'@storybook/addon-toolbars',
 			'@storybook/addon-viewport',


### PR DESCRIPTION
## Proposed Changes

On Storybook story pages, display the Controls panel before the Actions panel.

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/c217e09c-5460-4e0a-b209-6d25033a52a6" alt="Storybook panels, before" width="639">|<img src="https://github.com/user-attachments/assets/331e4a9e-606a-4d15-84cd-44d247ab680a" alt="Storybook panels, after" width="639">|


## Why are these changes being made?

The Controls panel is going to be much more used, especially once we fix existing stories and add new stories where the Controls are properly functioning.

## Testing Instructions

`yarn storybook:start`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
