### PR TITLE
Remove Webinars from global nav and footer

### DIFF
--- a/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
@@ -228,11 +228,6 @@ export const PureUniversalNavbarFooter = ( {
 									</a>
 								</li>
 								<li>
-									<a href={ localizeUrl( 'https://wordpress.com/webinars/' ) } target="_self">
-										{ __( 'Daily Webinars', __i18n_text_domain__ ) }
-									</a>
-								</li>
-								<li>
 									{ isEnglishLocale && (
 										<a href={ localizeUrl( 'https://wordpress.com/learn/' ) } target="_self">
 											{ __( 'Learn WordPress', __i18n_text_domain__ ) }

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -292,13 +292,6 @@ const UniversalNavbarHeader = ( {
 															type="dropdown"
 															target="_self"
 														/>
-														<ClickableItem
-															titleValue=""
-															content={ __( 'Daily Webinars', __i18n_text_domain__ ) }
-															urlValue={ localizeUrl( '//wordpress.com/webinars/' ) }
-															type="dropdown"
-															target="_self"
-														/>
 														{ isEnglishLocale && (
 															<ClickableItem
 																titleValue=""
@@ -610,12 +603,6 @@ const UniversalNavbarHeader = ( {
 												titleValue=""
 												content={ __( 'Blog Search', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/reader/search/' ) }
-												type="menu"
-											/>
-											<ClickableItem
-												titleValue=""
-												content={ __( 'Daily Webinars', __i18n_text_domain__ ) }
-												urlValue={ localizeUrl( '//wordpress.com/webinars/' ) }
 												type="menu"
 											/>
 											{ isEnglishLocale && (


### PR DESCRIPTION
## Proposed Changes

* Removes the Webinars link from the global nav and footer
  * PT: p58i-jD2-p2

## Why are these changes being made?

**Two reasons:**
* The /webinars/ page was already redirecting to /learn/webinars/
* The /learn/webinars/ page has now been deprecated while the support content team works on revamping the video content across /support/ and /learn/. 

## Testing Instructions

**Checkout this branch, then:**

* Use the Calypso live link or visit http://calypso.localhost:3000/themes. Make sure you're not logged-in.
  * Check the desktop and mobile nav to ensure the link to Webinars has been removed.
  * Check the footer to ensure the link to Webinars has been removed. 
* Check other pages like http://calypso.localhost:3000/plugins and http://calypso.localhost:3000/patterns to verify the links have been removed. 

**Before:**
<img width="1006" alt="Screenshot 2025-02-19 at 1 37 33 PM" src="https://github.com/user-attachments/assets/dbfa7131-7fab-4111-98ec-5b3e40a9f3f2" />
<img width="423" alt="Screenshot 2025-02-19 at 1 38 08 PM" src="https://github.com/user-attachments/assets/e5aef9cb-bb8b-4699-ae04-f1e08c6292cb" />
<img width="1016" alt="Screenshot 2025-02-19 at 1 52 49 PM" src="https://github.com/user-attachments/assets/9d636026-e867-4eb2-9fb8-04fa64ede2d5" />


**After:** 
<img width="1200" alt="Screenshot 2025-02-19 at 1 48 44 PM" src="https://github.com/user-attachments/assets/03a36936-5c2f-470b-b3eb-060d36b74cf3" />
<img width="319" alt="Screenshot 2025-02-19 at 1 50 04 PM" src="https://github.com/user-attachments/assets/d5247313-01cb-420c-9fcf-01134e0a19a9" />
<img width="1019" alt="Screenshot 2025-02-19 at 1 49 35 PM" src="https://github.com/user-attachments/assets/42d5daf6-0463-44b7-93a0-80a8554e9b94" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?