### PR TITLE
Marketplace installation: Support externally managed themes

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -366,15 +366,21 @@ const MarketplaceProductInstall = ( {
 				<EmptyContent
 					illustration="/calypso/images/illustrations/error.svg"
 					title={ null }
-					line={ translate(
-						"Your current plan doesn't allow plugin installation. Please upgrade to %(businessPlanName)s plan first.",
-						{
-							args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-						}
-					) }
-					action={ translate( 'Upgrade to %(planName)s Plan', {
-						args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-					} ) }
+					line={
+						// translators: %(businessPlanName)s is the name of the business plan.
+						translate(
+							"Your current plan doesn't allow plugin installation. Please upgrade to %(businessPlanName)s plan first.",
+							{
+								args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+							}
+						)
+					}
+					action={
+						// translators: %(planName)s is the name of the business plan.
+						translate( 'Upgrade to %(planName)s Plan', {
+							args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+						} )
+					}
 					actionURL={ `/checkout/${ selectedSite?.slug }/business?redirect_to=/marketplace/plugin/${ pluginSlug }/install/${ selectedSite?.slug }#step2` }
 				/>
 			);
@@ -410,9 +416,12 @@ const MarketplaceProductInstall = ( {
 						}
 						illustrationWidth={ thirdPartyTheme?.screenshot && 720 }
 						title={ productName }
-						line={ translate( 'Do you want to activate the theme %(theme)s?', {
-							args: { theme: thirdPartyTheme?.name },
-						} ) }
+						line={
+							// translators: %(theme)s is the name of the theme.
+							translate( 'Do you want to activate the theme %(theme)s?', {
+								args: { theme: thirdPartyTheme?.name },
+							} )
+						}
 					>
 						{ isProductListFetched && (
 							<div className="marketplace-plugin-install__direct-install-actions">

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -54,7 +54,11 @@ import {
 	installAndActivateTheme,
 	requestActiveTheme,
 } from 'calypso/state/themes/actions';
-import { getTheme, isThemeActive as getThemeActive } from 'calypso/state/themes/selectors';
+import {
+	getTheme,
+	isThemeActive as getThemeActive,
+	isExternallyManagedTheme,
+} from 'calypso/state/themes/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
@@ -111,9 +115,16 @@ const MarketplaceProductInstall = ( {
 		isMarketplaceProductSelector( state, pluginSlug )
 	);
 
-	const wpOrgTheme = useSelector( ( state ) => getTheme( state, 'wporg', themeSlug ) );
+	const thirdPartyTheme = useSelector( ( state ) => {
+		if ( isExternallyManagedTheme( state, themeSlug ) ) {
+			return getTheme( state, 'wpcom', themeSlug );
+		}
+		return getTheme( state, 'wporg', themeSlug );
+	} );
 	const isThemeActive = useSelector( ( state ) => getThemeActive( state, themeSlug, siteId ) );
+	// Fetch the theme from both wporg and wpcom APIs, to look up community and partner themes.
 	useQueryTheme( 'wporg', themeSlug );
+	useQueryTheme( 'wpcom', themeSlug );
 
 	const { data: wpComPluginData } = useWPCOMPlugin( pluginSlug, {
 		enabled: isProductListFetched && isMarketplaceProduct,
@@ -203,7 +214,7 @@ const MarketplaceProductInstall = ( {
 			( marketplaceInstallationInProgress || directInstallationAllowed ) &&
 			! isPluginUploadFlow &&
 			! initializeInstallFlow &&
-			( wporgPlugin || wpOrgTheme )
+			( wporgPlugin || thirdPartyTheme )
 		) {
 			const triggerInstallFlow = () => {
 				setInitializeInstallFlow( true );
@@ -211,9 +222,9 @@ const MarketplaceProductInstall = ( {
 			};
 
 			if ( isJetpack || isAtomic ) {
-				if ( wpOrgTheme ) {
+				if ( thirdPartyTheme ) {
 					// initilize theme activating
-					dispatch( installAndActivateTheme( wpOrgTheme.id, siteId ) );
+					dispatch( installAndActivateTheme( thirdPartyTheme.id, siteId ) );
 				} else {
 					// initialize plugin installing
 					dispatch( installPlugin( siteId, wporgPlugin, false ) );
@@ -222,7 +233,7 @@ const MarketplaceProductInstall = ( {
 				triggerInstallFlow();
 			} else if ( hasAtomicFeature ) {
 				// initialize atomic flow
-				if ( wpOrgTheme ) {
+				if ( thirdPartyTheme ) {
 					dispatch( initiateAtomicTransfer( siteId, { themeSlug, context: 'theme_install' } ) );
 				} else {
 					setAtomicFlow( true );
@@ -239,7 +250,7 @@ const MarketplaceProductInstall = ( {
 		initializeInstallFlow,
 		siteId,
 		wporgPlugin,
-		wpOrgTheme,
+		thirdPartyTheme,
 		pluginSlug,
 		themeSlug,
 		dispatch,
@@ -279,7 +290,7 @@ const MarketplaceProductInstall = ( {
 	const canManagePlugins = useSelector( ( state ) => {
 		return siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );
 	} );
-	// Check completition of all flows and redirect to thank you page
+	// Check completion of all flows and redirect to thank you page
 	useEffect( () => {
 		if (
 			// Happens in 3 cases:
@@ -314,21 +325,23 @@ const MarketplaceProductInstall = ( {
 
 	// Validate theme is already active
 	useEffect( () => {
-		if ( themeSlug && wpOrgTheme && isThemeActive ) {
+		if ( themeSlug && thirdPartyTheme && isThemeActive ) {
 			waitFor( 1 ).then( () =>
 				page.redirect(
 					`/marketplace/thank-you/${ selectedSiteSlug }?themes=${ themeSlug }&hide-progress-bar`
 				)
 			);
 		}
-	}, [ themeSlug, wpOrgTheme, isThemeActive, selectedSiteSlug ] );
+	}, [ themeSlug, thirdPartyTheme, isThemeActive, selectedSiteSlug ] );
 
 	// Polling for theme activation status
 	useInterval(
 		() => {
 			dispatch( requestActiveTheme( siteId ) );
 		},
-		! themeSlug || currentStep === 0 || ( themeSlug && wpOrgTheme && isThemeActive ) ? null : 3000
+		! themeSlug || currentStep === 0 || ( themeSlug && thirdPartyTheme && isThemeActive )
+			? null
+			: 3000
 	);
 
 	const steps = useMemo( () => {
@@ -385,18 +398,20 @@ const MarketplaceProductInstall = ( {
 			const variation = wpComPluginData?.variations?.[ variationPeriod ];
 			const marketplaceProductSlug = getProductSlugByPeriodVariation( variation, productsList );
 			const productPage = `/themes/${ themeSlug }/${ selectedSite?.slug }`;
-			const productName = wpOrgTheme?.name || themeSlug;
+			const productName = thirdPartyTheme?.name || themeSlug;
 
 			return (
 				<>
 					<QueryProductsList />
 					<EmptyContent
 						className="marketplace-plugin-install__direct-install-container"
-						illustration={ wpOrgTheme?.screenshot || '/calypso/images/illustrations/error.svg' }
-						illustrationWidth={ wpOrgTheme?.screenshot && 720 }
+						illustration={
+							thirdPartyTheme?.screenshot || '/calypso/images/illustrations/error.svg'
+						}
+						illustrationWidth={ thirdPartyTheme?.screenshot && 720 }
 						title={ productName }
 						line={ translate( 'Do you want to activate the theme %(theme)s?', {
-							args: { theme: wpOrgTheme?.name },
+							args: { theme: thirdPartyTheme?.name },
 						} ) }
 					>
 						{ isProductListFetched && (


### PR DESCRIPTION
Related to #95651

## Proposed Changes

Update the marketplace theme install to support "externally managed" themes (partner themes). 

## Why are these changes being made?

We want to use the marketplace install process to install both community and partner themes, since it handles the atomic transfer. Currently it works, more by accident— because it still installs the theme even though it doesn't recognize it as a community theme.

## Testing Instructions

- Gather a few community and partner themes to test with
    - Community: Find on https://wordpress.org/themes/, get the slug from the URL
    - Partner: Find on https://wordpress.com/themes/partner, get the slug from the URL
- Manually enter the marketplace install route, e.g., `/marketplace/theme/<theme slug>/install/<site>`
- You should see the correct thumbnail and theme title, not the theme slug
- The install process should work, assuming you have purchased the partner theme subscription

| Before | After |
|---|---|
| ![](https://github.com/user-attachments/assets/0893019d-2e06-43a1-8201-b26bf4d308ac) | ![](https://github.com/user-attachments/assets/1a2adca9-a32e-48ed-a988-b99d2ef21e80) |

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
