### PR TITLE
Fix connecting GitHub to an existing account via `/me/security/social-login` page

### DIFF
--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -28,6 +28,7 @@ type GithubLoginButtonProps = {
 	socialServiceResponse?: ExchangeCodeForTokenResponse | null;
 	userHasDisconnected?: boolean;
 	isLogin: boolean;
+	overrideRedirectUri?: string;
 };
 
 type ExchangeCodeForTokenResponse = {
@@ -42,10 +43,11 @@ const GitHubLoginButton = ( {
 	socialServiceResponse,
 	userHasDisconnected,
 	isLogin,
+	overrideRedirectUri,
 }: GithubLoginButtonProps ) => {
 	const translate = useTranslate();
-	const redirectUri = useSelector( ( state: AppState ) =>
-		getRedirectUri( 'github', state, isLogin )
+	const redirectUri = useSelector(
+		( state: AppState ) => overrideRedirectUri || getRedirectUri( 'github', state, isLogin )
 	);
 	const { code, service } = useSelector( ( state: AppState ) => state.route?.query?.initial ) ?? {};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/handle-social-response.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/handle-social-response.ts
@@ -35,10 +35,6 @@ export const useHandleSocialResponse = ( flowName: string ) => {
 			id_token: string | null = null,
 			userData: PreSignUpUserData | null
 		) => {
-			if ( ! id_token ) {
-				return;
-			}
-
 			const storedRedirectTo = window.sessionStorage.getItem( 'signup_redirect_to' );
 
 			if ( storedRedirectTo ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/handle-social-response.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/handle-social-response.ts
@@ -35,6 +35,10 @@ export const useHandleSocialResponse = ( flowName: string ) => {
 			id_token: string | null = null,
 			userData: PreSignUpUserData | null
 		) => {
+			if ( ! id_token ) {
+				return;
+			}
+
 			const storedRedirectTo = window.sessionStorage.getItem( 'signup_redirect_to' );
 
 			if ( storedRedirectTo ) {

--- a/client/me/social-login/action-button.jsx
+++ b/client/me/social-login/action-button.jsx
@@ -20,6 +20,7 @@ class SocialLoginActionButton extends Component {
 		connectSocialUser: PropTypes.func.isRequired,
 		disconnectSocialUser: PropTypes.func.isRequired,
 		socialServiceResponse: PropTypes.object,
+		redirectUri: PropTypes.string,
 	};
 
 	state = {
@@ -121,7 +122,7 @@ class SocialLoginActionButton extends Component {
 	};
 
 	render() {
-		const { service, isConnected, isUpdatingSocialConnection, translate } = this.props;
+		const { service, isConnected, isUpdatingSocialConnection, redirectUri, translate } = this.props;
 
 		const { fetchingUser, userHasDisconnected } = this.state;
 
@@ -175,6 +176,7 @@ class SocialLoginActionButton extends Component {
 					responseHandler={ this.handleSocialServiceResponse }
 					socialServiceResponse={ this.props.socialServiceResponse }
 					userHasDisconnected={ userHasDisconnected }
+					overrideRedirectUri={ redirectUri }
 				>
 					{ actionButton }
 				</GithubLoginButton>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/99834

## Proposed Changes

* Add `overrideRedirectUri` prop to `GithubLoginButton` component
  * It usually calculates its own redirect URI, but the user settings page needs to be able to direct the button back to the user settings again instead of the signup framework
* Reinstate the `redirectUri` prop on `SocialLoginActionButton` and pass it to the GitHub login button
  * This prop was still being passed, but was being ignored. It was removed in the https://github.com/Automattic/wp-calypso/pull/93654 PR, which I _think_ forgot to consider the "connect to existing account" case.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See escalation p1739618278208149-slack-C02FMH4G8

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log in to dotcom account that is not connected
* Go to `/me/security/social-login` and start GitHub connection flow
* Once complete you should land back on the social login settings page
* Log out and confirm you can log in using the newly connected GitHub account
* Confirm the "signup with GitHub" flow still works (that is, connecting GitHub to a brand new account)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?