### PR TITLE
Sites Dashboard: Remove behavior of closing the Sites View via pressing Esc

### DIFF
--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { SiteExcerptData } from '@automattic/sites';
 import { useI18n } from '@wordpress/react-i18n';
-import React, { useMemo, useEffect } from 'react';
+import React, { useMemo } from 'react';
 import ItemView from 'calypso/layout/hosting-dashboard/item-view';
 import { useRemoveDuplicateViewsExperimentEnabled } from 'calypso/lib/remove-duplicate-views-experiment';
 import HostingFeaturesIcon from 'calypso/sites/hosting-features/components/hosting-features-icon';
@@ -60,12 +60,6 @@ interface Props {
 	closeSitePreviewPane: () => void;
 	changeSitePreviewPane: ( siteId: number ) => void;
 }
-
-const OVERLAY_MODAL_SELECTORS = [
-	'body.modal-open',
-	'#wpnc-panel.wpnt-open',
-	'div.help-center__container:not(.is-minimized)',
-];
 
 const DotcomPreviewPane = ( {
 	site,
@@ -238,25 +232,6 @@ const DotcomPreviewPane = ( {
 		adminUrl: site.options?.admin_url || `${ site.URL }/wp-admin`,
 		withIcon: true,
 	};
-
-	useEffect( () => {
-		const handleKeydown = ( e: KeyboardEvent ) => {
-			if ( e.key !== 'Escape' ) {
-				return;
-			}
-
-			if ( document.querySelector( OVERLAY_MODAL_SELECTORS.join( ',' ) ) ) {
-				return;
-			}
-
-			closeSitePreviewPane();
-		};
-
-		document.addEventListener( 'keydown', handleKeydown, true );
-		return () => {
-			document.removeEventListener( 'keydown', handleKeydown, true );
-		};
-	}, [ closeSitePreviewPane ] );
 
 	const { data: stagingSites } = useStagingSite( site.ID, {
 		enabled: ! site.is_wpcom_staging_site && site.is_wpcom_atomic,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/98236

## Proposed Changes

This PR removes the behavior introduced in https://github.com/Automattic/wp-calypso/pull/90422. As mentioned in https://github.com/Automattic/wp-calypso/issues/98236, this behavior might be too unexpected for users who intended to use the Escape key to close popovers. Removing this behavior also makes it consistent with other DataViews implementations, such as Domains Management or A4A Sites Dashboard.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Overall WP.com polish.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /sites
* Click a site to bring up the Sites View
* Press the Escape key and ensure that the Sites View does not close

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
