### PR TITLE
Site Migration: Fix atomic site on the diy flow

### DIFF
--- a/client/landing/stepper/hooks/test/use-plugin-auto-installation.tsx
+++ b/client/landing/stepper/hooks/test/use-plugin-auto-installation.tsx
@@ -1,0 +1,287 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import React from 'react';
+import { logToLogstash } from 'calypso/lib/logstash';
+import { usePluginAutoInstallation } from '../use-plugin-auto-installation';
+import { replyWithEnvelope } from './helpers/nock';
+
+const Wrapper =
+	( queryClient: QueryClient ) =>
+	( { children } ) => {
+		return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+	};
+
+const PLUGIN = { name: 'migrate-guru/migrateguru', slug: 'migrate-guru' };
+const getSitePluginsEndpoint = ( siteId: number ) =>
+	`/rest/v1.2/sites/${ siteId }/plugins?http_envelope=1`;
+
+const getJetpackReconnectionEndpoint = ( siteId: number ) =>
+	`/rest/v1.2/sites/${ siteId }/migration-force-reconnection`;
+
+const getPluginInstallationEndpoint = ( siteId: number ) =>
+	`/rest/v1.2/sites/${ siteId }/plugins/migrate-guru/install?http_envelope=1`;
+
+const getPluginActivationEndpoint = ( siteId: number ) =>
+	`/rest/v1.2/sites/${ siteId }/plugins/migrate-guru%2Fmigrateguru`;
+
+const SITE_ID = 123;
+
+const render = ( { retry = 0, enabled = true } = {} ) => {
+	const queryClient = new QueryClient();
+
+	const renderResult = renderHook(
+		() => usePluginAutoInstallation( PLUGIN, SITE_ID, { retry, enabled } ),
+		{
+			wrapper: Wrapper( queryClient ),
+		}
+	);
+
+	return {
+		...renderResult,
+		queryClient,
+	};
+};
+const installationWithSuccess = replyWithEnvelope( 200 );
+const installationWithGenericError = replyWithEnvelope( 400, { error: 'any error' } );
+jest.mock( 'calypso/lib/logstash' );
+
+describe( 'usePluginAutoInstallation', () => {
+	beforeAll( () => {
+		nock.disableNetConnect();
+	} );
+	beforeEach( () => nock.cleanAll() );
+
+	it( 'returns success when the plugin is already installed and activated', async () => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( getSitePluginsEndpoint( SITE_ID ) )
+			.once()
+			.reply( 200, { plugins: [ { ...PLUGIN, active: true } ] } );
+
+		const { result } = render();
+
+		await waitFor( () => {
+			expect( result.current ).toEqual( {
+				status: 'success',
+				error: null,
+				completed: true,
+			} );
+		} );
+	} );
+
+	it( 'returns status "pending" when a retry is required to get the plugin list', async () => {
+		const siteId = 123;
+
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( getSitePluginsEndpoint( siteId ) )
+			.times( 4 )
+			.reply( 500, new Error( 'Error fetching plugins list' ) );
+
+		const { result } = render( { retry: 4 } );
+
+		await waitFor(
+			() => {
+				expect( result.current ).toEqual( {
+					status: 'pending',
+					error: null,
+					completed: false,
+				} );
+			},
+			{ timeout: 3000 }
+		);
+	} );
+
+	it( 'returns "pending" when a retry is required to install a plugin', async () => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( getSitePluginsEndpoint( SITE_ID ) )
+			.once()
+			.reply( 200, { plugins: [] } )
+			.post( getPluginInstallationEndpoint( SITE_ID ) )
+			.reply( installationWithGenericError() );
+		const { result } = render( { retry: 2 } );
+
+		await waitFor(
+			() => {
+				expect( result.current ).toEqual( {
+					status: 'pending',
+					error: null,
+					completed: false,
+				} );
+			},
+			{ timeout: 3000 }
+		);
+	} );
+
+	it( 'returns "pending" when a retry is required to active a plugin', async () => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( getSitePluginsEndpoint( SITE_ID ) )
+			.once()
+			.reply( 200, { plugins: [] } )
+			.post( getPluginInstallationEndpoint( SITE_ID ) )
+			.reply( installationWithSuccess() )
+			.post( getPluginActivationEndpoint( SITE_ID ) )
+			.reply( 500, new Error( 'Error activating plugin' ) );
+
+		const { result } = render( { retry: 2 } );
+
+		await waitFor(
+			() => {
+				expect( result.current ).toEqual( {
+					status: 'pending',
+					error: null,
+					completed: false,
+				} );
+			},
+			{ timeout: 3000 }
+		);
+	} );
+
+	it( 'returns completed and status success when all steps are successful', async () => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( getSitePluginsEndpoint( SITE_ID ) )
+			.once()
+			.reply( 200, { plugins: [] } )
+			.post( getPluginInstallationEndpoint( SITE_ID ) )
+			.reply( installationWithSuccess() )
+			.post( getPluginActivationEndpoint( SITE_ID ) )
+			.reply( 200 );
+
+		const { result } = render( { retry: 0 } );
+
+		await waitFor(
+			() => {
+				expect( result.current ).toEqual( {
+					status: 'success',
+					error: null,
+					completed: true,
+				} );
+			},
+			{ timeout: 3000 }
+		);
+	} );
+
+	it( 'returns error after all fetching plugin list retries failed', async () => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( getSitePluginsEndpoint( SITE_ID ) )
+			.once()
+			.times( 2 )
+			.reply( 500, new Error( 'Error fetching plugins list' ) );
+
+		nock( 'https://public-api.wordpress.com:443' )
+			.post( getJetpackReconnectionEndpoint( SITE_ID ) )
+			.reply( 200 )
+			.persist();
+
+		const { result } = render( { retry: 1 } );
+
+		await waitFor(
+			() => {
+				expect( result.current ).toEqual( {
+					status: 'error',
+					error: expect.any( Error ),
+					completed: false,
+				} );
+			},
+			{ timeout: 3000 }
+		);
+	} );
+
+	it( 'refresh the jetpack connnection after all plugin list retries', async () => {
+		// First 3 calls to get the plugins list will fail
+		// The reconnection endpoint will be called after the 3rd failure
+		// The 4th call to get the plugins list will succeed
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( getSitePluginsEndpoint( SITE_ID ) )
+			.times( 3 )
+			.reply( 500, new Error( 'Error fetching plugins list' ) )
+			.get( getSitePluginsEndpoint( SITE_ID ) )
+			.reply( 200, { plugins: [ { ...PLUGIN, active: true } ] } );
+
+		const refreshtokenCall = nock( 'https://public-api.wordpress.com:443' )
+			.post( getJetpackReconnectionEndpoint( SITE_ID ) )
+			.once()
+			.reply( 200 );
+
+		const { result } = render( { retry: 2 } );
+
+		await waitFor(
+			() => {
+				expect( refreshtokenCall.isDone() ).toBe( true );
+				expect( result.current ).toEqual( {
+					status: 'success',
+					error: null,
+					completed: true,
+				} );
+
+				expect( logToLogstash ).toHaveBeenCalledWith(
+					expect.objectContaining( { message: 'restoring jetpack connection' } )
+				);
+				expect( logToLogstash ).toHaveBeenCalledWith(
+					expect.objectContaining( { message: 'jetpack connection restored' } )
+				);
+			},
+			{ timeout: 3000 }
+		);
+	} );
+
+	it( 'logs to logstash when all jetpack connection were exhausted', async () => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( getSitePluginsEndpoint( SITE_ID ) )
+			.times( 9 )
+			.reply( 500, new Error( 'Error fetching plugins list' ) );
+
+		nock( 'https://public-api.wordpress.com:443' )
+			.post( getJetpackReconnectionEndpoint( SITE_ID ) )
+			.times( 3 )
+			.reply( 200 );
+
+		render( { retry: 1 } );
+
+		await waitFor(
+			() => {
+				expect( logToLogstash ).toHaveBeenCalledWith(
+					expect.objectContaining( { message: 'jetpack connection restoration attempts failed' } )
+				);
+			},
+			{ timeout: 3000 }
+		);
+	} );
+
+	it( 'returns error after all installation retries', async () => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( getSitePluginsEndpoint( SITE_ID ) )
+			.once()
+			.reply( 200, { plugins: [] } )
+			.post( getPluginInstallationEndpoint( SITE_ID ) )
+			.times( 4 )
+			.reply( installationWithGenericError )
+			.post( getPluginActivationEndpoint( SITE_ID ) )
+			.reply( 200 );
+
+		const { result } = render( { retry: 1 } );
+
+		await waitFor(
+			() => {
+				expect( result.current ).toEqual( {
+					status: 'error',
+					error: expect.any( Error ),
+					completed: false,
+				} );
+			},
+			{ timeout: 3000 }
+		);
+	} );
+
+	it( "doesn't start the operation when the enabled is set to false", async () => {
+		const { result } = render( { enabled: false } );
+
+		expect( result.current ).toEqual( {
+			status: 'idle',
+			error: null,
+			completed: false,
+		} );
+	} );
+} );

