### PR TITLE
i18n: `format-currency` - Remove `setCurrencySymbol` as redundant piece of logic / not used

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -235,7 +235,7 @@ function LineItemCostOverride( {
 				{ costOverride.discountAmount &&
 					formatCurrency( -costOverride.discountAmount, product.currency, {
 						isSmallestUnit: true,
-						signForPositive: true,
+						signForPositive: true, // TODO clk numberFormatCurrency signForPositive only usage
 					} ) }
 			</span>
 			<LineItemIntroOfferCostOverrideDetail product={ product } costOverride={ costOverride } />

--- a/packages/format-currency/CHANGELOG.md
+++ b/packages/format-currency/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Next
+
+### Breaking changes
+
+- Remove `setCurrencySymbol` ([#99924](https://github.com/Automattic/wp-calypso/pull/99924)).
+
+### Enhancements
+
 ## 2.0.0 - 2022-12-27
 
 ### Added

--- a/packages/format-currency/README.md
+++ b/packages/format-currency/README.md
@@ -43,16 +43,15 @@ Returns a formatter object that exposes the following methods:
 - `formatCurrency` (see below)
 - `getCurrencyObject` (see below)
 - `setDefaultLocale` (see below)
-- `setCurrencySymbol` (see below)
 - `geolocateCurrencySymbol` (see below)
 
 ## geolocateCurrencySymbol()
 
 `geolocateCurrencySymbol(): Promise<void>`
 
-This will attempt to make an unauthenticated network request to `https://public-api.wordpress.com/geo/`. This is to determine the country code to provide better USD formatting. By default, the currency symbol for USD will be based on the locale (unlike other currency codes which use a hard-coded list of overrides; see `setCurrencySymbol`); for `en-US`/`en` it will be `$` and for all other locales it will be `US$`. However, if the geolocation determines that the country is not inside the US, the USD symbol will be `US$` regardless of locale. This is to prevent confusion for users in non-US countries using an English locale.
+This will attempt to make an unauthenticated network request to `https://public-api.wordpress.com/geo/`. This is to determine the country code to provide better USD formatting. By default, the currency symbol for USD will be based on the locale (unlike other currency codes which use a hard-coded list of overrides); for `en-US`/`en` it will be `$` and for all other locales it will be `US$`. However, if the geolocation determines that the country is not inside the US, the USD symbol will be `US$` regardless of locale. This is to prevent confusion for users in non-US countries using an English locale.
 
-In the US, users will expect to see USD prices rendered with the currency symbol `$`. However, there are many other currencies which use `$` as their currency symbol (eg: `CAD`). This package tries to prevent confusion between these symbols by using an international version of the symbol when the locale does not match the currency. So if your locale is `en-CA`, USD prices will be rendered with the symbol `US$`. 
+In the US, users will expect to see USD prices rendered with the currency symbol `$`. However, there are many other currencies which use `$` as their currency symbol (eg: `CAD`). This package tries to prevent confusion between these symbols by using an international version of the symbol when the locale does not match the currency. So if your locale is `en-CA`, USD prices will be rendered with the symbol `US$`.
 
 However, this relies on the user having set their interface language to something other than `en-US`/`en`, and many English-speaking non-US users still have that interface language (eg: there's no English locale available in our settings for Argentinian English so such users would probably still have `en`). As a result, those users will see a price with `$` and could be misled about what currency is being displayed. `geolocateCurrencySymbol()` helps prevent that from happening by showing `US$` for those users.
 
@@ -85,18 +84,6 @@ Since rounding errors are common in floating point math, sometimes a price is pr
 `setDefaultLocale( locale: string | undefined ): void`
 
 A function that can be used to set a default locale for use by `formatCurrency()` and `getCurrencyObject()`. Note that this is global and will override any browser locale that is set! Use it with care.
-
-## setCurrencySymbol()
-
-`setCurrencySymbol( currencyCode: string, currencySymbol: string | undefined ): void`
-
-Change the currency symbol override used by formatting.
-
-By default, `formatCurrency` and `getCurrencyObject` use a currency symbol from a list of hard-coded overrides in this package keyed by the currency code. For example, `CAD` is always rendered as `C$` even if the locale is `en-CA` which would normally render the symbol `$`.
-
-With this function, you can change the override used by any given currency.
-
-Note that USD is the only currency that does not have a default override so it will use the locale's preference unless the geolocation network call succeeds (see `geolocateCurrencySymbol`).
 
 ## FormatCurrencyOptions
 

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -13,6 +13,7 @@ const fallbackLocale = 'en';
 const fallbackCurrency = 'USD';
 const geolocationEndpointUrl = 'https://public-api.wordpress.com/geo/';
 
+// TODO clk numberFormatCurrency exported only for tests
 export function createFormatter(): CurrencyFormatter {
 	const currencyOverrides: Record< string, { symbol?: string | undefined } > = {};
 	let defaultLocale: string | undefined = undefined;
@@ -233,26 +234,6 @@ export function createFormatter(): CurrencyFormatter {
 		return code;
 	}
 
-	/**
-	 * Change the currency symbol override used by formatting.
-	 *
-	 * By default, `formatCurrency` and `getCurrencyObject` use a currency symbol
-	 * from a list of hard-coded overrides in this package keyed by the currency
-	 * code. For example, `CAD` is always rendered as `C$` even if the locale is
-	 * `en-CA` which would normally render the symbol `$`.
-	 *
-	 * With this function, you can change the override used by any given currency.
-	 *
-	 * Note that this is global and will take effect no matter the locale! Use it
-	 * with care.
-	 */
-	function setCurrencySymbol( currencyCode: string, currencySymbol: string | undefined ): void {
-		if ( ! currencyOverrides[ currencyCode ] ) {
-			currencyOverrides[ currencyCode ] = {};
-		}
-		currencyOverrides[ currencyCode ].symbol = currencySymbol;
-	}
-
 	function getCurrencyOverride( code: string ): CurrencyOverride | undefined {
 		if ( code === 'USD' && geoLocation !== '' && geoLocation !== 'US' ) {
 			return { symbol: 'US$' };
@@ -277,7 +258,6 @@ export function createFormatter(): CurrencyFormatter {
 	return {
 		formatCurrency,
 		getCurrencyObject,
-		setCurrencySymbol,
 		setDefaultLocale,
 		geolocateCurrencySymbol,
 	};
@@ -308,6 +288,7 @@ function getFormatterCacheKey( {
 }
 
 function isNoDecimals( number: number, options: CurrencyObjectOptions ) {
+	// TODO clk numberFormatCurrency only isInteger part stays - the rest is same with "decimals" argument
 	if ( options.stripZeros && Number.isInteger( number ) ) {
 		return true;
 	}
@@ -378,6 +359,7 @@ function getCachedFormatter( {
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem#adding_a_numbering_system_via_the_locale_string
  */
 function addNumberingSystemToLocale( locale: string ): string {
+	// TODO clk numberFormatCurrency this can all go. it's just a static string added to locale
 	const numberingSystem = 'latn';
 	const numberingSystemUnicodeLocaleExtension = `-u-nu-${ numberingSystem }`;
 	const localeWithNumberingSystem = `${ locale }${ numberingSystemUnicodeLocaleExtension }`;
@@ -528,25 +510,6 @@ export function setDefaultLocale(
 	...args: Parameters< typeof defaultFormatter.setDefaultLocale >
 ) {
 	return defaultFormatter.setDefaultLocale( ...args );
-}
-
-/**
- * Change the currency symbol override used by formatting.
- *
- * By default, `formatCurrency` and `getCurrencyObject` use a currency symbol
- * from a list of hard-coded overrides in this package keyed by the currency
- * code. For example, `CAD` is always rendered as `C$` even if the locale is
- * `en-CA` which would normally render the symbol `$`.
- *
- * With this function, you can change the override used by any given currency.
- *
- * Note that this is global and will take effect no matter the locale! Use it
- * with care.
- */
-export function setCurrencySymbol(
-	...args: Parameters< typeof defaultFormatter.setCurrencySymbol >
-) {
-	return defaultFormatter.setCurrencySymbol( ...args );
 }
 
 export default defaultFormatter.formatCurrency;

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -15,7 +15,6 @@ const geolocationEndpointUrl = 'https://public-api.wordpress.com/geo/';
 
 // TODO clk numberFormatCurrency exported only for tests
 export function createFormatter(): CurrencyFormatter {
-	const currencyOverrides: Record< string, { symbol?: string | undefined } > = {};
 	let defaultLocale: string | undefined = undefined;
 	let geoLocation = '';
 
@@ -238,7 +237,7 @@ export function createFormatter(): CurrencyFormatter {
 		if ( code === 'USD' && geoLocation !== '' && geoLocation !== 'US' ) {
 			return { symbol: 'US$' };
 		}
-		return currencyOverrides[ code ] ?? defaultCurrencyOverrides[ code ];
+		return defaultCurrencyOverrides[ code ];
 	}
 
 	function doesCurrencyExist( code: string ): boolean {

--- a/packages/format-currency/src/types.ts
+++ b/packages/format-currency/src/types.ts
@@ -10,21 +10,6 @@ export interface CurrencyFormatter {
 	setDefaultLocale: ( locale: string | undefined ) => void;
 
 	/**
-	 * Change the currency symbol override used by formatting.
-	 *
-	 * By default, `formatCurrency` and `getCurrencyObject` use a currency symbol
-	 * from a list of hard-coded overrides in this package keyed by the currency
-	 * code. For example, `CAD` is always rendered as `C$` even if the locale is
-	 * `en-CA` which would normally render the symbol `$`.
-	 *
-	 * With this function, you can change the override used by any given currency.
-	 *
-	 * Note that this is global and will take effect no matter the locale! Use it
-	 * with care.
-	 */
-	setCurrencySymbol: ( currencyCode: string, currencySymbol: string | undefined ) => void;
-
-	/**
 	 * Formats money with a given currency code.
 	 *
 	 * The currency will define the properties to use for this formatting, but

--- a/packages/format-currency/test/index.ts
+++ b/packages/format-currency/test/index.ts
@@ -238,11 +238,6 @@ describe( 'formatCurrency', () => {
 			const money = formatter.formatCurrency( 9800900.32, 'USD' );
 			expect( money ).toBe( '$9,800,900.32' );
 		} );
-		test( 'USD with the currency symbol overridden', () => {
-			formatter.setCurrencySymbol( 'USD', 'US$' );
-			const money = formatter.formatCurrency( 9800900.32, 'USD' );
-			expect( money ).toBe( 'US$9,800,900.32' );
-		} );
 		test( 'USD in Canadian English', () => {
 			const money = formatter.formatCurrency( 9800900.32, 'USD', { locale: 'en-CA' } );
 			expect( money ).toBe( 'US$9,800,900.32' );
@@ -401,19 +396,6 @@ describe( 'getCurrencyObject()', () => {
 			const money = formatter.getCurrencyObject( 9800900.32, 'USD' );
 			expect( money ).toEqual( {
 				symbol: '$',
-				symbolPosition: 'before',
-				integer: '9,800,900',
-				fraction: '.32',
-				sign: '',
-				hasNonZeroFraction: true,
-			} );
-		} );
-
-		test( 'USD with the currency symbol overridden', () => {
-			formatter.setCurrencySymbol( 'USD', 'US$' );
-			const money = formatter.getCurrencyObject( 9800900.32, 'USD' );
-			expect( money ).toEqual( {
-				symbol: 'US$',
 				symbolPosition: 'before',
 				integer: '9,800,900',
 				fraction: '.32',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/939

## Proposed Changes

- Removes `setCurrencySymbol` logic from format-currency as it is not currently used in wp-calypso
- I am unaware if other NPM consumers are downloading and using this package, and calling this method. Within the wp-calypso repo, the function has no use.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- This is part of addressing https://github.com/Automattic/i18n-issues/issues/939, which aims at unifying number & currency-number formatting 
- Cleanup to help surface the said unification. The `format-currency` package may eventually be deprecated completely. We need to ensure only the important bits remain.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* No functional changes
* Confirm that there are no longer references to `setCurrencySymbol`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
