### PR TITLE
Fix the "Do you own it" link when you search for a domain that is transferrable

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -165,7 +165,7 @@ class DomainSearchResults extends Component {
 									// eslint-disable-next-line jsx-a11y/anchor-is-valid
 									<a
 										href="#"
-										onClick={ () => this.props.onClickUseYourDomain( domainArgument ) }
+										onClick={ this.props.onClickUseYourDomain }
 										data-tracks-button-click-source={ this.props.tracksButtonClickSource }
 									/>
 								),


### PR DESCRIPTION
Clicking on the "Do you own it" link in domain search when you search for a domain that's already registered and transferrable does not work. This PR fixes the issue which was introduced in https://github.com/Automattic/wp-calypso/pull/98981 probably by accident.

Related to #99839

## Proposed Changes

* Roll back a change in #98981 where the `onClick` handler was replaced with anonymous function

## Why are these changes being made?

* Clicking on the link doesn't work and throws an error in the browser console

## Testing Instructions

* Go to the Calypso domains flow and search for a domain that is registered. When you see the "Do you own it?" link you should click it and it would take you to the transfer form.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
