### PR TITLE
Stats: Traffic page linechart replacement data transformation

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -10,7 +10,6 @@ import Chart from 'calypso/components/chart';
 import { DEFAULT_HEARTBEAT } from 'calypso/components/data/query-site-stats/constants';
 import memoizeLast from 'calypso/lib/memoize-last';
 import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
-import LineChart from 'calypso/my-sites/stats/components/line-chart';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { requestChartCounts } from 'calypso/state/stats/chart-tabs/actions';

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -10,6 +10,7 @@ import Chart from 'calypso/components/chart';
 import { DEFAULT_HEARTBEAT } from 'calypso/components/data/query-site-stats/constants';
 import memoizeLast from 'calypso/lib/memoize-last';
 import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
+import LineChart from 'calypso/my-sites/stats/components/line-chart';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { requestChartCounts } from 'calypso/state/stats/chart-tabs/actions';

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -31,6 +31,17 @@ const ChartTabShape = PropTypes.shape( {
 	legendOptions: PropTypes.arrayOf( PropTypes.string ),
 } );
 
+const transformChartDataToLineFormat = ( chartData, activeLegend ) => {
+	return activeLegend.map( ( legend ) => ( {
+		label: legend,
+		options: {},
+		data: chartData.map( ( record ) => ( {
+			date: new Date( record.data.period ),
+			value: record.data[ legend ] || 0,
+		} ) ),
+	} ) );
+};
+
 class StatModuleChartTabs extends Component {
 	static propTypes = {
 		slug: PropTypes.string,
@@ -182,14 +193,11 @@ class StatModuleChartTabs extends Component {
 					<AsyncLoad
 						require="calypso/my-sites/stats/components/line-chart"
 						className="stats-chart-tabs__line-chart"
-						chartData={ this.generateDummyLineChartData() }
+						chartData={ transformChartDataToLineFormat( chartData, this.props.activeLegend ) }
 						height={ 200 }
-						moment={ this.props.moment }
-						formatTimeTick={ ( timestamp ) => {
-							const date = new Date( timestamp );
-							return formatDate( date, this.props.selectedPeriod );
-						} }
-						maxViews={ 100 }
+						moment={ moment }
+						formatTimeTick={ ( timestamp ) => formatDate( new Date( timestamp ), selectedPeriod ) }
+						maxViews={ Math.max( ...chartData.map( ( d ) => d.value ) ) }
 					/>
 				) }
 

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -120,25 +120,6 @@ class StatModuleChartTabs extends Component {
 		this.setState( { chartType: newType } );
 	};
 
-	//TODO: remove this once we connect up the real data
-	generateDummyLineChartData = () => {
-		return [
-			{
-				label: 'Views',
-				options: {},
-				data: [
-					{ date: new Date( '2024-01-01' ), value: 45 },
-					{ date: new Date( '2024-01-02' ), value: 32 },
-					{ date: new Date( '2024-01-03' ), value: 67 },
-					{ date: new Date( '2024-01-04' ), value: 89 },
-					{ date: new Date( '2024-01-05' ), value: 54 },
-					{ date: new Date( '2024-01-06' ), value: 78 },
-					{ date: new Date( '2024-01-07' ), value: 93 },
-				],
-			},
-		];
-	};
-
 	render() {
 		const { siteId, slug, queryParams, selectedPeriod, isActiveTabLoading, className, countsComp } =
 			this.props;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

related to: https://github.com/Automattic/jetpack-roadmap/issues/2317

## Proposed Changes

* This PR updates the new linechart on the traffic page to use a real data source
* It also removed the dummy data generator
* This is a followup PR from https://github.com/Automattic/wp-calypso/pull/99970

## Testing Instructions

* Open Calypso live branch
* Navigate to `/stats/day/{URL}`
* Check you cannot see anything unusual
* Append feature flag `flags=stats/chart-library`
* Check that now the toggle button appears
* Click on the toggle, and make sure it toggles between the bar chart and the line chart. 
* Ensure the line chart data being shown matches the data shown on the bar chart

![image](https://github.com/user-attachments/assets/042ab440-5041-4709-91ee-beaead362962)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
