### PR TITLE
Launchpad: Cleanup preview site task from site previewer

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -297,22 +297,6 @@ export const getTask = (
 				actionUrl: getTitanSetUpMailboxPath( siteSlug, task.domain ),
 			};
 			break;
-		case CHECKLIST_KNOWN_TASKS.BLOG_PREVIEWED:
-			taskData = {
-				timing: 1,
-				title: translate( 'Preview your blog' ),
-				description: translate(
-					"See how your site looks to site visitors. Remember, your blog is a work in progress — you can always choose a new theme or tweak your site's design."
-				),
-				actionText: translate( 'Preview blog' ),
-				actionUrl: `/view/${ siteSlug }`,
-				...( ! task.isCompleted && {
-					actionDispatch: requestSiteChecklistTaskUpdate,
-					actionDispatchArgs: [ siteId, task.id ],
-				} ),
-				isSkippable: true,
-			};
-			break;
 		case CHECKLIST_KNOWN_TASKS.THEMES_BROWSED:
 			taskData = {
 				timing: 2,

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -1,5 +1,4 @@
 import { Button, Gridicon } from '@automattic/components';
-import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { isWithinBreakpoint, isMobile, isDesktop } from '@automattic/viewport';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
@@ -11,10 +10,8 @@ import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
 import WebPreview from 'calypso/components/web-preview';
-import { useRequestSiteChecklistTaskUpdate } from 'calypso/data/site-checklist';
 import { addQueryArgs } from 'calypso/lib/route';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import { getSiteOption, isSitePreviewable } from 'calypso/state/sites/selectors';
@@ -228,10 +225,6 @@ const ConnectedPreviewMain = ( props ) => {
 		dispatch
 	);
 
-	useRequestSiteChecklistTaskUpdate( selectedSiteId, CHECKLIST_KNOWN_TASKS.BLOG_PREVIEWED );
-	updateLaunchpadSettings( selectedSiteId, {
-		checklist_statuses: { preview_site: true },
-	} );
 	return <PreviewMain { ...props } { ...stateToProps } { ...dispatchToProps } />;
 };
 

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -26,7 +26,6 @@ export const CHECKLIST_KNOWN_TASKS = {
 	JETPACK_VIDEO_HOSTING: 'jetpack_video_hosting',
 	JETPACK_SEARCH: 'jetpack_search',
 	PROFESSIONAL_EMAIL_MAILBOX_CREATED: 'professional_email_mailbox_created',
-	BLOG_PREVIEWED: 'blog_previewed',
 	THEMES_BROWSED: 'themes_browsed',
 	FIRST_POST_PUBLISHED: 'first_post_published',
 	POST_SHARING_ENABLED: 'post_sharing_enabled',


### PR DESCRIPTION
## Proposed Changes

Fully remove the site preview checklist task from the site previewer as a follow up to https://github.com/Automattic/jetpack/pull/41344.

Resolves a frequent error the users see when previewing their site.

## Why are these changes being made?

Fixes the second most frequent error reported on Sentry that occurs for many users:

![Screenshot 2025-02-17 at 9 19 13](https://github.com/user-attachments/assets/609d4bf3-235d-4f09-8de7-89f4f16a3987)
![Screenshot 2025-02-17 at 9 19 26](https://github.com/user-attachments/assets/a2e730fa-12e0-4822-ba15-4bb57460c6f9)

This is how it occurs in the console (including in production):
![Screenshot 2025-02-17 at 9 21 03](https://github.com/user-attachments/assets/9f1ccbc7-1d8c-4300-ab2c-018e68a5829c)

And the associated network request:
![Screenshot 2025-02-17 at 9 21 21](https://github.com/user-attachments/assets/fc98a63e-f54d-453a-8122-b5fe0d87de44)

Performs a cleanup of the `preview_site` task that was missed when doing https://github.com/Automattic/jetpack/pull/41344

See https://github.com/Automattic/wp-calypso/issues/98773 for more info.

## Testing Instructions
* Go to `/view/:site` where `:site` is a WP.com simple site. 
* Verify you no longer see the error in the console.