### PR TITLE
Shows social engagement section in Blaze for campaigns in moderation

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -659,6 +659,95 @@ export default function CampaignItemDetails( props: Props ) {
 		setHideTspMetricsBannerCookie( true );
 	};
 
+	const getCampaignTSPStats = ( showBanner: boolean ) => (
+		<>
+			<div className="campaign-item-details__main-stats-row" ref={ tspTargetRef }>
+				<TspMetricsBanner
+					onClose={ closeTspMetricsBanner }
+					display={ showBanner && showTspMetricsBanner }
+				/>
+				<div className="campaign-item-details__main-stats-title">
+					<span className="campaign-item-details__title">{ translate( 'Social Engagement' ) }</span>
+					<a
+						href={ permalink }
+						target="_blank"
+						rel="noreferrer"
+						className="campaign-item-details__tsp-permalink"
+						onClick={ () => {
+							recordTracksEvent( 'calypso_dsp_tsp_open_post_click', {} );
+						} }
+					>
+						<span>{ translate( 'Open Tumblr Post' ) }</span>
+						<Gridicon icon="external" size={ 16 } />
+					</a>
+				</div>
+				<div>
+					<span className="campaign-item-details__label">{ translate( 'Tumblr Post views' ) }</span>
+					<span className="campaign-item-details__text">
+						<span className="wp-brand-font">
+							{ ! isLoading ? tspImpressionsFormatted : <FlexibleSkeleton /> }
+						</span>
+					</span>
+				</div>
+				{ /* todo commenting this until we figure out if this is working properly*/ }
+				{ /*<div>*/ }
+				{ /*	<span className="campaign-item-details__label">*/ }
+				{ /*		{ translate( 'Site visits from Tumblr Post' ) }*/ }
+				{ /*	</span>*/ }
+				{ /*	<span className="campaign-item-details__text">*/ }
+				{ /*		<span className="wp-brand-font">*/ }
+				{ /*			{ ! isLoading ? tspClicksFormatted : <FlexibleSkeleton /> }*/ }
+				{ /*		</span>*/ }
+				{ /*	</span>*/ }
+				{ /*</div>*/ }
+			</div>
+			<div className="campaign-item-details__main-stats-row ">
+				<div>
+					<span className="campaign-item-details__label">{ translate( 'Replies' ) }</span>
+					<span className="campaign-item-details__text">
+						<span className="wp-brand-font">
+							{ ! isLoading ? repliesFormatted : <FlexibleSkeleton /> }
+						</span>
+					</span>
+				</div>
+				<div>
+					<span className="campaign-item-details__label">{ translate( 'Likes' ) }</span>
+					<span className="campaign-item-details__text">
+						<span className="wp-brand-font">
+							{ ! isLoading ? likesFormatted : <FlexibleSkeleton /> }
+						</span>
+					</span>
+				</div>
+				{ displayedReplies && replies && replies?.length > 0 && (
+					<div className="campaign-items-details__tsp-replies">
+						{ displayedReplies.map( ( reply, index ) => (
+							<div key={ index } className="campaign-items-details__tsp-reply">
+								<a href={ reply.blog_url } target="_blank" rel="noopener noreferrer">
+									@{ reply.blog_name }
+								</a>
+								<br />
+								{ reply?.reply_text || '-' }
+							</div>
+						) ) }
+						{ replies && replies?.length > 3 && (
+							<button
+								className="campaign-items-details__replies-show-more-button"
+								onClick={ () => {
+									if ( ! showAllReplies ) {
+										recordTracksEvent( 'calypso_dsp_tsp_section_replies_show_more_click', {} );
+									}
+									setShowAllReplies( ! showAllReplies );
+								} }
+							>
+								{ showAllReplies ? __( 'Show Less' ) : __( 'Show More' ) }
+							</button>
+						) }
+					</div>
+				) }
+			</div>
+		</>
+	);
+
 	return (
 		<div className="campaign-item__container">
 			<Dialog
@@ -1048,109 +1137,7 @@ export default function CampaignItemDetails( props: Props ) {
 											) }
 										</>
 									) }
