### PR TITLE
Reset ONBOARD_STORE state when starting a migration.

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -38,7 +38,7 @@ const siteMigration: Flow = {
 		useEffect( () => {
 			resetOnboardStore();
 			setIntent( Onboard.SiteIntent.SiteMigration );
-		}, [] );
+		}, [ resetOnboardStore, setIntent ] );
 		const { set, get } = useFlowState();
 		const urlQueryParams = useQuery();
 		const ref = urlQueryParams.get( 'ref' );

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -34,8 +34,9 @@ const siteMigration: Flow = {
 	__experimentalUseSessions: true,
 
 	useSideEffect() {
-		const { setIntent } = useDispatch( ONBOARD_STORE );
+		const { setIntent, resetOnboardStore } = useDispatch( ONBOARD_STORE );
 		useEffect( () => {
+			resetOnboardStore();
 			setIntent( Onboard.SiteIntent.SiteMigration );
 		}, [] );
 		const { set, get } = useFlowState();


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/10466

## Proposed Changes

After abandoning a site onboard, users are not able to complete a new migration.
This happens due the `/setup/hosted-site-migration` not cleaning up `ONBOARD_STORE`.
A video and more detailed explanation are available on the issue above. I recommend taking a look on it.

## Testing Instructions

- Navigate to http://calypso.localhost:3000/setup/onboarding
- Select a free domain
- Select a free plan
- Wait the site creation, but do not complete the next step of the flow
- Navigate to http://calypso.localhost:3000/setup/hosted-site-migration
- Enter you origin site address
- On the site picker step, click on `create a new one`
- You should see the site creation screen. The one that starts with `Laying the foundations`.
- After that you should see the `What do you want to do?` step.

After reaching that point you should be all good.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
