### PR TITLE
Use DataViews for all domains list

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain-header/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain-header/index.tsx
@@ -4,7 +4,7 @@ import NavigationHeader from 'calypso/components/navigation-header';
 
 import './style.scss';
 
-type NavigationItem = {
+export type NavigationItem = {
 	label: string;
 	subtitle?: string | ReactNode;
 	href?: string;

--- a/client/my-sites/domains/domain-management/dataviews/components/auto-renew-dialog.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/components/auto-renew-dialog.tsx
@@ -1,0 +1,83 @@
+import { SelectDropdown } from '@automattic/components';
+import { PartialDomainData } from '@automattic/data-stores';
+import transformIcon from '@automattic/domains-table/src/bulk-actions-toolbar/transform.svg';
+import { RenderModalProps } from '@wordpress/dataviews';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import { useDomainsDataViewsContext } from '../use-context';
+
+export const AutoRenewDiolog = ( {
+	items,
+	closeModal,
+	onActionPerformed,
+}: RenderModalProps< PartialDomainData > ) => {
+	const { handleAutoRenew } = useDomainsDataViewsContext();
+	const translate = useTranslate();
+	const [ controlKey, setControlKey ] = useState( 1 );
+
+	const enableLabel = translate( 'Turn {{strong}}on{{/strong}} auto-renew', {
+		components: { strong: <strong /> },
+	} );
+
+	const disableLabel = translate( 'Turn {{strong}}off{{/strong}} auto-renew', {
+		components: { strong: <strong /> },
+	} );
+
+	const handleAutoRenewSelect = ( { value }: { value: string } ) => {
+		if ( value === 'enable' ) {
+			handleAutoRenew( items, true );
+		} else if ( value === 'disable' ) {
+			handleAutoRenew( items, false );
+		}
+
+		// By default the SelectDropdown will "select" the item that was clicked. We don't
+		// want this so we force the components internal state to be reset, which keeps
+		// the selection set to `initialSelected="button-label"`.
+		setControlKey( ( oldKey ) => oldKey + 1 );
+
+		onActionPerformed?.( items );
+		closeModal?.();
+	};
+
+	return (
+		<div>
+			<p>
+				{ translate(
+					/* translators: domainCount will be the number of domains to update */
+					'Update auto-renew settings for %(domainCount)d domain',
+					'Update auto-renew settings for %(domainCount)d domains',
+					{
+						count: items.length,
+						args: {
+							domainCount: items.length,
+						},
+					}
+				) }
+			</p>
+			<SelectDropdown
+				key={ controlKey }
+				className="domains-table-bulk-actions-toolbar__select"
+				initialSelected="button-label"
+				showSelectedOption={ false }
+				onSelect={ handleAutoRenewSelect }
+				options={ [
+					{
+						value: 'button-label',
+						label: translate( 'Choose new status…' ),
+						icon: (
+							<img
+								className="domains-table-bulk-actions-toolbar__icon"
+								src={ transformIcon }
+								width={ 18 }
+								height={ 18 }
+								alt=""
+							/>
+						),
+					},
+					{ value: 'enable', label: enableLabel },
+					{ value: 'disable', label: disableLabel },
+				] }
+			/>
+		</div>
+	);
+};

--- a/client/my-sites/domains/domain-management/dataviews/components/bulk-update-notice.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/components/bulk-update-notice.tsx
@@ -1,0 +1,73 @@
+import { StatusPopover } from '@automattic/domains-table/src/status-popover';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import wpcomRequest from 'wpcom-proxy-request';
+import Notice from 'calypso/components/notice'; //eslint-disable-line no-restricted-imports
+import NoticeAction from 'calypso/components/notice/notice-action'; //eslint-disable-line no-restricted-imports
+import { useDomainsDataViewsContext } from '../use-context';
+
+export const BulkUpdateNotice = () => {
+	const translate = useTranslate();
+	const { completedJobs, handleRestartDomainStatusPolling, deleteBulkActionStatus } =
+		useDomainsDataViewsContext();
+	const [ dismissedJobs, setDismissedJobs ] = useState< string[] >( [] );
+
+	const handleDismissNotice = async ( jobId: string ) => {
+		setDismissedJobs( dismissedJobs.concat( [ jobId ] ) );
+		if ( deleteBulkActionStatus ) {
+			await deleteBulkActionStatus();
+		} else {
+			await wpcomRequest< void >( {
+				path: '/domains/bulk-actions',
+				apiNamespace: 'wpcom/v2',
+				apiVersion: '2',
+				method: 'DELETE',
+			} );
+		}
+		handleRestartDomainStatusPolling();
+	};
+
+	// completed jobs can be announced
+	return completedJobs
+		.filter( ( job ) => ! dismissedJobs.includes( job.id ) )
+		.map( ( job ) => {
+			if ( job.failed.length ) {
+				return (
+					<Notice
+						key={ job.id }
+						status="is-error"
+						text={ translate( 'Some domain updates were not successful.' ) }
+						onDismissClick={ () => handleDismissNotice( job.id ) }
+					>
+						<StatusPopover
+							position="bottom"
+							popoverTargetElement={
+								<NoticeAction href="#">{ translate( 'See failures' ) } </NoticeAction>
+							}
+						>
+							<div className="domains-table-bulk-actions-notice-popover">
+								{ job.failed.map( ( domain ) => (
+									<p key={ domain }> { domain } </p>
+								) ) }
+							</div>
+						</StatusPopover>
+					</Notice>
+				);
+			}
+
+			const message =
+				job.success.length > 1
+					? translate( 'Bulk domain updates finished successfully.' )
+					: translate( 'Domain update finished successfully.' );
+
+			return (
+				<Notice
+					key={ job.id }
+					status="is-success"
+					onDismissClick={ () => handleDismissNotice( job.id ) }
+				>
+					{ message }
+				</Notice>
+			);
+		} );
+};

--- a/client/my-sites/domains/domain-management/dataviews/dataviews-fields/domain-field.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/dataviews-fields/domain-field.tsx
@@ -1,0 +1,24 @@
+import { PartialDomainData } from '@automattic/data-stores';
+import { PrimaryDomainLabel } from '@automattic/domains-table';
+import { useDomainsDataViewsContext } from '../use-context';
+
+interface Props {
+	domain: PartialDomainData;
+	isAllSitesView: boolean;
+	selectedFeature?: string;
+}
+
+const DomainField = ( { domain: partialDomain, isAllSitesView }: Props ) => {
+	const { getFullDomain } = useDomainsDataViewsContext();
+	const domain = getFullDomain( partialDomain );
+	const showPrimaryDomainLabel = ! isAllSitesView && domain && domain.isPrimary;
+
+	return (
+		<>
+			{ showPrimaryDomainLabel && <PrimaryDomainLabel /> }
+			<div className="domains-dataviews__domain-name">{ partialDomain.domain }</div>
+		</>
+	);
+};
+
+export { DomainField };

--- a/client/my-sites/domains/domain-management/dataviews/dataviews-fields/domain-status-field.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/dataviews-fields/domain-status-field.tsx
@@ -1,0 +1,67 @@
+import { LoadingPlaceholder } from '@automattic/components';
+import { PartialDomainData, SiteDetails } from '@automattic/data-stores';
+import { DomainsTableStatusCell } from '@automattic/domains-table/src/domains-table/domains-table-status-cell';
+import { resolveDomainStatus } from '@automattic/domains-table/src/utils/resolve-domain-status';
+import { useTranslate } from 'i18n-calypso';
+import { useDomainsDataViewsContext } from '../use-context';
+
+interface Props {
+	domain: PartialDomainData;
+}
+
+const DomainStatusField = ( props: Props ) => {
+	const {
+		sites,
+		isLoadingSites,
+		getSiteSlug,
+		getFullDomain,
+		domainResults,
+		updatingDomain,
+		domainStatusPurchaseActions,
+	} = useDomainsDataViewsContext();
+	const translate = useTranslate();
+
+	const domain = getFullDomain( props.domain );
+	if ( ! domain || isLoadingSites ) {
+		return <LoadingPlaceholder />;
+	}
+
+	const siteSlug = getSiteSlug( props.domain );
+
+	const site = sites[ domain.blogId ] && ( sites[ domain.blogId ] as SiteDetails );
+	const pendingUpdates = domainResults.get( domain.domain ) ?? [];
+
+	if ( domain.domain === updatingDomain?.domain && updatingDomain?.message ) {
+		pendingUpdates.unshift( {
+			created_at: updatingDomain?.created_at,
+			message: updatingDomain?.message,
+			status: '',
+		} );
+	}
+
+	const domainStatus = domain
+		? resolveDomainStatus( domain, {
+				siteSlug: siteSlug,
+				translate,
+				getMappingErrors: true,
+				currentRoute: window.location.pathname,
+				isPurchasedDomain: domainStatusPurchaseActions?.isPurchasedDomain?.( domain ),
+				isCreditCardExpiring: domainStatusPurchaseActions?.isCreditCardExpiring?.( domain ),
+				onRenewNowClick: () =>
+					domainStatusPurchaseActions?.onRenewNowClick?.( siteSlug ?? '', domain ),
+				monthsUtilCreditCardExpires:
+					domainStatusPurchaseActions?.monthsUtilCreditCardExpires?.( domain ),
+				isVipSite: site?.is_vip,
+		  } )
+		: null;
+
+	return (
+		<DomainsTableStatusCell
+			domainStatus={ domainStatus }
+			pendingUpdates={ pendingUpdates }
+			as="div"
+		/>
+	);
+};
+
+export { DomainStatusField };

--- a/client/my-sites/domains/domain-management/dataviews/dataviews-fields/domain-type.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/dataviews-fields/domain-type.tsx
@@ -1,0 +1,20 @@
+import { PartialDomainData } from '@automattic/data-stores';
+import { domainInfoContext } from '@automattic/domains-table/src/utils/constants';
+import { getDomainTypeText } from '@automattic/domains-table/src/utils/get-domain-type-text';
+import { useI18n } from '@wordpress/react-i18n';
+import { useDomainsDataViewsContext } from '../use-context';
+
+const DomainType = ( { item }: { item: PartialDomainData } ) => {
+	const { __ } = useI18n();
+	const { getFullDomain } = useDomainsDataViewsContext();
+	const domain = getFullDomain( item );
+	const domainTypeText = domain
+		? getDomainTypeText( domain, __, domainInfoContext.DOMAIN_ROW )
+		: '';
+
+	return (
+		domainTypeText && <div className="domains-table-row__domain-type-text">{ domainTypeText }</div>
+	);
+};
+
+export { DomainType };

--- a/client/my-sites/domains/domain-management/dataviews/dataviews-fields/ssl-status-field.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/dataviews-fields/ssl-status-field.tsx
@@ -1,0 +1,37 @@
+import { LoadingPlaceholder } from '@automattic/components';
+import { PartialDomainData } from '@automattic/data-stores';
+import DomainsTableSslCell from '@automattic/domains-table/src/domains-table/domains-table-ssl-cell';
+import { domainManagementLink as getDomainManagementLink } from '@automattic/domains-table/src/utils/paths';
+import { useDomainsDataViewsContext } from '../use-context';
+
+interface Props {
+	domain: PartialDomainData;
+}
+
+const SslStatusField = ( props: Props ) => {
+	const { getFullDomain, getSiteSlug, isLoadingSites } = useDomainsDataViewsContext();
+	const domain = getFullDomain( props.domain );
+
+	if ( ! domain || isLoadingSites ) {
+		return <LoadingPlaceholder />;
+	}
+
+	const siteSlug = getSiteSlug( props.domain );
+
+	const domainManagementLink = ! domain.isWPCOMDomain
+		? getDomainManagementLink( domain, siteSlug, true )
+		: '';
+
+	const hasWpcomManagedSslCert = domain.type === 'wpcom';
+
+	return (
+		<DomainsTableSslCell
+			domainManagementLink={ domainManagementLink }
+			sslStatus={ domain.sslStatus }
+			hasWpcomManagedSslCert={ hasWpcomManagedSslCert }
+			as="div"
+		/>
+	);
+};
+
+export { SslStatusField };

--- a/client/my-sites/domains/domain-management/dataviews/domains-dataviews.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/domains-dataviews.tsx
@@ -1,0 +1,134 @@
+import { PartialDomainData } from '@automattic/data-stores';
+import { domainManagementLink as getDomainManagementLink } from '@automattic/domains-table/src/utils/paths';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useMemo, useState } from 'react';
+import { navigate } from 'calypso/lib/navigate';
+import { addQueryArgs } from 'calypso/lib/url';
+import { BulkUpdateNotice } from './components/bulk-update-notice';
+import {
+	DEFAULT_PER_PAGE,
+	DEFAULT_SORT_FIELD,
+	DEFAULT_SORT_DIRECTION,
+	buildPathWithQueryParams,
+	getQueryParams,
+} from './query-params';
+import { useActions } from './use-actions';
+import { useDomainsDataViewsContext } from './use-context';
+import { getDomainId } from './use-domains';
+import './style.scss';
+import { useFields } from './use-fields';
+import { initializeViewState, getFieldsByBreakpoint } from './view';
+
+type Props = {
+	domains: PartialDomainData[] | undefined;
+	isLoading: boolean;
+	sidebarMode?: boolean;
+	selectedDomainName?: string;
+};
+
+export const DomainsDataViews = ( {
+	domains,
+	isLoading,
+	sidebarMode,
+	selectedDomainName,
+}: Props ) => {
+	const translate = useTranslate();
+	const { isDesktop, getSiteSlug, selectedFeature } = useDomainsDataViewsContext();
+
+	const queryParams = getQueryParams();
+	const [ view, setView ] = useState( () =>
+		initializeViewState( isDesktop, queryParams, sidebarMode )
+	);
+	const fields = useFields();
+	const actions = useActions( view.type );
+	const { data: domainsToDisplay, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( domains || [], view, fields );
+	}, [ domains, view, fields ] );
+
+	const [ selectedIds, setSelectedIds ] = useState< string[] >( [] );
+	const selectedDomain = domainsToDisplay
+		.filter( ( d: PartialDomainData ) => d.domain === selectedDomainName )
+		.pop();
+
+	useEffect( () => {
+		const fieldsForBreakpoint = getFieldsByBreakpoint( isDesktop, sidebarMode );
+		const sortedFieldsForBreakpoint = [ ...fieldsForBreakpoint ].sort().toString();
+		const sortedExistingFields = [ ...( view?.fields ?? [] ) ].sort().toString();
+		// Compare the content of the arrays, not its referrences that will always be different.
+		// sort() sorts the array in place, so we need to clone them first.
+		if ( sortedExistingFields !== sortedFieldsForBreakpoint ) {
+			setView( ( prevState ) => ( { ...prevState, fields: fieldsForBreakpoint } ) );
+		}
+	}, [ isDesktop, sidebarMode, view, setView ] );
+
+	// Update URL with view control params on change.
+	useEffect( () => {
+		const queryParams = {
+			search: view.search?.trim(),
+			page: view.page && view.page > 1 ? view.page : undefined,
+			perPage: view.perPage === DEFAULT_PER_PAGE ? undefined : view.perPage,
+			sortField: view.sort?.field === DEFAULT_SORT_FIELD ? undefined : view.sort?.field,
+			sortDirection:
+				view.sort?.direction === DEFAULT_SORT_DIRECTION ? undefined : view.sort?.direction,
+		};
+
+		window.setTimeout( () => {
+			const url = buildPathWithQueryParams( queryParams );
+			navigate( url, false, false );
+		} );
+	}, [ view.search, view.page, view.perPage, view.sort?.field, view.sort?.direction ] );
+
+	const layout = sidebarMode ? { list: {} } : { table: {} };
+
+	const onClickDomain = ( item: PartialDomainData ) => {
+		const siteSlug = getSiteSlug( item );
+		const domainManagementLink = ! item.wpcom_domain
+			? addQueryArgs(
+					getQueryParams(),
+					getDomainManagementLink( item, siteSlug, true, selectedFeature )
+			  )
+			: '';
+
+		if ( ! domainManagementLink ) {
+			return;
+		}
+
+		navigate( domainManagementLink );
+	};
+
+	const onChangeSelection = ( items: string[] ) => {
+		setSelectedIds( items );
+		if ( view.type === 'list' ) {
+			const selectedItem = domains?.find( ( d ) => getDomainId( d ) === items[ 0 ] );
+			if ( selectedItem ) {
+				onClickDomain( selectedItem );
+			}
+		}
+	};
+
+	return (
+		<>
+			{ ! sidebarMode && <BulkUpdateNotice /> }
+			<div className={ clsx( 'domains-dataviews', { 'domains-dataviews-list': sidebarMode } ) }>
+				<DataViews
+					data={ domainsToDisplay }
+					fields={ fields }
+					onChangeView={ ( newView ) => setView( () => newView ) }
+					onClickItem={ onClickDomain }
+					view={ view }
+					actions={ actions }
+					search
+					searchLabel={ translate( 'Search by domain…' ) }
+					paginationInfo={ paginationInfo }
+					getItemId={ getDomainId }
+					selection={ selectedDomain ? [ getDomainId( selectedDomain ) ] : selectedIds }
+					onChangeSelection={ onChangeSelection }
+					isLoading={ isLoading }
+					defaultLayouts={ layout }
+				/>
+			</div>
+		</>
+	);
+};

