### PR TITLE
Reader Discovery V2: Add subscribe link to Discover feed cards

### DIFF
--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -1,5 +1,6 @@
 import { useBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useState } from 'react';
 import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
@@ -26,6 +27,7 @@ const CompactPost = ( props ) => {
 	// to see if the user is on the discover page, let's check the pathname
 	const path = window.location.pathname.split( '/' );
 	const isDiscover = path.length > 0 && path[ 1 ].includes( 'discover' );
+	const translate = useTranslate();
 
 	const isSmallScreen = useBreakpoint( '<660px' );
 	const [ hasExcerpt, setHasExcerpt ] = useState( true );
@@ -67,8 +69,8 @@ const CompactPost = ( props ) => {
 										siteUrl={ post.feed_URL || post.site_URL }
 										followSource={ READER_DISCOVER }
 										iconSize={ 20 }
-										followLabel="Subscribe"
-										followingLabel="Unsubscribe"
+										followLabel={ translate( 'Subscribe' ) }
+										followingLabel={ translate( 'Unsubscribe' ) }
 									/>
 								) }
 								<ReaderPostEllipsisMenu
@@ -98,8 +100,8 @@ const CompactPost = ( props ) => {
 										siteUrl={ post.feed_URL || post.site_URL }
 										followSource={ READER_DISCOVER }
 										iconSize={ 20 }
-										followLabel="Subscribe"
-										followingLabel="Unsubscribe"
+										followLabel={ translate( 'Subscribe' ) }
+										followingLabel={ translate( 'Unsubscribe' ) }
 									/>
 								) }
 								<ReaderPostEllipsisMenu

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -10,6 +10,13 @@ import ReaderFollowButton from 'calypso/reader/follow-button';
 import { READER_DISCOVER } from 'calypso/reader/follow-sources';
 import FeaturedAsset from './featured-asset';
 
