### PR TITLE
Reader: Update no results found message on Manage Subscriptions screen

### DIFF
--- a/client/reader/site-subscriptions-manager/not-found-site-subscriptions.tsx
+++ b/client/reader/site-subscriptions-manager/not-found-site-subscriptions.tsx
@@ -9,19 +9,16 @@ const NotFoundSiteSubscriptions = () => {
 	return (
 		<div className="not-found-site-subscriptions">
 			{ searchTerm && searchTerm.length
-				? translate(
-						"You're not subscribed to any matching sites. Here are some other sites related to your search.",
-						{
-							comment:
-								"When users type something into the search field of their site subscriptions manager in Reader, they'll see this message if their search doesn't find any of the websites they're currently subscribed to.",
-						}
-				  )
+				? translate( "You're not subscribed to any matching sites.", {
+						comment:
+							"When users type something into the search field of their site subscriptions manager in Reader, they'll see this message if their search doesn't find any of the websites they're currently subscribed to.",
+				  } )
 				: translate( 'No results found.', {
 						comment:
 							"When users type something into the search field of their site subscriptions manager in Reader, they'll see this message if their search doesn't find any of the websites they're currently subscribed to.",
 				  } ) }{ ' ' }
 			{ ( readFeedSearch?.feedItems.length ?? 0 ) > 0 &&
-				translate( 'Here are some other sites that match your search.' ) }
+				translate( 'Here are some other sites related to your search.' ) }
 		</div>
 	);
 };

--- a/client/reader/site-subscriptions-manager/not-found-site-subscriptions.tsx
+++ b/client/reader/site-subscriptions-manager/not-found-site-subscriptions.tsx
@@ -9,12 +9,13 @@ const NotFoundSiteSubscriptions = () => {
 	return (
 		<div className="not-found-site-subscriptions">
 			{ searchTerm && searchTerm.length
-				? /* translators: the string is the exact text that the user entered into the search input in site subscriptions manager in Reader */
-				  translate( 'No results found for “%s”.', {
-						args: searchTerm,
-						comment:
-							"When users type something into the search field of their site subscriptions manager in Reader, they'll see this message if their search doesn't find any of the websites they're currently subscribed to.",
-				  } )
+				? translate(
+						"You're not subscribed to any matching sites. Here are some other sites related to your search.",
+						{
+							comment:
+								"When users type something into the search field of their site subscriptions manager in Reader, they'll see this message if their search doesn't find any of the websites they're currently subscribed to.",
+						}
+				  )
 				: translate( 'No results found.', {
 						comment:
 							"When users type something into the search field of their site subscriptions manager in Reader, they'll see this message if their search doesn't find any of the websites they're currently subscribed to.",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99202

## Proposed Changes

Updating no results found message to reduce confusions.

### Before

![image](https://github.com/user-attachments/assets/40602cbd-2a68-4ed5-b2ae-78349e9ab70a)

### After

![image](https://github.com/user-attachments/assets/58d6bfd0-00d0-4aaa-87e3-f21a083b628d)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The current message is confusing so updating the message for more clarity ([more](https://github.com/Automattic/wp-calypso/issues/99202#issuecomment-2669430226))

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/reader/subscriptions`
* Type a site address on search box which you are not subscribed to.
* Verify the message.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
