### PR TITLE
Untangling: Fix missing headings in Settings -> Server

### DIFF
--- a/client/sites/settings/database/form.tsx
+++ b/client/sites/settings/database/form.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button, MaterialIcon } from '@automattic/components';
 import { PanelBody } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
@@ -69,7 +70,8 @@ export default function PhpMyAdminForm( { disabled }: PhpMyAdminFormProps ) {
 	const [ isRestorePasswordDialogVisible, setIsRestorePasswordDialogVisible ] = useState( false );
 	const { openPhpMyAdmin, loading } = useOpenPhpMyAdmin();
 
-	const isUntangled = useRemoveDuplicateViewsExperimentEnabled();
+	let isUntangled = useRemoveDuplicateViewsExperimentEnabled();
+	isUntangled = isUntangled && config.isEnabled( 'untangling/settings-i2' );
 
 	const form = (
 		<div className="phpmyadmin-card__wrapper">

--- a/client/sites/settings/performance/form.tsx
+++ b/client/sites/settings/performance/form.tsx
@@ -126,7 +126,8 @@ export default function CachingForm( { disabled }: CachingFormProps ) {
 				}
 		  );
 
-	const isUntangled = useRemoveDuplicateViewsExperimentEnabled();
+	let isUntangled = useRemoveDuplicateViewsExperimentEnabled();
+	isUntangled = isUntangled && config.isEnabled( 'untangling/settings-i2' );
 
 	return (
 		<HostingCard

--- a/client/sites/settings/sftp-ssh/sftp-form.tsx
+++ b/client/sites/settings/sftp-ssh/sftp-form.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { FEATURE_SFTP, FEATURE_SSH } from '@automattic/calypso-products';
 import { Button, FormLabel, Spinner, ExternalLink } from '@automattic/components';
 import { PanelBody, ToggleControl } from '@wordpress/components';
@@ -382,7 +383,8 @@ export const SftpForm = ( { disabled }: SftpFormProps ) => {
 		</div>
 	);
 
-	const isUntangled = useRemoveDuplicateViewsExperimentEnabled();
+	let isUntangled = useRemoveDuplicateViewsExperimentEnabled();
+	isUntangled = isUntangled && config.isEnabled( 'untangling/settings-i2' );
 
 	let ContainerComponent = HostingCard;
 	if ( isUntangled ) {


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/99641

## Proposed Changes

This PR fixes a regression where the headings are missing in Settings -> Server after the above PR is merged:

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/a090bb30-14d4-49fe-a152-a0d587d1e99e)|<img width="957" alt="image" src="https://github.com/user-attachments/assets/970c02f3-7331-48bd-890d-6ecbc7898bca" />|

## Why are these changes being made?

Fixes a regression

## Testing Instructions

1. Go to `/sites?flags=-untangling/settings-i2`
2. Select an Atomic site
3. Go to Settings -> Server
4. Verify that all cards have headings

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
