### PR TITLE
Storybook: Sort props consistently

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,14 @@
 import './index.scss';
 
 export const parameters = {
+	controls: {
+		sort: 'requiredFirst',
+	},
+	docs: {
+		controls: {
+			sort: 'requiredFirst',
+		},
+	},
 	layout: 'fullscreen',
 	viewport: {
 		viewports: {

--- a/packages/components/.storybook/preview.js
+++ b/packages/components/.storybook/preview.js
@@ -1,1 +1,12 @@
 import './style.scss';
+
+export const parameters = {
+	controls: {
+		sort: 'requiredFirst',
+	},
+	docs: {
+		controls: {
+			sort: 'requiredFirst',
+		},
+	},
+};


### PR DESCRIPTION
## Proposed Changes

Ensure a consistent and predictable prop sort order in the main Storybooks (root and components).

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/5dad938a-890e-441e-a625-65162366ff1e" alt="Prop order, before" width="495">|<img src="https://github.com/user-attachments/assets/e9c8d53b-cece-47f4-ae49-b5e28124cd15" alt="Prop order, after" width="494">|


## Why are these changes being made?

Without this, props will be displayed in declaration order, which makes it hard to scan for the prop you're looking for.

## Testing Instructions

`yarn storybook:start` and see a component with controls, e.g. `DomainsTable`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
