### PR TITLE
Allow manage contact information only for domains that are eligible for it

### DIFF
--- a/client/my-sites/domains/domain-management/dataviews/use-actions.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/use-actions.tsx
@@ -129,6 +129,7 @@ export function useActions( viewType: 'table' | 'list' | 'grid', onClose?: () =>
 				}
 				return (
 					domain.currentUserIsOwner &&
+					domain.canUpdateContactInfo &&
 					domain.type === domainTypes.REGISTERED &&
 					( isDomainUpdateable( domain ) || isDomainInGracePeriod( domain ) )
 				);


### PR DESCRIPTION
Related to #99898 

As part of CfT we got feedback that domains with 100-year plan are not eligible for updating contact information by the user.

Looking at how we can handle it, I found there is a property that we get from the backend that tells us whether we can update contact information (wasn't used neither in our DataViews implementation, not in the previous one with DomainsTable). It also works for 100-year domains.

## Proposed Changes

* Take `canUpdateContactInfo` property into account when we decide whether the Manage Contact Information action is available.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of addressing CfT feedback.

## Testing Instructions

* For testing, you need to have a 100-year domain. Here is a way how you can get it for testing purpose: pdtkmj-3no-p2#comment-6394
* Turn on feature flags in your browser's console: `window.sessionStorage.setItem('flags',  'calypso/domains-dataviews'])`
* Go to http://calypso.localhost:3000/domains/manage
* Make sure the Manage contact information action, either single domain or a bulk action, is not available.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?