### PR TITLE
Revert "E2E: Click on "Save" after "Get started""

### DIFF
--- a/test/e2e/specs/tools/advertising__promote.ts
+++ b/test/e2e/specs/tools/advertising__promote.ts
@@ -93,10 +93,6 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 			await blazeCampaignPage.clickButton( 'Get started' );
 		} );
 
-		it( 'Click on Save', async function () {
-			await blazeCampaignPage.clickButton( 'Save' );
-		} );
-
 		it( 'Upload image', async function () {
 			const testFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
 			await blazeCampaignPage.uploadImage( testFile );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#99985

Seems like that the intermediate step that was showing today is now gone
