### PR TITLE
A4A: WC Asia Sign-up page enhancements

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
@@ -136,17 +136,15 @@ const SignupContactForm = ( { onContinue }: Props ) => {
 
 			{ noCountryList && <QuerySmsCountries /> }
 
-			<FormField label={ translate( 'Phone number' ) } showOptionalLabel>
-				<FormPhoneInput
-					isDisabled={ noCountryList }
-					countriesList={ countriesList }
-					onChange={ handlePhoneInputChange }
-					className="contact-form__phone-input"
-					phoneInputProps={ {
-						placeholder: translate( 'Phone number' ),
-					} }
-				/>
-			</FormField>
+			<FormPhoneInput
+				isDisabled={ noCountryList }
+				countriesList={ countriesList }
+				onChange={ handlePhoneInputChange }
+				className="contact-form__phone-input"
+				phoneInputProps={ {
+					placeholder: translate( 'Phone number' ),
+				} }
+			/>
 
 			<div className="signup-contact-form__tos">
 				<p>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/style.scss
@@ -1,15 +1,21 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .contact-form__phone-input {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     gap: 16px;
 
-    .form-phone-input__country {
-        flex: 1;
-    }
+	@include break-xlarge {
+		flex-direction: row;
+		.form-phone-input__country {
+			flex: 1;
+		}
 
-    .form-phone-input__phone-number {
-        flex: 1;
-    }
+		.form-phone-input__phone-number {
+			flex: 1;
+		}
+	}
 }
 
 .signup-contact-form__tos  p {

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -5,11 +5,13 @@ import { useState, ChangeEvent, useMemo } from 'react';
 import Form from 'calypso/a8c-for-agencies/components/form';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
 import FormFooter from 'calypso/a8c-for-agencies/components/form/footer';
+import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
 import { useCountriesAndStates } from 'calypso/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-countries-and-states';
 import { AgencyDetailsSignupPayload } from 'calypso/a8c-for-agencies/sections/signup/types';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
 import MultiCheckbox from 'calypso/components/forms/multi-checkbox';
+import { preventWidows } from 'calypso/lib/formatting';
 import usePersonalizationFormValidation from './hooks/use-personalization-form-validation';
 
 import './style.scss';
@@ -96,6 +98,8 @@ export default function PersonalizationForm( { onContinue }: Props ) {
 		onContinue( formData );
 	};
 
+	const isUserSiteOwner = formData.userType === 'site_owner';
+
 	return (
 		<div className="signup-personalization-form">
 			<Form
@@ -136,55 +140,89 @@ export default function PersonalizationForm( { onContinue }: Props ) {
 					</FormField>
 				</FormFieldset>
 
-				<FormFieldset>
-					<FormField label={ translate( 'How many sites do you manage?' ) } isRequired>
-						<FormSelect
-							id="managed_sites"
-							value={ formData.managedSites }
-							onChange={ handleInputChange( 'managedSites' ) }
-						>
-							<option value="1-5">{ translate( '1-5' ) }</option>
-							<option value="6-20">{ translate( '6-20' ) }</option>
-							<option value="21-50">{ translate( '21-50' ) }</option>
-							<option value="50-100">{ translate( '50-100' ) }</option>
-							<option value="101-500">{ translate( '101-500' ) }</option>
-							<option value="500+">{ translate( '500+' ) }</option>
-						</FormSelect>
-					</FormField>
-				</FormFieldset>
+				{ ! isUserSiteOwner ? (
+					<>
+						<FormFieldset>
+							<FormField label={ translate( 'How many sites do you manage?' ) } isRequired>
+								<FormSelect
+									id="managed_sites"
+									value={ formData.managedSites }
+									onChange={ handleInputChange( 'managedSites' ) }
+								>
+									<option value="1-5">{ translate( '1-5' ) }</option>
+									<option value="6-20">{ translate( '6-20' ) }</option>
+									<option value="21-50">{ translate( '21-50' ) }</option>
+									<option value="50-100">{ translate( '50-100' ) }</option>
+									<option value="101-500">{ translate( '101-500' ) }</option>
+									<option value="500+">{ translate( '500+' ) }</option>
+								</FormSelect>
+							</FormField>
+						</FormFieldset>
 
-				<FormFieldset>
-					<FormField label={ translate( 'What services do you offer?' ) } isRequired>
-						<MultiCheckbox
-							id="services_offered"
-							name="services_offered"
-							checked={ formData.servicesOffered }
-							options={ servicesOfferedOptions }
-							onChange={ handleSetServicesOffered as any }
-						/>
-					</FormField>
-				</FormFieldset>
+						<FormFieldset className="signup-personalization-form__checkbox">
+							<FormField label={ translate( 'What services do you offer?' ) } isRequired>
+								<MultiCheckbox
+									id="services_offered"
+									name="services_offered"
+									checked={ formData.servicesOffered }
+									options={ servicesOfferedOptions }
+									onChange={ handleSetServicesOffered as any }
+								/>
+							</FormField>
+						</FormFieldset>
 
-				<FormFieldset className="signup-personalization-form__products-checkbox">
-					<FormField
-						label={ translate( 'What Automattic products do you currently offer your clients?' ) }
-						isRequired
+						<FormFieldset className="signup-personalization-form__checkbox">
+							<FormField
+								label={ translate(
+									'What Automattic products do you currently offer your clients?'
+								) }
+								isRequired
+							>
+								<MultiCheckbox
+									id="products_offered"
+									name="products_offered"
+									checked={ formData.productsOffered }
+									options={ productsOfferedOptions }
+									onChange={ handleSetProductsOffered as any }
+								/>
+							</FormField>
+						</FormFieldset>
+
+						<FormFooter>
+							<Button __next40pxDefaultSize variant="primary" onClick={ handleSubmit }>
+								{ translate( 'Continue' ) }
+							</Button>
+						</FormFooter>
+					</>
+				) : (
+					<LayoutBanner
+						hideCloseButton
+						level="warning"
+						title={ preventWidows(
+							translate( 'It seems like we might not be the perfect match right now.' )
+						) }
 					>
-						<MultiCheckbox
-							id="products_offered"
-							name="products_offered"
-							checked={ formData.productsOffered }
-							options={ productsOfferedOptions }
-							onChange={ handleSetProductsOffered as any }
-						/>
-					</FormField>
-				</FormFieldset>
-
-				<FormFooter>
-					<Button __next40pxDefaultSize variant="primary" onClick={ handleSubmit }>
-						{ translate( 'Continue' ) }
-					</Button>
-				</FormFooter>
+						<div>
+							{ preventWidows(
+								translate(
+									'Automattic for Agencies is a program designed for agencies, developers, and freelancers who work with and provide services to their clients.' +
+										" Depending on what you are looking for, you may want to check out one of our individual products, like {{wp}}WordPress.com{{/wp}}, {{pressable}}Pressable.com{{/pressable}}, {{woo}}Woo.com{{/woo}}, {{jetpack}}Jetpack.com{{/jetpack}}. If you really aren't sure where to go, feel free to contact us at {{email}}partnerships@automattic.com{{/email}} and we'll point you in the right direction.",
+									{
+										components: {
+											wp: <a href="https://wordpress.com" target="_blank" rel="noreferrer" />,
+											pressable: (
+												<a href="https://pressable.com" target="_blank" rel="noreferrer" />
+											),
+											woo: <a href="https://woocommerce.com" target="_blank" rel="noreferrer" />,
+											jetpack: <a href="https://jetpack.com" target="_blank" rel="noreferrer" />,
+											email: <a href="mailto:partnerships@automattic.com" />,
+										},
+									}
+								)
+							) }
+						</div>
+					</LayoutBanner>
+				) }
 			</Form>
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/style.scss
@@ -1,23 +1,20 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .signup-personalization-form {
-    .signup-personalization-form__products-checkbox {
-        .multi-checkbox label {
-            flex: 0 1 calc(32% - 16px); // 3 columns for products
-
-            @media (max-width: 782px) {
-                flex: 0 1 calc(50% - 12px); // 2 columns on tablets
-            }
-
-            @media (max-width: 600px) {
-                flex: 0 1 100%; // Full width on mobile
-            }
-        }
-    }
-
     .multi-checkbox {
         display: flex;
         flex-wrap: wrap;
         gap: 12px 24px;
     }
+
+	.signup-personalization-form__checkbox .a4a-form__section-field {
+		gap: 16px;
+
+		@include break-xlarge {
+			gap: 8px;
+		}
+	}
 
     .multi-checkbox label {
         display: flex;
@@ -26,10 +23,10 @@
         cursor: pointer;
         font-size: rem(14px);
         color: var(--color-neutral-80);
-        flex: 0 1 calc(50% - 12px); // 2 columns by default, accounting for gap
+        flex: 0 1 100%; // Full width on mobile
 
-        @media (max-width: 600px) {
-            flex: 0 1 100%; // Full width on mobile
+		@include break-xlarge {
+            flex: 0 1 calc(50% - 12px); // 2 columns
         }
     }
 

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .signup-multi-step-form {
 	.a4a-form {
 		max-width: 600px;
@@ -23,6 +26,10 @@
 		}
 	}
 
+	.a4a-layout__banner .notice-banner{
+		padding-inline: 16px;
+	}
+
 	.form-select,
     .searchable-dropdown {
         width: 100%;
@@ -30,6 +37,47 @@
 
 	.form-fieldset {
 		margin: 0;
+	}
+
+	.form-checkbox, .form-radio {
+		width: 20px;
+		height: 20px;
+
+		@include break-xlarge {
+			width: 16px;
+			height: 16px;
+		}
+	}
+
+	.form-checkbox {
+		line-height: 1;
+
+		@include break-xlarge {
+			line-height: 0.5;
+		}
+	}
+
+	.form-radio {
+		position: relative;
+		top: -2px;
+		margin-inline-end: 8px;
+
+		&:checked::before {
+			margin: 4px;
+			width: 10px;
+			height: 10px;
+		}
+
+		@include break-xlarge {
+			top: 0;
+			margin-inline-end: 4px;
+
+			&:checked::before {
+				margin: 3px;
+				width: 8px;
+				height: 8px;
+			}
+		}
 	}
 
 	.a4a-form__section-field-label,


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1778
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1781
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1787
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1782

## Proposed Changes

This PR makes some enhancements to the WC Asia Sign-up page.

## Why are these changes being made?

* To make some enhancements to the WC Asia Sign-up page.

## Testing Instructions

* Open the A4A live link
* Visit the WC Asia Sign-up page: /signup/wc-asia
* Verify that the `Phone number` field is not visible and the corresponding fields `Country code` and `Phone number` switches to 100% width for iPad screens(<1080 px)

Large Screen:

<img width="1725" alt="Screenshot 2025-02-17 at 11 44 43 AM" src="https://github.com/user-attachments/assets/8a4b7889-0114-4cb4-8e90-80db48a7c0a0" />

iPad:

<img width="517" alt="Screenshot 2025-02-17 at 11 45 21 AM" src="https://github.com/user-attachments/assets/8a8d3a5c-a94d-47e7-8af9-3c48af80e909" />

* Enter all the details > Go to step 2 > Select the option `Site owner` for `How would you describe yourself?` and verify that you cannot proceed further, and a warning banner is shown as displayed below. Verify it looks good on iPad screens as well

<img width="1728" alt="Screenshot 2025-02-17 at 11 49 26 AM" src="https://github.com/user-attachments/assets/b9732309-3993-4a46-aaf5-2cf0d4e4ddb2" />

* Also verify that all the checkboxes are left aligned, larger in size only on iPad screens, and take 2 columns on large screens

Large Screen:

<img width="1728" alt="Screenshot 2025-02-17 at 11 59 44 AM" src="https://github.com/user-attachments/assets/aff17cfb-8c0c-407f-bd94-a12fdda3919a" />

iPad:

<img width="1030" alt="Screenshot 2025-02-17 at 11 51 38 AM" src="https://github.com/user-attachments/assets/8c2151c9-1602-4b0f-8267-892913df2909" />

* Enter all the details and go to step 3 > Verify the radio boxes are larger in size only on iPad screens:

<img width="1027" alt="Screenshot 2025-02-17 at 12 10 24 PM" src="https://github.com/user-attachments/assets/5cd9132c-0283-4fb3-9a06-7b03da595bab" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
