### PR TITLE
handle the response of the replies now that we refactored the dsp side

### DIFF
--- a/client/data/promote-post/use-promote-post-campaigns-query.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query.ts
@@ -50,14 +50,10 @@ export type CampaignResponse = {
 			likes_total: number;
 			replies_total: number;
 			replies?: {
-				total_notes: number;
-				notes: {
-					blog_name: string;
-					type: string;
-					blog_url: string;
-					reply_text?: string;
-				}[];
-			};
+				blog_name: string;
+				blog_url: string;
+				reply_text?: string;
+			}[];
 		};
 	};
 	billing_data: {

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -187,7 +187,7 @@ export default function CampaignItemDetails( props: Props ) {
 		permalink,
 	} = tsp || {};
 
-	const displayedReplies = showAllReplies ? replies?.notes : replies?.notes.slice( 0, 3 );
+	const displayedReplies = showAllReplies ? replies : replies?.slice( 0, 3 );
 
 	// check if delivery outperformed
 	const calculateOutperformPercentage = ( estimates: string, total: number ): number => {
@@ -1057,20 +1057,22 @@ export default function CampaignItemDetails( props: Props ) {
 														</span>
 													</span>
 												</div>
-												{ displayedReplies && replies && replies?.total_notes > 0 && (
+												{ displayedReplies && replies && replies?.length > 0 && (
 													<div className="campaign-items-details__tsp-replies">
-														{ displayedReplies.map( ( note, index ) => (
+														{ displayedReplies.map( ( reply, index ) => (
 															<div key={ index } className="campaign-items-details__tsp-reply">
-																<a href={ note.blog_url } target="_blank" rel="noopener noreferrer">
-																	@{ note.blog_name }
+																<a
+																	href={ reply.blog_url }
+																	target="_blank"
+																	rel="noopener noreferrer"
+																>
+																	@{ reply.blog_name }
 																</a>
 																<br />
-																{ note.type === 'like' && translate( 'Liked this' ) }
-																{ note.type === 'reblog' && translate( 'Reblogged this' ) }
-																{ note.type === 'reply' && ( note?.reply_text || '-' ) }
+																{ reply?.reply_text || '-' }
 															</div>
 														) ) }
-														{ replies && replies?.total_notes > 3 && (
+														{ replies && replies?.length > 3 && (
 															<button
 																className="campaign-items-details__replies-show-more-button"
 																onClick={ () => setShowAllReplies( ! showAllReplies ) }


### PR DESCRIPTION

## Proposed Changes

this is a minor fix to handle the replies returned from the DSP. the object was refactored and we changed the structure..

this PR is fixing the new handling of the object

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

the dsp side of changes are now in production. so you can just checkout this branch (or use the preview link)

visit a campaign details page that has a tsp (with some replies) and check that everything works ok

do a CR

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
