### PR TITLE
Subscribers: Handle multiple filters

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -77,7 +77,7 @@ const SubscriberDataViews = ( {
 	const isEnglishLocale = useIsEnglishLocale();
 
 	const [ searchTerm, setSearchTerm ] = useState( '' );
-	const [ filterOption, setFilterOption ] = useState( SubscribersFilterBy.All );
+	const [ filters, setFilters ] = useState< SubscribersFilterBy[] >( [ SubscribersFilterBy.All ] );
 	const [ selectedSubscriber, setSelectedSubscriber ] = useState< Subscriber | null >( null );
 	const { isSimple, isAtomic } = useSelector( ( state ) => ( {
 		isSimple: isSimpleSite( state ),
@@ -104,7 +104,7 @@ const SubscriberDataViews = ( {
 		search: searchTerm,
 		sortTerm: currentView.sort?.field as SubscribersSortBy,
 		sortOrder: currentView.sort?.direction as 'asc' | 'desc',
-		filterOption,
+		filters: filters,
 		limitData: true,
 	} );
 
@@ -144,7 +144,7 @@ const SubscriberDataViews = ( {
 		siteId ?? null,
 		{
 			currentPage: currentView.page ?? 1,
-			filterOption,
+			filters,
 			searchTerm,
 			sortTerm: SubscribersSortBy.DateSubscribed,
 		},
@@ -351,9 +351,11 @@ const SubscriberDataViews = ( {
 		setSearchTerm( currentView.search ?? '' );
 
 		// Handle filter option from the view.
-		setFilterOption(
-			( currentView.filters?.[ 0 ]?.value as SubscribersFilterBy ) ?? SubscribersFilterBy.All
-		);
+		const filterValues =
+			( currentView.filters
+				?.filter( ( filter ) => filter.value !== undefined )
+				.map( ( filter ) => filter.value ) as SubscribersFilterBy[] ) ?? [];
+		setFilters( filterValues.length ? filterValues : [ SubscribersFilterBy.All ] );
 	}, [ currentView.search, currentView.filters ] );
 
 	// Memoize the data and pagination info.
@@ -384,7 +386,7 @@ const SubscriberDataViews = ( {
 						<SubscriberTotals
 							totalSubscribers={ grandTotal }
 							filteredCount={ total }
-							filterOption={ filterOption }
+							filters={ filters }
 							searchTerm={ searchTerm }
 							isLoading={ isLoading }
 						/>

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -353,6 +353,7 @@ const SubscriberDataViews = ( {
 		// Handle filter option from the view.
 		const filterValues =
 			( currentView.filters
+				// Filter out undefined values to prevent unnecessary queries.
 				?.filter( ( filter ) => filter.value !== undefined )
 				.map( ( filter ) => filter.value ) as SubscribersFilterBy[] ) ?? [];
 		setFilters( filterValues.length ? filterValues : [ SubscribersFilterBy.All ] );

--- a/client/my-sites/subscribers/components/subscriber-totals/index.tsx
+++ b/client/my-sites/subscribers/components/subscriber-totals/index.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import { SubscribersFilterBy } from '../../constants';
 import './style.scss';
@@ -5,21 +6,51 @@ import './style.scss';
 type SubscriberTotalsProps = {
 	totalSubscribers: number;
 	filteredCount: number;
-	filterOption: SubscribersFilterBy;
+	filters: SubscribersFilterBy[];
 	searchTerm: string;
 	isLoading: boolean;
 };
 
-const getFilterLabel = ( filterOption: SubscribersFilterBy, count: number ): string => {
-	switch ( filterOption ) {
-		case SubscribersFilterBy.Paid:
+const getFilterLabel = ( filters: SubscribersFilterBy[], count: number ): string => {
+	if ( filters.length === 0 || filters.includes( SubscribersFilterBy.All ) ) {
+		return count === 1 ? translate( 'subscriber' ) : translate( 'subscribers' );
+	}
+
+	// For multiple filters, sort to ensure consistent order
+	const sortedFilters = [ ...filters ].sort();
+	const filterKey = sortedFilters.join( ',' );
+
+	// Handle all filter combinations
+	switch ( filterKey ) {
+		// Single filter cases
+		case `${ SubscribersFilterBy.Paid }`:
 			return count === 1 ? translate( 'paid subscriber' ) : translate( 'paid subscribers' );
-		case SubscribersFilterBy.Free:
+		case `${ SubscribersFilterBy.Free }`:
 			return count === 1 ? translate( 'free subscriber' ) : translate( 'free subscribers' );
-		case SubscribersFilterBy.EmailSubscriber:
+		case `${ SubscribersFilterBy.EmailSubscriber }`:
 			return count === 1 ? translate( 'email subscriber' ) : translate( 'email subscribers' );
-		case SubscribersFilterBy.ReaderSubscriber:
+		case `${ SubscribersFilterBy.ReaderSubscriber }`:
 			return count === 1 ? translate( 'reader subscriber' ) : translate( 'reader subscribers' );
+
+		// Two filter combinations
+		case `${ SubscribersFilterBy.EmailSubscriber },${ SubscribersFilterBy.Paid }`:
+			return count === 1
+				? translate( 'paid email subscriber' )
+				: translate( 'paid email subscribers' );
+		case `${ SubscribersFilterBy.Paid },${ SubscribersFilterBy.ReaderSubscriber }`:
+			return count === 1
+				? translate( 'paid reader subscriber' )
+				: translate( 'paid reader subscribers' );
+		case `${ SubscribersFilterBy.EmailSubscriber },${ SubscribersFilterBy.Free }`:
+			return count === 1
+				? translate( 'free email subscriber' )
+				: translate( 'free email subscribers' );
+		case `${ SubscribersFilterBy.Free },${ SubscribersFilterBy.ReaderSubscriber }`:
+			return count === 1
+				? translate( 'free reader subscriber' )
+				: translate( 'free reader subscribers' );
+
+		// Default case
 		default:
 			return count === 1 ? translate( 'subscriber' ) : translate( 'subscribers' );
 	}
@@ -28,16 +59,20 @@ const getFilterLabel = ( filterOption: SubscribersFilterBy, count: number ): str
 const SubscriberTotals: React.FC< SubscriberTotalsProps > = ( {
 	totalSubscribers,
 	filteredCount,
-	filterOption,
+	filters,
 	searchTerm,
 	isLoading,
 } ) => {
 	if ( isLoading ) {
-		return <div className="subscriber-totals is-loading" />;
+		return (
+			<div className="subscriber-totals is-loading">
+				<Spinner />
+			</div>
+		);
 	}
 
-	const isFiltered = filterOption !== SubscribersFilterBy.All || !! searchTerm;
-	const filterLabel = getFilterLabel( filterOption, filteredCount );
+	const isFiltered = ! filters.includes( SubscribersFilterBy.All ) || !! searchTerm;
+	const filterLabel = getFilterLabel( filters, filteredCount );
 
 	return (
 		<div className="subscriber-totals">

--- a/client/my-sites/subscribers/components/subscriber-totals/index.tsx
+++ b/client/my-sites/subscribers/components/subscriber-totals/index.tsx
@@ -12,45 +12,40 @@ type SubscriberTotalsProps = {
 };
 
 const getFilterLabel = ( filters: SubscribersFilterBy[], count: number ): string => {
-	if ( filters.length === 0 || filters.includes( SubscribersFilterBy.All ) ) {
-		return count === 1 ? translate( 'subscriber' ) : translate( 'subscribers' );
-	}
-
-	// For multiple filters, sort to ensure consistent order
+	// Sort to make sure the filter order is consistent.
 	const sortedFilters = [ ...filters ].sort();
 	const filterKey = sortedFilters.join( ',' );
 
-	// Handle all filter combinations
 	switch ( filterKey ) {
-		// Single filter cases
-		case `${ SubscribersFilterBy.Paid }`:
+		// Single filter cases.
+		case SubscribersFilterBy.Paid:
 			return count === 1 ? translate( 'paid subscriber' ) : translate( 'paid subscribers' );
-		case `${ SubscribersFilterBy.Free }`:
+		case SubscribersFilterBy.Free:
 			return count === 1 ? translate( 'free subscriber' ) : translate( 'free subscribers' );
-		case `${ SubscribersFilterBy.EmailSubscriber }`:
+		case SubscribersFilterBy.EmailSubscriber:
 			return count === 1 ? translate( 'email subscriber' ) : translate( 'email subscribers' );
-		case `${ SubscribersFilterBy.ReaderSubscriber }`:
+		case SubscribersFilterBy.ReaderSubscriber:
 			return count === 1 ? translate( 'reader subscriber' ) : translate( 'reader subscribers' );
 
-		// Two filter combinations
-		case `${ SubscribersFilterBy.EmailSubscriber },${ SubscribersFilterBy.Paid }`:
+		// Two filter combinations.
+		case SubscribersFilterBy.EmailSubscriber + ',' + SubscribersFilterBy.Paid:
 			return count === 1
 				? translate( 'paid email subscriber' )
 				: translate( 'paid email subscribers' );
-		case `${ SubscribersFilterBy.Paid },${ SubscribersFilterBy.ReaderSubscriber }`:
+		case SubscribersFilterBy.Paid + ',' + SubscribersFilterBy.ReaderSubscriber:
 			return count === 1
 				? translate( 'paid reader subscriber' )
 				: translate( 'paid reader subscribers' );
-		case `${ SubscribersFilterBy.EmailSubscriber },${ SubscribersFilterBy.Free }`:
+		case SubscribersFilterBy.EmailSubscriber + ',' + SubscribersFilterBy.Free:
 			return count === 1
 				? translate( 'free email subscriber' )
 				: translate( 'free email subscribers' );
-		case `${ SubscribersFilterBy.Free },${ SubscribersFilterBy.ReaderSubscriber }`:
+		case SubscribersFilterBy.Free + ',' + SubscribersFilterBy.ReaderSubscriber:
 			return count === 1
 				? translate( 'free reader subscriber' )
 				: translate( 'free reader subscribers' );
 
-		// Default case
+		// Default case.
 		default:
 			return count === 1 ? translate( 'subscriber' ) : translate( 'subscribers' );
 	}

--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -1,3 +1,4 @@
+import { SubscribersFilterBy } from '../constants';
 import { SubscriberListArgs } from '../types';
 
 const getSubscribersCacheKey = (
@@ -7,6 +8,7 @@ const getSubscribersCacheKey = (
 	search?: string,
 	sortTerm?: string,
 	filterOption?: string,
+	filters?: SubscribersFilterBy[],
 	hasManySubscribers?: boolean,
 	timestamp?: number,
 	sortOrder?: 'asc' | 'desc'
@@ -26,6 +28,9 @@ const getSubscribersCacheKey = (
 	}
 	if ( filterOption ) {
 		cacheKey.push( 'filter-option', filterOption );
+	}
+	if ( filters?.length ) {
+		cacheKey.push( 'filters', filters.join( ',' ) );
 	}
 	if ( timestamp ) {
 		cacheKey.push( timestamp );

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -20,7 +20,14 @@ const useSubscriberRemoveMutation = (
 	args: SubscriberListArgs,
 	invalidateDetailsCache = false
 ) => {
-	const { currentPage, perPage = DEFAULT_PER_PAGE, filterOption, searchTerm, sortTerm } = args;
+	const {
+		currentPage,
+		perPage = DEFAULT_PER_PAGE,
+		filterOption,
+		filters = [],
+		searchTerm,
+		sortTerm,
+	} = args;
 	const queryClient = useQueryClient();
 	const recordSubscriberRemoved = useRecordSubscriberRemoved();
 	const { hasManySubscribers } = useManySubsSite( siteId );
@@ -31,6 +38,7 @@ const useSubscriberRemoveMutation = (
 		searchTerm,
 		sortTerm,
 		filterOption,
+		filters,
 		hasManySubscribers
 	);
 
@@ -127,6 +135,7 @@ const useSubscriberRemoveMutation = (
 								searchTerm,
 								sortTerm,
 								filterOption,
+								filters,
 								hasManySubscribers
 							)
 						);
@@ -177,6 +186,7 @@ const useSubscriberRemoveMutation = (
 							searchTerm,
 							sortTerm,
 							filterOption,
+							filters,
 							hasManySubscribers
 						),
 						previousSubscribers

--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -13,6 +13,7 @@ type SubscriberQueryParams = {
 	sortTerm?: SubscribersSortBy;
 	sortOrder?: 'asc' | 'desc';
 	filterOption?: SubscribersFilterBy;
+	filters?: SubscribersFilterBy[];
 	timestamp?: number;
 	limitData?: boolean;
 };
@@ -26,6 +27,7 @@ const useSubscribersQuery = ( {
 	sortTerm = SubscribersSortBy.DateSubscribed,
 	sortOrder,
 	filterOption = SubscribersFilterBy.All,
+	filters = [],
 	limitData = false,
 }: SubscriberQueryParams ) => {
 	const { hasManySubscribers, isLoading } = useManySubsSite( siteId );
@@ -40,6 +42,7 @@ const useSubscribersQuery = ( {
 			search,
 			sortTerm,
 			filterOption,
+			filters,
 			limitDataReturned,
 			timestamp,
 			sortOrder
@@ -61,6 +64,10 @@ const useSubscribersQuery = ( {
 				...( search && { search } ),
 				...( sortTerm && { sort: sortTerm } ),
 				...( sortOrder && { sort_order: sortOrder } ),
+			} );
+
+			filters.forEach( ( filter ) => {
+				params.append( 'filters[]', filter );
 			} );
 
 			return wpcom.req.get( {

--- a/client/my-sites/subscribers/types/index.ts
+++ b/client/my-sites/subscribers/types/index.ts
@@ -46,6 +46,7 @@ export type SubscriberListArgs = {
 	currentPage: number;
 	perPage?: number;
 	filterOption?: SubscribersFilterBy;
+	filters?: SubscribersFilterBy[];
 	searchTerm?: string;
 	sortTerm?: SubscribersSortBy;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/391

## Proposed Changes

* Add multi-filtering to /subscribers.

<img width="511" alt="Screen Shot 2025-02-14 at 4 57 10 PM" src="https://github.com/user-attachments/assets/dadea67b-45e5-4540-bec5-ba67e0280637" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* DataViews supports multi-filtering, but we didn't previously have the functionality.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch: 173665-ghe-Automattic/wpcom
* Sandbox the API. 
* Go to /subscribers and try filtering by both Email subscriber and Plan.
* Check that both the results and the totals update to reflect the filters.
* Test in Jetpack Cloud > Subscribers as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?