### PR TITLE
Fix wrong function argument being passed

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -165,7 +165,9 @@ class DomainSearchResults extends Component {
 									// eslint-disable-next-line jsx-a11y/anchor-is-valid
 									<a
 										href="#"
-										onClick={ () => this.props.onClickUseYourDomain( domainArgument ) }
+										onClick={ ( event ) =>
+											this.props.onClickUseYourDomain( event, domainArgument )
+										}
 										data-tracks-button-click-source={ this.props.tracksButtonClickSource }
 									/>
 								),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -262,7 +262,7 @@ export function DomainFormControl( {
 					showSkipButton={ showSkipButton }
 					shouldQuerySubdomains={ shouldQuerySubdomains }
 					suggestion={ initialQuery }
-					handleClickUseYourDomain={ onUseYourDomainClick }
+					handleClickUseYourDomain={ ( event, domain ) => onUseYourDomainClick( domain ) }
 					vendor={ getSuggestionsVendor( {
 						isSignup: true,
 						isDomainOnly: false,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -262,7 +262,9 @@ export function DomainFormControl( {
 					showSkipButton={ showSkipButton }
 					shouldQuerySubdomains={ shouldQuerySubdomains }
 					suggestion={ initialQuery }
-					handleClickUseYourDomain={ ( event, domain ) => onUseYourDomainClick( domain ) }
+					handleClickUseYourDomain={ ( event: React.MouseEvent, domain: string ) =>
+						onUseYourDomainClick( domain )
+					}
 					vendor={ getSuggestionsVendor( {
 						isSignup: true,
 						isDomainOnly: false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/99839

## Proposed Changes

The PR https://github.com/Automattic/wp-calypso/pull/98981 introduced a [change](https://github.com/Automattic/wp-calypso/pull/98981/files#diff-25b50fd8c3d32a470cba3533817479bd06c4d47b8b6f726bba112221aee9575fL167) where `domainArgument` was passed as the first argument for the callback `onClickUseYourDomain`.

However, [another reference](https://github.com/Automattic/wp-calypso/blob/trunk/client/components/domains/register-domain-step/index.jsx#L1804) to `onClickUseYourDomain` expects the first argument to be `event`. Thus, this PR updates so that the arguments to `onClickUseYourDomain` is `event`, then `domainArgument`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the reproduction steps in https://github.com/Automattic/wp-calypso/issues/99839 and ensure it's no longer reproducible.
* Also test https://wordpress.com/setup/hundred-year-plan/diy-or-difm the flow:
  * Click on the "I'll create my site on my own" button
  * Click on "New site"
  * Continue until the Domain Picker
  * Ensure that the "Do you own it" button works as before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
