### PR TITLE
Stats: add tooltips to action items

### DIFF
--- a/client/my-sites/stats/stats-list/action-link.jsx
+++ b/client/my-sites/stats/stats-list/action-link.jsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@wordpress/components';
 import { Icon, external } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -27,28 +28,31 @@ class StatsActionLink extends PureComponent {
 			return '';
 		}
 
+		const title = translate( 'View', {
+			textOnly: true,
+			context: 'Stats action tooltip: View content in a new window',
+		} );
+
 		return (
 			<li className="stats-list__item-action module-content-list-item-action">
-				<a
-					href={ href }
-					onClick={ this.onClick }
-					target="_blank"
-					rel="noopener noreferrer"
-					className="stats-list__item-action-wrapper module-content-list-item-action-wrapper"
-					title={ translate( 'View content in a new window', {
-						textOnly: true,
-						context: 'Stats action tooltip: View content in a new window',
-					} ) }
-					aria-label={ translate( 'View content in a new window', {
-						textOnly: true,
-						context: 'Stats ARIA label: View content in new window action',
-					} ) }
-				>
-					<Icon className="stats-icon" icon={ external } size={ 18 } />
-					<span className="stats-list__item-action-label module-content-list-item-action-label module-content-list-item-action-label-view">
-						{ translate( 'View', { context: 'Stats: List item action to view content' } ) }
-					</span>
-				</a>
+				<Tooltip position="top" text={ title }>
+					<a
+						href={ href }
+						onClick={ this.onClick }
+						target="_blank"
+						rel="noopener noreferrer"
+						className="stats-list__item-action-wrapper module-content-list-item-action-wrapper"
+						aria-label={ translate( 'View content in a new window', {
+							textOnly: true,
+							context: 'Stats ARIA label: View content in new window action',
+						} ) }
+					>
+						<Icon className="stats-icon" icon={ external } size={ 18 } />
+						<span className="stats-list__item-action-label module-content-list-item-action-label module-content-list-item-action-label-view">
+							{ translate( 'View', { context: 'Stats: List item action to view content' } ) }
+						</span>
+					</a>
+				</Tooltip>
 			</li>
 		);
 	}

--- a/client/my-sites/stats/stats-list/action-promote.jsx
+++ b/client/my-sites/stats/stats-list/action-promote.jsx
@@ -1,4 +1,5 @@
 import { blaze } from '@automattic/components/src/icons';
+import { Tooltip } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
@@ -36,6 +37,11 @@ const PromotePost = ( props ) => {
 		);
 	};
 
+	const title = translate( 'Promote', {
+		textOnly: true,
+		context: 'Stats action tooltip: Opens a pop-out post promotion tool',
+	} );
+
 	return (
 		<>
 			{ showPromotePost && (
@@ -46,25 +52,23 @@ const PromotePost = ( props ) => {
 						postId={ postId }
 						keyValue={ keyValue }
 					/>
-					<button
-						onClick={ showDSPWidget }
-						rel="noopener noreferrer"
-						className="stats-list__item-action-wrapper stats-list__item-action-promote module-content-list-item-action-wrapper"
-						title={ translate( 'Promote your post with our ad delivery system.', {
-							textOnly: true,
-							context: 'Stats action tooltip: Opens a pop-out post promotion tool',
-						} ) }
-						aria-label={ translate( 'Promote your post with our ad delivery system.', {
-							textOnly: true,
-							context: 'Stats ARIA label: Opens a pop-out post promotion tool',
-						} ) }
-					>
-						<Icon className="stats-icon" icon={ blaze } size={ 18 } />
+					<Tooltip position="top" text={ title }>
+						<button
+							onClick={ showDSPWidget }
+							rel="noopener noreferrer"
+							className="stats-list__item-action-wrapper stats-list__item-action-promote module-content-list-item-action-wrapper"
+							aria-label={ translate( 'Promote your post with our ad delivery system.', {
+								textOnly: true,
+								context: 'Stats ARIA label: Opens a pop-out post promotion tool',
+							} ) }
+						>
+							<Icon className="stats-icon" icon={ blaze } size={ 18 } />
 
-						<span className="stats-list__item-action-label module-content-list-item-action-label module-content-list-item-action-label-view">
-							{ translate( 'Promote', { context: 'Stats: List item action to view content' } ) }
-						</span>
-					</button>
+							<span className="stats-list__item-action-label module-content-list-item-action-label module-content-list-item-action-label-view">
+								{ translate( 'Promote', { context: 'Stats: List item action to view content' } ) }
+							</span>
+						</button>
+					</Tooltip>
 				</li>
 			) }
 		</>

--- a/client/my-sites/stats/stats-list/action-spam.jsx
+++ b/client/my-sites/stats/stats-list/action-spam.jsx
@@ -1,4 +1,5 @@
 import { Dialog } from '@automattic/components';
+import { Tooltip } from '@wordpress/components';
 import { Icon, warning } from '@wordpress/icons';
 import clsx from 'clsx';
 import debugFactory from 'debug';
@@ -86,17 +87,14 @@ class StatsActionSpam extends Component {
 
 		return (
 			<li className="stats-list__spam-action module-content-list-item-action">
-				<button
-					onClick={ this.clickHandler }
-					className={ wrapperClass }
-					title={ title }
-					aria-label={ title }
-				>
-					<Icon className="stats-icon" icon={ warning } size={ 22 } />
-					<span className="stats-list__spam-label module-content-list-item-action-label">
-						{ label }
-					</span>
-				</button>
+				<Tooltip position="top" text={ title }>
+					<button onClick={ this.clickHandler } className={ wrapperClass } aria-label={ title }>
+						<Icon className="stats-icon" icon={ warning } size={ 22 } />
+						<span className="stats-list__spam-label module-content-list-item-action-label">
+							{ label }
+						</span>
+					</button>
+				</Tooltip>
 				{ this.props.inHorizontalBarList && (
 					<Dialog
 						isVisible={ this.state.showConfirmDialog }

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -916,6 +916,7 @@ ul.module-content-list-legend {
 		.stats-list-actions {
 			display: flex;
 			align-items: center;
+			gap: 6px;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/jetpack-roadmap#2232.

## Proposed Changes

* Replace existing `title` HTML attributes with `Tooltip` components. They are more flexible, appear quickly, and we have full control over their customization.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Automattic/jetpack-roadmap#1818.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Access the Calypso Live link below.
- Go to the Stats page of a website that has meaningful data, like: `/stats/day/jetpack.com`
- Hover the items in the `Posts & pages` and `Referrers` cards, for instance. Their action items should quickly show a tooltip indicating what they do.
  - They should be better spaced as well.

| Before | After |
| - | - |
| <img alt="image" src="https://github.com/user-attachments/assets/5b78d16c-dc84-4f70-af74-85f251a048bf" /> | <img alt="image" src="https://github.com/user-attachments/assets/91864794-5a10-4561-b027-11dd0faa0269" /> |
| <img alt="image" src="https://github.com/user-attachments/assets/ee70960b-fbd5-4cbf-bd29-575955a9e37c" /> | <img alt="image" src="https://github.com/user-attachments/assets/8e6be6ae-c488-4ef7-bf2e-bde5659d5456" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
