### PR TITLE
Stats: Add chart type toggle to traffic page

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
@@ -3,6 +3,7 @@ import config from '@automattic/calypso-config';
 import { Icon, Button, ButtonGroup } from '@wordpress/components';
 import { chartBar, trendingUp } from '@wordpress/icons';
 import PropTypes from 'prop-types';
+import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import Legend from 'calypso/components/chart/legend';
 import IntervalDropdown from 'calypso/components/stats-interval-dropdown';
@@ -32,6 +33,8 @@ const ChartHeader = ( {
 
 	const isChartLibraryEnabled = config.isEnabled( 'stats/chart-library' );
 
+	const [ chartType, setChartType ] = useState( 'line' );
+
 	const onGatedHandler = ( events, source, statType ) => {
 		// Stop the popup from showing for Jetpack sites.
 		if ( isSiteJetpackNotAtomic ) {
@@ -40,6 +43,11 @@ const ChartHeader = ( {
 
 		events.forEach( ( event ) => recordTracksEvent( event.name, event.params ) );
 		dispatch( toggleUpsellModal( siteId, statType ) );
+	};
+
+	const handleChartTypeChange = ( newType ) => {
+		setChartType( newType );
+		//TODO: add tracks event for chart type change
 	};
 
 	return (

--- a/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import Legend from 'calypso/components/chart/legend';
@@ -26,6 +27,9 @@ const ChartHeader = ( {
 			treatAtomicAsJetpackSite: false,
 		} );
 	} );
+
+	const isChartLibraryEnabled = config.isEnabled( 'stats/chart-library' );
+
 	const onGatedHandler = ( events, source, statType ) => {
 		// Stop the popup from showing for Jetpack sites.
 		if ( isSiteJetpackNotAtomic ) {
@@ -53,6 +57,7 @@ const ChartHeader = ( {
 				intervals={ intervals }
 				onGatedHandler={ onGatedHandler }
 			/>
+			{ isChartLibraryEnabled && <div>Chart type switcher</div> }
 		</div>
 	);
 };

--- a/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
@@ -1,5 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
+import { Icon, Button, ButtonGroup } from '@wordpress/components';
+import { chartBar, trendingUp } from '@wordpress/icons';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import Legend from 'calypso/components/chart/legend';
@@ -57,7 +59,24 @@ const ChartHeader = ( {
 				intervals={ intervals }
 				onGatedHandler={ onGatedHandler }
 			/>
-			{ isChartLibraryEnabled && <div>Chart type switcher</div> }
+			{ isChartLibraryEnabled && (
+				<ButtonGroup className="stats-chart-tabs__type-toggle">
+					<Button
+						icon={ <Icon icon={ trendingUp } /> }
+						isSmall
+						isPrimary={ chartType === 'line' }
+						onClick={ () => handleChartTypeChange( 'line' ) }
+						aria-label="Switch to line chart"
+					/>
+					<Button
+						icon={ <Icon icon={ chartBar } /> }
+						isSmall
+						isPrimary={ chartType === 'bar' }
+						onClick={ () => handleChartTypeChange( 'bar' ) }
+						aria-label="Switch to bar chart"
+					/>
+				</ButtonGroup>
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

related to: https://github.com/Automattic/jetpack-roadmap/issues/2313

## Proposed Changes

* This PR updates the traffic page chart with a toggle to switch between line and bar chart
* It is only visible behind the feature flag
* It adds state handling for chart type change
* This is still a work in progress. Some things that need updated:
** Styling / colours / design improvements
** It doesn't actually change the charts yet


## Testing Instructions

* Open Calypso live branch
* Navigate to `/stats/day/{URL}`
* Check you cannot see anything unusual
* Append feature flag `flags=stats/chart-library`
* Check that now the toggle button appears

![image](https://github.com/user-attachments/assets/a6fbd1df-d172-46ab-9f96-e63686f7d4d8)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
