### PR TITLE
Follow button - make 'Unsubscribe' the default followed copy.

### DIFF
--- a/client/blocks/follow-button/button.jsx
+++ b/client/blocks/follow-button/button.jsx
@@ -54,7 +54,7 @@ class FollowButton extends Component {
 			menuClasses.push( 'is-following' );
 			label = this.props.followingLabel
 				? this.props.followingLabel
-				: this.props.translate( 'Unsubscribe' );
+				: this.props.translate( 'Subscribed' );
 		}
 
 		if ( this.props.disabled ) {

--- a/client/blocks/follow-button/button.jsx
+++ b/client/blocks/follow-button/button.jsx
@@ -54,7 +54,7 @@ class FollowButton extends Component {
 			menuClasses.push( 'is-following' );
 			label = this.props.followingLabel
 				? this.props.followingLabel
-				: this.props.translate( 'Subscribed' );
+				: this.props.translate( 'Unsubscribe' );
 		}
 
 		if ( this.props.disabled ) {

--- a/client/blocks/reader-feed-header/follow.jsx
+++ b/client/blocks/reader-feed-header/follow.jsx
@@ -80,6 +80,7 @@ export default function ReaderFeedHeaderFollow( props ) {
 							hasButtonStyle
 							iconSize={ 24 }
 							onFollowToggle={ openSuggestedFollowsModal }
+							followingLabel={ translate( 'Unsubscribe' ) }
 						/>
 					</div>
 				) }

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -1,5 +1,6 @@
 import { useBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useState } from 'react';
 import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
@@ -31,6 +32,7 @@ const CompactPost = ( props ) => {
 	} = props;
 
 	const isDiscoverPage = getIsDiscoverPage();
+	const translate = useTranslate();
 
 	const isSmallScreen = useBreakpoint( '<660px' );
 	const [ hasExcerpt, setHasExcerpt ] = useState( true );
@@ -53,6 +55,7 @@ const CompactPost = ( props ) => {
 					siteUrl={ post.feed_URL || post.site_URL }
 					followSource={ READER_DISCOVER }
 					iconSize={ 20 }
+					followingLabel={ translate( 'Unsubscribe' ) }
 				/>
 			) }
 			<ReaderPostEllipsisMenu

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -1,6 +1,5 @@
 import { useBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useState } from 'react';
 import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
@@ -32,7 +31,6 @@ const CompactPost = ( props ) => {
 	} = props;
 
 	const isDiscoverPage = getIsDiscoverPage();
-	const translate = useTranslate();
 
 	const isSmallScreen = useBreakpoint( '<660px' );
 	const [ hasExcerpt, setHasExcerpt ] = useState( true );
@@ -55,8 +53,6 @@ const CompactPost = ( props ) => {
 					siteUrl={ post.feed_URL || post.site_URL }
 					followSource={ READER_DISCOVER }
 					iconSize={ 20 }
-					followLabel={ translate( 'Subscribe' ) }
-					followingLabel={ translate( 'Unsubscribe' ) }
 				/>
 			) }
 			<ReaderPostEllipsisMenu

--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -347,6 +347,7 @@ class ReaderPostEllipsisMenu extends Component {
 						followSource={ followSource }
 						iconSize={ 20 }
 						onFollowToggle={ this.openSuggestedFollowsModal }
+						followingLabel={ translate( 'Unsubscribe' ) }
 					/>
 				) }
 

--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -346,8 +346,6 @@ class ReaderPostEllipsisMenu extends Component {
 						siteUrl={ post.feed_URL || post.site_URL }
 						followSource={ followSource }
 						iconSize={ 20 }
-						followLabel={ translate( 'Subscribe' ) }
-						followingLabel={ translate( 'Unsubscribe' ) }
 						onFollowToggle={ this.openSuggestedFollowsModal }
 					/>
 				) }

--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -346,8 +346,8 @@ class ReaderPostEllipsisMenu extends Component {
 						siteUrl={ post.feed_URL || post.site_URL }
 						followSource={ followSource }
 						iconSize={ 20 }
-						onFollowToggle={ this.openSuggestedFollowsModal }
 						followingLabel={ translate( 'Unsubscribe' ) }
+						onFollowToggle={ this.openSuggestedFollowsModal }
 					/>
 				) }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/98915

## Proposed Changes

* Updates the feed stream header follow button to use "Unsubscribe" as the custom label.
* Removes a couple redundant uses of `followLabel`  props, since they are passing the same string as the default.

BEFORE
![Screenshot 2025-02-18 at 8 50 06 AM](https://github.com/user-attachments/assets/ffcf6629-c1d3-408e-8da5-60c3bc032a6f)


AFTER
![Screenshot 2025-02-18 at 
8 49 58 AM](https://github.com/user-attachments/assets/59e38de3-3808-4889-82d3-ba77c05c87d9)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Noted on https://github.com/Automattic/wp-calypso/issues/98915 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the reader. The following places are also shown in the Before/After screenshots above.
* Go to the feed for an individual blog, verify the follow button in the headers followed state says "Unsubscribe"
* Verify the post card ellipsis menus and discover v2 cards still have the same "Subscribe" label when unsubscribed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
