### PR TITLE
adding analytics for tsp

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -8,7 +8,7 @@ import { __, _n, _x, sprintf } from '@wordpress/i18n';
 import { chevronDown, chevronLeft, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment/moment';
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import InfoPopover from 'calypso/components/info-popover';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
@@ -24,6 +24,7 @@ import {
 	Order,
 } from 'calypso/data/promote-post/use-promote-post-campaigns-query';
 import useCancelCampaignMutation from 'calypso/data/promote-post/use-promote-post-cancel-campaign-mutation';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useJetpackBlazeVersionCheck } from 'calypso/lib/promote-post';
 import AdPreview from 'calypso/my-sites/promote-post-i2/components/ad-preview';
 import AdPreviewModal from 'calypso/my-sites/promote-post-i2/components/campaign-item-details/AdPreviewModal';
@@ -608,6 +609,28 @@ export default function CampaignItemDetails( props: Props ) {
 		},
 	];
 
+	const tspTargetRef = useRef< HTMLDivElement | null >( null );
+
+	useEffect( () => {
+		const handleScroll = () => {
+			if ( tspTargetRef.current ) {
+				const rect = tspTargetRef.current.getBoundingClientRect();
+				const inView = rect.top >= 0 && rect.bottom <= window.innerHeight;
+				if ( inView ) {
+					window.removeEventListener( 'scroll', handleScroll );
+					recordTracksEvent( 'calypso_dsp_tsp_section_scroll_into_view', {} );
+				}
+			}
+		};
+
+		window.addEventListener( 'scroll', handleScroll );
+		handleScroll();
+
+		return () => {
+			window.removeEventListener( 'scroll', handleScroll );
+		};
+	}, [] );
+
 	return (
 		<div className="campaign-item__container">
 			<Dialog
@@ -999,7 +1022,7 @@ export default function CampaignItemDetails( props: Props ) {
 									) }
 									{ tsp && (
 										<>
-											<div className="campaign-item-details__main-stats-row ">
+											<div className="campaign-item-details__main-stats-row" ref={ tspTargetRef }>
 												<div className="campaign-item-details__main-stats-title">
 													<span className="campaign-item-details__title">
 														{ translate( 'Social Engagement' ) }
@@ -1009,8 +1032,11 @@ export default function CampaignItemDetails( props: Props ) {
 														target="_blank"
 														rel="noreferrer"
 														className="campaign-item-details__tsp-permalink"
+														onClick={ () => {
+															recordTracksEvent( 'calypso_dsp_tsp_open_post_click', {} );
+														} }
 													>
-														<span>{ translate( 'Open ad preview' ) }</span>
+														<span>{ translate( 'Open Tumblr Post”' ) }</span>
 														<Gridicon icon="external" size={ 16 } />
 													</a>
 												</div>

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -1036,7 +1036,7 @@ export default function CampaignItemDetails( props: Props ) {
 															recordTracksEvent( 'calypso_dsp_tsp_open_post_click', {} );
 														} }
 													>
-														<span>{ translate( 'Open Tumblr Post”' ) }</span>
+														<span>{ translate( 'Open Tumblr Post' ) }</span>
 														<Gridicon icon="external" size={ 16 } />
 													</a>
 												</div>

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -376,12 +376,13 @@ export default function CampaignItemDetails( props: Props ) {
 	};
 
 	const areStatsEnabled = useJetpackBlazeVersionCheck( siteId, '14.1', '0.5.3' );
+	const hasStats = !! impressions_total && areStatsEnabled;
 
 	const campaignStatsQuery = useCampaignChartStatsQuery(
 		siteId,
 		campaignId,
 		chartParams,
-		!! impressions_total && areStatsEnabled
+		hasStats
 	);
 	const { isLoading: campaignsStatsIsLoading } = campaignStatsQuery;
 	const { data: campaignStats } = campaignStatsQuery;
@@ -623,13 +624,17 @@ export default function CampaignItemDetails( props: Props ) {
 			}
 		};
 
-		window.addEventListener( 'scroll', handleScroll );
-		handleScroll();
+		// check that the page has loaded, before adding the listener
+		// check if the campaign has stats, in this case wait for the campaigns stats loading to complete
+		if ( ! isLoading && ( ! hasStats || ! campaignsStatsIsLoading ) ) {
+			window.addEventListener( 'scroll', handleScroll );
+			handleScroll();
+		}
 
 		return () => {
 			window.removeEventListener( 'scroll', handleScroll );
 		};
-	}, [] );
+	}, [ isLoading, hasStats, campaignsStatsIsLoading ] );
 
 	return (
 		<div className="campaign-item__container">
@@ -1099,7 +1104,15 @@ export default function CampaignItemDetails( props: Props ) {
 														{ replies && replies?.total_notes > 3 && (
 															<button
 																className="campaign-items-details__replies-show-more-button"
-																onClick={ () => setShowAllReplies( ! showAllReplies ) }
+																onClick={ () => {
+																	if ( ! showAllReplies ) {
+																		recordTracksEvent(
+																			'calypso_dsp_tsp_section_replies_show_more_click',
+																			{}
+																		);
+																	}
+																	setShowAllReplies( ! showAllReplies );
+																} }
 															>
 																{ showAllReplies ? __( 'Show Less' ) : __( 'Show More' ) }
 															</button>

--- a/client/my-sites/promote-post-i2/components/tsp-banner/index.tsx
+++ b/client/my-sites/promote-post-i2/components/tsp-banner/index.tsx
@@ -1,7 +1,7 @@
 import { ExternalLink, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import TspBannerImage from './tsp-banner-image';
-
 import './style.scss';
 
 type TspBannerProps = {
@@ -32,7 +32,13 @@ function TspBanner( props: TspBannerProps ) {
 								'Reach more people and spark conversations by promoting your content as a native Tumblr post, where users can like, reply, and engage directly with your ad.'
 							) }
 							&nbsp;
-							<ExternalLink href="#" target="_blank">
+							<ExternalLink
+								href="#"
+								target="_blank"
+								onClick={ () => {
+									recordTracksEvent( 'calypso_dsp_tsp_banner_learn_more_click', {} );
+								} }
+							>
 								{ translate( 'Learn more' ) }
 								<Gridicon icon="external" size={ 16 } />
 							</ExternalLink>


### PR DESCRIPTION

Related to #

3113-gh-tumblr/a8c-dsp

## Proposed Changes

adding analytics events for tsp related events


## Why are these changes being made?

we want to change the wording on this link

<img width="315" alt="Screenshot 2025-02-17 at 12 50 27 PM" src="https://github.com/user-attachments/assets/ab908ca5-d47e-495c-a135-5ae7b7849b8f" />

we also want to add analytics events when a click is registered and when the user scrolls to get the tsp data into view



## Testing Instructions

1. make your window short so that you can simulate scroll into view (you will need an active promoted post campaign with tsp - if you can get an old one that has some stats for the normal campaign it is better - so that the stats section is populated)

open network inspection and scroll the tsp section into view - check the network to see the event firing


<img width="375" alt="Screenshot 2025-02-17 at 12 51 48 PM" src="https://github.com/user-attachments/assets/5b3a6e00-5f5d-47ca-862e-6f3360911ed7" />


click on the above link
<img width="382" alt="Screenshot 2025-02-17 at 12 52 01 PM" src="https://github.com/user-attachments/assets/4c4667e1-8f7e-4d47-ab16-0e67d9dd39d4" />

do a CR

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
