### PR TITLE
Site lists: Hide A8C-owned sites by default

### DIFF
--- a/client/data/sites/use-site-excerpts-sorted.ts
+++ b/client/data/sites/use-site-excerpts-sorted.ts
@@ -1,4 +1,4 @@
-import { useSitesListSorting } from '@automattic/sites';
+import { useSitesListFiltering, useSitesListSorting } from '@automattic/sites';
 import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
 import { useSiteExcerptsQuery } from './use-site-excerpts-query';
 import type { SiteExcerptData } from '@automattic/sites';
@@ -9,5 +9,7 @@ export const useSiteExcerptsSorted = (): SiteExcerptData[] => {
 		( site ) => ! site.options?.is_domain_only
 	);
 	const { sitesSorting } = useSitesSorting();
-	return useSitesListSorting( allSites, sitesSorting );
+	const sortedSites = useSitesListSorting( allSites, sitesSorting );
+
+	return useSitesListFiltering( sortedSites, { includeA8CSites: false } );
 };

--- a/client/sites/components/sites-dashboard.tsx
+++ b/client/sites/components/sites-dashboard.tsx
@@ -292,9 +292,15 @@ const SitesDashboard = ( {
 		sortOrder: dataViewsState.sort?.direction || undefined,
 	} );
 
+	const includeA8CSites =
+		dataViewsState.filters?.some(
+			( { field, operator, value } ) => field === 'a8c_owned' && operator === 'is' && value === true
+		) ?? false;
+
 	// Filter sites list by search query.
 	const filteredSites = useSitesListFiltering( sortedSites, {
 		search: dataViewsState.search,
+		includeA8CSites,
 	} );
 
 	const paginatedSites =

--- a/client/sites/components/sites-dataviews/index.tsx
+++ b/client/sites/components/sites-dataviews/index.tsx
@@ -2,11 +2,13 @@ import { SiteExcerptData } from '@automattic/sites';
 import { DataViews, Field } from '@wordpress/dataviews';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useMemo } from 'react';
+import { useQueryReaderTeams } from 'calypso/components/data/query-reader-teams';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import TimeSince from 'calypso/components/time-since';
 import { SitePlan } from 'calypso/sites-dashboard/components/sites-site-plan';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { isA8cTeamMember } from 'calypso/state/teams/selectors';
 import { useActions } from './actions';
 import SiteField from './dataviews-fields/site-field';
 import SiteIcon from './site-icon';
@@ -87,9 +89,12 @@ const DotcomSitesDataViews = ( {
 
 	const siteStatusGroups = useSiteStatusGroups();
 
+	useQueryReaderTeams();
+	const isAutomattician = useSelector( isA8cTeamMember );
+
 	// Generate DataViews table field-columns
-	const fields = useMemo< Field< SiteExcerptData >[] >(
-		() => [
+	const fields = useMemo( () => {
+		const dataViewFields: Field< SiteExcerptData >[] = [
 			{
 				id: 'icon',
 				render: ( { item }: { item: SiteExcerptData } ) => {
@@ -164,9 +169,31 @@ const DotcomSitesDataViews = ( {
 				enableSorting: true,
 				getValue: () => null,
 			},
-		],
-		[ __, siteStatusGroups, openSitePreviewPane, dataViewsState.type, userId ]
-	);
+		];
+
+		if ( isAutomattician ) {
+			dataViewFields.push( {
+				id: 'a8c_owned',
+				label: __( 'Include A8C sites' ),
+				enableHiding: false,
+				elements: [
+					{
+						value: true,
+						label: __( 'Yes' ),
+					},
+					{
+						value: false,
+						label: __( 'No' ),
+					},
+				],
+				filterBy: {
+					operators: [ 'is' ],
+				},
+			} );
+		}
+
+		return dataViewFields;
+	}, [ __, siteStatusGroups, openSitePreviewPane, dataViewsState.type, userId, isAutomattician ] );
 
 	const actions = useActions( {
 		openSitePreviewPane,

--- a/packages/sites/src/site-type.ts
+++ b/packages/sites/src/site-type.ts
@@ -11,6 +11,7 @@ export interface MinimumSite {
 	launch_status?: string;
 	user_interactions?: string[];
 	is_wpcom_staging_site?: boolean;
+	site_owner?: number;
 	options?: {
 		wpcom_production_blog_id?: number;
 		wpcom_staging_blog_ids?: number[];

--- a/packages/sites/src/use-sites-list-filtering.tsx
+++ b/packages/sites/src/use-sites-list-filtering.tsx
@@ -1,17 +1,21 @@
 import { useFuzzySearch } from '@automattic/search';
+import { useMemo } from 'react';
 import { MinimumSite } from './site-type';
 
 export const SITES_SEARCH_INDEX_KEYS = [ 'name', 'slug', 'title', 'URL' ];
 
 export interface SitesFilterOptions {
 	search?: string;
+	includeA8CSites?: boolean;
 }
 
-type SiteForFiltering = Pick< MinimumSite, 'URL' | 'name' | 'slug' | 'title' >;
+type SiteForFiltering = Pick< MinimumSite, 'URL' | 'name' | 'slug' | 'title' | 'site_owner' >;
+
+const isA8CSite = ( site: SiteForFiltering ) => site.site_owner === 26957695;
 
 export function useSitesListFiltering< T extends SiteForFiltering >(
 	sites: T[],
-	{ search }: SitesFilterOptions
+	{ search, includeA8CSites = false }: SitesFilterOptions
 ) {
 	const filteredSites = useFuzzySearch( {
 		data: sites,
@@ -19,5 +23,11 @@ export function useSitesListFiltering< T extends SiteForFiltering >(
 		query: search,
 	} );
 
-	return filteredSites;
+	return useMemo( () => {
+		if ( ! includeA8CSites ) {
+			return filteredSites.filter( ( site ) => ! isA8CSite( site ) );
+		}
+
+		return filteredSites;
+	}, [ filteredSites, includeA8CSites ] );
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/10459.

## Proposed Changes

Hides A8C-owned sites from site lists. Please do not merge as I'll publish a heads-up post before deploying it.

## Why are these changes being made?

This prevents easy access for A8C-owned sites through site lists (e.g., site switcher, `/sites`). It should avoid the case where the user overlooks the site and changes crucial settings. 

## Testing Instructions

Enter `/sites` with your A8C account and verify you don't see A8C-owned sites by default. It should still be possible to see them by adding the filter:

![image](https://github.com/user-attachments/assets/0cf85f33-b869-400f-b101-9d23922ffb0b)

Enter `/setup/assembler-first` and verify the site picker do not list A8C sites. This is not customizable as the user shouldn't be applying user flows to these kind of sites.
