### PR TITLE
Reader: Fix check icon alignment on subscription management view

### DIFF
--- a/client/landing/subscriptions/components/add-sites-form/styles.scss
+++ b/client/landing/subscriptions/components/add-sites-form/styles.scss
@@ -48,9 +48,13 @@
 	}
 
 	.components-base-control__help {
+		display: flex;
+		align-items: center;
+		margin: 0;
 		position: absolute;
 		top: 0;
 		right: 0.5rem;
+		height: 100%;
 
 		svg {
 			fill: var(--color-success-50);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/472

## Proposed Changes

Fix check icon alignment on subscription management using CSS.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Added some CSS styles to fix the issue.

| Before | After |
|-------|-------|
|![image](https://github.com/user-attachments/assets/a0e18251-0f54-41fa-976b-6076cec4981e)|![image](https://github.com/user-attachments/assets/0f187db0-6fab-4e9f-bbe9-d8814237a57c)|
|![image](https://github.com/user-attachments/assets/3de6098a-83ad-435c-8e66-cd37f2a1e052)|![image](https://github.com/user-attachments/assets/5f412617-178c-4e89-8e85-9921f4f22572)|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/discover/add-new?flags=reader/discovery-v2`.
* Write a valid url and verify that the positioning of check icon is fixed.
* Go to `/reader/subscriptions`
* Click "New Subscription"
* Write a valid url and verify that the positioning of check icon is fixed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
