### PR TITLE
Discover v2: Update "Add new" and "Reddit" tab titles and use constants

### DIFF
--- a/client/reader/discover/components/navigation/v2/index.tsx
+++ b/client/reader/discover/components/navigation/v2/index.tsx
@@ -4,7 +4,13 @@ import { translate } from 'i18n-calypso';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
-import { DEFAULT_TAB, FIRST_POSTS_TAB, LATEST_TAB } from 'calypso/reader/discover/helper';
+import {
+	DEFAULT_TAB,
+	FIRST_POSTS_TAB,
+	LATEST_TAB,
+	ADD_NEW_TAB,
+	REDDIT_TAB,
+} from 'calypso/reader/discover/helper';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { useDispatch, useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -43,7 +49,7 @@ const DiscoverNavigationV2 = ( { selectedTab }: Props ) => {
 			path: '/discover',
 		},
 		{
-			slug: 'add-new',
+			slug: ADD_NEW_TAB,
 			title: translate( 'Add new' ),
 			path: '/discover/add-new',
 		},
@@ -58,7 +64,7 @@ const DiscoverNavigationV2 = ( { selectedTab }: Props ) => {
 			path: '/discover/tags?selectedTag=dailyprompt',
 		},
 		{
-			slug: 'reddit',
+			slug: REDDIT_TAB,
 			title: translate( 'Reddit' ),
 			path: '/discover/reddit',
 		},
@@ -69,9 +75,9 @@ const DiscoverNavigationV2 = ( { selectedTab }: Props ) => {
 		},
 	];
 
-	// Only show the add new tab if the user is logged in.
+	// Only show the "Add new" and "Reddit" tabs if the user is logged in.
 	const filteredTabs = baseTabs.filter(
-		( tab ) => ( tab.slug !== 'add-new' && tab.slug !== 'reddit' ) || isLoggedIn
+		( tab ) => ( tab.slug !== ADD_NEW_TAB && tab.slug !== REDDIT_TAB ) || isLoggedIn
 	);
 
 	// Add localization to paths if needed.

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -22,6 +22,8 @@ import {
 	buildDiscoverStreamKey,
 	FIRST_POSTS_TAB,
 	isDiscoveryV2Enabled,
+	ADD_NEW_TAB,
+	REDDIT_TAB,
 } from './helper';
 import './style.scss';
 
@@ -32,14 +34,25 @@ export const DiscoverHeader = ( props ) => {
 
 	const { selectedTab } = props;
 	const tabTitle = getSelectedTabTitle( selectedTab );
-	let subHeaderText = translate( 'Explore %s blogs that inspire, educate, and entertain.', {
-		args: [ tabTitle ],
-		comment: '%s is the type of blog being explored e.g. food, art, technology etc.',
-	} );
-	if ( selectedTab === FIRST_POSTS_TAB ) {
-		subHeaderText = translate(
-			'Fresh voices, fresh views. Explore first-time posts from new bloggers.'
-		);
+
+	let subHeaderText;
+	switch ( selectedTab ) {
+		case FIRST_POSTS_TAB:
+			subHeaderText = translate(
+				'Fresh voices, fresh views. Explore first-time posts from new bloggers.'
+			);
+			break;
+		case ADD_NEW_TAB:
+			subHeaderText = translate( 'Subscribe to new blogs, newsletters, and RSS feeds.' );
+			break;
+		case REDDIT_TAB:
+			subHeaderText = translate( 'Follow your favorite subreddits inside the Reader.' );
+			break;
+		default:
+			subHeaderText = translate( 'Explore %s blogs that inspire, educate, and entertain.', {
+				args: [ tabTitle ],
+				comment: '%s is the type of blog being explored e.g. food, art, technology etc.',
+			} );
 	}
 
 	return (
@@ -116,23 +129,18 @@ const DiscoverStream = ( props ) => {
 		);
 	};
 
-	if ( selectedTab === 'add-new' ) {
-		return (
-			<ReaderMain className={ clsx( 'following main', props.className ) }>
-				<HeaderAndNavigation />
-				<div className="reader__content">
-					<DiscoverAddNew />
-				</div>
-			</ReaderMain>
-		);
-	}
+	const TAB_COMPONENTS = {
+		[ ADD_NEW_TAB ]: DiscoverAddNew,
+		[ REDDIT_TAB ]: Reddit,
+	};
 
-	if ( selectedTab === 'reddit' ) {
+	const ContentComponent = TAB_COMPONENTS[ selectedTab ];
+	if ( ContentComponent ) {
 		return (
 			<ReaderMain className={ clsx( 'following main', props.className ) }>
 				<HeaderAndNavigation />
 				<div className="reader__content">
-					<Reddit />
+					<ContentComponent />
 				</div>
 			</ReaderMain>
 		);

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -4,6 +4,8 @@ const DEFAULT_DISCOVER_TAGS = [ 'dailyprompt', 'wordpress' ];
 export const DEFAULT_TAB = 'recommended';
 export const LATEST_TAB = 'latest';
 export const FIRST_POSTS_TAB = 'firstposts';
+export const ADD_NEW_TAB = 'add-new';
+export const REDDIT_TAB = 'reddit';
 
 /**
  * Filters tags data and returns the tags intended to be loaded by the discover pages recommended


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pe7F0s-2ua-p2

## Proposed Changes

* This PR creates custom titles for the "Add new" and "Reddit" tabs in Discover v2
* It creates constants for the "Add new" and "Reddit" tab slugs
* It does some minor DRY refactoring

<img width="1096" alt="Screenshot 2025-02-18 at 3 39 57 PM" src="https://github.com/user-attachments/assets/1467a1c0-93c8-4dfd-b2be-c92dfa30902d" />
<img width="1096" alt="Screenshot 2025-02-18 at 3 39 42 PM" src="https://github.com/user-attachments/assets/e7bc4fb4-fab6-475e-8ce2-56f60af0fb50" />




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Pushing the Discover v2 project forward.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using Calypso Live go to /discover
* Make sure all the tabs still work and double check all of the titles are correct.
* Using Calypso Live go to /discover?flags=-reader/discovery-v2 and confirm there are no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?