### PR TITLE
Replace the `launchpad-first` flag with the goals-first cumulative experiment

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -16,7 +16,7 @@ import { urlToSlug } from 'calypso/lib/url';
 import { useSelector, useDispatch } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
-import shouldShowLaunchpadFirst from 'calypso/state/selectors/should-show-launchpad-first';
+import { useShouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
 import { useQuery } from '../../../../hooks/use-query';
 import StepContent from './step-content';
 import { areLaunchpadTasksCompleted } from './task-helper';
@@ -92,8 +92,11 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 		}
 	}, [ verifiedParam, translate, dispatch ] );
 
+	const [ loadingShouldShowLaunchpadFirst, shouldShowLaunchpadFirst ] =
+		useShouldShowLaunchpadFirst( site );
+
 	// Avoid screen flickering when redirecting to other paths
-	if ( ! site?.options ) {
+	if ( ! site?.options || loadingShouldShowLaunchpadFirst ) {
 		return null;
 	}
 
@@ -102,7 +105,7 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 		return null;
 	}
 
-	if ( shouldShowLaunchpadFirst( site ) ) {
+	if ( shouldShowLaunchpadFirst ) {
 		window.location.replace( `/home/${ siteSlug }` );
 		return null;
 	}

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -77,7 +77,7 @@ export async function maybeRedirect( context, next ) {
 
 	const site = getSelectedSite( state );
 
-	if ( shouldShowLaunchpadFirst( site ) ) {
+	if ( await shouldShowLaunchpadFirst( site ) ) {
 		return next();
 	}
 

--- a/client/my-sites/customer-home/test/customer-home.tsx
+++ b/client/my-sites/customer-home/test/customer-home.tsx
@@ -13,12 +13,15 @@ import type { SiteDetails } from '@automattic/data-stores';
 
 jest.mock( '@wordpress/api-fetch' );
 
+let mockUseExperimentResult = [ false, true ];
+
 jest.mock( 'calypso/lib/explat', () => ( {
 	loadExperimentAssignment: jest.fn( ( slug ) =>
 		slug === 'calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131'
 			? Promise.resolve( { variationName: 'treatment_cumulative' } )
 			: Promise.reject( new Error( `Unmocked experiment slug: ${ slug }` ) )
 	),
+	useExperiment: jest.fn( () => mockUseExperimentResult ),
 } ) );
 
 jest.mock( '../components/home-content', () => () => (
@@ -174,6 +177,7 @@ describe( 'CustomerHome', () => {
 	} );
 
 	it( 'shows home content when site would be eligible to show launchpad, but user is in treatment_frozen group', async () => {
+		mockUseExperimentResult = [ false, false ];
 		const testSite = makeTestSite( {
 			launch_status: 'unlaunched',
 			options: { site_creation_flow: 'onboarding', launchpad_screen: false },

--- a/client/my-sites/customer-home/test/customer-home.tsx
+++ b/client/my-sites/customer-home/test/customer-home.tsx
@@ -43,13 +43,13 @@ function makeTestSite( site: Partial< SiteDetails > = {} ): SiteDetails {
 		URL: 'https://example.com',
 		domain: 'example.com',
 		launch_status: 'launched',
+		...site,
 		options: {
 			site_creation_flow: 'onboarding',
 			launchpad_screen: false,
 			created_at: '2025-02-17T00:00:00+00:00',
 			...site.options,
 		},
-		...site,
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	} as any; // This partial site object should be good enough for testing purposes
 }

--- a/client/my-sites/customer-home/test/customer-home.tsx
+++ b/client/my-sites/customer-home/test/customer-home.tsx
@@ -5,6 +5,7 @@ import { screen, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 import nock from 'nock';
 import React, { act } from 'react';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { reducer as ui } from 'calypso/state/ui/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import CustomerHome from '../main';
@@ -12,7 +13,7 @@ import type { SiteDetails } from '@automattic/data-stores';
 
 jest.mock( '@wordpress/api-fetch' );
 
-jest.mock( '../../../lib/explat', () => ( {
+jest.mock( 'calypso/lib/explat', () => ( {
 	loadExperimentAssignment: jest.fn( ( slug ) =>
 		slug === 'calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131'
 			? Promise.resolve( { variationName: 'treatment_cumulative' } )
@@ -157,5 +158,33 @@ describe( 'CustomerHome', () => {
 		act( () => launchSiteButton.click() );
 
 		expect( await screen.findByText( 'Congrats, your site is live!' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows home content when site would be eligible to show launchpad, but user is in control group', async () => {
+		const testSite = makeTestSite( {
+			launch_status: 'unlaunched',
+			options: { site_creation_flow: 'onboarding', launchpad_screen: false },
+		} );
+		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( { variationName: 'control' } );
+
+		renderWithProvider( <CustomerHome site={ testSite } /> );
+
+		await waitFor( () => expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument() );
+		expect( screen.queryByTestId( 'launchpad-first' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows home content when site would be eligible to show launchpad, but user is in treatment_frozen group', async () => {
+		const testSite = makeTestSite( {
+			launch_status: 'unlaunched',
+			options: { site_creation_flow: 'onboarding', launchpad_screen: false },
+		} );
+		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
+			variationName: 'treatment_frozen',
+		} );
+
+		renderWithProvider( <CustomerHome site={ testSite } /> );
+
+		await waitFor( () => expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument() );
+		expect( screen.queryByTestId( 'launchpad-first' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/my-sites/customer-home/test/customer-home.tsx
+++ b/client/my-sites/customer-home/test/customer-home.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 import nock from 'nock';
 import React, { act } from 'react';
@@ -12,11 +12,13 @@ import type { SiteDetails } from '@automattic/data-stores';
 
 jest.mock( '@wordpress/api-fetch' );
 
-jest.mock( '@automattic/calypso-config', () => {
-	const config = () => 'development';
-	config.isEnabled = ( property: string ) => property === 'home/launchpad-first';
-	return config;
-} );
+jest.mock( '../../../lib/explat', () => ( {
+	loadExperimentAssignment: jest.fn( ( slug ) =>
+		slug === 'calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131'
+			? Promise.resolve( { variationName: 'treatment_cumulative' } )
+			: Promise.reject( new Error( `Unmocked experiment slug: ${ slug }` ) )
+	),
+} ) );
 
 jest.mock( '../components/home-content', () => () => (
 	<div data-testid="home-content">Home Content</div>
@@ -41,7 +43,12 @@ function makeTestSite( site: Partial< SiteDetails > = {} ): SiteDetails {
 		URL: 'https://example.com',
 		domain: 'example.com',
 		launch_status: 'launched',
-		options: { site_creation_flow: 'onboarding', launchpad_screen: false, ...site.options },
+		options: {
+			site_creation_flow: 'onboarding',
+			launchpad_screen: false,
+			created_at: '2025-02-17T00:00:00+00:00',
+			...site.options,
+		},
 		...site,
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	} as any; // This partial site object should be good enough for testing purposes
@@ -56,16 +63,16 @@ describe( 'CustomerHome', () => {
 		nock.cleanAll();
 	} );
 
-	it( 'should show HomeContent for launched site', () => {
+	it( 'should show HomeContent for launched site', async () => {
 		const testSite = makeTestSite( { launch_status: 'launched' } );
 
 		renderWithProvider( <CustomerHome site={ testSite } /> );
 
-		expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument();
+		await waitFor( () => expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument() );
 		expect( screen.queryByTestId( 'launchpad-first' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'should show HomeContent for unlaunched site when launchpad is skipped', () => {
+	it( 'should show HomeContent for unlaunched site when launchpad is skipped', async () => {
 		const testSite = makeTestSite( {
 			launch_status: 'unlaunched',
 			options: { launchpad_screen: 'skipped' },
@@ -73,7 +80,7 @@ describe( 'CustomerHome', () => {
 
 		renderWithProvider( <CustomerHome site={ testSite } /> );
 
-		expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument();
+		await waitFor( () => expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument() );
 		expect( screen.queryByTestId( 'launchpad-first' ) ).not.toBeInTheDocument();
 	} );
 
@@ -85,7 +92,7 @@ describe( 'CustomerHome', () => {
 
 		renderWithProvider( <CustomerHome site={ testSite } /> );
 
-		expect( screen.getByTestId( 'launchpad-first' ) ).toBeInTheDocument();
+		await waitFor( () => expect( screen.getByTestId( 'launchpad-first' ) ).toBeInTheDocument() );
 		expect( screen.queryByTestId( 'home-content' ) ).not.toBeInTheDocument();
 
 		// Click the close button

--- a/client/state/selectors/should-show-launchpad-first.ts
+++ b/client/state/selectors/should-show-launchpad-first.ts
@@ -1,19 +1,66 @@
-import config from '@automattic/calypso-config';
 import { SiteDetails, Onboard } from '@automattic/data-stores';
+import { useEffect, useState } from 'react';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 
 const SiteIntent = Onboard.SiteIntent;
 
 /**
  * Determines if the launchpad should be shown first based on site createion flow
- * @param {SiteDetails|undefined} site Site object
- * @returns {boolean} Whether launchpad should be shown first
+ * @param site Site object
+ * @returns Whether launchpad should be shown first
  */
-export const shouldShowLaunchpadFirst = ( site: SiteDetails ) => {
-	const isLaunchpadFirstEnabled = config.isEnabled( 'home/launchpad-first' );
-	const wasSiteCreatedOnboardingFlow = site?.options?.site_creation_flow === 'onboarding';
-	const isNotBigSkyIntent = site?.options?.site_intent !== SiteIntent.AIAssembler;
+export const shouldShowLaunchpadFirst = async ( site: SiteDetails ): Promise< boolean > => {
+	const wasSiteCreatedOnboardingFlow = site.options?.site_creation_flow === 'onboarding';
+	const createdAfterExperimentStart =
+		( site.options?.created_at ?? '' ) > '2025-02-03T10:22:45+00:00'; // If created_at is null then this expression is false
+	const isBigSkyIntent = site?.options?.site_intent === SiteIntent.AIAssembler;
 
-	return isLaunchpadFirstEnabled && wasSiteCreatedOnboardingFlow && isNotBigSkyIntent;
+	if ( isBigSkyIntent || ! wasSiteCreatedOnboardingFlow || ! createdAfterExperimentStart ) {
+		return false;
+	}
+
+	const assignment = await loadExperimentAssignment(
+		'calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131'
+	);
+
+	return assignment?.variationName === 'treatment_cumulative';
 };
 
-export default shouldShowLaunchpadFirst;
+export const useShouldShowLaunchpadFirst = ( site?: SiteDetails | null ): [ boolean, boolean ] => {
+	const [ state, setState ] = useState< boolean | 'loading' >( 'loading' );
+
+	useEffect( () => {
+		let cancel = false;
+
+		const getResponse = async () => {
+			if ( ! site ) {
+				return;
+			}
+
+			try {
+				setState( 'loading' );
+				const result = await shouldShowLaunchpadFirst( site );
+				if ( ! cancel ) {
+					setState( result );
+				}
+			} catch ( err ) {
+				if ( ! cancel ) {
+					setState( false );
+				}
+			}
+		};
+
+		getResponse();
+
+		return () => {
+			cancel = true;
+		};
+	}, [ site ] );
+
+	if ( ! site ) {
+		// If the site isn't available yet we'll assume we're still loading
+		return [ true, false ];
+	}
+
+	return [ state === 'loading', state === 'loading' ? false : state ];
+};

--- a/config/development.json
+++ b/config/development.json
@@ -69,7 +69,6 @@
 		"global-styles/on-personal-plan": true,
 		"help": true,
 		"help/gpt-response": true,
-		"home/launchpad-first": false,
 		"home/layout-dev": true,
 		"hosting-server-settings-enhancements": true,
 		"hosting/datacenter-picker": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -35,7 +35,6 @@
 		"google-my-business": false,
 		"global-styles/on-personal-plan": true,
 		"help": true,
-		"home/launchpad-first": false,
 		"home/layout-dev": true,
 		"hosting-server-settings-enhancements": true,
 		"i18n/empathy-mode": false,

--- a/config/production.json
+++ b/config/production.json
@@ -48,7 +48,6 @@
 		"global-styles/on-personal-plan": true,
 		"help": true,
 		"help/gpt-response": true,
-		"home/launchpad-first": false,
 		"hosting-server-settings-enhancements": true,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -48,7 +48,6 @@
 		"global-styles/on-personal-plan": true,
 		"help": true,
 		"help/gpt-response": true,
-		"home/launchpad-first": false,
 		"hosting-server-settings-enhancements": true,
 		"i18n/empathy-mode": true,
 		"importer/site-backups": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -53,7 +53,6 @@
 		"global-styles/on-personal-plan": true,
 		"help": true,
 		"help/gpt-response": true,
-		"home/launchpad-first": true,
 		"home/layout-dev": true,
 		"hosting/datacenter-picker": true,
 		"hosting-server-settings-enhancements": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #99879

## Proposed Changes

I thought I would simply take the hook approach we've usually taken for experiments: replacing the `shouldShowLaunchpadFirst()` function with a `useShouldShowLaunchpadFirst()`. And it'd even be able to share logic with the `useGoalsFirstCumulativeExperience()` hook 👍.

The difference with this experiment though is that we need access to experiment assignment in the My Home control, and we can't use hooks there. So instead, this PR uses a promise-based approach to loading the experiment assignment, and wraps it in a hook when it needs to be used in React components.

* Convert `shouldShowLaunchpadFirst()` into an async function
* Replace the feature flag check with an experiment assignment
* Add logic to ensure we only give users the launchpad first experience when their site was created after the goals-first experiment started
  * Otherwise we'll be treating them as if they were in the cumulative experience when they never created their site with the goals-first experiment at all
* Create `useGoalsFirstCumulativeExperience()` hook for wrapping the `shouldShowLaunchpadFirst()`

**With Experiment**

https://github.com/user-attachments/assets/3871ee53-a24b-45d0-9ffd-76b0b40bb8c0

**Control**
(excuse the debugger 🙂)

https://github.com/user-attachments/assets/11f32280-a38e-4918-8ea8-de3db6107d54




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Switching from a feature flag to an experiment allows us to actually launch to customers.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself to an experiment cohort here: 22180-explat-experiment
* Test on a site you created a while ago (you should not get the focused launchpad)
* Test on a fresh site (you should get the focused launchpad if you were in the cumulative variant)
* Test with Big Sky, you should not see the launchpad

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?