### PR TITLE
Update congrats modal CTA copy

### DIFF
--- a/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
@@ -1,4 +1,5 @@
 import { Gridicon, ConfettiAnimation, Tooltip } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { Button, Modal } from '@wordpress/components';
 import { Icon, copy } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -23,6 +24,7 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 	const hasCustomDomain = Boolean(
 		transformedDomains.find( ( domain ) => ! domain.isWPCOMDomain )
 	);
+	const hasEnTranslation = useHasEnTranslation();
 
 	useEffect( () => {
 		// remove the celebrateLaunch URL param without reloading the page as soon as the modal loads
@@ -54,7 +56,9 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 					) }
 				</p>
 			);
-			buttonText = translate( 'Claim your domain' );
+			buttonText = hasEnTranslation( 'Get your domain' )
+				? translate( 'Get your domain' )
+				: translate( 'Claim your domain' );
 			buttonHref = `/domains/add/${ site.slug }`;
 		} else if ( isPaidPlan && isBilledMonthly && ! hasCustomDomain ) {
 			contentElement = (
@@ -64,7 +68,9 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 					) }
 				</p>
 			);
-			buttonText = translate( 'Claim your domain' );
+			buttonText = hasEnTranslation( 'Get your domain' )
+				? translate( 'Get your domain' )
+				: translate( 'Claim your domain' );
 			buttonHref = `/domains/add/${ site.slug }`;
 		} else if ( isPaidPlan && ! hasCustomDomain ) {
 			contentElement = (
@@ -75,7 +81,9 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 					) }
 				</p>
 			);
-			buttonText = translate( 'Claim your free domain' );
+			buttonText = hasEnTranslation( 'Get your free domain' )
+				? translate( 'Get your free domain' )
+				: translate( 'Claim your free domain' );
 			buttonHref = `/domains/add/${ site.slug }`;
 		} else if ( hasCustomDomain ) {
 			return null;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99816

## Proposed Changes

* We're updating the modal copy based on demo's call feedback:

| Before | After | After - paid plan |
|--------|--------|--------|
| ![image](https://github.com/user-attachments/assets/34f268ce-ef20-4a94-8b8a-a95b12c31a28) | ![image](https://github.com/user-attachments/assets/fd815da5-f3ed-4c31-8ce0-f45d7e469f3f) | ![image](https://github.com/user-attachments/assets/1f2bb6d3-5340-4cbf-8389-a1a85527df9d) |


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Onboarding flow
* Launch your site and ensure the copy is changed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
