### PR TITLE
Prevent 100-year domain screen from crashing if there are no search results

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -783,9 +783,10 @@ class RegisterDomainStep extends Component {
 		this.setState( ( state ) => {
 			const newPremiumDomains = { ...state.premiumDomains };
 			delete newPremiumDomains[ domainName ];
+			const searchResults = state.searchResults || [];
 			return {
 				premiumDomains: newPremiumDomains,
-				searchResults: state.searchResults.filter(
+				searchResults: searchResults.filter(
 					( suggestion ) => suggestion.domain_name !== domainName
 				),
 			};


### PR DESCRIPTION
## Proposed Changes

* Prevent [100-year domain screen from crashing if there are no search results](https://wordpress.com/setup/hundred-year-domain/domains?new=bero.blog&search=yes)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Ensure `searchResults` is an array before filtering it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* [Open this 100-year search result page](http://calypso.localhost:3000/setup/hundred-year-domain/domains?new=bero.blog&search=yes) and ensure it doesn't crash

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
