### PR TITLE
Add auto saving to action bar visibility toggle in general settings

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -364,7 +364,7 @@ export class SiteSettingsFormGeneral extends Component {
 	}
 
 	hideActionbar() {
-		const { translate, fields, updateFields } = this.props;
+		const { translate, fields, handleAutosavingToggle } = this.props;
 		return (
 			<FormFieldset>
 				<FormLabel htmlFor="site-settings__wpcom_hide_action_bar">
@@ -375,9 +375,7 @@ export class SiteSettingsFormGeneral extends Component {
 					__nextHasNoMarginBottom
 					label={ translate( 'Hide the Action Bar.' ) }
 					checked={ !! fields?.wpcom_hide_action_bar }
-					onChange={ ( newValue ) => {
-						updateFields( { wpcom_hide_action_bar: newValue } );
-					} }
+					onChange={ handleAutosavingToggle( 'wpcom_hide_action_bar' ) }
 				/>
 				<FormSettingExplanation>
 					{ translate(


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/10443

## Proposed Changes

Adds auto saving to the action bar visibility toggle in general settings:

https://github.com/user-attachments/assets/9e97f746-9e31-48bd-90c7-93489ef47e3d

## Testing Instructions

Requires RDV control ?force-assign-rdv-variation=control as this option is implemented in wp-admin general settings.
 
- Visit general settings https://wordpress.com/settings/general/test112431.wordpress.com
- Toggle action bar visibility, it should save the option value