### PR TITLE
Newsletter settings: update newsletter categories settings copy

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -324,6 +324,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/stats/',
 		post_id: 4454,
 	},
+	'subscribe-block': {
+		link: 'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/',
+		post_id: 170164,
+	},
 	tags: {
 		link: 'https://wordpress.com/support/posts/tags/',
 		post_id: 8586,

--- a/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-toggle.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-toggle.tsx
@@ -38,9 +38,14 @@ const NewsletterCategoriesToggle = ( {
 							},
 						}
 					),
-					oldCopy: translate(
-						'Newsletter categories allow visitors to subscribe only to specific topics. When enabled, only posts published under the categories selected below will be emailed to your subscribers.'
-					),
+					oldCopy:
+						translate(
+							'Newsletter categories allow visitors to subscribe only to specific topics.'
+						) +
+						' ' +
+						translate(
+							'When enabled, only posts published under the categories selected below will be emailed to your subscribers.'
+						),
 				} ) }
 			</FormSettingExplanation>
 		</div>

--- a/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-toggle.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-toggle.tsx
@@ -1,5 +1,5 @@
 import { ToggleControl } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 
@@ -27,14 +27,20 @@ const NewsletterCategoriesToggle = ( {
 				label={ translate( 'Enable newsletter categories' ) }
 			/>
 			<FormSettingExplanation>
-				{ translate(
-					'Newsletter categories let visitors subscribe to specific topics. When enabled, only posts in the selected categories will be emailed. By default, subscribers can choose from your selected categories, or you can pre-select categories in the {{link}}subscribe block{{/link}}.',
-					{
-						components: {
-							link: <InlineSupportLink showIcon={ false } supportContext="subscribe-block" />,
-						},
-					}
-				) }
+				{ i18n.fixMe( {
+					text: 'Newsletter categories let visitors subscribe to specific topics. When enabled, only posts in the selected categories will be emailed. By default, subscribers can choose from your selected categories, or you can pre-select categories in the subscribe block.',
+					newCopy: translate(
+						'Newsletter categories let visitors subscribe to specific topics. When enabled, only posts in the selected categories will be emailed. By default, subscribers can choose from your selected categories, or you can pre-select categories in the {{link}}subscribe block{{/link}}.',
+						{
+							components: {
+								link: <InlineSupportLink showIcon={ false } supportContext="subscribe-block" />,
+							},
+						}
+					),
+					oldCopy: translate(
+						'Newsletter categories allow visitors to subscribe only to specific topics. When enabled, only posts published under the categories selected below will be emailed to your subscribers.'
+					),
+				} ) }
 			</FormSettingExplanation>
 		</div>
 	);

--- a/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-toggle.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-toggle.tsx
@@ -1,6 +1,7 @@
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 
 export const NEWSLETTER_CATEGORIES_ENABLED_OPTION = 'wpcom_newsletter_categories_enabled';
 
@@ -27,12 +28,13 @@ const NewsletterCategoriesToggle = ( {
 			/>
 			<FormSettingExplanation>
 				{ translate(
-					'Newsletter categories allow visitors to subscribe only to specific topics.'
-				) +
-					' ' +
-					translate(
-						'When enabled, only posts published under the categories selected below will be emailed to your subscribers.'
-					) }
+					'Newsletter categories let visitors subscribe to specific topics. When enabled, only posts in the selected categories will be emailed. By default, subscribers can choose from your selected categories, or you can pre-select categories in the {{link}}subscribe block{{/link}}.',
+					{
+						components: {
+							link: <InlineSupportLink showIcon={ false } supportContext="subscribe-block" />,
+						},
+					}
+				) }
 			</FormSettingExplanation>
 		</div>
 	);

