### PR TITLE
Desktop app: Always register the /log-in/desktop routes

### DIFF
--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -68,30 +68,25 @@ const makeLoggedOutLayout = makeLayoutMiddleware( ReduxWrappedLayout );
 export default ( router ) => {
 	const lang = getLanguageRouteParam();
 
-	// In development environments, the desktop app can be launched in a way in which it does not bundle calypso,
-	// but instead uses a calypso instance that is running outside the desktop app.
-	// In such a scenario, `config.isEnabled( 'desktop' )` returns false, but we still want the route to be available.
-	// For this reason, we always enable the desktop login routes in development environments.
-	if ( config.isEnabled( 'desktop' ) || config( 'env_id' ) === 'development' ) {
-		router(
-			[ `/log-in/desktop/${ lang }` ],
-			redirectLoggedIn,
-			setLocaleMiddleware(),
-			setMetaTags,
-			setSectionMiddleware( { ...LOGIN_SECTION_DEFINITION, isomorphic: false } ),
-			desktopLogin,
-			makeLoggedOutLayout
-		);
-		router(
-			[ `/log-in/desktop/finalize` ],
-			redirectLoggedIn,
-			setLocaleMiddleware(),
-			setMetaTags,
-			setSectionMiddleware( { ...LOGIN_SECTION_DEFINITION, isomorphic: false } ),
-			desktopLoginFinalize,
-			makeLoggedOutLayout
-		);
-	}
+	// The /log-in/desktop routes are only used by the WordPress.com Desktop app.
+	router(
+		[ `/log-in/desktop/${ lang }` ],
+		redirectLoggedIn,
+		setLocaleMiddleware(),
+		setMetaTags,
+		setSectionMiddleware( { ...LOGIN_SECTION_DEFINITION, isomorphic: false } ),
+		desktopLogin,
+		makeLoggedOutLayout
+	);
+	router(
+		[ `/log-in/desktop/finalize` ],
+		redirectLoggedIn,
+		setLocaleMiddleware(),
+		setMetaTags,
+		setSectionMiddleware( { ...LOGIN_SECTION_DEFINITION, isomorphic: false } ),
+		desktopLoginFinalize,
+		makeLoggedOutLayout
+	);
 
 	if ( config.isEnabled( 'login/magic-login' ) ) {
 		router(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #98345

## Proposed Changes

The `/log-in/desktop` and `/log-in/desktop/finalize` routes introduced in #98345 are no longer conditionally registered, so will always be available.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The server does not know whether the endpoints are being called by the desktop app, so the routes need to always be available. Some discussion on this happened at p1739436931494659-slack-C7YPUHBB2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Make sure the routes do not 404:

```shell
curl http://calypso.localhost:3000/log-in/desktop
curl http://calypso.localhost:3000/log-in/desktop/finalize
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?