### PR TITLE
Change notice icon color to match background

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -107,7 +107,7 @@
 
 	&__icon.gridicon {
 		min-width: 18px;
-		fill: var(--studio-orange-40);
+		fill: var(--studio-gray-80);
 	}
 
 	&__message {
@@ -419,7 +419,7 @@
 
 	&__icon.gridicon {
 		min-width: 18px;
-		fill: var(--studio-orange-40);
+		fill: var(--studio-gray-80);
 	}
 
 	&__message {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9795

## Proposed Changes

* Change the icon color to match background as the issue suggests

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open a domain from /domains/manage
- Set the nameservers of that domain to so something other than on WPCOM, like Cloudflare
- Now open the DNS Records accordion
- Make sure that in the notice, the icon is of gray color, matching the background
- Open the Name servers accordion and click the "Edit custom name servers" button
- Make sure that in the notice, the icon is of gray color, matching the background

<img width="692" alt="image" src="https://github.com/user-attachments/assets/34520320-6b3a-448d-9509-52fb3f38a3ae" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
