### PR TITLE
Discover v2: Show verify email notice on "Add new" tab

### DIFF
--- a/client/reader/discover/components/add-new/index.tsx
+++ b/client/reader/discover/components/add-new/index.tsx
@@ -1,4 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
+import Notice from 'calypso/components/notice';
 import { AddSitesForm } from 'calypso/landing/subscriptions/components/add-sites-form';
 import { SiteSubscriptionsList } from 'calypso/landing/subscriptions/components/site-subscriptions-list';
 import {
@@ -6,25 +7,44 @@ import {
 	SubscriptionsPortal,
 } from 'calypso/landing/subscriptions/components/subscription-manager-context';
 import { useSelector } from 'calypso/state';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn, isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 
 import './style.scss';
 
 const DiscoverAddNew = () => {
 	const translate = useTranslate();
 	const isLoggedIn = useSelector( isUserLoggedIn );
+	const isEmailVerified = useSelector( isCurrentUserEmailVerified );
+	const needsEmailVerification = isLoggedIn && ! isEmailVerified;
 
 	return (
 		<div className="discover-add-new">
 			<SubscriptionManagerContextProvider portal={ SubscriptionsPortal.Reader }>
-				<div className="discover-add-new__form">
+				{ needsEmailVerification && (
+					<Notice
+						status="is-warning"
+						showDismiss={ false }
+						text={ translate( 'Please verify your email before subscribing.' ) }
+					>
+						<a href="/me/account" className="notice__action">
+							{ translate( 'Account Settings' ) }
+						</a>
+					</Notice>
+				) }
+				<div
+					className={ `discover-add-new__form${ needsEmailVerification ? ' is-disabled' : '' }` }
+				>
 					<h2 className="discover-add-new__form-title">
 						{ translate( 'Add new sites, newsletters, and RSS feeds to your reading list.' ) }
 					</h2>
 					<AddSitesForm />
 				</div>
 				{ isLoggedIn && (
-					<div className="discover-add-new__subscriptions">
+					<div
+						className={ `discover-add-new__subscriptions${
+							needsEmailVerification ? ' is-disabled' : ''
+						}` }
+					>
 						<h2 className="discover-add-new__subscriptions-title">
 							{ translate( 'Your subscriptions' ) }
 						</h2>

--- a/client/reader/discover/components/add-new/style.scss
+++ b/client/reader/discover/components/add-new/style.scss
@@ -1,7 +1,17 @@
-@import "@automattic/typography/styles/variables";
+@import '@automattic/typography/styles/variables';
 
 .discover-add-new {
 	padding: 10px;
+
+	.notice-banner {
+		margin-bottom: 20px;
+	}
+
+	.is-disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+		pointer-events: none;
+	}
 }
 
 .discover-add-new__form {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/476

## Proposed Changes

* Show a "verify email" notice on the "Add new" tab if the user hasn't verified their email.
* Disable the content of the "Add new" tab using CSS if the user hasn't verified their email.

<img width="1073" alt="Screenshot 2025-02-17 at 5 18 48 PM" src="https://github.com/user-attachments/assets/f8a416be-4516-496a-b055-024ae3820c6e" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve UX. We already show an error message if the user tries to add a new site before verifying their email, but this prevents the user from wasting time entering a valid URL before blocking them due to their unverified email.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Using an account with an unverified email, go to /discover/add-new. You should see a warning notification like the screenshot above. You should not be able to interact with the "Add new" form.
* Using an account with a verified email to go to /discover/add-new. You should NOT see a warning notification.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
