### PR TITLE
Settings: Fix spacing issues on apps page

### DIFF
--- a/client/blocks/get-apps/style.scss
+++ b/client/blocks/get-apps/style.scss
@@ -42,6 +42,7 @@ main.get-apps {
 		font-size: $font-body;
 		font-weight: 500;
 		color: var(--studio-gray-50);
+		margin-bottom: 16px;
 	}
 
 	.get-apps__card-title {
@@ -54,6 +55,7 @@ main.get-apps {
 		font-size: $font-body-small;
 		color: var(--studio-gray-50);
 		font-weight: 400;
+		margin-bottom: 0;
 	}
 
 	.components-card-body  {
@@ -98,6 +100,10 @@ main.get-apps {
 		flex-direction: column;
 		gap: 16px;
 		font-size: $font-body-extra-small;
+
+		@include break-medium {
+			flex-direction: row;
+		}
 	}
 
 	.get-apps__also-available-list {

--- a/client/blocks/get-apps/style.scss
+++ b/client/blocks/get-apps/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 main.get-apps {
 	.get-apps__wrapper {
@@ -42,7 +43,7 @@ main.get-apps {
 		font-size: $font-body;
 		font-weight: 500;
 		color: var(--studio-gray-50);
-		margin-bottom: 16px;
+		margin-bottom: $grid-unit-20;
 	}
 
 	.get-apps__card-title {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #100024

## Proposed Changes

* Fix spacing under section headers.
* Fix spacing inside app cards.
* Move "also available" links inline on desktop.

| Before | After |
|--------|--------|
| <img width="1567" alt="Screenshot 2025-02-19 at 17 01 10" src="https://github.com/user-attachments/assets/5b96f95c-ff87-419d-85ec-5d57ecb7cffe" /> | <img width="1567" alt="Screenshot 2025-02-19 at 17 01 25" src="https://github.com/user-attachments/assets/4cd884a8-86ec-4af1-a892-7181216aa9c4" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix broken spacing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the changes from this PR.
* Navigate to `/me/get-apps`
* Check that the spacing matches the screenshot above.
