### PR TITLE
Apps: Add TC build command for newsletter app

### DIFF
--- a/apps/newsletter/package.json
+++ b/apps/newsletter/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@automattic/newsletter",
 	"version": "1.0.0",
-	"description": "The Newsletter widget",
+	"description": "The Newsletter widget.",
 	"calypso:src": "src/index.js",
 	"main": "dist/build.min.js",
 	"module": "dist/build.esm.js",

--- a/apps/newsletter/package.json
+++ b/apps/newsletter/package.json
@@ -17,6 +17,7 @@
 		"build": "NODE_ENV=production yarn dev",
 		"build:newsletter": "calypso-build",
 		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/newsletter",
+		"teamcity:build-app": "yarn run build",
 		"translate": "rm -rf dist/strings && mkdirp dist && wp-babel-makepot '../../{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base '../../' --dir './dist/strings' --output './dist/whats-new-strings.pot' && build-app-languages --stringsFilePath='./dist/whats-new-strings.pot'"
 	},
 	"dependencies": {


### PR DESCRIPTION


## Proposed Changes

Adds a TeamCity build command for the new `newsletter` app.

Related to #99652

## Why are these changes being made?

To allow TC to build the new app as part of the WPCom Plugins CI check.

## Testing Instructions

CI should pass. 