### PR TITLE
Cleanup compact after refactor

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -349,7 +349,7 @@ export class SiteSettingsFormSEO extends Component {
 									/>
 								) }
 							</PanelCardHeading>
-							<div compact className="seo-settings__page-title-header">
+							<div className="seo-settings__page-title-header">
 								<img
 									className="seo-settings__page-title-header-image"
 									src={ pageTitleImage }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/99848

## Proposed Changes

* Removes `compact` boolean from a `div` element left after it was changed from `Card` to `div`

## Testing Instructions

Confirm the warning is no longer displayed on http://calypso.localhost:3000/marketing/traffic/, "Page Title Structure" form should match production layout.