### PR TITLE
A4A: Fix incorrect way of determining current pressable plan.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/index.tsx
@@ -16,9 +16,8 @@ import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import HostingAdditionalFeaturesSection from '../../../common/hosting-additional-features-section';
 import HostingTestimonialsSection from '../../../common/hosting-testimonials-section';
 import { MarketplaceTypeContext } from '../../../context';
-import useProductAndPlans from '../../../hooks/use-product-and-plans';
-import useExistingPressablePlan from '../../../pressable-overview/hooks/use-existing-pressable-plan';
 import useGetPressablePlanByProductId from '../../../pressable-overview/hooks/use-get-pressable-plan-by-product-id';
+import getPressablePlan from '../../../pressable-overview/lib/get-pressable-plan';
 import usePressableOwnershipType from '../../hooks/use-pressable-ownership-type';
 import ClientRelationships from '../common/client-relationships';
 import HostingFeatures from '../common/hosting-features';
@@ -42,22 +41,9 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
 	const pressableOwnership = usePressableOwnershipType();
 
-	const { pressablePlans } = useProductAndPlans( {
-		selectedSite: null,
-		productSearchQuery: '',
-	} );
-
-	const {
-		existingPlan,
-		pressablePlan: existingPlanInfo,
-		isReady: isExistingPlanFetched,
-	} = useExistingPressablePlan( {
-		plans: pressablePlans,
-	} );
-
 	const isReferralMode = marketplaceType === 'referral';
 
-	const { data } = useFetchLicenses(
+	const { data, isFetched: isExistingPlanFetched } = useFetchLicenses(
 		LicenseFilter.NotRevoked,
 		'pressable',
 		LicenseSortField.IssuedAt,
@@ -77,6 +63,8 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 		product_id: agencyPressableLicense ? agencyPressableLicense.productId : 0,
 	} );
 
+	const existingPlanInfo = getPressablePlan( agencyPressablePlan?.slug ?? '' );
+
 	return (
 		<div className="premier-agency-hosting">
 			{ agencyPressablePlan && ! isReferralMode && (
@@ -87,7 +75,7 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 				onSelect={ onAddToCart }
 				isReferralMode={ isReferralMode }
 				pressableOwnership={ isReferralMode || agencyPressablePlan ? 'agency' : pressableOwnership }
-				existingPlan={ existingPlan }
+				existingPlan={ agencyPressablePlan }
 				existingPlanInfo={ existingPlanInfo }
 				isFetching={ isExistingPlanFetched }
 			/>


### PR DESCRIPTION
At present, a bug on the Marketplace Pressable hosting page displays the wrong existing plan in the Plan selection. This issue occurs when an agency refers a Pressable plan to a client.

The UI incorrectly identified the client's pressable plan as the current plan owned by the agency, preventing some of the plans from being purchasable.

The problem arises because we rely on the license count endpoint to determine the existing Pressable plan. However, this approach fails to consider referred licenses, which means that referred Pressable plans for clients could be included mistakenly.

Context on how the bug is discovered: p1739887517846269-slack-C07JCE3ETST

## Proposed Changes

* To resolve this issue, we will modify the UI logic to retrieve the appropriate Pressable plan. The Usage component already accomplishes this effectively; we only need to utilize the data from that retrieval and hook it to the Plan selection component.

## Why are these changes being made?

* The bug prevents some of the agencies from purchasing plans.

## Testing Instructions
* Use the A4A live link to navigate to the `/marketplace/hosting/pressable` page.
* First, purchase a plan (e.g., **Pressable Growth**).
* After purchasing, return to the same page and confirm that the slider points to the next available plan, which is **Pressable Advance**.
   <img width="1588" alt="Screenshot 2025-02-19 at 11 51 51 PM" src="https://github.com/user-attachments/assets/470393fe-87b8-41cf-bc4e-13134cc9a29b" />

* Now refer a client to a higher-tier Pressable plan (e.g., **Pressable Enterprise 200**).
* Once the referral order is paid, go back to the same page.
* Confirm that the slider points to the correct plan, which is **Pressable Advance**.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?