### PR TITLE
Reader: fix search back button position

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -10,6 +10,9 @@
 	}
 	.navigation-header__main {
 		padding-top: 24px;
+		@media ( max-width: 1300px ) {
+			padding-top: 12px;
+		}
 	}
 }
 

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -1080,7 +1080,7 @@
 			button.is-compact.is-borderless {
 				@media ( max-width: 1300px ) {
 					margin: 0;
-					padding: 0 0 7px 0;
+					padding: 20px 0 0 0;
 				}
 				@media ( max-width: 600px ) {
 					padding: 0 0 0 14px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/99666

## Proposed Changes

* Fixes back button position in a wider resolution (>1300)

## Before
<img width="363" alt="Screenshot 2025-02-18 at 10 33 48" src="https://github.com/user-attachments/assets/0827c46d-3feb-4612-be67-61fd34a5abe8" />

## After
<img width="348" alt="Screenshot 2025-02-18 at 10 38 54" src="https://github.com/user-attachments/assets/282c2a29-4a55-4d7f-b8c4-46f67c4945eb" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Tidy UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Go to calypso.live `/reader/search`
* Ensure you are viewing in wide resolution
* Click on a post in search stream, then click back and you should see back button in the correct position
* Try different resolutions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
