### PR TITLE
Reader User Profile: Refactor CSS

### DIFF
--- a/client/reader/user-profile/index.tsx
+++ b/client/reader/user-profile/index.tsx
@@ -71,9 +71,9 @@ export function UserProfile( props: UserProfileProps ): JSX.Element | null {
 
 	return (
 		<div className="user-profile">
-			<div className={ `user-profile__content-wrapper${ showBack ? ' has-back-button' : '' }` }>
+			<div className={ `user-profile__wrapper${ showBack ? ' has-back-button' : '' }` }>
 				{ showBack && <BackButton onClick={ handleBack } /> }
-				<div className="user-profile__content">{ renderContent() }</div>
+				<div className="user-profile__wrapper-content">{ renderContent() }</div>
 			</div>
 		</div>
 	);

--- a/client/reader/user-profile/style.scss
+++ b/client/reader/user-profile/style.scss
@@ -2,18 +2,18 @@
 
 .is-section-reader {
 
-	.user-profile__404.empty-content {
-		max-width: initial;
-		margin: initial;
-		padding-top: 150px;
-	}
-
 	.user-profile {
 		position: relative;
 
-		&__content-wrapper {
+		&__404.empty-content {
+			max-width: initial;
+			margin: initial;
+			padding-top: 150px;
+		}
 
-			div.user-profile__content {
+		&__wrapper {
+
+			&-content {
 				padding-top: 36px;
 
 				@include breakpoint-deprecated( '<660px' ) {
@@ -43,7 +43,7 @@
 			}
 
 			&.has-back-button {
-				div.user-profile__content {
+				&-content {
 					padding-top: 0;
 				}
 
@@ -52,23 +52,23 @@
 				}
 			}
 		}
-	}
 
-	.user-profile__lists-body {
-		max-width: 768px;
-		margin: 0 auto;
+		&__lists-body {
+			max-width: 768px;
+			margin: 0 auto;
 
-		&-link {
-			color: var(--color-neutral-100);
-			cursor: pointer;
-			display: block;
-			line-height: 29px;
-			text-wrap: pretty;
+			&-link {
+				color: var(--color-neutral-100);
+				cursor: pointer;
+				display: block;
+				line-height: 29px;
+				text-wrap: pretty;
 
-			.reader-post-card__title {
-				margin-top: 0;
-				font-size: 1.25rem;
-				font-weight: 600;
+				.reader-post-card__title {
+					margin-top: 0;
+					font-size: 1.25rem;
+					font-weight: 600;
+				}
 			}
 		}
 	}

--- a/client/reader/user-profile/style.scss
+++ b/client/reader/user-profile/style.scss
@@ -2,7 +2,7 @@
 
 .is-section-reader {
 
-	div.user-profile {
+	.user-profile {
 		position: relative;
 
 		&__404.empty-content {
@@ -11,7 +11,7 @@
 			padding-top: 150px;
 		}
 
-		.user-profile__wrapper {
+		div.user-profile__wrapper {
 
 			&-content {
 				padding-top: 36px;

--- a/client/reader/user-profile/style.scss
+++ b/client/reader/user-profile/style.scss
@@ -11,7 +11,7 @@
 			padding-top: 150px;
 		}
 
-		&__wrapper {
+		.user-profile__wrapper {
 
 			&-content {
 				padding-top: 36px;
@@ -43,7 +43,7 @@
 			}
 
 			&.has-back-button {
-				&-content {
+				.user-profile__wrapper-content {
 					padding-top: 0;
 				}
 

--- a/client/reader/user-profile/style.scss
+++ b/client/reader/user-profile/style.scss
@@ -2,7 +2,7 @@
 
 .is-section-reader {
 
-	.user-profile {
+	div.user-profile {
 		position: relative;
 
 		&__404.empty-content {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99286

## Proposed Changes

This refactors the user profile page's CSS to make better use of SASS syntax.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The stylesheet for the profile page is disorganized.
Naming and SASS syntax is inconsistent, and it’s hard to add styles to it cleanly; this PR makes the styles more consistent so they're easier to maintain and understand.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

On the profile page...
- Make sure the padding is still being applied to `user-profile__wrapper` and `user-profile__wrapper-content` at desktop and mobile widths, and that the back button looks correct.
- Visit a nonexistent profile like `/reader/users/artemiosansafd` and make sure the styles still render properly for empty content.
- Visit the lists page and make sure those styles are still being applied.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