--- a/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-toggle.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-toggle.tsx
@@ -27,6 +27,7 @@ const NewsletterCategoriesToggle = ( {
 				label={ translate( 'Enable newsletter categories' ) }
 			/>
 			<FormSettingExplanation>
+				{ /* @ts-expect-error - fixMe method is not typed in the package. Once types are added upstream, remove this. */ }
 				{ i18n.fixMe( {
 					text: "Newsletter categories let you select the content that's emailed to subscribers. When enabled, only posts in the selected categories will be sent as newsletters. By default, subscribers can choose from your selected categories, or you can pre-select categories using the subscribe block.",
 					newCopy: translate(

--- a/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-toggle.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-toggle.tsx
@@ -28,9 +28,9 @@ const NewsletterCategoriesToggle = ( {
 			/>
 			<FormSettingExplanation>
 				{ i18n.fixMe( {
-					text: 'Newsletter categories let visitors subscribe to specific topics. When enabled, only posts in the selected categories will be emailed. By default, subscribers can choose from your selected categories, or you can pre-select categories in the subscribe block.',
+					text: "Newsletter categories let you select the content that's emailed to subscribers. When enabled, only posts in the selected categories will be sent as newsletters. By default, subscribers can choose from your selected categories, or you can pre-select categories using the subscribe block.",
 					newCopy: translate(
-						'Newsletter categories let visitors subscribe to specific topics. When enabled, only posts in the selected categories will be emailed. By default, subscribers can choose from your selected categories, or you can pre-select categories in the {{link}}subscribe block{{/link}}.',
+						"Newsletter categories let you select the content that's emailed to subscribers. When enabled, only posts in the selected categories will be sent as newsletters. By default, subscribers can choose from your selected categories, or you can pre-select categories using the {{link}}subscribe block{{/link}}.",
 						{
 							components: {
 								link: <InlineSupportLink showIcon={ false } supportContext="subscribe-block" />,

--- a/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/test/newsletter-categories-settings.test.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/test/newsletter-categories-settings.test.tsx
@@ -10,6 +10,7 @@ import { NEWSLETTER_CATEGORIES_ENABLED_OPTION } from '../newsletter-categories-t
 
 jest.mock( 'i18n-calypso' );
 jest.mock( 'calypso/blocks/term-tree-selector', () => () => 'MockTermTreeSelector' );
+jest.mock( 'calypso/components/inline-support-link', () => () => 'MockInlineSupportLink' );
 
 describe( 'NewsletterCategoriesSettings', () => {
 	beforeEach( () => {

--- a/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/test/newsletter-categories-toggle.test.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/test/newsletter-categories-toggle.test.tsx
@@ -10,6 +10,7 @@ import NewsletterCategoriesToggle, {
 } from '../newsletter-categories-toggle';
 
 jest.mock( 'i18n-calypso' );
+jest.mock( 'calypso/components/inline-support-link', () => () => 'MockInlineSupportLink' );
 
 describe( 'NewsletterCategoriesToggle', () => {
 	beforeEach( () => {

--- a/packages/i18n-calypso/src/types/index.d.ts
+++ b/packages/i18n-calypso/src/types/index.d.ts
@@ -115,6 +115,29 @@ export interface I18N {
 	on( eventName: string, listener: EventListener ): void;
 	off( eventName: string, listener: EventListener ): void;
 	emit( eventName: string, ...payload: any ): void;
+
+	/**
+	 * Returns `newCopy` if given `text` is translated or locale is English, otherwise returns the `oldCopy`.
+	 *
+	 * `newCopy` prop should be an actual `i18n.translate()` call from the consuming end.
+	 * This is the only way currently to ensure that it is picked up by our string extraction mechanism
+	 * and propagate into GlotPress for translation.
+	 * @param options
+	 * @param options.text - The text to check for translation.
+	 * @param options.newCopy - The translation to return if the text is translated.
+	 * @param options.oldCopy - The fallback to return if the text is not translated.
+	 * @example
+	 * i18n.fixMe( {
+	 * 	text: 'new copy',
+	 * 	newCopy: i18n.translate( 'new copy' ),
+	 * 	oldCopy: i18n.translate( 'old copy' ),
+	 * } );
+	 */
+	fixMe( options: {
+		text: string;
+		newCopy: ExistingReactNode;
+		oldCopy?: ExistingReactNode;
+	} ): ExistingReactNode | null;
 }
 
 declare const i18n: I18N;
@@ -136,6 +159,7 @@ export declare const registerComponentUpdateHook: typeof i18n.registerComponentU
 export declare const on: typeof i18n.on;
 export declare const off: typeof i18n.off;
 export declare const emit: typeof i18n.emit;
+export declare const fixMe: typeof i18n.fixMe;
 
 export interface LocalizeProps {
 	locale: string;

--- a/packages/i18n-calypso/src/types/index.d.ts
+++ b/packages/i18n-calypso/src/types/index.d.ts
@@ -115,29 +115,6 @@ export interface I18N {
 	on( eventName: string, listener: EventListener ): void;
 	off( eventName: string, listener: EventListener ): void;
 	emit( eventName: string, ...payload: any ): void;
-
-	/**
-	 * Returns `newCopy` if given `text` is translated or locale is English, otherwise returns the `oldCopy`.
-	 *
-	 * `newCopy` prop should be an actual `i18n.translate()` call from the consuming end.
-	 * This is the only way currently to ensure that it is picked up by our string extraction mechanism
-	 * and propagate into GlotPress for translation.
-	 * @param options
-	 * @param options.text - The text to check for translation.
-	 * @param options.newCopy - The translation to return if the text is translated.
-	 * @param options.oldCopy - The fallback to return if the text is not translated.
-	 * @example
-	 * i18n.fixMe( {
-	 * 	text: 'new copy',
-	 * 	newCopy: i18n.translate( 'new copy' ),
-	 * 	oldCopy: i18n.translate( 'old copy' ),
-	 * } );
-	 */
-	fixMe( options: {
-		text: string;
-		newCopy: ExistingReactNode;
-		oldCopy?: ExistingReactNode;
-	} ): ExistingReactNode | null;
 }
 
 declare const i18n: I18N;
@@ -159,7 +136,6 @@ export declare const registerComponentUpdateHook: typeof i18n.registerComponentU
 export declare const on: typeof i18n.on;
 export declare const off: typeof i18n.off;
 export declare const emit: typeof i18n.emit;
-export declare const fixMe: typeof i18n.fixMe;
 
 export interface LocalizeProps {
 	locale: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/loop#487

## Proposed Changes

* Updates the Newsletter Categories settings copy to provide more information about how the feature works.

| Before | After |
|-|-|
| <img width="734" alt="image" src="https://github.com/user-attachments/assets/3c1c0d35-b60a-46aa-8232-57abf13288a2" /> | <img width="734" alt="image" src="https://github.com/user-attachments/assets/8957d7ca-d5bb-4712-a4d6-1f1638551a7c" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve the UX

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to Settings -> Newsletter -> Newsletter Categories
* Ensure the copy matches what's in Automattic/loop#487
* Ensure the link to the subscribe block docs works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
