### PR TITLE
Confirm push to `trunk` only for primary repo

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn run install-if-no-packages && node bin/pre-push-hook.js
+yarn run install-if-no-packages && node bin/pre-push-hook.js "$@"

--- a/bin/pre-push-hook.js
+++ b/bin/pre-push-hook.js
@@ -9,6 +9,13 @@ console.log(
 		'GPLv2 compatible licenses — see docs/CONTRIBUTING.md for details.\n\n'
 );
 
+const [ , , , remoteUrl ] = process.argv;
+let isCalypsoRepo = false;
+
+if ( remoteUrl.match( /github\.com[:/]Automattic\/wp-calypso\.git/ ) ) {
+	isCalypsoRepo = true;
+}
+
 const currentBranch = execSync( 'git rev-parse --abbrev-ref HEAD' ).toString().trim();
 
 if ( 'trunk' === currentBranch ) {

--- a/bin/pre-push-hook.js
+++ b/bin/pre-push-hook.js
@@ -18,7 +18,7 @@ if ( remoteUrl.match( /github\.com[:/]Automattic\/wp-calypso\.git/ ) ) {
 
 const currentBranch = execSync( 'git rev-parse --abbrev-ref HEAD' ).toString().trim();
 
-if ( 'trunk' === currentBranch ) {
+if ( isCalypsoRepo && 'trunk' === currentBranch ) {
 	if ( ! readline.keyInYN( "You're about to push !!![ trunk ]!!!, is that what you intended?" ) ) {
 		process.exit( 1 );
 	}


### PR DESCRIPTION
This enhancement adds a check for whether the push remote is the [official Calypso repo](https://github.com/Automattic/wp-calypso), and suppresses the warning for `trunk` pushes to other forks.

## Proposed Changes

* Pass `push` args to pre-push-hook.js.
* Provide the warning/confirmation only when pushing to the official repo.
* Remote path is evaluated for both HTTPS (`https://github.com/Automattic/wp-calypso.git`) and SSH (`git@github.com:Automattic/wp-calypso.git`) format.

## Why are these changes being made?

In [pre-push-hook.js](https://github.com/Automattic/wp-calypso/blob/trunk/bin/pre-push-hook.js), users are asked to confirm pushing to `trunk`, even for personal forks. While it serves as a good reminder to review what you're doing, it seems primarily applicable to pushing to the main repo and Doing A Bad Thing. In my opinion, this warning should only surface when it affects the official repo.

## Testing Instructions

Given the following example (your remote names may vary):

```sh
➜ git remote -v
origin	git@github.com:ironprogrammer/wp-calypso.git (fetch)
origin	git@github.com:ironprogrammer/wp-calypso.git (push)
upstream	git@github.com:Automattic/wp-calypso.git (fetch)
upstream	git@github.com:Automattic/wp-calypso.git (push)

➜ git checkout trunk
Switched to branch 'trunk'
Your branch is up to date with 'origin/trunk'.

➜ git pull upstream trunk
...
```

### Before update -- asks for confirmation regardless of remote:
```sh
➜ git push origin trunk

By contributing to this project, you license the materials you contribute under the GNU General Public License v2 (or later). All materials must have GPLv2 compatible licenses — see docs/CONTRIBUTING.md for details.


You're about to push !!![ trunk ]!!!, is that what you intended? [y/n]: 
```

### After update

#### No confirmation for personal fork:
```sh
➜ git push origin trunk

By contributing to this project, you license the materials you contribute under the GNU General Public License v2 (or later). All materials must have GPLv2 compatible licenses — see docs/CONTRIBUTING.md for details.


Total 0 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To github.com:ironprogrammer/wp-calypso.git
   faf8b17ba0..13588b4360  trunk -> trunk
```

#### Still requires confirmation for primary repo:
```sh
➜ git push upstream trunk

By contributing to this project, you license the materials you contribute under the GNU General Public License v2 (or later). All materials must have GPLv2 compatible licenses — see docs/CONTRIBUTING.md for details.


You're about to push !!![ trunk ]!!!, is that what you intended? [y/n]: 
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
