### PR TITLE
Reader Add Site: Use form element and nondeprecated Button

### DIFF
--- a/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
@@ -1,6 +1,6 @@
-import { Button, FormInputValidation } from '@automattic/components';
+import { FormInputValidation } from '@automattic/components';
 import { SubscriptionManager } from '@automattic/data-stores';
-import { TextControl } from '@wordpress/components';
+import { Button, TextControl } from '@wordpress/components';
 import { check, Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -64,62 +64,67 @@ const AddSitesForm = ( { onAddFinished = () => {} }: AddSitesFormProps ) => {
 		[ validateInputValue ]
 	);
 
-	const onAddSite = useCallback( () => {
-		if ( ! isLoggedIn ) {
-			setShowLoginDialog( true );
-			return;
-		}
+	const onSubmit = useCallback(
+		( e: React.FormEvent ) => {
+			e.preventDefault();
 
-		if ( isValidInput ) {
-			setIsSubmitting( true );
-			subscribe(
-				{ url: inputValue },
-				{
-					onSuccess: ( data ) => {
-						if ( data?.info === 'already_subscribed' ) {
-							showWarningNotice( inputValue );
-						} else {
-							if ( data?.subscription?.blog_ID ) {
-								recordSiteSubscribed( {
-									blog_id: data?.subscription?.blog_ID,
-									url: inputValue,
-									source: SOURCE_SUBSCRIPTIONS_ADD_SITES_MODAL,
-								} );
+			if ( ! isLoggedIn ) {
+				setShowLoginDialog( true );
+				return;
+			}
+
+			if ( isValidInput ) {
+				setIsSubmitting( true );
+				subscribe(
+					{ url: inputValue },
+					{
+						onSuccess: ( data ) => {
+							if ( data?.info === 'already_subscribed' ) {
+								showWarningNotice( inputValue );
+							} else {
+								if ( data?.subscription?.blog_ID ) {
+									recordSiteSubscribed( {
+										blog_id: data?.subscription?.blog_ID,
+										url: inputValue,
+										source: SOURCE_SUBSCRIPTIONS_ADD_SITES_MODAL,
+									} );
+								}
+
+								showSuccessNotice( inputValue );
+
+								// Reset fields.
+								setInputValue( '' );
+								setIsValidInput( false );
 							}
-
-							showSuccessNotice( inputValue );
-
-							// Reset fields.
-							setInputValue( '' );
-							setIsValidInput( false );
-						}
-						onAddFinished();
-					},
-					onError: ( error: SubscriptionError ) => {
-						showErrorNotice( inputValue, error );
-						onAddFinished();
-					},
-					onSettled: (): void => {
-						setIsSubmitting( false );
-					},
-				}
-			);
-		}
-	}, [
-		inputValue,
-		isValidInput,
-		isLoggedIn,
-		onAddFinished,
-		recordSiteSubscribed,
-		showErrorNotice,
-		showSuccessNotice,
-		showWarningNotice,
-		subscribe,
-	] );
+							onAddFinished();
+						},
+						onError: ( error: SubscriptionError ) => {
+							showErrorNotice( inputValue, error );
+							onAddFinished();
+						},
+						onSettled: (): void => {
+							setIsSubmitting( false );
+						},
+					}
+				);
+			}
+		},
+		[
+			inputValue,
+			isValidInput,
+			isLoggedIn,
+			onAddFinished,
+			recordSiteSubscribed,
+			showErrorNotice,
+			showSuccessNotice,
+			showWarningNotice,
+			subscribe,
+		]
+	);
 
 	return (
 		<>
-			<div className="subscriptions-add-sites__form--container">
+			<form onSubmit={ onSubmit } className="subscriptions-add-sites__form--container">
 				<div className="subscriptions-add-sites__form-field">
 					<TextControl
 						className={ clsx(
@@ -139,15 +144,16 @@ const AddSitesForm = ( { onAddFinished = () => {} }: AddSitesFormProps ) => {
 				</div>
 
 				<Button
-					primary
-					className="subscriptions-add-sites__save-button"
+					variant="primary"
+					className="button subscriptions-add-sites__save-button"
 					disabled={ ! inputValue || !! inputFieldError || subscribing }
-					busy={ isSubmitting }
-					onClick={ onAddSite }
+					isBusy={ isSubmitting }
+					type="submit"
+					__next40pxDefaultSize
 				>
 					{ translate( 'Add site' ) }
 				</Button>
-			</div>
+			</form>
 
 			<ReaderJoinConversationDialog
 				isVisible={ showLoginDialog }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/410

## Proposed Changes

* Update the AddSitesForm component to use the nondeprecated Button component.
* Refactor to wrap the input and button in a form element so when the input field is focused, pressing enter will submit the form.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the UX (pressing enter when input is focused submits the form).
* Replaces deprecated component

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live and go to /discover/add-new
* Submit a valid RSS feed by pressing the enter key on your keyboard.
* Everything should work as expected. The button should enable, disable, and show the loading animation as expected.
* Make sure the behavior for an invalid RSS feed works as expected.
* Now go to /reader/subscriptions and click "New subscription" in the upper right.
* Repeat the test to make sure it also works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
