### PR TITLE
Launchpad in My Home: Only display the confetti and launch site modal after launching the site

### DIFF
--- a/client/data/home/use-home-layout-query-params.ts
+++ b/client/data/home/use-home-layout-query-params.ts
@@ -8,10 +8,10 @@ export interface HomeLayoutQueryParams {
 }
 
 export function useHomeLayoutQueryParams(): HomeLayoutQueryParams {
-	const { dev, view } = useSelector( getCurrentQueryArguments ) as any;
+	const { dev, view } = useSelector( getCurrentQueryArguments ) ?? {};
 
 	return {
 		dev: dev === 'true' || ( ! dev && config.isEnabled( 'home/layout-dev' ) ) || undefined,
-		view,
+		view: view?.toString(),
 	};
 }

--- a/client/my-sites/customer-home/cards/launchpad/test/focused-launchpad.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/test/focused-launchpad.tsx
@@ -1,36 +1,29 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen, act } from '@testing-library/react';
-import React from 'react';
+import { screen } from '@testing-library/react';
+import React, { act } from 'react';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import CustomerHome from '../../../main';
 import type { SiteDetails } from '@automattic/data-stores';
 
-jest.mock( '@automattic/calypso-config', () => ( {
-	isEnabled: jest.fn( ( flag ) => flag === 'home/launchpad-first' ),
-} ) );
-
-jest.mock( '../../../components/full-screen-launchpad', () => ( {
-	FullScreenLaunchpad: ( { onClose }: { onClose: () => void } ) => (
-		<div data-testid="launchpad">
-			<button onClick={ onClose } data-testid="close-launchpad">
-				Close Launchpad
-			</button>
-		</div>
-	),
-} ) );
+jest.mock( '@automattic/calypso-config', () => {
+	const config = () => 'development';
+	config.isEnabled = ( property: string ) => property === 'home/launchpad-first';
+	return config;
+} );
 
 jest.mock( '../../../components/home-content', () => () => (
 	<div data-testid="home-content">Home Content</div>
 ) );
 
