### PR TITLE
A4A: Signup v2 form optimization.

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form-2/hooks/use-blueprint-form-2-validation.ts
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form-2/hooks/use-blueprint-form-2-validation.ts
@@ -1,0 +1,38 @@
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useState } from 'react';
+import { AgencyDetailsSignupPayload } from 'calypso/a8c-for-agencies/sections/signup/types';
+
+type ValidationState = {
+	workWithClients?: string;
+};
+
+const useBlueprintForm2Validation = () => {
+	const translate = useTranslate();
+	const [ validationError, setValidationError ] = useState< ValidationState >( {} );
+
+	const updateValidationError = ( newState: ValidationState ) => {
+		return setValidationError( ( prev ) => ( { ...prev, ...newState } ) );
+	};
+
+	const validate = useCallback(
+		async ( payload: Partial< AgencyDetailsSignupPayload > ) => {
+			const newValidationError: ValidationState = {};
+
+			if ( payload.workWithClients === '' ) {
+				newValidationError.workWithClients = translate( `Please select an option` );
+			}
+
+			if ( Object.keys( newValidationError ).length > 0 ) {
+				setValidationError( newValidationError );
+				return newValidationError;
+			}
+
+			return null;
+		},
+		[ setValidationError, translate ]
+	);
+
+	return { validate, validationError, updateValidationError };
+};
+
+export default useBlueprintForm2Validation;

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form-2/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form-2/index.tsx
@@ -10,6 +10,7 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import { preventWidows } from 'calypso/lib/formatting';
 import { AgencyDetailsSignupPayload } from '../../../../types';