--- a/client/landing/stepper/hooks/test/use-plugin-installation.tsx
+++ b/client/landing/stepper/hooks/test/use-plugin-installation.tsx
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import React from 'react';
+import { usePluginInstallation } from '../use-plugin-installation';
+import { replyWithSuccess, replyWithError } from './helpers/nock';
+
+const installationWithSuccess = replyWithSuccess( 200 );
+const installationWithGenericError = replyWithError( { error: 'any generic error' } );
+const installationWithPluginAlreadyInstalled = replyWithError( {
+	error: 'plugin_already_installed',
+} );
+
+const Wrapper =
+	( queryClient: QueryClient ) =>
+	( { children } ) => (
+		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+	);
+
+const render = ( { siteId }, options = { retry: 0 } ) => {
+	const queryClient = new QueryClient();
+
+	const renderResult = renderHook( () => usePluginInstallation( 'migrate-guru', siteId, options ), {
+		wrapper: Wrapper( queryClient ),
+	} );
+
+	return {
+		...renderResult,
+		queryClient,
+	};
+};
+
+describe( 'usePluginInstallation', () => {
+	const siteId = 123;
+
+	beforeAll( () => nock.disableNetConnect() );
+
+	it( 'returns success when the installation was completed', async () => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.post( `/rest/v1.2/sites/${ siteId }/plugins/migrate-guru/install` )
+			.once()
+			.query( { http_envelope: 1 } )
+			.reply( installationWithSuccess );
+
+		const { result } = render( { siteId } );
+		result.current.mutate();
+
+		await waitFor( () => {
+			expect( result.current.isSuccess ).toEqual( true );
+		} );
+	} );
+
+	it( 'returns error when there is an error to install', async () => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.post( `/rest/v1.2/sites/${ siteId }/plugins/migrate-guru/install` )
+			.query( { http_envelope: 1 } )
+			.reply( installationWithGenericError );
+
+		const { result } = render( { siteId } );
+
+		result.current.mutate();
+
+		await waitFor( () => {
+			expect( result.current.isError ).toBe( true );
+		} );
+	} );
+
+	it( 'returns success when the plugin is already installed', async () => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.post( `/rest/v1.2/sites/${ siteId }/plugins/migrate-guru/install` )
+			.query( { http_envelope: 1 } )
+			.reply( installationWithPluginAlreadyInstalled );
+
+		const { result } = render( { siteId } );
+
+		result.current.mutate();
+
+		await waitFor( () => {
+			expect( result.current.isSuccess ).toEqual( true );
+		} );
+	} );
+} );

