### PR TITLE
Stats: improve Download CSV consistency

### DIFF
--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -1,4 +1,5 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { download } from '@wordpress/icons';
 import { saveAs } from 'browser-filesaver';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -92,11 +93,11 @@ class StatsDownloadCsv extends Component {
 				onClick={ this.downloadCsv }
 				disabled={ disabled }
 				borderless={ borderless }
+				icon={ download }
 			>
 				{ ! skipQuery && siteId && statType && query && (
 					<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
 				) }
-				<Gridicon icon="cloud-download" />{ ' ' }
 				{ translate( 'Download CSV', {
 					context: 'Action shown in stats to download data as csv.',
 				} ) }

--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -97,7 +97,7 @@ class StatsDownloadCsv extends Component {
 					<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
 				) }
 				<Gridicon icon="cloud-download" />{ ' ' }
-				{ translate( 'Download data as CSV', {
+				{ translate( 'Download CSV', {
 					context: 'Action shown in stats to download data as csv.',
 				} ) }
 			</Button>

--- a/client/my-sites/stats/stats-list/stats-list-card.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-card.jsx
@@ -22,6 +22,7 @@ const StatsListCard = ( {
 	showMore,
 	title,
 	titleNodes,
+	downloadCsv,
 	emptyMessage,
 	loader,
 	useShortLabel,
@@ -30,6 +31,7 @@ const StatsListCard = ( {
 	heroElement, // a node placed before the list
 	metricLabel, // a label to use for the values on the right side of the bars - `Views` by default
 	splitHeader, // instead of using a simple header containing the name of the card use additional columns and header items
+	multiHeader,
 	mainItemLabel,
 	additionalColumns, // additional columns to be displayed next to the default `views` column
 	toggleControl, // component to be placed in a split header
@@ -140,11 +142,13 @@ const StatsListCard = ( {
 			emptyMessage={ emptyMessage }
 			isEmpty={ ! loader && ( ! data || ! data?.length ) }
 			titleNodes={ titleNodes }
+			downloadCsv={ downloadCsv }
 			className={ clsx( `list-${ moduleType }`, className ) }
 			headerClassName={ listItemClassName }
 			metricLabel={ metricLabel }
 			heroElement={ heroElement }
 			splitHeader={ splitHeader }
+			multiHeader={ multiHeader }
 			mainItemLabel={ mainItemLabel }
 			additionalHeaderColumns={ additionalColumns?.header }
 			toggleControl={ toggleControl }

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -183,7 +183,6 @@ class StatsModule extends Component {
 	isAllTimeList() {
 		const { summary, statType } = this.props;
 		const summarizedTypes = [
-			'statsCountryViews',
 			'statsTopPosts',
 			'statsSearchTerms',
 			'statsClicks',

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -261,9 +261,25 @@ class StatsModule extends Component {
 		const summaryLink = ! this.props.hideSummaryLink && this.getSummaryLink();
 		const displaySummaryLink = data && summaryLink;
 		const isAllTime = this.isAllTimeList();
-		const footerClass = clsx( 'stats-module__footer-actions', {
-			'stats-module__footer-actions--summary': summary,
-		} );
+
+		const renderDownloadCsv = () => {
+			if ( gateDownloads ) {
+				return <DownloadCsvUpsell siteId={ siteId } borderless />;
+			}
+
+			return (
+				<DownloadCsv
+					statType={ statType }
+					query={ query }
+					path={ path }
+					borderless
+					period={ period }
+					skipQuery={ skipQuery }
+				/>
+			);
+		};
+
+		const downloadCsv = renderDownloadCsv();
 
 		const emptyMessage = isRealTime ? 'gathering info…' : moduleStrings.empty;
 		// TODO: Translate empty message
@@ -281,6 +297,7 @@ class StatsModule extends Component {
 					useShortLabel={ useShortLabel }
 					title={ this.props.moduleStrings?.title }
 					titleNodes={ titleNodes }
+					downloadCsv={ downloadCsv }
 					emptyMessage={ emptyMessage }
 					metricLabel={ metricLabel }
 					showMore={
@@ -305,6 +322,7 @@ class StatsModule extends Component {
 					}
 					additionalColumns={ additionalColumns }
 					splitHeader={ !! additionalColumns }
+					multiHeader={ isAllTime }
 					mainItemLabel={ mainItemLabel }
 					showLeftIcon={ path === 'authors' }
 					listItemClassName={ listItemClassName }
@@ -322,22 +340,6 @@ class StatsModule extends Component {
 					}
 					formatValue={ formatValue }
 				/>
-				{ isAllTime && (
-					<div className={ footerClass }>
-						{ gateDownloads ? (
-							<DownloadCsvUpsell siteId={ siteId } borderless />
-						) : (
-							<DownloadCsv
-								statType={ statType }
-								query={ query }
-								path={ path }
-								borderless
-								period={ period }
-								skipQuery={ skipQuery }
-							/>
-						) }
-					</div>
-				) }
 			</>
 		);
 	}

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -188,6 +188,8 @@ class StatsModule extends Component {
 			'statsSearchTerms',
 			'statsClicks',
 			'statsReferrers',
+			'statsTopAuthors',
+			'statsFileDownloads',
 			// statsEmailsOpen and statsEmailsClick are not used. statsEmailsSummary are used at the moment,
 			// besides this, email page uses separate summary component: <StatsEmailSummary />
 			'statsEmailsOpen',

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -218,7 +218,7 @@ class StatsSummary extends Component {
 				/* eslint-disable wpcalypso/jsx-classname-namespace */
 				summaryView = (
 					<Fragment key="authors-summary">
-						{ this.renderSummaryHeader( path, statType, true, query ) }
+						{ this.renderSummaryHeader( path, statType, false, query ) }
 						<StatsModuleAuthors
 							moduleStrings={ StatsStrings.authors }
 							period={ this.props.period }
@@ -261,7 +261,7 @@ class StatsSummary extends Component {
 
 				summaryView = (
 					<Fragment key="filedownloads-summary">
-						{ this.renderSummaryHeader( path, statType, true, query ) }
+						{ this.renderSummaryHeader( path, statType, false, query ) }
 						<StatsModuleDownloads
 							moduleStrings={ StatsStrings.filedownloads }
 							period={ this.props.period }

--- a/packages/components/src/horizontal-bar-list/stats-card.scss
+++ b/packages/components/src/horizontal-bar-list/stats-card.scss
@@ -69,6 +69,19 @@
 			width: $value-column-width;
 			text-align: right;
 		}
+
+		.stats-download-csv {
+			color: var(--color-link);
+
+			&[disabled],
+			&.disabled {
+				color: var(--color-neutral-20);
+			}
+
+			&:hover:not([disabled]) {
+				color: var(--color-link-dark);
+			}
+		}
 	}
 
 	.stats-card-sub-header {

--- a/packages/components/src/horizontal-bar-list/stats-card.scss
+++ b/packages/components/src/horizontal-bar-list/stats-card.scss
@@ -71,6 +71,12 @@
 		}
 	}
 
+	.stats-card-sub-header {
+		display: flex;
+		justify-content: space-between;
+		padding: 0 $padding-outside $header-spacer $padding-outside;
+	}
+
 	.stats-card-header--main {
 		display: flex;
 		justify-content: space-between;

--- a/packages/components/src/horizontal-bar-list/stats-card.scss
+++ b/packages/components/src/horizontal-bar-list/stats-card.scss
@@ -72,6 +72,7 @@
 
 		.stats-download-csv {
 			color: var(--color-link);
+			gap: 4px;
 
 			&[disabled],
 			&.disabled {

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -24,9 +24,11 @@ const StatsCard = ( props: StatsCardProps ) => {
 		titleURL,
 		titleAriaLevel = 4,
 		titleNodes,
+		downloadCsv,
 		footerAction,
 		isEmpty,
 		emptyMessage,
+		multiHeader,
 		metricLabel,
 		mainItemLabel,
 		additionalHeaderColumns,
@@ -55,6 +57,22 @@ const StatsCard = ( props: StatsCardProps ) => {
 			{ titleNode }
 			{ ! isEmpty && <div>{ metricLabel ?? translate( 'Views' ) }</div> }
 		</div>
+	);
+
+	// Show card title and download csv button on one line, description and metric label on another:
+	const multiHeaderNode = (
+		<>
+			<div className={ clsx( `${ BASE_CLASS_NAME }-header`, headerClassName ) }>
+				{ titleNode }
+				{ ! isEmpty && downloadCsv }
+			</div>
+			{ ! isEmpty && (
+				<div className={ clsx( `${ BASE_CLASS_NAME }-sub-header`, headerClassName ) }>
+					<div> All { title.toLowerCase() } </div>
+					<div>{ metricLabel ?? translate( 'Views' ) }</div>
+				</div>
+			) }
+		</>
 	);
 
 	// Show Card title on one line and all other column header(s) below:
@@ -87,6 +105,16 @@ const StatsCard = ( props: StatsCardProps ) => {
 		</div>
 	);
 
+	const getHeaderNode = () => {
+		if ( multiHeader ) {
+			return multiHeaderNode;
+		}
+		if ( splitHeader ) {
+			return splitHeaderNode;
+		}
+		return simpleHeaderNode;
+	};
+
 	return (
 		<div
 			className={ clsx( className, BASE_CLASS_NAME, {
@@ -101,7 +129,7 @@ const StatsCard = ( props: StatsCardProps ) => {
 					</div>
 				) }
 				<div className={ `${ BASE_CLASS_NAME }--header-and-body` }>
-					{ splitHeader ? splitHeaderNode : simpleHeaderNode }
+					{ getHeaderNode() }
 					<div
 						className={ clsx( `${ BASE_CLASS_NAME }--body`, {
 							[ `${ BASE_CLASS_NAME }--body-empty` ]: isEmpty,

--- a/packages/components/src/horizontal-bar-list/types.ts
+++ b/packages/components/src/horizontal-bar-list/types.ts
@@ -76,6 +76,10 @@ export type StatsCardProps = {
 	 * @property {React.ReactNode} titleNodes - additional nodes to be displayed next to the title - use TitleExtras component for unified resutl.
 	 */
 	titleNodes?: React.ReactNode;
+	/**
+	 * @property {React.ReactNode} downloadCsv - a node to be displayed next to the title - use DownloadCsv component for unified result.
+	 */
+	downloadCsv?: React.ReactNode;
 	footerAction?: {
 		label?: string;
 		url?: string;
@@ -98,6 +102,10 @@ export type StatsCardProps = {
 	 * @property {React.ReactNode} heroElement - a node placed before the list
 	 */
 	heroElement?: React.ReactNode;
+	/**
+	 * @property {boolean} multiHeader - adds a sub-header row, including metric label, after the header containing the name of the card and download csv button
+	 */
+	multiHeader?: boolean;
 	/**
 	 * @property {boolean} splitHeader - instead of using a simple header containing the name of the card use additional columns and header items
 	 */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/jetpack-roadmap/issues/2241.

## Proposed Changes

* Improve Download CSV action consistency for almost all cards, except `UTM` and `Videos` that have different designs.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Automattic/jetpack-roadmap#1818

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the Calypso live link below and go to a site that has meaningful data, like `/stats/day/jetpack.com`.
* Click on `View all`/`View details` links for different cards. The `Download CSV` button should be shown in the upper-right corner.
  * There will be a second row/sub-header, where the metric (like `Views`) will be now part of.
* This is how `Posts & pages`, for example, should look like:

| Before | After |
| - | - |
| <img alt="image" src="https://github.com/user-attachments/assets/0389802e-ea67-4c19-ae0b-5a7dfb57e06f" /> | <img alt="image" src="https://github.com/user-attachments/assets/99422fac-89bb-4e3a-a04f-98ef39783f6d" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
