### PR TITLE
Step: Fix header margin in horizontal layout mode

### DIFF
--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -77,7 +77,6 @@ const ImageSection = styled.div`
 	min-width: 540px;
 	width: 50%;
 	height: 562px;
-	padding-top: 75px;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -41,6 +41,12 @@
 				padding-inline-end: 20px;
 			}
 		}
+
+		@include break-xlarge {
+			.step-container__header .formatted-header {
+				margin-top: 0;
+			}
+		}
 	}
 
 	.step-container__buttons {
@@ -85,6 +91,8 @@
 			}
 
 			.formatted-header__title {
+				margin: 0;
+
 				@include onboarding-font-recoleta;
 				color: var(--color-neutral-100);
 				font-size: 2rem;


### PR DESCRIPTION
## Proposed Changes

Fixes a bug introduced in https://github.com/Automattic/wp-calypso/pull/99551 that pushed the heading down in steps using the horizontal layout mode.

| Before | After |
| -------| ------ |
| ![image](https://github.com/user-attachments/assets/34aa8d62-581d-49ca-8de6-05f0ddd147d9) | ![image](https://github.com/user-attachments/assets/56d43ceb-c2d7-4069-a711-6a9c4bb12367) |

## Testing Instructions

Enter `/setup/site-setup/intent?siteSlug=%s` and verify the header is aligned to the top instead of centered-ish.
