### PR TITLE
A4A: new signup flow adjustments

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form-2/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form-2/index.tsx
@@ -1,0 +1,128 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import Form from 'calypso/a8c-for-agencies/components/form';
+import FormField from 'calypso/a8c-for-agencies/components/form/field';
+import FormFooter from 'calypso/a8c-for-agencies/components/form/footer';
+import FormRadio from 'calypso/components/forms/form-radio';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import { preventWidows } from 'calypso/lib/formatting';
+import { AgencyDetailsSignupPayload } from '../../../../types';
+
+import './style.scss';
+
+type Props = {
+	onContinue: ( data: Partial< AgencyDetailsSignupPayload > ) => void;
+};
+
+const BlueprintFormRadio = ( {
+	label,
+	checked,
+	onChange,
+}: {
+	label: string;
+	checked: boolean;
+	onChange: () => void;
+} ) => {
+	return (
+		<div
+			className="blue-print-form__radio"
+			onClick={ onChange }
+			role="button"
+			tabIndex={ 0 }
+			onKeyDown={ ( e ) => {
+				if ( e.key === 'Enter' ) {
+					onChange();
+				}
+			} }
+		>
+			<FormRadio label={ label } checked={ checked } onChange={ onChange } />
+		</div>
+	);
+};
+
+const BlueprintForm2: React.FC< Props > = ( { onContinue } ) => {
+	const translate = useTranslate();
+	const [ formData, setFormData ] = useState< Partial< AgencyDetailsSignupPayload > >( {
+		workWithClients: '',
+		workWithClientsOther: '',
+		approachAndChallenges: '',
+	} );
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		onContinue( formData );
+	};
+
+	const workModelOptions = [
+		{
+			label: translate(
+				'Refer customers to Automattic products/services to purchase on their own'
+			),
+			value: 'refer_customers',
+		},
+		{
+			label: translate( "Purchase on our clients' behalf and resell Automattic products/services" ),
+			value: 'purchase_resell',
+		},
+		{ label: translate( 'A combination of referring and reselling' ), value: 'combination' },
+		{ label: translate( 'Other models (please explain)' ), value: 'other' },
+	];
+
+	return (
+		<Form
+			className="blueprint-form"
+			title={ preventWidows( translate( "Let's build your blueprint" ) ) }
+		>
+			<FormField
+				label={ translate(
+					"How does your agency typically work with clients regarding Automattic's solutions?"
+				) }
+				isRequired
+			>
+				<div className="blueprint-form__radio-group">
+					{ workModelOptions.map( ( option ) => (
+						<BlueprintFormRadio
+							key={ `work-model-option-${ option.value }` }
+							label={ option.label }
+							checked={ formData.workWithClients === option.value }
+							onChange={ () => setFormData( { ...formData, workWithClients: option.value } ) }
+						/>
+					) ) }
+					{ formData.workWithClients === 'other' && (
+						<FormTextInput
+							value={ formData.workWithClientsOther }
+							onChange={ ( e: React.ChangeEvent< HTMLInputElement > ) =>
+								setFormData( { ...formData, workWithClientsOther: e.target.value } )
+							}
+							placeholder={ translate( 'Add your explanation' ) }
+						/>
+					) }
+				</div>
+			</FormField>
+
+			<FormField
+				label={ translate(
+					`Is there anything specific about your agency's approach or any challenges you face that you would like us to consider when creating your blueprint?`
+				) }
+			>
+				<FormTextarea
+					value={ formData.approachAndChallenges }
+					onChange={ ( e: React.ChangeEvent< HTMLTextAreaElement > ) =>
+						setFormData( { ...formData, approachAndChallenges: e.target.value } )
+					}
+					placeholder={ translate( 'Add your approach' ) }
+				/>
+			</FormField>
+
+			<FormFooter>
+				<Button variant="primary" onClick={ handleSubmit } __next40pxDefaultSize>
+					{ translate( 'Continue' ) }
+				</Button>
+			</FormFooter>
+		</Form>
+	);
+};
+
+export default BlueprintForm2;

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form-2/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form-2/style.scss
@@ -1,0 +1,13 @@
+.blueprint-form__radio-group {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.blue-print-form__radio {
+	cursor: pointer;
+
+	.form-radio__label {
+		@include a4a-font-body-md;
+	}
+}

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
@@ -5,8 +5,6 @@ import Form from 'calypso/a8c-for-agencies/components/form';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
 import FormFooter from 'calypso/a8c-for-agencies/components/form/footer';
 import FormRadio from 'calypso/components/forms/form-radio';
-import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormTextarea from 'calypso/components/forms/form-textarea';
 import { preventWidows } from 'calypso/lib/formatting';
 import { AgencyDetailsSignupPayload } from '../../../../types';
 
@@ -47,9 +45,6 @@ const BlueprintForm: React.FC< Props > = ( { onContinue } ) => {
 	const [ formData, setFormData ] = useState< Partial< AgencyDetailsSignupPayload > >( {
 		topPartneringGoal: '',
 		topYearlyGoal: '',
-		workWithClients: '',
-		workWithClientsOther: '',
-		approachAndChallenges: '',
 	} );
 
 	const handleSubmit = ( e: React.FormEvent ) => {
@@ -86,21 +81,6 @@ const BlueprintForm: React.FC< Props > = ( { onContinue } ) => {
 			label: translate( "Strengthening the agency's brand and reputation" ),
 			value: 'strengthening_brand',
 		},
-	];
-
-	const workModelOptions = [
-		{
-			label: translate(
-				'Refer customers to Automattic products/services to purchase on their own'
-			),
-			value: 'refer_customers',
-		},
-		{
-			label: translate( "Purchase on our clients' behalf and resell Automattic products/services" ),
-			value: 'purchase_resell',
-		},
-		{ label: translate( 'A combination of referring and reselling' ), value: 'combination' },
-		{ label: translate( 'Other models (please explain)' ), value: 'other' },
 	];
 
 	return (
@@ -141,47 +121,6 @@ const BlueprintForm: React.FC< Props > = ( { onContinue } ) => {
 						/>
 					) ) }
 				</div>
-			</FormField>
-
-			<FormField
-				label={ translate(
-					"How does your agency typically work with clients regarding Automattic's solutions?"
-				) }
-				isRequired
-			>
-				<div className="blueprint-form__radio-group">
-					{ workModelOptions.map( ( option ) => (
-						<BlueprintFormRadio
-							key={ `work-model-option-${ option.value }` }
-							label={ option.label }
-							checked={ formData.workWithClients === option.value }
-							onChange={ () => setFormData( { ...formData, workWithClients: option.value } ) }
-						/>
-					) ) }
-					{ formData.workWithClients === 'other' && (
-						<FormTextInput
-							value={ formData.workWithClientsOther }
-							onChange={ ( e: React.ChangeEvent< HTMLInputElement > ) =>
-								setFormData( { ...formData, workWithClientsOther: e.target.value } )
-							}
-							placeholder={ translate( 'Add your explanation' ) }
-						/>
-					) }
-				</div>
-			</FormField>
-
-			<FormField
-				label={ translate(
-					`Is there anything specific about your agency's approach or any challenges you face that you would like us to consider when creating your blueprint?`
-				) }
-			>
-				<FormTextarea
-					value={ formData.approachAndChallenges }
-					onChange={ ( e: React.ChangeEvent< HTMLTextAreaElement > ) =>
-						setFormData( { ...formData, approachAndChallenges: e.target.value } )
-					}
-					placeholder={ translate( 'Add your approach' ) }
-				/>
 			</FormField>
 
 			<FormFooter>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/index.tsx
@@ -24,8 +24,6 @@ const ChoiceBlueprint: React.FC< Props > = ( { onContinue, onSkip } ) => {
 				`By answering a few simple questions, we'll provide tips on maximizing your agency's impact.`
 			) }
 		>