--- a/client/landing/stepper/hooks/use-install-wpcom-migration-plugin.ts
+++ b/client/landing/stepper/hooks/use-install-wpcom-migration-plugin.ts
@@ -1,0 +1,29 @@
+import { useMutation } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+export const useInstallWPCOMMigrationPlugin = ( siteId: number ) => {
+	return useMutation< Response, Error >( {
+		mutationKey: [ 'install-wpcom-migration-plugin', siteId ],
+		mutationFn: () => {
+			return wpcom.req.post( {
+				path: `/sites/${ siteId }/plugins/wpcom-migration/install`,
+				apiNamespace: 'rest/v1.2',
+			} );
+		},
+	} );
+};
+
+export const useActivateWPCOMMigrationPlugin = ( siteId: number ) => {
+	return useMutation< Response, Error >( {
+		mutationKey: [ 'activate-wpcom-migration-plugin', siteId ],
+		mutationFn: () => {
+			return wpcom.req.post( {
+				path: `/sites/${ siteId }/plugins/wpcom-migration%2fwpcom_migration`,
+				apiNamespace: 'rest/v1.2',
+				body: {
+					active: true,
+				},
+			} );
+		},
+	} );
+};

--- a/client/landing/stepper/hooks/use-plugin-auto-installation.ts
+++ b/client/landing/stepper/hooks/use-plugin-auto-installation.ts
@@ -1,0 +1,222 @@
+import config from '@automattic/calypso-config';
+import { useMutation, useQuery, UseQueryOptions, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { logToLogstash } from 'calypso/lib/logstash';
+import wpcom from 'calypso/lib/wp';
+import { usePluginInstallation } from './use-plugin-installation';
+import type { SitePlugin } from 'calypso/data/plugins/types';
+
+interface Response {
+	plugins: SitePlugin[];
+}
+
+type SitePluginParam = Pick< SitePlugin, 'slug' | 'name' >;
+type Status = 'idle' | 'pending' | 'success' | 'error';
+
+interface SiteMigrationStatus {
+	status: Status;
+	completed: boolean;
+	error: Error | null;
+}
+
+export type Options = Pick< UseQueryOptions, 'enabled' | 'retry' >;
+export const DEFAULT_RETRY = process.env.NODE_ENV === 'test' ? 1 : 10;
+const DEFAULT_RETRY_DELAY = process.env.NODE_ENV === 'test' ? 300 : 5000;
+
+const REFRESH_JETPACK_TOTAL_ATTEMPTS = process.env.NODE_ENV === 'test' ? 1 : 3;
+
+const fetchPluginsForSite = async ( siteId: number ): Promise< Response > =>
+	wpcom.req.get( `/sites/${ siteId }/plugins?http_envelope=1`, {
+		apiNamespace: 'rest/v1.2',
+	} );
+
+const refreshJetpackConnecion = async ( siteId: number ) =>
+	wpcom.req.post(
+		{
+			path: `/sites/${ siteId }/migration-force-reconnection`,
+		},
+		{ apiVersion: '1.2' },
+		{}
+	);
+
+const activatePlugin = async ( siteId: number, pluginName: string ) =>
+	wpcom.req.post( {
+		path: `/sites/${ siteId }/plugins/${ encodeURIComponent( pluginName ) }`,
+		apiNamespace: 'rest/v1.2',
+		body: {
+			active: true,
+		},
+	} );
+
+const safeLogToLogstash = ( message: string, properties: Record< string, unknown > ) => {
+	try {
+		logToLogstash( {
+			feature: 'calypso_client',
+			message,
+			properties: {
+				env: config( 'env_id' ),
+				type: 'calypso_prepare_site_for_migration',
+				action: 'fetch_plugins_for_site',
+				...properties,
+			},
+		} );
+	} catch ( e ) {
+		// eslint-disable-next-line no-console
+		console.error( e );
+	}
+};
+
+const usePluginStatus = ( pluginSlug: string, siteId?: number, options?: Options ) => {
+	const queryClient = useQueryClient();
+	const remainingAttempts = useRef( REFRESH_JETPACK_TOTAL_ATTEMPTS );
+	const hasSuccessLogged = useRef( false );
+
+	const response = useQuery( {
+		queryKey: [ 'onboarding-site-plugin-status', siteId, pluginSlug ],
+		queryFn: () => fetchPluginsForSite( siteId! ),
+		enabled: !! siteId && ( options?.enabled ?? true ),
+		retry: options?.retry ?? DEFAULT_RETRY,
+		retryDelay: DEFAULT_RETRY_DELAY,
+		refetchOnWindowFocus: false,
+		select: ( data ) => {
+			return {
+				isActive: data.plugins.some( ( plugin ) => plugin.slug === pluginSlug && plugin.active ),
+				isInstalled: data.plugins.some( ( plugin ) => plugin.slug === pluginSlug ),
+			};
+		},
+	} );
+
+	if ( response.isError && remainingAttempts.current >= 0 ) {
+		refreshJetpackConnecion( siteId! );
+
+		queryClient.invalidateQueries( {
+			queryKey: [ 'onboarding-site-plugin-status', siteId, pluginSlug ],
+		} );
+
+		safeLogToLogstash( 'restoring jetpack connection', {
+			site: siteId,
+			attempts: remainingAttempts.current,
+			reason: response.error.message,
+		} );
+
+		remainingAttempts.current--;
+
+		return {
+			data: undefined,
+			error: null,
+			fetchStatus: 'pending',
+		};
+	}
+
+	if ( response.isError && remainingAttempts.current <= 0 ) {
+		safeLogToLogstash( 'jetpack connection restoration attempts failed', {
+			site: siteId,
+			reason: response.error.message,
+		} );
+	}
+
+	if ( response.isSuccess && remainingAttempts.current < REFRESH_JETPACK_TOTAL_ATTEMPTS ) {
+		//Temporary fix for the issue where the success message is logged multiple times
+		if ( ! hasSuccessLogged.current ) {
+			hasSuccessLogged.current = true;
+			safeLogToLogstash( 'jetpack connection restored', { site: siteId } );
+		}
+	}
+
+	return response;
+};
+
+const usePluginActivation = ( pluginName: string, siteId?: number, options?: Options ) => {
+	return useMutation( {
+		mutationKey: [ 'onboarding-site-plugin-activation', siteId, pluginName ],
+		mutationFn: async () => activatePlugin( siteId!, pluginName ),
+		retryDelay: DEFAULT_RETRY_DELAY,
+		retry: options?.retry ?? DEFAULT_RETRY,
+	} );
+};
+
+export const usePluginAutoInstallation = (
+	plugin: SitePluginParam,
+	siteId?: number,
+	options?: Options
+): SiteMigrationStatus => {
+	const {
+		data: status,
+		error: statusError,
+		fetchStatus: pluginStatus,
+	} = usePluginStatus( plugin.slug, siteId, options );
+
+	const {
+		mutate: install,
+		error: installationError,
+		status: installationRequestStatus,
+		isSuccess: isInstalled,
+	} = usePluginInstallation( plugin.slug, siteId, options );
+
+	const {
+		mutate: activate,
+		status: activationRequestStatus,
+		error: activationError,
+		isSuccess: isActivated,
+	} = usePluginActivation( plugin.name, siteId, options );
+
+	const isPluginInstalled = status?.isInstalled || isInstalled;
+	const isPluginActivated = status?.isActive || isActivated;
+
+	const shouldInstall =
+		( status && ! isPluginInstalled && installationRequestStatus === 'idle' ) ?? false;
+	const shouldActivate =
+		( status && isPluginInstalled && ! isPluginActivated && activationRequestStatus === 'idle' ) ??
+		false;
+
+	const completed = ( status && isPluginInstalled && isPluginActivated ) ?? false;
+	const error = statusError || installationError || activationError;
+
+	const isPending = [ installationRequestStatus, activationRequestStatus, pluginStatus ].some(
+		( status ) => status === 'pending' || status === 'fetching'
+	);
+
+	useEffect( () => {
+		if ( ! shouldInstall ) {
+			return;
+		}
+
+		install();
+	}, [ install, shouldInstall ] );
+
+	useEffect( () => {
+		if ( ! shouldActivate ) {
+			return;
+		}
+
+		activate();
+	}, [ activate, shouldActivate ] );
+
+	const getStatus = (): Status => {
+		if ( completed ) {
+			return 'success';
+		}
+
+		if ( isPending ) {
+			return 'pending';
+		}
+
+		if ( error ) {
+			recordTracksEvent( 'calypso_onboarding_plugin_installation_error', {
+				plugin: plugin.slug,
+				error: error.message,
+				site_id: siteId,
+			} );
+			return 'error';
+		}
+
+		return 'idle';
+	};
+
+	return {
+		status: getStatus(),
+		completed,
+		error: ! isPending && error ? error : null,
+	};
+};

--- a/client/landing/stepper/hooks/use-plugin-auto-installation.ts
+++ b/client/landing/stepper/hooks/use-plugin-auto-installation.ts
@@ -31,7 +31,7 @@ const fetchPluginsForSite = async ( siteId: number ): Promise< Response > =>
 		apiNamespace: 'rest/v1.2',
 	} );
 
