### PR TITLE
Reader: Improve form submission of adding new subscription on discover tab

### DIFF
--- a/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
@@ -23,6 +23,7 @@ type SubscriptionError = {
 const AddSitesForm = ( { onAddFinished = () => {} }: AddSitesFormProps ) => {
 	const translate = useTranslate();
 	const [ inputValue, setInputValue ] = useState( '' );
+	const [ isSubmitting, setIsSubmitting ] = useState< boolean >( false );
 	const [ inputFieldError, setInputFieldError ] = useState< string | null >( null );
 	const [ isValidInput, setIsValidInput ] = useState( false );
 	const [ showLoginDialog, setShowLoginDialog ] = useState( false );
@@ -70,6 +71,7 @@ const AddSitesForm = ( { onAddFinished = () => {} }: AddSitesFormProps ) => {
 		}
 
 		if ( isValidInput ) {
+			setIsSubmitting( true );
 			subscribe(
 				{ url: inputValue },
 				{
@@ -86,12 +88,19 @@ const AddSitesForm = ( { onAddFinished = () => {} }: AddSitesFormProps ) => {
 							}
 
 							showSuccessNotice( inputValue );
+
+							// Reset fields.
+							setInputValue( '' );
+							setIsValidInput( false );
 						}
 						onAddFinished();
 					},
 					onError: ( error: SubscriptionError ) => {
 						showErrorNotice( inputValue, error );
 						onAddFinished();
+					},
+					onSettled: (): void => {
+						setIsSubmitting( false );
 					},
 				}
 			);
@@ -133,6 +142,7 @@ const AddSitesForm = ( { onAddFinished = () => {} }: AddSitesFormProps ) => {
 					primary
 					className="subscriptions-add-sites__save-button"
 					disabled={ ! inputValue || !! inputFieldError || subscribing }
+					busy={ isSubmitting }
 					onClick={ onAddSite }
 				>
 					{ translate( 'Add site' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/474

## Proposed Changes

Improve the "Add New" form submission experience by adding an animation to the "Add Site" button and automatically clearing its values after a successful submission.

### Before

https://github.com/user-attachments/assets/f5f96dd3-4b34-491d-9661-365bb1c9ca6c

### After

https://github.com/user-attachments/assets/c6553884-4118-479e-97ff-37fd1777efa9

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- On form submission we were disabling the submit button which wasn't looking good.
- We were keeping the form values even after successful submission.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Go to `/discover/add-new?flags=reader/discovery-v2`.
* Add new subscription and verify the loading states.
* Go to `/reader/subscriptions`
* Click "New Subscription"
* Add new subscription and verify the loading states.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
