### PR TITLE
Reader: Improve add new form styling on discover tab

### DIFF
--- a/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
@@ -111,21 +111,23 @@ const AddSitesForm = ( { onAddFinished = () => {} }: AddSitesFormProps ) => {
 	return (
 		<>
 			<div className="subscriptions-add-sites__form--container">
-				<TextControl
-					className={ clsx(
-						'subscriptions-add-sites__form-input',
-						inputFieldError ? 'is-error' : ''
-					) }
-					disabled={ subscribing }
-					placeholder={ translate( 'https://www.site.com' ) }
-					value={ inputValue }
-					type="url"
-					onChange={ onTextFieldChange }
-					help={ isValidInput ? <Icon icon={ check } data-testid="check-icon" /> : undefined }
-					onBlur={ () => validateInputValue( inputValue, true ) }
-				/>
+				<div className="subscriptions-add-sites__form-field">
+					<TextControl
+						className={ clsx(
+							'subscriptions-add-sites__form-input',
+							inputFieldError ? 'is-error' : ''
+						) }
+						disabled={ subscribing }
+						placeholder={ translate( 'https://www.site.com' ) }
+						value={ inputValue }
+						type="url"
+						onChange={ onTextFieldChange }
+						help={ isValidInput ? <Icon icon={ check } data-testid="check-icon" /> : undefined }
+						onBlur={ () => validateInputValue( inputValue, true ) }
+					/>
 
-				{ inputFieldError ? <FormInputValidation isError text={ inputFieldError } /> : null }
+					{ inputFieldError ? <FormInputValidation isError text={ inputFieldError } /> : null }
+				</div>
 
 				<Button
 					primary

--- a/client/landing/subscriptions/components/add-sites-form/styles.scss
+++ b/client/landing/subscriptions/components/add-sites-form/styles.scss
@@ -12,7 +12,7 @@
 	}
 
 	.components-base-control__field {
-		margin-bottom: 16px;
+		margin-bottom: 20px;
 	}
 
 	.is-error .components-base-control__field {
@@ -27,6 +27,7 @@
 		padding: rem(10px) rem(16px);
 		/* We need to allow space for the SVG checkmark */
 		padding-right: calc(0.5rem + 24px);
+		height: 40px;
 
 		&::placeholder {
 			color: var(--studio-gray-20);

--- a/client/reader/discover/components/add-new/style.scss
+++ b/client/reader/discover/components/add-new/style.scss
@@ -1,3 +1,5 @@
+@import "@automattic/typography/styles/variables";
+
 .discover-add-new {
 	padding: 10px;
 }
@@ -5,4 +7,14 @@
 .discover-add-new__subscriptions {
 	padding-top: 20px;
 	clear: both;
+}
+
+.discover-add-new__form-title {
+	margin-bottom: 10px;
+}
+
+.discover-add-new__subscriptions-title {
+	font-size: $font-title-small;
+	font-weight: 500;
+	margin-bottom: 10px;
 }

--- a/client/reader/discover/components/add-new/style.scss
+++ b/client/reader/discover/components/add-new/style.scss
@@ -4,13 +4,32 @@
 	padding: 10px;
 }
 
-.discover-add-new__subscriptions {
-	padding-top: 20px;
-	clear: both;
+.discover-add-new__form {
+	.subscriptions-add-sites__form--container {
+		display: flex;
+		align-items: flex-start;
+		gap: 8px;
+	}
+
+	.subscriptions-add-sites__form-field {
+		flex: 1;
+
+		.components-base-control__field {
+			margin-bottom: 0;
+		}
+	}
+
+	.components-text-control__input {
+		height: 40px;
+	}
 }
 
 .discover-add-new__form-title {
 	margin-bottom: 10px;
+}
+
+.discover-add-new__subscriptions {
+	padding-top: 30px;
 }
 
 .discover-add-new__subscriptions-title {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/473

## Proposed Changes

* Change form orientation to inline.
* Improve styling of typography.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To make UI better.

| Before | After |
|--------|------|
|![image](https://github.com/user-attachments/assets/0f2f06cb-7fe5-4b43-b7ea-6b9c67d0630d)|![image](https://github.com/user-attachments/assets/82080907-a55b-42fb-a8de-e8473ae61839)|
|![image](https://github.com/user-attachments/assets/ea6e4d1f-a139-4a9c-ad91-f27b5682b2f5)|![image](https://github.com/user-attachments/assets/e3cd75f5-7ca8-4d24-a279-7853ec184a4f)|
|![image](https://github.com/user-attachments/assets/35fd49e4-cbcf-4a2a-974f-a5d2b1e4966a)|![image](https://github.com/user-attachments/assets/ea5668ff-cecf-43c7-8161-e916dd749bbc)|
|![image](https://github.com/user-attachments/assets/53fc5f54-9cb6-4f00-b44f-61ce8a60be77)|![image](https://github.com/user-attachments/assets/c93bd686-5dff-4642-9445-8d76e2537ece)|




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/discover/add-new?flags=reader/discovery-v2`.
* Verify styling of the form. Also check the error state.
* Go to `/reader/subscriptions`
* Click "New Subscription"
* Verify styling of the form. Also check the error state.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