-const refreshJetpackConnecion = async ( siteId: number ) =>
+const refreshJetpackConnection = async ( siteId: number ) =>
 	wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/migration-force-reconnection`,
@@ -88,7 +88,7 @@ const usePluginStatus = ( pluginSlug: string, siteId?: number, options?: Options
 	} );
 
 	if ( response.isError && remainingAttempts.current >= 0 ) {
-		refreshJetpackConnecion( siteId! );
+		refreshJetpackConnection( siteId! );
 
 		queryClient.invalidateQueries( {
 			queryKey: [ 'onboarding-site-plugin-status', siteId, pluginSlug ],

--- a/client/landing/stepper/hooks/use-plugin-installation.ts
+++ b/client/landing/stepper/hooks/use-plugin-installation.ts
@@ -1,0 +1,33 @@
+import { useMutation } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { DEFAULT_RETRY, Options } from './use-plugin-auto-installation';
+
+interface WPError {
+	name: string;
+}
+
+const installPlugin = async ( siteId: number, pluginSlug: string ) => {
+	try {
+		const response = await wpcom.req.post(
+			{
+				path: `/sites/${ siteId }/plugins/${ pluginSlug }/install`,
+			},
+			{ apiVersion: '1.2', http_envelope: 1 },
+			{}
+		);
+		return response;
+	} catch ( error ) {
+		if ( ( error as WPError ).name === 'PluginAlreadyInstalledError' ) {
+			return 'success';
+		}
+		throw error;
+	}
+};
+
+export const usePluginInstallation = ( pluginSlug: string, siteId?: number, options?: Options ) => {
+	return useMutation( {
+		mutationKey: [ 'onboarding-site-plugin-installation', siteId, pluginSlug ],
+		mutationFn: async () => installPlugin( siteId!, pluginSlug ),
+		retry: options?.retry ?? DEFAULT_RETRY,
+	} );
+};

--- a/client/landing/stepper/hooks/use-site-has-wpcom-migration-plugin.ts
+++ b/client/landing/stepper/hooks/use-site-has-wpcom-migration-plugin.ts
@@ -1,0 +1,26 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+type Options = Pick< UseQueryOptions, 'retry' | 'enabled' >;
+
+const getSiteHasWPCOMMigrationPlugin = ( siteId: number ) => {
+	return wpcom.req.get( {
+		path: `/sites/${ siteId }/plugins`,
+		apiVersion: '1.1',
+	} );
+};
+
+export const useSiteHasWPCOMMigrationPlugin = ( siteId: number, options: Options ) => {
+	const { retry, enabled = false } = options;
+	const { data, error, isLoading, isSuccess } = useQuery( {
+		queryKey: [ 'site-has-wpcom-migration-plugin', siteId ],
+		queryFn: () => getSiteHasWPCOMMigrationPlugin( siteId ),
+		retry,
+		enabled,
+	} );
+
+	const pluginRecord = data?.plugins.find( ( plugin: any ) => plugin.slug === 'wpcom-migration' );
+	const hasWPCOMMigraitonPlugin = Boolean( pluginRecord );
+
+	return { data, error, isLoading, isSuccess, pluginRecord, hasWPCOMMigraitonPlugin };
+};

--- a/client/landing/stepper/hooks/use-site-transfer/index.ts
+++ b/client/landing/stepper/hooks/use-site-transfer/index.ts
@@ -4,7 +4,7 @@ import { useSiteTransferMutation } from './mutation';
 import { useSiteTransferStatusQuery } from './query';
 
 type Status = 'idle' | 'pending' | 'success' | 'error';
-type Options = Pick< UseQueryOptions, 'retry' > & { from?: string };
+type Options = Pick< UseQueryOptions, 'retry' | 'enabled' > & { from?: string };
 
 /**
  * Hook to initiate a site transfer and monitor its progress


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #99760

## Proposed Changes

* Add a check to verify if the WPCOM Migration plugin is installed in the instructions step.
* If the plugin is not installed, we should install it.
* If the plugin is not active, we should activate it.
* This will ensure we can retrieve the Migration Key.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We found a bug that prevented the users from getting the Migration Key in the DIY flow in case the site in which they were migrating to was already atomic. The problem was that the WPCOM Migration plugin installation only happens in the Atomic Transfer. Since the site is already atomic, we were assuming that the plugin was installed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link below
* Navigate to the `/move` page and start the migration
* When you reach the site picker step, you should select a site that is already atomic
* Ensure your site hasn't installed the wpcom-migration plugin, or is at least deactivated.
* Go through the DIY flow
* You should be able to retrieve the Migration Key after a few seconds

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