-jest.mock( 'i18n-calypso', () => ( {
-	useTranslate: () => ( str: string ) => str,
+jest.mock( 'calypso/landing/stepper/utils/skip-launchpad', () => ( {
+	skipLaunchpad: jest.fn(),
 } ) );
 
-jest.mock( 'calypso/components/main', () => ( { children }: { children: React.ReactNode } ) => (
-	<div data-testid="main">{ children }</div>
-) );
+jest.mock( 'calypso/state/sites/actions', () => ( {
+	requestSite: jest.fn().mockReturnValue( () => {} ),
+} ) );
 
 jest.mock( 'calypso/components/data/document-head', () => () => null );
 jest.mock( 'calypso/lib/analytics/page-view-tracker', () => () => null );
@@ -52,10 +45,11 @@ function makeTestSite( site: Partial< SiteDetails > = {} ): SiteDetails {
 describe( 'Make sure CustomerHome render traditional home or Focused Launchpad', () => {
 	it( 'should show HomeContent for launched site', () => {
 		const testSite = makeTestSite( { launch_status: 'launched' } );
-		render( <CustomerHome site={ testSite } /> );
+
+		renderWithProvider( <CustomerHome site={ testSite } /> );
 
 		expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument();
-		expect( screen.queryByTestId( 'launchpad' ) ).not.toBeInTheDocument();
+		expect( screen.queryByTestId( 'launchpad-first' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should show HomeContent for unlaunched site when launchpad is skipped', () => {
@@ -63,10 +57,11 @@ describe( 'Make sure CustomerHome render traditional home or Focused Launchpad',
 			launch_status: 'unlaunched',
 			options: { launchpad_screen: 'skipped' },
 		} );
-		render( <CustomerHome site={ testSite } /> );
+
+		renderWithProvider( <CustomerHome site={ testSite } /> );
 
 		expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument();
-		expect( screen.queryByTestId( 'launchpad' ) ).not.toBeInTheDocument();
+		expect( screen.queryByTestId( 'launchpad-first' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should show Launchpad when site is unlaunched, created by onboarding flow, and launchpad is unskipped', async () => {
@@ -74,18 +69,19 @@ describe( 'Make sure CustomerHome render traditional home or Focused Launchpad',
 			launch_status: 'unlaunched',
 			options: { site_creation_flow: 'onboarding', launchpad_screen: false },
 		} );
-		render( <CustomerHome site={ testSite } /> );
 
-		expect( screen.getByTestId( 'launchpad' ) ).toBeInTheDocument();
+		renderWithProvider( <CustomerHome site={ testSite } /> );
+
+		expect( screen.getByTestId( 'launchpad-first' ) ).toBeInTheDocument();
 		expect( screen.queryByTestId( 'home-content' ) ).not.toBeInTheDocument();
 
 		// Click the close button
-		await act( async () => {
-			screen.getByTestId( 'close-launchpad' ).click();
+		act( () => {
+			screen.getByText( 'Skip to dashboard' ).click();
 		} );
 
 		// Verify HomeContent is now shown
 		expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument();
-		expect( screen.queryByTestId( 'launchpad' ) ).not.toBeInTheDocument();
+		expect( screen.queryByTestId( 'launchpad-first' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
@@ -85,8 +85,7 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 			<div className="launched__modal-upsell">
 				<div className="launched__modal-upsell-content">{ contentElement }</div>
 				<Button
-					isLarge
-					isPrimary
+					variant="primary"
 					href={ buttonHref }
 					onClick={ () =>
 						dispatch(

--- a/client/my-sites/customer-home/components/full-screen-launchpad.scss
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.scss
@@ -82,17 +82,13 @@
             }
         }
 
-		&:nth-last-child(2) {
+		&:last-child {
 			border-radius: 0 0 4px 4px;
             border-bottom: 1px solid var(--studio-gray-5);
 
             a, button {
                 border-radius: 0 0 2px 2px;
             }
-		}
-
-		&:last-child {
-			display: none;
 		}
 	}
 
@@ -110,7 +106,7 @@
 		.components-button {
 			font-size: 1rem;
 		}
-		
+
 		.launchpad-site-launch {
 			order: 0;
 		}

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -117,6 +117,7 @@ export const FullScreenLaunchpad = ( {
 					siteSlug={ siteSlug }
 					checklistSlug={ checklistSlug }
 					launchpadContext={ launchpadContext }
+					onPostFilterTasks={ ( tasks ) => tasks.filter( ( task ) => ! task.isLaunchTask ) }
 					onSiteLaunched={ onSiteLaunched }
 					highlightNextAction
 				/>

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -97,7 +97,7 @@ export const FullScreenLaunchpad = ( {
 		completedSteps >= numberOfSteps - ( launchSiteTask ? 1 : 0 );
 
 	return (
-		<div className="is-launchpad-first" css={ { width: '100%' } }>
+		<div data-testid="launchpad-first" className="is-launchpad-first" css={ { width: '100%' } }>
 			<div
 				className={ clsx( `customer-home-launchpad customer-home__card is-small-hero`, {
 					'all-tasks-completed': isAllTasksCompleted,

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -1,4 +1,4 @@
-import { CircularProgressBar, ConfettiAnimation } from '@automattic/components';
+import { CircularProgressBar } from '@automattic/components';
 import { updateLaunchpadSettings, useSortedLaunchpadTasks } from '@automattic/data-stores';
 import { Launchpad, Task } from '@automattic/launchpad';
 import { Button } from '@wordpress/components';
@@ -17,7 +17,13 @@ import { AppState } from 'calypso/types';
 import { useLaunchpad } from '../cards/launchpad/use-launchpad';
 import './full-screen-launchpad.scss';
 
-export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ): JSX.Element | null => {
+export const FullScreenLaunchpad = ( {
+	onClose,
+	onSiteLaunch,
+}: {
+	onClose: () => void;
+	onSiteLaunch: () => void;
+} ): JSX.Element | null => {
 	const dispatch = useDispatch();
 	const { __ } = useI18n();
 	const [ isLaunching, setIsLaunching ] = useState( false );
@@ -53,7 +59,7 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ): JSX
 					await refetch?.();
 					await layout?.refetch();
 					await dispatch( requestSite( siteId ) );
-					onClose();
+					onSiteLaunch();
 				} finally {
 					setIsLaunching( false );
 				}
@@ -107,7 +113,6 @@ export const FullScreenLaunchpad = ( { onClose }: { onClose: () => void } ): JSX
 					<h2>{ ! isAllTasksCompleted ? __( "Let's get started!" ) : __( "You're all set!" ) }</h2>
 					<span>{ ! isAllTasksCompleted && launchpadTitle }</span>
 				</div>
-				{ isAllTasksCompleted && <ConfettiAnimation /> }
 				<Launchpad
 					siteSlug={ siteSlug }
 					checklistSlug={ checklistSlug }

--- a/client/my-sites/customer-home/main.tsx
+++ b/client/my-sites/customer-home/main.tsx
@@ -1,9 +1,12 @@
+import { ConfettiAnimation } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
+import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import shouldShowLaunchpadFirst from 'calypso/state/selectors/should-show-launchpad-first';
+import CelebrateLaunchModal from './components/celebrate-launch-modal';
 import { FullScreenLaunchpad } from './components/full-screen-launchpad';
 import HomeContent from './components/home-content';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -22,14 +25,36 @@ export default function CustomerHome( { site }: { site: SiteDetails } ) {
 
 	const translate = useTranslate();
 
+	const [ showSiteLaunchedModal, setShowSiteLaunchedModal ] = useState( false );
+
+	const { data: allDomains = [] } = useGetDomainsQuery( site?.ID ?? null, {
+		retry: false,
+	} );
+
 	return (
 		<Main wideLayout>
 			<PageViewTracker path="/home/:site" title={ translate( 'My Home' ) } />
 			<DocumentHead title={ translate( 'My Home' ) } />
 			{ isShowingLaunchpad ? (
-				<FullScreenLaunchpad onClose={ () => setIsShowingLaunchpad( false ) } />
+				<FullScreenLaunchpad
+					onClose={ () => setIsShowingLaunchpad( false ) }
+					onSiteLaunch={ () => {
+						setIsShowingLaunchpad( false );
+						setShowSiteLaunchedModal( true );
+					} }
+				/>
 			) : (
 				<HomeContent />
+			) }
+			{ showSiteLaunchedModal && (
+				<>
+					<ConfettiAnimation />
+					<CelebrateLaunchModal
+						setModalIsOpen={ setShowSiteLaunchedModal }
+						site={ site }
+						allDomains={ allDomains }
+					/>
+				</>
 			) }
 		</Main>
 	);

--- a/client/my-sites/customer-home/test/customer-home.tsx
+++ b/client/my-sites/customer-home/test/customer-home.tsx
@@ -1,11 +1,16 @@
 /**
  * @jest-environment jsdom
  */
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import nock from 'nock';
 import React, { act } from 'react';
+import { reducer as ui } from 'calypso/state/ui/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
-import CustomerHome from '../../../main';
+import CustomerHome from '../main';
 import type { SiteDetails } from '@automattic/data-stores';
+
+jest.mock( '@wordpress/api-fetch' );
 
 jest.mock( '@automattic/calypso-config', () => {
 	const config = () => 'development';
@@ -13,7 +18,7 @@ jest.mock( '@automattic/calypso-config', () => {
 	return config;
 } );
 
-jest.mock( '../../../components/home-content', () => () => (
+jest.mock( '../components/home-content', () => () => (
 	<div data-testid="home-content">Home Content</div>
 ) );
 
@@ -32,7 +37,7 @@ function makeTestSite( site: Partial< SiteDetails > = {} ): SiteDetails {
 	return {
 		ID: 1,
 		title: 'Test Site',
-		slug: 'https://example.com',
+		slug: 'example.com',
 		URL: 'https://example.com',
 		domain: 'example.com',
 		launch_status: 'launched',
@@ -42,7 +47,15 @@ function makeTestSite( site: Partial< SiteDetails > = {} ): SiteDetails {
 	} as any; // This partial site object should be good enough for testing purposes
 }
 
-describe( 'Make sure CustomerHome render traditional home or Focused Launchpad', () => {
+describe( 'CustomerHome', () => {
+	beforeEach( () => {
+		nock.disableNetConnect();
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
+	} );
+
 	it( 'should show HomeContent for launched site', () => {
 		const testSite = makeTestSite( { launch_status: 'launched' } );
 
@@ -83,5 +96,59 @@ describe( 'Make sure CustomerHome render traditional home or Focused Launchpad',
 		// Verify HomeContent is now shown
 		expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument();
 		expect( screen.queryByTestId( 'launchpad-first' ) ).not.toBeInTheDocument();
+	} );
+
+	it.only( 'should show the site launched modal once the site is launched', async () => {
+		const testSite = makeTestSite( {
+			launch_status: 'unlaunched',
+			options: { site_creation_flow: 'onboarding', site_intent: 'write', launchpad_screen: false },
+		} );
+
+		nock( 'https://public-api.wordpress.com' ).get( '/wpcom/v2/sites/1/home/layout' ).reply( 200, {
+			primary: [],
+			secondary: [],
+		} );
+
+		const data = {
+			checklist_statuses: {
+				design_completed: true,
+				site_theme_selected: true,
+				site_launched: false,
+				site_edited: true,
+			},
+			launchpad_screen: 'full',
+			site_intent: 'write',
+			checklist: [
+				{
+					id: 'site_launched',
+					isLaunchTask: true,
+					title: 'Launch your site',
+					completed: false,
+				},
+			],
+		};
+
+		jest.mocked( apiFetch ).mockResolvedValue( data );
+
+		renderWithProvider( <CustomerHome site={ testSite } />, {
+			reducers: { ui },
+			initialState: {
+				sites: {
+					items: {
+						[ testSite.ID ]: testSite,
+					},
+				},
+				ui: {
+					selectedSiteId: testSite.ID,
+				},
+			},
+		} );
+
+		const launchSiteButton = await screen.findByRole( 'button', { name: 'Launch your site' } );
+
+		// Click the Launch site button
+		act( () => launchSiteButton.click() );
+
+		expect( await screen.findByText( 'Congrats, your site is live!' ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/my-sites/customer-home/test/customer-home.tsx
+++ b/client/my-sites/customer-home/test/customer-home.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 import nock from 'nock';
 import React, { act } from 'react';
@@ -98,7 +98,7 @@ describe( 'CustomerHome', () => {
 		expect( screen.queryByTestId( 'launchpad-first' ) ).not.toBeInTheDocument();
 	} );
 
-	it.only( 'should show the site launched modal once the site is launched', async () => {
+	it( 'should show the site launched modal once the site is launched', async () => {
 		const testSite = makeTestSite( {
 			launch_status: 'unlaunched',
 			options: { site_creation_flow: 'onboarding', site_intent: 'write', launchpad_screen: false },


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/99735.

## Proposed Changes


https://github.com/user-attachments/assets/5e284ede-38da-4934-88e0-1ddd61488c16



## Testing Instructions

Verify you only see the confetti and the "your site is live" modal ONCE after pressing the "Launch site" button.