### PR TITLE
Revert "Replace the `launchpad-first` flag with the goals-first cumulative experiment" - Just in case

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -16,7 +16,7 @@ import { urlToSlug } from 'calypso/lib/url';
 import { useSelector, useDispatch } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
-import { useShouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
+import shouldShowLaunchpadFirst from 'calypso/state/selectors/should-show-launchpad-first';
 import { useQuery } from '../../../../hooks/use-query';
 import StepContent from './step-content';
 import { areLaunchpadTasksCompleted } from './task-helper';
@@ -92,11 +92,8 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 		}
 	}, [ verifiedParam, translate, dispatch ] );
 
-	const [ loadingShouldShowLaunchpadFirst, shouldShowLaunchpadFirst ] =
-		useShouldShowLaunchpadFirst( site );
-
 	// Avoid screen flickering when redirecting to other paths
-	if ( ! site?.options || loadingShouldShowLaunchpadFirst ) {
+	if ( ! site?.options ) {
 		return null;
 	}
 
@@ -105,7 +102,7 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 		return null;
 	}
 
-	if ( shouldShowLaunchpadFirst ) {
+	if ( shouldShowLaunchpadFirst( site ) ) {
 		window.location.replace( `/home/${ siteSlug }` );
 		return null;
 	}

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -77,7 +77,7 @@ export async function maybeRedirect( context, next ) {
 
 	const site = getSelectedSite( state );
 
-	if ( await shouldShowLaunchpadFirst( site ) ) {
+	if ( shouldShowLaunchpadFirst( site ) ) {
 		return next();
 	}
 

--- a/client/my-sites/customer-home/main.tsx
+++ b/client/my-sites/customer-home/main.tsx
@@ -5,22 +5,22 @@ import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { useShouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
+import shouldShowLaunchpadFirst from 'calypso/state/selectors/should-show-launchpad-first';
 import CelebrateLaunchModal from './components/celebrate-launch-modal';
 import { FullScreenLaunchpad } from './components/full-screen-launchpad';
 import HomeContent from './components/home-content';
 import type { SiteDetails } from '@automattic/data-stores';
 
 export default function CustomerHome( { site }: { site: SiteDetails } ) {
-	const [ isLoadingShouldShowLaunchpadFirst, shouldShowLaunchpadFirst ] =
-		useShouldShowLaunchpadFirst( site );
+	const showLaunchpadFirst = shouldShowLaunchpadFirst( site );
 
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
 
-	const [ isFullLaunchpadDismissed, setIsFullLaunchpadDismissed ] = useState(
-		site.options?.launchpad_screen === undefined ||
-			site.options.launchpad_screen === 'skipped' ||
-			isSiteLaunched
+	const [ isShowingLaunchpad, setIsShowingLaunchpad ] = useState(
+		showLaunchpadFirst &&
+			site.options?.launchpad_screen !== undefined &&
+			site.options?.launchpad_screen !== 'skipped' &&
+			! isSiteLaunched
 	);
 
 	const translate = useTranslate();
@@ -35,29 +35,25 @@ export default function CustomerHome( { site }: { site: SiteDetails } ) {
 		<Main wideLayout>
 			<PageViewTracker path="/home/:site" title={ translate( 'My Home' ) } />
 			<DocumentHead title={ translate( 'My Home' ) } />
-			{ ! isLoadingShouldShowLaunchpadFirst && (
+			{ isShowingLaunchpad ? (
+				<FullScreenLaunchpad
+					onClose={ () => setIsShowingLaunchpad( false ) }
+					onSiteLaunch={ () => {
+						setIsShowingLaunchpad( false );
+						setShowSiteLaunchedModal( true );
+					} }
+				/>
+			) : (
+				<HomeContent />
+			) }
+			{ showSiteLaunchedModal && (
 				<>
-					{ shouldShowLaunchpadFirst && ! isFullLaunchpadDismissed ? (
-						<FullScreenLaunchpad
-							onClose={ () => setIsFullLaunchpadDismissed( true ) }
-							onSiteLaunch={ () => {
-								setIsFullLaunchpadDismissed( true );
-								setShowSiteLaunchedModal( true );
-							} }
-						/>
-					) : (
-						<HomeContent />
-					) }
-					{ showSiteLaunchedModal && (
-						<>
-							<ConfettiAnimation />
-							<CelebrateLaunchModal
-								setModalIsOpen={ setShowSiteLaunchedModal }
-								site={ site }
-								allDomains={ allDomains }
-							/>
-						</>
-					) }
+					<ConfettiAnimation />
+					<CelebrateLaunchModal
+						setModalIsOpen={ setShowSiteLaunchedModal }
+						site={ site }
+						allDomains={ allDomains }
+					/>
 				</>
 			) }
 		</Main>

--- a/client/my-sites/customer-home/test/customer-home.tsx
+++ b/client/my-sites/customer-home/test/customer-home.tsx
@@ -1,11 +1,10 @@
 /**
  * @jest-environment jsdom
  */
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 import nock from 'nock';
 import React, { act } from 'react';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { reducer as ui } from 'calypso/state/ui/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import CustomerHome from '../main';
@@ -13,16 +12,11 @@ import type { SiteDetails } from '@automattic/data-stores';
 
 jest.mock( '@wordpress/api-fetch' );
 
-let mockUseExperimentResult = [ false, true ];
-
-jest.mock( 'calypso/lib/explat', () => ( {
-	loadExperimentAssignment: jest.fn( ( slug ) =>
-		slug === 'calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131'
-			? Promise.resolve( { variationName: 'treatment_cumulative' } )
-			: Promise.reject( new Error( `Unmocked experiment slug: ${ slug }` ) )
-	),
-	useExperiment: jest.fn( () => mockUseExperimentResult ),
-} ) );
+jest.mock( '@automattic/calypso-config', () => {
+	const config = () => 'development';
+	config.isEnabled = ( property: string ) => property === 'home/launchpad-first';
+	return config;
+} );
 
 jest.mock( '../components/home-content', () => () => (
 	<div data-testid="home-content">Home Content</div>
@@ -47,13 +41,8 @@ function makeTestSite( site: Partial< SiteDetails > = {} ): SiteDetails {
 		URL: 'https://example.com',
 		domain: 'example.com',
 		launch_status: 'launched',
+		options: { site_creation_flow: 'onboarding', launchpad_screen: false, ...site.options },
 		...site,
-		options: {
-			site_creation_flow: 'onboarding',
-			launchpad_screen: false,
-			created_at: '2025-02-17T00:00:00+00:00',
-			...site.options,
-		},
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	} as any; // This partial site object should be good enough for testing purposes
 }
@@ -67,16 +56,16 @@ describe( 'CustomerHome', () => {
 		nock.cleanAll();
 	} );
 
-	it( 'should show HomeContent for launched site', async () => {
+	it( 'should show HomeContent for launched site', () => {
 		const testSite = makeTestSite( { launch_status: 'launched' } );
 
 		renderWithProvider( <CustomerHome site={ testSite } /> );
 
-		await waitFor( () => expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument() );
+		expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument();
 		expect( screen.queryByTestId( 'launchpad-first' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'should show HomeContent for unlaunched site when launchpad is skipped', async () => {
+	it( 'should show HomeContent for unlaunched site when launchpad is skipped', () => {
 		const testSite = makeTestSite( {
 			launch_status: 'unlaunched',
 			options: { launchpad_screen: 'skipped' },
@@ -84,7 +73,7 @@ describe( 'CustomerHome', () => {
 
 		renderWithProvider( <CustomerHome site={ testSite } /> );
 
-		await waitFor( () => expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument() );
+		expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument();
 		expect( screen.queryByTestId( 'launchpad-first' ) ).not.toBeInTheDocument();
 	} );
 
@@ -96,7 +85,7 @@ describe( 'CustomerHome', () => {
 
 		renderWithProvider( <CustomerHome site={ testSite } /> );
 
-		await waitFor( () => expect( screen.getByTestId( 'launchpad-first' ) ).toBeInTheDocument() );
+		expect( screen.getByTestId( 'launchpad-first' ) ).toBeInTheDocument();
 		expect( screen.queryByTestId( 'home-content' ) ).not.toBeInTheDocument();
 
 		// Click the close button
@@ -161,34 +150,5 @@ describe( 'CustomerHome', () => {
 		act( () => launchSiteButton.click() );
 
 		expect( await screen.findByText( 'Congrats, your site is live!' ) ).toBeInTheDocument();
-	} );
-
-	it( 'shows home content when site would be eligible to show launchpad, but user is in control group', async () => {
-		const testSite = makeTestSite( {
-			launch_status: 'unlaunched',
-			options: { site_creation_flow: 'onboarding', launchpad_screen: false },
-		} );
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( { variationName: 'control' } );
-
-		renderWithProvider( <CustomerHome site={ testSite } /> );
-
-		await waitFor( () => expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument() );
-		expect( screen.queryByTestId( 'launchpad-first' ) ).not.toBeInTheDocument();
-	} );
-
-	it( 'shows home content when site would be eligible to show launchpad, but user is in treatment_frozen group', async () => {
-		mockUseExperimentResult = [ false, false ];
-		const testSite = makeTestSite( {
-			launch_status: 'unlaunched',
-			options: { site_creation_flow: 'onboarding', launchpad_screen: false },
-		} );
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
-			variationName: 'treatment_frozen',
-		} );
-
-		renderWithProvider( <CustomerHome site={ testSite } /> );
-
-		await waitFor( () => expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument() );
-		expect( screen.queryByTestId( 'launchpad-first' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/state/selectors/should-show-launchpad-first.ts
+++ b/client/state/selectors/should-show-launchpad-first.ts
@@ -1,66 +1,19 @@
+import config from '@automattic/calypso-config';
 import { SiteDetails, Onboard } from '@automattic/data-stores';
-import { useEffect, useState } from 'react';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
 
 const SiteIntent = Onboard.SiteIntent;
 
 /**
  * Determines if the launchpad should be shown first based on site createion flow
- * @param site Site object
- * @returns Whether launchpad should be shown first
+ * @param {SiteDetails|undefined} site Site object
+ * @returns {boolean} Whether launchpad should be shown first
  */
-export const shouldShowLaunchpadFirst = async ( site: SiteDetails ): Promise< boolean > => {
-	const wasSiteCreatedOnboardingFlow = site.options?.site_creation_flow === 'onboarding';
-	const createdAfterExperimentStart =
-		( site.options?.created_at ?? '' ) > '2025-02-03T10:22:45+00:00'; // If created_at is null then this expression is false
-	const isBigSkyIntent = site?.options?.site_intent === SiteIntent.AIAssembler;
+export const shouldShowLaunchpadFirst = ( site: SiteDetails ) => {
+	const isLaunchpadFirstEnabled = config.isEnabled( 'home/launchpad-first' );
+	const wasSiteCreatedOnboardingFlow = site?.options?.site_creation_flow === 'onboarding';
+	const isNotBigSkyIntent = site?.options?.site_intent !== SiteIntent.AIAssembler;
 
-	if ( isBigSkyIntent || ! wasSiteCreatedOnboardingFlow || ! createdAfterExperimentStart ) {
-		return false;
-	}
-
-	const assignment = await loadExperimentAssignment(
-		'calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131'
-	);
-
-	return assignment?.variationName === 'treatment_cumulative';
+	return isLaunchpadFirstEnabled && wasSiteCreatedOnboardingFlow && isNotBigSkyIntent;
 };
 
-export const useShouldShowLaunchpadFirst = ( site?: SiteDetails | null ): [ boolean, boolean ] => {
-	const [ state, setState ] = useState< boolean | 'loading' >( 'loading' );
-
-	useEffect( () => {
-		let cancel = false;
-
-		const getResponse = async () => {
-			if ( ! site ) {
-				return;
-			}
-
-			try {
-				setState( 'loading' );
-				const result = await shouldShowLaunchpadFirst( site );
-				if ( ! cancel ) {
-					setState( result );
-				}
-			} catch ( err ) {
-				if ( ! cancel ) {
-					setState( false );
-				}
-			}
-		};
-
-		getResponse();
-
-		return () => {
-			cancel = true;
-		};
-	}, [ site ] );
-
-	if ( ! site ) {
-		// If the site isn't available yet we'll assume we're still loading
-		return [ true, false ];
-	}
-
-	return [ state === 'loading', state === 'loading' ? false : state ];
-};
+export default shouldShowLaunchpadFirst;

--- a/client/state/selectors/test/should-show-launchpad-first.ts
+++ b/client/state/selectors/test/should-show-launchpad-first.ts
@@ -1,171 +1,54 @@
-/**
- * @jest-environment jsdom
- */
-import { act, renderHook, waitFor } from '@testing-library/react';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
-import {
-	shouldShowLaunchpadFirst,
-	useShouldShowLaunchpadFirst,
-} from '../should-show-launchpad-first';
-import type { SiteDetails } from '@automattic/data-stores';
+import config from '@automattic/calypso-config';
+import { shouldShowLaunchpadFirst } from '../should-show-launchpad-first';
 
-jest.mock( 'calypso/lib/explat', () => ( {
-	loadExperimentAssignment: jest.fn(),
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: jest.fn(),
 } ) );
 
-beforeEach( () => {
-	jest.clearAllMocks();
-} );
-
 describe( 'shouldShowLaunchpadFirst', () => {
-	it( 'should return true when site was created via onboarding flow and assigned to experiment', async () => {
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
-			variationName: 'treatment_cumulative',
-		} );
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should return true when site was created via onboarding flow and feature flag is enabled', () => {
+		( config.isEnabled as jest.Mock ).mockReturnValue( true );
 		const site = {
 			options: {
 				site_creation_flow: 'onboarding',
-				created_at: '2025-02-18T00:00:00+00:00',
 			},
-		} as SiteDetails;
+		};
 
-		expect( await shouldShowLaunchpadFirst( site ) ).toBe( true );
+		expect( shouldShowLaunchpadFirst( site ) ).toBe( true );
 	} );
 
-	it( 'should return false when site was created via onboarding flow but assigned to control', async () => {
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
-			variationName: 'control',
-		} );
+	it( 'should return false when site was created via onboarding flow but feature flag is disabled', () => {
+		( config.isEnabled as jest.Mock ).mockReturnValue( false );
 		const site = {
 			options: {
 				site_creation_flow: 'onboarding',
-				created_at: '2025-02-18T00:00:00+00:00',
 			},
-		} as SiteDetails;
+		};
 
-		expect( await shouldShowLaunchpadFirst( site ) ).toBe( false );
+		expect( shouldShowLaunchpadFirst( site ) ).toBe( false );
 	} );
 
-	it( 'should return false when site was not created via onboarding flow', async () => {
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
-			variationName: 'treatment_cumulative',
-		} );
+	it( 'should return false when site was not created via onboarding flow', () => {
+		( config.isEnabled as jest.Mock ).mockReturnValue( true );
 		const site = {
 			options: {
 				site_creation_flow: 'other',
-				created_at: '2025-02-18T00:00:00+00:00',
 			},
-		} as SiteDetails;
+		};
 
-		expect( await shouldShowLaunchpadFirst( site ) ).toBe( false );
+		expect( shouldShowLaunchpadFirst( site ) ).toBe( false );
 	} );
 
-	it( 'should return false when site has no creation flow information', async () => {
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
-			variationName: 'treatment_cumulative',
-		} );
+	it( 'should return false when site has no creation flow information', () => {
+		( config.isEnabled as jest.Mock ).mockReturnValue( true );
 		const site = {
-			options: {
-				created_at: '2025-02-18T00:00:00+00:00',
-			},
-		} as SiteDetails;
+			options: {},
+		};
 
-		expect( await shouldShowLaunchpadFirst( site ) ).toBe( false );
+		expect( shouldShowLaunchpadFirst( site ) ).toBe( false );
 	} );
 } );
-
-describe( 'useShouldShowLaunchpadFirst', () => {
-	it( 'returns loading state until promise resolves', async () => {
-		const { promise, resolve } = promiseWithResolvers();
-		( loadExperimentAssignment as jest.Mock ).mockReturnValue( promise );
-		const site = {
-			options: {
-				site_creation_flow: 'onboarding',
-				created_at: '2025-02-18T00:00:00+00:00',
-			},
-		} as SiteDetails;
-
-		const { result } = renderHook( () => useShouldShowLaunchpadFirst( site ) );
-
-		expect( result.current[ 0 ] ).toBe( true );
-
-		await act( () => resolve( { variationName: 'treatment_cumulative' } ) );
-
-		expect( result.current ).toEqual( [ false, true ] );
-	} );
-
-	it( 'should return true when site was created via onboarding flow and assigned to experiment', async () => {
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
-			variationName: 'treatment_cumulative',
-		} );
-		const site = {
-			options: {
-				site_creation_flow: 'onboarding',
-				created_at: '2025-02-18T00:00:00+00:00',
-			},
-		} as SiteDetails;
-
-		const { result } = renderHook( () => useShouldShowLaunchpadFirst( site ) );
-
-		await waitFor( () => expect( result.current ).toEqual( [ false, true ] ) );
-	} );
-
-	it( 'should return false when site was created via onboarding flow but assigned to control', async () => {
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
-			variationName: 'control',
-		} );
-		const site = {
-			options: {
-				site_creation_flow: 'onboarding',
-				created_at: '2025-02-18T00:00:00+00:00',
-			},
-		} as SiteDetails;
-
-		const { result } = renderHook( () => useShouldShowLaunchpadFirst( site ) );
-
-		await waitFor( () => expect( result.current ).toEqual( [ false, false ] ) );
-	} );
-
-	it( 'should return false when site was not created via onboarding flow', async () => {
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
-			variationName: 'treatment_cumulative',
-		} );
-		const site = {
-			options: {
-				site_creation_flow: 'other',
-				created_at: '2025-02-18T00:00:00+00:00',
-			},
-		} as SiteDetails;
-
-		const { result } = renderHook( () => useShouldShowLaunchpadFirst( site ) );
-
-		await waitFor( () => expect( result.current ).toEqual( [ false, false ] ) );
-	} );
-
-	it( 'should return false when site has no creation flow information', async () => {
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
-			variationName: 'treatment_cumulative',
-		} );
-		const site = {
-			options: {
-				created_at: '2025-02-18T00:00:00+00:00',
-			},
-		} as SiteDetails;
-
-		const { result } = renderHook( () => useShouldShowLaunchpadFirst( site ) );
-
-		await waitFor( () => expect( result.current ).toEqual( [ false, false ] ) );
-	} );
-} );
-
-// Our TS Config doesn't know the standard Promise.withResolvers is available
-// in our version of Node.
-function promiseWithResolvers() {
-	let resolve;
-	let reject;
-	const promise = new Promise( ( res, rej ) => {
-		resolve = res;
-		reject = rej;
-	} );
-	return { promise, resolve, reject };
-}

--- a/config/development.json
+++ b/config/development.json
@@ -69,6 +69,7 @@
 		"global-styles/on-personal-plan": true,
 		"help": true,
 		"help/gpt-response": true,
+		"home/launchpad-first": false,
 		"home/layout-dev": true,
 		"hosting-server-settings-enhancements": true,
 		"hosting/datacenter-picker": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -35,6 +35,7 @@
 		"google-my-business": false,
 		"global-styles/on-personal-plan": true,
 		"help": true,
+		"home/launchpad-first": false,
 		"home/layout-dev": true,
 		"hosting-server-settings-enhancements": true,
 		"i18n/empathy-mode": false,

--- a/config/production.json
+++ b/config/production.json
@@ -48,6 +48,7 @@
 		"global-styles/on-personal-plan": true,
 		"help": true,
 		"help/gpt-response": true,
+		"home/launchpad-first": false,
 		"hosting-server-settings-enhancements": true,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -48,6 +48,7 @@
 		"global-styles/on-personal-plan": true,
 		"help": true,
 		"help/gpt-response": true,
+		"home/launchpad-first": false,
 		"hosting-server-settings-enhancements": true,
 		"i18n/empathy-mode": true,
 		"importer/site-backups": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -53,6 +53,7 @@
 		"global-styles/on-personal-plan": true,
 		"help": true,
 		"help/gpt-response": true,
+		"home/launchpad-first": true,
 		"home/layout-dev": true,
 		"hosting/datacenter-picker": true,
 		"hosting-server-settings-enhancements": true,


### PR DESCRIPTION
Creating revert just in case
Reverts Automattic/wp-calypso#99914