### PR TITLE
Stats: Add linechart with dummy data to the chart type switcher

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -9,6 +9,7 @@ import Chart from 'calypso/components/chart';
 import { DEFAULT_HEARTBEAT } from 'calypso/components/data/query-site-stats/constants';
 import memoizeLast from 'calypso/lib/memoize-last';
 import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
+import LineChart from 'calypso/my-sites/stats/components/line-chart';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { requestChartCounts } from 'calypso/state/stats/chart-tabs/actions';
@@ -159,9 +160,7 @@ class StatModuleChartTabs extends Component {
 						/>
 					</Chart>
 				) : (
-					<div className="stats-chart-tabs__line-chart-placeholder">
-						<span>Line chart coming soon</span>
-					</div>
+					<LineChart className="stats-chart-tabs__line-chart" chartData={ [] } height={ 200 } />
 				) }
 
 				<StatTabs

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -5,11 +5,11 @@ import moment from 'moment';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import AsyncLoad from 'calypso/components/async-load';
 import Chart from 'calypso/components/chart';
 import { DEFAULT_HEARTBEAT } from 'calypso/components/data/query-site-stats/constants';
 import memoizeLast from 'calypso/lib/memoize-last';
 import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
-import LineChart from 'calypso/my-sites/stats/components/line-chart';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { requestChartCounts } from 'calypso/state/stats/chart-tabs/actions';
@@ -179,7 +179,8 @@ class StatModuleChartTabs extends Component {
 						/>
 					</Chart>
 				) : (
-					<LineChart
+					<AsyncLoad
+						require="calypso/my-sites/stats/components/line-chart"
 						className="stats-chart-tabs__line-chart"
 						chartData={ this.generateDummyLineChartData() }
 						height={ 200 }

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -20,7 +20,7 @@ import StatsEmptyState from '../stats-empty-state';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatTabs from '../stats-tabs';
 import ChartHeader from './chart-header';
-import { buildChartData, getQueryDate } from './utility';
+import { buildChartData, getQueryDate, formatDate } from './utility';
 
 import './style.scss';
 
@@ -116,13 +116,13 @@ class StatModuleChartTabs extends Component {
 				label: 'Views',
 				options: {},
 				data: [
-					{ date: '2024-01-01', value: 45 },
-					{ date: '2024-01-02', value: 32 },
-					{ date: '2024-01-03', value: 67 },
-					{ date: '2024-01-04', value: 89 },
-					{ date: '2024-01-05', value: 54 },
-					{ date: '2024-01-06', value: 78 },
-					{ date: '2024-01-07', value: 93 },
+					{ date: new Date( '2024-01-01' ), value: 45 },
+					{ date: new Date( '2024-01-02' ), value: 32 },
+					{ date: new Date( '2024-01-03' ), value: 67 },
+					{ date: new Date( '2024-01-04' ), value: 89 },
+					{ date: new Date( '2024-01-05' ), value: 54 },
+					{ date: new Date( '2024-01-06' ), value: 78 },
+					{ date: new Date( '2024-01-07' ), value: 93 },
 				],
 			},
 		];
@@ -179,7 +179,17 @@ class StatModuleChartTabs extends Component {
 						/>
 					</Chart>
 				) : (
-					<LineChart className="stats-chart-tabs__line-chart" chartData={ [] } height={ 200 } />
+					<LineChart
+						className="stats-chart-tabs__line-chart"
+						chartData={ this.generateDummyLineChartData() }
+						height={ 200 }
+						moment={ this.props.moment }
+						formatTimeTick={ ( timestamp ) => {
+							const date = new Date( timestamp );
+							return formatDate( date, this.props.selectedPeriod );
+						} }
+						maxViews={ 100 }
+					/>
 				) }
 
 				<StatTabs

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -109,6 +109,25 @@ class StatModuleChartTabs extends Component {
 		this.setState( { chartType: newType } );
 	};
 
+	//TODO: remove this once we connect up the real data
+	generateDummyLineChartData = () => {
+		return [
+			{
+				label: 'Views',
+				options: {},
+				data: [
+					{ date: '2024-01-01', value: 45 },
+					{ date: '2024-01-02', value: 32 },
+					{ date: '2024-01-03', value: 67 },
+					{ date: '2024-01-04', value: 89 },
+					{ date: '2024-01-05', value: 54 },
+					{ date: '2024-01-06', value: 78 },
+					{ date: '2024-01-07', value: 93 },
+				],
+			},
+		];
+	};
+
 	render() {
 		const { siteId, slug, queryParams, selectedPeriod, isActiveTabLoading, className, countsComp } =
 			this.props;

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -298,3 +298,9 @@ ul.module-tabs {
 	}
 
 }
+
+.stats-chart-tabs__line-chart {
+	margin: 0 -24px;
+	padding: 0 24px;
+	min-height: 200px;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

related to: https://github.com/Automattic/jetpack-roadmap/issues/2317

## Proposed Changes

* This PR updates the new toggle switch to show a linechart when you select it
* It is only visible behind the feature flag
* It adds the line chart component for switching between the two chart types
* This is still a work in progress. Some things that need updated:
** It adds a line chart, but using dummy data at this point. The correct data transformation and connection is coming in a followup. 

## Testing Instructions

* Open Calypso live branch
* Navigate to `/stats/day/{URL}`
* Check you cannot see anything unusual
* Append feature flag `flags=stats/chart-library`
* Check that now the toggle button appears
* Click on the toggle, and make sure it toggles between the bar chart and the line chart. 
* 
![image](https://github.com/user-attachments/assets/29f5de93-e73d-43da-8443-b85ed21a4f4c)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
