### PR TITLE
Subscribers: Fix failing removal test

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/subscribers-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/subscribers-page.ts
@@ -42,14 +42,13 @@ export class SubscribersPage {
 	 * @param {string} identifier Identifier to locate and remove.
 	 */
 	async removeSubscriber( identifier: string ) {
-		// First find the row containing the subscriber
-		const row = this.anchor.getByRole( 'row' ).filter( { hasText: identifier } );
-
-		// Wait for the row to be visible
-		await row.waitFor( { state: 'visible' } );
-
-		// Find and click the actions button within that row
-		await row.locator( 'button.dataviews-all-actions-button[aria-label="Actions"]' ).click();
+		// First open the hamburger menu of the row containing the subscriber
+		// to remove.
+		await this.anchor
+			.getByRole( 'row' )
+			.filter( { hasText: identifier } )
+			.getByRole( 'button', { name: 'Actions' } )
+			.click();
 
 		// Click on the remove menu item.
 		await this.page.getByRole( 'menuitem', { name: 'Remove' } ).click();
@@ -61,6 +60,9 @@ export class SubscribersPage {
 			.click();
 
 		// Ensure the subscriber is no longer present.
-		await row.waitFor( { state: 'detached', timeout: 5000 } );
+		await this.anchor
+			.getByRole( 'row' )
+			.filter( { hasText: identifier } )
+			.waitFor( { state: 'detached' } );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/subscribers-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/subscribers-page.ts
@@ -42,13 +42,14 @@ export class SubscribersPage {
 	 * @param {string} identifier Identifier to locate and remove.
 	 */
 	async removeSubscriber( identifier: string ) {
-		// First open the hamburger menu of the row containing the subscriber
-		// to remove.
-		await this.anchor
-			.getByRole( 'row' )
-			.filter( { hasText: identifier } )
-			.getByRole( 'button', { name: 'Actions' } )
-			.click();
+		// First find the row containing the subscriber
+		const row = this.anchor.getByRole( 'row' ).filter( { hasText: identifier } );
+
+		// Wait for the row to be visible
+		await row.waitFor( { state: 'visible' } );
+
+		// Find and click the actions button within that row
+		await row.locator( 'button.dataviews-all-actions-button[aria-label="Actions"]' ).click();
 
 		// Click on the remove menu item.
 		await this.page.getByRole( 'menuitem', { name: 'Remove' } ).click();
@@ -60,9 +61,6 @@ export class SubscribersPage {
 			.click();
 
 		// Ensure the subscriber is no longer present.
-		await this.anchor
-			.getByRole( 'row' )
-			.filter( { hasText: identifier } )
-			.waitFor( { state: 'detached' } );
+		await row.waitFor( { state: 'detached', timeout: 5000 } );
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1739814775807209-slack-C02DQP0FP

## Proposed Changes

* Refactor the removal mutation to update the UI more quickly.


https://github.com/user-attachments/assets/4f37326c-2281-49d8-89e2-c2dcc4ca891a



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The UI was updating too slowly, and failing a Jetpack test.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit /subscribers
* Remove a subscriber by clicking the three dots (Actions) > Remove. The UI should update immediately.
* Remove a subscriber by clicking the subscriber, and then "Delete subscriber." The UI should update immediately.
* Verify that you can still sort, filter, search, and add subscribers.
* Check that tests pass locally:

`export CALYPSO_BASE_URL=http://calypso.localhost:3000`

`yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" yarn workspace wp-e2e-tests test test/e2e/specs/users/newsletter__subscribe-remove.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?