### PR TITLE
Untangle Calypso Settings: Fix the page got redirected to wp-admin after reload

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -319,7 +319,7 @@ export async function redirectToHostingPromoIfNotAtomic( context, next ) {
 
 	if ( ! isAtomicSite || site.plan?.expired ) {
 		// Keep the user within the Settings tab
-		const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( state, dispatch );
+		const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( getState, dispatch );
 		if ( isUntangled ) {
 			return page.redirect( '/sites/settings/site/' + context.params.site_id );
 		}
@@ -402,10 +402,10 @@ export const ssrSetupLocale = ( _context, next ) => {
 
 export const redirectIfDuplicatedView = ( wpAdminPath ) => async ( context, next ) => {
 	const { getState, dispatch } = context.store;
-	const state = getState();
-	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( state, dispatch );
+	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( getState, dispatch );
 
 	if ( isE2ETest() || isUntangled ) {
+		const state = getState();
 		const siteId = getSelectedSiteId( state );
 		const wpAdminUrl = getSiteAdminUrl( state, siteId, wpAdminPath );
 		if ( wpAdminUrl ) {

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -312,13 +312,14 @@ export function redirectIfJetpackNonAtomic( context, next ) {
  * @returns {void}
  */
 export async function redirectToHostingPromoIfNotAtomic( context, next ) {
-	const state = context.store.getState();
+	const { getState, dispatch } = context.store;
+	const state = getState();
 	const site = getSelectedSite( state );
 	const isAtomicSite = !! site?.is_wpcom_atomic || !! site?.is_wpcom_staging_site;
 
 	if ( ! isAtomicSite || site.plan?.expired ) {
 		// Keep the user within the Settings tab
-		const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( context.store.getState() );
+		const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( state, dispatch );
 		if ( isUntangled ) {
 			return page.redirect( '/sites/settings/site/' + context.params.site_id );
 		}
@@ -400,10 +401,11 @@ export const ssrSetupLocale = ( _context, next ) => {
 };
 
 export const redirectIfDuplicatedView = ( wpAdminPath ) => async ( context, next ) => {
-	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( context.store.getState() );
+	const { getState, dispatch } = context.store;
+	const state = getState();
+	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( state, dispatch );
 
 	if ( isE2ETest() || isUntangled ) {
-		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );
 		const wpAdminUrl = getSiteAdminUrl( state, siteId, wpAdminPath );
 		if ( wpAdminUrl ) {

--- a/client/hosting/overview/controller.tsx
+++ b/client/hosting/overview/controller.tsx
@@ -21,9 +21,11 @@ export function hostingOverview( context: PageJSContext, next: () => void ) {
 }
 
 export async function hostingConfiguration( context: PageJSContext, next: () => void ) {
+	const { getState, dispatch } = context.store;
+
 	// Update the url and show the notice after a redirect
 	if ( context.query && context.query.hosting_features === 'activated' ) {
-		context.store.dispatch(
+		dispatch(
 			successNotice( i18n.translate( 'Hosting features activated successfully!' ), {
 				displayOnNextPage: true,
 			} )
@@ -35,7 +37,7 @@ export async function hostingConfiguration( context: PageJSContext, next: () => 
 			removeQueryArgs( window.location.href, 'hosting_features' )
 		);
 	}
-	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( context.store.getState() );
+	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( getState(), dispatch );
 	context.primary = isUntangled ? (
 		<PanelWithSidebar>
 			<SettingsSidebar />
@@ -52,7 +54,8 @@ export async function hostingConfiguration( context: PageJSContext, next: () => 
 }
 
 export async function hostingActivate( context: PageJSContext, next: () => void ) {
-	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( context.store.getState() );
+	const { getState, dispatch } = context.store;
+	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( getState(), dispatch );
 	context.primary = isUntangled ? (
 		<PanelWithSidebar>
 			<SettingsSidebar />

--- a/client/hosting/overview/controller.tsx
+++ b/client/hosting/overview/controller.tsx
@@ -37,7 +37,7 @@ export async function hostingConfiguration( context: PageJSContext, next: () => 
 			removeQueryArgs( window.location.href, 'hosting_features' )
 		);
 	}
-	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( getState(), dispatch );
+	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( getState, dispatch );
 	context.primary = isUntangled ? (
 		<PanelWithSidebar>
 			<SettingsSidebar />
@@ -55,7 +55,7 @@ export async function hostingConfiguration( context: PageJSContext, next: () => 
 
 export async function hostingActivate( context: PageJSContext, next: () => void ) {
 	const { getState, dispatch } = context.store;
-	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( getState(), dispatch );
+	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( getState, dispatch );
 	context.primary = isUntangled ? (
 		<PanelWithSidebar>
 			<SettingsSidebar />

--- a/client/hosting/server-settings/test/index.js
+++ b/client/hosting/server-settings/test/index.js
@@ -121,6 +121,7 @@ const createTestStore = ( {
 		explatExperiments: {
 			experimentAssignments: {},
 		},
+		preferences: {},
 	} );
 	return store;
 };

--- a/client/lib/remove-duplicate-views-experiment/index.ts
+++ b/client/lib/remove-duplicate-views-experiment/index.ts
@@ -7,6 +7,9 @@ import {
 	getIsRemoveDuplicateViewsExperimentOverride,
 	getIsRemoveDuplicateViewsExperimentEnabled,
 } from 'calypso/state/explat-experiments/selectors';
+import { fetchPreferences } from 'calypso/state/preferences/actions';
+import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+import type { CalypsoDispatch } from 'calypso/state/types';
 import type { AppState } from 'calypso/types';
 
 export const REMOVE_DUPLICATE_VIEWS_EXPERIMENT = 'calypso_post_onboarding_holdout_160125';
@@ -14,11 +17,28 @@ export const REMOVE_DUPLICATE_VIEWS_EXPERIMENT_OVERRIDE =
 	'remove_duplicate_views_experiment_assignment_160125';
 const REMOVE_DUPLICATE_VIEWS_EXPERIMENT_AA_TEST = 'calypso_post_onboarding_aa_150125';
 
-export const loadRemoveDuplicateViewsExperimentAssignment = async ( state: AppState ) => {
+const loadRemoveDuplicateViewsExperimentOverride = async (
+	state: AppState,
+	dispatch: CalypsoDispatch
+) => {
+	/**
+	 * The overrideAssignment relies on the preferences so we have to ensure the preferences is fetched.
+	 */
+	if ( ! hasReceivedRemotePreferences( state ) ) {
+		await dispatch( fetchPreferences() );
+	}
+
+	return getIsRemoveDuplicateViewsExperimentOverride( state );
+};
+
+export const loadRemoveDuplicateViewsExperimentAssignment = async (
+	state: AppState,
+	dispatch: CalypsoDispatch
+) => {
 	/**
 	 * This is for escape hatch users to override the experiment assignment: p7DVsv-m73-p2
 	 */
-	const overrideAssignment = getIsRemoveDuplicateViewsExperimentOverride( state );
+	const overrideAssignment = await loadRemoveDuplicateViewsExperimentOverride( state, dispatch );
 	if ( overrideAssignment ) {
 		return overrideAssignment;
 	}
@@ -34,8 +54,14 @@ export const loadRemoveDuplicateViewsExperimentAssignment = async ( state: AppSt
 	return experimentAssignment?.variationName;
 };
 
-export const isRemoveDuplicateViewsExperimentEnabled = async ( state: AppState ) => {
-	const experimentAssignment = await loadRemoveDuplicateViewsExperimentAssignment( state );
+export const isRemoveDuplicateViewsExperimentEnabled = async (
+	state: AppState,
+	dispatch: CalypsoDispatch
+) => {
+	const experimentAssignment = await loadRemoveDuplicateViewsExperimentAssignment(
+		state,
+		dispatch
+	);
 	if ( experimentAssignment === 'treatment' ) {
 		return true;
 	}

--- a/client/lib/remove-duplicate-views-experiment/index.ts
+++ b/client/lib/remove-duplicate-views-experiment/index.ts
@@ -18,27 +18,27 @@ export const REMOVE_DUPLICATE_VIEWS_EXPERIMENT_OVERRIDE =
 const REMOVE_DUPLICATE_VIEWS_EXPERIMENT_AA_TEST = 'calypso_post_onboarding_aa_150125';
 
 const loadRemoveDuplicateViewsExperimentOverride = async (
-	state: AppState,
+	getState: () => AppState,
 	dispatch: CalypsoDispatch
 ) => {
 	/**
 	 * The overrideAssignment relies on the preferences so we have to ensure the preferences is fetched.
 	 */
-	if ( ! hasReceivedRemotePreferences( state ) ) {
+	if ( ! hasReceivedRemotePreferences( getState() ) ) {
 		await dispatch( fetchPreferences() );
 	}
 
-	return getIsRemoveDuplicateViewsExperimentOverride( state );
+	return getIsRemoveDuplicateViewsExperimentOverride( getState() );
 };
 
 export const loadRemoveDuplicateViewsExperimentAssignment = async (
-	state: AppState,
+	getState: () => AppState,
 	dispatch: CalypsoDispatch
 ) => {
 	/**
 	 * This is for escape hatch users to override the experiment assignment: p7DVsv-m73-p2
 	 */
-	const overrideAssignment = await loadRemoveDuplicateViewsExperimentOverride( state, dispatch );
+	const overrideAssignment = await loadRemoveDuplicateViewsExperimentOverride( getState, dispatch );
 	if ( overrideAssignment ) {
 		return overrideAssignment;
 	}
@@ -55,11 +55,11 @@ export const loadRemoveDuplicateViewsExperimentAssignment = async (
 };
 
 export const isRemoveDuplicateViewsExperimentEnabled = async (
-	state: AppState,
+	getState: () => AppState,
 	dispatch: CalypsoDispatch
 ) => {
 	const experimentAssignment = await loadRemoveDuplicateViewsExperimentAssignment(
-		state,
+		getState,
 		dispatch
 	);
 	if ( experimentAssignment === 'treatment' ) {

--- a/client/lib/remove-duplicate-views-experiment/test/index.ts
+++ b/client/lib/remove-duplicate-views-experiment/test/index.ts
@@ -1,30 +1,45 @@
+import configureStore from 'redux-mock-store';
+import { thunk } from 'redux-thunk';
 import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { loadRemoveDuplicateViewsExperimentAssignment } from '../index';
-import type { AppState } from 'calypso/types';
 
 jest.mock( 'calypso/lib/explat', () => ( {
 	loadExperimentAssignment: jest.fn(),
 } ) );
 
+const createTestStore = ( state = {} ) => {
+	const middlewares = [ thunk ];
+	const mockStore = configureStore( middlewares );
+	return mockStore( state );
+};
+
 describe( 'loadRemoveDuplicateViewsExperimentAssignment', () => {
 	it( 'returns override if present', async () => {
-		const mockState = {
+		const store = createTestStore( {
 			preferences: {
 				localValues: {
 					remove_duplicate_views_experiment_assignment_160125: 'control',
 				},
 			},
-		} as AppState;
-		const result = await loadRemoveDuplicateViewsExperimentAssignment( mockState );
+		} );
+		const result = await loadRemoveDuplicateViewsExperimentAssignment(
+			store.getState,
+			store.dispatch
+		);
 		expect( result ).toBe( 'control' );
 	} );
 
 	it( 'calls experiment assignment when no override', async () => {
-		const mockState = {} as AppState;
+		const store = createTestStore( {
+			preferences: {},
+		} );
 
 		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( { variationName: 'treatment' } );
 
-		const result = await loadRemoveDuplicateViewsExperimentAssignment( mockState );
+		const result = await loadRemoveDuplicateViewsExperimentAssignment(
+			store.getState,
+			store.dispatch
+		);
 
 		expect( loadExperimentAssignment ).toHaveBeenCalledWith( 'calypso_post_onboarding_aa_150125' );
 		expect( loadExperimentAssignment ).toHaveBeenCalledWith(

--- a/client/my-sites/site-settings/settings-controller.js
+++ b/client/my-sites/site-settings/settings-controller.js
@@ -39,7 +39,7 @@ export function redirectToJetpackNewsletterSettingsIfNeeded( context, next ) {
  */
 export const redirectToolsIfRemoveDuplicateViewsExperimentEnabled = async ( context, next ) => {
 	const { getState, dispatch } = context.store;
-	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( getState(), dispatch );
+	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( getState, dispatch );
 
 	if ( isUntangled ) {
 		const slug = context.path.split( '/' )[ 2 ];
@@ -78,7 +78,7 @@ export const redirectToolsIfRemoveDuplicateViewsExperimentEnabled = async ( cont
  */
 export const redirectSettingsIfDuplciatedViewsEnabled = async ( context ) => {
 	const { getState, dispatch } = context.store;
-	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( getState(), dispatch );
+	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( getState, dispatch );
 
 	if ( isUntangled ) {
 		return page.redirect( `/sites/settings/site` );
@@ -93,9 +93,8 @@ export const redirectSettingsIfDuplciatedViewsEnabled = async ( context ) => {
  */
 export async function redirectSiteSettingsIfDuplicatedViewsDisabled( context, next ) {
 	const { getState, dispatch } = context.store;
-	const state = getState();
-	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( state, dispatch );
-	const siteSlug = getSelectedSiteSlug( state );
+	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( getState, dispatch );
+	const siteSlug = getSelectedSiteSlug( getState() );
 
 	if ( ! isUntangled ) {
 		return page.redirect( `/settings/general/${ siteSlug }` );

--- a/client/my-sites/site-settings/settings-controller.js
+++ b/client/my-sites/site-settings/settings-controller.js
@@ -38,7 +38,8 @@ export function redirectToJetpackNewsletterSettingsIfNeeded( context, next ) {
  * @returns
  */
 export const redirectToolsIfRemoveDuplicateViewsExperimentEnabled = async ( context, next ) => {
-	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( context.store.getState() );
+	const { getState, dispatch } = context.store;
+	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( getState(), dispatch );
 
 	if ( isUntangled ) {
 		const slug = context.path.split( '/' )[ 2 ];
@@ -76,7 +77,8 @@ export const redirectToolsIfRemoveDuplicateViewsExperimentEnabled = async ( cont
  * - /settings/general can always redirect to /wp-admin/options-general.php
  */
 export const redirectSettingsIfDuplciatedViewsEnabled = async ( context ) => {
-	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( context.store.getState() );
+	const { getState, dispatch } = context.store;
+	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( getState(), dispatch );
 
 	if ( isUntangled ) {
 		return page.redirect( `/sites/settings/site` );
@@ -90,8 +92,9 @@ export const redirectSettingsIfDuplciatedViewsEnabled = async ( context ) => {
  * since /sites/settings/site/:site looks broken for those users.
  */
 export async function redirectSiteSettingsIfDuplicatedViewsDisabled( context, next ) {
-	const state = context.store.getState();
-	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( state );
+	const { getState, dispatch } = context.store;
+	const state = getState();
+	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( state, dispatch );
 	const siteSlug = getSelectedSiteSlug( state );
 
 	if ( ! isUntangled ) {

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -35,6 +35,7 @@ import editorReducer from 'calypso/state/editor/reducer';
 import explatExperimentsReducer from 'calypso/state/explat-experiments/reducers';
 import jetpackReducer from 'calypso/state/jetpack/reducer';
 import mediaReducer from 'calypso/state/media/reducer';
+import preferencesReducer from 'calypso/state/preferences/reducer';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import siteSettingsReducer from 'calypso/state/site-settings/reducer';
 import timezonesReducer from 'calypso/state/timezones/reducer';
@@ -66,6 +67,7 @@ const initialState = {
 	},
 	ui: {},
 	jetpack: {},
+	preferences: {},
 };
 
 function renderWithRedux( ui, customInitialState = {} ) {
@@ -82,6 +84,7 @@ function renderWithRedux( ui, customInitialState = {} ) {
 			ui: uiReducer,
 			jetpack: jetpackReducer,
 			explatExperiments: explatExperimentsReducer,
+			preferences: preferencesReducer,
 		},
 	} );
 }

--- a/client/sites/settings/administration/controller.ts
+++ b/client/sites/settings/administration/controller.ts
@@ -53,7 +53,8 @@ export function redirectIfCantStartSiteOwnerTransfer( context: PageJSContext, ne
 }
 
 async function redirectToAdministration( context: PageJSContext, siteSlug: string | null ) {
-	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( context.store.getState() );
+	const { getState, dispatch } = context.store;
+	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( getState(), dispatch );
 	return isUntangled
 		? page.redirect( '/sites/settings/site/' + siteSlug )
 		: page.redirect( '/settings/general/' + siteSlug );

--- a/client/sites/settings/administration/controller.ts
+++ b/client/sites/settings/administration/controller.ts
@@ -54,7 +54,7 @@ export function redirectIfCantStartSiteOwnerTransfer( context: PageJSContext, ne
 
 async function redirectToAdministration( context: PageJSContext, siteSlug: string | null ) {
 	const { getState, dispatch } = context.store;
-	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( getState(), dispatch );
+	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( getState, dispatch );
 	return isUntangled
 		? page.redirect( '/sites/settings/site/' + siteSlug )
 		: page.redirect( '/settings/general/' + siteSlug );

--- a/client/sites/settings/administration/tools/delete-site/test/index.js
+++ b/client/sites/settings/administration/tools/delete-site/test/index.js
@@ -40,6 +40,7 @@ const initialState = {
 	explatExperiments: {
 		experimentAssignments: {},
 	},
+	preferences: {},
 };
 
 const mockDeleteSite = jest.fn();

--- a/client/state/explat-experiments/actions.ts
+++ b/client/state/explat-experiments/actions.ts
@@ -22,8 +22,10 @@ export const getExperimentAssignment = ( experimentName: string ) => {
 
 export const getRemoveDuplicateViewsExperimentAssignment = () => {
 	return async ( dispatch: CalypsoDispatch, getState: () => AppState ) => {
-		const state = getState();
-		const experimentAssignment = await loadRemoveDuplicateViewsExperimentAssignment( state );
+		const experimentAssignment = await loadRemoveDuplicateViewsExperimentAssignment(
+			getState,
+			dispatch
+		);
 		dispatch( {
 			type: EXPERIMENT_ASSIGNMENT_RECEIVE,
 			experimentName: REMOVE_DUPLICATE_VIEWS_EXPERIMENT,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1739514607975719/1739500138.346709-slack-CRWCHQGUB

## Proposed Changes

* The Settings on the Hosting Overview got redirected to the WP Admin because of the overrideAssignment. p1739514607975719/1739500138.346709-slack-CRWCHQGUB describes the root cause that the preferences weren't not available at the beginning so `/settings/general` is allowed to load instead of `/sites/settings/site` and then got redirected to WP Admin.
* This PR proposed to ensure the preferences is loaded before we check the result of the overrideAssignment to resolve the above issue. Maybe we can make `isRemoveDuplicateViewsExperimentEnabled` to an thunk action 🤔

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Settings on the Hosting Overview is not available due to redirection

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Clear the `Indexed DB > calypso > calypso_store` via DevTools > Application
* Ensure the result of the `calypso_post_onboarding_holdout_160125` exp on your user is `control`
* Ensure the result of the `remove_duplicate_views_experiment_assignment_160125` on your user preferences is `treatment`
* Go to `/sites/settings/site/:site` directly
* Ensure it won't be redirected to WP Admin

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?