### PR TITLE
A4A > Signup: Update WC Asia Sign-up "Thank you" messages

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/finish-signup-survey/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/finish-signup-survey/index.tsx
@@ -5,17 +5,29 @@ import FormFooter from 'calypso/a8c-for-agencies/components/form/footer';
 
 type Props = {
 	onContinue: () => void;
+	blueprintRequested: boolean;
 };
 
-const FinishSignupSurvey: React.FC< Props > = ( { onContinue } ) => {
+const FinishSignupSurvey: React.FC< Props > = ( { onContinue, blueprintRequested } ) => {
 	const translate = useTranslate();
 
 	return (
 		<Form
 			title={ translate( 'Thank you!' ) }
-			description={ translate(
-				'We have sent you an email with more details about the program and instructions for logging in. You will also receive your blueprint in the coming days; keep an eye out for it!'
-			) }
+			description={
+				blueprintRequested
+					? translate(
+							'We have sent you an email with more details about the program and instructions for logging in. A member of our team will be reaching out to you soon with your custom blueprint; keep an eye out for an email from {{b}}partnerships@automattic.com{{/b}}.',
+							{
+								components: {
+									b: <b />,
+								},
+							}
+					  )
+					: translate(
+							'We have sent you an email with more details about the program and instructions for logging in.'
+					  )
+			}
 		>
 			<FormFooter>
 				<Button variant="primary" onClick={ onContinue } __next40pxDefaultSize>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
@@ -22,6 +22,7 @@ const MultiStepForm = () => {
 	const notificationId = 'a4a-agency-signup-form';
 
 	const [ formData, setFormData ] = useState< Partial< AgencyDetailsSignupPayload > >( {} );
+	const [ blueprintRequested, setBlueprintRequested ] = useState( false );
 
 	const steps = [
 		{ label: translate( 'Sign up' ), isActive: currentStep === 1, isComplete: currentStep > 1 },
@@ -67,6 +68,7 @@ const MultiStepForm = () => {
 
 	const clearDataAndRefresh = () => {
 		setFormData( {} );
+		setBlueprintRequested( false );
 		window.location.reload();
 	};
 
@@ -86,13 +88,25 @@ const MultiStepForm = () => {
 			case 4:
 				return <BlueprintForm onContinue={ ( data ) => updateDataAndContinue( data, 5 ) } />;
 			case 5:
-				return <BlueprintForm2 onContinue={ ( data ) => updateDataAndContinue( data, 6 ) } />;
+				return (
+					<BlueprintForm2
+						onContinue={ ( data ) => {
+							setBlueprintRequested( true );
+							updateDataAndContinue( data, 6 );
+						} }
+					/>
+				);
 			case 6:
-				return <FinishSignupSurvey onContinue={ clearDataAndRefresh } />;
+				return (
+					<FinishSignupSurvey
+						onContinue={ clearDataAndRefresh }
+						blueprintRequested={ blueprintRequested }
+					/>
+				);
 			default:
 				return null;
 		}
-	}, [ currentStep, updateDataAndContinue ] );
+	}, [ blueprintRequested, currentStep, updateDataAndContinue ] );
 
 	return (
 		<div className="signup-multi-step-form">


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1805

## Proposed Changes

* This PR updates the "Thank you" messages on the WC Asia Sign-up page.

## Testing Instructions

* Open the A4A live link
* Visit the `/signup/wc-asia` page > Enter all the details > Choose `Build my custom blueprint` in the Personalize step and fill in all the details > Verify the below message is shown when the last step is complete

<img width="1728" alt="Screenshot 2025-02-18 at 11 38 22 AM" src="https://github.com/user-attachments/assets/d49bf585-a54c-4617-b987-6b97821438cd" />

* Enter all the details > Choose `Not right now` in the Personalize step and fill in all the details > Verify the below message is shown when the last step is complete

<img width="1728" alt="Screenshot 2025-02-18 at 11 38 10 AM" src="https://github.com/user-attachments/assets/b054d9d2-30bb-4cc1-8cae-8505fbe4ef95" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
