### PR TITLE
Reader: Makes navigation header styling consistent across all screens

### DIFF
--- a/client/reader/conversations/stream.scss
+++ b/client/reader/conversations/stream.scss
@@ -1,11 +1,3 @@
-.is-section-reader .conversations__header.navigation-header {
-	margin: 0 auto;
-
-	@media only screen and (max-width: 660px) {
-		padding: 0 24px;
-	}
-}
-
 .conversations__stream .reader-post-card.card.is-compact .reader-post-options-menu {
 	position: absolute;
 	right: -2px;

--- a/client/reader/discover/components/navigation/v2/style.scss
+++ b/client/reader/discover/components/navigation/v2/style.scss
@@ -9,5 +9,9 @@
 		.section-nav-tabs__list {
 			overflow-x: auto;
 		}
+
+		.section-nav-tab__link {
+			padding-top: 5px;
+		}
 	}
 }

--- a/client/reader/discover/style.scss
+++ b/client/reader/discover/style.scss
@@ -1,12 +1,5 @@
 .is-section-reader {
 	.navigation-header.discover-stream-header {
-		margin: 0 auto;
-		padding: 0 0 24px 0;
-
-		@media only screen and ( max-width: 660px ) {
-			padding: 0 16px 24px;
-		}
-
 		&.reader-dual-column {
 			max-width: 968px; // Max width of dual column reader stream.
 		}

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -1,25 +1,12 @@
 @import "@wordpress/base-styles/breakpoints";
 
 .is-section-reader .navigation-header.following-stream-header {
-	margin: 0 auto;
-	padding: 0;
 	&.reader-dual-column {
 		max-width: 968px; // Max width of dual column reader stream.
 	}
-
-	.navigation-header__main {
-		margin-bottom: 24px;
-	}
-
-	@media (max-width: 600px) {
-		padding: 0 16px;
-		.navigation-header__main {
-			min-height: auto;
-		}
-	}
 }
 
-.following.main  .section-nav {
+.following.main .section-nav {
 	margin-top: 0;
 
 	.section-nav-tabs__list {

--- a/client/reader/liked-stream/main.jsx
+++ b/client/reader/liked-stream/main.jsx
@@ -4,7 +4,6 @@ import DocumentHead from 'calypso/components/data/document-head';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Stream from 'calypso/reader/stream';
 import EmptyContent from './empty';
-import './style.scss';
 
 const title = translate( 'My Likes' );
 const documentTitle = translate( '%s ‹ Reader', {

--- a/client/reader/liked-stream/style.scss
+++ b/client/reader/liked-stream/style.scss
@@ -1,7 +1,0 @@
-.is-section-reader .navigation-header.liked-stream-header {
-	@media only screen and (max-width: 660px) {
-		.navigation-header__main {
-			min-height: auto;
-		}
-	}
-}

--- a/client/reader/liked-stream/style.scss
+++ b/client/reader/liked-stream/style.scss
@@ -1,9 +1,5 @@
 .is-section-reader .navigation-header.liked-stream-header {
-	margin: 0 auto;
-
 	@media only screen and (max-width: 660px) {
-		padding: 0 16px;
-
 		.navigation-header__main {
 			min-height: auto;
 		}

--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -1,5 +1,4 @@
-import { Card, Gridicon, Button } from '@automattic/components';
-import clsx from 'clsx';
+import { Gridicon, Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import FollowButton from 'calypso/blocks/follow-button/button';
@@ -9,7 +8,6 @@ import ReaderFollowFeedIcon from 'calypso/reader/components/icons/follow-feed-ic
 import ReaderFollowingFeedIcon from 'calypso/reader/components/icons/following-feed-icon';
 
 const ListStreamHeader = ( {
-	isPlaceholder,
 	isPublic,
 	title,
 	description,
@@ -20,47 +18,38 @@ const ListStreamHeader = ( {
 	onFollowToggle,
 	translate,
 } ) => {
-	const classes = clsx( {
-		'list-stream__header': true,
-		'is-placeholder': isPlaceholder,
-		'has-description': !! description,
-	} );
-
 	return (
-		<Card className={ classes }>
-			<NavigationHeader title={ title } subtitle={ description }>
-				{ ! isPublic && (
-					<div className="list-stream__header-title-privacy">
-						<Gridicon icon="lock" size={ 24 } title={ translate( 'Private list' ) } />
-					</div>
-				) }
+		<NavigationHeader title={ title } subtitle={ description }>
+			{ ! isPublic && (
+				<div className="list-stream__header-title-privacy">
+					<Gridicon icon="lock" size={ 24 } title={ translate( 'Private list' ) } />
+				</div>
+			) }
 
-				{ showFollow && (
-					<div className="list-stream__header-follow">
-						<FollowButton
-							iconSize={ 24 }
-							following={ following }
-							onFollowToggle={ onFollowToggle }
-							followIcon={ ReaderFollowFeedIcon( { iconSize: 24 } ) }
-							followingIcon={ ReaderFollowingFeedIcon( { iconSize: 24 } ) }
-						/>
-					</div>
-				) }
+			{ showFollow && (
+				<div className="list-stream__header-follow">
+					<FollowButton
+						iconSize={ 24 }
+						following={ following }
+						onFollowToggle={ onFollowToggle }
+						followIcon={ ReaderFollowFeedIcon( { iconSize: 24 } ) }
+						followingIcon={ ReaderFollowingFeedIcon( { iconSize: 24 } ) }
+					/>
+				</div>
+			) }
 
-				{ showEdit && editUrl && (
-					<div className="list-stream__header-edit">
-						<Button rel={ isExternal( editUrl ) ? 'external' : '' } href={ editUrl }>
-							{ translate( 'Edit' ) }
-						</Button>
-					</div>
-				) }
-			</NavigationHeader>
-		</Card>
+			{ showEdit && editUrl && (
+				<div className="list-stream__header-edit">
+					<Button rel={ isExternal( editUrl ) ? 'external' : '' } href={ editUrl }>
+						{ translate( 'Edit' ) }
+					</Button>
+				</div>
+			) }
+		</NavigationHeader>
 	);
 };
 
 ListStreamHeader.propTypes = {
-	isPlaceholder: PropTypes.bool,
 	isPublic: PropTypes.bool,
 	title: PropTypes.string,
 	description: PropTypes.string,

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -83,7 +83,6 @@ class ListStream extends Component {
 				/>
 				<QueryReaderList owner={ this.props.owner } slug={ this.props.slug } />
 				<ListStreamHeader
-					isPlaceholder={ ! list }
 					isPublic={ list?.is_public }
 					icon={
 						<svg

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -1,79 +1,6 @@
-.is-group-reader .card.list-stream__header {
-	box-shadow: none;
-	border-bottom: 1px solid var(--color-neutral-10);
-	background: var(--studio-white);
-	display: flex;
-	flex-direction: row;
-	padding: 0;
-
-	@include breakpoint-deprecated( ">660px" ) {
-		padding-left: 0;
-		padding-right: 0;
-		margin-top: 0;
-	}
-
-	&:hover {
-		cursor: default;
-	}
-}
-
-.list-stream__header-icon {
-	height: 48px;
-	width: 48px;
-	background: var(--color-neutral-10);
-	text-align: center;
-
-	.gridicon {
-		fill: var(--color-text-inverted);
-		height: 24px;
-		position: relative;
-		top: 12px;
-		width: 24px;
-	}
-}
-
-.list-stream__header-details {
-	align-self: center;
-	display: flex;
-	flex-direction: column;
-	margin: 0 10px;
-	width: calc(100% - 15px);
-
-	@include breakpoint-deprecated( ">660px" ) {
-		width: calc(100% - 165px);
-	}
-}
-
-.list-stream__header-title {
-	color: var(--color-neutral-70);
-	display: flex;
-	font-size: $font-body;
-
-	.gridicon {
-		color: var(--color-text-subtle);
-		height: 14px;
-	}
-}
-
 .list-stream__header-title-privacy {
 	margin-left: 2px;
 	margin-top: 1px;
-}
-
-.list-stream__header-description {
-	margin: 0;
-	color: var(--color-text-subtle);
-}
-
-.list-stream__header-title,
-.list-stream__header-description {
-	height: 22px;
-	overflow: hidden;
-	position: relative;
-
-	&::after {
-		@include long-content-fade( $size: 15% );
-	}
 }
 
 .list-stream__header-follow {
@@ -110,16 +37,11 @@
 	pointer-events: none;
 	user-select: none;
 
-	.list-stream__header-title,
 	.follow-button,
 	.follow-button__label {
 		color: transparent;
 		background-color: var(--color-neutral-0);
 		animation: loading-fade 1.6s ease-in-out infinite;
-	}
-
-	.list-stream__header-title {
-		margin-right: 25%;
 	}
 
 	.gridicon {

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -15,16 +15,6 @@
 	&:hover {
 		cursor: default;
 	}
-
-	// Main layout already has mx
-	.navigation-header {
-		margin: 0 auto;
-		padding: 0 0 16px 0;
-
-		@include breakpoint-deprecated( "<660px" ) {
-			padding: 0 16px 16px;
-		}
-	}
 }
 
 .list-stream__header-icon {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -2,20 +2,6 @@
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
 
-.is-section-reader .search-stream__fixed-area {
-	.navigation-header {
-		@include break-medium {
-			padding: 0;
-		}
-	}
-	.navigation-header__main {
-		padding-top: 24px;
-		@media ( max-width: 1300px ) {
-			padding-top: 12px;
-		}
-	}
-}
-
 // .has-header-section only applies for logged out views
 .layout.has-header-section.is-section-reader .search-stream__fixed-area .navigation-header h1 {
 	@extend .wp-brand-font;

--- a/client/reader/site-subscriptions-manager/style.scss
+++ b/client/reader/site-subscriptions-manager/style.scss
@@ -34,10 +34,16 @@ body.is-section-reader .layout.is-section-reader .site-subscriptions-manager {
 		margin: 0 auto;
 
 		@media (max-width: $break-small) {
-			padding: 0 16px;
+			padding: 16px;
 		}
 
 		@extend %search-component-subscriptions-style;
+	}
+
+	.navigation-header {
+		@media (max-width: $break-small) {
+			padding: 0;
+		}
 	}
 
 	&__header-h-stack {

--- a/client/reader/site-subscriptions-manager/style.scss
+++ b/client/reader/site-subscriptions-manager/style.scss
@@ -35,10 +35,6 @@ body.is-section-reader .layout.is-section-reader .site-subscriptions-manager {
 
 		@media (max-width: $break-small) {
 			padding: 0 16px;
-
-			.navigation-header {
-				padding: 16px 0;
-			}
 		}
 
 		@extend %search-component-subscriptions-style;

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -1076,23 +1076,6 @@
 	}
 
 	&.search-stream {
-		.back-button {
-			button.is-compact.is-borderless {
-				@media ( max-width: 1300px ) {
-					margin: 0;
-					padding: 20px 0 0 0;
-				}
-				@media ( max-width: 600px ) {
-					padding: 0 0 0 14px;
-				}
-			}
-	
-			@media ( max-width: 1300px ) {
-				position: unset;
-				display: flex;
-			}
-		}
-
 		.following {
 			.back-button {
 				display: none;

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -6,11 +6,72 @@ body.is-section-reader {
 		.main {
 			padding: 24px;
 			border-block-end: 1px solid var(--studio-gray-0);
-			
-			&.search-stream {
-				padding-top: 0;
+
+			@media (max-width: $break-small) {
+				padding: 24px 0;
 			}
 		}
+
+		.back-button {
+			@media ( max-width: 1300px ) {
+				position: unset;
+				display: flex;
+			}
+
+			button.is-compact.is-borderless {
+				@media ( max-width: 1300px ) {
+					margin: 0;
+					padding: 5px 0 0 0;
+				}
+
+				@media ( max-width: $break-small ) {
+					padding: 0 0 0 14px;
+				}
+			}
+
+			+ .has-back-button .navigation-header,
+			+ .navigation-header {
+				@media (max-width: 1300px) {
+					padding-top: 12px;
+				}
+
+				@media (max-width: $break-small) {
+					padding: 12px 16px 0;
+				}
+			}
+		}
+
+		.navigation-header {
+			margin: 0 auto;
+			padding: 0;
+			
+			@media (max-width: $break-small) {
+				padding: 16px 0;
+			}
+	
+			&::after {
+				content: "";
+				display: block;
+				position: relative;
+				left: calc(-1 * (100vw - 100%)/2 - 132px);
+				margin: 18px 0;
+				width: 110vw;
+				height: 1px;
+				background: var(--color-border-secondary);
+	
+				@media screen and (min-width: $break-medium) {
+					margin: 24px 0;
+				}
+			}
+		}
+
+		// For reader/a8c
+		.section-header {
+			@media ( max-width: 1300px ) {
+				padding-top: 12px;
+			}
+		}
+
 		.layout__primary > div:not(:has(.recent-feed)) {
 			background: var(--color-surface);
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
@@ -30,17 +91,6 @@ body.is-section-reader {
 			overflow-x: auto;
 		}
 	}
-
-	@media only screen and (max-width: 600px) {
-		div.layout.is-global-sidebar-visible .main {
-			padding: 24px 0;
-		}
-	}
-
-	.navigation-header {
-		margin: 0 auto;
-		padding: 0;
-	}
 }
 
 .is-group-reader .async-load {
@@ -51,16 +101,6 @@ body.is-section-reader {
 .is-reader-page .reader__content,
 .is-reader-page .reader-start {
 	margin-top: 0;
-}
-
-.is-reader-page .recommended-for-you.main,
-.is-reader-page .following.main,
-.is-reader-page .tag-stream__main.main,
-.is-reader-page .search-stream__with-sites.main {
-	margin: 0 auto;
-	@include breakpoint-deprecated( "<660px" ) {
-		margin: 16px auto;
-	}
 }
 
 .is-reader-page .reader-full-post__story-content {
@@ -273,20 +313,6 @@ body.is-section-reader {
 	}
 }
 
-.is-group-reader {
-	@media screen and (min-width: $break-medium) {
-		.navigation-header::after {
-			content: "";
-			display: block;
-			position: relative;
-			left: calc(-1 * (100vw - 100%)/2 - 132px);
-			margin: 24px 0;
-			width: 110vw;
-			height: 1px;
-			background: var(--color-border-secondary);
-		}
-	}
-}
 .is-group-reader .reader-notifications__panel {
 	@media only screen and (min-width: 1114px) {
 		.wpnc__main {

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -36,6 +36,11 @@ body.is-section-reader {
 			padding: 24px 0;
 		}
 	}
+
+	.navigation-header {
+		margin: 0 auto;
+		padding: 0;
+	}
 }
 
 .is-group-reader .async-load {

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -13,18 +13,18 @@ body.is-section-reader {
 		}
 
 		.back-button {
-			@media ( max-width: 1300px ) {
+			@media (max-width: 1300px) {
 				position: unset;
 				display: flex;
 			}
 
 			button.is-compact.is-borderless {
-				@media ( max-width: 1300px ) {
+				@media (max-width: 1300px) {
 					margin: 0;
 					padding: 5px 0 0 0;
 				}
 
-				@media ( max-width: $break-small ) {
+				@media (max-width: $break-small) {
 					padding: 0 0 0 14px;
 				}
 			}
@@ -44,9 +44,9 @@ body.is-section-reader {
 		.navigation-header {
 			margin: 0 auto;
 			padding: 0;
-			
+
 			@media (max-width: $break-small) {
-				padding: 16px 0;
+				padding: 0 16px;
 			}
 	
 			&::after {
@@ -58,7 +58,7 @@ body.is-section-reader {
 				width: 110vw;
 				height: 1px;
 				background: var(--color-border-secondary);
-	
+
 				@media screen and (min-width: $break-medium) {
 					margin: 24px 0;
 				}
@@ -67,7 +67,7 @@ body.is-section-reader {
 
 		// For reader/a8c
 		.section-header {
-			@media ( max-width: 1300px ) {
+			@media (max-width: 1300px) {
 				padding-top: 12px;
 			}
 		}

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -13,11 +13,8 @@
 	}
 
 	.navigation-header {
-		margin: 0 auto;
-		padding: 0 0 16px 0;
-
-		@include breakpoint-deprecated( "<660px" ) {
-			padding: 0 16px 16px;
+		&::after {
+			top: 6px;
 		}
 	}
 }
@@ -39,11 +36,11 @@
 }
 
 .reader__content .tag-stream__header {
-	margin-bottom: 24px;
-}
+	margin-bottom: 20px;
 
-.reader__content .tag-stream__header.has-description {
-	padding-bottom: 16px;
+	&.has-description {
+		padding-bottom: 16px;
+	}
 }
 
 .tag-stream__header-title-group {
@@ -64,6 +61,7 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: flex-start;
+	padding-top: 3px;
 
 	@include breakpoint-deprecated( "<660px" ) {
 		margin: 0 16px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/483

## Proposed Changes

Makes reader navigation header styling consitent. This involves removing stylings from multiple places and keeping them in a common place so that we can apply it consistently.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- Currently each reader screen implemented the navigation header styles in a bit different way which looks odd while navigating between different screens.

- Responsiveness of the header is also not consitent.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to following urls and notice difference in spacings and responsiveness.
	- https://wordpress.com/reader/search
	- https://wordpress.com/reader
	- https://wordpress.com/discover
	- https://wordpress.com/activities/likes
	- https://wordpress.com/reader/list/automattic/a12s
	- https://wordpress.com/tag/dailyprompt
	- https://wordpress.com/reader/a8c
	- https://wordpress.com/reader/conversations/a8c
	- https://wordpress.com/reader/subscriptions
	
* Check out this PR.
* Verify spacings and responsiveness of above urls again.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
