### PR TITLE
Site-setup flow: Refetch site after customization

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -11,6 +11,7 @@ import { addQueryArgs } from 'calypso/lib/route';
 import { useDispatch as reduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getInitialQueryArguments } from 'calypso/state/selectors/get-initial-query-arguments';
+import { requestSite } from 'calypso/state/sites/actions';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { WRITE_INTENT_DEFAULT_DESIGN } from '../constants';
 import { useActivateDesign } from '../hooks/use-activate-design';
@@ -231,7 +232,10 @@ const siteSetupFlow: FlowV1 = {
 						} )
 					);
 
-					Promise.all( pendingActions ).then( () => window.location.assign( redirectionUrl ) );
+					Promise.all( pendingActions )
+						// Refetch the site to get the latest data, including the new intent.
+						.then( () => dispatch( requestSite( siteSlug ) ) )
+						.then( () => window.location.assign( redirectionUrl ) );
 				} );
 			} );
 


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/99727.

## Proposed Changes

The site was created without intent, and we saved it using the `/setup/site-setup`'s `exitFlow` action. However, the cached site has incomplete and outdated information (i.e., the intent in the Redux cache is empty, but the remote site has it.)

In `FocusedLaunchpad,` we fetch the site from the cache, but because it's outdated, we refetch it. While that happens, the Launchpad is already on the screen, so we saw the list blink: it first fetched it without the intent and then with the intent.

**This PR invalidates the existing site data before redirecting so that data is always up to date on subsequent navigations.**

## Testing Instructions

Verify you don't see the Launchpad blink after creating a site in `/setup/onboarding`.