### PR TITLE
Desktop app: Beta release for OAuth login

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -36,7 +36,7 @@ Refer to the [development guide](docs/development.md) for help with how the app 
 
 ## Running The End-To-End Test Suite
 
-1. Set the environment variables `E2EUSERNAME` and `E2EPASSWORD`.
+1. Set the environment variables `E2EGUTENBERGUSER` and `E2EPASSWORD`.
 2. Use `yarn run test:e2e` or `make e2e` to invoke the test suite.
 
 To manually start each platform's _pre-packaged_ executable used for end-to-end testing:

--- a/desktop/app/lib/config/index.js
+++ b/desktop/app/lib/config/index.js
@@ -9,7 +9,7 @@ config.author = pkg.author;
 
 config.protocol = 'wpdesktop';
 
-config.oauthLoginEnabled = true;
+config.oauthLoginEnabled = process.platform !== 'linux';
 
 config.loginURL = function () {
 	const loginUri = ! config.oauthLoginEnabled ? 'log-in' : 'log-in/desktop';

--- a/desktop/app/lib/config/index.js
+++ b/desktop/app/lib/config/index.js
@@ -9,8 +9,11 @@ config.author = pkg.author;
 
 config.protocol = 'wpdesktop';
 
+config.oauthLoginEnabled = false;
+
 config.loginURL = function () {
-	return this.baseURL() + 'log-in';
+	const loginUri = ! config.oauthLoginEnabled ? 'log-in' : 'log-in/desktop';
+	return this.baseURL() + loginUri;
 };
 
 config.baseURL = function () {

--- a/desktop/app/lib/config/index.js
+++ b/desktop/app/lib/config/index.js
@@ -9,7 +9,7 @@ config.author = pkg.author;
 
 config.protocol = 'wpdesktop';
 
-config.oauthLoginEnabled = false;
+config.oauthLoginEnabled = true;
 
 config.loginURL = function () {
 	const loginUri = ! config.oauthLoginEnabled ? 'log-in' : 'log-in/desktop';

--- a/desktop/app/lib/login/index.js
+++ b/desktop/app/lib/login/index.js
@@ -6,8 +6,13 @@
  * @returns {boolean}
  */
 function isNonDesktopLoginUrl( url ) {
-	const u = new URL( url );
-	const path = u.pathname.replace( u.search, '' );
+	let path = '';
+	try {
+		const u = new URL( url );
+		path = u.pathname.replace( u.search, '' );
+	} catch ( e ) {
+		return false;
+	}
 	return path === '/log-in' || path === '/log-in/';
 }
 

--- a/desktop/app/lib/login/index.js
+++ b/desktop/app/lib/login/index.js
@@ -1,0 +1,14 @@
+/**
+ * Tells whether a URL points to the regular login page.
+ * This is useful in places where we need to send the user to the desktop app's
+ * login page (/log-in/desktop), instead of the regular login page.
+ * @param url string
+ * @returns {boolean}
+ */
+function isNonDesktopLoginUrl( url ) {
+	const u = new URL( url );
+	const path = u.pathname.replace( u.search, '' );
+	return path === '/log-in' || path === '/log-in/';
+}
+
+module.exports = { isNonDesktopLoginUrl };

--- a/desktop/app/mainWindow/index.js
+++ b/desktop/app/mainWindow/index.js
@@ -17,13 +17,17 @@ let mainWindow = null;
 
 function getInitialUrl() {
 	let appUrl = Config.loginURL();
-	if ( ! process.env.CI && ! process.env.WP_DESKTOP_DEBUG ) {
-		log.info( 'Overriding window with last location...' );
-		const lastLocation = Settings.getSetting( settingConstants.LAST_LOCATION );
-		if ( lastLocation && lastLocation.startsWith( 'http' ) ) {
-			appUrl = lastLocation;
-		}
+	if ( process.env.CI || process.env.WP_DESKTOP_DEBUG ) {
+		return appUrl;
 	}
+
+	const lastLocation = Settings.getSetting( settingConstants.LAST_LOCATION );
+	if ( ! lastLocation || ! lastLocation.startsWith( 'http' ) ) {
+		return appUrl;
+	}
+
+	log.info( `Will use last location as initial URL ${ lastLocation }` );
+	appUrl = lastLocation;
 	return appUrl;
 }
 

--- a/desktop/app/mainWindow/index.js
+++ b/desktop/app/mainWindow/index.js
@@ -15,10 +15,8 @@ const TITLE_BAR_HEIGHT = 38;
 
 let mainWindow = null;
 
-function showAppWindow() {
-	const preloadFile = getPath( 'preload.js' );
+function getInitialUrl() {
 	let appUrl = Config.loginURL();
-
 	if ( ! process.env.CI && ! process.env.WP_DESKTOP_DEBUG ) {
 		log.info( 'Overriding window with last location...' );
 		const lastLocation = Settings.getSetting( settingConstants.LAST_LOCATION );
@@ -26,6 +24,12 @@ function showAppWindow() {
 			appUrl = lastLocation;
 		}
 	}
+	return appUrl;
+}
+
+function showAppWindow() {
+	const preloadFile = getPath( 'preload.js' );
+	const appUrl = getInitialUrl();
 	log.info( 'Loading app (' + appUrl + ') in mainWindow' );
 
 	const windowConfig = Settings.getSettingGroup( Config.mainWindow, null );
@@ -142,7 +146,8 @@ function showAppWindow() {
 		return Settings.toRenderer();
 	} );
 
-	mainView.webContents.loadURL( appUrl );
+	log.info( `Loading URL: '${ appUrl }'` );
+	void mainView.webContents.loadURL( appUrl );
 
 	mainWindow.on( 'close', function () {
 		const currentURL = mainView.webContents.getURL();

--- a/desktop/app/mainWindow/index.js
+++ b/desktop/app/mainWindow/index.js
@@ -2,6 +2,7 @@ const { app, BrowserWindow, BrowserView, ipcMain: ipc } = require( 'electron' );
 const { getPath } = require( '../lib/assets' );
 const Config = require( '../lib/config' );
 const log = require( '../lib/logger' )( 'desktop:runapp' );
+const { isNonDesktopLoginUrl } = require( '../lib/login' );
 const platform = require( '../lib/platform' );
 const SessionManager = require( '../lib/session' );
 const Settings = require( '../lib/settings' );
@@ -26,8 +27,15 @@ function getInitialUrl() {
 		return appUrl;
 	}
 
-	log.info( `Will use last location as initial URL ${ lastLocation }` );
+	log.info( `Will use last location as initial URL: ${ lastLocation }` );
 	appUrl = lastLocation;
+
+	if ( Config.oauthLoginEnabled && isNonDesktopLoginUrl( appUrl ) ) {
+		appUrl = Config.loginURL();
+		log.info(
+			`Last location pointed to the regular login URL, will use the desktop login URL instead: ${ appUrl }`
+		);
+	}
 	return appUrl;
 }
 

--- a/desktop/app/window-handlers/login/index.js
+++ b/desktop/app/window-handlers/login/index.js
@@ -1,12 +1,23 @@
 const { shell } = require( 'electron' );
 const config = require( '../../lib/config' );
 const log = require( '../../lib/logger' )( 'desktop:authentication' );
+const { isNonDesktopLoginUrl } = require( '../../lib/login' );
 
 module.exports = function ( { view } ) {
 	if ( ! config.oauthLoginEnabled ) {
 		return;
 	}
 
+	// Intercept attempts to load the normal login page,
+	// and instead open the desktop login page.
+	view.webContents.on( 'will-navigate', function ( event, url ) {
+		if ( isNonDesktopLoginUrl( url ) ) {
+			void view.webContents.loadURL( config.loginURL() );
+		}
+	} );
+
+	// The button in the desktop login page links to /desktop-start-login.
+	// We intercept those links here, and start the oauth authentication flow.
 	view.webContents.on( 'will-navigate', function ( event, url ) {
 		if ( url.includes( '/desktop-start-login' ) ) {
 			event.preventDefault();

--- a/desktop/app/window-handlers/login/index.js
+++ b/desktop/app/window-handlers/login/index.js
@@ -3,6 +3,10 @@ const config = require( '../../lib/config' );
 const log = require( '../../lib/logger' )( 'desktop:authentication' );
 
 module.exports = function ( { view } ) {
+	if ( ! config.oauthLoginEnabled ) {
+		return;
+	}
+
 	view.webContents.on( 'will-navigate', function ( event, url ) {
 		if ( url.includes( '/desktop-start-login' ) ) {
 			event.preventDefault();

--- a/desktop/app/window-handlers/login/index.js
+++ b/desktop/app/window-handlers/login/index.js
@@ -8,20 +8,19 @@ module.exports = function ( { view } ) {
 		return;
 	}
 
-	// Intercept attempts to load the normal login page,
-	// and instead open the desktop login page.
 	view.webContents.on( 'will-navigate', function ( event, url ) {
-		if ( isNonDesktopLoginUrl( url ) ) {
-			void view.webContents.loadURL( config.loginURL() );
-		}
-	} );
-
-	// The button in the desktop login page links to /desktop-start-login.
-	// We intercept those links here, and start the oauth authentication flow.
-	view.webContents.on( 'will-navigate', function ( event, url ) {
+		// The button in the desktop login page links to /desktop-start-login.
+		// We intercept those links here, and start the oauth authentication flow.
 		if ( url.includes( '/desktop-start-login' ) ) {
 			event.preventDefault();
 			startAuthentication();
+			return;
+		}
+
+		// Intercept attempts to load the normal login page,
+		// and instead open the desktop login page.
+		if ( isNonDesktopLoginUrl( url ) ) {
+			void view.webContents.loadURL( config.loginURL() );
 		}
 	} );
 };

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "8.0.4",
+	"version": "8.1.0-beta1",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/",

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -38,6 +38,7 @@ const WP_DEBUG_LOG = path.resolve( __dirname, '../results/app.log' );
 const BASE_URL = process.env.WP_DESKTOP_BASE_URL?.replace( /\/$/, '' ) ?? 'https://wordpress.com';
 
 const skipIfOAuthLogin = config.oauthLoginEnabled ? it.skip : it;
+const runIfOAuthLogin = config.oauthLoginEnabled ? it : it.skip;
 
 describe( 'User Can log in', () => {
 	jest.setTimeout( 60000 );
@@ -90,6 +91,15 @@ describe( 'User Can log in', () => {
 		for ( const [ , frame ] of mainWindow.frames().entries() ) {
 			await frame.waitForLoadState();
 		}
+	} );
+
+	runIfOAuthLogin( 'Start the OAuth login flow', async function () {
+		const loginButton = await mainWindow.waitForSelector(
+			'a:has-text("Log in with WordPress.com")'
+		);
+		const href = await loginButton.getAttribute( 'href' );
+		// eslint-disable-next-line jest/no-standalone-expect
+		expect( href ).toBe( '/desktop-start-login' );
 	} );
 
 	skipIfOAuthLogin( 'Log in with username and password', async function () {

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -3,6 +3,7 @@ const { createWriteStream } = require( 'fs' );
 const { mkdir } = require( 'fs/promises' );
 const path = require( 'path' );
 const { _electron: electron } = require( 'playwright' );
+const config = require( '../../../app/lib/config' );
 
 let APP_PATH;
 
@@ -35,6 +36,8 @@ const HAR_PATH = path.join( __dirname, '../results/network.har' );
 const WP_DEBUG_LOG = path.resolve( __dirname, '../results/app.log' );
 
 const BASE_URL = process.env.WP_DESKTOP_BASE_URL?.replace( /\/$/, '' ) ?? 'https://wordpress.com';
+
+const skipIfOAuthLogin = config.oauthLoginEnabled ? it.skip : it;
 
 describe( 'User Can log in', () => {
 	jest.setTimeout( 60000 );
@@ -89,8 +92,7 @@ describe( 'User Can log in', () => {
 		}
 	} );
 
-	// eslint-disable-next-line jest/expect-expect
-	it( 'Log in', async function () {
+	skipIfOAuthLogin( 'Log in with username and password', async function () {
 		await mainWindow.fill( '#usernameOrEmail', process.env.E2EGUTENBERGUSER );
 		await mainWindow.keyboard.press( 'Enter' );
 		await mainWindow.fill( '#password', process.env.E2EPASSWORD );
@@ -114,6 +116,7 @@ describe( 'User Can log in', () => {
 			);
 		}
 
+		// eslint-disable-next-line jest/no-standalone-expect
 		expect( response.status() ).toBe( 200 );
 	} );
 


### PR DESCRIPTION
> I would recommend reviewing this PR commit-by-commit, each commit should be self-explanatory.

Related to #89736 #72754 #55611

## Proposed Changes

In #98345 we introduced a new OAuth login flow for the desktop app, but kept it disabled. This PR enables that flow, and issues a new beta release so that these changes can be tested before releasing to customers. Please see the description of #98345 for details on the changes that are being introduced.

In addition to enabling the OAuth flow, this PR also fixes issues that were found during testing, namely preventing that the user ever sees the regular login page, and instead always sees the desktop login page.

## Why are these changes being made?
Please see the description of #98345.

## Testing Instructions

1. Download and install the beta app for the system you're testing on ([Mac](https://app.circleci.com/pipelines/github/Automattic/wp-calypso/261994/workflows/ed777c72-6c69-4c88-84cb-3d25999b0ca4/jobs/1176470/artifacts), [Linux](https://app.circleci.com/pipelines/github/Automattic/wp-calypso/261994/workflows/4388195f-802d-4e43-8956-7132492ebc2d/jobs/1176472/artifacts), [Windows](https://app.circleci.com/pipelines/github/Automattic/wp-calypso/261994/workflows/ed777c72-6c69-4c88-84cb-3d25999b0ca4/jobs/1176471/artifacts))
    - On macOS, you need to run the following command after installing: `xattr -c /Applications/WordPress.com.app`
1. Set your default browser to the one you'd like to test (Please consider testing with a browser that is not yet marked as checked in the list below)
1. Open the app
1. If you're logged-in, log out
1. You should see the new Desktop login page that only displays a "Log in with WordPress.com" button
1. Click "Log in with WordPress.com"
1. The browser that you set as default should open
1. Go through the authentication flow in the browser
1. At the end, when you click "Authorize" the app should re-open automatically, and should log you in
1. Close the app and reopen, you should still be logged in.
1. If successful, check the corresponding entry in the list below
1. Leave a comment in this PR stating what system/browser you tested, and feel free to mention any feedback you might have

- Mac
    - [x] Firefox
    - [x] Chrome
    - [x] Safari
- Windows
    - [x] Edge
    - [x] Firefox
    - [x] Chrome
- Linux
    - [ ] Firefox
    - [ ] Chrome/Chromium

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
