### PR TITLE
Add back action on use my domain available domain error

### DIFF
--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -51,6 +51,7 @@ function UseMyDomain( props ) {
 		setUseMyDomainMode,
 		isStepper = false,
 		stepLocation,
+		errorAction,
 	} = props;
 
 	const { __ } = useI18n();
@@ -151,9 +152,10 @@ function UseMyDomain( props ) {
 				availabilityData: wpRegistrationCheckData,
 				domainName: filteredDomainName,
 				selectedSite,
+				errorAction,
 			} ),
 		};
-	}, [ filterDomainName, domainName, selectedSite ] );
+	}, [ filterDomainName, domainName, selectedSite, errorAction ] );
 
 	const getAvailability = useCallback( async () => {
 		const filteredDomainName = filterDomainName( domainName );
@@ -173,9 +175,10 @@ function UseMyDomain( props ) {
 				availabilityData,
 				domainName: filteredDomainName,
 				selectedSite,
+				errorAction,
 			} ),
 		};
-	}, [ filterDomainName, domainName, getWpcomAvailabilityErrors, selectedSite ] );
+	}, [ filterDomainName, domainName, getWpcomAvailabilityErrors, selectedSite, errorAction ] );
 
 	const setTransferStepsAndLockStatus = useCallback(
 		( isDomainUnlocked ) => {
@@ -481,6 +484,7 @@ UseMyDomain.propTypes = {
 	setUseMyDomainMode: PropTypes.func,
 	isStepper: PropTypes.bool,
 	stepLocation: PropTypes.object,
+	errorAction: PropTypes.func,
 };
 
 export default connect( ( state ) => ( {

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -51,7 +51,7 @@ function UseMyDomain( props ) {
 		setUseMyDomainMode,
 		isStepper = false,
 		stepLocation,
-		errorAction,
+		registerNowAction,
 	} = props;
 
 	const { __ } = useI18n();
@@ -152,10 +152,10 @@ function UseMyDomain( props ) {
 				availabilityData: wpRegistrationCheckData,
 				domainName: filteredDomainName,
 				selectedSite,
-				errorAction,
+				registerNowAction,
 			} ),
 		};
-	}, [ filterDomainName, domainName, selectedSite, errorAction ] );
+	}, [ filterDomainName, domainName, selectedSite, registerNowAction ] );
 
 	const getAvailability = useCallback( async () => {
 		const filteredDomainName = filterDomainName( domainName );
@@ -175,10 +175,16 @@ function UseMyDomain( props ) {
 				availabilityData,
 				domainName: filteredDomainName,
 				selectedSite,
-				errorAction,
+				registerNowAction,
 			} ),
 		};
