### PR TITLE
[Odie] Remove pending status from Tracks Events

### DIFF
--- a/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
@@ -41,7 +41,7 @@ export function useCanConnectToZendeskMessaging( enabled = true ) {
 		if ( ! query.data ) {
 			recordTracksEvent( 'calypso_helpcenter_zendesk_config_error', {
 				status: query.status,
-				statusText: query.error?.message,
+				status_text: query.error?.message,
 			} );
 		}
 	}, [ query.data, query.error?.message, query.status ] );

--- a/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
@@ -5,7 +5,6 @@ import { useState, useEffect } from '@wordpress/element';
 async function fetchZendeskConfig(): Promise< boolean > {
 	const config = await fetch( 'https://wpcom.zendesk.com/embeddable/config' );
 	const validResponse = config.ok && config.status === 200;
-
 	return validResponse;
 }
 
@@ -38,7 +37,7 @@ export function useCanConnectToZendeskMessaging( enabled = true ) {
 	}, [ query.isSuccess, queryClient ] );
 
 	useEffect( () => {
-		if ( ! query.data ) {
+		if ( ! query.data && query.status !== 'pending' ) {
 			recordTracksEvent( 'calypso_helpcenter_zendesk_config_error', {
 				status: query.status,
 				status_text: query.error?.message,


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/99793

## Proposed Changes

We are registering more events that the one that we should. All pending requests are being logged as anomalous requests. This patch address it

## Why are these changes being made?
We don't need to log pending requests.

## Testing Instructions
Visual spection is enough, but you can assert that while you open the Help Center tracks are not fired if no error is happening in Zendesk endpoint

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
