### PR TITLE
Remove the center alignment to fix checks layout in upgrade modal.

### DIFF
--- a/client/components/theme-upgrade-modal/style.scss
+++ b/client/components/theme-upgrade-modal/style.scss
@@ -226,7 +226,6 @@
 
 			> div {
 				display: flex;
-				align-items: center;
 			}
 		}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/78043

## Proposed Changes

* Remove the center alignment for checkmark items in the onboarding upgrade modal.

## Why are these changes being made?
 If there are multi-line items, the checkmark alignment doesn't make sense.

### Screenshots

| Before | After |
|--------|--------|
| <img width="1158" alt="Screenshot 2025-02-17 at 11 55 21 AM" src="https://github.com/user-attachments/assets/0c1ad9ba-91eb-46e5-92ee-bf61b7126e7f" /> | <img width="1162" alt="Screenshot 2025-02-17 at 11 55 31 AM" src="https://github.com/user-attachments/assets/a668468f-88dd-4ffe-96bd-f38bea2e4b74" /> | 


## Testing Instructions
- Add new site
- Choose free plan
- Select a theme that requires a premium plan
- Click "Unlock theme"
- Expect the arrows to alight properly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
