### PR TITLE
Preview Themes: Fix the Preview for Personal themes

### DIFF
--- a/client/state/themes/selectors/can-use-theme.js
+++ b/client/state/themes/selectors/can-use-theme.js
@@ -3,6 +3,7 @@ import {
 	WPCOM_FEATURES_ATOMIC,
 	WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
 	FEATURE_INSTALL_THEMES,
+	WPCOM_FEATURES_PREMIUM_THEMES_LIMITED,
 } from '@automattic/calypso-products';
 import {
 	FREE_THEME,
@@ -10,6 +11,7 @@ import {
 	DOT_ORG_THEME,
 	BUNDLED_THEME,
 	MARKETPLACE_THEME,
+	PERSONAL_THEME,
 } from '@automattic/design-picker';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getThemeType, getThemeSoftwareSet } from 'calypso/state/themes/selectors';
@@ -32,6 +34,10 @@ export function canUseTheme( state, siteId, themeId ) {
 
 	if ( type === FREE_THEME ) {
 		return true;
+	}
+
+	if ( type === PERSONAL_THEME ) {
+		return siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES_LIMITED );
 	}
 
 	if ( type === PREMIUM_THEME ) {

--- a/client/state/themes/selectors/get-is-live-preview-supported.ts
+++ b/client/state/themes/selectors/get-is-live-preview-supported.ts
@@ -1,7 +1,7 @@
-import config from '@automattic/calypso-config';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { isSimpleSite } from 'calypso/state/sites/selectors';
 import { isMarketplaceThemeSubscribed } from 'calypso/state/themes/selectors/is-marketplace-theme-subscribed';
+import { isThemePersonal } from 'calypso/state/themes/selectors/is-theme-personal';
 import { AppState } from 'calypso/types';
 import {
 	isWpcomTheme,
@@ -156,8 +156,9 @@ export const getIsLivePreviewSupported = ( state: AppState, themeId: string, sit
 			 * @see https://github.com/Automattic/wp-calypso/issues/79223
 			 */
 			if (
-				config.isEnabled( 'themes/block-theme-previews-premium-and-woo' ) &&
-				( isThemePremium( state, themeId ) || isThemeWooCommerce( state, themeId ) )
+				isThemePersonal( state, themeId ) ||
+				isThemePremium( state, themeId ) ||
+				isThemeWooCommerce( state, themeId )
 			) {
 				return true;
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Personal themes were not properly handled in the logic that determines if the theme preview should be enabled for a given theme. 

## Proposed Changes

* Support theme preview for Personal themes

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Personal themes were not handled properly in the theme preview logic

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the live link
* Go to a free site and go to /theme/bute
* Notice that you can preview it
* Go to a Premium site and go to /theme/bute
* Notice that you can preview it

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
