### PR TITLE
Stats: Add chart switching functionality to chart type toggle

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
@@ -3,7 +3,6 @@ import config from '@automattic/calypso-config';
 import { Icon, Button, ButtonGroup } from '@wordpress/components';
 import { chartBar, trendingUp } from '@wordpress/icons';
 import PropTypes from 'prop-types';
-import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import Legend from 'calypso/components/chart/legend';
 import IntervalDropdown from 'calypso/components/stats-interval-dropdown';
@@ -22,6 +21,8 @@ const ChartHeader = ( {
 	availableLegend,
 	onLegendClick,
 	charts,
+	chartType,
+	onChartTypeChange,
 } ) => {
 	const intervals = useIntervals( siteId );
 	const dispatch = useDispatch();
@@ -32,8 +33,6 @@ const ChartHeader = ( {
 	} );
 
 	const isChartLibraryEnabled = config.isEnabled( 'stats/chart-library' );
-
-	const [ chartType, setChartType ] = useState( 'line' );
 
 	const onGatedHandler = ( events, source, statType ) => {
 		// Stop the popup from showing for Jetpack sites.
@@ -46,8 +45,7 @@ const ChartHeader = ( {
 	};
 
 	const handleChartTypeChange = ( newType ) => {
-		setChartType( newType );
-		//TODO: add tracks event for chart type change
+		onChartTypeChange( newType );
 	};
 
 	return (
@@ -96,6 +94,8 @@ ChartHeader.propTypes = {
 	availableLegend: PropTypes.arrayOf( PropTypes.string ),
 	onLegendClick: PropTypes.func,
 	charts: PropTypes.array,
+	chartType: PropTypes.oneOf( [ 'line', 'bar' ] ).isRequired,
+	onChartTypeChange: PropTypes.func.isRequired,
 };
 
 export default ChartHeader;

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -54,6 +54,10 @@ class StatModuleChartTabs extends Component {
 		onChangeLegend: PropTypes.func.isRequired,
 	};
 
+	state = {
+		chartType: 'bar',
+	};
+
 	intervalId = null;
 
 	componentDidMount() {
@@ -100,9 +104,14 @@ class StatModuleChartTabs extends Component {
 		this.props.queryDayComp && this.props.requestChartCounts( this.props.queryDayComp );
 	};
 
+	handleChartTypeChange = ( newType ) => {
+		this.setState( { chartType: newType } );
+	};
+
 	render() {
 		const { siteId, slug, queryParams, selectedPeriod, isActiveTabLoading, className, countsComp } =
 			this.props;
+		const { chartType } = this.state;
 
 		const chartData = this.props.chartData.map( ( record ) => {
 			record.className = record.className?.replaceAll( 'is-selected', '' );
@@ -130,6 +139,8 @@ class StatModuleChartTabs extends Component {
 					slug={ slug }
 					period={ selectedPeriod }
 					queryParams={ queryParams }
+					chartType={ chartType }
+					onChartTypeChange={ this.handleChartTypeChange }
 				/>
 
 				<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -144,18 +144,26 @@ class StatModuleChartTabs extends Component {
 				/>
 
 				<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />
-				<Chart barClick={ this.props.barClick } data={ chartData } minBarWidth={ 35 }>
-					<StatsEmptyState
-						headingText={
-							selectedPeriod === 'hour' ? translate( 'No hourly data available' ) : null
-						}
-						infoText={
-							selectedPeriod === 'hour'
-								? translate( 'Try selecting a different time frame.' )
-								: null
-						}
-					/>
-				</Chart>
+
+				{ chartType === 'bar' ? (
+					<Chart barClick={ this.props.barClick } data={ chartData } minBarWidth={ 35 }>
+						<StatsEmptyState
+							headingText={
+								selectedPeriod === 'hour' ? translate( 'No hourly data available' ) : null
+							}
+							infoText={
+								selectedPeriod === 'hour'
+									? translate( 'Try selecting a different time frame.' )
+									: null
+							}
+						/>
+					</Chart>
+				) : (
+					<div className="stats-chart-tabs__line-chart-placeholder">
+						<span>Line chart coming soon</span>
+					</div>
+				) }
+
 				<StatTabs
 					data={ this.props.counts }
 					previousData={ countsComp }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

related to: https://github.com/Automattic/jetpack-roadmap/issues/2313

## Proposed Changes

* This PR updates the new toggle to switch between line and bar chart
* It is only visible behind the feature flag
* It adds the logic for switching between the two chart types
* This is still a work in progress. Some things that need updated:
** The toggle button styles still need updating
** It doesn't add a line chart yet, it just handles the switching logic and puts a placeholder in its place. Linechart to come in followup PR

## Testing Instructions

* Open Calypso live branch
* Navigate to `/stats/day/{URL}`
* Check you cannot see anything unusual
* Append feature flag `flags=stats/chart-library`
* Check that now the toggle button appears
* Click on the toggle, and make sure it toggles between the bar chart and the `Line chart coming soon` placeholder text

![image](https://github.com/user-attachments/assets/8c15cae2-5659-4e1a-95e8-2b11695b0b05)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
