### PR TITLE
Reader: Fix search scroll behaviour

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -169,27 +169,6 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	margin-bottom: 0;
 }
 
-.reader-full-post .back-button {
-	border: none;
-	position: absolute;
-	top: 0;
-	left: 0;
-	right: unset;
-	background-color: transparent;
-
-	button.is-compact.is-borderless {
-		margin: 2px;
-		@media ( max-width: 781px ) {
-			padding-top: 12px;
-			padding-bottom: 12px;
-		}
-	}
-
-	@include breakpoint-deprecated( '<660px' ) {
-		left: 14px;
-	}
-}
-
 .reader-full-post .author-compact-profile {
 	display: inline-flex;
 	flex-direction: column;

--- a/client/components/back-button/style.scss
+++ b/client/components/back-button/style.scss
@@ -20,11 +20,11 @@
 	}
 }
 
-.back-button__label {
-	@media ( max-width: 1180px ) {
-		display: none;
-	}
-}
+// .back-button__label {
+// 	@media ( max-width: 1180px ) {
+// 		display: none;
+// 	}
+// }
 
 .back-button__example {
 	.back-button {

--- a/client/components/back-button/style.scss
+++ b/client/components/back-button/style.scss
@@ -3,7 +3,7 @@
 .back-button {
 	margin: 0;
 	position: fixed;
-	top: var(--masterbar-height);
+	top: calc(var(--masterbar-height) + 20px);
 	left: 0;
 	z-index: z-index(".masterbar", ".reader-back");
 
@@ -11,22 +11,17 @@
 		padding: 20px 8px 16px;
 
 		@include breakpoint-deprecated( ">660px" ) {
-			padding: 18px 40px 18px 20px;
+			padding: 18px 40px 18px 10px;
 		}
 	}
 
 	@include breakpoint-deprecated( "<660px" ) {
-		top: 0;
-		left: 0;
-		right: 0;
-		height: 46px;
-		background: var(--color-surface);
-		border-bottom: 1px solid var(--color-neutral-0);
+		display: none;
 	}
 }
 
 .back-button__label {
-	@include breakpoint-deprecated( "<660px" ) {
+	@media ( max-width: 1180px ) {
 		display: none;
 	}
 }

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -115,6 +115,7 @@ export function following( context, next ) {
 		streamKey: 'following',
 		startDate,
 		recsStreamKey: 'custom_recs_posts_with_images',
+		showBack: userHasHistory( context ),
 		trackScrollPage: trackScrollPage.bind(
 			null,
 			basePath,

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -89,6 +89,7 @@ const DiscoverStream = ( props ) => {
 		useCompactCards: true,
 		sidebarTabTitle: isDefaultTab ? translate( 'Sites' ) : translate( 'Related' ),
 		selectedStreamName: selectedTab,
+		showBack: true,
 	};
 
 	return (

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -25,7 +25,7 @@ const getReaderSiteId = ( feed ) => ( feed && feed.blog_ID === 0 ? null : feed &
 const emptyContent = () => <EmptyContent />;
 
 const FeedStream = ( props ) => {
-	const { className = 'is-site-stream', feedId, showBack = true } = props;
+	const { className = 'is-site-stream', feedId } = props;
 	const translate = useTranslate();
 	let feed = useSelector( ( state ) => getFeed( state, feedId ) );
 	const siteId = getReaderSiteId( feed );
@@ -88,7 +88,7 @@ const FeedStream = ( props ) => {
 			<ReaderFeedHeader
 				feed={ feed }
 				site={ site }
-				showBack={ showBack }
+				showBack={ false }
 				streamKey={ props.streamKey }
 			/>
 			{ siteId && <QueryPostCounts siteId={ siteId } type="post" /> }

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -12,10 +12,12 @@ import { useSiteSubscriptions } from './use-site-subscriptions';
 import { useFollowingView } from './view-preference';
 import ViewToggle from './view-toggle';
 import './style.scss';
+import HeaderBack from '../header-back';
 
 function FollowingStream( { ...props } ) {
 	const { currentView } = useFollowingView();
 	const { isLoading, hasNonSelfSubscriptions } = useSiteSubscriptions();
+	console.log( 'props', props );
 
 	if ( ! isLoading && ! hasNonSelfSubscriptions ) {
 		return (

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -6,6 +6,7 @@ import { trim, flatMap } from 'lodash';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import { connect } from 'react-redux';
+import BackButton from 'calypso/components/back-button';
 import DocumentHead from 'calypso/components/data/document-head';
 import NavigationHeader from 'calypso/components/navigation-header';
 import SearchInput from 'calypso/components/search';
@@ -107,12 +108,18 @@ class SearchStream extends React.Component {
 		this.props.recordReaderTracksEvent( 'calypso_reader_search_tags_page_link_clicked' );
 	};
 
+	handleBack = () => {
+		if ( typeof window !== 'undefined' ) {
+			window.history.back();
+		}
+	};
+
 	handleFixedAreaMounted = ( ref ) => ( this.fixedAreaRef = ref );
 
 	handleSearchTypeSelection = ( searchType ) => updateQueryArg( { show: searchType } );
 
 	render() {
-		const { query, translate, searchType, suggestions, isLoggedIn } = this.props;
+		const { query, translate, searchType, suggestions, isLoggedIn, showBack } = this.props;
 		const sortOrder = this.props.sort;
 		const wideDisplay = this.props.width > WIDE_DISPLAY_CUTOFF;
 		const segmentedControlClass = wideDisplay
@@ -165,6 +172,7 @@ class SearchStream extends React.Component {
 			<div>
 				<DocumentHead title={ documentTitle } />
 				<div className="search-stream__fixed-area" ref={ this.handleFixedAreaMounted }>
+					{ showBack && <BackButton onClick={ this.handleBack } /> }
 					<NavigationHeader
 						title={ translate( 'Search' ) }
 						subtitle={ translate( 'Search for specific topics, authors, or blogs.' ) }

--- a/client/reader/search-stream/post-results.jsx
+++ b/client/reader/search-stream/post-results.jsx
@@ -2,7 +2,6 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { RelatedPostCard } from 'calypso/blocks/reader-related-card';
-import HeaderBack from 'calypso/reader/header-back';
 import Stream from 'calypso/reader/stream';
 import PostPlaceholder from 'calypso/reader/stream/post-placeholder';
 import EmptyContent from './empty';
@@ -14,6 +13,7 @@ class PostResults extends Component {
 		query: PropTypes.string,
 		streamKey: PropTypes.string,
 		fixedHeaderHeight: PropTypes.number,
+		showBack: PropTypes.bool,
 	};
 
 	placeholderFactory = ( { key, ...rest } ) => {
@@ -46,7 +46,6 @@ class PostResults extends Component {
 				isMain={ false }
 				fixedHeaderHeight={ this.props.fixedHeaderHeight }
 			>
-				{ this.props.showBack && <HeaderBack /> }
 				<div ref={ this.handleStreamMounted } />
 			</Stream>
 		);

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -8,6 +8,9 @@
 			padding: 0;
 		}
 	}
+	.navigation-header__main {
+		padding-top: 24px;
+	}
 }
 
 // .has-header-section only applies for logged out views
@@ -71,7 +74,9 @@
 	top: 0;
 	z-index: 20;
 	-webkit-font-smoothing: subpixel-antialiased; // Fixes fixed elements text aliasing in Safari
-
+	padding: 0 1px;
+    margin: 0 -1px;
+	
 	@media only screen and (min-width: 601px) and (max-width: 660px) {
 		width: calc(100% - 96px);
 	}
@@ -127,6 +132,7 @@
 	@include breakpoint-deprecated( "<660px" ) {
 		perspective: none; // Fix search bar pushed up behind the masterbar in Safari
 	}
+	padding: 0;
 }
 
 // Post recommendations in Search

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -5,6 +5,7 @@ import {
 	trackPageLoad,
 	trackUpdatesLoaded,
 	trackScrollPage,
+	userHasHistory,
 } from 'calypso/reader/controller-helper';
 import { SEARCH_TYPES } from 'calypso/reader/search-stream/search-stream-header';
 import { recordTrack } from 'calypso/reader/stats';
@@ -83,7 +84,7 @@ const exported = {
 								mcKey
 							) }
 							onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-							showBack={ false }
+							showBack={ userHasHistory( context ) }
 							autoFocusInput={ autoFocusInput }
 							onQueryChange={ reportQueryChange }
 							onSortChange={ reportSortChange }

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -23,7 +23,7 @@ import EmptyContent from './empty';
 const emptyContent = () => <EmptyContent />;
 
 const SiteStream = ( props ) => {
-	const { className = 'is-site-stream', showBack = true, siteId } = props;
+	const { className = 'is-site-stream', siteId } = props;
 	const translate = useTranslate();
 	const site = useSelector( ( state ) => getSite( state, siteId ) );
 	const feed = useSelector( ( state ) => site && site.feed_ID && getFeed( state, site.feed_ID ) );
@@ -83,7 +83,7 @@ const SiteStream = ( props ) => {
 			<ReaderFeedHeader
 				site={ site }
 				feed={ feed }
-				showBack={ showBack }
+				showBack={ false }
 				streamKey={ props.streamKey }
 			/>
 			{ siteId && <QueryPostCounts siteId={ siteId } type="post" /> }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -740,7 +740,6 @@ class ReaderStream extends Component {
 			<TopLevel className={ baseClassnames }>
 				<div ref={ this.overlayRef } className="stream__init-overlay" />
 				{ shouldPoll && <Interval onTick={ this.poll } period={ EVERY_MINUTE } /> }
-
 				<UpdateNotice streamKey={ streamKey } onClick={ this.showUpdates } />
 				{ this.props.showBack && <BackButton onClick={ this.handleBack } /> }
 				{ this.props.children }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -78,6 +78,7 @@ class ReaderStream extends Component {
 		showDefaultEmptyContentIfMissing: PropTypes.bool,
 		showFollowButton: PropTypes.bool,
 		showFollowInHeader: PropTypes.bool,
+		showBack: PropTypes.bool,
 		sidebarTabTitle: PropTypes.string,
 		streamHeader: PropTypes.func,
 		streamSidebar: PropTypes.func,
@@ -99,6 +100,7 @@ class ReaderStream extends Component {
 		showDefaultEmptyContentIfMissing: true,
 		showFollowButton: true,
 		showFollowInHeader: false,
+		showBack: true,
 		suppressSiteNameLink: false,
 		useCompactCards: false,
 	};
@@ -740,7 +742,7 @@ class ReaderStream extends Component {
 				{ shouldPoll && <Interval onTick={ this.poll } period={ EVERY_MINUTE } /> }
 
 				<UpdateNotice streamKey={ streamKey } onClick={ this.showUpdates } />
-				<BackButton onClick={ this.handleBack } />
+				{ this.props.showBack && <BackButton onClick={ this.handleBack } /> }
 				{ this.props.children }
 				{ showingStream && items.length ? this.props.intro?.() : null }
 				{ body }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -8,6 +8,7 @@ import * as React from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import AppPromo from 'calypso/blocks/app-promo';
+import BackButton from 'calypso/components/back-button';
 import InfiniteList from 'calypso/components/infinite-list';
 import ListEnd from 'calypso/components/list-end';
 import SectionNav from 'calypso/components/section-nav';
@@ -613,6 +614,12 @@ class ReaderStream extends Component {
 		return this.getScrollContainer( node.parentNode );
 	};
 
+	handleBack = () => {
+		if ( typeof window !== 'undefined' ) {
+			window.history.back();
+		}
+	};
+
 	render() {
 		const { translate, forcePlaceholders, lastPage, streamHeader, streamKey, selectedPostKey } =
 			this.props;
@@ -733,6 +740,7 @@ class ReaderStream extends Component {
 				{ shouldPoll && <Interval onTick={ this.poll } period={ EVERY_MINUTE } /> }
 
 				<UpdateNotice streamKey={ streamKey } onClick={ this.showUpdates } />
+				<BackButton onClick={ this.handleBack } />
 				{ this.props.children }
 				{ showingStream && items.length ? this.props.intro?.() : null }
 				{ body }

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -1045,12 +1045,6 @@
 		z-index: z-index(".masterbar", ".reader-back");
 	
 		button.is-compact.is-borderless {
-			// margin: 2px;
-			// @media ( min-width: 1180px ) {
-			// 	padding-top: 12px;
-			// 	padding-bottom: 12px;
-			// }
-
 			@media ( max-width: 1180px ) {
 				margin: -5px 0 7px 0;
 				padding: 0;
@@ -1064,6 +1058,19 @@
 		@media ( max-width: 1180px ) {
 			position: unset;
 			display: flex;
+		}
+	}
+
+	&.tag-stream__main {
+		.back-button {
+			button.is-compact.is-borderless {	
+				@media ( max-width: 660px ) {
+					padding: 0 0 0 16px;
+				}
+				@media ( max-width: 600px ) {
+					padding: 0 0 8px 0;
+				}
+			}
 		}
 	}
 

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -1039,21 +1039,31 @@
 	.back-button {
 		border: none;
 		position: fixed;
-		top: calc(var(--masterbar-height) + 20px);
+		top: calc(var(--masterbar-height) + 29px);
 		left: var(--sidebar-width-max);
 		background-color: transparent;
 		z-index: z-index(".masterbar", ".reader-back");
 	
 		button.is-compact.is-borderless {
-			margin: 2px;
-			@media ( max-width: 781px ) {
-				padding-top: 12px;
-				padding-bottom: 12px;
+			// margin: 2px;
+			// @media ( min-width: 1180px ) {
+			// 	padding-top: 12px;
+			// 	padding-bottom: 12px;
+			// }
+
+			@media ( max-width: 1180px ) {
+				margin: -5px 0 7px 0;
+				padding: 0;
+			}
+
+			@media ( max-width: 600px ) {
+				margin: 0 0 0 15px;
 			}
 		}
 	
 		@media ( max-width: 1180px ) {
-			display: none;
+			position: unset;
+			display: flex;
 		}
 	}
 

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -1051,7 +1051,7 @@
 			}
 
 			@media ( max-width: 600px ) {
-				margin: 0 0 0 15px;
+				margin: 0 0 14px 14px;
 			}
 		}
 	
@@ -1074,8 +1074,7 @@
 		}
 	}
 
-	&.reader-full-post,
-	&.search-stream {
+	&.reader-full-post {
 		.back-button {
 			button.is-compact.is-borderless {
 				@media ( max-width: 1180px ) {
@@ -1084,18 +1083,30 @@
 				}
 			}
 		}
+	}
 
-		// &.is-wide-layout {
-		// 	.back-button {	
-		// 		@media ( max-width: 1280px ) {
-		// 			display: none;
-		// 		}
-		// 	}
-		// 	.back-button__label {
-		// 		@media ( max-width: 1300px ) {
-		// 			display: none;
-		// 		}
-		// 	}
-		// }
+	&.search-stream {
+		.back-button {
+			button.is-compact.is-borderless {
+				@media ( max-width: 1300px ) {
+					margin: 0;
+					padding: 0 0 7px 0;
+				}
+				@media ( max-width: 600px ) {
+					padding: 0 0 0 14px;
+				}
+			}
+	
+			@media ( max-width: 1300px ) {
+				position: unset;
+				display: flex;
+			}
+		}
+
+		.following {
+			.back-button {
+				display: none;
+			}
+		}
 	}
 }

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -1035,4 +1035,62 @@
 			z-index: z-index("root", ".stream__init-overlay-enabled");
 		}
 	}
+
+	.back-button {
+		border: none;
+		position: fixed;
+		top: calc(var(--masterbar-height) + 20px);
+		left: var(--sidebar-width-max);
+		background-color: transparent;
+		z-index: z-index(".masterbar", ".reader-back");
+	
+		button.is-compact.is-borderless {
+			margin: 2px;
+			@media ( max-width: 781px ) {
+				padding-top: 12px;
+				padding-bottom: 12px;
+			}
+		}
+	
+		@media ( max-width: 1180px ) {
+			display: none;
+		}
+	}
+
+	&.reader-full-post,
+	&.search-stream {
+		.back-button {
+			border: none;
+			position: absolute;
+			top: 0;
+			left: 0;
+			right: unset;
+			background-color: transparent;
+
+			button.is-compact.is-borderless {
+				margin: 2px;
+				@media ( max-width: 781px ) {
+					padding-top: 12px;
+					padding-bottom: 12px;
+				}
+			}
+
+			@include breakpoint-deprecated( '<660px' ) {
+				left: 14px;
+			}		
+		}
+
+		&.is-wide-layout {
+			.back-button {	
+				@media ( max-width: 1280px ) {
+					display: none;
+				}
+			}
+			.back-button__label {
+				@media ( max-width: 1300px ) {
+					display: none;
+				}
+			}
+		}
+	}
 }

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -1077,37 +1077,25 @@
 	&.reader-full-post,
 	&.search-stream {
 		.back-button {
-			border: none;
-			position: absolute;
-			top: 0;
-			left: 0;
-			right: unset;
-			background-color: transparent;
-
 			button.is-compact.is-borderless {
-				margin: 2px;
-				@media ( max-width: 781px ) {
-					padding-top: 12px;
-					padding-bottom: 12px;
-				}
-			}
-
-			@include breakpoint-deprecated( '<660px' ) {
-				left: 14px;
-			}		
-		}
-
-		&.is-wide-layout {
-			.back-button {	
-				@media ( max-width: 1280px ) {
-					display: none;
-				}
-			}
-			.back-button__label {
-				@media ( max-width: 1300px ) {
-					display: none;
+				@media ( max-width: 1180px ) {
+					margin: 7px 0 0 0;
+					padding: 0 0 0 24px;
 				}
 			}
 		}
+
+		// &.is-wide-layout {
+		// 	.back-button {	
+		// 		@media ( max-width: 1280px ) {
+		// 			display: none;
+		// 		}
+		// 	}
+		// 	.back-button__label {
+		// 		@media ( max-width: 1300px ) {
+		// 			display: none;
+		// 		}
+		// 	}
+		// }
 	}
 }

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -6,6 +6,10 @@ body.is-section-reader {
 		.main {
 			padding: 24px;
 			border-block-end: 1px solid var(--studio-gray-0);
+
+			&.search-stream {
+				padding-top: 0;
+			}
 		}
 		.layout__primary > div:not(:has(.recent-feed)) {
 			background: var(--color-surface);

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -126,7 +126,7 @@ class TagStream extends Component {
 						// unfollow if that was the case.
 						showFollow={ tag.id && this.isSubscribed() }
 						showSort={ false }
-						showBack={ this.props.showBack }
+						showBack={ false }
 					/>
 					{ emptyContent() }
 				</ReaderMain>

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -175,7 +175,6 @@ class TagStream extends Component {
 			>
 				<QueryReaderFollowedTags />
 				<QueryReaderTag tag={ this.props.decodedTagSlug } />
-				{ this.props.showBack && <HeaderBack /> }
 			</Stream>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR fixes a bug I noticed in the search page. When you scroll, the static search header moves with the scroll slightly. 
There is also an issue where the border of the post cards can be seen when the scroll goes behind the search header.

## Before

https://github.com/user-attachments/assets/6a5b9f38-6b0f-4c9c-872c-e176ba4ea61c

## After

https://github.com/user-attachments/assets/ec17ce06-a2aa-4dcd-bd2a-361c8093bfd2

## Proposed Changes

* Updates styles to fix scroll behaviour so the search header remains static when the page is scrolled
* The content of the post/sites stream is hidden when it goes behind the search header

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Tidy up UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to calypso.live `/search` and confirm scroll behaviour is as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
