### PR TITLE
Revert "Notifications - update user links to use new reader user profile page."

### DIFF
--- a/apps/notifications/src/panel/templates/block-user.jsx
+++ b/apps/notifications/src/panel/templates/block-user.jsx
@@ -162,28 +162,15 @@ export class UserBlock extends Component {
 			);
 		}
 
-		const userId = this.props.block?.meta?.ids?.user;
-		const readerProfileUrl = userId ? `https://wordpress.com/reader/users/${ userId }` : home_url;
-
 		if ( home_url ) {
 			return (
 				<div className="wpnc__user">
-					<a
-						className="wpnc__user__site"
-						href={ readerProfileUrl }
-						target="_blank"
-						rel="noreferrer"
-					>
+					<a className="wpnc__user__site" href={ home_url } target="_blank" rel="noreferrer">
 						<img src={ grav.url } height={ grav.height } width={ grav.width } alt="Avatar" />
 					</a>
 					<div>
 						<span className="wpnc__user__username">
-							<a
-								className="wpnc__user__home"
-								href={ readerProfileUrl }
-								target="_blank"
-								rel="noreferrer"
-							>
+							<a className="wpnc__user__home" href={ home_url } target="_blank" rel="noreferrer">
 								{ this.props.block.text }
 							</a>
 						</span>

--- a/apps/notifications/src/panel/templates/summary-in-single.jsx
+++ b/apps/notifications/src/panel/templates/summary-in-single.jsx
@@ -16,13 +16,7 @@ class UserHeader extends Component {
 	render() {
 		const grav = this.props.user.media[ 0 ];
 		const grav_tag = <img src={ grav.url } height={ grav.height } width={ grav.width } alt="" />;
-		const base_home_url = this.props.user.ranges[ 0 ].url;
-		// Some site notifications populate Id with the siteId, so consider the userId falsy in this
-		// case.
-		const userId =
-			this.props.user.ranges[ 0 ].id !== this.props.user.ranges[ 0 ].site_id &&
-			this.props.user.ranges[ 0 ].id;
-		const home_url = userId ? `https://wordpress.com/reader/users/${ userId }` : base_home_url;
+		const home_url = this.props.user.ranges[ 0 ].url;
 		const note = this.props.note;
 
 		const get_home_link = function ( classNames, children ) {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#99946

reverting this, theres an edge case with conflict between userIDs and numberic usernames in the user profile page itself, and this makes it much more prominent. I will follow up to re-release this with better handling on both sides.