### PR TITLE
Discover v2: Hide "Add new" tab and redirect page if logged out

### DIFF
--- a/client/reader/discover/components/navigation/v2/index.tsx
+++ b/client/reader/discover/components/navigation/v2/index.tsx
@@ -6,6 +6,8 @@ import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import { DEFAULT_TAB, FIRST_POSTS_TAB, LATEST_TAB } from 'calypso/reader/discover/helper';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { useSelector } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import './style.scss';
 
 interface Tab {
@@ -20,6 +22,7 @@ interface Props {
 
 const DiscoverNavigationV2 = ( { selectedTab }: Props ) => {
 	const currentLocale = useLocale();
+	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	const recordTabClick = () => {
 		recordAction( 'click_discover_tab' );
@@ -63,8 +66,11 @@ const DiscoverNavigationV2 = ( { selectedTab }: Props ) => {
 		},
 	];
 
+	// Only show the add new tab if the user is logged in.
+	const filteredTabs = baseTabs.filter( ( tab ) => tab.slug !== 'add-new' || isLoggedIn );
+
 	// Add localization to paths if needed.
-	const tabs = baseTabs.map( ( tab ) => ( {
+	const tabs = filteredTabs.map( ( tab ) => ( {
 		...tab,
 		path: getLocalizedPath( tab.path ),
 	} ) );

--- a/client/reader/discover/index.node.js
+++ b/client/reader/discover/index.node.js
@@ -4,6 +4,7 @@ import {
 } from '@automattic/i18n-utils';
 import { makeLayout, ssrSetupLocale } from 'calypso/controller';
 import PostPlaceholder from 'calypso/reader/stream/post-placeholder';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import renderHeaderSection from '../lib/header-section';
 import { DiscoverDocumentHead } from './discover-document-head';
 import { DiscoverHeader } from './discover-stream';
@@ -22,6 +23,12 @@ const discoverSsr = ( context, next ) => {
 		const pathParts = pathWithoutLocale.split( '/' );
 		// Now pathParts[2] will consistently be the tab.
 		selectedTab = pathParts[ 2 ] || DEFAULT_TAB;
+
+		// Redirect /discover/add-new to /discover if logged out.
+		if ( selectedTab === 'add-new' && ! isUserLoggedIn( context.store.getState() ) ) {
+			context.res.redirect( '/discover' );
+			return;
+		}
 	} else {
 		// Use query parameter for v1.
 		selectedTab = context.query.selectedTab || DEFAULT_TAB;

--- a/client/reader/discover/index.node.js
+++ b/client/reader/discover/index.node.js
@@ -4,7 +4,6 @@ import {
 } from '@automattic/i18n-utils';
 import { makeLayout, ssrSetupLocale } from 'calypso/controller';
 import PostPlaceholder from 'calypso/reader/stream/post-placeholder';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import renderHeaderSection from '../lib/header-section';
 import { DiscoverDocumentHead } from './discover-document-head';
 import { DiscoverHeader } from './discover-stream';
@@ -23,12 +22,6 @@ const discoverSsr = ( context, next ) => {
 		const pathParts = pathWithoutLocale.split( '/' );
 		// Now pathParts[2] will consistently be the tab.
 		selectedTab = pathParts[ 2 ] || DEFAULT_TAB;
-
-		// Redirect /discover/add-new to /discover if logged out.
-		if ( selectedTab === 'add-new' && ! isUserLoggedIn( context.store.getState() ) ) {
-			context.res.redirect( '/discover' );
-			return;
-		}
 	} else {
 		// Use query parameter for v1.
 		selectedTab = context.query.selectedTab || DEFAULT_TAB;

--- a/client/reader/discover/index.web.js
+++ b/client/reader/discover/index.web.js
@@ -36,7 +36,6 @@ const discover = ( context, next ) => {
 	const state = context.store.getState();
 	const currentRoute = getCurrentRoute( state );
 	const currentQueryArgs = new URLSearchParams( getCurrentQueryArguments( state ) ).toString();
-	const isLoggedIn = isUserLoggedIn( state );
 
 	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 	recordTrack(
@@ -45,7 +44,7 @@ const discover = ( context, next ) => {
 		{ pathnameOverride: `${ currentRoute }?${ currentQueryArgs }` }
 	);
 
-	if ( ! isLoggedIn ) {
+	if ( ! isUserLoggedIn( state ) ) {
 		context.renderHeaderSection = renderHeaderSection;
 	}
 

--- a/client/reader/discover/index.web.js
+++ b/client/reader/discover/index.web.js
@@ -1,4 +1,3 @@
-import page from '@automattic/calypso-router';
 import {
 	getAnyLanguageRouteParam,
 	removeLocaleFromPathLocaleInFront,
@@ -8,6 +7,7 @@ import {
 	makeLayout,
 	redirectInvalidLanguage,
 	redirectWithoutLocaleParamInFrontIfLoggedIn,
+	redirectLoggedOutToSignup,
 	render as clientRender,
 } from 'calypso/controller';
 import { setLocaleMiddleware } from 'calypso/controller/shared';
@@ -59,11 +59,6 @@ const discover = ( context, next ) => {
 		const pathParts = pathWithoutLocale.split( '/' );
 		// Now pathParts[2] will consistently be the tab.
 		selectedTab = pathParts[ 2 ] || DEFAULT_TAB;
-
-		// Redirect /discover/add-new to /discover if logged out.
-		if ( selectedTab === 'add-new' && ! isLoggedIn ) {
-			return page.redirect( '/discover' );
-		}
 	} else {
 		// Use query parameter for v1.
 		selectedTab = context.query.selectedTab || DEFAULT_TAB;
@@ -102,43 +97,42 @@ const discover = ( context, next ) => {
 export default function ( router ) {
 	const anyLangParam = getAnyLanguageRouteParam();
 
+	const commonMiddleware = [
+		redirectInvalidLanguage,
+		redirectWithoutLocaleParamInFrontIfLoggedIn,
+		setLocaleMiddleware(),
+		updateLastRoute,
+		sidebar,
+		discover,
+		makeLayout,
+		clientRender,
+	];
+
 	if ( isDiscoveryV2Enabled() ) {
+		// Must be logged in to access.
+		router(
+			[ '/discover/add-new', `/${ anyLangParam }/discover/add-new` ],
+			redirectLoggedOutToSignup,
+			...commonMiddleware
+		);
+
 		router(
 			[
 				'/discover',
-				'/discover/add-new',
 				'/discover/firstposts',
 				'/discover/tags',
 				'/discover/reddit',
 				'/discover/latest',
 				`/${ anyLangParam }/discover`,
-				`/${ anyLangParam }/discover/add-new`,
 				`/${ anyLangParam }/discover/firstposts`,
 				`/${ anyLangParam }/discover/tags`,
 				`/${ anyLangParam }/discover/reddit`,
 				`/${ anyLangParam }/discover/latest`,
 			],
-			redirectInvalidLanguage,
-			redirectWithoutLocaleParamInFrontIfLoggedIn,
-			setLocaleMiddleware(),
-			updateLastRoute,
-			sidebar,
-			discover,
-			makeLayout,
-			clientRender
+			...commonMiddleware
 		);
 	} else {
 		// Original query parameter-based route for v1
-		router(
-			[ '/discover', `/${ anyLangParam }/discover` ],
-			redirectInvalidLanguage,
-			redirectWithoutLocaleParamInFrontIfLoggedIn,
-			setLocaleMiddleware(),
-			updateLastRoute,
-			sidebar,
-			discover,
-			makeLayout,
-			clientRender
-		);
+		router( [ '/discover', `/${ anyLangParam }/discover` ], ...commonMiddleware );
 	}
 }

--- a/client/reader/discover/index.web.js
+++ b/client/reader/discover/index.web.js
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import {
 	getAnyLanguageRouteParam,
 	removeLocaleFromPathLocaleInFront,
@@ -33,9 +34,9 @@ const discover = ( context, next ) => {
 	const streamKey = 'discover:recommended';
 	const mcKey = 'discover';
 	const state = context.store.getState();
-
 	const currentRoute = getCurrentRoute( state );
 	const currentQueryArgs = new URLSearchParams( getCurrentQueryArguments( state ) ).toString();
+	const isLoggedIn = isUserLoggedIn( state );
 
 	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 	recordTrack(
@@ -44,7 +45,7 @@ const discover = ( context, next ) => {
 		{ pathnameOverride: `${ currentRoute }?${ currentQueryArgs }` }
 	);
 
-	if ( ! isUserLoggedIn( state ) ) {
+	if ( ! isLoggedIn ) {
 		context.renderHeaderSection = renderHeaderSection;
 	}
 
@@ -58,6 +59,11 @@ const discover = ( context, next ) => {
 		const pathParts = pathWithoutLocale.split( '/' );
 		// Now pathParts[2] will consistently be the tab.
 		selectedTab = pathParts[ 2 ] || DEFAULT_TAB;
+
+		// Redirect /discover/add-new to /discover if logged out.
+		if ( selectedTab === 'add-new' && ! isLoggedIn ) {
+			return page.redirect( '/discover' );
+		}
 	} else {
 		// Use query parameter for v1.
 		selectedTab = context.query.selectedTab || DEFAULT_TAB;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/481

## Proposed Changes

* Hide the "Add new" tab if the user is logged out.
* Redirect /discover/add-new to "Sign up" if the user is logged out.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the UX of Discover v2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using Calypso Live log in and go to /discover. You should see a functional "Add new" tab.
* Log out and go to /discover. You should NOT see the "Add new" tab.
* Try going to /discover/add-new directly. You should be redirected to /start/account/user-social

> [!NOTE]  
> If you go to /{locale}/discover/add-new while logged-out, the locale is ignored, and you are redirected to /start/account/user-social. This is an issue upstream in the `redirectLoggedOutToSignup` middleware that I'd like to address in a different PR. For this particular PR, it is a very small edge case.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
