### PR TITLE
Localize price url on offer button.

### DIFF
--- a/client/components/sites-add-new-site/content/index.tsx
+++ b/client/components/sites-add-new-site/content/index.tsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import page from '@automattic/calypso-router';
 import { WordPressLogo, JetpackLogo } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { download, reusableBlock, Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -50,7 +51,7 @@ const offerClick = () => {
 	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
 		action: 'offer',
 	} );
-	window.location.assign( 'https://wordpress.com/pricing/' );
+	window.location.assign( localizeUrl( 'https://wordpress.com/pricing/' ) );
 };
 
 export const Content = () => {


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/10458

## Proposed Changes

We got this comment pdtkmj-3kJ-p2#comment-6364 for the external links from Calypso to `/pricing` not respecting the language.
![image](https://github.com/user-attachments/assets/bda88805-664b-4974-ab8a-05168a1f1d95)


This is a one line PR that applies `localizeUrl` before redirecting the user to `https://wordpress.com/pricing/`.
 

## Testing Instructions

- Switch to a non english idiom like Portuguese or Greek.
- Access http://calypso.localhost:3000/sites.
- Click on the "Add new site" button on the top right.
- Click on the offer option, the one most right on the banner.
- You should be redirected to a localized version of the pricing page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?