### PR TITLE
Emphasize Longer Term Plans: Technical Spike

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-eligibility-for-term-savings-price-display.ts
+++ b/client/my-sites/plans-features-main/hooks/use-eligibility-for-term-savings-price-display.ts
@@ -12,11 +12,9 @@ import {
 	usePlansFromTypes,
 	usePlanTypesWithIntent,
 } from '@automattic/plans-grid-next';
-import useLongerPlanTermDefaultExperiment from './experiments/use-longer-plan-term-default-experiment';
 import useCheckPlanAvailabilityForPurchase from './use-check-plan-availability-for-purchase';
 
 const useEligibilityForTermSavingsPriceDisplay = ( {
-	flowName,
 	hiddenPlans,
 	intent,
 	isSubdomainNotGenerated,
@@ -25,7 +23,6 @@ const useEligibilityForTermSavingsPriceDisplay = ( {
 	displayedIntervals,
 	coupon,
 	siteId,
-	isInSignup,
 }: {
 	flowName?: string | null;
 	hiddenPlans?: HiddenPlans;
@@ -36,9 +33,7 @@ const useEligibilityForTermSavingsPriceDisplay = ( {
 	displayedIntervals: UrlFriendlyTermType[];
 	coupon?: string;
 	siteId?: number | null;
-	isInSignup?: boolean;
 } ) => {
-	const longerPlanTermDefaultExperiment = useLongerPlanTermDefaultExperiment( flowName );
 	const availablePlanSlugs = usePlansFromTypes( {
 		planTypes: usePlanTypesWithIntent( {
 			intent,
@@ -79,7 +74,7 @@ const useEligibilityForTermSavingsPriceDisplay = ( {
 		return false;
 	}
 
-	return longerPlanTermDefaultExperiment.isEligibleForTermSavings && isInSignup;
+	return true;
 };
 
 export default useEligibilityForTermSavingsPriceDisplay;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -424,7 +424,6 @@ const PlansFeaturesMain = ( {
 	};
 
 	const enableTermSavingsPriceDisplay = useEligibilityForTermSavingsPriceDisplay( {
-		flowName: flowName,
 		selectedPlan,
 		hiddenPlans,
 		isSubdomainNotGenerated: ! resolvedSubdomainName.result,
@@ -433,7 +432,6 @@ const PlansFeaturesMain = ( {
 		displayedIntervals: filteredDisplayedIntervals,
 		coupon,
 		siteId,
-		isInSignup,
 	} );
 
 	// we need all the plans that are available to pick for comparison grid (these should extend into plans-ui data store selectors)

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -185,7 +185,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 		);
 	}
 
-	if ( enableTermSavingsPriceDisplay && termVariantPricing && savings ) {
+	if ( enableTermSavingsPriceDisplay && termVariantPricing && savings && ! current ) {
 		return (
 			<div className="plans-grid-next-header-price">
 				<div className="plans-grid-next-header-price__badge">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Shows the longer term plans savings badge to all onboarding flows
* Hides the badge for the logged in plans page spotlight plan
* TODO: For the logged in plans page, hide the badges for any plan tiers lower than the currently owned plan ( we don't want to promote lower tier plans )

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