-			<p className="choice-blueprint__text">{ translate( 'Ready?' ) }</p>
-
 			<FormFooter>
 				<Button
 					className="choice-blueprint__button"
@@ -33,7 +31,7 @@ const ChoiceBlueprint: React.FC< Props > = ( { onContinue, onSkip } ) => {
 					onClick={ onContinue }
 					__next40pxDefaultSize
 				>
-					{ translate( 'Yes' ) }
+					{ translate( 'Build my custom blueprint' ) }
 				</Button>
 				<Button
 					className="choice-blueprint__button"

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/style.scss
@@ -8,6 +8,6 @@
 }
 
 .choice-blueprint__button {
-	width: 180px;
+	width: 200px;
 	justify-content: center;
 }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/style.scss
@@ -1,12 +1,3 @@
-.choice-blueprint__text {
-	@include a4a-font-body-lg;
-    color: var(--color-neutral-60);
-
-	@media (prefers-color-scheme: dark) {
-			color: var(--color-text-inverted);
-	}
-}
-
 .choice-blueprint__button {
 	width: 200px;
 	justify-content: center;

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
@@ -21,7 +21,8 @@ type Props = {
 
 const SignupContactForm = ( { onContinue }: Props ) => {
 	const translate = useTranslate();
-	const { validate, validationError, updateValidationError } = useContactFormValidation();
+	const { validate, validationError, updateValidationError, isValidating } =
+		useContactFormValidation();
 
 	const countriesList = useGetSupportedSMSCountries();
 	const noCountryList = countriesList.length === 0;
@@ -169,7 +170,12 @@ const SignupContactForm = ( { onContinue }: Props ) => {
 			</div>
 
 			<FormFooter>
-				<Button __next40pxDefaultSize variant="primary" onClick={ handleSubmit }>
+				<Button
+					__next40pxDefaultSize
+					disabled={ isValidating }
+					variant="primary"
+					onClick={ handleSubmit }
+				>
 					{ translate( 'Continue' ) }
 				</Button>
 			</FormFooter>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
@@ -7,6 +7,7 @@ import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import useCreateSignupMutation from '../../../hooks/use-create-signup-mutation';
 import StepProgress from '../step-progress';
 import BlueprintForm from './blueprint-form';
+import BlueprintForm2 from './blueprint-form-2';
 import ChoiceBlueprint from './choice-blueprint';
 import SignupContactForm from './contact-form';
 import FinishSignupSurvey from './finish-signup-survey';
@@ -28,11 +29,18 @@ const MultiStepForm = () => {
 			label: translate( 'Personalize' ),
 			isActive: currentStep === 2 || currentStep === 3 || currentStep === 4,
 			isComplete: currentStep > 2,
+			half: true,
+		},
+		{
+			label: '',
+			isActive: currentStep === 5,
+			isComplete: currentStep > 5,
+			half: true,
 		},
 		{
 			label: translate( 'Finish survey' ),
-			isActive: currentStep === 5,
-			isComplete: currentStep > 5,
+			isActive: currentStep === 6,
+			isComplete: currentStep > 6,
 		},
 	];
 
@@ -50,7 +58,7 @@ const MultiStepForm = () => {
 			const newFormData = { ...formData, ...data };
 			setFormData( newFormData );
 			setCurrentStep( nextStep );
-			if ( nextStep === 5 ) {
+			if ( nextStep === 6 ) {
 				createSignup.mutate( newFormData as AgencyDetailsSignupPayload );
 			}
 		},
@@ -59,7 +67,7 @@ const MultiStepForm = () => {
 
 	const clearDataAndRefresh = () => {
 		setFormData( {} );
-		setCurrentStep( 1 );
+		window.location.reload();
 	};
 
 	const currentForm = useMemo( () => {
@@ -72,12 +80,14 @@ const MultiStepForm = () => {
 				return (
 					<ChoiceBlueprint
 						onContinue={ () => updateDataAndContinue( {}, 4 ) }
-						onSkip={ () => updateDataAndContinue( {}, 5 ) }
+						onSkip={ () => updateDataAndContinue( {}, 6 ) }
 					/>
 				);
 			case 4:
 				return <BlueprintForm onContinue={ ( data ) => updateDataAndContinue( data, 5 ) } />;
 			case 5:
+				return <BlueprintForm2 onContinue={ ( data ) => updateDataAndContinue( data, 6 ) } />;
+			case 6:
 				return <FinishSignupSurvey onContinue={ clearDataAndRefresh } />;
 			default:
 				return null;

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -152,7 +152,7 @@ export default function PersonalizationForm( { onContinue }: Props ) {
 									<option value="1-5">{ translate( '1-5' ) }</option>
 									<option value="6-20">{ translate( '6-20' ) }</option>
 									<option value="21-50">{ translate( '21-50' ) }</option>
-									<option value="50-100">{ translate( '50-100' ) }</option>
+									<option value="51-100">{ translate( '51-100' ) }</option>
 									<option value="101-500">{ translate( '101-500' ) }</option>
 									<option value="500+">{ translate( '500+' ) }</option>
 								</FormSelect>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/step-progress/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/step-progress/index.tsx
@@ -6,6 +6,7 @@ type Step = {
 	label: string;
 	isActive: boolean;
 	isComplete: boolean;
+	half?: boolean;
 };
 
 type Props = {
@@ -23,10 +24,11 @@ const StepProgress = ( { steps }: Props ) => {
 							className={ clsx( 'step-progress__step', {
 								'is-active': step.isActive,
 								'is-complete': step.isComplete,
+								'is-half': step.half,
 							} ) }
 						>
-							<div className="step-progress__step-indicator" />
 							<span className="step-progress__step-label">{ step.label }</span>
+							<div className="step-progress__step-indicator" />
 						</div>
 					) ) }
 				</div>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/step-progress/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/step-progress/style.scss
@@ -12,15 +12,21 @@
 
 	.step-progress__steps-container {
 		display: grid;
-		grid-template-columns: repeat(3, 1fr);
+		grid-template-columns: repeat(6, 1fr);
 		gap: 8px;
 		width: 100%;
 	}
 
 	.step-progress__step {
+		justify-content: space-between;
 		display: flex;
 		flex-direction: column;
 		gap: 8px;
+		grid-column: span 2;
+
+		&.is-half {
+			grid-column: span 1;
+		}
 	}
 
 	.step-progress__step.is-active {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1776
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1779
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1780
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1790
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1791

## Proposed Changes

This PR addresses the number of issues raised:

- **Split personalize step in two for 2 blueprint questions**

| First | Second |
|--------|--------|
| <img width="582" alt="Screenshot 2025-02-14 at 3 24 13 PM" src="https://github.com/user-attachments/assets/40c39bb0-7a92-41d7-83d3-126bcb71d804" /> | <img width="649" alt="Screenshot 2025-02-14 at 3 24 17 PM" src="https://github.com/user-attachments/assets/92a6274e-f254-456b-8f55-04a54278a721" /> |

- **Removed `Ready` and replaced `Yes` button to `Build my custom blueprint`**

<img width="520" alt="Screenshot 2025-02-14 at 3 42 33 PM" src="https://github.com/user-attachments/assets/8892473d-8a04-4622-a8af-82e8036cf3c5" />

- **After final step, page is reloaded to clear out states and notices**

- **Fixes incorrect number of sites, `50-100` -> `51-100`**

<img width="628" alt="Screenshot 2025-02-14 at 3 21 26 PM" src="https://github.com/user-attachments/assets/c1d568fb-ef86-4554-8ed8-6e49e4a221fd" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link verify fixes mentioned above using new signup flow `/signup/wc-asia`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
