### PR TITLE
A4A > Signup: Implement go-back functionality to WC Asia Sign-up form

### DIFF
--- a/client/a8c-for-agencies/components/form/footer/style.scss
+++ b/client/a8c-for-agencies/components/form/footer/style.scss
@@ -1,5 +1,11 @@
 .a4a-form__footer {
 	margin-block-start: 8px;
+	padding-block: 24px;
+	border-block-start: 1px solid #C3C4C7;
+
 	display: flex;
 	gap: 24px;
+
+	justify-content: space-between;
+	align-items: center;
 }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form-2/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form-2/index.tsx
@@ -12,6 +12,8 @@ import { AgencyDetailsSignupPayload } from '../../../../types';
 
 type Props = {
 	onContinue: ( data: Partial< AgencyDetailsSignupPayload > ) => void;
+	initialFormData: Partial< AgencyDetailsSignupPayload >;
+	goBack: () => void;
 };
 
 const BlueprintFormRadio = ( {
@@ -40,12 +42,12 @@ const BlueprintFormRadio = ( {
 	);
 };
 
-const BlueprintForm2: React.FC< Props > = ( { onContinue } ) => {
+const BlueprintForm2: React.FC< Props > = ( { onContinue, initialFormData, goBack } ) => {
 	const translate = useTranslate();
 	const [ formData, setFormData ] = useState< Partial< AgencyDetailsSignupPayload > >( {
-		workWithClients: '',
-		workWithClientsOther: '',
-		approachAndChallenges: '',
+		workWithClients: initialFormData.workWithClients || '',
+		workWithClientsOther: initialFormData.workWithClientsOther || '',
+		approachAndChallenges: initialFormData.approachAndChallenges || '',
 	} );
 
 	const handleSubmit = ( e: React.FormEvent ) => {
@@ -115,6 +117,9 @@ const BlueprintForm2: React.FC< Props > = ( { onContinue } ) => {
 			</FormField>
 
 			<FormFooter>
+				<Button variant="secondary" onClick={ goBack } __next40pxDefaultSize>
+					{ translate( 'Go back' ) }
+				</Button>
 				<Button variant="primary" onClick={ handleSubmit } __next40pxDefaultSize>
 					{ translate( 'Continue' ) }
 				</Button>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form-2/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form-2/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@wordpress/components';
+import { Icon, arrowLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import Form from 'calypso/a8c-for-agencies/components/form';
@@ -117,9 +118,10 @@ const BlueprintForm2: React.FC< Props > = ( { onContinue, initialFormData, goBac
 			</FormField>
 
 			<FormFooter>
-				<Button variant="secondary" onClick={ goBack } __next40pxDefaultSize>
-					{ translate( 'Go back' ) }
-				</Button>
+				<button className="signup-multi-step-form__back-button" onClick={ goBack }>
+					<Icon icon={ arrowLeft } size={ 18 } />
+					{ translate( 'Back' ) }
+				</button>
 				<Button variant="primary" onClick={ handleSubmit } __next40pxDefaultSize>
 					{ translate( 'Continue' ) }
 				</Button>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form-2/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form-2/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@wordpress/components';
-import { Icon, arrowLeft } from '@wordpress/icons';
+import { arrowLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import Form from 'calypso/a8c-for-agencies/components/form';
@@ -118,10 +118,16 @@ const BlueprintForm2: React.FC< Props > = ( { onContinue, initialFormData, goBac
 			</FormField>
 
 			<FormFooter>
-				<button className="signup-multi-step-form__back-button" onClick={ goBack }>
-					<Icon icon={ arrowLeft } size={ 18 } />
+				<Button
+					className="signup-multi-step-form__back-button"
+					variant="tertiary"
+					onClick={ goBack }
+					icon={ arrowLeft }
+					iconSize={ 18 }
+				>
 					{ translate( 'Back' ) }
-				</button>
+				</Button>
+
 				<Button variant="primary" onClick={ handleSubmit } __next40pxDefaultSize>
 					{ translate( 'Continue' ) }
 				</Button>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@wordpress/components';
-import { Icon, arrowLeft } from '@wordpress/icons';
+import { arrowLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import Form from 'calypso/a8c-for-agencies/components/form';
@@ -125,10 +125,16 @@ const BlueprintForm: React.FC< Props > = ( { onContinue, initialFormData, goBack
 			</FormField>
 
 			<FormFooter>
-				<button className="signup-multi-step-form__back-button" onClick={ goBack }>
-					<Icon icon={ arrowLeft } size={ 18 } />
+				<Button
+					className="signup-multi-step-form__back-button"
+					variant="tertiary"
+					onClick={ goBack }
+					icon={ arrowLeft }
+					iconSize={ 18 }
+				>
 					{ translate( 'Back' ) }
-				</button>
+				</Button>
+
 				<Button variant="primary" onClick={ handleSubmit } __next40pxDefaultSize>
 					{ translate( 'Continue' ) }
 				</Button>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@wordpress/components';
+import { Icon, arrowLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import Form from 'calypso/a8c-for-agencies/components/form';
@@ -124,9 +125,10 @@ const BlueprintForm: React.FC< Props > = ( { onContinue, initialFormData, goBack
 			</FormField>
 
 			<FormFooter>
-				<Button variant="secondary" onClick={ goBack } __next40pxDefaultSize>
-					{ translate( 'Go back' ) }
-				</Button>
+				<button className="signup-multi-step-form__back-button" onClick={ goBack }>
+					<Icon icon={ arrowLeft } size={ 18 } />
+					{ translate( 'Back' ) }
+				</button>
 				<Button variant="primary" onClick={ handleSubmit } __next40pxDefaultSize>
 					{ translate( 'Continue' ) }
 				</Button>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
@@ -10,6 +10,8 @@ import { AgencyDetailsSignupPayload } from '../../../../types';
 
 type Props = {
 	onContinue: ( data: Partial< AgencyDetailsSignupPayload > ) => void;
+	initialFormData: Partial< AgencyDetailsSignupPayload >;
+	goBack: () => void;
 };
 
 const BlueprintFormRadio = ( {
@@ -38,11 +40,11 @@ const BlueprintFormRadio = ( {
 	);
 };
 
-const BlueprintForm: React.FC< Props > = ( { onContinue } ) => {
+const BlueprintForm: React.FC< Props > = ( { onContinue, initialFormData, goBack } ) => {
 	const translate = useTranslate();
 	const [ formData, setFormData ] = useState< Partial< AgencyDetailsSignupPayload > >( {
-		topPartneringGoal: '',
-		topYearlyGoal: '',
+		topPartneringGoal: initialFormData.topPartneringGoal || '',
+		topYearlyGoal: initialFormData.topYearlyGoal || '',
 	} );
 
 	const handleSubmit = ( e: React.FormEvent ) => {
@@ -122,6 +124,9 @@ const BlueprintForm: React.FC< Props > = ( { onContinue } ) => {
 			</FormField>
 
 			<FormFooter>
+				<Button variant="secondary" onClick={ goBack } __next40pxDefaultSize>
+					{ translate( 'Go back' ) }
+				</Button>
 				<Button variant="primary" onClick={ handleSubmit } __next40pxDefaultSize>
 					{ translate( 'Continue' ) }
 				</Button>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@wordpress/components';
-import { Icon, arrowLeft } from '@wordpress/icons';
+import { arrowLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import Form from 'calypso/a8c-for-agencies/components/form';
 import FormFooter from 'calypso/a8c-for-agencies/components/form/footer';
@@ -27,12 +27,16 @@ const ChoiceBlueprint: React.FC< Props > = ( { onContinue, onSkip, goBack } ) =>
 			) }
 		>
 			<FormFooter>
-				<div>
-					<button className="signup-multi-step-form__back-button" onClick={ goBack }>
-						<Icon icon={ arrowLeft } size={ 18 } />
-						{ translate( 'Back' ) }
-					</button>
-				</div>
+				<Button
+					className="signup-multi-step-form__back-button"
+					variant="tertiary"
+					onClick={ goBack }
+					icon={ arrowLeft }
+					iconSize={ 18 }
+				>
+					{ translate( 'Back' ) }
+				</Button>
+
 				<div>
 					<Button
 						className="choice-blueprint__cancel-button"

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@wordpress/components';
+import { Icon, arrowLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import Form from 'calypso/a8c-for-agencies/components/form';
 import FormFooter from 'calypso/a8c-for-agencies/components/form/footer';
@@ -26,31 +27,31 @@ const ChoiceBlueprint: React.FC< Props > = ( { onContinue, onSkip, goBack } ) =>
 			) }
 		>
 			<FormFooter>
-				<Button
-					className="choice-blueprint__button"
-					variant="primary"
-					onClick={ onContinue }
-					__next40pxDefaultSize
-				>
-					{ translate( 'Build my custom blueprint' ) }
-				</Button>
-				<Button
-					className="choice-blueprint__button"
-					variant="secondary"
-					onClick={ onSkip }
-					__next40pxDefaultSize
-				>
-					{ translate( 'Not right now' ) }
-				</Button>
+				<div>
+					<button className="signup-multi-step-form__back-button" onClick={ goBack }>
+						<Icon icon={ arrowLeft } size={ 18 } />
+						{ translate( 'Back' ) }
+					</button>
+				</div>
+				<div>
+					<Button
+						className="choice-blueprint__cancel-button"
+						variant="tertiary"
+						onClick={ onSkip }
+						__next40pxDefaultSize
+					>
+						{ translate( 'Not right now' ) }
+					</Button>
+					<Button
+						className="choice-blueprint__button"
+						variant="primary"
+						onClick={ onContinue }
+						__next40pxDefaultSize
+					>
+						{ translate( 'Build my custom blueprint' ) }
+					</Button>
+				</div>
 			</FormFooter>
-			<Button
-				className="choice-blueprint__go-back-button"
-				variant="secondary"
-				onClick={ goBack }
-				__next40pxDefaultSize
-			>
-				{ translate( 'Go back' ) }
-			</Button>
 		</Form>
 	);
 };

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/index.tsx
@@ -9,9 +9,10 @@ import './style.scss';
 type Props = {
 	onContinue: () => void;
 	onSkip: () => void;
+	goBack: () => void;
 };
 
-const ChoiceBlueprint: React.FC< Props > = ( { onContinue, onSkip } ) => {
+const ChoiceBlueprint: React.FC< Props > = ( { onContinue, onSkip, goBack } ) => {
 	const translate = useTranslate();
 
 	return (
@@ -42,6 +43,14 @@ const ChoiceBlueprint: React.FC< Props > = ( { onContinue, onSkip } ) => {
 					{ translate( 'Not right now' ) }
 				</Button>
 			</FormFooter>
+			<Button
+				className="choice-blueprint__go-back-button"
+				variant="secondary"
+				onClick={ goBack }
+				__next40pxDefaultSize
+			>
+				{ translate( 'Go back' ) }
+			</Button>
 		</Form>
 	);
 };

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/style.scss
@@ -2,3 +2,7 @@
 	width: 200px;
 	justify-content: center;
 }
+
+.choice-blueprint__go-back-button {
+	width: fit-content;
+}

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/style.scss
@@ -6,3 +6,7 @@
 .choice-blueprint__go-back-button {
 	width: fit-content;
 }
+
+.choice-blueprint__cancel-button {
+	margin-inline-end: 8px;
+}

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
@@ -17,9 +17,10 @@ import './style.scss';
 
 type Props = {
 	onContinue: ( data: Partial< AgencyDetailsSignupPayload > ) => void;
+	initialFormData: Partial< AgencyDetailsSignupPayload >;
 };
 
-const SignupContactForm = ( { onContinue }: Props ) => {
+const SignupContactForm = ( { onContinue, initialFormData }: Props ) => {
 	const translate = useTranslate();
 	const [ showTosModal, setShowTosModal ] = useState( false );
 	const { validate, validationError, updateValidationError, isValidating } =
@@ -29,12 +30,12 @@ const SignupContactForm = ( { onContinue }: Props ) => {
 	const noCountryList = countriesList.length === 0;
 
 	const [ formData, setFormData ] = useState< Partial< AgencyDetailsSignupPayload > >( {
-		firstName: '',
-		lastName: '',
-		email: '',
-		agencyName: '',
-		agencyUrl: '',
-		phoneNumber: '',
+		firstName: initialFormData.firstName || '',
+		lastName: initialFormData.lastName || '',
+		email: initialFormData.email || '',
+		agencyName: initialFormData.agencyName || '',
+		agencyUrl: initialFormData.agencyUrl || '',
+		phoneNumber: initialFormData.phoneNumber || '',
 	} );
 
 	const handlePhoneInputChange = ( data: { phoneNumberFull: string } ) => {
@@ -146,6 +147,7 @@ const SignupContactForm = ( { onContinue }: Props ) => {
 				phoneInputProps={ {
 					placeholder: translate( 'Phone number' ),
 				} }
+				initialCountryCode="US"
 			/>
 			<TosModal
 				show={ showTosModal }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
@@ -87,12 +87,26 @@ const MultiStepForm = () => {
 	} );
 
 	const updateDataAndContinue = useCallback(
-		( data: Partial< AgencyDetailsSignupPayload >, nextStep: number ) => {
+		(
+			data: Partial< AgencyDetailsSignupPayload >,
+			nextStep: number,
+			isBlueprintRequested = false
+		) => {
 			const newFormData = { ...formData, ...data };
 			setFormData( newFormData );
 			setCurrentStep( nextStep );
 			if ( nextStep === 6 ) {
-				createSignup.mutate( newFormData as AgencyDetailsSignupPayload );
+				const {
+					topPartneringGoal,
+					topYearlyGoal,
+					workWithClients,
+					workWithClientsOther,
+					approachAndChallenges,
+					...rest
+				} = newFormData;
+				const payload = isBlueprintRequested ? newFormData : rest;
+				debugger;
+				createSignup.mutate( payload as AgencyDetailsSignupPayload );
 			}
 		},
 		[ formData, createSignup ]
@@ -107,25 +121,45 @@ const MultiStepForm = () => {
 	const currentForm = useMemo( () => {
 		switch ( currentStep ) {
 			case 1:
-				return <SignupContactForm onContinue={ ( data ) => updateDataAndContinue( data, 2 ) } />;
+				return (
+					<SignupContactForm
+						onContinue={ ( data ) => updateDataAndContinue( data, 2 ) }
+						initialFormData={ formData }
+					/>
+				);
 			case 2:
-				return <PersonalizationForm onContinue={ ( data ) => updateDataAndContinue( data, 3 ) } />;
+				return (
+					<PersonalizationForm
+						onContinue={ ( data ) => updateDataAndContinue( data, 3 ) }
+						initialFormData={ formData }
+						goBack={ () => setCurrentStep( 1 ) }
+					/>
+				);
 			case 3:
 				return (
 					<ChoiceBlueprint
 						onContinue={ () => updateDataAndContinue( {}, 4 ) }
 						onSkip={ () => updateDataAndContinue( {}, 6 ) }
+						goBack={ () => setCurrentStep( 2 ) }
 					/>
 				);
 			case 4:
-				return <BlueprintForm onContinue={ ( data ) => updateDataAndContinue( data, 5 ) } />;
+				return (
+					<BlueprintForm
+						onContinue={ ( data ) => updateDataAndContinue( data, 5 ) }
+						initialFormData={ formData }
+						goBack={ () => setCurrentStep( 3 ) }
+					/>
+				);
 			case 5:
 				return (
 					<BlueprintForm2
 						onContinue={ ( data ) => {
 							setBlueprintRequested( true );
-							updateDataAndContinue( data, 6 );
+							updateDataAndContinue( data, 6, true );
 						} }
+						initialFormData={ formData }
+						goBack={ () => setCurrentStep( 4 ) }
 					/>
 				);
 			case 6:
@@ -138,7 +172,7 @@ const MultiStepForm = () => {
 			default:
 				return null;
 		}
-	}, [ blueprintRequested, currentStep, updateDataAndContinue ] );
+	}, [ blueprintRequested, currentStep, formData, updateDataAndContinue ] );
 
 	return (
 		<div className="signup-multi-step-form">

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
@@ -105,7 +105,6 @@ const MultiStepForm = () => {
 					...rest
 				} = newFormData;
 				const payload = isBlueprintRequested ? newFormData : rest;
-				debugger;
 				createSignup.mutate( payload as AgencyDetailsSignupPayload );
 			}
 		},

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -1,6 +1,6 @@
 import { SearchableDropdown } from '@automattic/components';
 import { Button } from '@wordpress/components';
-import { Icon, arrowLeft } from '@wordpress/icons';
+import { arrowLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, ChangeEvent, useMemo } from 'react';
 import Form from 'calypso/a8c-for-agencies/components/form';
@@ -192,10 +192,16 @@ export default function PersonalizationForm( { onContinue, goBack, initialFormDa
 						</FormFieldset>
 
 						<FormFooter>
-							<button className="signup-multi-step-form__back-button" onClick={ goBack }>
-								<Icon icon={ arrowLeft } size={ 18 } />
+							<Button
+								className="signup-multi-step-form__back-button"
+								variant="tertiary"
+								onClick={ goBack }
+								icon={ arrowLeft }
+								iconSize={ 18 }
+							>
 								{ translate( 'Back' ) }
-							</button>
+							</Button>
+
 							<Button __next40pxDefaultSize variant="primary" onClick={ handleSubmit }>
 								{ translate( 'Continue' ) }
 							</Button>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -1,5 +1,6 @@
 import { SearchableDropdown } from '@automattic/components';
 import { Button } from '@wordpress/components';
+import { Icon, arrowLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, ChangeEvent, useMemo } from 'react';
 import Form from 'calypso/a8c-for-agencies/components/form';
@@ -191,9 +192,10 @@ export default function PersonalizationForm( { onContinue, goBack, initialFormDa
 						</FormFieldset>
 
 						<FormFooter>
-							<Button __next40pxDefaultSize variant="secondary" onClick={ goBack }>
-								{ translate( 'Go back' ) }
-							</Button>
+							<button className="signup-multi-step-form__back-button" onClick={ goBack }>
+								<Icon icon={ arrowLeft } size={ 18 } />
+								{ translate( 'Back' ) }
+							</button>
 							<Button __next40pxDefaultSize variant="primary" onClick={ handleSubmit }>
 								{ translate( 'Continue' ) }
 							</Button>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -18,19 +18,21 @@ import './style.scss';
 
 interface Props {
 	onContinue: ( data: Partial< AgencyDetailsSignupPayload > ) => void;
+	goBack: () => void;
+	initialFormData: Partial< AgencyDetailsSignupPayload >;
 }
 
-export default function PersonalizationForm( { onContinue }: Props ) {
+export default function PersonalizationForm( { onContinue, goBack, initialFormData }: Props ) {
 	const translate = useTranslate();
 	const { countryOptions } = useCountriesAndStates();
 	const { validate, validationError, updateValidationError } = usePersonalizationFormValidation();
 
 	const [ formData, setFormData ] = useState< Partial< AgencyDetailsSignupPayload > >( {
-		country: '',
-		userType: 'agency_owner',
-		managedSites: '1-5',
-		servicesOffered: [],
-		productsOffered: [],
+		country: initialFormData.country || '',
+		userType: initialFormData.userType || 'agency_owner',
+		managedSites: initialFormData.managedSites || '1-5',
+		servicesOffered: initialFormData.servicesOffered || [],
+		productsOffered: initialFormData.productsOffered || [],
 	} );
 
 	const handleInputChange =
@@ -189,6 +191,9 @@ export default function PersonalizationForm( { onContinue }: Props ) {
 						</FormFieldset>
 
 						<FormFooter>
+							<Button __next40pxDefaultSize variant="secondary" onClick={ goBack }>
+								{ translate( 'Go back' ) }
+							</Button>
 							<Button __next40pxDefaultSize variant="primary" onClick={ handleSubmit }>
 								{ translate( 'Continue' ) }
 							</Button>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/style.scss
@@ -8,11 +8,15 @@
         gap: 12px 24px;
     }
 
-	.signup-personalization-form__checkbox .a4a-form__section-field {
-		gap: 16px;
+	.signup-personalization-form__checkbox {
+		padding-block: 8px;
 
-		@include break-xlarge {
-			gap: 8px;
+		.a4a-form__section-field {
+			gap: 16px;
+
+			@include break-xlarge {
+				gap: 8px;
+			}
 		}
 	}
 

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
@@ -138,3 +138,18 @@
 	}
 }
 
+.signup-multi-step-form__back-button {
+	cursor: pointer;
+	display: inline-flex;
+	justify-content: center;
+	align-items: center;
+	gap: 4px;
+	height: 100%;
+}
+
+.blueprint-form, .signup-personalization-form, .choice-blueprint-form {
+	.a4a-form__footer {
+		justify-content: space-between;
+	}
+}
+

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
@@ -98,6 +98,10 @@
 		@include a4a-font-heading-sm($font-size: rem(14px));
 	}
 
+	.signup-multi-step-form__back-button.signup-multi-step-form__back-button.signup-multi-step-form__back-button {
+		color: var(--color-text);
+	}
+
 	@media (prefers-color-scheme: dark) {
 		.a4a-form__heading .a4a-form__heading-title,
 		.a4a-form__heading .a4a-form__heading-description,
@@ -106,7 +110,9 @@
 		.signup-personalization-form .multi-checkbox label,
 		.form-phone-input label,
 		.form-radio__label,
-		.components-form-token-field__suggestion {
+		.components-form-token-field__suggestion,
+		.components-button.is-tertiary,
+		.signup-multi-step-form__back-button.signup-multi-step-form__back-button.signup-multi-step-form__back-button {
 			color: var(--color-text-inverted);
 		}
 
@@ -137,19 +143,3 @@
 		}
 	}
 }
-
-.signup-multi-step-form__back-button {
-	cursor: pointer;
-	display: inline-flex;
-	justify-content: center;
-	align-items: center;
-	gap: 4px;
-	height: 100%;
-}
-
-.blueprint-form, .signup-personalization-form, .choice-blueprint-form {
-	.a4a-form__footer {
-		justify-content: space-between;
-	}
-}
-


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1816
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1789
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1817

## Proposed Changes

This PR:

- Adds some extra spacing between the multi-select fields on the `Personalize` step.
- Preselects the country code as "US"
- Implements "go-back functionality.


## Testing Instructions

* Open the A4A live link
* Verify that you can fill out the steps, go back and forth, and make sure everything works as expected.

<img width="1728" alt="Screenshot 2025-02-19 at 5 05 11 PM" src="https://github.com/user-attachments/assets/e00dc574-c2a4-40d9-93ee-a537716059ea" />
<img width="1728" alt="Screenshot 2025-02-19 at 5 05 17 PM" src="https://github.com/user-attachments/assets/67383882-a32b-49f0-8183-65e4bf86e424" />
<img width="1728" alt="Screenshot 2025-02-19 at 5 05 24 PM" src="https://github.com/user-attachments/assets/5547d6d8-9217-40a0-9f3a-e8b0697a6f41" />
<img width="1728" alt="Screenshot 2025-02-19 at 5 05 34 PM" src="https://github.com/user-attachments/assets/ffc24a92-193e-47d7-9845-001bee22e99b" />
<img width="1728" alt="Screenshot 2025-02-19 at 5 05 41 PM" src="https://github.com/user-attachments/assets/e613c77d-c864-4739-91e9-c1eb2546a583" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
