### PR TITLE
Help Center: Customize back button on chat

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
@@ -84,7 +84,7 @@ export function DefaultMasterbarContact() {
 		} );
 
 		if ( hasPremiumSupport ) {
-			setShowHelpCenter( ! isShowingHelpCenter, hasPremiumSupport );
+			setShowHelpCenter( ! isShowingHelpCenter, hasPremiumSupport, { hideBackButton: true } );
 			setNavigateToRoute(
 				`/odie?provider=zendesk&userFieldMessage=${ initialMessage }&siteUrl=${ siteSlug }&siteId=${ siteId }`
 			);

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
@@ -1,7 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Gridicon } from '@automattic/components';
 import { HelpCenter, HelpCenterSelect } from '@automattic/data-stores';
-import { useProductsWithPremiumSupport } from '@automattic/help-center/src/hooks';
+import {
+	useProductsCustomOptions,
+	useProductsWithPremiumSupport,
+} from '@automattic/help-center/src/hooks';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import styled from '@emotion/styled';
 import { Button } from '@wordpress/components';
@@ -71,6 +74,8 @@ export function DefaultMasterbarContact() {
 	const { hasPremiumSupport, initialMessage } = useProductsWithPremiumSupport(
 		responseCart.products
 	);
+	const helpCenterOptions = useProductsCustomOptions( responseCart.products );
+
 	const { setShowHelpCenter, setNavigateToRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
 
 	const isShowingHelpCenter = useDataStoreSelect(
@@ -84,7 +89,7 @@ export function DefaultMasterbarContact() {
 		} );
 
 		if ( hasPremiumSupport ) {
-			setShowHelpCenter( ! isShowingHelpCenter, hasPremiumSupport, { hideBackButton: true } );
+			setShowHelpCenter( ! isShowingHelpCenter, hasPremiumSupport, helpCenterOptions );
 			setNavigateToRoute(
 				`/odie?provider=zendesk&userFieldMessage=${ initialMessage }&siteUrl=${ siteSlug }&siteId=${ siteId }`
 			);

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
@@ -72,8 +72,10 @@ export function DefaultMasterbarContact() {
 	const { responseCart } = useShoppingCart( cartKey );
 
 	const { hasPremiumSupport, initialMessage } = useProductsWithPremiumSupport(
-		responseCart.products
+		responseCart.products,
+		'checkout'
 	);
+
 	const helpCenterOptions = useProductsCustomOptions( responseCart.products );
 
 	const { setShowHelpCenter, setNavigateToRoute } = useDataStoreDispatch( HELP_CENTER_STORE );

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -5,7 +5,7 @@ import { GeneratorReturnType } from '../mapped-types';
 import { SiteDetails } from '../site';
 import { wpcomRequest } from '../wpcom-request-controls';
 import { isE2ETest } from '.';
-import type { APIFetchOptions } from './types';
+import type { APIFetchOptions, HelpCenterOptions } from './types';
 import type { SupportInteraction } from '@automattic/odie-client/src/types';
 
 export const receiveHasSeenWhatsNewModal = ( value: boolean | undefined ) =>
@@ -112,7 +112,16 @@ export const setAllowPremiumSupport = ( allow: boolean ) =>
 		allow,
 	} ) as const;
 
-export const setShowHelpCenter = function* ( show: boolean, allowPremiumSupport = false ) {
+export const setHelpCenterOptions = ( options: HelpCenterOptions ) => ( {
+	type: 'HELP_CENTER_SET_OPTIONS' as const,
+	options,
+} );
+
+export const setShowHelpCenter = function* (
+	show: boolean,
+	allowPremiumSupport = false,
+	options = { hideBackButton: false }
+) {
 	if ( ! isE2ETest() ) {
 		try {
 			if ( canAccessWpcomApis() ) {
@@ -146,6 +155,10 @@ export const setShowHelpCenter = function* ( show: boolean, allowPremiumSupport 
 	yield setIsMinimized( false );
 	if ( allowPremiumSupport ) {
 		yield setAllowPremiumSupport( true );
+	}
+
+	if ( options?.hideBackButton ) {
+		yield setHelpCenterOptions( options );
 	}
 
 	return {
@@ -222,5 +235,6 @@ export type HelpCenterAction =
 			| typeof setOdieBotNameSlug
 			| typeof setCurrentSupportInteraction
 			| typeof setAllowPremiumSupport
+			| typeof setHelpCenterOptions
 	  >
 	| GeneratorReturnType< typeof setShowHelpCenter | typeof setHasSeenWhatsNewModal >;

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from '@wordpress/data';
 import { SiteDetails } from '../site';
 import type { HelpCenterAction } from './actions';
+import type { HelpCenterOptions } from './types';
 import type { SupportInteraction } from '@automattic/odie-client/src/types';
 import type { Reducer } from 'redux';
 
@@ -167,6 +168,16 @@ const allowPremiumSupport: Reducer< boolean, HelpCenterAction > = ( state = fals
 	return state;
 };
 
+const helpCenterOptions: Reducer< HelpCenterOptions, HelpCenterAction > = (
+	state = {},
+	action
+) => {
+	if ( action.type === 'HELP_CENTER_SET_OPTIONS' ) {
+		return { ...state, ...action.options };
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	currentSupportInteraction,
 	showHelpCenter,
@@ -186,6 +197,7 @@ const reducer = combineReducers( {
 	odieInitialPromptText,
 	odieBotNameSlug,
 	allowPremiumSupport,
+	helpCenterOptions,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/help-center/selectors.ts
+++ b/packages/data-stores/src/help-center/selectors.ts
@@ -19,3 +19,4 @@ export const getOdieInitialPromptText = ( state: State ) => state.odieInitialPro
 export const getOdieBotNameSlug = ( state: State ) => state.odieBotNameSlug;
 export const getCurrentSupportInteraction = ( state: State ) => state.currentSupportInteraction;
 export const getAllowPremiumSupport = ( state: State ) => state.allowPremiumSupport;
+export const getHelpCenterOptions = ( state: State ) => state.helpCenterOptions;

--- a/packages/data-stores/src/help-center/types.ts
+++ b/packages/data-stores/src/help-center/types.ts
@@ -46,3 +46,7 @@ export interface APIFetchOptions {
 }
 
 export type HelpCenterSelect = SelectFromMap< typeof selectors >;
+
+export interface HelpCenterOptions {
+	hideBackButton?: boolean;
+}

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -198,14 +198,26 @@ const Content = ( { onMinimize }: { onMinimize?: () => void } ) => {
 	const { __ } = useI18n();
 	const { pathname } = useLocation();
 
-	const shouldDisplayClearChatButton = pathname.startsWith( '/odie' );
+	const { helpCenterOptions } = useSelect( ( select ) => {
+		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
+		return {
+			helpCenterOptions: store.getHelpCenterOptions(),
+		};
+	}, [] );
+
+	const isChat = pathname.startsWith( '/odie' );
 	const isHelpCenterHome = pathname === '/';
+	// Show the back button if it's not the help center home page and:
+	// - it's a chat and the hideBackButton option is not set
+	// - it's not a chat
+	const shouldShowBackButton =
+		! isHelpCenterHome && ( ( isChat && ! helpCenterOptions?.hideBackButton ) || ! isChat );
 
 	return (
 		<>
-			{ isHelpCenterHome ? <DragIcon /> : <BackButton /> }
+			{ shouldShowBackButton ? <BackButton /> : <DragIcon /> }
 			<HeaderText />
-			{ shouldDisplayClearChatButton && <ChatEllipsisMenu /> }
+			{ isChat && <ChatEllipsisMenu /> }
 			<Button
 				className="help-center-header__minimize"
 				label={ __( 'Minimize Help Center', __i18n_text_domain__ ) }

--- a/packages/help-center/src/hooks/index.ts
+++ b/packages/help-center/src/hooks/index.ts
@@ -10,3 +10,4 @@ export { useOpenArticleInHelpCenter } from './use-open-article-in-help-center';
 export { usePostByUrl } from './use-post-by-url';
 export { useContentFilter } from './use-content-filter';
 export { useProductsWithPremiumSupport } from './use-products-with-premium-support';
+export { useProductsCustomOptions } from './use-products-custom-options';

--- a/packages/help-center/src/hooks/use-products-custom-options.ts
+++ b/packages/help-center/src/hooks/use-products-custom-options.ts
@@ -1,0 +1,15 @@
+import { isDIFMProduct } from '@automattic/calypso-products';
+import { ResponseCartProduct } from '@automattic/shopping-cart';
+
+// We want to give the Help Center custom options based on the products in the cart ( the flow in which the user is in )
+export function useProductsCustomOptions( products: ResponseCartProduct[] ) {
+	for ( const product of products ) {
+		if ( isDIFMProduct( product ) ) {
+			return {
+				hideBackButton: true,
+			};
+		}
+	}
+
+	return null;
+}

--- a/packages/help-center/src/hooks/use-products-with-premium-support.ts
+++ b/packages/help-center/src/hooks/use-products-with-premium-support.ts
@@ -1,7 +1,7 @@
 import { isDIFMProduct, PLAN_100_YEARS } from '@automattic/calypso-products';
 import { ResponseCartProduct } from '@automattic/shopping-cart';
 
-export function useProductsWithPremiumSupport( products: ResponseCartProduct[] ) {
+export function useProductsWithPremiumSupport( products: ResponseCartProduct[], url?: string ) {
 	let hasDIFMProduct = false;
 	let has100YPlan = false;
 
@@ -15,8 +15,8 @@ export function useProductsWithPremiumSupport( products: ResponseCartProduct[] )
 	}
 
 	const initialMessage = hasDIFMProduct
-		? 'User is purchasing DIFM plan.'
-		: 'User is purchasing 100 year plan.';
+		? `User is purchasing DIFM plan${ url ? `. URL: ${ url }` : '' }`
+		: `User is purchasing 100 year plan.`;
 
 	const hasPremiumSupport = hasDIFMProduct || has100YPlan;
 

--- a/packages/help-center/src/hooks/use-products-with-premium-support.ts
+++ b/packages/help-center/src/hooks/use-products-with-premium-support.ts
@@ -15,7 +15,7 @@ export function useProductsWithPremiumSupport( products: ResponseCartProduct[], 
 	}
 
 	const initialMessage = hasDIFMProduct
-		? `User is purchasing DIFM plan${ url ? `. URL: ${ url }` : '' }`
+		? `User is purchasing DIFM plan.${ url ? ` URL: ${ url }` : '' }`
 		: `User is purchasing 100 year plan.`;
 
 	const hasPremiumSupport = hasDIFMProduct || has100YPlan;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Context: pdh1Xd-31k-p2#comment-2979

## Proposed Changes

For the DIFM flow, if we open the Help Center in checkout we now hide the back button in the header.

This PR introduces **a new hook** to set custom options to be passed to the Help Center when we open it.
The hook analyzes the products in the cart, but can be then updated to decide upon the flow the user is in, for example.

## Testing Instructions


* Reach the DIFM flow clicking on `Let us build a custom site for youLet us build a custom site for you` 
* Reach checkout
* Click on top right to get help.
* You should be seeing a new chat with an happiness engineer, with no back button on top left of the Help Center.