### PR TITLE
Goal features: Move to enable_features_for_goals for flexibility

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { Site } from '@automattic/data-stores';
+import { Site, Onboard } from '@automattic/data-stores';
 import { FREE_THEME } from '@automattic/design-picker';
 import {
 	ENTREPRENEUR_FLOW,
@@ -211,6 +211,20 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 
 		const siteIntent = isMigrationSignupFlow( flow ) ? 'migration' : '';
 
+		const getEnableFeaturesForGoals = () => {
+			if ( ! isGoalsFirstCumulativeExperience ) {
+				return undefined;
+			}
+
+			const featuresForGoals: Onboard.SiteGoal[] = [];
+
+			if ( config.isEnabled( 'onboarding/enable-write-goal-features' ) ) {
+				featuresForGoals.push( Onboard.SiteGoal.Write );
+			}
+
+			return featuresForGoals.length > 0 ? featuresForGoals : undefined;
+		};
+
 		const sourceSlug = hasSourceSlug( data ) ? data.sourceSlug : undefined;
 		const site = await createSiteWithCart(
 			flow,
@@ -232,8 +246,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 			sourceSlug,
 			siteIntent,
 			shouldSaveSiteGoals ? siteGoals : undefined,
-			isGoalsFirstCumulativeExperience &&
-				config.isEnabled( 'onboarding/enable-write-goal-features' )
+			getEnableFeaturesForGoals()
 		);
 
 		if ( preselectedThemeSlug && site?.siteSlug ) {

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -159,7 +159,7 @@ export const createSiteWithCart = async (
 	sourceSlug?: string,
 	siteIntent?: string,
 	siteGoals?: SiteGoal[],
-	shouldEnableWriteGoalFeatures?: boolean
+	enableFeaturesForGoals?: SiteGoal[]
 ) => {
 	const siteUrl = storedSiteUrl || domainItem?.domain_name;
 	const isFreeThemePreselected = startsWith( themeSlugWithRepo, 'pub' );
@@ -207,8 +207,8 @@ export const createSiteWithCart = async (
 					? { segmentation_survey_answers_anon_id: segmentationSurveyAnswersAnonId }
 					: {} ),
 				...( siteGoals && { site_goals: siteGoals } ),
-				...( shouldEnableWriteGoalFeatures && {
-					should_enable_write_goal_features: true,
+				...( enableFeaturesForGoals && {
+					enable_features_for_goals: enableFeaturesForGoals,
 				} ),
 			},
 		},


### PR DESCRIPTION
## Proposed Changes

Pass an array of goals that enable features in a site instead of a boolean.

## Why are these changes being made?

For flexibility, because we're doing the same thing with the `promote` goal.

## Testing Instructions

Checkout 173946-ghe-Automattic/wpcom and follow the instructions from https://github.com/Automattic/wp-calypso/pull/99484.