### PR TITLE
[Site Admin]: Introduce `SiteHub` Component

### DIFF
--- a/packages/site-admin/.storybook/mock-registry/index.ts
+++ b/packages/site-admin/.storybook/mock-registry/index.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { createReduxStore, createRegistry } from '@wordpress/data';
+import { action } from '@storybook/addon-actions';
 
 /**
  * Types
@@ -12,17 +13,52 @@ type WPDataRegistry = ReturnType< typeof createRegistry >;
 /**
  * Registers a mock store with the given initial state.
  */
+import { store as commandsStore } from '@wordpress/commands';
+
 const registerMockStore = ( registry, storeName, initialState ) => {
+	/*
+	 * `core/commands` store
+	 */
+	if ( storeName === commandsStore.name ) {
+		const mockCommandsStore = createReduxStore( storeName, {
+			reducer: ( state = { isOpen: false }, action ) => {
+				switch ( action.type ) {
+					case 'OPEN':
+						return { ...state, isOpen: true };
+					case 'CLOSE':
+						return { ...state, isOpen: false };
+					default:
+						return state;
+				}
+			},
+			actions: {
+				open: () => {
+					action( '[`core/commands`] Open Command Center' )();
+					return { type: 'OPEN' };
+				},
+				close: () => {
+					action( '[`core/commands`] Close Command Center' )();
+					return { type: 'CLOSE' };
+				},
+			},
+			selectors: {
+				isOpen: ( state ) => state.isOpen,
+			},
+		} );
+
+		registry.register( mockCommandsStore );
+		return;
+	}
+
+	/*
+	 * `core` store
+	 */
 	const store = createReduxStore( storeName, {
 		reducer: ( state = initialState ) => state,
 		selectors: {
 			getEntityRecord: ( state, kind, name ) => {
 				const mockStateKey = `${ kind }/${ name }`;
-				if ( ! state[ mockStateKey ] ) {
-					return null;
-				}
-
-				return state[ mockStateKey ];
+				return state[ mockStateKey ] || null;
 			},
 		},
 		actions: {},

--- a/packages/site-admin/.storybook/mock-registry/index.ts
+++ b/packages/site-admin/.storybook/mock-registry/index.ts
@@ -17,10 +17,12 @@ const registerMockStore = ( registry, storeName, initialState ) => {
 		reducer: ( state = initialState ) => state,
 		selectors: {
 			getEntityRecord: ( state, kind, name ) => {
-				if ( kind === 'root' && name === '__unstableBase' ) {
-					return state[ 'root/__unstableBase' ] || null;
+				const mockStateKey = `${ kind }/${ name }`;
+				if ( ! state[ mockStateKey ] ) {
+					return null;
 				}
-				return null;
+
+				return state[ mockStateKey ];
 			},
 		},
 		actions: {},

--- a/packages/site-admin/.storybook/mock-registry/stores.ts
+++ b/packages/site-admin/.storybook/mock-registry/stores.ts
@@ -27,6 +27,7 @@ const stores = {
 			description:
 				'WooCommerce Analytics is a powerful tool that helps you understand how your store is performing and how you can improve your store’s performance.',
 			'root/__unstableBase': { site_icon_url: image_url_01 },
+			'root/site': { title: 'WooCommerce Analytics Site', url: 'https://woocommerce.com' },
 		},
 	},
 	[ REGULAR_SITE_KEY ]: {
@@ -34,6 +35,7 @@ const stores = {
 			name: 'Regular Site',
 			description: 'A regular site with no special features.',
 			'root/__unstableBase': { site_icon_url: undefined },
+			'root/site': { title: 'My Regular Site', url: 'https://example.com' },
 		},
 	},
 	[ JETPACK_SITE_KEY ]: {
@@ -41,6 +43,7 @@ const stores = {
 			name: 'Jetpack Site',
 			description: 'A site with Jetpack installed.',
 			'root/__unstableBase': { site_icon_url: image_url_02 },
+			'root/site': { title: 'Jetpack Super Site', url: 'https://jetpack.com' },
 		},
 	},
 };

--- a/packages/site-admin/.storybook/mock-registry/stores.ts
+++ b/packages/site-admin/.storybook/mock-registry/stores.ts
@@ -3,6 +3,7 @@
  */
 import { createRegistry } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
+import { store as commandsStore } from '@wordpress/commands';
 
 type WPDataRegistry = ReturnType< typeof createRegistry >;
 
@@ -20,7 +21,7 @@ export type MockStores = Record< MockSiteKey, Record< string, WPDataRegistry > >
 const image_url_01 = 'https://i.pravatar.cc/300';
 const image_url_02 = 'https://i.pravatar.cc/301';
 
-const stores = {
+const mockStores = {
 	[ WOOCOMMERCE_ANALYTICS_SITE_KEY ]: {
 		[ coreDataStore.name ]: {
 			name: 'WooCommerce Analytics',
@@ -29,6 +30,7 @@ const stores = {
 			'root/__unstableBase': { site_icon_url: image_url_01 },
 			'root/site': { title: 'WooCommerce Analytics Site', url: 'https://woocommerce.com' },
 		},
+		[ commandsStore.name ]: {},
 	},
 	[ REGULAR_SITE_KEY ]: {
 		[ coreDataStore.name ]: {
@@ -37,6 +39,7 @@ const stores = {
 			'root/__unstableBase': { site_icon_url: undefined },
 			'root/site': { title: 'My Regular Site', url: 'https://example.com' },
 		},
+		[ commandsStore.name ]: {},
 	},
 	[ JETPACK_SITE_KEY ]: {
 		[ coreDataStore.name ]: {
@@ -45,7 +48,8 @@ const stores = {
 			'root/__unstableBase': { site_icon_url: image_url_02 },
 			'root/site': { title: 'Jetpack Super Site', url: 'https://jetpack.com' },
 		},
+		[ commandsStore.name ]: {},
 	},
 };
 
-export default stores;
+export default mockStores;

--- a/packages/site-admin/CHANGELOG.md
+++ b/packages/site-admin/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @automattic/site-admin 0.0.1
+## 0.0.1
 
 Initial release of the site-admin package providing a framework for building modern WordPress admin interfaces.
 
@@ -21,8 +21,6 @@ Initial release of the site-admin package providing a framework for building mod
 - `useLocation`: Hook for accessing current route location
 - `useMatch`: Hook for route matching functionality
 
-
 ## Next
 
 - `SiteHub`: Site navigation and context switcher
-

--- a/packages/site-admin/CHANGELOG.md
+++ b/packages/site-admin/CHANGELOG.md
@@ -1,6 +1,28 @@
+# @automattic/site-admin 0.0.1
+
+Initial release of the site-admin package providing a framework for building modern WordPress admin interfaces.
+
+## Core Components
+
+- `SidebarButton`: Base button component for sidebar interactions
+- `SidebarContent`: Main sidebar layout component with navigation context
+- `SidebarNavigationItem`: Interactive navigation items with icon support
+- `SidebarNavigationScreen`: Screen container for sidebar navigation
+- `SiteIcon`: Site icon display component
+
+## Routing System
+- `RoutesContext`: Context provider for current matched route
+- `ConfigContext`: Context for router configuration and settings
+- `browserHistory`: Browser history instance for navigation state
+
+### Router Hooks
+- `useHistory`: Hook for navigation and history management
+- `useLink`: Hook for handling link navigation
+- `useLocation`: Hook for accessing current route location
+- `useMatch`: Hook for route matching functionality
+
+
 ## Next
 
-## 0.0.1
+- `SiteHub`: Site navigation and context switcher
 
-- Introduce package. Create skeleton.
-- Expose [getMeta()](./src/utils/meta/README.md)

--- a/packages/site-admin/README.md
+++ b/packages/site-admin/README.md
@@ -120,7 +120,7 @@ const SidebarContent = () => {
                 uid="reports"
                 aria-current={ path === '/reports' }
             >
-                { __( 'Reports', 'a8c-site-admin' }
+                { __( 'Reports', 'a8c-site-admin' ) }
             </SidebarNavigationItem>
 
             <SidebarNavigationItem
@@ -130,7 +130,7 @@ const SidebarContent = () => {
                 uid="settings"
                 aria-current={ path === '/settings' }
             >
-                { __( 'Settings', 'a8c-site-admin' }
+                { __( 'Settings', 'a8c-site-admin' ) }
             </SidebarNavigationItem>
 
             <SidebarNavigationItem
@@ -140,7 +140,7 @@ const SidebarContent = () => {
                 uid="archive"
                 aria-current={ path === '/archive' }
             >
-                { __( 'Archive', 'a8c-site-admin' }
+                { __( 'Archive', 'a8c-site-admin' ) }
             </SidebarNavigationItem>
         </ItemGroup>
     );
@@ -159,7 +159,7 @@ the necessary context for the navigation elements to work correctly.
     <RouterProvider routes={ appRoutes } pathArg="page">
         <SidebarNavigationScreen
             isRoot
-            title={ __( 'Home', 'a8c-site-admin' }
+            title={ __( 'Home', 'a8c-site-admin' ) }
             content={ <SidebarContent /> }
         />
         

--- a/packages/site-admin/README.md
+++ b/packages/site-admin/README.md
@@ -120,7 +120,7 @@ const SidebarContent = () => {
                 uid="reports"
                 aria-current={ path === '/reports' }
             >
-                { __( 'Reports' ) }
+                { __( 'Reports', 'a8c-site-admin' }
             </SidebarNavigationItem>
 
             <SidebarNavigationItem
@@ -130,7 +130,7 @@ const SidebarContent = () => {
                 uid="settings"
                 aria-current={ path === '/settings' }
             >
-                { __( 'Settings' ) }
+                { __( 'Settings', 'a8c-site-admin' }
             </SidebarNavigationItem>
 
             <SidebarNavigationItem
@@ -140,7 +140,7 @@ const SidebarContent = () => {
                 uid="archive"
                 aria-current={ path === '/archive' }
             >
-                { __( 'Archive' ) }
+                { __( 'Archive', 'a8c-site-admin' }
             </SidebarNavigationItem>
         </ItemGroup>
     );
@@ -159,7 +159,7 @@ the necessary context for the navigation elements to work correctly.
     <RouterProvider routes={ appRoutes } pathArg="page">
         <SidebarNavigationScreen
             isRoot
-            title={ __( 'Home' ) }
+            title={ __( 'Home', 'a8c-site-admin' }
             content={ <SidebarContent /> }
         />
         

--- a/packages/site-admin/package.json
+++ b/packages/site-admin/package.json
@@ -57,7 +57,7 @@
 	},
 	"dependencies": {
 		"@wordpress/base-styles": "^5.20.0",
-		"@wordpress/commands": "^1.19.0",
+		"@wordpress/commands": "^1.20.0",
 		"@wordpress/components": "^29.6.0",
 		"@wordpress/compose": "^7.20.0",
 		"@wordpress/core-data": "^7.20.0",

--- a/packages/site-admin/package.json
+++ b/packages/site-admin/package.json
@@ -57,6 +57,7 @@
 	},
 	"dependencies": {
 		"@wordpress/base-styles": "^5.20.0",
+		"@wordpress/commands": "^1.19.0",
 		"@wordpress/components": "^29.6.0",
 		"@wordpress/compose": "^7.20.0",
 		"@wordpress/core-data": "^7.20.0",

--- a/packages/site-admin/src/components/index.ts
+++ b/packages/site-admin/src/components/index.ts
@@ -1,5 +1,6 @@
-export { SiteIcon } from './site-icon';
-export { SidebarContent, SidebarNavigationContext, createNavState } from './sidebar';
 export { SidebarButton } from './sidebar-button';
+export { SidebarContent, SidebarNavigationContext, createNavState } from './sidebar';
 export { SidebarNavigationItem } from './sidebar-navigation-item';
 export { SidebarNavigationScreen } from './sidebar-navigation-screen';
+export { SiteIcon } from './site-icon';
+export { SiteHub } from './site-hub';

--- a/packages/site-admin/src/components/sidebar/stories/index.stories.tsx
+++ b/packages/site-admin/src/components/sidebar/stories/index.stories.tsx
@@ -72,8 +72,8 @@ export const Default: Story = {
 			<RouterProvider routes={ [] } pathArg="page">
 				<SiteHub
 					isTransparent
-					navigationBackLabel={ __( 'Go to the Dashboard', 'a8c-site-admin' ) }
-					navigationBackLink="/"
+					exitLabel={ __( 'Go to the Dashboard', 'a8c-site-admin' ) }
+					exitLink="/"
 				/>
 				<SidebarContent { ...args }>
 					<SidebarNavigationScreen

--- a/packages/site-admin/src/components/sidebar/stories/index.stories.tsx
+++ b/packages/site-admin/src/components/sidebar/stories/index.stories.tsx
@@ -7,7 +7,7 @@ import { archive, navigation, settings } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { SidebarContent, SidebarNavigationItem, SidebarNavigationScreen } from '../../';
+import { SidebarContent, SidebarNavigationItem, SidebarNavigationScreen, SiteHub } from '../../';
 import { useLocation, RouterProvider } from '../../../router';
 /**
  * Types
@@ -70,6 +70,7 @@ export const Default: Story = {
 	render: function Template( args: SidebarContentProps ) {
 		return (
 			<RouterProvider routes={ [] } pathArg="page">
+				<SiteHub isTransparent navigationBackLink="/" navigationBackLabel="Go to the Dashboard" />
 				<SidebarContent { ...args }>
 					<SidebarNavigationScreen
 						isRoot

--- a/packages/site-admin/src/components/sidebar/stories/index.stories.tsx
+++ b/packages/site-admin/src/components/sidebar/stories/index.stories.tsx
@@ -72,7 +72,7 @@ export const Default: Story = {
 			<RouterProvider routes={ [] } pathArg="page">
 				<SiteHub
 					isTransparent
-					navigationBackLabel={ __( 'Go to the Dashboard' ) }
+					navigationBackLabel={ __( 'Go to the Dashboard', 'a8c-site-admin' ) }
 					navigationBackLink="/"
 				/>
 				<SidebarContent { ...args }>

--- a/packages/site-admin/src/components/sidebar/stories/index.stories.tsx
+++ b/packages/site-admin/src/components/sidebar/stories/index.stories.tsx
@@ -70,7 +70,11 @@ export const Default: Story = {
 	render: function Template( args: SidebarContentProps ) {
 		return (
 			<RouterProvider routes={ [] } pathArg="page">
-				<SiteHub isTransparent navigationBackLink="/" navigationBackLabel="Go to the Dashboard" />
+				<SiteHub
+					isTransparent
+					navigationBackLabel={ __( 'Go to the Dashboard' ) }
+					navigationBackLink="/"
+				/>
 				<SidebarContent { ...args }>
 					<SidebarNavigationScreen
 						isRoot

--- a/packages/site-admin/src/components/site-hub/README.md
+++ b/packages/site-admin/src/components/site-hub/README.md
@@ -1,0 +1,53 @@
+# SiteHub
+
+The `SiteHub` component provides a top-level navigation element displaying
+the site title, a back navigation button, and access to the command palette.
+It integrates with WordPress Core's entity data to
+dynamically fetch site information.
+
+## Usage
+
+```tsx
+import { SiteHub } from '@automattic/site-admin';
+
+export default function Example() {
+	return (
+		<SiteHub
+			isTransparent={false}
+			navigationBackLabel="Back to Dashboard"
+			navigationBackLink="/dashboard"
+		/>
+	);
+}
+```
+
+## Handling ref in SiteHub
+
+The SiteHub component uses `forwardRef` to allow external components to pass
+a ref that directly references the navigation button.
+This is useful for managing focus, triggering actions,
+or integrating with accessibility tools.
+
+```tsx
+import { useRef, useEffect } from 'react';
+import { SiteHub } from './SiteHub';
+
+export default function Example() {
+	const buttonRef = useRef< HTMLButtonElement >( null );
+
+	useEffect( () => {
+		if ( buttonRef.current ) {
+			buttonRef.current.focus();
+		}
+	}, [] );
+
+	return (
+		<SiteHub
+			ref={ buttonRef }
+			isTransparent={ false }
+			navigationBackLabel="Back"
+			navigationBackLink="/"
+		/>;
+	);
+}
+```

--- a/packages/site-admin/src/components/site-hub/README.md
+++ b/packages/site-admin/src/components/site-hub/README.md
@@ -8,8 +8,6 @@ dynamically fetch site information.
 ## Usage
 
 ```tsx
-import { SiteHub } from '@automattic/site-admin';
-
 export default function Example() {
 	return (
 		<SiteHub
@@ -30,7 +28,6 @@ or integrating with accessibility tools.
 
 ```tsx
 import { useRef, useEffect } from 'react';
-import { SiteHub } from './SiteHub';
 
 export default function Example() {
 	const buttonRef = useRef< HTMLButtonElement >( null );

--- a/packages/site-admin/src/components/site-hub/README.md
+++ b/packages/site-admin/src/components/site-hub/README.md
@@ -11,9 +11,9 @@ dynamically fetch site information.
 export default function Example() {
 	return (
 		<SiteHub
-			isTransparent={false}
-			navigationBackLabel="Back to Dashboard"
-			navigationBackLink="/dashboard"
+			isTransparent={ false }
+			exitLabel="Back to Dashboard"
+			exitLink="/dashboard"
 		/>
 	);
 }
@@ -42,8 +42,8 @@ export default function Example() {
 		<SiteHub
 			ref={ buttonRef }
 			isTransparent={ false }
-			navigationBackLabel="Back"
-			navigationBackLink="/"
+			exitLabel="Back"
+			exitLink="/"
 		/>;
 	);
 }

--- a/packages/site-admin/src/components/site-hub/README.md
+++ b/packages/site-admin/src/components/site-hub/README.md
@@ -44,7 +44,7 @@ export default function Example() {
 			isTransparent={ false }
 			exitLabel="Back"
 			exitLink="/"
-		/>;
+		/>
 	);
 }
 ```

--- a/packages/site-admin/src/components/site-hub/index.tsx
+++ b/packages/site-admin/src/components/site-hub/index.tsx
@@ -1,0 +1,116 @@
+/**
+ * External dependencies
+ */
+import { store as commandsStore } from '@wordpress/commands';
+import { Button, VisuallyHidden, __experimentalHStack as HStack } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { memo, forwardRef } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __ } from '@wordpress/i18n';
+import { search } from '@wordpress/icons';
+import { displayShortcut } from '@wordpress/keycodes';
+import { filterURLForDisplay } from '@wordpress/url';
+import clsx from 'clsx';
+/**
+ * Internal dependencies
+ */
+import { SiteIcon } from '../';
+import './style.scss';
+
+interface SiteData {
+	title: string;
+	url: string;
+	show_on_front?: string;
+	page_on_front?: string | number;
+	page_for_posts?: string | number;
+}
+
+interface SiteHubProps {
+	isTransparent: boolean;
+
+	navigationBackLabel: string;
+	navigationBackLink: string; // core picks this prop (dashboardLink) from site-admin store.
+}
+
+export const SiteHub = memo(
+	forwardRef(
+		(
+			{
+				isTransparent,
+				navigationBackLink = '/',
+				navigationBackLabel = __( 'Go to the Dashboard' ),
+			}: SiteHubProps,
+			ref
+		) => {
+			const { homeUrl, siteTitle } = useSelect( ( select ) => {
+				const { getEntityRecord } = select( coreStore );
+
+				const _site = getEntityRecord( 'root', 'site' ) as SiteData;
+				const home = getEntityRecord< {
+					home: string;
+				} >( 'root', '__unstableBase' )?.home;
+
+				return {
+					homeUrl: home,
+					siteTitle:
+						! _site?.title && !! _site?.url ? filterURLForDisplay( _site?.url ) : _site?.title,
+				};
+			}, [] );
+
+			const { open: openCommandCenter } = useDispatch( commandsStore );
+
+			return (
+				<div className="site-admin-site-hub">
+					<HStack justify="flex-start" spacing="0">
+						<div
+							className={ clsx( 'site-admin-site-hub__view-mode-toggle-container', {
+								'has-transparent-background': isTransparent,
+							} ) }
+						>
+							<Button
+								__next40pxDefaultSize
+								ref={ ref }
+								href={ navigationBackLink }
+								label={ navigationBackLabel }
+								className="site-admin-layout__view-mode-toggle"
+								style={ {
+									transform: 'scale(0.5333) translateX(-4px)', // Offset to position the icon 12px from viewport edge
+									borderRadius: 4,
+								} }
+							>
+								<SiteIcon className="site-admin-layout__view-mode-toggle-icon" />
+							</Button>
+						</div>
+
+						<HStack>
+							<div className="site-admin-site-hub__title">
+								<Button __next40pxDefaultSize variant="link" href={ homeUrl } target="_blank">
+									{ decodeEntities( siteTitle ) }
+									<VisuallyHidden as="span">
+										{
+											/* translators: accessibility text */
+											__( '(opens in a new tab)' )
+										}
+									</VisuallyHidden>
+								</Button>
+							</div>
+
+							<HStack spacing={ 0 } expanded={ false } className="site-admin-site-hub__actions">
+								<Button
+									size="compact"
+									// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+									className="site-admin-site-hub_toggle-command-center"
+									icon={ search }
+									onClick={ () => openCommandCenter() }
+									label={ __( 'Open command palette' ) }
+									shortcut={ displayShortcut.primary( 'k' ) }
+								/>
+							</HStack>
+						</HStack>
+					</HStack>
+				</div>
+			);
+		}
+	)
+);

--- a/packages/site-admin/src/components/site-hub/index.tsx
+++ b/packages/site-admin/src/components/site-hub/index.tsx
@@ -83,11 +83,11 @@ export const SiteHub = memo(
 							} ) }
 						>
 							<Button
+								className="site-admin-layout__view-mode-toggle"
 								__next40pxDefaultSize
 								ref={ ref }
 								href={ navigationBackLink }
 								label={ navigationBackLabel }
-								className="site-admin-layout__view-mode-toggle"
 							>
 								<SiteIcon className="site-admin-layout__view-mode-toggle-icon" />
 							</Button>
@@ -95,7 +95,13 @@ export const SiteHub = memo(
 
 						<HStack>
 							<div className="site-admin-site-hub__title">
-								<Button __next40pxDefaultSize variant="link" href={ homeUrl } target="_blank">
+								<Button
+									className="site-admin-site-hub__title-button"
+									__next40pxDefaultSize
+									variant="link"
+									href={ homeUrl }
+									target="_blank"
+								>
 									{ decodeEntities( siteTitle ) }
 									<VisuallyHidden as="span">
 										{

--- a/packages/site-admin/src/components/site-hub/index.tsx
+++ b/packages/site-admin/src/components/site-hub/index.tsx
@@ -17,6 +17,10 @@ import clsx from 'clsx';
  */
 import { SiteIcon } from '../';
 import './style.scss';
+/**
+ * Types
+ */
+import type { JSX } from 'react';
 
 interface SiteData {
 	title: string;
@@ -33,6 +37,16 @@ interface SiteHubProps {
 	navigationBackLink: string; // core picks this prop (dashboardLink) from site-admin store.
 }
 
+/**
+ * SiteHub Component
+ *
+ * Provides a top-level navigation element displaying the site title,
+ * a back navigation button, and access to the command palette.
+ * It integrates with WordPress Core's entity data
+ * to fetch site information dynamically.
+ * @param {SiteHubProps} props - The component props.
+ * @returns {JSX.Element} The rendered SiteHub component.
+ */
 export const SiteHub = memo(
 	forwardRef(
 		(
@@ -42,7 +56,7 @@ export const SiteHub = memo(
 				navigationBackLabel = __( 'Go to the Dashboard' ),
 			}: SiteHubProps,
 			ref
-		) => {
+		): JSX.Element => {
 			const { homeUrl, siteTitle } = useSelect( ( select ) => {
 				const { getEntityRecord } = select( coreStore );
 

--- a/packages/site-admin/src/components/site-hub/index.tsx
+++ b/packages/site-admin/src/components/site-hub/index.tsx
@@ -53,7 +53,7 @@ export const SiteHub = memo(
 			{
 				isTransparent,
 				navigationBackLink = '/',
-				navigationBackLabel = __( 'Go to the Dashboard' ),
+				navigationBackLabel = __( 'Go to the Dashboard', 'a8c-site-admin' ),
 			}: SiteHubProps,
 			ref
 		): JSX.Element => {
@@ -100,7 +100,7 @@ export const SiteHub = memo(
 									<VisuallyHidden as="span">
 										{
 											/* translators: accessibility text */
-											__( '(opens in a new tab)' )
+											__( '(opens in a new tab)', 'a8c-site-admin' )
 										}
 									</VisuallyHidden>
 								</Button>
@@ -112,7 +112,7 @@ export const SiteHub = memo(
 									className="site-admin-site-hub__toggle-command-center"
 									icon={ search }
 									onClick={ () => openCommandCenter() }
-									label={ __( 'Open command palette' ) }
+									label={ __( 'Open command palette', 'a8c-site-admin' ) }
 									shortcut={ displayShortcut.primary( 'k' ) }
 								/>
 							</HStack>

--- a/packages/site-admin/src/components/site-hub/index.tsx
+++ b/packages/site-admin/src/components/site-hub/index.tsx
@@ -99,8 +99,7 @@ export const SiteHub = memo(
 							<HStack spacing={ 0 } expanded={ false } className="site-admin-site-hub__actions">
 								<Button
 									size="compact"
-									// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-									className="site-admin-site-hub_toggle-command-center"
+									className="site-admin-site-hub__toggle-command-center"
 									icon={ search }
 									onClick={ () => openCommandCenter() }
 									label={ __( 'Open command palette' ) }

--- a/packages/site-admin/src/components/site-hub/index.tsx
+++ b/packages/site-admin/src/components/site-hub/index.tsx
@@ -32,9 +32,8 @@ interface SiteData {
 
 interface SiteHubProps {
 	isTransparent: boolean;
-
-	navigationBackLabel: string;
-	navigationBackLink: string; // core picks this prop (dashboardLink) from site-admin store.
+	exitLabel: string;
+	exitLink: string;
 }
 
 /**
@@ -52,8 +51,8 @@ export const SiteHub = memo(
 		(
 			{
 				isTransparent,
-				navigationBackLink = '/',
-				navigationBackLabel = __( 'Go to the Dashboard', 'a8c-site-admin' ),
+				exitLink = '/',
+				exitLabel = __( 'Go to the Dashboard', 'a8c-site-admin' ),
 			}: SiteHubProps,
 			ref
 		): JSX.Element => {
@@ -86,8 +85,8 @@ export const SiteHub = memo(
 								className="site-admin-layout__view-mode-toggle"
 								__next40pxDefaultSize
 								ref={ ref }
-								href={ navigationBackLink }
-								label={ navigationBackLabel }
+								href={ exitLink }
+								label={ exitLabel }
 							>
 								<SiteIcon className="site-admin-layout__view-mode-toggle-icon" />
 							</Button>

--- a/packages/site-admin/src/components/site-hub/index.tsx
+++ b/packages/site-admin/src/components/site-hub/index.tsx
@@ -88,10 +88,6 @@ export const SiteHub = memo(
 								href={ navigationBackLink }
 								label={ navigationBackLabel }
 								className="site-admin-layout__view-mode-toggle"
-								style={ {
-									transform: 'scale(0.5333) translateX(-4px)', // Offset to position the icon 12px from viewport edge
-									borderRadius: 4,
-								} }
 							>
 								<SiteIcon className="site-admin-layout__view-mode-toggle-icon" />
 							</Button>

--- a/packages/site-admin/src/components/site-hub/stories/index.stories.tsx
+++ b/packages/site-admin/src/components/site-hub/stories/index.stories.tsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { SiteHub } from '../../';
+import { RouterProvider } from '../../../router';
+/**
+ * Types
+ */
+import type { Meta, StoryObj } from '@storybook/react';
+
+/**
+ * Storybook metadata
+ */
+const meta: Meta< typeof SiteHub > = {
+	title: 'Components/SiteHub',
+	component: SiteHub,
+};
+
+export default meta;
+
+type Story = StoryObj< typeof SiteHub >;
+
+export const Default: Story = {
+	render: function Template() {
+		return (
+			<RouterProvider routes={ [] } pathArg="page">
+				<SiteHub
+					isTransparent
+					navigationBackLabel={ __( 'Go to the Dashboard', 'a8c-site-admin' ) }
+					navigationBackLink="/"
+				/>
+			</RouterProvider>
+		);
+	},
+};

--- a/packages/site-admin/src/components/site-hub/stories/index.stories.tsx
+++ b/packages/site-admin/src/components/site-hub/stories/index.stories.tsx
@@ -32,8 +32,8 @@ export const Default: Story = {
 			<RouterProvider routes={ [] } pathArg="page">
 				<SiteHub
 					isTransparent
-					navigationBackLabel={ __( 'Go to the Dashboard', 'a8c-site-admin' ) }
-					navigationBackLink="/"
+					exitLabel={ __( 'Go to the Dashboard', 'a8c-site-admin' ) }
+					exitLink="/"
 				/>
 			</RouterProvider>
 		);
@@ -53,8 +53,8 @@ export const FocusButtonOnMount: Story = {
 			<RouterProvider routes={ [] } pathArg="page">
 				<SiteHub
 					isTransparent
-					navigationBackLabel={ __( 'Go to the Dashboard', 'a8c-site-admin' ) }
-					navigationBackLink="/"
+					exitLabel={ __( 'Go to the Dashboard', 'a8c-site-admin' ) }
+					exitLink="/"
 					ref={ buttonRef }
 				/>
 			</RouterProvider>

--- a/packages/site-admin/src/components/site-hub/stories/index.stories.tsx
+++ b/packages/site-admin/src/components/site-hub/stories/index.stories.tsx
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
+import { action } from '@storybook/addon-actions';
+import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -32,6 +34,28 @@ export const Default: Story = {
 					isTransparent
 					navigationBackLabel={ __( 'Go to the Dashboard', 'a8c-site-admin' ) }
 					navigationBackLink="/"
+				/>
+			</RouterProvider>
+		);
+	},
+};
+
+export const FocusButtonOnMount: Story = {
+	render: function Template() {
+		const buttonRef = useRef< HTMLButtonElement >( null );
+
+		useEffect( () => {
+			buttonRef.current?.focus();
+			action( 'Focus button' )( 'Focus on button' );
+		}, [] );
+
+		return (
+			<RouterProvider routes={ [] } pathArg="page">
+				<SiteHub
+					isTransparent
+					navigationBackLabel={ __( 'Go to the Dashboard', 'a8c-site-admin' ) }
+					navigationBackLink="/"
+					ref={ buttonRef }
 				/>
 			</RouterProvider>
 		);

--- a/packages/site-admin/src/components/site-hub/style.scss
+++ b/packages/site-admin/src/components/site-hub/style.scss
@@ -83,7 +83,7 @@
 	}
 }
 
-.site-admin-site-hub_toggle-command-center {
+.site-admin-site-hub__toggle-command-center {
 	color: $gray-200;
 
 	&:hover,

--- a/packages/site-admin/src/components/site-hub/style.scss
+++ b/packages/site-admin/src/components/site-hub/style.scss
@@ -106,7 +106,7 @@
 	align-items: center;
 	justify-content: center;
 	background: $gray-900;
-	border-radius: 4;
+	border-radius: 4px;
 	transform: scale(0.5333) translateX(-4px); // Offset to position the icon 12px from viewport edge
 
 	&:hover,

--- a/packages/site-admin/src/components/site-hub/style.scss
+++ b/packages/site-admin/src/components/site-hub/style.scss
@@ -24,7 +24,7 @@
 	}
 }
 
-.site-admin-site-hub__title .components-button {
+.site-admin-site-hub__title .site-admin-site-hub__title-button {
 	color: $gray-200;
 	display: block;
 	flex-grow: 1;

--- a/packages/site-admin/src/components/site-hub/style.scss
+++ b/packages/site-admin/src/components/site-hub/style.scss
@@ -19,6 +19,58 @@
 	width: $header-height;
 	flex-shrink: 0;
 
+	.site-admin-layout__view-mode-toggle {
+		view-transition-name: toggle;
+		position: relative;
+		color: $white;
+		height: $header-height;
+		width: $header-height;
+		overflow: hidden;
+		padding: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: $gray-900;
+		border-radius: 4px;
+		transform: scale(0.5333) translateX(-4px); // Offset to position the icon 12px from viewport edge
+	
+		&:hover,
+		&:active {
+			color: $white;
+		}
+	
+		&:focus-visible,
+		&:focus {
+			box-shadow: 0 0 0 3px #1e1e1e, 0 0 0 6px var(--wp-admin-theme-color);
+			outline: 4px solid #0000;
+			outline-offset: 4px;
+		}
+	
+		&::before {
+			content: "";
+			display: block;
+			position: absolute;
+			top: 9px;
+			right: 9px;
+			bottom: 9px;
+			left: 9px;
+			border-radius: $radius-medium;
+			box-shadow: none;
+	
+			@media not (prefers-reduced-motion) {
+				transition: box-shadow 0.1s ease;
+			}
+		}
+	
+		.site-admin-layout__view-mode-toggle-icon {
+			display: flex;
+			height: $header-height;
+			width: $header-height;
+			justify-content: center;
+			align-items: center;
+		}
+	}
+
 	&.has-transparent-background .site-admin-layout__view-mode-toggle-icon {
 		background: transparent;
 	}
@@ -94,54 +146,3 @@
 	}
 }
 
-.site-admin-layout__view-mode-toggle.components-button {
-	view-transition-name: toggle;
-	position: relative;
-	color: $white;
-	height: $header-height;
-	width: $header-height;
-	overflow: hidden;
-	padding: 0;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	background: $gray-900;
-	border-radius: 4px;
-	transform: scale(0.5333) translateX(-4px); // Offset to position the icon 12px from viewport edge
-
-	&:hover,
-	&:active {
-		color: $white;
-	}
-
-	&:focus-visible,
-	&:focus {
-		box-shadow: 0 0 0 3px #1e1e1e, 0 0 0 6px var(--wp-admin-theme-color);
-		outline: 4px solid #0000;
-		outline-offset: 4px;
-	}
-
-	&::before {
-		content: "";
-		display: block;
-		position: absolute;
-		top: 9px;
-		right: 9px;
-		bottom: 9px;
-		left: 9px;
-		border-radius: $radius-medium;
-		box-shadow: none;
-
-		@media not (prefers-reduced-motion) {
-			transition: box-shadow 0.1s ease;
-		}
-	}
-
-	.site-admin-layout__view-mode-toggle-icon {
-		display: flex;
-		height: $header-height;
-		width: $header-height;
-		justify-content: center;
-		align-items: center;
-	}
-}

--- a/packages/site-admin/src/components/site-hub/style.scss
+++ b/packages/site-admin/src/components/site-hub/style.scss
@@ -106,7 +106,8 @@
 	align-items: center;
 	justify-content: center;
 	background: $gray-900;
-	border-radius: 0;
+	border-radius: 4;
+	transform: scale(0.5333) translateX(-4px); // Offset to position the icon 12px from viewport edge
 
 	&:hover,
 	&:active {

--- a/packages/site-admin/src/components/site-hub/style.scss
+++ b/packages/site-admin/src/components/site-hub/style.scss
@@ -1,0 +1,95 @@
+@import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/mixins';
+
+.site-admin-site-hub {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: $grid-unit-10;
+	margin-right: $grid-unit-15;
+	height: $header-height;
+}
+
+.site-admin-site-hub__actions {
+	flex-shrink: 0;
+}
+
+.site-admin-site-hub__view-mode-toggle-container {
+	height: $header-height;
+	width: $header-height;
+	flex-shrink: 0;
+
+	&.has-transparent-background .site-admin-layout__view-mode-toggle-icon {
+		background: transparent;
+	}
+}
+
+.site-admin-site-hub__title .components-button {
+	color: $gray-200;
+	display: block;
+	flex-grow: 1;
+	font-size: $font-size-large; // @unstable: different from core: 15px;
+	font-weight: 500;
+	overflow: hidden;
+	// Add space for the ↗ to render.
+	padding-right: $grid-unit-20;
+
+	// Create 12px gap between site icon and site title
+	margin-left: -$grid-unit-05;
+	position: relative;
+	text-decoration: none;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+
+	&:hover,
+	&:focus,
+	&:active {
+		color: $gray-200;
+	}
+
+	&:focus {
+		// Defer to :focus-visible below.
+		box-shadow: none;
+		outline: none;
+	}
+
+	&:focus-visible {
+		// Push the shadow away from the title.
+		box-shadow:
+			0 0 0 var( --wp-admin-border-width-focus ) $gray-900,
+			0 0 0 calc( 2 * var( --wp-admin-border-width-focus ) ) var( --wp-admin-theme-color );
+
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		outline: 2px solid transparent;
+		outline-offset: 2px;
+	}
+
+	&::after {
+		content: '\2197';
+		font-weight: 400;
+		opacity: 0;
+		position: absolute;
+		right: 0;
+
+		@media not ( prefers-reduced-motion ) {
+			transition: opacity 0.1s linear;
+		}
+	}
+
+	&:hover::after,
+	&:focus::after,
+	&:active::after {
+		opacity: 1;
+	}
+}
+
+.site-admin-site-hub_toggle-command-center {
+	color: $gray-200;
+
+	&:hover,
+	&:active {
+		svg {
+			fill: $gray-100;
+		}
+	}
+}

--- a/packages/site-admin/src/components/site-hub/style.scss
+++ b/packages/site-admin/src/components/site-hub/style.scss
@@ -93,3 +93,54 @@
 		}
 	}
 }
+
+.site-admin-layout__view-mode-toggle.components-button {
+	view-transition-name: toggle;
+	position: relative;
+	color: $white;
+	height: $header-height;
+	width: $header-height;
+	overflow: hidden;
+	padding: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: $gray-900;
+	border-radius: 0;
+
+	&:hover,
+	&:active {
+		color: $white;
+	}
+
+	&:focus-visible,
+	&:focus {
+		box-shadow: 0 0 0 3px #1e1e1e, 0 0 0 6px var(--wp-admin-theme-color);
+		outline: 4px solid #0000;
+		outline-offset: 4px;
+	}
+
+	&::before {
+		content: "";
+		display: block;
+		position: absolute;
+		top: 9px;
+		right: 9px;
+		bottom: 9px;
+		left: 9px;
+		border-radius: $radius-medium;
+		box-shadow: none;
+
+		@media not (prefers-reduced-motion) {
+			transition: box-shadow 0.1s ease;
+		}
+	}
+
+	.site-admin-layout__view-mode-toggle-icon {
+		display: flex;
+		height: $header-height;
+		width: $header-height;
+		justify-content: center;
+		align-items: center;
+	}
+}

--- a/packages/site-admin/src/components/site-icon/index.tsx
+++ b/packages/site-admin/src/components/site-icon/index.tsx
@@ -5,12 +5,14 @@ import { store as coreDataStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { Icon, wordpress } from '@wordpress/icons';
 import clsx from 'clsx';
-import type { JSX } from 'react';
-
 /**
  * Internal dependencies
  */
 import './style.scss';
+/**
+ * Types
+ */
+import type { JSX } from 'react';
 
 type SiteIconProps = {
 	/**

--- a/packages/site-admin/src/type-declarations.d.ts
+++ b/packages/site-admin/src/type-declarations.d.ts
@@ -1,0 +1,37 @@
+/**
+ * Temporary `type declarations for `@wordpress/commands`
+ * @todo Remove this once the types are added to the core package
+ */
+declare module '@wordpress/commands' {
+	import { StoreDescriptor } from '@wordpress/data';
+
+	export interface WPCommand {
+		name: string;
+		label: string;
+		searchLabel?: string;
+		callback: () => void;
+		icon?: React.ReactElement | string;
+		context?: string;
+	}
+
+	export interface CommandsActions {
+		registerCommand: ( command: WPCommand ) => void;
+		unregisterCommand: ( commandName: string ) => void;
+		open: () => void;
+		close: () => void;
+	}
+
+	export interface CommandsSelectors {
+		getCommands: () => WPCommand[];
+	}
+
+	export interface CommandsStoreConfig {
+		reducer: ( state: CommandsState | undefined, action: any ) => CommandsState;
+		actions: CommandsActions;
+		selectors: CommandsSelectors;
+	}
+
+	export const store: StoreDescriptor< CommandsStoreConfig >;
+
+	export function useCommand( command: WPCommand ): void;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1794,6 +1794,7 @@ __metadata:
     "@storybook/cli": "npm:^7.6.20"
     "@storybook/react": "npm:^7.6.20"
     "@wordpress/base-styles": "npm:^5.20.0"
+    "@wordpress/commands": "npm:^1.19.0"
     "@wordpress/components": "npm:^29.6.0"
     "@wordpress/compose": "npm:^7.20.0"
     "@wordpress/core-data": "npm:^7.20.0"
@@ -8314,7 +8315,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/debug@npm:^4.0.0, @types/debug@npm:^4.1.12, @types/debug@npm:^4.1.6":
+"@types/debug@npm:^4.0.0, @types/debug@npm:^4.1.6":
+  version: 4.1.8
+  resolution: "@types/debug@npm:4.1.8"
+  dependencies:
+    "@types/ms": "npm:*"
+  checksum: 913aea60b8c94cd0009bbdd531d8a3594ec3275ca0e8d1cbcf783417884252b3c53113f6665fd2fb0076b8ce628ee12cd083d2af107ed26c0f2e75852d8bc074
+  languageName: node
+  linkType: hard
+
+"@types/debug@npm:^4.1.12":
   version: 4.1.12
   resolution: "@types/debug@npm:4.1.12"
   dependencies:
@@ -10460,6 +10470,27 @@ __metadata:
   version: 6.20.0
   resolution: "@wordpress/browserslist-config@npm:6.20.0"
   checksum: 451d25358238f7d10d24545f10784c6f15890ec818cf632e31fca87c77a3a5f5040d192665beb004076be6190b849d53e454a313a9a300dbfcddd09ed13dc720
+  languageName: node
+  linkType: hard
+
+"@wordpress/commands@npm:^1.19.0":
+  version: 1.19.0
+  resolution: "@wordpress/commands@npm:1.19.0"
+  dependencies:
+    "@babel/runtime": "npm:7.25.7"
+    "@wordpress/components": "npm:^29.5.0"
+    "@wordpress/data": "npm:^10.19.0"
+    "@wordpress/element": "npm:^6.19.0"
+    "@wordpress/i18n": "npm:^5.19.0"
+    "@wordpress/icons": "npm:^10.19.0"
+    "@wordpress/keyboard-shortcuts": "npm:^5.19.0"
+    "@wordpress/private-apis": "npm:^1.19.0"
+    clsx: "npm:^2.1.1"
+    cmdk: "npm:^1.0.0"
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: 700c94b35a94a5d9bbd3a8a07f2a568aa9b7b3b6fd416cd48373384acbfe65622a05a6444f74a87c9f3b6b0c246cad28d4b4cd4d1e4ab2ba961f435d36ba7a80
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1794,7 +1794,7 @@ __metadata:
     "@storybook/cli": "npm:^7.6.20"
     "@storybook/react": "npm:^7.6.20"
     "@wordpress/base-styles": "npm:^5.20.0"
-    "@wordpress/commands": "npm:^1.19.0"
+    "@wordpress/commands": "npm:^1.20.0"
     "@wordpress/components": "npm:^29.6.0"
     "@wordpress/compose": "npm:^7.20.0"
     "@wordpress/core-data": "npm:^7.20.0"
@@ -10470,27 +10470,6 @@ __metadata:
   version: 6.20.0
   resolution: "@wordpress/browserslist-config@npm:6.20.0"
   checksum: 451d25358238f7d10d24545f10784c6f15890ec818cf632e31fca87c77a3a5f5040d192665beb004076be6190b849d53e454a313a9a300dbfcddd09ed13dc720
-  languageName: node
-  linkType: hard
-
-"@wordpress/commands@npm:^1.19.0":
-  version: 1.19.0
-  resolution: "@wordpress/commands@npm:1.19.0"
-  dependencies:
-    "@babel/runtime": "npm:7.25.7"
-    "@wordpress/components": "npm:^29.5.0"
-    "@wordpress/data": "npm:^10.19.0"
-    "@wordpress/element": "npm:^6.19.0"
-    "@wordpress/i18n": "npm:^5.19.0"
-    "@wordpress/icons": "npm:^10.19.0"
-    "@wordpress/keyboard-shortcuts": "npm:^5.19.0"
-    "@wordpress/private-apis": "npm:^1.19.0"
-    clsx: "npm:^2.1.1"
-    cmdk: "npm:^1.0.0"
-  peerDependencies:
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  checksum: 700c94b35a94a5d9bbd3a8a07f2a568aa9b7b3b6fd416cd48373384acbfe65622a05a6444f74a87c9f3b6b0c246cad28d4b4cd4d1e4ab2ba961f435d36ba7a80
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8315,16 +8315,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/debug@npm:^4.0.0, @types/debug@npm:^4.1.6":
-  version: 4.1.8
-  resolution: "@types/debug@npm:4.1.8"
-  dependencies:
-    "@types/ms": "npm:*"
-  checksum: 913aea60b8c94cd0009bbdd531d8a3594ec3275ca0e8d1cbcf783417884252b3c53113f6665fd2fb0076b8ce628ee12cd083d2af107ed26c0f2e75852d8bc074
-  languageName: node
-  linkType: hard
-
-"@types/debug@npm:^4.1.12":
+"@types/debug@npm:^4.0.0, @types/debug@npm:^4.1.12, @types/debug@npm:^4.1.6":
   version: 4.1.12
   resolution: "@types/debug@npm:4.1.12"
   dependencies:


### PR DESCRIPTION
~# ❗ Branched off from #99754~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR introduces the `SiteHub` component, a top-level navigation element for Site Admin that displays the site title, a back navigation button, and a shortcut to the command palette.
This implementation is inspired by the Site Editor Hub in WordPress Core but adapted for Site Admin needs.

### Example Usage  

```tsx
<SiteHub
	isTransparent={ false }
	navigationBackLabel="Back to Dashboard"
	navigationBackLink="/dashboard"
/>
```

### Disclaimer: Command Palette Integration  

The `SiteHub` component does not handle command registration or UI management for the Command Palette.
Command definitions and their behavior are managed through the `@wordpress/commands` store.  

This component only dispatches the `open` action to trigger the Command Palette modal.

Closes #99780

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* [Site Admin]: Introduce `SiteHub` Component

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Testi with storybbok

1. Update just in case

```sh
yarn install
```

2. Run the Storybook app instance for this package
```sh
yarn workspace @automattic/site-admin run storybook
```

3. Use the `Sidebar` story to test the SiteHub component
  * Confirm it shows the site icon
  * Confirm it shows the site Title and Url
  * Confirm it dispatches the `open` commands action when clicking the magnificent icon.

![site-admin-site-hub](https://github.com/user-attachments/assets/9a5ee25a-e1f2-4f2d-9f9c-2fbd0d72d725)

4. Use the SiteHub stories
5. Confirm the `Focus Button On Mount` story focuses on the Site button once the component is rendered

![admin-site-site-hub](https://github.com/user-attachments/assets/df3c6a91-302c-451c-953a-bd20d861e8ad)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
