### PR TITLE
Support Card: Redirect to open Help Center

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/support-card.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/support-card.tsx
@@ -1,3 +1,4 @@
+import { CALYPSO_HELP_WITH_HELP_CENTER } from '@automattic/urls';
 import styled from '@emotion/styled';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -26,7 +27,7 @@ export default function SupportCard( { domain, backUrl }: { domain: string; back
 			{ createInterpolateElement( __( 'Need help? <a>Contact support</a>' ), {
 				a: (
 					<SupportLinkStyle
-						href={ addQueryArgs( '/help/contact', {
+						href={ addQueryArgs( CALYPSO_HELP_WITH_HELP_CENTER, {
 							redirect_to: backUrl || `${ window.location.pathname }?siteSlug=${ domain }`,
 						} ) }
 						target="_blank"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pbxlJb-6S8-p2#comment-4133

## Proposed Changes

Update the redirect to /help with the Help Center open.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The Support Card redirects to /help/contact, that no longer exists.