### PR TITLE
Close modal when help center is open

### DIFF
--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -33,6 +33,7 @@ class InlineSupportLink extends Component {
 		statsName: PropTypes.string,
 		showSupportModal: PropTypes.bool,
 		noWrap: PropTypes.bool,
+		onClick: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -60,10 +61,11 @@ class InlineSupportLink extends Component {
 	}
 
 	onSupportLinkClick( event, supportPostId, url, blogId ) {
-		const { showSupportModal, openDialog } = this.props;
+		const { showSupportModal, openDialog, onClick } = this.props;
 		if ( ! showSupportModal ) {
 			return;
 		}
+		onClick?.();
 		openDialog( event, supportPostId, url, blogId );
 	}
 

--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -189,6 +189,7 @@ class AccountCloseConfirmDialog extends Component {
 									<InlineSupportLink
 										supportPostId={ supportPostId }
 										supportLink={ supportLink }
+										onClick={ this.handleCancel }
 										showText={ false }
 										iconSize={ 20 }
 										tracksEvent="calypso_close_account_alternative_clicked"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/99806

## Proposed Changes

* Close deletion modal when help center is open

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve help center usability

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to https://wordpress.com/me/account
- Click on Delete your account permanently
- Click on Delete account
- Click on the blue help icon that's to the right of Change your site's address
- Check if the dialog is closed and the Help Center is visible and accessible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
