### PR TITLE
Auto save gift sub toggling and remove save button

### DIFF
--- a/client/sites/settings/site/form.jsx
+++ b/client/sites/settings/site/form.jsx
@@ -20,6 +20,7 @@ export default function SiteSettingsForm( {
 	updateFields,
 	onChangeField,
 	handleToggle,
+	handleAutosavingToggle,
 	handleSubmitForm,
 	isRequestingSettings,
 	isSavingSettings,
@@ -84,8 +85,7 @@ export default function SiteSettingsForm( {
 
 			<SubscriptionGiftingForm
 				fields={ fields }
-				handleToggle={ handleToggle }
-				onSave={ handleSubmitForm }
+				handleAutosavingToggle={ handleAutosavingToggle }
 				disabled={ isRequestingSettings || isSavingSettings }
 				isSaving={ isSavingSettings }
 			/>

--- a/client/sites/settings/site/subscription-gifting.jsx
+++ b/client/sites/settings/site/subscription-gifting.jsx
@@ -1,5 +1,5 @@
 import { WPCOM_FEATURES_SUBSCRIPTION_GIFTING } from '@automattic/calypso-products/src';
-import { Button, CompactCard } from '@automattic/components';
+import { CompactCard } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
@@ -13,8 +13,7 @@ import { useSelectedSiteSelector } from 'calypso/state/sites/hooks';
 
 export default function SubscriptionGiftingForm( {
 	fields,
-	handleToggle,
-	onSave,
+	handleAutosavingToggle,
 	isSaving,
 	disabled,
 } ) {
@@ -38,7 +37,7 @@ export default function SubscriptionGiftingForm( {
 					className="site-settings__gifting-toggle"
 					label={ translate( 'Allow site visitors to gift your plan and domain renewal costs' ) }
 					checked={ fields.wpcom_gifting_subscription }
-					onChange={ handleToggle( 'wpcom_gifting_subscription' ) }
+					onChange={ handleAutosavingToggle( 'wpcom_gifting_subscription' ) }
 					__next40pxDefaultSize
 				/>
 				{ ! isUntangled && (
@@ -65,8 +64,6 @@ export default function SubscriptionGiftingForm( {
 					id="site-settings__gifting-header"
 					disabled={ disabled }
 					isSaving={ isSaving }
-					onButtonClick={ onSave }
-					showButton
 				/>
 				<CompactCard className="site-settings__gifting-content">{ renderForm() }</CompactCard>
 			</div>
@@ -87,9 +84,6 @@ export default function SubscriptionGiftingForm( {
 				) }
 			</PanelCardDescription>
 			{ renderForm() }
-			<Button busy={ isSaving } disabled={ disabled } onClick={ onSave }>
-				{ translate( 'Save' ) }
-			</Button>
 		</PanelCard>
 	);
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/10443

Auto save gift sub toggling and remove save button

Before

![Screenshot 2025-02-19 at 16-18-28 Sites ‹ Site Title — WordPress com](https://github.com/user-attachments/assets/8cb7c9ee-4a53-40af-83fc-dd0783d1f0d0)

After

![Screenshot 2025-02-19 at 16-18-18 Sites ‹ Site Title — WordPress com](https://github.com/user-attachments/assets/c13c28eb-b6ee-456c-91e1-8fe997d06736)

## Testing Instructions

- https://wordpress.com/sites/settings/site/test112431.wordpress.com
- Disable and enable gift settings, confirm the option is being saved and tracks events are still being triggered for `wpcom_gifting_subscription`

Repeat for default view + RDV control site as well `?force-assign-rdv-variation=control`