--- a/client/my-sites/domains/domain-management/dataviews/index.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/index.tsx
@@ -1,0 +1,14 @@
+import { DomainsDataViews } from './domains-dataviews';
+import { DomainsDataViewsProps } from './types';
+import { useGenerateDomainsDataViewsState, DomainsDataViewsContext } from './use-context';
+
+const DotcomDomainsDataViews = ( props: DomainsDataViewsProps ) => {
+	const state = useGenerateDomainsDataViewsState( props );
+	return (
+		<DomainsDataViewsContext.Provider value={ state }>
+			<DomainsDataViews { ...props } />
+		</DomainsDataViewsContext.Provider>
+	);
+};
+
+export default DotcomDomainsDataViews;

--- a/client/my-sites/domains/domain-management/dataviews/query-params.ts
+++ b/client/my-sites/domains/domain-management/dataviews/query-params.ts
@@ -1,0 +1,54 @@
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_PER_PAGE = 50;
+export const DEFAULT_SORT_FIELD = 'domain_name';
+export const DEFAULT_SORT_DIRECTION = 'asc';
+
+export type QueryParams = {
+	page?: number;
+	perPage?: number;
+	search?: string;
+	sortField?: string;
+	sortDirection?: 'asc' | 'desc';
+};
+
+const getDefaultParams = () => ( {
+	page: DEFAULT_PAGE,
+	perPage: DEFAULT_PER_PAGE,
+	search: '',
+	sortField: DEFAULT_SORT_FIELD,
+	sortDirection: DEFAULT_SORT_DIRECTION,
+} );
+
+export function getQueryParams() {
+	const queryParams = new URLSearchParams( window.location.search );
+	return {
+		...getDefaultParams(),
+		page: queryParams.get( 'page' )?.length
+			? parseInt( queryParams.get( 'page' ) as string, 10 )
+			: DEFAULT_PAGE,
+		perPage: queryParams.get( 'perPage' )?.length
+			? parseInt( queryParams.get( 'perPage' ) as string, 10 )
+			: DEFAULT_PER_PAGE,
+		search: queryParams.get( 'search' ),
+		sortField: queryParams.get( 'sortField' ) || DEFAULT_SORT_FIELD,
+		sortDirection:
+			queryParams.get( 'sortDirection' ) &&
+			[ 'asc', 'desc' ].includes( queryParams.get( 'sortDirection' ) as string )
+				? queryParams.get( 'sortDirection' )
+				: DEFAULT_SORT_DIRECTION,
+	} as QueryParams;
+}
+
+export function buildPathWithQueryParams( queryParams: QueryParams ) {
+	const url = new URL( window.location.href );
+	Object.keys( queryParams ).forEach( ( key ) => {
+		const value = queryParams[ key as keyof QueryParams ];
+		if ( value ) {
+			url.searchParams.set( key, value.toString() );
+		} else {
+			url.searchParams.delete( key );
+		}
+	} );
+
+	return url.pathname + url.search + url.hash;
+}

