### PR TITLE
Untangling: show breadcrumbs on administration tools

### DIFF
--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -16,10 +16,6 @@
 		visibility: hidden;
 	}
 
-	&.is-hidden {
-		border: none !important;
-	}
-
 	@include breakpoint-deprecated( "<480px" ) {
 		&.is-open {
 			box-shadow: 0 0 0 1px var(--color-neutral-light), 0 2px 4px var(--color-neutral-10);

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -16,6 +16,10 @@
 		visibility: hidden;
 	}
 
+	&.is-hidden {
+		border: none !important;
+	}
+
 	@include breakpoint-deprecated( "<480px" ) {
 		&.is-open {
 			box-shadow: 0 0 0 1px var(--color-neutral-light), 0 2px 4px var(--color-neutral-10);

--- a/client/layout/hosting-dashboard/item-view/index.tsx
+++ b/client/layout/hosting-dashboard/item-view/index.tsx
@@ -7,6 +7,7 @@ import NavTabs from 'calypso/components/section-nav/tabs';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import ItemViewContent from './item-view-content';
 import ItemViewHeader from './item-view-header';
+import ItemViewBreadcrumbsHeader from './item-view-header/breadcrumbs';
 import { FeaturePreviewInterface, ItemViewProps } from './types';
 
 import './style.scss';
@@ -42,6 +43,8 @@ export default function ItemView( {
 	hideNavIfSingleTab,
 	enforceTabsView,
 	hideHeader,
+	breadcrumbs,
+	shouldShowBreadcrumbs,
 }: ItemViewProps ) {
 	const [ navRef, setNavRef ] = useState< HTMLElement | null >( null );
 
@@ -84,11 +87,13 @@ export default function ItemView( {
 
 	const isMobileApp = isWpMobileApp();
 
-	const shouldHideNav = ( hideNavIfSingleTab && featureTabs.length <= 1 ) || isMobileApp;
+	const shouldHideHeader = hideHeader || shouldShowBreadcrumbs;
+	const shouldHideNav =
+		( hideNavIfSingleTab && featureTabs.length <= 1 ) || isMobileApp || shouldShowBreadcrumbs;
 
 	return (
 		<div className={ clsx( 'hosting-dashboard-item-view', className ) }>
-			{ ! hideHeader && (
+			{ ! shouldHideHeader && (
 				<ItemViewHeader
 					closeItemView={ closeItemView }
 					itemData={ itemData }
@@ -96,6 +101,7 @@ export default function ItemView( {
 					extraProps={ itemViewHeaderExtraProps }
 				/>
 			) }
+			{ shouldShowBreadcrumbs && <ItemViewBreadcrumbsHeader breadcrumbs={ breadcrumbs } /> }
 			<div ref={ setNavRef }>
 				<SectionNav
 					className={ clsx( 'hosting-dashboard-item-view__navigation', {

--- a/client/layout/hosting-dashboard/item-view/item-view-header/breadcrumbs.jsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/breadcrumbs.jsx
@@ -1,0 +1,13 @@
+import NavigationHeader from 'calypso/components/navigation-header';
+import './style.scss';
+
+export default function ItemViewBreadcrumbsHeader( { breadcrumbs } ) {
+	return (
+		<div className="hosting-dashboard-item-view__header">
+			<NavigationHeader
+				className="hosting-dashboard-item-view__header-content hosting-dashboard-item-view__header-breadcrumbs"
+				navigationItems={ breadcrumbs }
+			/>
+		</div>
+	);
+}

--- a/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
+++ b/client/layout/hosting-dashboard/item-view/item-view-header/style.scss
@@ -49,6 +49,11 @@ $blueberry-color: #3858e9;
 		.item-view__close-button {
 			margin-right: 15px;
 		}
+
+		&.hosting-dashboard-item-view__header-breadcrumbs {
+			padding-top: 22px;
+			padding-bottom: 22px;
+		}
 	}
 
 	.hosting-dashboard-item-view__header-favicon {

--- a/client/layout/hosting-dashboard/item-view/types.ts
+++ b/client/layout/hosting-dashboard/item-view/types.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import { SiteFaviconFallback } from 'calypso/blocks/site-favicon';
+import { Item as BreadcrumbItem } from 'calypso/components/breadcrumb';
 
 export interface FeaturePreviewInterface {
 	id: string;
@@ -10,6 +11,7 @@ export interface FeaturePreviewInterface {
 
 export interface FeatureTabInterface {
 	label: string | React.ReactNode;
+	href?: string;
 	countValue?: number;
 	countColor?: string;
 	selected?: boolean;
@@ -43,6 +45,8 @@ export interface ItemViewProps {
 	hideNavIfSingleTab?: boolean;
 	enforceTabsView?: boolean;
 	hideHeader?: boolean;
+	breadcrumbs?: BreadcrumbItem[];
+	shouldShowBreadcrumbs?: boolean;
 }
 
 export interface ItemViewHeaderExtraProps {

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -265,7 +265,7 @@ const DotcomPreviewPane = ( {
 			dispatch(
 				appendBreadcrumb( {
 					id: 'site',
-					label: site.name,
+					label: site.title,
 					href: `/overview/${ site.slug }`,
 					icon: <SiteIcon site={ site } viewType="breadcrumb" disableClick />,
 				} )

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -2,17 +2,20 @@ import config from '@automattic/calypso-config';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { SiteExcerptData } from '@automattic/sites';
 import { useI18n } from '@wordpress/react-i18n';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import ItemView from 'calypso/layout/hosting-dashboard/item-view';
 import { useRemoveDuplicateViewsExperimentEnabled } from 'calypso/lib/remove-duplicate-views-experiment';
 import HostingFeaturesIcon from 'calypso/sites/hosting-features/components/hosting-features-icon';
 import { areHostingFeaturesSupported } from 'calypso/sites/hosting-features/features';
 import { useStagingSite } from 'calypso/sites/tools/staging-site/hooks/use-staging-site';
 import { getMigrationStatus } from 'calypso/sites-dashboard/utils';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { appendBreadcrumb } from 'calypso/state/breadcrumb/actions';
 import { StagingSiteStatus } from 'calypso/state/staging-site/constants';
 import { getStagingSiteStatus } from 'calypso/state/staging-site/selectors';
+import useBreadcrumbs from '../../hooks/use-breadcrumbs';
 import { showSitesPage } from '../sites-dashboard';
+import SiteIcon from '../sites-dataviews/site-icon';
 import { SiteStatus } from '../sites-dataviews/sites-site-status';
 import {
 	FEATURE_TO_ROUTE_MAP,
@@ -188,17 +191,21 @@ const DotcomPreviewPane = ( {
 		return siteFeatures.map( ( { label, enabled, featureIds } ) => {
 			const selected = enabled && featureIds.includes( selectedSiteFeature );
 			const defaultFeatureId = featureIds[ 0 ] as string;
+			const defaultRoute = `/${ FEATURE_TO_ROUTE_MAP[ defaultFeatureId ].replace(
+				':site',
+				site.slug
+			) }`;
+
 			return {
 				id: defaultFeatureId,
 				tab: {
 					label,
+					href: defaultRoute,
 					visible: enabled,
 					selected,
 					onTabClick: () => {
 						if ( enabled && ! selected ) {
-							showSitesPage(
-								`/${ FEATURE_TO_ROUTE_MAP[ defaultFeatureId ].replace( ':site', site.slug ) }`
-							);
+							showSitesPage( defaultRoute );
 						}
 					},
 				},
@@ -243,6 +250,31 @@ const DotcomPreviewPane = ( {
 		stagingStatus === StagingSiteStatus.NONE ||
 		stagingStatus === StagingSiteStatus.UNSET;
 
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		const selectedTab = features.find( ( feature ) => feature.tab.selected )?.tab;
+		if ( selectedTab ) {
+			dispatch(
+				appendBreadcrumb( {
+					id: 'tab',
+					label: selectedTab.label,
+					href: selectedTab.href,
+				} )
+			);
+			dispatch(
+				appendBreadcrumb( {
+					id: 'site',
+					label: site.name,
+					href: `/overview/${ site.slug }`,
+					icon: <SiteIcon site={ site } viewType="breadcrumb" disableClick />,
+				} )
+			);
+		}
+	}, [ site.ID, features, selectedSiteFeature ] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+	const { breadcrumbs, shouldShowBreadcrumbs } = useBreadcrumbs();
+
 	return (
 		<ItemView
 			itemData={ itemData }
@@ -264,6 +296,8 @@ const DotcomPreviewPane = ( {
 					}
 				},
 			} }
+			breadcrumbs={ breadcrumbs }
+			shouldShowBreadcrumbs={ shouldShowBreadcrumbs }
 		/>
 	);
 };

--- a/client/sites/components/style.scss
+++ b/client/sites/components/style.scss
@@ -251,6 +251,11 @@
 				box-shadow: none;
 				border-bottom: 1px solid var(--color-border-subtle);
 				padding-top: 1px;
+
+				&.is-hidden {
+					border-bottom: none;
+					padding-top: none;
+				}
 			}
 		}
 

--- a/client/sites/hooks/use-breadcrumbs.ts
+++ b/client/sites/hooks/use-breadcrumbs.ts
@@ -1,14 +1,16 @@
+import { useRemoveDuplicateViewsExperimentEnabled } from 'calypso/lib/remove-duplicate-views-experiment';
 import { useSelector } from 'calypso/state';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 
 export default function useBreadcrumbs() {
 	const breadcrumbs = useSelector( getBreadcrumbs );
+	const isRemoveDuplicateViewsExperimentEnabled = useRemoveDuplicateViewsExperimentEnabled();
 
 	return {
 		// In sites dashboard, the components are rendered from the innermost level,
 		// and so the breadcrumb items are added in reversed order.
 		// Here we reverse them again so that they are shown in the correct order.
 		breadcrumbs: [ ...breadcrumbs ].reverse(),
-		shouldShowBreadcrumbs: breadcrumbs.length >= 3,
+		shouldShowBreadcrumbs: isRemoveDuplicateViewsExperimentEnabled && breadcrumbs.length >= 3,
 	};
 }

--- a/client/sites/hooks/use-breadcrumbs.ts
+++ b/client/sites/hooks/use-breadcrumbs.ts
@@ -1,0 +1,14 @@
+import { useSelector } from 'calypso/state';
+import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
+
+export default function useBreadcrumbs() {
+	const breadcrumbs = useSelector( getBreadcrumbs );
+
+	return {
+		// In sites dashboard, the components are rendered from the innermost level,
+		// and so the breadcrumb items are added in reversed order.
+		// Here we reverse them again so that they are shown in the correct order.
+		breadcrumbs: [ ...breadcrumbs ].reverse(),
+		shouldShowBreadcrumbs: breadcrumbs.length >= 3,
+	};
+}

--- a/client/sites/settings/administration/tools/delete-site/index.jsx
+++ b/client/sites/settings/administration/tools/delete-site/index.jsx
@@ -16,6 +16,7 @@ import { Panel, PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import withP2HubP2Count from 'calypso/data/p2/with-p2-hub-p2-count';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSettingsSource } from 'calypso/my-sites/site-settings/site-tools/utils';
+import { resetBreadcrumbs, updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
 import { getRemoveDuplicateViewsExperimentAssignment } from 'calypso/state/explat-experiments/actions';
 import { getIsRemoveDuplicateViewsExperimentEnabled } from 'calypso/state/explat-experiments/selectors';
 import { hasLoadedSitePurchasesFromServer } from 'calypso/state/purchases/selectors';
@@ -176,6 +177,17 @@ class DeleteSite extends Component {
 		page( `${ source }/${ siteSlug }` );
 	};
 
+	refreshBreadcrumbs( prevProps ) {
+		if ( this.props.siteId && this.props.siteId !== prevProps?.siteId ) {
+			this.props.updateBreadcrumbs( [
+				{
+					id: 'subtab',
+					label: translate( 'Delete site' ),
+				},
+			] );
+		}
+	}
+
 	componentDidUpdate( prevProps ) {
 		const { siteId, siteExists, useSitesAsLandingPage } = this.props;
 
@@ -187,10 +199,17 @@ class DeleteSite extends Component {
 				page.redirect( '/' );
 			}
 		}
+
+		this.refreshBreadcrumbs( prevProps );
 	}
 
 	componentDidMount() {
 		this.props.getRemoveDuplicateViewsExperimentAssignment();
+		this.refreshBreadcrumbs( undefined );
+	}
+
+	componentWillUnmount() {
+		this.props.resetBreadcrumbs();
 	}
 
 	_checkSiteLoaded = ( event ) => {
@@ -207,7 +226,7 @@ class DeleteSite extends Component {
 	};
 
 	render() {
-		const { isUntangled } = this.state;
+		const { isUntangled } = this.props;
 		const { isAtomic, isFreePlan, siteId, hasCancelablePurchases, p2HubP2Count } = this.props;
 		const isAtomicRemovalInProgress = isFreePlan && isAtomic;
 		const canDeleteSite =
@@ -221,7 +240,7 @@ class DeleteSite extends Component {
 
 		return (
 			<Panel className="settings-administration__delete-site">
-				<HeaderCakeBack icon="chevron-left" onClick={ this._goBack } />
+				{ ! isUntangled && <HeaderCakeBack icon="chevron-left" onClick={ this._goBack } /> }
 				<NavigationHeader
 					compactBreadcrumb={ false }
 					navigationItems={ [] }
@@ -287,5 +306,7 @@ export default connect(
 		deleteSite,
 		setSelectedSiteId,
 		getRemoveDuplicateViewsExperimentAssignment,
+		updateBreadcrumbs,
+		resetBreadcrumbs,
 	}
 )( localize( withP2HubP2Count( DeleteSite ) ) );

--- a/client/sites/settings/administration/tools/reset-site/index.jsx
+++ b/client/sites/settings/administration/tools/reset-site/index.jsx
@@ -8,6 +8,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { createInterpolateElement, useState } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { localize } from 'i18n-calypso';
+import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -21,6 +22,7 @@ import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
 import { useRemoveDuplicateViewsExperimentEnabled } from 'calypso/lib/remove-duplicate-views-experiment';
 import { getSettingsSource } from 'calypso/my-sites/site-settings/site-tools/utils';
 import { useDispatch, useSelector } from 'calypso/state';
+import { resetBreadcrumbs, updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { getSite, getSiteDomain, isJetpackSite } from 'calypso/state/sites/selectors';
@@ -50,6 +52,20 @@ function SiteResetCard( {
 
 	const title = isUntangled ? translate( 'Reset site' ) : translate( 'Site Reset' );
 	const source = isUntangled ? '/sites/settings/site' : getSettingsSource();
+
+	useEffect( () => {
+		dispatch(
+			updateBreadcrumbs( [
+				{
+					id: 'subtab',
+					label: title,
+				},
+			] )
+		);
+		return () => {
+			dispatch( resetBreadcrumbs() );
+		};
+	}, [ siteId ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	const checkStatus = async () => {
 		if ( status?.status !== 'completed' && isAtomic ) {
@@ -304,7 +320,9 @@ function SiteResetCard( {
 	return (
 		<Panel className="settings-administration__reset-site">
 			{ ! isLoading && <Interval onTick={ checkStatus } period={ EVERY_FIVE_SECONDS } /> }
-			<HeaderCakeBack icon="chevron-left" href={ `${ source }/${ selectedSiteSlug }` } />
+			{ ! isUntangled && (
+				<HeaderCakeBack icon="chevron-left" href={ `${ source }/${ selectedSiteSlug }` } />
+			) }
 			<NavigationHeader
 				title={ title }
 				subtitle={ translate(

--- a/client/sites/settings/administration/tools/reset-site/index.jsx
+++ b/client/sites/settings/administration/tools/reset-site/index.jsx
@@ -65,7 +65,7 @@ function SiteResetCard( {
 		return () => {
 			dispatch( resetBreadcrumbs() );
 		};
-	}, [ siteId ] ); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [ siteId, title ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	const checkStatus = async () => {
 		if ( status?.status !== 'completed' && isAtomic ) {

--- a/client/sites/settings/administration/tools/transfer-site/index.tsx
+++ b/client/sites/settings/administration/tools/transfer-site/index.tsx
@@ -92,14 +92,14 @@ const SiteOwnerTransfer = () => {
 
 	if ( confirmationHash ) {
 		return (
-			<SiteTransferCard onClick={ onBackClick }>
+			<SiteTransferCard siteId={ selectedSite.ID } onClick={ onBackClick }>
 				<ConfirmationTransfer siteId={ selectedSite.ID } confirmationHash={ confirmationHash } />
 			</SiteTransferCard>
 		);
 	}
 
 	return (
-		<SiteTransferCard onClick={ onBackClick }>
+		<SiteTransferCard siteId={ selectedSite.ID } onClick={ onBackClick }>
 			{ pendingDomain && <PendingDomainTransfer domain={ pendingDomain } /> }
 			{ ! pendingDomain && ! newSiteOwner && (
 				<SiteOwnerTransferEligibility

--- a/client/sites/settings/administration/tools/transfer-site/site-transfer-card.tsx
+++ b/client/sites/settings/administration/tools/transfer-site/site-transfer-card.tsx
@@ -1,24 +1,46 @@
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import HeaderCakeBack from 'calypso/components/header-cake/back';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { Panel, PanelCard } from 'calypso/components/panel';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useRemoveDuplicateViewsExperimentEnabled } from 'calypso/lib/remove-duplicate-views-experiment';
+import { useDispatch } from 'calypso/state';
+import { resetBreadcrumbs, updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
 
 export function SiteTransferCard( {
 	children,
+	siteId,
 	onClick,
 }: {
 	children: React.ReactNode;
+	siteId: number;
 	onClick: () => void;
 } ) {
 	const translate = useTranslate();
 	const isUntangled = useRemoveDuplicateViewsExperimentEnabled();
 	const title = isUntangled ? translate( 'Transfer site' ) : translate( 'Site Transfer' );
+
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		dispatch(
+			updateBreadcrumbs( [
+				{
+					id: 'subtab',
+					label: title,
+				},
+			] )
+		);
+		return () => {
+			dispatch( resetBreadcrumbs() );
+		};
+	}, [ siteId ] ); // eslint-disable-line react-hooks/exhaustive-deps
+
 	return (
 		<Panel className="settings-administration__transfer-site">
-			<HeaderCakeBack icon="chevron-left" onClick={ onClick } />
+			{ ! isUntangled && <HeaderCakeBack icon="chevron-left" onClick={ onClick } /> }
 			<NavigationHeader
 				title={ title }
 				subtitle={ translate(

--- a/client/sites/settings/administration/tools/transfer-site/site-transfer-card.tsx
+++ b/client/sites/settings/administration/tools/transfer-site/site-transfer-card.tsx
@@ -36,7 +36,7 @@ export function SiteTransferCard( {
 		return () => {
 			dispatch( resetBreadcrumbs() );
 		};
-	}, [ siteId ] ); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [ siteId, title ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	return (
 		<Panel className="settings-administration__transfer-site">

--- a/client/sites/settings/controller.tsx
+++ b/client/sites/settings/controller.tsx
@@ -8,6 +8,7 @@ import { isSimpleSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { getRouteFromContext } from 'calypso/utils';
 import { SidebarItem, Sidebar, PanelWithSidebar } from '../components/panel-sidebar';
+import useBreadcrumbs from '../hooks/use-breadcrumbs';
 import {
 	areAdvancedHostingFeaturesSupported,
 	areHostingFeaturesSupported,
@@ -33,7 +34,9 @@ export function SettingsSidebar() {
 	const areHostingFeaturesSupported = useAreHostingFeaturesSupported();
 	const areAdvancedHostingFeaturesSupported = useAreAdvancedHostingFeaturesSupported();
 
-	if ( isSimple ) {
+	const { shouldShowBreadcrumbs } = useBreadcrumbs();
+
+	if ( isSimple || shouldShowBreadcrumbs ) {
 		return null;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/10442

## Proposed Changes

This PR implements breadcrumbs on administration tools as follows

Figma: TvapEJxLZ98RGWobNN1Xd1-fi-562_37651

|Tool|Before|After|
|-|-|-|
|Reset site|<img width="968" alt="image" src="https://github.com/user-attachments/assets/70320919-9b06-44a7-9759-7998caa3ae5b" />|<img width="790" alt="image" src="https://github.com/user-attachments/assets/db0bc48d-844a-41cf-a1da-788e58a3737d" />|
|Transfer site|<img width="968" alt="image" src="https://github.com/user-attachments/assets/6dd33839-4ce0-4029-901b-328f6097680b" />|<img width="790" alt="image" src="https://github.com/user-attachments/assets/7b19f738-8a83-44eb-b04f-0178e875a930" />|
|Delete site|<img width="968" alt="image" src="https://github.com/user-attachments/assets/a7d1e31b-eee1-48e4-bd5c-faae2b36b457" />|<img width="790" alt="image" src="https://github.com/user-attachments/assets/1921bdb5-5aa9-4243-8222-9d38497cdecd" />|


## Why are these changes being made?

pbxlJb-6TO-p2

## Testing Instructions

On treatment user in the holdout experiment (22167-explat-experiment):
1. Go to /sites
1. Pick a Simple site
2. Go to Settings
3. Go to each of {Reset site, Transfer site, Delete site}:
    - Verify you can see the breadcrumbs
    - Verify you can click around the breadcrumb items
1. Repeat the above with an Atomic site
    - Verify you also don't see the Settings sidebar

On control user in the holdout experiment (22167-explat-experiment):
1. Go to /sites
1. Pick a Simple site
2. Go to My Home then Settings -> General
3. Go to each of {Reset site, Transfer site, Delete site}:
    - Verify you DON'T see the breadcrumbs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?