### PR TITLE
Goals-first onboarding: Save site intent on creation

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -81,6 +81,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 		progress,
 		partnerBundle,
 		siteGoals,
+		intent,
 	} = useSelect(
 		( select: ( arg: string ) => OnboardSelect ) => ( {
 			domainItem: select( ONBOARD_STORE ).getSelectedDomain(),
@@ -93,6 +94,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 			progress: select( ONBOARD_STORE ).getProgress(),
 			partnerBundle: select( ONBOARD_STORE ).getPartnerBundle(),
 			siteGoals: select( ONBOARD_STORE ).getGoals(),
+			intent: select( ONBOARD_STORE ).getIntent(),
 		} ),
 		[]
 	);
@@ -109,7 +111,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 		mergedDomainCartItems.push( domainCartItem );
 	}
 
-	const shouldSaveSiteGoals = isOnboardingFlow( flow ) && isGoalsFirstExperiment;
+	const isGoalsFirstOnboarding = isOnboardingFlow( flow ) && isGoalsFirstExperiment;
 
 	const username = useSelector( getCurrentUserName );
 
@@ -209,7 +211,12 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 			};
 		}
 
-		const siteIntent = isMigrationSignupFlow( flow ) ? 'migration' : '';
+		// eslint-disable-next-line no-nested-ternary
+		const siteIntent = isMigrationSignupFlow( flow )
+			? 'migration'
+			: isGoalsFirstOnboarding
+			? intent
+			: '';
 
 		const sourceSlug = hasSourceSlug( data ) ? data.sourceSlug : undefined;
 		const site = await createSiteWithCart(
@@ -231,7 +238,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 			domainItem,
 			sourceSlug,
 			siteIntent,
-			shouldSaveSiteGoals ? siteGoals : undefined,
+			isGoalsFirstOnboarding ? siteGoals : undefined,
 			isGoalsFirstCumulativeExperience &&
 				config.isEnabled( 'onboarding/enable-write-goal-features' )
 		);


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/99727.

## Proposed Changes

The site gets created without intent and, on `/setup/site-setup`, we save it. That triggers a duplicated `getSite` request which, in turn, triggers a duplicated Launchpad request, causing the double Launchpad loading state observed in the reported issue.

## Testing Instructions

1. Verify you don't see the Launchpad blink after creating a site in `/setup/onboarding`;
2. Verify the intent is empty after creating a site in the account-first version of `/setup/onboarding`.