### PR TITLE
i18n: `format-currency` - Refactor caching to be more generic. Extract and simplify

### DIFF
--- a/packages/format-currency/src/get-cached-formatter.ts
+++ b/packages/format-currency/src/get-cached-formatter.ts
@@ -1,31 +1,4 @@
 const formatterCache = new Map();
-const fallbackLocale = 'en';
-
-/**
- * `numberingSystem` is an option to `Intl.NumberFormat` and is available
- * in all major browsers according to
- * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#options
- * but is not part of the TypeScript types in `es2020`:
- *
- * https://github.com/microsoft/TypeScript/blob/cfd472f7aa5a2010a3115263bf457b30c5b489f3/src/lib/es2020.intl.d.ts#L272
- *
- * However, it is part of the TypeScript types in `es5`:
- *
- * https://github.com/microsoft/TypeScript/blob/cfd472f7aa5a2010a3115263bf457b30c5b489f3/src/lib/es5.d.ts#L4310
- *
- * Apparently calypso uses `es2020` so we cannot use that option here right
- * now. Instead, we will use the unicode extension to the locale, documented
- * here:
- *
- * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem#adding_a_numbering_system_via_the_locale_string
- */
-function addNumberingSystemToLocale( locale: string ): string {
-	// TODO clk numberFormatCurrency this can all go. it's just a static string added to locale
-	const numberingSystem = 'latn';
-	const numberingSystemUnicodeLocaleExtension = `-u-nu-${ numberingSystem }`;
-	const localeWithNumberingSystem = `${ locale }${ numberingSystemUnicodeLocaleExtension }`;
-	return localeWithNumberingSystem;
-}
 
 /**
  * Creating an Intl.NumberFormat is expensive, so this allows caching.
@@ -35,9 +8,11 @@ function addNumberingSystemToLocale( locale: string ): string {
  */
 export function getCachedFormatter( {
 	locale,
+	fallbackLocale = 'en',
 	options,
 }: {
 	locale: string;
+	fallbackLocale?: string;
 	options?: Intl.NumberFormatOptions;
 } ): Intl.NumberFormat {
 	const cacheKey = JSON.stringify( [ locale, options ] );
@@ -45,9 +20,7 @@ export function getCachedFormatter( {
 	try {
 		return (
 			formatterCache.get( cacheKey ) ??
-			formatterCache
-				.set( cacheKey, new Intl.NumberFormat( addNumberingSystemToLocale( locale ), options ) )
-				.get( cacheKey )
+			formatterCache.set( cacheKey, new Intl.NumberFormat( locale, options ) ).get( cacheKey )
 		);
 	} catch ( error ) {
 		// If the locale is invalid, creating the NumberFormat will throw.

--- a/packages/format-currency/src/get-cached-formatter.ts
+++ b/packages/format-currency/src/get-cached-formatter.ts
@@ -1,0 +1,64 @@
+const formatterCache = new Map();
+const fallbackLocale = 'en';
+
+/**
+ * `numberingSystem` is an option to `Intl.NumberFormat` and is available
+ * in all major browsers according to
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#options
+ * but is not part of the TypeScript types in `es2020`:
+ *
+ * https://github.com/microsoft/TypeScript/blob/cfd472f7aa5a2010a3115263bf457b30c5b489f3/src/lib/es2020.intl.d.ts#L272
+ *
+ * However, it is part of the TypeScript types in `es5`:
+ *
+ * https://github.com/microsoft/TypeScript/blob/cfd472f7aa5a2010a3115263bf457b30c5b489f3/src/lib/es5.d.ts#L4310
+ *
+ * Apparently calypso uses `es2020` so we cannot use that option here right
+ * now. Instead, we will use the unicode extension to the locale, documented
+ * here:
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem#adding_a_numbering_system_via_the_locale_string
+ */
+function addNumberingSystemToLocale( locale: string ): string {
+	// TODO clk numberFormatCurrency this can all go. it's just a static string added to locale
+	const numberingSystem = 'latn';
+	const numberingSystemUnicodeLocaleExtension = `-u-nu-${ numberingSystem }`;
+	const localeWithNumberingSystem = `${ locale }${ numberingSystemUnicodeLocaleExtension }`;
+	return localeWithNumberingSystem;
+}
+
+/**
+ * Creating an Intl.NumberFormat is expensive, so this allows caching.
+ *
+ * TODO clk numberFormatCurrency Caching logic now same as numberFormat, except for fallback.
+ * TODO clk numberFormatCurrency This should replace numberFormat's caching logic, after some cleanup (remove console.warn).
+ */
+export function getCachedFormatter( {
+	locale,
+	options,
+}: {
+	locale: string;
+	options?: Intl.NumberFormatOptions;
+} ): Intl.NumberFormat {
+	const cacheKey = JSON.stringify( [ locale, options ] );
+
+	try {
+		return (
+			formatterCache.get( cacheKey ) ??
+			formatterCache
+				.set( cacheKey, new Intl.NumberFormat( addNumberingSystemToLocale( locale ), options ) )
+				.get( cacheKey )
+		);
+	} catch ( error ) {
+		// If the locale is invalid, creating the NumberFormat will throw.
+		// eslint-disable-next-line no-console
+		console.warn(
+			`Intl.NumberFormat was called with a non-existent locale "${ locale }"; falling back to ${ fallbackLocale }`
+		);
+
+		return getCachedFormatter( {
+			locale: fallbackLocale,
+			options,
+		} );
+	}
+}

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -50,10 +50,12 @@ export function createFormatter(): CurrencyFormatter {
 		const numberFormatOptions: Intl.NumberFormatOptions = {
 			style: 'currency',
 			currency: code,
-			...( isNoDecimals( number, options )
-				? { maximumFractionDigits: 0, minimumFractionDigits: 0 }
-				: {} ),
-			...( options.signForPositive ? { signDisplay: 'exceptZero' } : {} ),
+			...( options.stripZeros &&
+				Number.isInteger( number ) && {
+					maximumFractionDigits: 0,
+					minimumFractionDigits: 0,
+				} ),
+			...( options.signForPositive && { signDisplay: 'exceptZero' } ),
 		};
 
 		return getCachedFormatter( {
@@ -285,14 +287,6 @@ function getLocaleFromBrowser() {
 		return window.navigator.languages[ 0 ];
 	}
 	return window.navigator?.language ?? fallbackLocale;
-}
-
-function isNoDecimals( number: number, options: CurrencyObjectOptions ) {
-	// TODO clk numberFormatCurrency only isInteger part stays - the rest is same with "decimals" argument
-	if ( options.stripZeros && Number.isInteger( number ) ) {
-		return true;
-	}
-	return false;
 }
 
 function prepareNumberForFormatting(

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -268,7 +268,7 @@ export function createFormatter(): CurrencyFormatter {
 		currency: string
 	): number | undefined {
 		const formatter = getFormatter( 0, currency, { locale } );
-		return formatter.resolvedOptions().maximumFractionDigits ?? 3; // 3 is the default for Intl.NumberFormat
+		return formatter.resolvedOptions().maximumFractionDigits ?? 3; // 3 is the default for Intl.NumberFormat if minimumFractionDigits is not set
 	}
 
 	return {

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -8,7 +8,7 @@ import type {
 
 export * from './types';
 
-const formatterCache = new Map< string, Intl.NumberFormat >();
+const formatterCache = new Map();
 const fallbackLocale = 'en';
 const fallbackCurrency = 'USD';
 const geolocationEndpointUrl = 'https://public-api.wordpress.com/geo/';
@@ -272,20 +272,6 @@ function getLocaleFromBrowser() {
 	return window.navigator?.language ?? fallbackLocale;
 }
 
-function getFormatterCacheKey( {
-	locale,
-	currency,
-	noDecimals,
-	signForPositive,
-}: {
-	locale: string;
-	currency: string;
-	noDecimals: boolean;
-	signForPositive: boolean;
-} ): string {
-	return `currency:${ currency },locale:${ locale },noDecimals:${ noDecimals },signForPositive:${ signForPositive }`;
-}
-
 function isNoDecimals( number: number, options: CurrencyObjectOptions ) {
 	// TODO clk numberFormatCurrency only isInteger part stays - the rest is same with "decimals" argument
 	if ( options.stripZeros && Number.isInteger( number ) ) {
@@ -296,6 +282,8 @@ function isNoDecimals( number: number, options: CurrencyObjectOptions ) {
 
 /**
  * Creating an Intl.NumberFormat is expensive, so this allows caching.
+ *
+ * TODO clk numberFormatCurrency caching logic identical to numberFormat, except for fallback
  */
 function getCachedFormatter( {
 	locale,
@@ -308,34 +296,39 @@ function getCachedFormatter( {
 	noDecimals: boolean;
 	signForPositive: boolean;
 } ): Intl.NumberFormat {
-	const cacheKey = getFormatterCacheKey( { locale, currency, noDecimals, signForPositive } );
-	if ( formatterCache.has( cacheKey ) ) {
-		const formatter = formatterCache.get( cacheKey );
-		if ( formatter ) {
-			return formatter;
-		}
-	}
+	const numberFormatOptions: Intl.NumberFormatOptions = {
+		style: 'currency',
+		currency,
+		...( signForPositive ? { signDisplay: 'exceptZero' } : {} ),
+		// There's an option called `trailingZeroDisplay` but it does not yet work
+		// in FF so we have to strip zeros manually.
+		...( noDecimals ? { maximumFractionDigits: 0, minimumFractionDigits: 0 } : {} ),
+	};
+	const cacheKey = JSON.stringify( [ locale, numberFormatOptions ] );
 
 	try {
-		const formatter = new Intl.NumberFormat( addNumberingSystemToLocale( locale ), {
-			style: 'currency',
-			currency,
-			...( signForPositive ? { signDisplay: 'exceptZero' } : {} ),
-			// There's an option called `trailingZeroDisplay` but it does not yet work
-			// in FF so we have to strip zeros manually.
-			...( noDecimals ? { maximumFractionDigits: 0, minimumFractionDigits: 0 } : {} ),
-		} );
-
-		formatterCache.set( cacheKey, formatter );
-
-		return formatter;
+		return (
+			formatterCache.get( cacheKey ) ??
+			formatterCache
+				.set(
+					cacheKey,
+					new Intl.NumberFormat( addNumberingSystemToLocale( locale ), numberFormatOptions )
+				)
+				.get( cacheKey )
+		);
 	} catch ( error ) {
 		// If the locale is invalid, creating the NumberFormat will throw.
 		// eslint-disable-next-line no-console
 		console.warn(
 			`formatCurrency was called with a non-existent locale "${ locale }"; falling back to ${ fallbackLocale }`
 		);
-		return getCachedFormatter( { locale: fallbackLocale, currency, noDecimals, signForPositive } );
+
+		return getCachedFormatter( {
+			locale: fallbackLocale,
+			currency,
+			noDecimals,
+			signForPositive,
+		} );
 	}
 }
 

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -13,32 +13,6 @@ const fallbackLocale = 'en';
 const fallbackCurrency = 'USD';
 const geolocationEndpointUrl = 'https://public-api.wordpress.com/geo/';
 
-/**
- * `numberingSystem` is an option to `Intl.NumberFormat` and is available
- * in all major browsers according to
- * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#options
- * but is not part of the TypeScript types in `es2020`:
- *
- * https://github.com/microsoft/TypeScript/blob/cfd472f7aa5a2010a3115263bf457b30c5b489f3/src/lib/es2020.intl.d.ts#L272
- *
- * However, it is part of the TypeScript types in `es5`:
- *
- * https://github.com/microsoft/TypeScript/blob/cfd472f7aa5a2010a3115263bf457b30c5b489f3/src/lib/es5.d.ts#L4310
- *
- * Apparently calypso uses `es2020` so we cannot use that option here right
- * now. Instead, we will use the unicode extension to the locale, documented
- * here:
- *
- * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem#adding_a_numbering_system_via_the_locale_string
- */
-function addNumberingSystemToLocale( locale: string ): string {
-	// TODO clk numberFormatCurrency this can all go. it's just a static string added to locale
-	const numberingSystem = 'latn';
-	const numberingSystemUnicodeLocaleExtension = `-u-nu-${ numberingSystem }`;
-	const localeWithNumberingSystem = `${ locale }${ numberingSystemUnicodeLocaleExtension }`;
-	return localeWithNumberingSystem;
-}
-
 // TODO clk numberFormatCurrency exported only for tests
 export function createFormatter(): CurrencyFormatter {
 	let defaultLocale: string | undefined = undefined;
@@ -85,7 +59,7 @@ export function createFormatter(): CurrencyFormatter {
 		};
 
 		return getCachedFormatter( {
-			locale: addNumberingSystemToLocale( getLocaleToUse( options ) ),
+			locale: `${ getLocaleToUse( options ) }-u-nu-latn`,
 			options: numberFormatOptions,
 		} );
 	}

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -52,6 +52,10 @@ export function createFormatter(): CurrencyFormatter {
 			currency: code,
 			...( options.stripZeros &&
 				Number.isInteger( number ) && {
+					/**
+					 * There's an option called `trailingZeroDisplay` but it does not yet work
+					 * in FF so we have to strip zeros manually.
+					 */
 					maximumFractionDigits: 0,
 					minimumFractionDigits: 0,
 				} ),

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -58,6 +58,24 @@ export function createFormatter(): CurrencyFormatter {
 			...( options.signForPositive && { signDisplay: 'exceptZero' } ),
 		};
 
+		/**
+		 * `numberingSystem` is an option to `Intl.NumberFormat` and is available
+		 * in all major browsers according to
+		 * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#options
+		 * but is not part of the TypeScript types in `es2020`:
+		 *
+		 * https://github.com/microsoft/TypeScript/blob/cfd472f7aa5a2010a3115263bf457b30c5b489f3/src/lib/es2020.intl.d.ts#L272
+		 *
+		 * However, it is part of the TypeScript types in `es5`:
+		 *
+		 * https://github.com/microsoft/TypeScript/blob/cfd472f7aa5a2010a3115263bf457b30c5b489f3/src/lib/es5.d.ts#L4310
+		 *
+		 * Apparently calypso uses `es2020` so we cannot use that option here right
+		 * now. Instead, we will use the unicode extension to the locale, documented
+		 * here:
+		 *
+		 * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem#adding_a_numbering_system_via_the_locale_string
+		 */
 		return getCachedFormatter( {
 			locale: `${ getLocaleToUse( options ) }-u-nu-latn`,
 			options: numberFormatOptions,

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -13,6 +13,32 @@ const fallbackLocale = 'en';
 const fallbackCurrency = 'USD';
 const geolocationEndpointUrl = 'https://public-api.wordpress.com/geo/';
 
+/**
+ * `numberingSystem` is an option to `Intl.NumberFormat` and is available
+ * in all major browsers according to
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#options
+ * but is not part of the TypeScript types in `es2020`:
+ *
+ * https://github.com/microsoft/TypeScript/blob/cfd472f7aa5a2010a3115263bf457b30c5b489f3/src/lib/es2020.intl.d.ts#L272
+ *
+ * However, it is part of the TypeScript types in `es5`:
+ *
+ * https://github.com/microsoft/TypeScript/blob/cfd472f7aa5a2010a3115263bf457b30c5b489f3/src/lib/es5.d.ts#L4310
+ *
+ * Apparently calypso uses `es2020` so we cannot use that option here right
+ * now. Instead, we will use the unicode extension to the locale, documented
+ * here:
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem#adding_a_numbering_system_via_the_locale_string
+ */
+function addNumberingSystemToLocale( locale: string ): string {
+	// TODO clk numberFormatCurrency this can all go. it's just a static string added to locale
+	const numberingSystem = 'latn';
+	const numberingSystemUnicodeLocaleExtension = `-u-nu-${ numberingSystem }`;
+	const localeWithNumberingSystem = `${ locale }${ numberingSystemUnicodeLocaleExtension }`;
+	return localeWithNumberingSystem;
+}
+
 // TODO clk numberFormatCurrency exported only for tests
 export function createFormatter(): CurrencyFormatter {
 	let defaultLocale: string | undefined = undefined;
@@ -59,7 +85,7 @@ export function createFormatter(): CurrencyFormatter {
 		};
 
 		return getCachedFormatter( {
-			locale: getLocaleToUse( options ),
+			locale: addNumberingSystemToLocale( getLocaleToUse( options ) ),
 			options: numberFormatOptions,
 		} );
 	}

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -1,4 +1,5 @@
 import { defaultCurrencyOverrides } from './currencies';
+import { getCachedFormatter } from './get-cached-formatter';
 import type {
 	CurrencyObject,
 	CurrencyObjectOptions,
@@ -8,7 +9,6 @@ import type {
 
 export * from './types';
 
-const formatterCache = new Map();
 const fallbackLocale = 'en';
 const fallbackCurrency = 'USD';
 const geolocationEndpointUrl = 'https://public-api.wordpress.com/geo/';
@@ -42,16 +42,23 @@ export function createFormatter(): CurrencyFormatter {
 		return options.locale ?? defaultLocale ?? getLocaleFromBrowser();
 	}
 
-	function getFormatter(
+	function getCurrencyFormatter(
 		number: number,
 		code: string,
 		options: CurrencyObjectOptions
 	): Intl.NumberFormat {
+		const numberFormatOptions: Intl.NumberFormatOptions = {
+			style: 'currency',
+			currency: code,
+			...( isNoDecimals( number, options )
+				? { maximumFractionDigits: 0, minimumFractionDigits: 0 }
+				: {} ),
+			...( options.signForPositive ? { signDisplay: 'exceptZero' } : {} ),
+		};
+
 		return getCachedFormatter( {
 			locale: getLocaleToUse( options ),
-			currency: code,
-			noDecimals: isNoDecimals( number, options ),
-			signForPositive: options.signForPositive ?? false,
+			options: numberFormatOptions,
 		} );
 	}
 
@@ -93,12 +100,12 @@ export function createFormatter(): CurrencyFormatter {
 		options: CurrencyObjectOptions = {}
 	): string {
 		const locale = getLocaleToUse( options );
-		code = getValidCurrency( code );
-		const currencyOverride = getCurrencyOverride( code );
-		const currencyPrecision = getPrecisionForLocaleAndCurrency( locale, code );
+		const validCurrency = getValidCurrency( code );
+		const currencyOverride = getCurrencyOverride( validCurrency );
+		const currencyPrecision = getPrecisionForLocaleAndCurrency( locale, validCurrency );
 
-		const numberAsFloat = prepareNumberForFormatting( number, currencyPrecision, options );
-		const formatter = getFormatter( numberAsFloat, code, options );
+		const numberAsFloat = prepareNumberForFormatting( number, currencyPrecision ?? 0, options );
+		const formatter = getCurrencyFormatter( numberAsFloat, validCurrency, options );
 		const parts = formatter.formatToParts( numberAsFloat );
 
 		return parts.reduce( ( formatted, part ) => {
@@ -159,12 +166,12 @@ export function createFormatter(): CurrencyFormatter {
 		options: CurrencyObjectOptions = {}
 	): CurrencyObject {
 		const locale = getLocaleToUse( options );
-		code = getValidCurrency( code );
-		const currencyOverride = getCurrencyOverride( code );
-		const currencyPrecision = getPrecisionForLocaleAndCurrency( locale, code );
+		const validCurrency = getValidCurrency( code );
+		const currencyOverride = getCurrencyOverride( validCurrency );
+		const currencyPrecision = getPrecisionForLocaleAndCurrency( locale, validCurrency );
 
-		const numberAsFloat = prepareNumberForFormatting( number, currencyPrecision, options );
-		const formatter = getFormatter( numberAsFloat, code, options );
+		const numberAsFloat = prepareNumberForFormatting( number, currencyPrecision ?? 0, options );
+		const formatter = getCurrencyFormatter( numberAsFloat, validCurrency, options );
 		const parts = formatter.formatToParts( numberAsFloat );
 
 		let sign = '' as CurrencyObject[ 'sign' ];
@@ -254,6 +261,14 @@ export function createFormatter(): CurrencyFormatter {
 		defaultLocale = locale;
 	}
 
+	function getPrecisionForLocaleAndCurrency(
+		locale: string,
+		currency: string
+	): number | undefined {
+		const formatter = getCurrencyFormatter( 0, currency, { locale } );
+		return formatter.resolvedOptions().maximumFractionDigits ?? 3; // 3 is the default for Intl.NumberFormat
+	}
+
 	return {
 		formatCurrency,
 		getCurrencyObject,
@@ -278,94 +293,6 @@ function isNoDecimals( number: number, options: CurrencyObjectOptions ) {
 		return true;
 	}
 	return false;
-}
-
-/**
- * Creating an Intl.NumberFormat is expensive, so this allows caching.
- *
- * TODO clk numberFormatCurrency caching logic identical to numberFormat, except for fallback
- */
-function getCachedFormatter( {
-	locale,
-	currency,
-	noDecimals,
-	signForPositive,
-}: {
-	locale: string;
-	currency: string;
-	noDecimals: boolean;
-	signForPositive: boolean;
-} ): Intl.NumberFormat {
-	const numberFormatOptions: Intl.NumberFormatOptions = {
-		style: 'currency',
-		currency,
-		...( signForPositive ? { signDisplay: 'exceptZero' } : {} ),
-		// There's an option called `trailingZeroDisplay` but it does not yet work
-		// in FF so we have to strip zeros manually.
-		...( noDecimals ? { maximumFractionDigits: 0, minimumFractionDigits: 0 } : {} ),
-	};
-	const cacheKey = JSON.stringify( [ locale, numberFormatOptions ] );
-
-	try {
-		return (
-			formatterCache.get( cacheKey ) ??
-			formatterCache
-				.set(
-					cacheKey,
-					new Intl.NumberFormat( addNumberingSystemToLocale( locale ), numberFormatOptions )
-				)
-				.get( cacheKey )
-		);
-	} catch ( error ) {
-		// If the locale is invalid, creating the NumberFormat will throw.
-		// eslint-disable-next-line no-console
-		console.warn(
-			`formatCurrency was called with a non-existent locale "${ locale }"; falling back to ${ fallbackLocale }`
-		);
-
-		return getCachedFormatter( {
-			locale: fallbackLocale,
-			currency,
-			noDecimals,
-			signForPositive,
-		} );
-	}
-}
-
-/**
- * `numberingSystem` is an option to `Intl.NumberFormat` and is available
- * in all major browsers according to
- * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#options
- * but is not part of the TypeScript types in `es2020`:
- *
- * https://github.com/microsoft/TypeScript/blob/cfd472f7aa5a2010a3115263bf457b30c5b489f3/src/lib/es2020.intl.d.ts#L272
- *
- * However, it is part of the TypeScript types in `es5`:
- *
- * https://github.com/microsoft/TypeScript/blob/cfd472f7aa5a2010a3115263bf457b30c5b489f3/src/lib/es5.d.ts#L4310
- *
- * Apparently calypso uses `es2020` so we cannot use that option here right
- * now. Instead, we will use the unicode extension to the locale, documented
- * here:
- *
- * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem#adding_a_numbering_system_via_the_locale_string
- */
-function addNumberingSystemToLocale( locale: string ): string {
-	// TODO clk numberFormatCurrency this can all go. it's just a static string added to locale
-	const numberingSystem = 'latn';
-	const numberingSystemUnicodeLocaleExtension = `-u-nu-${ numberingSystem }`;
-	const localeWithNumberingSystem = `${ locale }${ numberingSystemUnicodeLocaleExtension }`;
-	return localeWithNumberingSystem;
-}
-
-function getPrecisionForLocaleAndCurrency( locale: string, currency: string ): number {
-	const defaultFormatter = getCachedFormatter( {
-		locale,
-		currency,
-		noDecimals: false,
-		signForPositive: false,
-	} );
-	return defaultFormatter.resolvedOptions().maximumFractionDigits;
 }
 
 function prepareNumberForFormatting(

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -42,7 +42,7 @@ export function createFormatter(): CurrencyFormatter {
 		return options.locale ?? defaultLocale ?? getLocaleFromBrowser();
 	}
 
-	function getCurrencyFormatter(
+	function getFormatter(
 		number: number,
 		code: string,
 		options: CurrencyObjectOptions
@@ -107,7 +107,7 @@ export function createFormatter(): CurrencyFormatter {
 		const currencyPrecision = getPrecisionForLocaleAndCurrency( locale, validCurrency );
 
 		const numberAsFloat = prepareNumberForFormatting( number, currencyPrecision ?? 0, options );
-		const formatter = getCurrencyFormatter( numberAsFloat, validCurrency, options );
+		const formatter = getFormatter( numberAsFloat, validCurrency, options );
 		const parts = formatter.formatToParts( numberAsFloat );
 
 		return parts.reduce( ( formatted, part ) => {
@@ -173,7 +173,7 @@ export function createFormatter(): CurrencyFormatter {
 		const currencyPrecision = getPrecisionForLocaleAndCurrency( locale, validCurrency );
 
 		const numberAsFloat = prepareNumberForFormatting( number, currencyPrecision ?? 0, options );
-		const formatter = getCurrencyFormatter( numberAsFloat, validCurrency, options );
+		const formatter = getFormatter( numberAsFloat, validCurrency, options );
 		const parts = formatter.formatToParts( numberAsFloat );
 
 		let sign = '' as CurrencyObject[ 'sign' ];
@@ -267,7 +267,7 @@ export function createFormatter(): CurrencyFormatter {
 		locale: string,
 		currency: string
 	): number | undefined {
-		const formatter = getCurrencyFormatter( 0, currency, { locale } );
+		const formatter = getFormatter( 0, currency, { locale } );
 		return formatter.resolvedOptions().maximumFractionDigits ?? 3; // 3 is the default for Intl.NumberFormat
 	}
 

--- a/packages/format-currency/test/get-cached-formatter.ts
+++ b/packages/format-currency/test/get-cached-formatter.ts
@@ -1,0 +1,39 @@
+import { getCachedFormatter } from '../src/get-cached-formatter';
+
+describe( 'getFormatter', () => {
+	it( 'should return a cached formatter when one exists', () => {
+		const locale = 'en-US';
+		const options: Intl.NumberFormatOptions = { style: 'currency', currency: 'USD' };
+
+		// Get formatter for the first time
+		const formatter1 = getCachedFormatter( { locale, options } );
+
+		// Get formatter for the second time
+		const formatter2 = getCachedFormatter( { locale, options } );
+
+		// Check that the same formatter instance is returned
+		expect( formatter1 ).toBe( formatter2 );
+
+		// Check that the formatter formats correctly
+		expect( formatter1.format( 1234.56 ) ).toBe( '$1,234.56' );
+	} );
+
+	it( 'should create a new formatter when options are different', () => {
+		const locale = 'en-US';
+		const options1: Intl.NumberFormatOptions = { style: 'currency', currency: 'USD' };
+		const options2: Intl.NumberFormatOptions = { style: 'currency', currency: 'EUR' };
+
+		// Get formatter for the first set of options
+		const formatter1 = getCachedFormatter( { locale, options: options1 } );
+
+		// Get formatter for the second set of options
+		const formatter2 = getCachedFormatter( { locale, options: options2 } );
+
+		// Check that different formatter instances are returned
+		expect( formatter1 ).not.toBe( formatter2 );
+
+		// Check that the formatters format correctly
+		expect( formatter1.format( 1234.56 ) ).toBe( '$1,234.56' );
+		expect( formatter2.format( 1234.56 ) ).toBe( '€1,234.56' );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/939
Based off https://github.com/Automattic/wp-calypso/pull/99924

## Proposed Changes

Updates the `get-cached-formatter` logic to more closely match the one from `i18n-calypso`. This should be nearly identical to the one in `i18n-calypso`, albeit with more processing here (so this should replace the other one eventually)

- Stops being a concatenated list of strings, uses a generic serializer instead. Approach tested and benchmarked in https://github.com/Automattic/wp-calypso/pull/99110 and https://github.com/Automattic/wp-calypso/pull/99538
- The generic parts extracted into a separate module with tests added 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- This is part of addressing https://github.com/Automattic/i18n-issues/issues/939, which aims at unifying number & currency-number formatting

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The essential functionality is covered by the unit tests. A couple more added
* Confirm a few places that prices render correctly across different locales and selected currencies.
    * Switch to EL locale
    * Switch currency to USD from store admin
    * Go to `/start/plans` -> prices should render as `123 US$` img below

<img width="800" alt="Screenshot 2025-02-19 at 10 53 49 AM" src="https://github.com/user-attachments/assets/2edf88a3-3747-4702-b445-347ba43f58b3" />




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
