### PR TITLE
Create Course Goal: Store the create-course goal based on the feature flag

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
@@ -61,6 +62,8 @@ const GoalsStep: Step = ( { navigation, flow } ) => {
 
 	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 	const [ , isIntentNewsletterGoalEnabled ] = useGoalsFirstCumulativeExperience();
+	// Use the experiment flag instead of the feature flag to ensure the experiment is running
+	const isIntentCreateCourseGoalEnabled = config.isEnabled( 'onboarding/create-course' );
 
 	useEffect( () => {
 		resetIntent();
@@ -113,7 +116,10 @@ const GoalsStep: Step = ( { navigation, flow } ) => {
 	const getStepSubmissionHandler =
 		( action: string, eventProps: Record< string, unknown > = {} ) =>
 		() => {
-			const intent = goalsToIntent( goals, isIntentNewsletterGoalEnabled );
+			const intent = goalsToIntent( goals, {
+				isIntentNewsletterGoalEnabled,
+				isIntentCreateCourseGoalEnabled,
+			} );
 			setIntent( intent );
 
 			recordGoalsSelectTracksEvent( goals, intent );

--- a/client/landing/stepper/declarative-flow/site-setup-wg-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-wg-flow.ts
@@ -31,7 +31,7 @@ const siteSetupWithoutGoalsFlow: FlowV1 = {
 		const { site } = useSiteData();
 
 		useEffect( () => {
-			setIntent( goalsToIntent( site?.options?.site_goals ?? [], false ) );
+			setIntent( goalsToIntent( site?.options?.site_goals ?? [] ) );
 			setGoals( site?.options?.site_goals ?? [] );
 		}, [ site, setIntent, setGoals ] );
 

--- a/config/development.json
+++ b/config/development.json
@@ -70,6 +70,7 @@
 		"help": true,
 		"help/gpt-response": true,
 		"home/layout-dev": true,
+
 		"hosting-server-settings-enhancements": true,
 		"hosting/datacenter-picker": true,
 		"i18n/community-translator": false,
@@ -130,6 +131,7 @@
 		"migration-flow/introductory-offer": true,
 		"network-connection": true,
 		"oauth": false,
+		"onboarding/create-course": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,
@@ -144,6 +146,7 @@
 		"onboarding/trail-map-feature-grid": false,
 		"onboarding/user-on-stepper-hosting": true,
 		"onboarding/force-goals-first": false,
+
 		"p2/p2-plus": true,
 		"p2-enabled": false,
 		"page/export": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -85,6 +85,7 @@
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
 		"network-connection": true,
+		"onboarding/create-course": true,
 		"p2/p2-plus": true,
 		"p2-enabled": false,
 		"plans/hosting-trial": true,

--- a/config/production.json
+++ b/config/production.json
@@ -103,6 +103,7 @@
 		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -100,6 +100,7 @@
 		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/test.json
+++ b/config/test.json
@@ -82,6 +82,7 @@
 		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"onboarding/create-course": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -106,6 +106,7 @@
 		"migration-flow/introductory-offer": true,
 		"network-connection": true,
 		"onboarding/enable-write-goal-features": true,
+		"onboarding/create-course": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/packages/data-stores/src/onboard/constants.ts
+++ b/packages/data-stores/src/onboard/constants.ts
@@ -38,6 +38,7 @@ export enum SiteIntent {
 	AIAssembler = 'ai-assembler',
 	Newsletter = 'newsletter',
 	NewsletterGoal = 'intent-newsletter-goal',
+	CreateCourseGoal = 'create-course-goal',
 	FreePostSetup = 'free-post-setup', // non-signup flow
 	SiteMigration = 'site-migration',
 	LinkInBioPostSetup = 'link-in-bio-post-setup', // non-signup flow

--- a/packages/data-stores/src/onboard/test/utils.ts
+++ b/packages/data-stores/src/onboard/test/utils.ts
@@ -41,30 +41,42 @@ describe( 'Test onboard utils', () => {
 		{
 			goals: [ SiteGoal.Write, SiteGoal.Newsletter ],
 			expectedIntent: SiteIntent.Write,
-			isIntentNewsletterGoalsEnabled: false,
+			featureFlags: {
+				isIntentNewsletterGoalEnabled: false,
+			},
 		},
 		{
 			goals: [ SiteGoal.Write, SiteGoal.Newsletter ],
 			expectedIntent: SiteIntent.NewsletterGoal,
-			isIntentNewsletterGoalsEnabled: true,
+			featureFlags: {
+				isIntentNewsletterGoalEnabled: true,
+			},
 		},
 		{
 			goals: [ SiteGoal.Sell, SiteGoal.Newsletter ],
 			expectedIntent: SiteIntent.Sell,
-			isIntentNewsletterGoalsEnabled: false,
+			featureFlags: {
+				isIntentNewsletterGoalEnabled: false,
+			},
+		},
+		{
+			goals: [ SiteGoal.Sell, SiteGoal.Courses ],
+			expectedIntent: SiteIntent.CreateCourseGoal,
+			featureFlags: {
+				isIntentCreateCourseGoalEnabled: true,
+			},
 		},
 		{
 			goals: [ SiteGoal.Sell, SiteGoal.Newsletter ],
 			expectedIntent: SiteIntent.NewsletterGoal,
-			isIntentNewsletterGoalsEnabled: true,
+			featureFlags: {
+				isIntentNewsletterGoalEnabled: true,
+			},
 		},
 	] )(
 		'Should map the $goals to $expectedIntent intent ($featureFlags)',
-		( { goals, expectedIntent, featureFlags = {}, isIntentNewsletterGoalsEnabled = false } ) => {
-			( config.isEnabled as jest.Mock ).mockImplementation( ( flag ) =>
-				Boolean( featureFlags[ flag ] )
-			);
-			expect( goalsToIntent( goals, isIntentNewsletterGoalsEnabled ) ).toBe( expectedIntent );
+		( { goals, expectedIntent, featureFlags } ) => {
+			expect( goalsToIntent( goals, featureFlags ) ).toBe( expectedIntent );
 		}
 	);
 } );

--- a/packages/data-stores/src/onboard/utils.ts
+++ b/packages/data-stores/src/onboard/utils.ts
@@ -1,9 +1,13 @@
 import { SiteGoal, SiteIntent } from './constants';
 
-export const goalsToIntent = (
-	goals: SiteGoal[],
-	isIntentNewsletterGoalEnabled: boolean
-): SiteIntent => {
+interface Flags {
+	isIntentNewsletterGoalEnabled?: boolean;
+	isIntentCreateCourseGoalEnabled?: boolean;
+}
+
+export const goalsToIntent = ( goals: SiteGoal[], flags?: Flags ): SiteIntent => {
+	const { isIntentNewsletterGoalEnabled, isIntentCreateCourseGoalEnabled } = flags ?? {};
+
 	// When DIFM and Import goals are selected together, DIFM Intent will have the priority and will be set.
 	if ( goals.includes( SiteGoal.DIFM ) ) {
 		return SiteIntent.DIFM;
@@ -11,6 +15,10 @@ export const goalsToIntent = (
 
 	if ( goals.includes( SiteGoal.Import ) ) {
 		return SiteIntent.Import;
+	}
+
+	if ( goals.includes( SiteGoal.Courses ) && isIntentCreateCourseGoalEnabled ) {
+		return SiteIntent.CreateCourseGoal;
 	}
 
 	// Newsletter flow


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/10492

## Proposed Changes
* Add the temporary `onboarding/create-course`  feature flag. It needs to be replaced by the experiment name as soon we have it configured. 
*  Store the site intent `create-course-goal` temporarily until we have a better way to store the goals

## Testing Instructions
* Go to the /start
* Open the Developer Console and run `sessionStorage.setItem('flags', 'onboarding/create-course');`
* Refresh the page
* Select any plan
* Follow the steps, choosing "create course" as a goal. 
* Finish the site setup flow
* Go to https://developer.wordpress.com/docs/api/console/  and set the values as described on the image
![CleanShot 2025-02-19 at 16 14 46@2x](https://github.com/user-attachments/assets/aeeae3e7-59d5-4548-b2d3-5301ddf88484)
* Check if the correct site intent was set

![CleanShot 2025-02-19 at 16 16 29@2x](https://github.com/user-attachments/assets/cf5da244-dabc-4cf1-9bc9-d31c3fd7a818)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
