### PR TITLE
P2s list: Do not include the A8C-owned sites filter

### DIFF
--- a/client/sites/components/sites-dashboard.tsx
+++ b/client/sites/components/sites-dashboard.tsx
@@ -291,10 +291,12 @@ const SitesDashboard = ( {
 		sortOrder: dataViewsState.sort?.direction || undefined,
 	} );
 
-	const includeA8CSites =
+	const hasA8CSitesFilter =
 		dataViewsState.filters?.some(
 			( { field, operator, value } ) => field === 'a8c_owned' && operator === 'is' && value === true
-		) ?? siteType === 'p2';
+		) ?? false;
+
+	const includeA8CSites = siteType === 'p2' || hasA8CSitesFilter;
 
 	// Filter sites list by search query.
 	const filteredSites = useSitesListFiltering( sortedSites, {
@@ -413,6 +415,7 @@ const SitesDashboard = ( {
 
 					<DotcomSitesDataViews
 						sites={ paginatedSites }
+						siteType={ siteType }
 						isLoading={ isLoading || ! initialSortApplied }
 						paginationInfo={ getSitesPagination( filteredSites, perPage ) }
 						dataViewsState={ dataViewsState }

--- a/client/sites/components/sites-dataviews/index.tsx
+++ b/client/sites/components/sites-dataviews/index.tsx
@@ -21,6 +21,7 @@ import './dataview-style.scss';
 
 type Props = {
 	sites: SiteExcerptData[];
+	siteType: 'p2' | 'non-p2';
 	isLoading: boolean;
 	paginationInfo: { totalItems: number; totalPages: number };
 	dataViewsState: View;
@@ -50,6 +51,7 @@ export function useSiteStatusGroups() {
 
 const DotcomSitesDataViews = ( {
 	sites,
+	siteType,
 	isLoading,
 	paginationInfo,
 	dataViewsState,
@@ -171,7 +173,7 @@ const DotcomSitesDataViews = ( {
 			},
 		];
 
-		if ( isAutomattician ) {
+		if ( isAutomattician && siteType === 'non-p2' ) {
 			dataViewFields.push( {
 				id: 'a8c_owned',
 				label: __( 'Include A8C sites' ),
@@ -193,7 +195,15 @@ const DotcomSitesDataViews = ( {
 		}
 
 		return dataViewFields;
-	}, [ __, siteStatusGroups, openSitePreviewPane, dataViewsState.type, userId, isAutomattician ] );
+	}, [
+		__,
+		siteStatusGroups,
+		openSitePreviewPane,
+		dataViewsState.type,
+		userId,
+		isAutomattician,
+		siteType,
+	] );
 
 	const actions = useActions( {
 		openSitePreviewPane,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/pull/100034#issuecomment-2669922909.


## Testing Instructions

- Verify you see P2s;
- Verify you don't see the "Include A8C sites filter" in the P2s list;
- Verify you don't see A8C-owned sites in /sites;
- Verify you can see these sites if the filter is applied.