-									{ tsp && (
-										<>
-											<div className="campaign-item-details__main-stats-row" ref={ tspTargetRef }>
-												<TspMetricsBanner
-													onClose={ closeTspMetricsBanner }
-													display={ showTspMetricsBanner }
-												/>
-												<div className="campaign-item-details__main-stats-title">
-													<span className="campaign-item-details__title">
-														{ translate( 'Social Engagement' ) }
-													</span>
-													<a
-														href={ permalink }
-														target="_blank"
-														rel="noreferrer"
-														className="campaign-item-details__tsp-permalink"
-														onClick={ () => {
-															recordTracksEvent( 'calypso_dsp_tsp_open_post_click', {} );
-														} }
-													>
-														<span>{ translate( 'Open Tumblr Post' ) }</span>
-														<Gridicon icon="external" size={ 16 } />
-													</a>
-												</div>
-												<div>
-													<span className="campaign-item-details__label">
-														{ translate( 'Tumblr Post views' ) }
-													</span>
-													<span className="campaign-item-details__text">
-														<span className="wp-brand-font">
-															{ ! isLoading ? tspImpressionsFormatted : <FlexibleSkeleton /> }
-														</span>
-													</span>
-												</div>
-												{ /* todo commenting this until we figure out if this is working properly*/ }
-												{ /*<div>*/ }
-												{ /*	<span className="campaign-item-details__label">*/ }
-												{ /*		{ translate( 'Site visits from Tumblr Post' ) }*/ }
-												{ /*	</span>*/ }
-												{ /*	<span className="campaign-item-details__text">*/ }
-												{ /*		<span className="wp-brand-font">*/ }
-												{ /*			{ ! isLoading ? tspClicksFormatted : <FlexibleSkeleton /> }*/ }
-												{ /*		</span>*/ }
-												{ /*	</span>*/ }
-												{ /*</div>*/ }
-											</div>
-											<div className="campaign-item-details__main-stats-row ">
-												<div>
-													<span className="campaign-item-details__label">
-														{ translate( 'Replies' ) }
-													</span>
-													<span className="campaign-item-details__text">
-														<span className="wp-brand-font">
-															{ ! isLoading ? repliesFormatted : <FlexibleSkeleton /> }
-														</span>
-													</span>
-												</div>
-												<div>
-													<span className="campaign-item-details__label">
-														{ translate( 'Likes' ) }
-													</span>
-													<span className="campaign-item-details__text">
-														<span className="wp-brand-font">
-															{ ! isLoading ? likesFormatted : <FlexibleSkeleton /> }
-														</span>
-													</span>
-												</div>
-												{ displayedReplies && replies && replies?.length > 0 && (
-													<div className="campaign-items-details__tsp-replies">
-														{ displayedReplies.map( ( reply, index ) => (
-															<div key={ index } className="campaign-items-details__tsp-reply">
-																<a
-																	href={ reply.blog_url }
-																	target="_blank"
-																	rel="noopener noreferrer"
-																>
-																	@{ reply.blog_name }
-																</a>
-																<br />
-																{ reply?.reply_text || '-' }
-															</div>
-														) ) }
-														{ replies && replies?.length > 3 && (
-															<button
-																className="campaign-items-details__replies-show-more-button"
-																onClick={ () => {
-																	if ( ! showAllReplies ) {
-																		recordTracksEvent(
-																			'calypso_dsp_tsp_section_replies_show_more_click',
-																			{}
-																		);
-																	}
-																	setShowAllReplies( ! showAllReplies );
-																} }
-															>
-																{ showAllReplies ? __( 'Show Less' ) : __( 'Show More' ) }
-															</button>
-														) }
-													</div>
-												) }
-											</div>
-										</>
-									) }
+									{ tsp && getCampaignTSPStats( true ) }
 								</div>
 							</div>
 						) }
@@ -1256,6 +1243,12 @@ export default function CampaignItemDetails( props: Props ) {
 								) }
 							</div>
 						</div>
+
+						{ ! shouldShowStats && tsp && (
+							<div className="campaign-item-details__main-stats-container">
+								{ getCampaignTSPStats( false ) }
+							</div>
+						) }
 
 						<div className="campaign-item-details__main-stats-container">
 							<div className="campaign-item-details__secondary-stats">


### PR DESCRIPTION
## Proposed Changes

Show the TSP social engagement section even if the Blaze campaign hasn't been moderated yet

## Why are these changes being made?

When a user chooses to create a campaign using the new Social engagement feature, we want to provide them with early feedback about how their post will look on Tumblr. Because of this, we are enabling the TSP section of the campaigns to be shown in moderation. 

Users will see the Open Tumblr post link, verify how the content looks on Tumblr, and cancel the campaign if they are unhappy with the result.

## Testing Instructions

* Open the Live preview and navigate to Tools->Advertiser
* Create a new campaign, enabling the Social engagement feature
* Go to the campaign details page for the campaign, and verify that you see the default social engagement section

![Screenshot 2025-02-19 at 5 36 26 PM](https://github.com/user-attachments/assets/16601b29-9b2a-4894-83fa-f57b3cabbff3)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
