### PR TITLE
Domain Management: Fix error due to accessing domain.name when domain is undefined

### DIFF
--- a/client/my-sites/email/email-providers-comparison/stacked/provider-cards/get-on-submit-new-mailboxes-handler.ts
+++ b/client/my-sites/email/email-providers-comparison/stacked/provider-cards/get-on-submit-new-mailboxes-handler.ts
@@ -98,7 +98,7 @@ const getOnSubmitNewMailboxesHandler =
 
 		const checkoutPath = getEmailCheckoutPath(
 			siteSlug,
-			domain.name,
+			domain?.name,
 			currentRoute,
 			mailboxOperations.mailboxes[ 0 ].getAsCartItem().email
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/99715

## Proposed Changes

This PR adds a defensive check when accessing domain.name to prevent a JS error blocking the rest of the flow.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Upgrades > Email 
* Click on Just Search for a Domain button
* Select any Domain
* In the Email upsell step, enter Email Address and Password
* Ensure that clicking the Purchase button does not block the flow and redirects to the checkout page

![SCR-20250214-hxuk](https://github.com/user-attachments/assets/28070355-15b9-44ea-9197-07af1b8fd7f1)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
