### PR TITLE
Remove the email verification requirement domain suggestion search

### DIFF
--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -12,7 +12,6 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import { useMyDomainInputMode } from 'calypso/components/domains/connect-domain-step/constants';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
-import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
@@ -418,31 +417,26 @@ class DomainSearch extends Component< DomainSearchProps > {
 							) }
 						</div>
 
-						<EmailVerificationGate
-							noticeText={ translate( 'You must verify your email to register new domains.' ) }
-							noticeStatus="is-info"
-						>
-							{ ! hasPlanInCart && ! this.props.domainAndPlanUpsellFlow && (
-								<NewDomainsRedirectionNoticeUpsell />
-							) }
-							<RegisterDomainStep
-								suggestion={ this.getInitialSuggestion() }
-								domainAndPlanUpsellFlow={ this.props.domainAndPlanUpsellFlow }
-								domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-								onDomainsAvailabilityChange={ this.handleDomainsAvailabilityChange }
-								onAddDomain={ this.handleAddRemoveDomain }
-								onAddMapping={ this.handleAddMapping }
-								onAddTransfer={ this.handleAddTransfer }
-								isCartPendingUpdate={ this.props.shoppingCartManager.isPendingUpdate }
-								showAlreadyOwnADomain
-								selectedSite={ selectedSite }
-								basePath={ this.props.basePath }
-								products={ this.props.productsList }
-								vendor={ getSuggestionsVendor( {
-									flowName: isEcommerceSite ? ECOMMERCE_FLOW : '',
-								} ) }
-							/>
-						</EmailVerificationGate>
+						{ ! hasPlanInCart && ! this.props.domainAndPlanUpsellFlow && (
+							<NewDomainsRedirectionNoticeUpsell />
+						) }
+						<RegisterDomainStep
+							suggestion={ this.getInitialSuggestion() }
+							domainAndPlanUpsellFlow={ this.props.domainAndPlanUpsellFlow }
+							domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+							onDomainsAvailabilityChange={ this.handleDomainsAvailabilityChange }
+							onAddDomain={ this.handleAddRemoveDomain }
+							onAddMapping={ this.handleAddMapping }
+							onAddTransfer={ this.handleAddTransfer }
+							isCartPendingUpdate={ this.props.shoppingCartManager.isPendingUpdate }
+							showAlreadyOwnADomain
+							selectedSite={ selectedSite }
+							basePath={ this.props.basePath }
+							products={ this.props.productsList }
+							vendor={ getSuggestionsVendor( {
+								flowName: isEcommerceSite ? ECOMMERCE_FLOW : '',
+							} ) }
+						/>
 					</div>
 				</span>
 			);


### PR DESCRIPTION
We have a weird limitation that prevents customers from searching for a domain in case their email is not verified. We had some requests to remove the limitation before and they were always rejected because we expect it might lead to abuse and higher number of support requests. However we've discussed this during the Domainson meetup and I think we should be okay to remove the limit and see if it actually increases the number of suspended domains

## Proposed Changes

* Remove the `EmailVerificationGate` from the domain suggestions screen

## Why are these changes being made?

* Because we believe that allowing the customer to register domain won't increase the number of suspended domains. We already allow customers to buy domain before they have verified their WPCOM email in the signup anyway.

## Testing Instructions

* Logging in with unverified account should not prevent you from getting domain suggestions

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
