### PR TITLE
Discovery v2 - add tracking for clicking tabs and tag tabs.

### DIFF
--- a/client/reader/discover/components/navigation/v2/index.tsx
+++ b/client/reader/discover/components/navigation/v2/index.tsx
@@ -6,6 +6,8 @@ import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import { DEFAULT_TAB, FIRST_POSTS_TAB, LATEST_TAB } from 'calypso/reader/discover/helper';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { useDispatch } from 'calypso/state';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import './style.scss';
 
 interface Tab {
@@ -20,10 +22,12 @@ interface Props {
 
 const DiscoverNavigationV2 = ( { selectedTab }: Props ) => {
 	const currentLocale = useLocale();
+	const dispatch = useDispatch();
 
-	const recordTabClick = () => {
+	const recordTabClick = ( tab: string ) => {
 		recordAction( 'click_discover_tab' );
 		recordGaEvent( 'Clicked Discover Tab' );
+		dispatch( recordReaderTracksEvent( 'calypso_reader_discover_tab_clicked', { tab } ) );
 	};
 
 	const getLocalizedPath = ( path: string ) => {
@@ -83,7 +87,7 @@ const DiscoverNavigationV2 = ( { selectedTab }: Props ) => {
 						key={ tab.slug }
 						selected={ selectedTab === tab.slug }
 						path={ tab.path }
-						onClick={ recordTabClick }
+						onClick={ () => recordTabClick( tab.slug ) }
 					>
 						{ tab.title }
 					</NavItem>

--- a/client/reader/discover/components/tags-navigation/index.tsx
+++ b/client/reader/discover/components/tags-navigation/index.tsx
@@ -63,7 +63,7 @@ const DiscoverTagsNavigation = ( { selectedTag, width, onTagSelect }: Props ) =>
 	const recordTabClick = ( tab: string ) => {
 		recordAction( 'click_discover_tag' );
 		recordGaEvent( 'Clicked Discover Tag' );
-		dispatch( recordReaderTracksEvent( 'calypso_reader_discover_tag_clicked', { tag: tab } ) );
+		dispatch( recordReaderTracksEvent( 'calypso_reader_discover_tag_tab_clicked', { tag: tab } ) );
 	};
 
 	const menuTabClick = ( tab: string ) => {

--- a/client/reader/discover/components/tags-navigation/index.tsx
+++ b/client/reader/discover/components/tags-navigation/index.tsx
@@ -5,6 +5,8 @@ import ScrollableHorizontalNavigation from 'calypso/components/scrollable-horizo
 import isBloganuary from 'calypso/data/blogging-prompt/is-bloganuary';
 import wpcom from 'calypso/lib/wp';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { useDispatch } from 'calypso/state';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 interface Tag {
 	title: string;
@@ -56,15 +58,17 @@ export const useRecommendedTags = (): Tag[] => {
 
 const DiscoverTagsNavigation = ( { selectedTag, width, onTagSelect }: Props ) => {
 	const recommendedTags = useRecommendedTags();
+	const dispatch = useDispatch();
 
-	const recordTabClick = () => {
-		recordAction( 'click_discover_tab' );
-		recordGaEvent( 'Clicked Discover Tab' );
+	const recordTabClick = ( tab: string ) => {
+		recordAction( 'click_discover_tag' );
+		recordGaEvent( 'Clicked Discover Tag' );
+		dispatch( recordReaderTracksEvent( 'calypso_reader_discover_tag_clicked', { tag: tab } ) );
 	};
 
 	const menuTabClick = ( tab: string ) => {
 		onTagSelect( tab );
-		recordTabClick();
+		recordTabClick( tab );
 	};
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pe7F0s-2ua-p2

## Proposed Changes

* Adds tracking events for discovery v2 tabs. 
    * `calypso_reader_discover_tag_tab_clicked` with property `tag` and value of the tag slug.
    * `calypso_reader_discover_tab_clicked` with property `tab` and value of the tab slug.
* Updates action names at tag level to be non redundant.
    * In the reader discover tags navigation we udpate the actions around "tabs" to be around "tags". In v2 we are also using the same "tabs" strings at the higher level of discover tabs.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Tracking for new features is good.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to discover v2.
* Click on any of the top level tabs. Verify you see a tracking event like this, with a "tab" value reflecting the tab you clicked.
![Screenshot 2025-02-17 at 1 24 54 PM](https://github.com/user-attachments/assets/1195b9ab-d9c6-4fda-8fad-3b3f150aca6a)
    * You can filter network on t.gif or more simple use tracks vigilante extension found in the FG.
* Click on the "tags" tab. Now select different tags. When selecting a tag you should see another event for this with the `tag` value corresponding to the tag you clicked on:
![Screenshot 2025-02-17 at 1 25 41 PM](https://github.com/user-attachments/assets/d44eabf0-2801-4821-a0eb-8f1576c20311)

Note - the `ui_algo` general reader tracking property above is currently not adapted for discover v2 and will be handled separately. [issue here](https://github.com/Automattic/loop/issues/482).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?