+import useBlueprintForm2Validation from './hooks/use-blueprint-form-2-validation';
 
 type Props = {
 	onContinue: ( data: Partial< AgencyDetailsSignupPayload > ) => void;
@@ -51,8 +52,15 @@ const BlueprintForm2: React.FC< Props > = ( { onContinue, initialFormData, goBac
 		approachAndChallenges: initialFormData.approachAndChallenges || '',
 	} );
 
-	const handleSubmit = ( e: React.FormEvent ) => {
+	const { validate, validationError, updateValidationError } = useBlueprintForm2Validation();
+
+	const handleSubmit = async ( e: React.FormEvent ) => {
 		e.preventDefault();
+		const error = await validate( formData );
+		if ( error ) {
+			return;
+		}
+
 		onContinue( formData );
 	};
 
@@ -80,6 +88,7 @@ const BlueprintForm2: React.FC< Props > = ( { onContinue, initialFormData, goBac
 				label={ translate(
 					"How does your agency typically work with clients regarding Automattic's solutions?"
 				) }
+				error={ validationError.workWithClients }
 				isRequired
 			>
 				<div className="blueprint-form__radio-group">
@@ -88,7 +97,10 @@ const BlueprintForm2: React.FC< Props > = ( { onContinue, initialFormData, goBac
 							key={ `work-model-option-${ option.value }` }
 							label={ option.label }
 							checked={ formData.workWithClients === option.value }
-							onChange={ () => setFormData( { ...formData, workWithClients: option.value } ) }
+							onChange={ () => {
+								setFormData( { ...formData, workWithClients: option.value } );
+								updateValidationError( { workWithClients: undefined } );
+							} }
 						/>
 					) ) }
 					{ formData.workWithClients === 'other' && (

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/hooks/use-blueprint-form-validation.ts
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/hooks/use-blueprint-form-validation.ts
@@ -1,0 +1,43 @@
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useState } from 'react';
+import { AgencyDetailsSignupPayload } from 'calypso/a8c-for-agencies/sections/signup/types';
+
+type ValidationState = {
+	topPartneringGoal?: string;
+	topYearlyGoal?: string;
+};
+
+const useBlueprintFormValidation = () => {
+	const translate = useTranslate();
+	const [ validationError, setValidationError ] = useState< ValidationState >( {} );
+
+	const updateValidationError = ( newState: ValidationState ) => {
+		return setValidationError( ( prev ) => ( { ...prev, ...newState } ) );
+	};
+
+	const validate = useCallback(
+		async ( payload: Partial< AgencyDetailsSignupPayload > ) => {
+			const newValidationError: ValidationState = {};
+
+			if ( payload.topPartneringGoal === '' ) {
+				newValidationError.topPartneringGoal = translate( `Please select a goal` );
+			}
+
+			if ( payload.topYearlyGoal === '' ) {
+				newValidationError.topYearlyGoal = translate( `Please select a goal` );
+			}
+
+			if ( Object.keys( newValidationError ).length > 0 ) {
+				setValidationError( newValidationError );
+				return newValidationError;
+			}
+
+			return null;
+		},
+		[ setValidationError, translate ]
+	);
+
+	return { validate, validationError, updateValidationError };
+};
+
+export default useBlueprintFormValidation;

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
@@ -8,6 +8,7 @@ import FormFooter from 'calypso/a8c-for-agencies/components/form/footer';
 import FormRadio from 'calypso/components/forms/form-radio';
 import { preventWidows } from 'calypso/lib/formatting';
 import { AgencyDetailsSignupPayload } from '../../../../types';
+import useBlueprintFormValidation from './hooks/use-blueprint-form-validation';
 
 type Props = {
 	onContinue: ( data: Partial< AgencyDetailsSignupPayload > ) => void;
@@ -43,13 +44,19 @@ const BlueprintFormRadio = ( {
 
 const BlueprintForm: React.FC< Props > = ( { onContinue, initialFormData, goBack } ) => {
 	const translate = useTranslate();
+	const { validate, validationError, updateValidationError } = useBlueprintFormValidation();
 	const [ formData, setFormData ] = useState< Partial< AgencyDetailsSignupPayload > >( {
 		topPartneringGoal: initialFormData.topPartneringGoal || '',
 		topYearlyGoal: initialFormData.topYearlyGoal || '',
 	} );
 
-	const handleSubmit = ( e: React.FormEvent ) => {
+	const handleSubmit = async ( e: React.FormEvent ) => {
 		e.preventDefault();
+		const error = await validate( formData );
+		if ( error ) {
+			return;
+		}
+
 		onContinue( formData );
 	};
 
@@ -94,6 +101,7 @@ const BlueprintForm: React.FC< Props > = ( { onContinue, initialFormData, goBack
 		>
 			<FormField
 				label={ translate( 'What is your top goal when partnering with a technology provider?' ) }
+				error={ validationError.topPartneringGoal }
 				isRequired
 			>
 				<div className="blueprint-form__radio-group">
@@ -102,7 +110,10 @@ const BlueprintForm: React.FC< Props > = ( { onContinue, initialFormData, goBack
 							key={ `goal-option-${ option.value }` }
 							label={ option.label }
 							checked={ formData.topPartneringGoal === option.value }
-							onChange={ () => setFormData( { ...formData, topPartneringGoal: option.value } ) }
+							onChange={ () => {
+								setFormData( { ...formData, topPartneringGoal: option.value } );
+								updateValidationError( { topPartneringGoal: undefined } );
+							} }
 						/>
 					) ) }
 				</div>
@@ -110,6 +121,7 @@ const BlueprintForm: React.FC< Props > = ( { onContinue, initialFormData, goBack
 
 			<FormField
 				label={ translate( 'What is the main goal you hope to achieve in 2025?' ) }
+				error={ validationError.topYearlyGoal }
 				isRequired
 			>
 				<div className="blueprint-form__radio-group">
@@ -118,7 +130,10 @@ const BlueprintForm: React.FC< Props > = ( { onContinue, initialFormData, goBack
 							key={ `main-goal-2025-option-${ option.value }` }
 							label={ option.label }
 							checked={ formData.topYearlyGoal === option.value }
-							onChange={ () => setFormData( { ...formData, topYearlyGoal: option.value } ) }
+							onChange={ () => {
+								setFormData( { ...formData, topYearlyGoal: option.value } );
+								updateValidationError( { topYearlyGoal: undefined } );
+							} }
 						/>
 					) ) }
 				</div>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/index.tsx
@@ -22,15 +22,17 @@ const ChoiceBlueprint: React.FC< Props > = ( { onContinue, onSkip, goBack } ) =>
 			title={ preventWidows(
 				translate( 'Grow your business with a free personalized blueprint' )
 			) }
-			description={ translate(
-				`By answering a few simple questions, we'll provide tips on maximizing your agency's impact.`
-			) }
 		>
 			<div className="choice-blueprint__content">
+				<p>
+					{ translate(
+						"Answer a few questions about your agency's goals for the year, and you'll receive a custom program blueprint tailored to your unique objectives. The guide will include:"
+					) }
+				</p>
 				<ul className="choice-blueprint__content-list">
 					<li>
 						{ translate(
-							'Partner strategies that are specifically aligned with your agency’s goals to help you achieve them more efficiently through the Automattic for Agencies Program.'
+							"Partner strategies that are specifically aligned with your agency's goals to help you achieve them more efficiently through the Automattic for Agencies Program."
 						) }
 					</li>
 					<li>
@@ -45,9 +47,7 @@ const ChoiceBlueprint: React.FC< Props > = ( { onContinue, onSkip, goBack } ) =>
 					</li>
 				</ul>
 
-				<p className="choice-blueprint__content-footer">
-					{ translate( 'The survey will take less than a minute.' ) }
-				</p>
+				<p>{ translate( 'The survey will take less than a minute.' ) }</p>
 			</div>
 			<FormFooter>
 				<Button

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/index.tsx
@@ -26,6 +26,29 @@ const ChoiceBlueprint: React.FC< Props > = ( { onContinue, onSkip, goBack } ) =>
 				`By answering a few simple questions, we'll provide tips on maximizing your agency's impact.`
 			) }
 		>
+			<div className="choice-blueprint__content">
+				<ul className="choice-blueprint__content-list">
+					<li>
+						{ translate(
+							'Partner strategies that are specifically aligned with your agency’s goals to help you achieve them more efficiently through the Automattic for Agencies Program.'
+						) }
+					</li>
+					<li>
+						{ translate(
+							'Recommendations for Automattic products and agency tools that will streamline your operations, boosting productivity and client satisfaction.'
+						) }
+					</li>
+					<li>
+						{ translate(
+							'Revenue growth opportunities tailored to your current product usage, only through the Automattic for Agencies Program.'
+						) }
+					</li>
+				</ul>
+
+				<p className="choice-blueprint__content-footer">
+					{ translate( 'The survey will take less than a minute.' ) }
+				</p>
+			</div>
 			<FormFooter>
 				<Button
 					className="signup-multi-step-form__back-button"
@@ -52,7 +75,7 @@ const ChoiceBlueprint: React.FC< Props > = ( { onContinue, onSkip, goBack } ) =>
 						onClick={ onContinue }
 						__next40pxDefaultSize
 					>
-						{ translate( 'Build my custom blueprint' ) }
+						{ translate( 'Take me to the survey' ) }
 					</Button>
 				</div>
 			</FormFooter>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .choice-blueprint__button {
 	width: 200px;
 	justify-content: center;
@@ -9,4 +12,18 @@
 
 .choice-blueprint__cancel-button {
 	margin-inline-end: 8px;
+}
+
+.choice-blueprint__content-list {
+	margin: 0 16px 16px;
+
+	li {
+		margin-block-end: 8px;
+	}
+}
+
+.choice-blueprint__content-list li,
+.choice-blueprint__content-footer {
+	@include body-large;
+	color: var(--color-neutral-60);
 }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/style.scss
@@ -15,15 +15,20 @@
 }
 
 .choice-blueprint__content-list {
-	margin: 0 16px 16px;
-
-	li {
-		margin-block-end: 8px;
-	}
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin: 0 16px 0;
 }
 
-.choice-blueprint__content-list li,
-.choice-blueprint__content-footer {
+.choice-blueprint__content {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.choice-blueprint__content p,
+.choice-blueprint__content-list li {
 	@include body-large;
-	color: var(--color-neutral-60);
+	color: var(--color-text);
 }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -65,6 +65,7 @@ export default function PersonalizationForm( { onContinue, goBack, initialFormDa
 			{ value: 'performance_optimization', label: translate( 'Performance optimization' ) },
 			{ value: 'digital_strategy_marketing', label: translate( 'Digital strategy & marketing' ) },
 			{ value: 'maintenance_support_plans', label: translate( 'Maintenance & support plans' ) },
+			{ value: 'other', label: translate( 'Other' ) },
 		],
 		[ translate ]
 	);
@@ -163,7 +164,7 @@ export default function PersonalizationForm( { onContinue, goBack, initialFormDa
 						</FormFieldset>
 
 						<FormFieldset className="signup-personalization-form__checkbox">
-							<FormField label={ translate( 'What services do you offer?' ) } isRequired>
+							<FormField label={ translate( 'What services do you offer?' ) }>
 								<MultiCheckbox
 									id="services_offered"
 									name="services_offered"
@@ -179,7 +180,6 @@ export default function PersonalizationForm( { onContinue, goBack, initialFormDa
 								label={ translate(
 									'What Automattic products do you currently offer your clients?'
 								) }
-								isRequired
 							>
 								<MultiCheckbox
 									id="products_offered"

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
@@ -108,6 +108,8 @@
 		.a4a-form__section-field-label,
 		.a4a-form__section-field-required,
 		.signup-personalization-form .multi-checkbox label,
+		.choice-blueprint__content li,
+		.choice-blueprint__content p,
 		.form-phone-input label,
 		.form-radio__label,
 		.components-form-token-field__suggestion,

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
@@ -98,10 +98,6 @@
 		@include a4a-font-heading-sm($font-size: rem(14px));
 	}
 
-	.signup-multi-step-form__back-button.signup-multi-step-form__back-button.signup-multi-step-form__back-button {
-		color: var(--color-text);
-	}
-
 	@media (prefers-color-scheme: dark) {
 		.a4a-form__heading .a4a-form__heading-title,
 		.a4a-form__heading .a4a-form__heading-description,
@@ -113,9 +109,12 @@
 		.form-phone-input label,
 		.form-radio__label,
 		.components-form-token-field__suggestion,
-		.components-button.is-tertiary,
-		.signup-multi-step-form__back-button.signup-multi-step-form__back-button.signup-multi-step-form__back-button {
+		.choice-blueprint__cancel-button.choice-blueprint__cancel-button.choice-blueprint__cancel-button {
 			color: var(--color-text-inverted);
+		}
+
+		.signup-multi-step-form__back-button.signup-multi-step-form__back-button.signup-multi-step-form__back-button {
+			color: #E6F5FF;
 		}
 
 		input[type="text"].form-text-input,
@@ -144,4 +143,8 @@
 			background-color: var(--color-text-inverted);
 		}
 	}
+}
+
+.signup-multi-step-form__back-button.signup-multi-step-form__back-button.signup-multi-step-form__back-button {
+	color: var(--color-neutral-50);
 }


### PR DESCRIPTION
This PR adds a few improvements to the Signup form based on feedback gathered from CFT.

Context: pfunGA-59N-p2#comment-8760

## Proposed Changes

| Description | Before | After |
|--------|--------|--------|
| We have removed the `*` for both the services and products offered in the personalization form. Additionally, we added the 'Other' option for the services offered. **NOTE: Please test this with the backend patch** | <img width="645" alt="Screenshot 2025-02-19 at 10 05 08 PM" src="https://github.com/user-attachments/assets/1eb4ef9d-a31a-4d6c-a5cf-eeb85aa7903d" /> | <img width="679" alt="Screenshot 2025-02-19 at 10 06 37 PM" src="https://github.com/user-attachments/assets/2039ff35-8913-4085-8f55-be0157d83643" /> |
| Updated the Blueprint introduction message with more copies. | <img width="674" alt="Screenshot 2025-02-19 at 10 08 04 PM" src="https://github.com/user-attachments/assets/6ef23225-5b5e-42dd-ad56-95e788f827d4" /> | <img width="725" alt="Screenshot 2025-02-19 at 10 07 44 PM" src="https://github.com/user-attachments/assets/28ab3a35-c53e-462e-8398-9d668c07eaca" /> |
| Added form validation on the Blueprint form. | | <img width="527" alt="Screenshot 2025-02-19 at 10 09 04 PM" src="https://github.com/user-attachments/assets/6fdae89d-d66f-4a3d-8526-bfa673b1d7f3" /> <img width="620" alt="Screenshot 2025-02-19 at 10 09 14 PM" src="https://github.com/user-attachments/assets/3f893ce9-3337-47ad-ae06-b35cb82f7614" /> | 

## Why are these changes being made?

* This is part of the new Signup form that will be used in WC Asia.

## Testing Instructions

* Use the A4A live link and go to the `/signup/wc-asia` page.
* Verify the changes above if it works.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?