### PR TITLE
commenting out the site/styles.scss to fix the issue of leaked styles

### DIFF
--- a/apps/blaze-dashboard/src/routes.js
+++ b/apps/blaze-dashboard/src/routes.js
@@ -13,7 +13,7 @@ import { setup } from './pages/controller';
 
 import 'calypso/my-sites/promote-post-i2/style.scss';
 // Needed because the placeholder component that we use doesn't import the css, webpack excludes it from the final build
-import 'calypso/blocks/site/style.scss';
+// import 'calypso/blocks/site/style.scss';
 
 const siteSelection = ( context, next ) => {
 	context.store.dispatch( setSelectedSiteId( config( 'blog_id' ) ) );


### PR DESCRIPTION

Related to #

3168-gh-tumblr/a8c-dsp

and 

https://github.com/Automattic/wp-calypso/issues/99743


## Proposed Changes

I commented out the import to site/styles.scss

I can see the issue is fixed but I am not sure if this change is affecting something else . (I am not sure why we added it in the first place)

<img width="382" alt="Screenshot 2025-02-17 at 11 11 52 AM" src="https://github.com/user-attachments/assets/fa852222-67c7-4a46-b705-34fc2a0f3711" />

I will monitor and test this change to make sure we are not breaking anything. but please review and test this PR to help me figure this out

## Why are these changes being made?

we had issues with styles leaking from blaze app to the wp dashboard

## Testing Instructions

checkout branch. 
use `yarn dev --sync` to sync the blaze dashboard files in your sandbox and open hosts to get widgets.wp.com from your sanbox

(I tested a jetpack site, in calypso local and in Wordpress - I didn't see anything breaking, but I could be missing something)

the problem mentioned is only visible when in https://:blog-url.wordpress.com/ 

in local calypso or jetpack the problem was not present.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
