### PR TITLE
Stats: Add Y-axis domain support to align zero to the bottom

### DIFF
--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -64,7 +64,7 @@ function StatsLineChart( {
 					options={ {
 						yScale: {
 							type: 'linear',
-							zero: true,
+							domain: [ 0, maxViews ],
 						},
 						axis: {
 							x: {

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/calypso-razorpay": "workspace:^",
 		"@automattic/calypso-router": "workspace:^",
-		"@automattic/charts": "^0.8.1",
+		"@automattic/charts": "^0.8.2",
 		"@automattic/color-studio": "^3.0.1",
 		"@automattic/command-palette": "workspace:^",
 		"@automattic/components": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -565,9 +565,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/charts@npm:^0.8.1":
-  version: 0.8.1
-  resolution: "@automattic/charts@npm:0.8.1"
+"@automattic/charts@npm:^0.8.2":
+  version: 0.8.2
+  resolution: "@automattic/charts@npm:0.8.2"
   dependencies:
     "@babel/runtime": "npm:7.26.0"
     "@react-spring/web": "npm:9.7.3"
@@ -589,7 +589,7 @@ __metadata:
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-  checksum: 6e5119e2e1a993c36d4211d468d80e95a1b0b19583938cc89587d503cfe4ce5d22752e156102258ca78a28d5d2aa47f2239a0f229b9190226e8ec66df94c5d70
+  checksum: 1cc176d865d356dc3900d7502a327f8822b6b503a90c4494a99637cd9806bef185abc62fd377f420105b8ae3acec6d9b58c1afe957b88dde6d7ac25c6f75cbd1
   languageName: node
   linkType: hard
 
@@ -36238,7 +36238,7 @@ __metadata:
     "@automattic/calypso-razorpay": "workspace:^"
     "@automattic/calypso-router": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
-    "@automattic/charts": "npm:^0.8.1"
+    "@automattic/charts": "npm:^0.8.2"
     "@automattic/color-studio": "npm:^3.0.1"
     "@automattic/command-palette": "workspace:^"
     "@automattic/components": "workspace:^"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/99557

## Proposed Changes

* Add `yScale.domain` option to support aligning Y-axis zero values to the bottom.

|Before|After|
|-|-|
|<img width="1279" alt="截圖 2025-02-15 凌晨12 30 46" src="https://github.com/user-attachments/assets/79a8071e-ed53-4550-b7ad-8b9664371f4e" />|<img width="1297" alt="截圖 2025-02-15 凌晨12 26 01" src="https://github.com/user-attachments/assets/0e8d7511-bd23-430a-8bc7-c355aa6f694b" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Follow-up to tweak the real-time chart.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Realtime page with the feature flag: `?flags=stats/real-time-tab`.
* Ensure the zero value line is at the bottom when all point values are zero.

<img width="1297" alt="截圖 2025-02-15 凌晨12 26 01" src="https://github.com/user-attachments/assets/ae90b09a-2695-4b69-b525-80b0f44b23c6" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