-	}, [ filterDomainName, domainName, getWpcomAvailabilityErrors, selectedSite, errorAction ] );
+	}, [
+		filterDomainName,
+		domainName,
+		getWpcomAvailabilityErrors,
+		selectedSite,
+		registerNowAction,
+	] );
 
 	const setTransferStepsAndLockStatus = useCallback(
 		( isDomainUnlocked ) => {
@@ -484,7 +490,7 @@ UseMyDomain.propTypes = {
 	setUseMyDomainMode: PropTypes.func,
 	isStepper: PropTypes.bool,
 	stepLocation: PropTypes.object,
-	errorAction: PropTypes.func,
+	registerNowAction: PropTypes.func,
 };
 
 export default connect( ( state ) => ( {

--- a/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
+++ b/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
@@ -4,7 +4,12 @@ import { domainAvailability } from 'calypso/lib/domains/constants';
 import { getAvailabilityNotice } from 'calypso/lib/domains/registration/availability-messages';
 import { domainAddNew } from 'calypso/my-sites/domains/paths';
 
-export function getAvailabilityErrorMessage( { availabilityData, domainName, selectedSite } ) {
+export function getAvailabilityErrorMessage( {
+	availabilityData,
+	domainName,
+	selectedSite,
+	errorAction,
+} ) {
 	const { status, mappable, maintenance_end_time, other_site_domain, other_site_domain_only } =
 		availabilityData;
 
@@ -17,6 +22,18 @@ export function getAvailabilityErrorMessage( { availabilityData, domainName, sel
 					a: createElement( 'a', { href: searchPageLink } ),
 				}
 			);
+		}
+
+		if ( errorAction ) {
+			return createInterpolateElement( __( "This domain isn't registered. <a>Register now.</a>" ), {
+				a: createElement( 'a', {
+					href: '#',
+					onClick: ( event ) => {
+						event.preventDefault();
+						errorAction();
+					},
+				} ),
+			} );
 		}
 
 		return __( "This domain isn't registered. Try again." );

--- a/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
+++ b/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
@@ -8,7 +8,7 @@ export function getAvailabilityErrorMessage( {
 	availabilityData,
 	domainName,
 	selectedSite,
-	errorAction = undefined,
+	registerNowAction = undefined,
 } ) {
 	const { status, mappable, maintenance_end_time, other_site_domain, other_site_domain_only } =
 		availabilityData;
@@ -24,13 +24,13 @@ export function getAvailabilityErrorMessage( {
 			);
 		}
 
-		if ( errorAction ) {
+		if ( registerNowAction ) {
 			return createInterpolateElement( __( "This domain isn't registered. <a>Register now.</a>" ), {
 				a: createElement( 'a', {
 					href: '#',
 					onClick: ( event ) => {
 						event.preventDefault();
-						errorAction();
+						registerNowAction();
 					},
 				} ),
 			} );

--- a/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
+++ b/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
@@ -8,7 +8,7 @@ export function getAvailabilityErrorMessage( {
 	availabilityData,
 	domainName,
 	selectedSite,
-	errorAction,
+	errorAction = undefined,
 } ) {
 	const { status, mappable, maintenance_end_time, other_site_domain, other_site_domain_only } =
 		availabilityData;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -98,6 +98,7 @@ const UseMyDomain: Step = function UseMyDomain( { navigation, flow } ) {
 					onNextStep={ handleOnNext }
 					isStepper
 					stepLocation={ location }
+					errorAction={ handleGoBack }
 				/>
 			</CalypsoShoppingCartProvider>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -98,7 +98,7 @@ const UseMyDomain: Step = function UseMyDomain( { navigation, flow } ) {
 					onNextStep={ handleOnNext }
 					isStepper
 					stepLocation={ location }
-					errorAction={ handleGoBack }
+					registerNowAction={ handleGoBack }
 				/>
 			</CalypsoShoppingCartProvider>
 		);

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1092,6 +1092,7 @@ export class RenderDomainsStep extends Component {
 				forceExactSuggestion={ this.props?.queryObject?.source === 'general-settings' }
 				replaceDomainFailedMessage={ this.state.replaceDomainFailedMessage }
 				dismissReplaceDomainFailed={ this.dismissReplaceDomainFailed }
+				handleClickUseYourDomain={ this.handleUseYourDomainClick }
 			/>
 		);
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #99284
Fixes #99931 

## Proposed Changes

* Include action in the 'domain isn't registered action' to navigate back to the search page.
* Fixed an issue where the option "use a domain I own" at the end of the results list wasn't working.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When you go through our onboarding flow and pick the "Use a domain I own" option, you're brought to a domain transfer screen. If you enter a domain that hasn't been registered, you're left without any options but to try again. We can make it easier for people to either pick this domain to purchase or take them to the search results.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `wordpress.com/sites`
* Add a new site on WordPress.com
* Search for a domain.
* On the bottom of the results list, click "Use a domain I own".
* On the "Use a domain I own page" select an unregistered domain
* Validate the error message
* Clicking "Register Now" should take the user back to the domain search page
* Test the workflow again, using the action from "Already own a domain?" on the right side of the page

Before:
![image](https://github.com/user-attachments/assets/423d2924-6b9a-4d2a-909e-daeff95f0193)

After:
![image](https://github.com/user-attachments/assets/a6324262-3974-42b6-8d2b-5ab2a842d9b5)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
