### PR TITLE
Forwards: Tokenize email invites on blur

### DIFF
--- a/client/my-sites/email/email-forwards-add/add-new-form/destination-input.tsx
+++ b/client/my-sites/email/email-forwards-add/add-new-form/destination-input.tsx
@@ -44,6 +44,7 @@ export function DestinationsInput( props: DestinationsInputProps ) {
 				value={ values.slice( 0, limit ) }
 				maxLength={ limit }
 				onInputChange={ () => setError( null ) }
+				tokenizeOnBlur
 				__experimentalValidateInput={ ( value ) => {
 					const error = isValidDestination(
 						value,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/99606

This tokenizes email input when the input field is blurred. 

I would add `tokenizeOnSpace` as well, but sadly, it doesn't call `__experimentalValidateInput` and it tokenizes invalid email addresses.