### PR TITLE
Reader: fix search page scroll

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -8,6 +8,9 @@
 			padding: 0;
 		}
 	}
+	.navigation-header__main {
+		padding-top: 24px;
+	}
 }
 
 // .has-header-section only applies for logged out views
@@ -71,7 +74,8 @@
 	top: 0;
 	z-index: 20;
 	-webkit-font-smoothing: subpixel-antialiased; // Fixes fixed elements text aliasing in Safari
-
+	padding: 0 1px;
+    margin: 0 -1px;
 	@media only screen and (min-width: 601px) and (max-width: 660px) {
 		width: calc(100% - 96px);
 	}
@@ -127,6 +131,7 @@
 	@include breakpoint-deprecated( "<660px" ) {
 		perspective: none; // Fix search bar pushed up behind the masterbar in Safari
 	}
+	padding: 0;
 }
 
 // Post recommendations in Search

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -6,6 +6,10 @@ body.is-section-reader {
 		.main {
 			padding: 24px;
 			border-block-end: 1px solid var(--studio-gray-0);
+			
+			&.search-stream {
+				padding-top: 0;
+			}
 		}
 		.layout__primary > div:not(:has(.recent-feed)) {
 			background: var(--color-surface);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR fixes a bug I noticed in the search page. When you scroll, the static search header moves with the scroll slightly. 
There is also an issue where the border of the post cards can be seen when the scroll goes behind the search header.

## Before

https://github.com/user-attachments/assets/6a5b9f38-6b0f-4c9c-872c-e176ba4ea61c

## After

https://github.com/user-attachments/assets/ec17ce06-a2aa-4dcd-bd2a-361c8093bfd2

## Proposed Changes

* Updates styles to fix scroll behaviour so the search header remains static when the page is scrolled
* The content of the post/sites stream is hidden when it goes behind the search header

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Tidy up UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to calypso.live `/search` and confirm scroll behaviour is as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
