### PR TITLE
Discover v2 (reader) - update reader tracking getLocation for new discover format.

### DIFF
--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -4,6 +4,7 @@ import { pick } from 'lodash';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { bumpStat, bumpStatWithPageView } from 'calypso/lib/analytics/mc';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { isDiscoveryV2Enabled } from 'calypso/reader/discover/helper';
 
 const debug = debugFactory( 'calypso:reader:stats' );
 
@@ -67,8 +68,24 @@ function getLocation( path ) {
 		return 'postlike';
 	}
 	if ( path.indexOf( '/discover' ) === 0 ) {
-		const selectedTab = searchParams.get( 'selectedTab' );
+		if ( isDiscoveryV2Enabled() ) {
+			const selectedTag = searchParams.get( 'selectedTag' );
+			if ( path.indexOf( '/discover/add-new' ) === 0 ) {
+				return 'discover_addnew';
+			} else if ( path.indexOf( '/discover/firstposts' ) === 0 ) {
+				return 'discover_firstposts';
+			} else if ( path.indexOf( '/discover/reddit' ) === 0 ) {
+				return 'discover_reddit';
+			} else if ( path.indexOf( '/discover/latest' ) === 0 ) {
+				return 'discover_latest';
+			} else if ( path.indexOf( '/discover/tags' ) === 0 ) {
+				return `discover_tag:${ selectedTag }`;
+			}
+			return `discover_recommended`;
+		}
 
+		// old discover v1, can be removed once above feature check is fully rolled out.
+		const selectedTab = searchParams.get( 'selectedTab' );
 		if ( ! selectedTab || selectedTab === 'recommended' ) {
 			return 'discover_recommended';
 		} else if ( selectedTab === 'latest' ) {

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -80,8 +80,12 @@ function getLocation( path ) {
 				return 'discover_latest';
 			} else if ( path.indexOf( '/discover/tags' ) === 0 ) {
 				return `discover_tag:${ selectedTag }`;
+			} else if ( path.split( '?' )[ 0 ] === '/discover' ) {
+				return `discover_recommended`;
 			}
-			return `discover_recommended`;
+			// Ideally we should not get here, but its good to have a fallback if other tabs are
+			// added and not handled.
+			return `discover_unknown`;
 		}
 
 		// old discover v1, can be removed once above feature check is fully rolled out.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/loop/issues/482

## Proposed Changes

Updates getLocation function in reader stats to understand new routes for discover v2.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Update tracking for new ui format

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to new discover v2.
* The following events can be found filtering network tab on t.gif, or more simply by using tracks vigilante extension from FG.
* When loading the recommended tab, check `discover_recommended` is the ui_algo prop, the post display event is good to look at:
![Screenshot 2025-02-18 at 7 44 56 AM](https://github.com/user-attachments/assets/98d1f5e0-ff20-462f-b5d1-f249d002a96f)
* When on first-posts, verify it is `discover_firstposts`.
* When on reddit, verify it is `discover_reddit`
* When on latest, verify it is `discover_latest`
* when on tags, verify it is `discover_tag:{tagSlug}` and changes per the tag selected.
* Since add-new has no posts rendered currently, we can test another action. Select the add-new tab. Now while on the add-new tab, select another tab such as "Recommended". Check for the "tab clicked" event. This should have a `ui_algo` value for `add-new` since the event happened from the add-new section - however note that the "tab" will still show the name of whichever tab you clicked on:
![Screenshot 2025-02-18 at 7 54 42 AM](https://github.com/user-attachments/assets/e2cb8d84-3f51-4eb6-a817-64af1dd5d7bd)

* Verify no changes during v1 (?flags=-reader/discovery-v2)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
