### PR TITLE
Reader Discover: Require a Tracks source prop on AddSitesForm

### DIFF
--- a/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
@@ -8,13 +8,14 @@ import { useCallback, useState } from 'react';
 import ReaderJoinConversationDialog from 'calypso/blocks/reader-join-conversation/dialog';
 import { isValidUrl } from '../../helpers';
 import { useAddSitesModalNotices } from '../../hooks';
-import { SOURCE_SUBSCRIPTIONS_ADD_SITES_MODAL, useRecordSiteSubscribed } from '../../tracks';
+import { useRecordSiteSubscribed } from '../../tracks';
 import './styles.scss';
 
 type AddSitesFormProps = {
 	onAddFinished?: () => void;
 	placeholder?: string;
 	buttonText?: string;
+	source: string;
 };
 
 type SubscriptionError = {
@@ -26,6 +27,7 @@ const AddSitesForm = ( {
 	onAddFinished = () => {},
 	placeholder,
 	buttonText,
+	source,
 }: AddSitesFormProps ) => {
 	const translate = useTranslate();
 	const [ inputValue, setInputValue ] = useState( '' );
@@ -92,7 +94,7 @@ const AddSitesForm = ( {
 									recordSiteSubscribed( {
 										blog_id: data?.subscription?.blog_ID,
 										url: inputValue,
-										source: SOURCE_SUBSCRIPTIONS_ADD_SITES_MODAL,
+										source,
 									} );
 								}
 
@@ -125,6 +127,7 @@ const AddSitesForm = ( {
 			showSuccessNotice,
 			showWarningNotice,
 			subscribe,
+			source,
 		]
 	);
 

--- a/client/landing/subscriptions/components/add-sites-form/test/add-sites-form.test.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/test/add-sites-form.test.tsx
@@ -22,6 +22,7 @@ const renderWithContextProvider = ( component: React.ReactNode ) => {
 describe( 'AddSitesForm', () => {
 	const mockProps = {
 		onAddFinished: jest.fn(),
+		source: 'test-source',
 	};
 
 	test( 'displays an error message with invalid URL', () => {

--- a/client/landing/subscriptions/components/add-sites-modal/add-sites-modal.tsx
+++ b/client/landing/subscriptions/components/add-sites-modal/add-sites-modal.tsx
@@ -1,6 +1,7 @@
 import { Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { AddSitesForm } from 'calypso/landing/subscriptions/components/add-sites-form';
+import { SOURCE_SUBSCRIPTIONS_ADD_SITES_MODAL } from 'calypso/landing/subscriptions/tracks/constants';
 import './styles.scss';
 
 type AddSitesModalProps = {
@@ -31,7 +32,10 @@ const AddSitesModal = ( { showModal, onClose, onAddFinished }: AddSitesModalProp
 				{ translate( 'Subscribe to sites, newsletters, and RSS feeds.' ) }
 			</p>
 
-			<AddSitesForm onAddFinished={ onAddFinished } />
+			<AddSitesForm
+				onAddFinished={ onAddFinished }
+				source={ SOURCE_SUBSCRIPTIONS_ADD_SITES_MODAL }
+			/>
 		</Modal>
 	);
 };

--- a/client/reader/discover/components/add-new/index.tsx
+++ b/client/reader/discover/components/add-new/index.tsx
@@ -37,7 +37,7 @@ const DiscoverAddNew = () => {
 					<h2 className="discover-add-new__form-title">
 						{ translate( 'Add new sites, newsletters, and RSS feeds to your reading list.' ) }
 					</h2>
-					<AddSitesForm />
+					<AddSitesForm source="discover-add-new" />
 				</div>
 				{ isLoggedIn && (
 					<div

--- a/client/reader/discover/components/reddit/index.tsx
+++ b/client/reader/discover/components/reddit/index.tsx
@@ -35,6 +35,7 @@ const Reddit = () => {
 					<AddSitesForm
 						placeholder={ translate( 'Search by Reddit URL' ) }
 						buttonText={ translate( 'Add Feed' ) }
+						source="discover-reddit"
 					/>
 				</div>
 				<div className="discover-reddit__instructions">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/477

## Proposed Changes

* Require a Tracks `source` prop on the `AddSitesForm` component.
* Pass a unique `source` everwhere we use `AddSitesForm`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Originally, the `AddSitesForm` component was only used in one place, so it only had one `source`. Now, we're using this component in multiple places, and we need to know where it's being used. So a `source` is required, and we pass an appropriate value everywhere it is used.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* How to watch Tracks events fire: PCYsg-nSS-p2
* Using Calypso Live subscribe to a new site via /reader/subscriptions
* In the Tracks event `calypso_subscriptions_site_subscribed` you should see the source prop set to `subscriptions-add-sites-modal`
* Subscribe to a site via /discover/add-new
* In the Tracks event `calypso_subscriptions_site_subscribed` you should see the source prop set to `discover-add-new`
* Subscribe to a site via /discover/reddit
* In the Tracks event `calypso_subscriptions_site_subscribed` you should see the source prop set to `discover-reddit`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?