### PR TITLE
Remove cloudflare analytics mention in the plans table feature list

### DIFF
--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -2720,7 +2720,7 @@ const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_CONNECT_ANALYTICS ]: {
 		getSlug: () => FEATURE_CONNECT_ANALYTICS,
-		getTitle: () => i18n.translate( 'Connect Google Analytics and Cloudflare Web Analytics' ),
+		getTitle: () => i18n.translate( 'Connect Google Analytics' ),
 		getDescription: () =>
 			i18n.translate(
 				'Link your accounts to gain more valuable insights in seconds. No coding required.'


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/99847

Follow up after disabling Cloudflare web analytics feature. We shouldn't mention this in the plans page feature list anymore.

## Proposed Changes

* Removes mention of Cloudflare web analytics from the plans page feature list.

## Why are these changes being made?

* See pfsHM7-1tK-p2

## Testing Instructions

* http://calypso.localhost:3000/plans/testingtesterson1175.blog
* Check cf is no longer mentioned here:

![Screenshot(88)](https://github.com/user-attachments/assets/35c3e66d-df03-4c47-9dc5-0ed0e745a09f)
