### PR TITLE
Theme Preview: Set the max-height to 100vw on mobile to align with the container

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -60,6 +60,7 @@
 		top: 24px;
 		left: 24px;
 		right: 24px;
+		bottom: 24px;
 		width: calc(100% - 46px); /* IE11 fix */
 	}
 }

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -343,7 +343,13 @@ $button-border: 4px;
 	min-height: $iframe-viewport-height-scaled;
 
 	.theme-preview__frame-wrapper {
+		max-height: 100vw;
 		pointer-events: none;
+
+		.theme-preview__frame {
+			max-height: 100%;
+		}
+
 		@include breakpoint-deprecated( ">960px" ) {
 			max-height: calc(100vh - var(--masterbar-height));
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -355,7 +355,7 @@ $button-border: 4px;
 
 			.theme-preview__frame {
 				height: 200%;
-				max-height: 200vh;
+				max-height: 200%;
 				max-width: 200%;
 				min-height: $iframe-viewport-height-scaled;
 				transform: scale(0.5) !important;

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -28,7 +28,8 @@ $button-border: 4px;
 
 		.theme__sheet-web-preview .theme-preview__frame-wrapper {
 			@include breakpoint-deprecated( ">960px" ) {
-				max-height: calc(100vh - 32px - var(--masterbar-height));
+				// Inner padding: 96px.
+				max-height: calc(100vh - var(--content-padding-top) - var(--content-padding-bottom) - var(--masterbar-height) - 96px );
 			}
 		}
 	}

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -19,17 +19,10 @@ $button-border: 4px;
 		overflow: clip;
 		padding-top: 47px;
 
-		.theme__sheet-screenshot,
-		.theme__sheet-web-preview {
-			@include breakpoint-deprecated( ">960px" ) {
-				top: calc(var(--masterbar-height) + 16px);
-			}
-		}
-
 		.theme__sheet-web-preview .theme-preview__frame-wrapper {
 			@include breakpoint-deprecated( ">960px" ) {
-				// Inner padding: 96px.
-				max-height: calc(100vh - var(--content-padding-top) - var(--content-padding-bottom) - var(--masterbar-height) - 96px );
+				// Inner padding: 32px.
+				max-height: calc(100vh - var(--content-padding-top) - var(--content-padding-bottom) - var(--masterbar-height) - 32px );
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99954

## Proposed Changes

* Fix the broken theme preview on mobile by setting the max-height of the `theme-preview__frame-wrapper` to align with the parent container.

| | Before | After |
| - | - | - |
| Mobile | <img width="582" alt="image" src="https://github.com/user-attachments/assets/c3653e56-9b20-42c3-b09e-f5d2b6f7059a" /> | <img width="584" alt="image" src="https://github.com/user-attachments/assets/0314d098-6913-4339-a2b8-24cf74846392" /> |
| Desktop | <img width="1109" alt="image" src="https://github.com/user-attachments/assets/d2eb9ca5-91ce-41d0-af22-e515761ce5ca" /> | <img width="1109" alt="image" src="https://github.com/user-attachments/assets/f79bab56-7086-46f7-b91a-64832ba22858" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The preview looks broken

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /theme/resonar on mobile
* It should look better

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
