### PR TITLE
Focused Launchpad: Add extra track events to fullscreen launchpad

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -5,9 +5,8 @@ import { useTranslate } from 'i18n-calypso';
 import { type FC } from 'react';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import { useGoalsFirstCumulativeExperience } from 'calypso/data/experiment/use-goals-first-cumulative-experience';
 import { useLaunchpad } from './use-launchpad';
-
+import { useLaunchpadContext } from './utils';
 import './style.scss';
 
 interface CustomerHomeLaunchpadProps {
@@ -93,14 +92,5 @@ const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( {
 		</div>
 	);
 };
-
-function useLaunchpadContext() {
-	const [ isLoading, isCumulative ] = useGoalsFirstCumulativeExperience();
-	if ( isLoading ) {
-		return null;
-	}
-
-	return isCumulative ? 'customer-home-treatment-cumulative' : 'customer-home';
-}
 
 export default CustomerHomeLaunchpad;

--- a/client/my-sites/customer-home/cards/launchpad/utils.ts
+++ b/client/my-sites/customer-home/cards/launchpad/utils.ts
@@ -1,0 +1,10 @@
+import { useGoalsFirstCumulativeExperience } from 'calypso/data/experiment/use-goals-first-cumulative-experience';
+
+export function useLaunchpadContext() {
+	const [ isLoading, isCumulative ] = useGoalsFirstCumulativeExperience();
+	if ( isLoading ) {
+		return null;
+	}
+
+	return isCumulative ? 'customer-home-treatment-cumulative' : 'customer-home';
+}

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -10,12 +10,14 @@ import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { launchSiteApi } from 'calypso/lib/signup/step-actions';
 import { useDispatch } from 'calypso/state';
+import { recordEvent } from 'calypso/state/analytics/actions';
 import { requestSite } from 'calypso/state/sites/actions';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
 import { useLaunchpad } from '../cards/launchpad/use-launchpad';
 import './full-screen-launchpad.scss';
+import { useLaunchpadContext } from '../cards/launchpad/utils';
 
 export const FullScreenLaunchpad = ( {
 	onClose,
@@ -32,7 +34,7 @@ export const FullScreenLaunchpad = ( {
 	const checklistSlug = site?.options?.site_intent ?? '';
 	const layout = useHomeLayoutQuery( siteId || null );
 
-	const launchpadContext = 'customer-home';
+	const launchpadContext = useLaunchpadContext() ?? 'customer-home';
 
 	const {
 		siteSlug,
@@ -59,6 +61,7 @@ export const FullScreenLaunchpad = ( {
 					await refetch?.();
 					await layout?.refetch();
 					await dispatch( requestSite( siteId ) );
+					recordEvent( 'calypso_full_screen_launchpad_launch_site' );
 					onSiteLaunch();
 				} finally {
 					setIsLaunching( false );
@@ -76,6 +79,8 @@ export const FullScreenLaunchpad = ( {
 			siteSlug,
 			redirectToHome: false,
 		} );
+
+		recordEvent( 'calypso_full_screen_launchpad_skip' );
 
 		dispatch( requestSite( siteId ) );
 	};
@@ -118,7 +123,6 @@ export const FullScreenLaunchpad = ( {
 					checklistSlug={ checklistSlug }
 					launchpadContext={ launchpadContext }
 					onPostFilterTasks={ ( tasks ) => tasks.filter( ( task ) => ! task.isLaunchTask ) }
-					onSiteLaunched={ onSiteLaunched }
 					highlightNextAction
 				/>
 				<div className="launchpad-actions">

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -10,7 +10,7 @@ import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { launchSiteApi } from 'calypso/lib/signup/step-actions';
 import { useDispatch } from 'calypso/state';
-import { recordEvent } from 'calypso/state/analytics/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestSite } from 'calypso/state/sites/actions';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -61,7 +61,7 @@ export const FullScreenLaunchpad = ( {
 					await refetch?.();
 					await layout?.refetch();
 					await dispatch( requestSite( siteId ) );
-					recordEvent( 'calypso_full_screen_launchpad_launch_site' );
+					recordTracksEvent( 'calypso_full_screen_launchpad_launch_site' );
 					onSiteLaunch();
 				} finally {
 					setIsLaunching( false );
@@ -80,7 +80,9 @@ export const FullScreenLaunchpad = ( {
 			redirectToHome: false,
 		} );
 
-		recordEvent( 'calypso_full_screen_launchpad_skip' );
+		recordTracksEvent( 'calypso_full_screen_launchpad_skip', {
+			context: launchpadContext,
+		} );
 
 		dispatch( requestSite( siteId ) );
 	};

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { CircularProgressBar } from '@automattic/components';
 import { updateLaunchpadSettings, useSortedLaunchpadTasks } from '@automattic/data-stores';
 import { Launchpad, Task } from '@automattic/launchpad';
@@ -10,7 +11,6 @@ import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { launchSiteApi } from 'calypso/lib/signup/step-actions';
 import { useDispatch } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestSite } from 'calypso/state/sites/actions';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -61,7 +61,9 @@ export const FullScreenLaunchpad = ( {
 					await refetch?.();
 					await layout?.refetch();
 					await dispatch( requestSite( siteId ) );
-					recordTracksEvent( 'calypso_full_screen_launchpad_launch_site' );
+					recordTracksEvent( 'calypso_full_screen_launchpad_launch_site', {
+						context: launchpadContext,
+					} );
 					onSiteLaunch();
 				} finally {
 					setIsLaunching( false );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98784

## Proposed Changes

* Include the `customer-home-treatment-cumulative` prop to fullscreen launchpad tasks events
* Add `calypso_full_screen_launchpad_skip` and `calypso_full_screen_launchpad_launch_site` events to track the `Launch site` and `Skip to dashboard` CTAs

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the fullscreen launchpad is shown using the `flags=home/launchpad-first` at `/home/:site`
* Perform the `Skip to dashboard` and `Launch site` actions from the fullscreen launchpad
* Verify the events are being recorded.

![image](https://github.com/user-attachments/assets/4993f0be-6f4b-4073-a0f8-5d0b27181ce0)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
