### PR TITLE
Domains: Add max length for TLD validation message

### DIFF
--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -38,6 +38,7 @@ export const domainAvailability = {
 	FORBIDDEN_SUBDOMAIN: 'forbidden_subdomain',
 	IN_REDEMPTION: 'in_redemption',
 	INVALID: 'invalid_domain',
+	INVALID_LENGTH: 'invalid_length',
 	INVALID_QUERY: 'invalid_query',
 	INVALID_TLD: 'invalid_tld',
 	MAINTENANCE: 'tld_in_maintenance',

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -616,6 +616,10 @@ function getAvailabilityNotice(
 			);
 			break;
 
+		case domainAvailability.INVALID_LENGTH:
+			message = translate( 'The domain name you entered is too long.' );
+			break;
+
 		case 'blocked':
 			const supportURL = 'https://wordpress.com/error-report/?url=496@' + ( site?.slug || '' );
 			message = translate(

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -617,7 +617,7 @@ function getAvailabilityNotice(
 			break;
 
 		case domainAvailability.INVALID_LENGTH:
-			message = translate( 'The domain name you entered is too long.' );
+			message = translate( 'The domain name is too long.' );
 			break;
 
 		case 'blocked':


### PR DESCRIPTION
Depends on 173802-ghe-Automattic/wpcom

## Proposed Changes
When we search for a domain name that's too long, we'll get weird behavior where the domain is either reported as unavailable or we get an error, depending on the flow.
This PR adds the validation and specific error message for this case.

## Why are these changes being made?
Because the current behavior causes confusion for users and can mislead them during the flows, increase support interactions, etc.

## Testing Instructions
- Try to search for a domain name that is too long (`.com.br` uses 26 as max length for its SLDs, for instance);
- Ensure you get the correct error message in any flow you're in.

## Previews
### Domain Search
| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/f82f4534-bc36-4bbc-b2f5-0bc8b342632e) | ![image](https://github.com/user-attachments/assets/bab6443b-853f-4ee8-bdd5-73820b4d3338)| 
### Use a domain I own
| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/59bcd62e-4b0f-42cb-91dc-a1165172afe9)| ![image](https://github.com/user-attachments/assets/62401b6b-f495-4dac-b105-b0458622753d)| 

## Pre-merge Checklist
- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [X] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?