### PR TITLE
Stats: add highlights loading placeholder

### DIFF
--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -245,6 +245,10 @@ $custom-stats-tab-mobile-break: $break-medium;
 						// Prevent different heights of Flexbox items.
 						white-space: nowrap;
 					}
+					.stats-tabs__highlight-loading {
+						padding: 5px;
+						width: 100%;
+					}
 					.stats-tabs__highlight {
 						display: flex;
 						justify-content: start;

--- a/client/my-sites/stats/stats-tabs/tab.jsx
+++ b/client/my-sites/stats/stats-tabs/tab.jsx
@@ -1,3 +1,4 @@
+import { LoadingPlaceholder } from '@automattic/components';
 import { TooltipContent } from '@automattic/components/src/highlight-cards/count-card';
 import { TrendComparison } from '@automattic/components/src/highlight-cards/count-comparison-card';
 import Popover from '@automattic/components/src/popover';
@@ -98,8 +99,13 @@ class StatsTabsTab extends Component {
 					{ children }
 					{ hasPreviousData && (
 						<div className="stats-tabs__highlight">
-							<span className="stats-tabs__highlight-value" ref={ this.tooltipRef }>
-								{ numberFormatCompact( value ) }
+							<span
+								className={ clsx( 'stats-tabs__highlight-value', {
+									'stats-tabs__highlight-loading': loading,
+								} ) }
+								ref={ this.tooltipRef }
+							>
+								{ loading ? <LoadingPlaceholder height="30px" /> : numberFormatCompact( value ) }
 							</span>
 							<TrendComparison count={ value } previousCount={ previousValue } />
 							<Popover


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/jetpack-roadmap#2239.

## Proposed Changes

* Improve the highlights display by showing a loading placeholder while data is being loaded.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Automattic/jetpack-roadmap#1818

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Access the Calypso Live link below.
- Access the Stats page of a site that has meaningful highlights data, like `/stats/day/jetpack.com`
- Check if the loading placeholder is displayed for the highlights that take a little longer to load, like `Likes` and `Comments`.
  - This may be easier to check by pausing the execution in the `Sources` tab (on Chrome) of the browser console.
  - Their box sizes should also be consistent with the highlights already loaded.

### Before

- `Likes` and `Comments` were being shown in a smaller box with no indication that the data is being loaded:

![image](https://github.com/user-attachments/assets/3a2a5c40-1013-4fa7-a289-df5840e35a68)

### After

- A loading placeholder, in the same size as the previous boxes, is shown for both `Likes` and `Comments`:

https://github.com/user-attachments/assets/a65ac8bc-9a8e-4642-845d-2b1147b4e8da

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