--- a/client/my-sites/domains/domain-management/dataviews/style.scss
+++ b/client/my-sites/domains/domain-management/dataviews/style.scss
@@ -1,0 +1,147 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/dataviews/build-style/style.css";
+
+body.is-section-domains.is-bulk-all-domains-page {
+	main.dataviews {
+		background: var(--color-surface);
+		max-width: none;
+		height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
+		display: flex;
+		flex-direction: column;
+		flex-wrap: nowrap;
+		overflow-y: auto;
+
+		.navigation-header {
+			padding-top: 24px;
+
+			.formatted-header {
+				max-height: 41px;
+			}
+
+			.navigation-header__main {
+				align-items: center;
+			}
+
+			.formatted-header__title {
+				color: var( --studio-gray-80, #2c3338 );
+				font-size: 1.5rem;
+				font-style: normal;
+				font-weight: 500;
+				line-height: 1.2;
+			}
+
+			.domain-header__buttons .button {
+				line-height: 22px;
+				white-space: nowrap;
+				margin-left: 0;
+			}
+
+			.domain-header__buttons-mobile {
+				white-space: nowrap;
+			}
+		}
+
+		.domains-dataviews {
+			flex-grow: 1;
+			margin-top: 0;
+			overflow: hidden;
+			padding-bottom: 0;
+
+			.domains-dataviews__domain-name-button {
+				width: 100%;
+				height: 100%;
+				display: inline-block;
+				padding: 0;
+
+				div {
+					text-align: left;
+				}
+			}
+
+			&.domains-dataviews-list {
+				.domains-dataviews__domain-name-button {
+					width: 280px;
+				}
+			}
+
+			.domains-dataviews__domain-name {
+				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+				font-size: 14px;
+				font-weight: 500;
+
+				a:hover {
+					text-decoration: underline;
+					color: var(--color-link);
+				}
+			}
+
+			.domains-dataviews__primary-domain-label {
+				margin-bottom: 4px;
+			}
+
+			.list-status-cell__bubble {
+				display: flex;
+				width: 18px;
+				background: var(--studio-red-40);
+				border-radius: 16px; /* stylelint-disable-line scales/radii */
+				justify-content: center;
+				align-items: center;
+				color: #fff;
+				font-size: $font-body-extra-small;
+				height: 18px;
+				margin: 0 4px;
+				line-height: 20px;
+			}
+
+			.domains-table-row__ssl-cell {
+				gap: 2px;
+				display: flex;
+
+
+				&__active {
+					fill: var(--studio-green-50);
+					color: var(--studio-green-50);
+				}
+
+				&__pending,
+				&__disabled {
+					fill: var(--studio-orange-50);
+					color: var(--studio-orange-50);
+				}
+			}
+
+			.domains-table-row__ssl-status-button {
+				color: inherit;
+			}
+
+			.domains-table-row__status-cell {
+				white-space: pre-line;
+				display: flex;
+				align-items: center;
+				gap: 4px;
+				font-size: $font-body-small;
+
+				svg {
+					color: currentColor;
+				}
+
+				&__status-success,
+				&__status-premium {
+					color: var(--studio-green-50);
+				}
+
+				&__status-verifying,
+				&__status-warning {
+					color: var(--studio-orange-50);
+				}
+
+				&__status-alert,
+				&__status-error {
+					color: var(--studio-red-50);
+				}
+			}
+		}
+	}
+}
+

--- a/client/my-sites/domains/domain-management/dataviews/types.ts
+++ b/client/my-sites/domains/domain-management/dataviews/types.ts
@@ -1,0 +1,108 @@
+import {
+	DomainUpdateStatus,
+	JobStatus,
+	BulkUpdateVariables,
+	BulkDomainUpdateStatusQueryFnData,
+	PartialDomainData,
+} from '@automattic/data-stores';
+import { SiteDomainsQueryFnData } from '@automattic/data-stores/src/queries/use-site-domains-query';
+import { DomainStatusPurchaseActions, ResponseDomain } from '@automattic/domains-table';
+import { DomainAction } from '@automattic/domains-table/src/domains-table/domains-table-row-actions';
+import { SiteExcerptData } from '@automattic/sites';
+
+/**
+ * Utility type for domain action descriptions.
+ */
+type DomainActionDescription = {
+	message?: string;
+	action: () => void | Promise< void >;
+};
+
+/**
+ * Utility type for domain action handlers.
+ */
+export type OnDomainAction = (
+	action: DomainAction,
+	domain: ResponseDomain
+) => DomainActionDescription | void;
+
+/**
+ * Utility type for updating domain state.
+ */
+interface DomainsDataViewsUpdatingDomain {
+	action: DomainAction;
+	domain: string;
+	created_at: number;
+	message?: string;
+}
+
+type DomainsDataViewUsage = 'domains' | 'site' | string;
+
+/**
+ * Base props for the domains DataViews.
+ */
+interface BaseDomainsDataViewsProps {
+	className?: string;
+	domains: PartialDomainData[] | undefined;
+	isLoading: boolean;
+	selectedItem: PartialDomainData | null | undefined;
+	isAllSitesView: boolean;
+	domainStatusPurchaseActions?: DomainStatusPurchaseActions;
+	onDomainAction?: OnDomainAction;
+	userCanSetPrimaryDomains?: boolean;
+	hideCheckbox?: boolean;
+	isLoadingDomains?: boolean;
+	useMobileCards?: boolean;
+	sidebarMode?: boolean;
+	selectedDomainName?: string;
+	selectedFeature?: string;
+	fetchSiteDomains?: (
+		siteIdOrSlug: number | string | null | undefined
+	) => Promise< SiteDomainsQueryFnData >;
+	createBulkAction?: ( variables: BulkUpdateVariables ) => Promise< void >;
+	fetchBulkActionStatus?: () => Promise< BulkDomainUpdateStatusQueryFnData >;
+	deleteBulkActionStatus?: () => Promise< void >;
+	currentUserCanBulkUpdateContactInfo?: boolean;
+	hasConnectableSites?: boolean;
+	context?: DomainsDataViewUsage;
+}
+
+/**
+ * Props for the domains DataViews, extends the base props with additional properties.
+ */
+export type DomainsDataViewsProps =
+	| ( BaseDomainsDataViewsProps & { isAllSitesView: true } )
+	| ( BaseDomainsDataViewsProps & { isAllSitesView: false; siteSlug: string | null } );
+
+/**
+ * Context for the domains DataViews.
+ */
+export interface Context {
+	sites: Record< number, SiteExcerptData >;
+	getFullDomain: ( domain: PartialDomainData ) => ResponseDomain | undefined;
+	getSiteSlug: ( domain: PartialDomainData ) => string;
+	isLoadingSites?: boolean;
+	isLoadingDomains?: boolean;
+	fetchSiteDomains?: (
+		siteIdOrSlug: number | string | null | undefined
+	) => Promise< SiteDomainsQueryFnData >;
+	createBulkAction?: ( variables: BulkUpdateVariables ) => Promise< void >;
+	fetchBulkActionStatus?: () => Promise< BulkDomainUpdateStatusQueryFnData >;
+	deleteBulkActionStatus?: () => Promise< void >;
+	isAllSitesView: boolean;
+	domainStatusPurchaseActions?: DomainStatusPurchaseActions;
+	domainsRequiringAttention?: number;
+	handleAutoRenew: ( domains: PartialDomainData[], enable: boolean ) => void;
+	handleUpdateContactInfo: ( domains: PartialDomainData[] ) => void;
+	onDomainsRequiringAttentionChange: ( domainsRequiringAttention: number ) => void;
+	completedJobs: JobStatus[];
+	domainResults: Map< string, DomainUpdateStatus[] >;
+	handleRestartDomainStatusPolling: () => void;
+	onDomainAction( ...parameters: Parameters< OnDomainAction > ): void;
+	updatingDomain: DomainsDataViewsUpdatingDomain | null;
+	userCanSetPrimaryDomains: BaseDomainsDataViewsProps[ 'userCanSetPrimaryDomains' ];
+	isDesktop: boolean;
+	selectedFeature?: string;
+	hasConnectableSites: boolean;
+	context?: DomainsDataViewUsage;
+}

--- a/client/my-sites/domains/domain-management/dataviews/use-actions.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/use-actions.tsx
@@ -1,0 +1,273 @@
+import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
+import { PartialDomainData, SiteDetails } from '@automattic/data-stores';
+import { canSetAsPrimary } from '@automattic/domains-table/src/utils/can-set-as-primary';
+import {
+	type as domainTypes,
+	transferStatus,
+	useMyDomainInputMode,
+} from '@automattic/domains-table/src/utils/constants';
+import { isFreeUrlDomainName } from '@automattic/domains-table/src/utils/is-free-url-domain-name';
+import { isDomainInGracePeriod } from '@automattic/domains-table/src/utils/is-in-grace-period';
+import { isRecentlyRegistered } from '@automattic/domains-table/src/utils/is-recently-registered';
+import { isDomainRenewable } from '@automattic/domains-table/src/utils/is-renewable';
+import { isDomainUpdateable } from '@automattic/domains-table/src/utils/is-updateable';
+import {
+	domainManagementDNS,
+	domainManagementLink,
+	domainManagementTransferToOtherSiteLink,
+	domainUseMyDomain,
+	domainManagementEditContactInfo,
+} from '@automattic/domains-table/src/utils/paths';
+import { shouldUpgradeToMakeDomainPrimary } from '@automattic/domains-table/src/utils/should-upgrade-to-make-domain-primary';
+import { Action } from '@wordpress/dataviews';
+import { Icon, drawerLeft, info, update } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { navigate } from 'calypso/lib/navigate';
+import { AutoRenewDiolog } from './components/auto-renew-dialog';
+import { useDomainsDataViewsContext } from './use-context';
+
+export function useActions( viewType: 'table' | 'list' | 'grid', onClose?: () => void ) {
+	const translate = useTranslate();
+	const {
+		getFullDomain,
+		sites,
+		getSiteSlug,
+		isAllSitesView,
+		domainStatusPurchaseActions,
+		updatingDomain,
+		userCanSetPrimaryDomains = false,
+		onDomainAction,
+		handleUpdateContactInfo,
+		context,
+	} = useDomainsDataViewsContext();
+
+	const actions: Action< PartialDomainData >[] = [
+		...( viewType !== 'list'
+			? [
+					{
+						id: 'manage-domain',
+						isPrimary: true,
+						icon: drawerLeft,
+						label: ( domains: Array< PartialDomainData > ) => {
+							const domain = domains.length > 0 && domains[ 0 ] && getFullDomain( domains[ 0 ] );
+							return domain && domain.type === domainTypes.TRANSFER
+								? translate( 'View transfer' )
+								: translate( 'View settings' );
+						},
+						callback: ( domains: Array< PartialDomainData > ) => {
+							const domain = domains.length > 0 && domains[ 0 ] && getFullDomain( domains[ 0 ] );
+							if ( ! domain ) {
+								return;
+							}
+							const url = domainManagementLink(
+								domain,
+								getSiteSlug( domains[ 0 ] ),
+								isAllSitesView
+							);
+							navigate( url );
+						},
+						isEligible( partialDomain: PartialDomainData ) {
+							const domain = getFullDomain( partialDomain );
+							if ( ! domain ) {
+								return false;
+							}
+							return domain.type !== domainTypes.WPCOM;
+						},
+					},
+			  ]
+			: [] ),
+		{
+			id: 'manage-dns-settings',
+			callback: ( domains: Array< PartialDomainData > ) => {
+				const domain = domains.length > 0 && domains[ 0 ] && getFullDomain( domains[ 0 ] );
+				if ( domain ) {
+					onDomainAction?.( 'manage-dns-settings', domain );
+					const url = domainManagementDNS( getSiteSlug( domains[ 0 ] ), domain.domain, context );
+					navigate( url );
+				}
+			},
+			label: translate( 'Manage DNS' ),
+			supportsBulk: false,
+			isEligible( partialDomain: PartialDomainData ) {
+				const domain = getFullDomain( partialDomain );
+				if ( ! domain ) {
+					return false;
+				}
+				return (
+					domain.canManageDnsRecords &&
+					domain.transferStatus !== transferStatus.PENDING_ASYNC &&
+					domain.type !== domainTypes.SITE_REDIRECT
+				);
+			},
+		},
+		{
+			id: 'manage-contact-info',
+			icon: <Icon icon={ info } />,
+			callback: ( domains: Array< PartialDomainData > ) => {
+				if ( domains.length === 0 ) {
+					return;
+				}
+				if ( domains.length === 1 ) {
+					const domain = domains[ 0 ];
+					const url = domainManagementEditContactInfo(
+						getSiteSlug( domain ),
+						domain.domain,
+						null,
+						context
+					);
+					navigate( url );
+				} else {
+					handleUpdateContactInfo( domains );
+				}
+			},
+			label: translate( 'Manage contact information' ),
+			supportsBulk: true,
+			isEligible( partialDomain: PartialDomainData ) {
+				const domain = getFullDomain( partialDomain );
+				if ( ! domain ) {
+					return false;
+				}
+				return (
+					domain.currentUserIsOwner &&
+					domain.type === domainTypes.REGISTERED &&
+					( isDomainUpdateable( domain ) || isDomainInGracePeriod( domain ) )
+				);
+			},
+		},
+		{
+			id: 'set-primary-site-address',
+			callback: ( domains: Array< PartialDomainData > ) => {
+				const domain = domains.length > 0 && domains[ 0 ] && getFullDomain( domains[ 0 ] );
+				if ( domain ) {
+					onDomainAction?.( 'set-primary-address', domain );
+					onClose?.();
+				}
+			},
+			label: translate( 'Make primary site address' ),
+			disabled: updatingDomain?.action === 'set-primary-address',
+			supportsBulk: false,
+			isEligible( partialDomain: PartialDomainData ) {
+				const domain = getFullDomain( partialDomain );
+				if ( ! domain ) {
+					return false;
+				}
+
+				const site = sites[ domain.blogId ] && ( sites[ domain.blogId ] as SiteDetails );
+				const canSetPrimaryDomainForSite =
+					site?.plan?.features.active.includes( FEATURE_SET_PRIMARY_CUSTOM_DOMAIN ) ?? false;
+				const isSiteOnFreePlan = site?.plan?.is_free ?? true;
+
+				return (
+					! isAllSitesView &&
+					canSetAsPrimary(
+						domain,
+						shouldUpgradeToMakeDomainPrimary( domain, {
+							isDomainOnly: domain.currentUserCanCreateSiteFromDomainOnly,
+							canSetPrimaryDomainForSite,
+							userCanSetPrimaryDomains,
+							isSiteOnFreePlan,
+						} )
+					) &&
+					! isRecentlyRegistered( domain.registrationDate )
+				);
+			},
+		},
+		{
+			id: 'transfer-domain',
+			callback: ( domains: Array< PartialDomainData > ) => {
+				const domain = domains.length > 0 && domains[ 0 ];
+				if ( domain ) {
+					const url = domainUseMyDomain(
+						getSiteSlug( domain ),
+						domain.domain,
+						useMyDomainInputMode.transferDomain
+					);
+					navigate( url );
+				}
+			},
+			label: translate( 'Transfer to WordPress.com' ),
+			supportsBulk: false,
+			isEligible( partialDomain: PartialDomainData ) {
+				const domain = getFullDomain( partialDomain );
+				if ( ! domain ) {
+					return false;
+				}
+				return domain.type === domainTypes.MAPPED && domain.isEligibleForInboundTransfer;
+			},
+		},
+		{
+			id: 'connect-to-site',
+			callback: ( domains: Array< PartialDomainData > ) => {
+				const domain = domains.length > 0 && domains[ 0 ];
+				if ( domain ) {
+					const url = domainManagementTransferToOtherSiteLink(
+						getSiteSlug( domains[ 0 ] ),
+						domain.domain
+					);
+					navigate( url );
+				}
+			},
+			label: translate( 'Attach to an existing site' ),
+			supportsBulk: false,
+			isEligible( partialDomain: PartialDomainData ) {
+				const domain = getFullDomain( partialDomain );
+				if ( ! domain ) {
+					return false;
+				}
+				return domain.currentUserCanCreateSiteFromDomainOnly;
+			},
+		},
+		{
+			id: 'change-site-address',
+			callback: ( domains: Array< PartialDomainData > ) => {
+				const domain = domains.length > 0 && domains[ 0 ] && getFullDomain( domains[ 0 ] );
+				if ( domain ) {
+					onDomainAction?.( 'change-site-address', domain );
+					onClose?.();
+				}
+			},
+			label: translate( 'Change site address' ),
+			supportsBulk: false,
+			isEligible( domain: PartialDomainData ) {
+				const site = sites[ domain.blog_id ] && ( sites[ domain.blog_id ] as SiteDetails );
+				const isSimpleSite = ! site?.is_wpcom_atomic;
+				return ! isAllSitesView && isSimpleSite && isFreeUrlDomainName( domain.domain );
+			},
+		},
+		{
+			id: 'renew-domain',
+			callback: ( domains: Array< PartialDomainData > ) => {
+				const domain = domains.length > 0 && domains[ 0 ] && getFullDomain( domains[ 0 ] );
+				if ( domain ) {
+					domainStatusPurchaseActions?.onRenewNowClick?.( domain.domain ?? '', domain );
+					onClose?.();
+				}
+			},
+			label: translate( 'Renew now' ),
+			supportsBulk: false,
+			isEligible( partialDomain: PartialDomainData ) {
+				const domain = getFullDomain( partialDomain );
+				if ( ! domain ) {
+					return false;
+				}
+				return isDomainRenewable( domain );
+			},
+		},
+		{
+			id: 'manage-auto-renew',
+			icon: <Icon icon={ update } />,
+			label: translate( 'Manage auto-renew' ),
+			supportsBulk: true,
+			isEligible( partialDomain: PartialDomainData ) {
+				const domain = getFullDomain( partialDomain );
+				if ( ! domain ) {
+					return false;
+				}
+				return isDomainRenewable( domain );
+			},
+			RenderModal: ( props ) => <AutoRenewDiolog { ...props } />,
+		},
+	];
+
+	return actions;
+}

--- a/client/my-sites/domains/domain-management/dataviews/use-context.ts
+++ b/client/my-sites/domains/domain-management/dataviews/use-context.ts
@@ -1,0 +1,212 @@
+import page from '@automattic/calypso-router';
+import {
+	PartialDomainData,
+	getSiteDomainsQueryObject,
+	useDomainsBulkActionsMutation,
+} from '@automattic/data-stores';
+import { ResponseDomain } from '@automattic/domains-table';
+import { useDomainBulkUpdateStatus } from '@automattic/domains-table/src/use-domain-bulk-update-status';
+import { createSiteDomainObject } from '@automattic/domains-table/src/utils/assembler';
+import { SiteExcerptData } from '@automattic/sites';
+import { DESKTOP_BREAKPOINT } from '@automattic/viewport';
+import { useBreakpoint } from '@automattic/viewport-react';
+import { useQueries } from '@tanstack/react-query';
+import { addQueryArgs } from '@wordpress/url';
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
+import { Context, DomainsDataViewsProps } from './types';
+
+export const DomainsDataViewsContext = createContext< Context | undefined >( undefined );
+
+export const useDomainsDataViewsContext = () => useContext( DomainsDataViewsContext ) as Context;
+
+export const useGenerateDomainsDataViewsState = ( props: DomainsDataViewsProps ) => {
+	const {
+		domains: allDomains,
+		fetchSiteDomains,
+		createBulkAction,
+		fetchBulkActionStatus,
+		deleteBulkActionStatus,
+		isAllSitesView,
+		domainStatusPurchaseActions,
+		onDomainAction,
+		userCanSetPrimaryDomains,
+		isLoadingDomains,
+		selectedFeature,
+		hasConnectableSites,
+		context: dataViewsUsage,
+	} = props;
+
+	const isDesktop = useBreakpoint( DESKTOP_BREAKPOINT );
+	const [ domainsRequiringAttention, setDomainsRequiringAttention ] = useState<
+		number | undefined
+	>( undefined );
+
+	const domains = useMemo( () => {
+		if ( isAllSitesView || ! allDomains ) {
+			return allDomains;
+		}
+
+		const hasWpcomStagingDomain = allDomains.find(
+			( domain: PartialDomainData ) => domain.is_wpcom_staging_domain
+		);
+
+		if ( ! hasWpcomStagingDomain ) {
+			return allDomains;
+		}
+
+		return allDomains.filter( ( domain: PartialDomainData ) => {
+			if ( domain.wpcom_domain ) {
+				return domain.is_wpcom_staging_domain;
+			}
+
+			return true;
+		} );
+	}, [ allDomains, isAllSitesView ] );
+
+	const allSiteIds = [
+		...new Set( domains?.map( ( domain: PartialDomainData ) => domain.blog_id ) ?? [] ),
+	];
+
+	const allSiteDomains = useQueries( {
+		queries: allSiteIds.map( ( siteId ) =>
+			getSiteDomainsQueryObject( siteId, {
+				...( fetchSiteDomains && { queryFn: () => fetchSiteDomains( siteId ) } ),
+			} )
+		),
+	} );
+
+	const siteDomains = useMemo( () => {
+		const fetchedSiteDomains: Record< number, ResponseDomain[] > = {};
+		for ( const { data } of allSiteDomains ) {
+			const siteId = data?.domains?.[ 0 ]?.blog_id;
+			if ( typeof siteId === 'number' ) {
+				fetchedSiteDomains[ siteId ] = data?.domains.map( createSiteDomainObject ) ?? [];
+			}
+		}
+		return fetchedSiteDomains;
+	}, [ allSiteDomains ] );
+
+	const getFullDomain = ( domain: PartialDomainData ) => {
+		const domains = siteDomains[ domain.blog_id ] ?? [];
+		return domains.find( ( d ) => d.name === domain.domain );
+	};
+
+	const sitesFilterCallback = ( site: SiteExcerptData ) => {
+		return allSiteIds.includes( site.ID );
+	};
+
+	const { data: allSites = [], isLoading: isLoadingSites } = useSiteExcerptsQuery(
+		[],
+		sitesFilterCallback,
+		'all',
+		[ 'is_a4a_dev_site', 'site_migration', 'is_vip' ],
+		[ 'theme_slug' ]
+	);
+
+	const sites = allSites.reduce(
+		( acc, site ) => {
+			const siteId = site.ID;
+			if ( typeof siteId === 'number' ) {
+				acc[ siteId ] = site;
+			}
+			return acc;
+		},
+		{} as Record< number, SiteExcerptData >
+	);
+
+	const getSiteSlug = ( domain: PartialDomainData ) => {
+		const site = sites[ domain.blog_id ];
+		if ( ! site?.URL ) {
+			// Fall back to the site's ID if we're still loading detailed site data
+			return domain.blog_id.toString( 10 );
+		}
+
+		if ( site.options?.is_redirect && site.options?.unmapped_url ) {
+			return new URL( site.options.unmapped_url ).host;
+		}
+
+		return new URL( site.URL ).host.replace( /\//g, '::' );
+	};
+
+	const { setAutoRenew } = useDomainsBulkActionsMutation(
+		createBulkAction && { mutationFn: createBulkAction }
+	);
+
+	const { completedJobs, domainResults, handleRestartDomainStatusPolling } =
+		useDomainBulkUpdateStatus( fetchBulkActionStatus );
+
+	const onDomainsRequiringAttentionChange = useCallback( ( domainsRequiringAttention: number ) => {
+		setDomainsRequiringAttention( domainsRequiringAttention );
+	}, [] );
+
+	const [ updatingDomain, setUpdatingDomain ] = useState< Context[ 'updatingDomain' ] >( null );
+
+	const handleAutoRenew = ( domains: PartialDomainData[], enable: boolean ) => {
+		const domainNames = domains.map( ( domain: PartialDomainData ) => domain.domain );
+		const blogIds = [
+			...new Set< number >( domains.map( ( domain: PartialDomainData ) => domain.blog_id ) ),
+		];
+		setAutoRenew( domainNames, blogIds, enable );
+		handleRestartDomainStatusPolling();
+	};
+
+	const handleUpdateContactInfo = ( domains: PartialDomainData[] ) => {
+		const baseUrl = isAllSitesView
+			? '/domains/manage/all/edit-selected-contact-info'
+			: `/domains/manage/edit-selected-contact-info/${ props.siteSlug }`;
+		const formLink = addQueryArgs( baseUrl, {
+			selected: domains.map( ( domain: PartialDomainData ) => domain.domain ),
+		} );
+		page( formLink );
+	};
+
+	const context: Context = {
+		sites,
+		getFullDomain,
+		getSiteSlug,
+		isLoadingSites,
+		fetchSiteDomains,
+		createBulkAction,
+		fetchBulkActionStatus,
+		deleteBulkActionStatus,
+		isAllSitesView,
+		domainStatusPurchaseActions,
+		domainsRequiringAttention,
+		handleAutoRenew,
+		handleUpdateContactInfo,
+		onDomainsRequiringAttentionChange,
+		completedJobs,
+		domainResults,
+		handleRestartDomainStatusPolling,
+		onDomainAction: async ( actionType, domain ) => {
+			const actionDescription = onDomainAction?.( actionType, domain );
+
+			if ( ! actionDescription ) {
+				return;
+			}
+
+			const { action, message } = actionDescription;
+
+			setUpdatingDomain( {
+				action: actionType,
+				domain: domain.domain,
+				created_at: new Date().valueOf() / 1000,
+				message,
+			} );
+
+			await action();
+
+			setUpdatingDomain( null );
+		},
+		updatingDomain,
+		userCanSetPrimaryDomains,
+		isLoadingDomains,
+		isDesktop,
+		selectedFeature,
+		hasConnectableSites: hasConnectableSites ?? false,
+		context: dataViewsUsage,
+	};
+
+	return context;
+};

--- a/client/my-sites/domains/domain-management/dataviews/use-domains.ts
+++ b/client/my-sites/domains/domain-management/dataviews/use-domains.ts
@@ -1,0 +1,5 @@
+import { PartialDomainData } from '@automattic/data-stores';
+
+export function getDomainId( domain: PartialDomainData ): string {
+	return domain.domain + domain.blog_id;
+}

--- a/client/my-sites/domains/domain-management/dataviews/use-fields.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/use-fields.tsx
@@ -1,0 +1,152 @@
+import { LoadingPlaceholder } from '@automattic/components';
+import { PartialDomainData } from '@automattic/data-stores';
+import { DomainsTableExpiresRenewsOnCell } from '@automattic/domains-table/src/domains-table/domains-table-expires-renews-cell';
+import { DomainsTableSiteCell } from '@automattic/domains-table/src/domains-table/domains-table-site-cell';
+import { Field } from '@wordpress/dataviews';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { DomainField } from './dataviews-fields/domain-field';
+import { DomainStatusField } from './dataviews-fields/domain-status-field';
+import { DomainType } from './dataviews-fields/domain-type';
+import { SslStatusField } from './dataviews-fields/ssl-status-field';
+import { useDomainsDataViewsContext } from './use-context';
+
+export function useFields() {
+	const translate = useTranslate();
+	const {
+		isAllSitesView,
+		domainsRequiringAttention,
+		sites,
+		isLoadingSites,
+		getSiteSlug,
+		getFullDomain,
+		hasConnectableSites,
+	} = useDomainsDataViewsContext();
+
+	const fields = useMemo< Field< PartialDomainData >[] >(
+		() => [
+			{
+				id: 'domain_name',
+				label: translate( 'Domains' ),
+				enableHiding: false,
+				enableSorting: true,
+				enableGlobalSearch: true,
+				getValue: ( { item }: { item: PartialDomainData } ) => item.domain,
+				render: ( { item }: { item: PartialDomainData } ) => (
+					<DomainField domain={ item } isAllSitesView={ isAllSitesView } />
+				),
+			},
+			{
+				id: 'domain_type',
+				label: translate( 'Domain type' ),
+				enableHiding: false,
+				enableSorting: false,
+				render: ( { item }: { item: PartialDomainData } ) => <DomainType item={ item } />,
+			},
+			{
+				id: 'owner',
+				label: translate( 'Owner' ),
+				enableHiding: false,
+				enableSorting: true,
+				getValue: ( { item }: { item: PartialDomainData } ) => {
+					const domain = getFullDomain( item );
+					if ( ! domain ) {
+						return '';
+					}
+					if ( ! domain.owner ) {
+						return '';
+					}
+					// Removes the username that appears in parentheses after the owner's name.
+					// Uses $ and the negative lookahead assertion (?!.*\() to ensure we only match the very last parenthetical.
+					return domain.owner.replace( / \((?!.*\().+\)$/, '' );
+				},
+				render: ( { item }: { item: PartialDomainData } ) => {
+					const domain = getFullDomain( item );
+					if ( ! domain ) {
+						return <LoadingPlaceholder />;
+					}
+					if ( ! domain.owner ) {
+						return '-';
+					}
+					return domain.owner.replace( / \((?!.*\().+\)$/, '' );
+				},
+			},
+			{
+				id: 'site',
+				label: translate( 'Site' ),
+				enableHiding: false,
+				enableSorting: true,
+				getValue: ( { item }: { item: PartialDomainData } ) => sites[ item.blog_id ]?.name ?? '',
+				render: ( { item }: { item: PartialDomainData } ) => {
+					const domain = getFullDomain( item );
+					if ( isLoadingSites || ! domain ) {
+						return <LoadingPlaceholder />;
+					}
+
+					const site = sites[ item.blog_id ];
+					const userCanAddSiteToDomain = domain?.currentUserCanCreateSiteFromDomainOnly ?? false;
+
+					return (
+						<DomainsTableSiteCell
+							site={ site }
+							userCanAddSiteToDomain={ userCanAddSiteToDomain }
+							siteSlug={ getSiteSlug( item ) }
+							domainName={ domain.domain }
+							hasConnectableSites={ hasConnectableSites }
+						/>
+					);
+				},
+			},
+			{
+				id: 'ssl_status',
+				label: translate( 'SSL' ),
+				enableHiding: false,
+				enableSorting: true,
+				getValue: ( { item }: { item: PartialDomainData } ) => {
+					const domain = getFullDomain( item );
+					return domain?.sslStatus || '';
+				},
+				render: ( { item }: { item: PartialDomainData } ) => <SslStatusField domain={ item } />,
+			},
+			{
+				id: 'expiry',
+				label: translate( 'Expires/Renews on' ),
+				enableHiding: false,
+				enableSorting: true,
+				getValue: ( { item }: { item: PartialDomainData } ) =>
+					item.expiry ? Date.parse( item.expiry ) : 0,
+				render: ( { item }: { item: PartialDomainData } ) => (
+					<DomainsTableExpiresRenewsOnCell domain={ item } as="div" />
+				),
+			},
+			{
+				id: 'domain_status',
+				label: translate( 'Status' ),
+				enableHiding: false,
+				enableSorting: true,
+				header: domainsRequiringAttention ? (
+					<>
+						{ translate( 'Status' ) }
+						<span className="list-status-cell__bubble">{ domainsRequiringAttention }</span>
+					</>
+				) : (
+					translate( 'Status' )
+				),
+				getValue: ( { item }: { item: PartialDomainData } ) => item.domain_status?.status,
+				render: ( { item }: { item: PartialDomainData } ) => <DomainStatusField domain={ item } />,
+			},
+		],
+		[
+			domainsRequiringAttention,
+			isAllSitesView,
+			sites,
+			translate,
+			getFullDomain,
+			getSiteSlug,
+			isLoadingSites,
+			hasConnectableSites,
+		]
+	);
+
+	return fields;
+}

--- a/client/my-sites/domains/domain-management/dataviews/view.ts
+++ b/client/my-sites/domains/domain-management/dataviews/view.ts
@@ -1,0 +1,58 @@
+import { View } from '@wordpress/dataviews';
+import {
+	DEFAULT_PAGE,
+	DEFAULT_PER_PAGE,
+	DEFAULT_SORT_FIELD,
+	DEFAULT_SORT_DIRECTION,
+	QueryParams,
+} from './query-params';
+
+export function getFieldsByBreakpoint( isDesktop: boolean, sidebarMode?: boolean ) {
+	if ( isDesktop && ! sidebarMode ) {
+		return [ 'owner', 'site', 'ssl_status', 'expiry', 'domain_status' ];
+	}
+
+	return [];
+}
+
+export function initializeViewState(
+	isDesktop: boolean,
+	{ page, perPage, search, sortField, sortDirection }: QueryParams,
+	sidebarMode?: boolean
+) {
+	const initialViewState: View = {
+		filters: [],
+		sort: {
+			field: sortField || DEFAULT_SORT_FIELD,
+			direction: sortDirection || DEFAULT_SORT_DIRECTION,
+		},
+		page: page || DEFAULT_PAGE,
+		perPage: perPage || DEFAULT_PER_PAGE,
+		search: search || '',
+		type: sidebarMode ? 'list' : 'table',
+		showMedia: false,
+		titleField: 'domain_name',
+		descriptionField: 'domain_type',
+		fields: getFieldsByBreakpoint( isDesktop, sidebarMode ),
+	};
+
+	if ( initialViewState.type === 'table' && initialViewState.layout ) {
+		initialViewState.layout.styles = {
+			domain_name: {
+				minWidth: '1fr',
+				maxWidth: '2fr',
+			},
+			owner: {
+				width: '2fr',
+			},
+			blog_name: {},
+			ssl: {
+				width: '50px',
+			},
+			expiration: {},
+			status: {},
+		};
+	}
+
+	return initialViewState;
+}

--- a/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
@@ -7,9 +7,11 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo, useRef } from 'react';
 import NavigationHeader from 'calypso/components/navigation-header';
 import ItemView from 'calypso/layout/hosting-dashboard/item-view';
+import { addQueryArgs } from 'calypso/lib/url';
 import * as paths from 'calypso/my-sites/domains/paths';
 import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';
 import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
+import { getQueryParams } from '../dataviews/query-params';
 import {
 	FEATURE_TO_ROUTE_MAP,
 	DOMAIN_OVERVIEW,
@@ -130,11 +132,11 @@ const DomainOverviewPane = ( {
 								? FEATURE_TO_ROUTE_MAP_IN_SITE_CONTEXT
 								: FEATURE_TO_ROUTE_MAP;
 
-							showDomainManagementPage(
-								featureMap[ defaultFeatureId ]
-									.replace( ':domain', selectedDomain )
-									.replace( ':site', siteSlug )
-							);
+							const featureUrl = featureMap[ defaultFeatureId ]
+								.replace( ':domain', selectedDomain )
+								.replace( ':site', siteSlug );
+
+							showDomainManagementPage( addQueryArgs( getQueryParams(), featureUrl ) );
 						}
 					},
 				},
@@ -187,7 +189,9 @@ const DomainOverviewPane = ( {
 			<ItemView
 				itemData={ itemData }
 				closeItemView={ () => {
-					inSiteContext ? page.show( '/sites' ) : page.show( paths.domainManagementRoot() );
+					inSiteContext
+						? page.show( '/sites' )
+						: page.show( addQueryArgs( getQueryParams(), paths.domainManagementRoot() ) );
 				} }
 				features={ features }
 				enforceTabsView

--- a/client/my-sites/domains/domain-management/domain-overview-pane/test/index.test.tsx
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/test/index.test.tsx
@@ -132,14 +132,16 @@ describe( 'DomainOverviewPane', () => {
 		renderComponent();
 		fireEvent.click( screen.getByText( 'Email' ) );
 		expect( page.show ).toHaveBeenCalledWith(
-			'/domains/manage/all/email/example.com/example.wordpress.com'
+			'/domains/manage/all/email/example.com/example.wordpress.com?page=1&perPage=50&sortField=domain_name&sortDirection=asc'
 		);
 	} );
 
 	it( 'handles close button click', () => {
 		renderComponent();
 		fireEvent.click( screen.getByText( 'Close' ) );
-		expect( page.show ).toHaveBeenCalledWith( '/domains/manage' );
+		expect( page.show ).toHaveBeenCalledWith(
+			'/domains/manage?page=1&perPage=50&sortField=domain_name&sortDirection=asc'
+		);
 	} );
 } );
 

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -1,4 +1,10 @@
-import { DomainsTable, useDomainsTable } from '@automattic/domains-table';
+import config from '@automattic/calypso-config';
+import { PartialDomainData } from '@automattic/data-stores';
+import {
+	DomainStatusPurchaseActions,
+	DomainsTable,
+	useDomainsTable,
+} from '@automattic/domains-table';
 import { Global, css } from '@emotion/react';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -9,7 +15,8 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useSelector } from 'calypso/state';
 import { canAnySiteConnectDomains } from 'calypso/state/selectors/can-any-site-connect-domains';
 import { isSupportSession } from 'calypso/state/support/selectors';
-import DomainHeader from '../components/domain-header';
+import DomainHeader, { NavigationItem } from '../components/domain-header';
+import DotcomDomainsDataViews from '../dataviews';
 import {
 	createBulkAction,
 	deleteBulkActionStatus,
@@ -22,7 +29,6 @@ import EmptyState from './empty-state';
 import GoogleDomainOwnerBanner from './google-domain-owner-banner';
 import OptionsDomainButton from './options-domain-button';
 import { usePurchaseActions } from './use-purchase-actions';
-
 import './style.scss';
 
 interface BulkAllDomainsProps {
@@ -33,130 +39,337 @@ interface BulkAllDomainsProps {
 	selectedFeature?: string;
 }
 
-export default function BulkAllDomains( props: BulkAllDomainsProps ) {
-	const { domains = [], isFetched, isLoading } = useDomainsTable( fetchAllDomains );
-	const translate = useTranslate();
-	const isInSupportSession = Boolean( useSelector( isSupportSession ) );
-	const hasConnectableSites = useSelector( canAnySiteConnectDomains );
-	const sitesDashboardGlobalStyles = css`
-		html {
-			overflow-y: auto;
+const domainsDataViewsGlobalStyles = css`
+	body.is-bulk-all-domains-page {
+		background: var( --studio-gray-0 );
+
+		header.navigation-header {
+			border-block-end: 1px solid var( --color-neutral-5 );
+			padding-block-start: 24px;
+			padding-block-end: 24px;
 		}
-		body.is-bulk-all-domains-page {
-			background: var( --studio-gray-0 );
 
-			&.rtl .layout__content {
-				padding: 16px calc( var( --sidebar-width-max ) ) 16px 16px;
-			}
-
+		div.layout.is-global-sidebar-visible {
 			.layout__content {
-				// Add border around everything
-				overflow: hidden;
-				min-height: 100vh;
-				padding-top: calc( var( --masterbar-height ) + 16px );
-				padding-right: 16px;
-				padding-bottom: 16px;
-				padding-left: calc( var( --sidebar-width-max ) );
+				padding-top: calc( var( --masterbar-height ) + var( --content-padding-top ) );
+				padding-bottom: var( --content-padding-bottom );
+			}
+			.layout__primary > main {
+				height: calc(
+					100vh - var( --masterbar-height ) - var( --content-padding-top ) - var(
+							--content-padding-bottom
+						)
+				);
+			}
+		}
 
-				.layout_primary > main {
-					padding-bottom: 0;
+		@media only screen and ( min-width: 782px ) {
+			.is-global-sidebar-visible {
+				header.navigation-header {
+					padding-inline: 16px;
 				}
 			}
+		}
+	}
+`;
 
-			.layout__secondary .global-sidebar {
-				border: none;
+const domainsDashboardGlobalStyles = css`
+	html {
+		overflow-y: auto;
+	}
+	body.is-bulk-all-domains-page {
+		background: var( --studio-gray-0 );
+
+		&.rtl .layout__content {
+			padding: 16px calc( var( --sidebar-width-max ) ) 16px 16px;
+		}
+
+		.layout__content {
+			// Add border around everything
+			overflow: hidden;
+			min-height: 100vh;
+			padding-top: calc( var( --masterbar-height ) + 16px );
+			padding-right: 16px;
+			padding-bottom: 16px;
+			padding-left: calc( var( --sidebar-width-max ) );
+
+			.layout_primary > main {
+				padding-bottom: 0;
+			}
+		}
+
+		.layout__secondary .global-sidebar {
+			border: none;
+		}
+
+		.has-no-masterbar .layout__content {
+			padding-top: 16px !important;
+		}
+
+		.select-dropdown,
+		.select-dropdown__header {
+			height: var( --domains-table-toolbar-height, 40px );
+			border-radius: 4px;
+		}
+
+		.domains-overview__list .navigation-header {
+			padding-top: 24px;
+
+			.formatted-header {
+				max-height: 41px;
 			}
 
-			.has-no-masterbar .layout__content {
-				padding-top: 16px !important;
+			.navigation-header__main {
+				align-items: center;
 			}
 
-			.select-dropdown,
-			.select-dropdown__header {
-				height: var( --domains-table-toolbar-height, 40px );
-				border-radius: 4px;
+			.formatted-header__title {
+				color: var( --studio-gray-80, #2c3338 );
+				font-size: 1.5rem;
+				font-style: normal;
+				font-weight: 500;
+				line-height: 1.2;
 			}
-
-			.domains-overview__list .navigation-header {
-				padding-top: 24px;
-
-				.formatted-header {
-					max-height: 41px;
-				}
-
-				.navigation-header__main {
-					align-items: center;
-				}
-
-				.formatted-header__title {
-					color: var( --studio-gray-80, #2c3338 );
-					font-size: 1.5rem;
-					font-style: normal;
-					font-weight: 500;
-					line-height: 1.2;
-				}
-				.domain-header__buttons .button {
-					line-height: 22px;
-					white-space: nowrap;
-					margin-left: 0;
-				}
+			.domain-header__buttons .button {
+				line-height: 22px;
+				white-space: nowrap;
+				margin-left: 0;
+			}
+			.domain-header__buttons-mobile {
+				white-space: nowrap;
+			}
+			@media only screen and ( max-width: 479px ) {
 				.domain-header__buttons-mobile {
-					white-space: nowrap;
+					.options-domain-button__add {
+						height: 24px;
+						width: 24px;
+						transition: transform 0.2s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
+					}
+
+					.is-menu-visible .options-domain-button__add {
+						transform: rotate( 180deg );
+					}
+
+					.options-domain-button {
+						width: 48px;
+					}
 				}
-				@media only screen and ( max-width: 479px ) {
-					.domain-header__buttons-mobile {
-						.options-domain-button__add {
-							height: 24px;
-							width: 24px;
-							transition: transform 0.2s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
-						}
+			}
+		}
 
-						.is-menu-visible .options-domain-button__add {
-							transform: rotate( 180deg );
-						}
+		.domains-table {
+			.domains-table-toolbar {
+				margin-inline: 48px;
+				padding: 16px 0;
 
-						.options-domain-button {
-							width: 48px;
+				.domains-table-bulk-actions-toolbar {
+					align-items: flex-start;
+
+					.button {
+						padding: 4px 12px 4px 8px;
+
+						&:disabled img {
+							opacity: 0.5;
+						}
+					}
+
+					.select-dropdown {
+						border-radius: 2px;
+
+						.select-dropdown__header {
+							border-radius: 2px;
+							height: 32px;
+							padding: 0 8px;
 						}
 					}
 				}
 			}
+			table {
+				overflow-y: auto;
+				max-height: calc( 100vh - 235px );
+				margin-bottom: 0;
+				padding-inline: 0;
+				margin-inline-start: 0;
+				margin-top: 0;
 
+				grid-template-columns: 75px 1fr minmax( auto, 1fr ) auto auto auto auto;
+
+				th:last-child,
+				td:last-child {
+					padding-right: 16px;
+				}
+
+				th:first-child,
+				td:first-child {
+					padding-left: 56px;
+				}
+
+				thead.domains-table-header {
+					position: sticky;
+					top: 0;
+					z-index: 2;
+				}
+
+				th {
+					padding-top: 14px;
+					padding-bottom: 14px;
+
+					.list__header-column {
+						color: #1e1e1e;
+
+						&:hover {
+							color: var( --color-accent );
+						}
+					}
+				}
+			}
+		}
+
+		.search-component.domains-table-filter__search.is-open.has-open-icon {
+			border-radius: 4px;
+			height: 40px;
+			flex-direction: row-reverse;
+			padding-inline: 10px 8px;
+			font-size: 14px;
+			color: var( --studio-gray-40 );
+			svg {
+				fill: var( --studio-gray-40 );
+				color: var( --studio-gray-40 );
+			}
+
+			input.search-component__input[type='search'] {
+				font-size: 14px;
+				height: 40px;
+
+				&::placeholder {
+					color: var( --studio-gray-40 );
+				}
+			}
+			max-width: 245px;
+			transition: none;
+		}
+
+		.search-component.domains-table-filter__search.is-open.has-focus {
+			border-color: var( --wp-components-color-accent, var( --wp-admin-theme-color, #3858e9 ) );
+			box-shadow: 0 0 0 0.5px
+				var( --wp-components-color-accent, var( --wp-admin-theme-color, #3858e9 ) );
+		}
+
+		div.layout.is-global-sidebar-visible {
+			.layout__content {
+				padding-top: calc( var( --masterbar-height ) + var( --content-padding-top ) );
+				padding-bottom: var( --content-padding-bottom );
+			}
+			.layout__primary > main {
+				height: calc(
+					100vh - var( --masterbar-height ) - var( --content-padding-top ) - var(
+							--content-padding-bottom
+						)
+				);
+			}
+		}
+
+		.domains-overview__list.multi-sites-dashboard-layout-column,
+		.domains-overview__list.main .hosting-dashboard-layout-column__container,
+		.domains-overview__list.main .hosting-dashboard-layout-column__container > .main,
+		.domains-overview__list .multi-sites-dashboard-layout-column__container,
+		.domains-overview__details .multi-sites-dashboard-layout-column__container,
+		.multi-sites-dashboard-layout-column.domains-overview__list.main
+			.multi-sites-dashboard-layout-column__container
+			.main {
+			height: 100%;
+		}
+
+		.multi-sites-dashboard-layout-column.domains-overview__list.main
+			.multi-sites-dashboard-layout-column__container
+			.main,
+		.domains-overview__list.main .hosting-dashboard-layout-column__container > .main {
+			display: flex;
+			flex-direction: column;
+			padding-bottom: 0;
+
+			.domains-table {
+				flex-grow: 1;
+				margin-top: 0;
+				overflow: auto;
+				padding-bottom: 0;
+				width: 100%;
+
+				table {
+					max-height: unset;
+				}
+			}
+		}
+
+		.domains-overview__list {
+			.domains-table__row {
+				.gridicons-ellipsis {
+					rotate: 90deg;
+					visibility: hidden;
+				}
+
+				&:hover,
+				&.is-selected {
+					.gridicons-ellipsis {
+						visibility: visible;
+					}
+				}
+			}
+		}
+
+		@media only screen and ( min-width: 782px ) {
+			.is-global-sidebar-visible {
+				header.navigation-header {
+					padding-top: 24px;
+					padding-inline: 16px;
+					border-block-end: 1px solid var( --color-neutral-5 );
+				}
+			}
+		}
+
+		@media only screen and ( min-width: 960px ) {
 			.domains-table {
 				.domains-table-toolbar {
 					margin-inline: 48px;
-					padding: 16px 0;
-
-					.domains-table-bulk-actions-toolbar {
-						align-items: flex-start;
-
-						.button {
-							padding: 4px 12px 4px 8px;
-
-							&:disabled img {
-								opacity: 0.5;
-							}
-						}
-
-						.select-dropdown {
-							border-radius: 2px;
-
-							.select-dropdown__header {
-								border-radius: 2px;
-								height: 32px;
-								padding: 0 8px;
-							}
-						}
-					}
 				}
 				table {
-					overflow-y: auto;
-					max-height: calc( 100vh - 235px );
-					margin-bottom: 0;
-					padding-inline: 0;
-					margin-inline-start: 0;
-					margin-top: 0;
+					grid-template-columns: 75px 2fr 1fr 1fr 1fr auto auto auto auto;
 
+					th:last-child,
+					td:last-child {
+						padding-right: 56px;
+					}
+
+					th:first-child,
+					td:first-child {
+						padding-left: 56px;
+					}
+				}
+			}
+			.domains-overview__list .domains-table {
+				table {
+					grid-template-columns: 4fr auto;
+					max-height: 100%;
+
+					.domains-table__domain-name {
+						overflow-wrap: anywhere;
+					}
+				}
+			}
+			.is-global-sidebar-visible header.navigation-header {
+				padding-inline: 26px;
+			}
+		}
+
+		@media only screen and ( max-width: 600px ) {
+			.navigation-header__main {
+				justify-content: space-between;
+				.formatted-header {
+					flex: none;
+				}
+			}
+			.domains-table {
+				table {
 					grid-template-columns: 75px 1fr minmax( auto, 1fr ) auto auto auto auto;
 
 					th:last-child,
@@ -166,193 +379,15 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 
 					th:first-child,
 					td:first-child {
-						padding-left: 56px;
-					}
-
-					thead.domains-table-header {
-						position: sticky;
-						top: 0;
-						z-index: 2;
-					}
-
-					th {
-						padding-top: 14px;
-						padding-bottom: 14px;
-
-						.list__header-column {
-							color: #1e1e1e;
-
-							&:hover {
-								color: var( --color-accent );
-							}
-						}
+						padding: 0 0 0 40px;
+						padding-left: 40px;
 					}
 				}
 			}
-
-			.search-component.domains-table-filter__search.is-open.has-open-icon {
-				border-radius: 4px;
-				height: 40px;
-				flex-direction: row-reverse;
-				padding-inline: 10px 8px;
-				font-size: 14px;
-				color: var( --studio-gray-40 );
-				svg {
-					fill: var( --studio-gray-40 );
-					color: var( --studio-gray-40 );
-				}
-
-				input.search-component__input[type='search'] {
-					font-size: 14px;
-					height: 40px;
-
-					&::placeholder {
-						color: var( --studio-gray-40 );
-					}
-				}
-				max-width: 245px;
-				transition: none;
+			.domains-table-toolbar {
+				margin-inline: 32px;
 			}
-
-			.search-component.domains-table-filter__search.is-open.has-focus {
-				border-color: var( --wp-components-color-accent, var( --wp-admin-theme-color, #3858e9 ) );
-				box-shadow: 0 0 0 0.5px
-					var( --wp-components-color-accent, var( --wp-admin-theme-color, #3858e9 ) );
-			}
-
-			div.layout.is-global-sidebar-visible {
-				.layout__content {
-					padding-top: calc( var( --masterbar-height ) + var( --content-padding-top ) );
-					padding-bottom: var( --content-padding-bottom );
-				}
-				.layout__primary > main {
-					height: calc(
-						100vh - var( --masterbar-height ) - var( --content-padding-top ) - var(
-								--content-padding-bottom
-							)
-					);
-				}
-			}
-
-			.domains-overview__list.multi-sites-dashboard-layout-column,
-			.domains-overview__list.main .hosting-dashboard-layout-column__container,
-			.domains-overview__list.main .hosting-dashboard-layout-column__container > .main,
-			.domains-overview__list .multi-sites-dashboard-layout-column__container,
-			.domains-overview__details .multi-sites-dashboard-layout-column__container,
-			.multi-sites-dashboard-layout-column.domains-overview__list.main
-				.multi-sites-dashboard-layout-column__container
-				.main {
-				height: 100%;
-			}
-
-			.multi-sites-dashboard-layout-column.domains-overview__list.main
-				.multi-sites-dashboard-layout-column__container
-				.main,
-			.domains-overview__list.main .hosting-dashboard-layout-column__container > .main {
-				display: flex;
-				flex-direction: column;
-				padding-bottom: 0;
-
-				.domains-table {
-					flex-grow: 1;
-					margin-top: 0;
-					overflow: auto;
-					padding-bottom: 0;
-					width: 100%;
-
-					table {
-						max-height: unset;
-					}
-				}
-			}
-
-			.domains-overview__list {
-				.domains-table__row {
-					.gridicons-ellipsis {
-						rotate: 90deg;
-						visibility: hidden;
-					}
-
-					&:hover,
-					&.is-selected {
-						.gridicons-ellipsis {
-							visibility: visible;
-						}
-					}
-				}
-			}
-
-			@media only screen and ( min-width: 782px ) {
-				.is-global-sidebar-visible {
-					header.navigation-header {
-						padding-top: 24px;
-						padding-inline: 16px;
-						border-block-end: 1px solid var( --color-neutral-5 );
-					}
-				}
-			}
-
-			@media only screen and ( min-width: 960px ) {
-				.domains-table {
-					.domains-table-toolbar {
-						margin-inline: 48px;
-					}
-					table {
-						grid-template-columns: 75px 2fr 1fr 1fr 1fr auto auto auto auto;
-
-						th:last-child,
-						td:last-child {
-							padding-right: 56px;
-						}
-
-						th:first-child,
-						td:first-child {
-							padding-left: 56px;
-						}
-					}
-				}
-				.domains-overview__list .domains-table {
-					table {
-						grid-template-columns: 4fr auto;
-						max-height: 100%;
-
-						.domains-table__domain-name {
-							overflow-wrap: anywhere;
-						}
-					}
-				}
-				.is-global-sidebar-visible header.navigation-header {
-					padding-inline: 26px;
-				}
-			}
-
-			@media only screen and ( max-width: 600px ) {
-				.navigation-header__main {
-					justify-content: space-between;
-					.formatted-header {
-						flex: none;
-					}
-				}
-				.domains-table {
-					table {
-						grid-template-columns: 75px 1fr minmax( auto, 1fr ) auto auto auto auto;
-
-						th:last-child,
-						td:last-child {
-							padding-right: 16px;
-						}
-
-						th:first-child,
-						td:first-child {
-							padding: 0 0 0 40px;
-							padding-left: 40px;
-						}
-					}
-				}
-				.domains-table-toolbar {
-					margin-inline: 32px;
-				}
-			}
+		}
 
 			@media only screen and ( max-width: 781px ) {
 				div.layout.is-global-sidebar-visible {
@@ -371,28 +406,119 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					padding-top: 24px;
 				}
 			}
-			@media only screen and ( min-width: 601px ) and ( max-width: 781px ) {
-				.domains-table {
-					.domains-table-toolbar {
-						margin-inline: 48px;
+			.layout__primary > main {
+				background: var( --color-surface );
+				margin: 0;
+				border-radius: 8px;
+			}
+			header.navigation-header {
+				padding-inline: 16px;
+				padding-bottom: 0;
+			}
+		}
+		@media only screen and ( min-width: 601px ) and ( max-width: 781px ) {
+			.domains-table {
+				.domains-table-toolbar {
+					margin-inline: 48px;
+				}
+				table {
+					grid-template-columns: 75px 1fr minmax( auto, 1fr ) auto auto auto auto;
+
+					th:last-child,
+					td:last-child {
+						padding-right: 16px;
 					}
-					table {
-						grid-template-columns: 75px 1fr minmax( auto, 1fr ) auto auto auto auto;
 
-						th:last-child,
-						td:last-child {
-							padding-right: 16px;
-						}
-
-						th:first-child,
-						td:first-child {
-							padding-left: 56px;
-						}
+					th:first-child,
+					td:first-child {
+						padding-left: 56px;
 					}
 				}
 			}
 		}
-	`;
+	}
+`;
+
+type RendererProps = {
+	isInSupportSession: boolean;
+	purchaseActions: DomainStatusPurchaseActions;
+	sidebarMode?: boolean;
+	selectedDomainName?: string;
+	item: NavigationItem;
+	selectedFeature?: string;
+	hasConnectableSites?: boolean;
+	domains: PartialDomainData[];
+	isLoading?: boolean;
+};
+
+function DomainsTableRenderer( {
+	isInSupportSession,
+	purchaseActions,
+	sidebarMode,
+	selectedDomainName,
+	selectedFeature,
+	hasConnectableSites,
+	domains,
+	isLoading,
+}: RendererProps ) {
+	return (
+		<DomainsTable
+			context="domains"
+			isLoadingDomains={ isLoading }
+			domains={ domains }
+			isAllSitesView
+			domainStatusPurchaseActions={ purchaseActions }
+			currentUserCanBulkUpdateContactInfo={ ! isInSupportSession }
+			fetchAllDomains={ fetchAllDomains }
+			fetchSite={ fetchSite }
+			fetchSiteDomains={ fetchSiteDomains }
+			createBulkAction={ createBulkAction }
+			fetchBulkActionStatus={ fetchBulkActionStatus }
+			deleteBulkActionStatus={ deleteBulkActionStatus }
+			sidebarMode={ sidebarMode }
+			selectedFeature={ selectedFeature }
+			selectedDomainName={ selectedDomainName }
+			hasConnectableSites={ hasConnectableSites }
+		/>
+	);
+}
+
+function DomainsDataViewsRenderer( {
+	isInSupportSession,
+	purchaseActions,
+	sidebarMode,
+	selectedDomainName,
+	selectedFeature,
+	domains,
+	isLoading,
+	hasConnectableSites,
+}: RendererProps ) {
+	return (
+		<DotcomDomainsDataViews
+			domains={ domains ?? [] }
+			isLoading={ !! isLoading }
+			selectedItem={ undefined }
+			isAllSitesView
+			domainStatusPurchaseActions={ purchaseActions }
+			currentUserCanBulkUpdateContactInfo={ ! isInSupportSession }
+			fetchSiteDomains={ fetchSiteDomains }
+			createBulkAction={ createBulkAction }
+			fetchBulkActionStatus={ fetchBulkActionStatus }
+			selectedDomainName={ selectedDomainName }
+			sidebarMode={ sidebarMode }
+			selectedFeature={ selectedFeature }
+			hasConnectableSites={ hasConnectableSites }
+			context="domains"
+		/>
+	);
+}
+
+export default function BulkAllDomains( props: BulkAllDomainsProps ) {
+	const isDomainsDataViewsEnabled = config.isEnabled( 'calypso/domains-dataviews' );
+
+	const translate = useTranslate();
+	const isInSupportSession = Boolean( useSelector( isSupportSession ) );
+	const hasConnectableSites = useSelector( canAnySiteConnectDomains );
 	const item = {
 		label: translate( 'Domains' ),
 		helpBubble: translate(
@@ -405,6 +531,9 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 		),
 	};
 
+	const purchaseActions = usePurchaseActions();
+	const { domains = [], isFetched, isLoading } = useDomainsTable( fetchAllDomains );
+
 	const isDomainsEmpty = isFetched && domains.length === 0;
 	const buttons = ! isDomainsEmpty
 		? [
@@ -415,13 +544,18 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				/>,
 		  ]
 		: [];
-	const purchaseActions = usePurchaseActions();
+
+	const Element = isDomainsDataViewsEnabled ? DomainsDataViewsRenderer : DomainsTableRenderer;
 
 	return (
 		<>
-			<Global styles={ sitesDashboardGlobalStyles } />
+			<Global
+				styles={
+					isDomainsDataViewsEnabled ? domainsDataViewsGlobalStyles : domainsDashboardGlobalStyles
+				}
+			/>
 			<PageViewTracker path={ props.analyticsPath } title={ props.analyticsTitle } />
-			<Main>
+			<Main className={ isDomainsDataViewsEnabled ? 'dataviews' : '' }>
 				<DocumentHead title={ translate( 'Domains' ) } />
 				<BodySectionCssClass
 					bodyClass={ [ 'edit__body-white', 'is-bulk-domains-page', 'is-bulk-all-domains-page' ] }
@@ -429,23 +563,16 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
 				{ ! isLoading && ! isDomainsEmpty && <GoogleDomainOwnerBanner /> }
 				{ ! isDomainsEmpty ? (
-					<DomainsTable
-						context="domains"
-						isLoadingDomains={ isLoading }
-						domains={ domains }
-						isAllSitesView
-						domainStatusPurchaseActions={ purchaseActions }
-						currentUserCanBulkUpdateContactInfo={ ! isInSupportSession }
-						fetchAllDomains={ fetchAllDomains }
-						fetchSite={ fetchSite }
-						fetchSiteDomains={ fetchSiteDomains }
-						createBulkAction={ createBulkAction }
-						fetchBulkActionStatus={ fetchBulkActionStatus }
-						deleteBulkActionStatus={ deleteBulkActionStatus }
+					<Element
+						isInSupportSession={ isInSupportSession }
+						hasConnectableSites={ hasConnectableSites }
+						purchaseActions={ purchaseActions }
 						sidebarMode={ props.sidebarMode }
 						selectedDomainName={ props.selectedDomainName }
 						selectedFeature={ props.selectedFeature }
-						hasConnectableSites={ hasConnectableSites }
+						item={ item }
+						domains={ domains }
+						isLoading={ isLoading }
 					/>
 				) : (
 					<div className="bulk-domains-empty-state">

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -389,21 +389,10 @@ const domainsDashboardGlobalStyles = css`
 			}
 		}
 
-			@media only screen and ( max-width: 781px ) {
-				div.layout.is-global-sidebar-visible {
-					.layout__primary {
-						overflow-x: unset;
-					}
-				}
-				.layout__primary > main {
-					background: var( --color-surface );
-					margin: 0;
-					border-radius: 8px;
-				}
-				header.navigation-header {
-					padding-inline: 16px;
-					padding-bottom: 0;
-					padding-top: 24px;
+		@media only screen and ( max-width: 781px ) {
+			div.layout.is-global-sidebar-visible {
+				.layout__primary {
+					overflow-x: unset;
 				}
 			}
 			.layout__primary > main {
@@ -414,6 +403,7 @@ const domainsDashboardGlobalStyles = css`
 			header.navigation-header {
 				padding-inline: 16px;
 				padding-bottom: 0;
+				padding-top: 24px;
 			}
 		}
 		@media only screen and ( min-width: 601px ) and ( max-width: 781px ) {

--- a/config/development.json
+++ b/config/development.json
@@ -40,6 +40,7 @@
 		"calypso/ai-blogging-prompts": true,
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
+		"calypso/domains-dataviews": false,
 		"cancellation-offers": true,
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,

--- a/config/production.json
+++ b/config/production.json
@@ -30,6 +30,7 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"bilmur-script": true,
+		"calypso/domains-dataviews": false,
 		"cancellation-offers": true,
 		"catch-js-errors": true,
 		"checkout/ebanx-pix": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -28,6 +28,7 @@
 		"calypso/ai-blogging-prompts": false,
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
+		"calypso/domains-dataviews": false,
 		"cancellation-offers": true,
 		"catch-js-errors": true,
 		"checkout/ebanx-pix": true,

--- a/config/test.json
+++ b/config/test.json
@@ -28,6 +28,7 @@
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/application-password": true,
 		"calypso/all-domain-management": true,
+		"calypso/domains-dataviews": false,
 		"cancellation-offers": true,
 		"catch-js-errors": false,
 		"checkout/ebanx-pix": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -27,6 +27,7 @@
 		"calypso/ai-blogging-prompts": true,
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
+		"calypso/domains-dataviews": false,
 		"cancellation-offers": true,
 		"catch-js-errors": false,
 		"checkout/ebanx-pix": true,

--- a/packages/data-stores/src/queries/use-all-domains-query.ts
+++ b/packages/data-stores/src/queries/use-all-domains-query.ts
@@ -23,6 +23,7 @@ export type PartialDomainData = Pick<
 	| 'tld_maintenance_end_time'
 	| 'type'
 	| 'wpcom_domain'
+	| 'domain_status'
 >;
 
 export interface AllDomainsQueryFnData {
@@ -31,6 +32,7 @@ export interface AllDomainsQueryFnData {
 
 export interface AllDomainsQueryArgs {
 	no_wpcom?: boolean;
+	resolve_status?: boolean;
 }
 
 export const getAllDomainsQueryKey = ( queryArgs: AllDomainsQueryArgs = {} ) => [

--- a/packages/data-stores/src/queries/use-site-domains-query.ts
+++ b/packages/data-stores/src/queries/use-site-domains-query.ts
@@ -130,6 +130,11 @@ export interface DomainData {
 	pending_registration_at_registry_url: string;
 	registered_via_trustee: boolean;
 	registered_via_trustee_url: string;
+	domain_status?: {
+		status: string;
+		status_type: string;
+		status_weight: number;
+	};
 }
 
 export interface SiteDomainsQueryFnData {

--- a/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
@@ -8,12 +8,14 @@ interface DomainsTableSslCellProps {
 	domainManagementLink: string;
 	sslStatus: DomainData[ 'ssl_status' ];
 	hasWpcomManagedSslCert: boolean;
+	as?: 'td' | 'div';
 }
 
 export default function DomainsTableSslCell( {
 	domainManagementLink,
 	sslStatus,
 	hasWpcomManagedSslCert,
+	as: Element = 'td',
 }: DomainsTableSslCellProps ) {
 	const translate = useTranslate();
 	// WordPress.com managed subdomains (e.g. *.wordpress.com, *.wpcomstaging.com, etc.)
@@ -53,7 +55,7 @@ export default function DomainsTableSslCell( {
 	}
 
 	return (
-		<td
+		<Element
 			className={ clsx( `domains-table-row__ssl-cell`, {
 				[ `domains-table-row__ssl-cell__active` ]: isActiveSsl,
 				[ `domains-table-row__ssl-cell__pending` ]: isPendingSsl,
@@ -62,6 +64,6 @@ export default function DomainsTableSslCell( {
 		>
 			{ domainHasSsl && <Icon icon={ lock } size={ 18 } /> }
 			{ button }
-		</td>
+		</Element>
 	);
 }

--- a/packages/domains-table/src/use-domains-table.ts
+++ b/packages/domains-table/src/use-domains-table.ts
@@ -7,7 +7,7 @@ import {
 export function useDomainsTable(
 	fetchAllDomains?: ( queryArgs?: AllDomainsQueryArgs ) => Promise< AllDomainsQueryFnData >
 ) {
-	const queryArgs = { no_wpcom: true };
+	const queryArgs = { no_wpcom: true, resolve_status: true };
 
 	const { data, ...queryResult } = useAllDomainsQuery(
 		queryArgs,

--- a/packages/domains-table/src/utils/get-domain-type-text.tsx
+++ b/packages/domains-table/src/utils/get-domain-type-text.tsx
@@ -2,8 +2,13 @@ import { type as domainTypes, domainInfoContext } from './constants';
 import { ResponseDomain } from './types';
 import type { __ as __type } from '@wordpress/i18n';
 
+type PartialDomainInfo = Pick<
+	ResponseDomain,
+	'tldMaintenanceEndTime' | 'type' | 'isSubdomain' | 'isPremium'
+>;
+
 export function getDomainTypeText(
-	domain: ResponseDomain,
+	domain: PartialDomainInfo,
 	__: typeof __type = ( text: string ) => text,
 	context = domainInfoContext.DOMAIN_ITEM
 ) {


### PR DESCRIPTION
Related to #96674

## Proposed Changes

* Reapplies the changes from https://github.com/Automattic/wp-calypso/pull/97677
* Fixes an issue with padding in the header.

## Why are these changes being made?

* Use the standard approach to render a list on WordPress.
* Needed to revert the first PR as the issue in header was found.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Please follow the testing instructions from the original PR:
* Turn on feature flags in your browser's console: `window.sessionStorage.setItem('flags',  'calypso/domains-dataviews'])`
* Go to http://calypso.localhost:3000/domains/manage
* Check filtering, sorting, actions, bulk actions.
    * For bulk actions, you need to have at least two domains you own. 
* Click on a domain and check if it opened a pane on the right.
* Switch the tab on the right to Email.
* Click on another domain and make sure the same tab (Email) opened for it.
* Now disable DataViews: `window.sessionStorage.removeItem('flags');` and test everything works with the previous implementation.

Additionally, check the padding-bottom it the header:
* Bad:
![CleanShot 2025-02-13 at 13 04 25@2x](https://github.com/user-attachments/assets/fa627ce0-7d93-4650-9d4f-aec82e65028c)
* Good:
![CleanShot 2025-02-13 at 13 49 54@2x](https://github.com/user-attachments/assets/7dfa617d-276d-4abf-ba56-6e7673c705b9)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
