### PR TITLE
Removes Classic style + RDV redirection for /settings/general to /sites/settings/site 

### DIFF
--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { get } from 'lodash';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import { makeLayout, render as clientRender, redirectIfDuplicatedView } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import {
 	acceptSiteTransfer,
@@ -21,7 +21,6 @@ import {
 	siteSettings,
 	redirectToolsIfRemoveDuplicateViewsExperimentEnabled,
 	redirectSettingsIfDuplciatedViewsEnabled,
-	redirectGeneralSettingsIfDuplicatedViewsEnabled,
 } from 'calypso/my-sites/site-settings/settings-controller';
 import {
 	redirectIfCantDeleteSite,
@@ -33,7 +32,7 @@ export default function () {
 	page(
 		'/settings/general/:site_id',
 		siteSelection,
-		redirectGeneralSettingsIfDuplicatedViewsEnabled,
+		redirectIfDuplicatedView( 'options-general.php' ),
 		navigation,
 		setScroll,
 		siteSettings,

--- a/client/my-sites/site-settings/settings-controller.js
+++ b/client/my-sites/site-settings/settings-controller.js
@@ -67,6 +67,13 @@ export const redirectToolsIfRemoveDuplicateViewsExperimentEnabled = async ( cont
  * Redirect /settings to /sites/settings/site when the Remove Duplicate Views experiment is enabled.
  *
  * Previously /settings redirected to /settings/general which now redirects to /wp-admin/options-general.php
+ *
+ * This is to maintain previous behavior by providing HE's with a consistent location, `/settings`, to link
+ * to for visibility and site launching options.
+ *
+ * When the experiment is over:
+ * - /settings can always redirect to /sites/settings/site
+ * - /settings/general can always redirect to /wp-admin/options-general.php
  */
 export const redirectSettingsIfDuplciatedViewsEnabled = async ( context ) => {
 	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( context.store.getState() );

--- a/client/my-sites/site-settings/settings-controller.js
+++ b/client/my-sites/site-settings/settings-controller.js
@@ -1,6 +1,5 @@
 import page from '@automattic/calypso-router';
 import titlecase from 'to-title-case';
-import { redirectIfDuplicatedView } from 'calypso/controller';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
 import { navigate } from 'calypso/lib/navigate';
 import { isRemoveDuplicateViewsExperimentEnabled } from 'calypso/lib/remove-duplicate-views-experiment';
@@ -78,25 +77,6 @@ export const redirectSettingsIfDuplciatedViewsEnabled = async ( context ) => {
 
 	return page.redirect( '/settings/general' );
 };
-
-/**
- * Redirect to /sites/settings/site/:site when Classic sites' users try to access the Hosting > Site Settings
- * if the Remove Duplicate Views experiment is enabled.
- */
-export async function redirectGeneralSettingsIfDuplicatedViewsEnabled( context, next ) {
-	const state = context.store.getState();
-	const siteId = getSelectedSiteId( state );
-	const siteSlug = getSelectedSiteSlug( state );
-
-	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( state );
-	const hasClassicAdminInterfaceStyle =
-		getSiteOption( state, siteId, 'wpcom_admin_interface' ) === 'wp-admin';
-	if ( isUntangled && hasClassicAdminInterfaceStyle ) {
-		return page.redirect( `/sites/settings/site/${ siteSlug }` );
-	}
-
-	redirectIfDuplicatedView( 'options-general.php' )( context, next );
-}
 
 /**
  * Redirect to /settings/general if the Remove Duplicate Views experiment is DISABLED


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/99391

Follow up / calypso side of https://github.com/Automattic/jetpack/pull/41776

## Proposed Changes

* Removes Classic style + RDV redirection for /settings/general to /sites/settings/site as we no longer link to /settings/general in the sidebar for Site Settings. /settings/general will continue to redirect to options-general.php for RDV users.

## Testing Instructions

### Treatment user:
- [x] Classic view `Hosting > Site Settings` should link to `/sites/settings/site`.
- [x] Default view and classic view visiting `/settings/general` should redirect to options-general.php.

### Control user:
- [x] Classic view `Hosting > Site Settings` should link to `/settings/general`.
- [x] Default and classic view visiting `/settings/general` should not redirect to options-general.php