### PR TITLE
Add better error message when email is invalid for Gravatar login.

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -763,6 +763,10 @@ class MagicLogin extends Component {
 			errorText = translate(
 				'Your two-factor code via SMS can only be requested once per minute. Please wait, then request a new code via email to proceed.'
 			);
+		} else if ( codeValidationError?.type === 'user_email' ) {
+			errorText = translate(
+				"We're sorry, you can't create a new account at this time. Please try a different email address or disable any VPN before trying again."
+			);
 		} else if ( codeValidationError?.code === 403 ) {
 			errorText = translate(
 				'Invalid code. If the error persists, please request a new code and try again.'


### PR DESCRIPTION
Related to 109743-ghe-Automattic/gravatar

## Proposed Changes

* Add better error message for Gravatar when email is invalid.

## Why are these changes being made?

* This improves the experience for Gravatar login, since the users were seeing a generic "Something went wrong." error.

## Testing Instructions

* Checkout to this branch.
* Run `yarn && yarn start`.
* Continue with testing steps in 174114-ghe-Automattic/wpcom.

## Screenshot

![image](https://github.com/user-attachments/assets/c6759604-d942-4d68-b1bf-13c49d44ba86)

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?~