### PR TITLE
Open the side panel instead of reloading the page

### DIFF
--- a/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
@@ -3,6 +3,7 @@ import { Icon } from '@wordpress/components';
 import { lock } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { navigate } from 'calypso/lib/navigate'; // eslint-disable-line no-restricted-imports
 
 interface DomainsTableSslCellProps {
 	domainManagementLink: string;
@@ -40,13 +41,15 @@ export default function DomainsTableSslCell( {
 
 	if ( sslStatus ) {
 		button = (
-			<a
+			<button
 				className="domains-table-row__ssl-status-button"
-				href={ `${ domainManagementLink }?ssl-open=true` }
-				onClick={ ( event ) => event.stopPropagation() }
+				onClick={ ( event ) => {
+					event.stopPropagation();
+					navigate( `${ domainManagementLink }?ssl-open=true` );
+				} }
 			>
 				{ getSslStatusText() }
-			</a>
+			</button>
 		);
 	} else if ( hasWpcomManagedSslCert ) {
 		button = <span>{ translate( 'Active' ) }</span>;

--- a/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
@@ -1,9 +1,9 @@
+import page from '@automattic/calypso-router';
 import { DomainData } from '@automattic/data-stores';
 import { Icon } from '@wordpress/components';
 import { lock } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { navigate } from 'calypso/lib/navigate'; // eslint-disable-line no-restricted-imports
 
 interface DomainsTableSslCellProps {
 	domainManagementLink: string;
@@ -45,7 +45,7 @@ export default function DomainsTableSslCell( {
 				className="domains-table-row__ssl-status-button"
 				onClick={ ( event ) => {
 					event.stopPropagation();
-					navigate( `${ domainManagementLink }?ssl-open=true` );
+					page.show( `${ domainManagementLink }?ssl-open=true` );
 				} }
 			>
 				{ getSslStatusText() }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #99908 

## Proposed Changes

* Open the side panel without reloading the page.

## Why are these changes being made?

* We want to address CfT feedback, make UX more consistent.

## Testing Instructions

* Turn on feature flags in your browser's console: `window.sessionStorage.setItem('flags',  'calypso/domains-dataviews'])`
* Go to http://calypso.localhost:3000/domains/manage
* Revise SSL column, make sure the status looks properly (no changes in appearance).
* Click on "Active" or "Pending" in the SSL column.
* Make sure the pane on the right opened without reloading the page.
* Now disable DataViews: `window.sessionStorage.removeItem('flags');` and repeat the test.
* Make sure the previous version (DomainsTable) looks and works properly, it also opens the pane without reloading the page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
