### PR TITLE
A4A: update finish button text

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form-2/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form-2/index.tsx
@@ -141,7 +141,7 @@ const BlueprintForm2: React.FC< Props > = ( { onContinue, initialFormData, goBac
 				</Button>
 
 				<Button variant="primary" onClick={ handleSubmit } __next40pxDefaultSize>
-					{ translate( 'Continue' ) }
+					{ translate( 'Finish' ) }
 				</Button>
 			</FormFooter>
 		</Form>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/index.tsx
@@ -67,7 +67,7 @@ const ChoiceBlueprint: React.FC< Props > = ( { onContinue, onSkip, goBack } ) =>
 						onClick={ onSkip }
 						__next40pxDefaultSize
 					>
-						{ translate( 'Not right now' ) }
+						{ translate( 'Skip and finish' ) }
 					</Button>
 					<Button
 						className="choice-blueprint__button"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1739960395938899-slack-C047ACYM8UQ

## Proposed Changes

Update wording to clearly state when we are Finishing and form will be submit.

| Description | Screenshot |
|--------|--------|
| Skipping blueprint | <img width="714" alt="Screenshot 2025-02-19 at 9 10 18 AM" src="https://github.com/user-attachments/assets/c8463592-e5c6-4b54-9c41-d18864b25116" /> |
| After finishing blueprint | <img width="758" alt="Screenshot 2025-02-19 at 9 10 32 AM" src="https://github.com/user-attachments/assets/bb8c7549-e8fc-4fe0-b7dd-dd6cbf30af13" /> | 


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link test out the form

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?