### PR TITLE
Design picker: Lazy load mShot thumbnails images

### DIFF
--- a/packages/onboarding/src/mshots-image/index.tsx
+++ b/packages/onboarding/src/mshots-image/index.tsx
@@ -142,7 +142,8 @@ const useMshotsImg = (
 // Temporary for A/B test.
 const useMshotsImgTreatment = (
 	src: string,
-	options: MShotsOptions
+	options: MShotsOptions,
+	shouldShowImage: boolean
 ): HTMLImageElement | undefined => {
 	const [ loadedImg, setLoadedImg ] = useState< HTMLImageElement >();
 	const [ count, setCount ] = useState( 0 );
@@ -161,6 +162,10 @@ const useMshotsImgTreatment = (
 	// to browser caching. Getting this wrong looks like the url resolving
 	// before the image is ready.
 	useEffect( () => {
+		if ( ! shouldShowImage ) {
+			return;
+		}
+
 		// If there's been a "props" change we need to reset everything:
 		if (
 			options !== previousOptions.current ||
@@ -222,7 +227,7 @@ const useMshotsImgTreatment = (
 			}
 			clearTimeout( timeoutIdRef.current );
 		};
-	}, [ src, count, options ] );
+	}, [ src, count, options, shouldShowImage ] );
 
 	return loadedImg;
 };
@@ -268,7 +273,7 @@ const MShotsImageControl = ( {
 		) : (
 			<img
 				ref={ imgRef }
-				{ ...{ className, style, src, alt } }
+				{ ...{ className, style, src, alt, loading } }
 				aria-labelledby={ labelledby }
 				alt={ alt }
 			/>
@@ -302,11 +307,36 @@ const MShotsImageTreatment = ( {
 	alt,
 	options,
 	scrollable = false,
+	loading = 'lazy',
 }: MShotsImageProps ) => {
-	const maybeImage = useMshotsImgTreatment( url, options );
+	const [ shouldShowImage, setShouldShowImage ] = useState( loading === 'eager' );
+	const divRef = useRef< HTMLDivElement | null >( null );
+	const imgRef = useRef< HTMLImageElement | null >( null );
+
+	const maybeImage = useMshotsImgTreatment( url, options, shouldShowImage );
 	const src: string = maybeImage?.src || '';
 	const visible = !! src;
 	const backgroundImage = maybeImage?.src && `url( ${ maybeImage?.src } )`;
+
+	useEffect( () => {
+		if ( loading === 'lazy' && ! shouldShowImage ) {
+			const observer = new IntersectionObserver( ( entries ) => {
+				if ( entries[ 0 ]?.isIntersecting ) {
+					setShouldShowImage( true );
+					observer.disconnect();
+				}
+			} );
+
+			const elementToObserve = scrollable || ! visible ? divRef.current : imgRef.current;
+			if ( elementToObserve ) {
+				observer.observe( elementToObserve );
+			}
+
+			return () => {
+				observer.disconnect();
+			};
+		}
+	}, [ loading, shouldShowImage, scrollable, visible ] );
 
 	const animationScrollSpeedInPixelsPerSecond = 400;
 	const animationDuration =
@@ -331,9 +361,14 @@ const MShotsImageTreatment = ( {
 	// rule effecting the placeholder while loading static images:
 	// '.design-picker .design-picker__image-frame img { ..., height: auto }'
 	return scrollable || ! visible ? (
-		<div className={ className } style={ style } aria-labelledby={ labelledby } />
+		<div ref={ divRef } className={ className } style={ style } aria-labelledby={ labelledby } />
 	) : (
-		<img { ...{ className, style, src, alt } } aria-labelledby={ labelledby } alt={ alt } />
+		<img
+			ref={ imgRef }
+			{ ...{ className, style, src, alt, loading } }
+			aria-labelledby={ labelledby }
+			alt={ alt }
+		/>
 	);
 };
 

--- a/packages/onboarding/src/mshots-image/index.tsx
+++ b/packages/onboarding/src/mshots-image/index.tsx
@@ -275,7 +275,6 @@ const MShotsImageControl = ( {
 				ref={ imgRef }
 				{ ...{ className, style, src, alt, loading } }
 				aria-labelledby={ labelledby }
-				alt={ alt }
 			/>
 		);
 	} // else, prettier doesn't like having an else after a return
@@ -295,7 +294,6 @@ const MShotsImageControl = ( {
 			ref={ imgRef }
 			{ ...{ className, style, src, alt } }
 			aria-labelledby={ labelledby }
-			alt={ alt }
 		/>
 	);
 };
@@ -367,7 +365,6 @@ const MShotsImageTreatment = ( {
 			ref={ imgRef }
 			{ ...{ className, style, src, alt, loading } }
 			aria-labelledby={ labelledby }
-			alt={ alt }
 		/>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #99283 

## Proposed Changes

* Adds lazy loading to images
* Use `IntersectionObserver` so the changes work on Firefox

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The changes suggested on https://github.com/Automattic/wp-calypso/pull/99700 didn't work for Firefox.
* This PR follows up on that work, but uses a different approach with `IntersectionObserver`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Borrowing @gavande1 instructions

* Visit `/setup/site-setup/goals?siteSlug=23hjrev23gh.wordpress.com`
* Open the network tab in the developer tools and select `img` requests.
* Click on Next
* Look for the number of requests sent for images. It should only send requests for images visible on the viewport.

| Before | After |
|--------|--------|
| ![CleanShot 2025-02-13 at 11 22 53@2x](https://github.com/user-attachments/assets/e30caf8f-bf53-4e20-a877-3f4357830da5) | ![CleanShot 2025-02-13 at 11 23 23@2x](https://github.com/user-attachments/assets/643e5dd7-613c-48be-b764-8539fe07cd2d) |  

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