+// Rather than create complex logic to create context or pass props
+// to see if the user is on thediscover page, let's check the pathname
+const getIsDiscover = () => {
+	const path = window.location.pathname.split( '/' );
+	return path.length > 0 && path[ 1 ].includes( 'discover' );
+};
+
 const CompactPost = ( props ) => {
 	const {
 		children,
@@ -22,11 +29,7 @@ const CompactPost = ( props ) => {
 		teams,
 		openSuggestedFollows,
 	} = props;
-
-	// Rather than create complex logic to create context or pass props
-	// to see if the user is on the discover page, let's check the pathname
-	const path = window.location.pathname.split( '/' );
-	const isDiscover = path.length > 0 && path[ 1 ].includes( 'discover' );
+	const isDiscover = getIsDiscover();
 	const translate = useTranslate();
 
 	const isSmallScreen = useBreakpoint( '<660px' );

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -12,7 +13,7 @@ import FeaturedAsset from './featured-asset';
 
 // Rather than create complex logic to create context or pass props
 // to see if the user is on thediscover page, let's check the pathname
-const getIsDiscover = () => {
+const getIsDiscoverPage = () => {
 	const path = window.location.pathname.split( '/' );
 	return path.length > 0 && path[ 1 ].includes( 'discover' );
 };
@@ -29,7 +30,9 @@ const CompactPost = ( props ) => {
 		teams,
 		openSuggestedFollows,
 	} = props;
-	const isDiscover = getIsDiscover();
+
+	const isDiscoveryV2Enabled = config.isEnabled( 'reader/discovery-v2' );
+	const isDiscoverPage = getIsDiscoverPage();
 	const translate = useTranslate();
 
 	const isSmallScreen = useBreakpoint( '<660px' );
@@ -66,7 +69,7 @@ const CompactPost = ( props ) => {
 						</div>
 						{ ( imagePostWithoutExcerpt || ! post.canonical_media || isSmallScreen ) && (
 							<div className="reader-post-card__post-options">
-								{ isDiscover && (
+								{ isDiscoveryV2Enabled && isDiscoverPage && (
 									<ReaderFollowButton
 										tagName="div"
 										siteUrl={ post.feed_URL || post.site_URL }
@@ -97,7 +100,7 @@ const CompactPost = ( props ) => {
 					<div className="reader-post-card__post-media">
 						{ ! isSmallScreen && hasExcerpt && (
 							<div className="reader-post-card__post-options">
-								{ isDiscover && (
+								{ isDiscoveryV2Enabled && isDiscoverPage && (
 									<ReaderFollowButton
 										tagName="div"
 										siteUrl={ post.feed_URL || post.site_URL }

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -5,19 +5,28 @@ import { useState } from 'react';
 import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
 import ReaderPostEllipsisMenu from 'calypso/blocks/reader-post-options-menu/reader-post-ellipsis-menu';
 import AutoDirection from 'calypso/components/auto-direction';
+import ReaderFollowButton from 'calypso/reader/follow-button';
+import { READER_DISCOVER } from 'calypso/reader/follow-sources';
 import FeaturedAsset from './featured-asset';
 
-const CompactPost = ( {
-	children,
-	post,
-	expandCard,
-	postKey,
-	isExpanded,
-	site,
-	postByline,
-	teams,
-	openSuggestedFollows,
-} ) => {
+const CompactPost = ( props ) => {
+	const {
+		children,
+		post,
+		expandCard,
+		postKey,
+		isExpanded,
+		site,
+		postByline,
+		teams,
+		openSuggestedFollows,
+	} = props;
+
+	// Rather than create complex logic to create context or pass props
+	// to see if the user is on the discover page, let's check the pathname
+	const path = window.location.pathname.split( '/' );
+	const isDiscover = path.length > 0 && path[ 1 ].includes( 'discover' );
+
 	const isSmallScreen = useBreakpoint( '<660px' );
 	const [ hasExcerpt, setHasExcerpt ] = useState( true );
 	const [ showExcerpt, setShowExcerpt ] = useState( ! isExpanded ?? true );
@@ -51,13 +60,25 @@ const CompactPost = ( {
 							{ postByline }
 						</div>
 						{ ( imagePostWithoutExcerpt || ! post.canonical_media || isSmallScreen ) && (
-							<ReaderPostEllipsisMenu
-								site={ site }
-								teams={ teams }
-								post={ post }
-								showFollow
-								openSuggestedFollows={ openSuggestedFollows }
-							/>
+							<div className="reader-post-card__post-options">
+								{ isDiscover && (
+									<ReaderFollowButton
+										tagName="div"
+										siteUrl={ post.feed_URL || post.site_URL }
+										followSource={ READER_DISCOVER }
+										iconSize={ 20 }
+										followLabel="Subscribe"
+										followingLabel="Unsubscribe"
+									/>
+								) }
+								<ReaderPostEllipsisMenu
+									site={ site }
+									teams={ teams }
+									post={ post }
+									showFollow
+									openSuggestedFollows={ openSuggestedFollows }
+								/>
+							</div>
 						) }
 					</div>
 					<ReaderExcerpt
@@ -70,13 +91,25 @@ const CompactPost = ( {
 				{ post.canonical_media && (
 					<div className="reader-post-card__post-media">
 						{ ! isSmallScreen && hasExcerpt && (
-							<ReaderPostEllipsisMenu
-								site={ site }
-								teams={ teams }
-								post={ post }
-								showFollow
-								openSuggestedFollows={ openSuggestedFollows }
-							/>
+							<div className="reader-post-card__post-options">
+								{ isDiscover && (
+									<ReaderFollowButton
+										tagName="div"
+										siteUrl={ post.feed_URL || post.site_URL }
+										followSource={ READER_DISCOVER }
+										iconSize={ 20 }
+										followLabel="Subscribe"
+										followingLabel="Unsubscribe"
+									/>
+								) }
+								<ReaderPostEllipsisMenu
+									site={ site }
+									teams={ teams }
+									post={ post }
+									showFollow
+									openSuggestedFollows={ openSuggestedFollows }
+								/>
+							</div>
 						) }
 						<FeaturedAsset
 							post={ post }

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { useBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -7,6 +6,7 @@ import { useState } from 'react';
 import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
 import ReaderPostEllipsisMenu from 'calypso/blocks/reader-post-options-menu/reader-post-ellipsis-menu';
 import AutoDirection from 'calypso/components/auto-direction';
+import { isDiscoveryV2Enabled } from 'calypso/reader/discover/helper';
 import ReaderFollowButton from 'calypso/reader/follow-button';
 import { READER_DISCOVER } from 'calypso/reader/follow-sources';
 import FeaturedAsset from './featured-asset';
@@ -31,7 +31,6 @@ const CompactPost = ( props ) => {
 		openSuggestedFollows,
 	} = props;
 
-	const isDiscoveryV2Enabled = config.isEnabled( 'reader/discovery-v2' );
 	const isDiscoverPage = getIsDiscoverPage();
 	const translate = useTranslate();
 
@@ -50,7 +49,7 @@ const CompactPost = ( props ) => {
 
 	const postOptions = (
 		<div className="reader-post-card__post-options">
-			{ isDiscoveryV2Enabled && isDiscoverPage && (
+			{ isDiscoveryV2Enabled() && isDiscoverPage && (
 				<ReaderFollowButton
 					tagName="div"
 					siteUrl={ post.feed_URL || post.site_URL }

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -48,6 +48,28 @@ const CompactPost = ( props ) => {
 			  }
 			: null;
 
+	const postOptions = (
+		<div className="reader-post-card__post-options">
+			{ isDiscoveryV2Enabled && isDiscoverPage && (
+				<ReaderFollowButton
+					tagName="div"
+					siteUrl={ post.feed_URL || post.site_URL }
+					followSource={ READER_DISCOVER }
+					iconSize={ 20 }
+					followLabel={ translate( 'Subscribe' ) }
+					followingLabel={ translate( 'Unsubscribe' ) }
+				/>
+			) }
+			<ReaderPostEllipsisMenu
+				site={ site }
+				teams={ teams }
+				post={ post }
+				showFollow
+				openSuggestedFollows={ openSuggestedFollows }
+			/>
+		</div>
+	);
+
 	return (
 		<div className="reader-post-card__post">
 			<div
@@ -67,27 +89,8 @@ const CompactPost = ( props ) => {
 							</AutoDirection>
 							{ postByline }
 						</div>
-						{ ( imagePostWithoutExcerpt || ! post.canonical_media || isSmallScreen ) && (
-							<div className="reader-post-card__post-options">
-								{ isDiscoveryV2Enabled && isDiscoverPage && (
-									<ReaderFollowButton
-										tagName="div"
-										siteUrl={ post.feed_URL || post.site_URL }
-										followSource={ READER_DISCOVER }
-										iconSize={ 20 }
-										followLabel={ translate( 'Subscribe' ) }
-										followingLabel={ translate( 'Unsubscribe' ) }
-									/>
-								) }
-								<ReaderPostEllipsisMenu
-									site={ site }
-									teams={ teams }
-									post={ post }
-									showFollow
-									openSuggestedFollows={ openSuggestedFollows }
-								/>
-							</div>
-						) }
+						{ ( imagePostWithoutExcerpt || ! post.canonical_media || isSmallScreen ) &&
+							postOptions }
 					</div>
 					<ReaderExcerpt
 						post={ post }
@@ -98,27 +101,7 @@ const CompactPost = ( props ) => {
 				</div>
 				{ post.canonical_media && (
 					<div className="reader-post-card__post-media">
-						{ ! isSmallScreen && hasExcerpt && (
-							<div className="reader-post-card__post-options">
-								{ isDiscoveryV2Enabled && isDiscoverPage && (
-									<ReaderFollowButton
-										tagName="div"
-										siteUrl={ post.feed_URL || post.site_URL }
-										followSource={ READER_DISCOVER }
-										iconSize={ 20 }
-										followLabel={ translate( 'Subscribe' ) }
-										followingLabel={ translate( 'Unsubscribe' ) }
-									/>
-								) }
-								<ReaderPostEllipsisMenu
-									site={ site }
-									teams={ teams }
-									post={ post }
-									showFollow
-									openSuggestedFollows={ openSuggestedFollows }
-								/>
-							</div>
-						) }
+						{ ! isSmallScreen && hasExcerpt && postOptions }
 						<FeaturedAsset
 							post={ post }
 							canonicalMedia={ post.canonical_media }

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -223,6 +223,10 @@
 			}
 		}
 
+		.ellipsis-menu__toggle {
+			padding-bottom: 36px;
+		}
+
 		.reader-excerpt {
 			max-height: none;
 			-webkit-line-clamp: 3;
@@ -267,12 +271,6 @@
 			@include breakpoint-deprecated( "<660px" ) {
 				margin: 24px 0 0;
 			}
-		}
-	}
-
-	&.is-compact.has-thumbnail {
-		.ellipsis-menu__toggle {
-			padding-bottom: 36px;
 		}
 	}
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -213,6 +213,16 @@
 			text-align: right;
 		}
 
+		.reader-post-card__post-options {
+			display: flex;
+			justify-content: flex-end;
+			align-items: center;
+
+			> .follow-button {
+				padding-bottom: 5px;
+			}
+		}
+
 		.reader-excerpt {
 			max-height: none;
 			-webkit-line-clamp: 3;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -217,6 +217,7 @@
 			display: flex;
 			justify-content: flex-end;
 			align-items: center;
+			margin-bottom: 5px;
 
 			> .follow-button {
 				padding-bottom: 5px;

--- a/client/reader/follow-sources.ts
+++ b/client/reader/follow-sources.ts
@@ -4,3 +4,4 @@ export const SEARCH_RESULTS_SITES = 'search-results-sites';
 export const READER_POST_OPTIONS_MENU = 'reader-post-options-menu';
 export const READER_SUGGESTED_FOLLOWS_DIALOG = 'reader-suggested-follows-dialog';
 export const READER_SEARCH_POPULAR_SITES = 'reader-search-popular-sites';
+export const READER_DISCOVER = 'reader-discover';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/382

## Proposed Changes

- This adds the `ReaderFollowButton` component to the `CompactPost` component behind the `reader/discovery-v2` config flag
- It adds a URL check to make sure we're on the Discover page.
- It synchronizes the padding across compact posts with and without thumbnails.

### Before

<img width="1184" alt="Screenshot 2025-02-13 at 22 18 53" src="https://github.com/user-attachments/assets/3b9f4ff0-c77d-46a3-bb24-ee731a94f5c2" />

<img width="642" alt="Screenshot 2025-02-13 at 22 20 24" src="https://github.com/user-attachments/assets/13d037af-2f6d-4a77-99c5-956b64e663d4" />

### After

<img width="1189" alt="Screenshot 2025-02-13 at 22 16 40" src="https://github.com/user-attachments/assets/312d9a75-c8f3-48c0-8291-b38df7697c48" />

<img width="555" alt="Screenshot 2025-02-13 at 22 17 02" src="https://github.com/user-attachments/assets/444f5818-6d25-4abc-a033-2396b40593a1" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of the overall improvements to the Discover experience.



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Ensure the subscribe button DOES appear with the `reader/discovery-v2` config flag ON:

1. Visit `/discover?flags=reader/discovery-v2`
2. See that the Subscribe button is now on the feed cards
3. Try subscribing and unsubscribing — make sure this still works on desktop and mobile
4. Visit the Tag page, Profile page, and other pages parts of the Reader — make sure the Subscribe button is only visible on the cards when you're on Discover

Ensure the subscribe button DOES NOT appear with the `reader/discovery-v2` config flag OFF:

1. Visit `/discover?flags=-reader/discovery-v2`
2. See that the new Subscribe button is not visible.
3. Check the Tag page, Profile page, and other pages — make sure the new Subscribe button does not render there, either.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
