### PR TITLE
Stepper: refactor Domains Transfer flow to v2

### DIFF
--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -17,6 +17,7 @@ import {
 	AssertConditionState,
 	FlowV1,
 } from './internals/types';
+import { STEPS } from './internals/steps';
 import type { UserSelect } from '@automattic/data-stores';
 
 const domainTransfer: FlowV1 = {
@@ -26,6 +27,7 @@ const domainTransfer: FlowV1 = {
 	},
 	isSignupFlow: false,
 	initialize() {
+		// TODO: move to client/landing/stepper/declarative-flow/internals/steps.tsx ?
 		return [
 			{
 				slug: 'intro',
@@ -35,10 +37,7 @@ const domainTransfer: FlowV1 = {
 				slug: 'domains',
 				asyncComponent: () => import( './internals/steps-repository/domain-transfer-domains' ),
 			},
-			{
-				slug: 'processing',
-				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
-			},
+			STEPS.PROCESSING,
 		];
 	},
 

--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -22,18 +22,7 @@ const domainTransfer: Flow = {
 	},
 	isSignupFlow: false,
 	initialize() {
-		// TODO: move to client/landing/stepper/declarative-flow/internals/steps.tsx ?
-		return [
-			{
-				slug: 'intro',
-				asyncComponent: () => import( './internals/steps-repository/domain-transfer-intro' ),
-			},
-			{
-				slug: 'domains',
-				asyncComponent: () => import( './internals/steps-repository/domain-transfer-domains' ),
-			},
-			STEPS.PROCESSING,
-		];
+		return [ STEPS.DOMAIN_TRANSFER_INTRO, STEPS.DOMAIN_TRANSFER_DOMAINS, STEPS.PROCESSING ];
 	},
 
 	useSideEffect( _currentStepSlug, navigate ) {

--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -25,7 +25,7 @@ const domainTransfer: FlowV1 = {
 		return translate( 'Bulk domain transfer' );
 	},
 	isSignupFlow: false,
-	useSteps() {
+	initialize() {
 		return [
 			{
 				slug: 'intro',

--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -12,7 +12,6 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { USER_STORE } from '../stores';
 import { useLoginUrl } from '../utils/path';
 import {
-	ProvidedDependencies,
 	AssertConditionResult,
 	AssertConditionState,
 	FlowV1,
@@ -66,8 +65,9 @@ const domainTransfer: FlowV1 = {
 			pageTitle: 'Bulk Transfer',
 		} );
 
-		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
-			switch ( _currentStepSlug ) {
+		const submit: ReturnType< Flow[ 'useStepNavigation' ] >[ 'submit' ] = (
+			providedDependencies = {}
+		) => {
 				case 'intro':
 					clearSignupDestinationCookie();
 
@@ -81,7 +81,7 @@ const domainTransfer: FlowV1 = {
 					return navigate( 'processing', undefined );
 				}
 				case 'processing': {
-					setSignupCompleteSlug( providedDependencies?.siteSlug );
+					setSignupCompleteSlug( providedDependencies.siteSlug );
 					setSignupCompleteFlowName( flowName );
 
 					const checkoutBackURL = new URL(

--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -11,10 +11,6 @@ import {
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { USER_STORE } from '../stores';
 import { useLoginUrl } from '../utils/path';
-import {
-	AssertConditionResult,
-	AssertConditionState,
-} from './internals/types';
 import { STEPS } from './internals/steps';
 import { Flow } from './internals/types';
 import type { UserSelect } from '@automattic/data-stores';

--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -52,7 +52,7 @@ const domainTransfer: FlowV1 = {
 		}, [ isLoggedIn ] );
 	},
 
-	useStepNavigation( _currentStepSlug, navigate ) {
+	useStepNavigation( currentStepSlug, navigate ) {
 		const flowName = this.name;
 		const userIsLoggedIn = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
@@ -68,6 +68,7 @@ const domainTransfer: FlowV1 = {
 		const submit: ReturnType< Flow[ 'useStepNavigation' ] >[ 'submit' ] = (
 			providedDependencies = {}
 		) => {
+			switch ( currentStepSlug ) {
 				case 'intro':
 					clearSignupDestinationCookie();
 
@@ -104,7 +105,7 @@ const domainTransfer: FlowV1 = {
 		};
 
 		const goBack = () => {
-			switch ( _currentStepSlug ) {
+			switch ( currentStepSlug ) {
 				case 'domains':
 					return navigate( 'intro' );
 				default:

--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -1,17 +1,13 @@
 import { DOMAIN_TRANSFER } from '@automattic/onboarding';
-import { useSelect } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
 import {
 	clearSignupDestinationCookie,
 	setSignupCompleteSlug,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
-import { USER_STORE } from '../stores';
-import { useLoginUrl } from '../utils/path';
 import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 import { STEPS } from './internals/steps';
 import { FlowV2 } from './internals/types';
-import type { UserSelect } from '@automattic/data-stores';
 
 const domainTransfer: FlowV2 = {
 	name: DOMAIN_TRANSFER,
@@ -28,16 +24,6 @@ const domainTransfer: FlowV2 = {
 
 	useStepNavigation( currentStepSlug, navigate ) {
 		const flowName = this.name;
-		const userIsLoggedIn = useSelect(
-			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
-			[]
-		);
-
-		const logInUrl = useLoginUrl( {
-			variationName: flowName,
-			redirectTo: `/setup/${ flowName }/domains`,
-			pageTitle: 'Bulk Transfer',
-		} );
 
 		const submit: ReturnType< FlowV2[ 'useStepNavigation' ] >[ 'submit' ] = (
 			providedDependencies = {}
@@ -46,13 +32,13 @@ const domainTransfer: FlowV2 = {
 				case 'intro':
 					clearSignupDestinationCookie();
 
-					if ( userIsLoggedIn ) {
-						return navigate( 'domains' );
-					}
-					return window.location.assign( logInUrl );
+					return navigate( 'domains' );
 				case 'domains': {
 					// go to processing step without pushing it to history
 					// so the back button would go back to domains step
+					// Why the explicit undefined?
+					// If we want to replace, should that be using the third
+					// `replace` argument/
 					return navigate( 'processing', undefined );
 				}
 				case 'processing': {

--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -11,6 +11,7 @@ import {
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { USER_STORE } from '../stores';
 import { useLoginUrl } from '../utils/path';
+import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 import { STEPS } from './internals/steps';
 import { Flow } from './internals/types';
 import type { UserSelect } from '@automattic/data-stores';
@@ -22,19 +23,10 @@ const domainTransfer: Flow = {
 	},
 	isSignupFlow: false,
 	initialize() {
-		return [ STEPS.DOMAIN_TRANSFER_INTRO, STEPS.DOMAIN_TRANSFER_DOMAINS, STEPS.PROCESSING ];
-	},
-
-	useSideEffect( _currentStepSlug, navigate ) {
-		const isLoggedIn = useSelector( isUserLoggedIn );
-
-		// TODO: use `stepsWithRequiredLogin` instead of `useSideEffect` ?
-		useEffect( () => {
-			if ( ! isLoggedIn && navigate ) {
-				navigate( 'intro' );
-			}
-			// eslint-disable-next-line react-hooks/exhaustive-deps
-		}, [ isLoggedIn ] );
+		return [
+			STEPS.DOMAIN_TRANSFER_INTRO,
+			...stepsWithRequiredLogin( [ STEPS.DOMAIN_TRANSFER_DOMAINS, STEPS.PROCESSING ] ),
+		];
 	},
 
 	useStepNavigation( currentStepSlug, navigate ) {

--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -14,12 +14,12 @@ import { useLoginUrl } from '../utils/path';
 import {
 	AssertConditionResult,
 	AssertConditionState,
-	FlowV1,
 } from './internals/types';
 import { STEPS } from './internals/steps';
+import { Flow } from './internals/types';
 import type { UserSelect } from '@automattic/data-stores';
 
-const domainTransfer: FlowV1 = {
+const domainTransfer: Flow = {
 	name: DOMAIN_TRANSFER,
 	get title() {
 		return translate( 'Bulk domain transfer' );

--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -42,17 +42,16 @@ const domainTransfer: FlowV1 = {
 		];
 	},
 
-	useAssertConditions( navigate ): AssertConditionResult {
+	useSideEffect( _currentStepSlug, navigate ) {
 		const isLoggedIn = useSelector( isUserLoggedIn );
 
+		// TODO: use `stepsWithRequiredLogin` instead of `useSideEffect` ?
 		useEffect( () => {
 			if ( ! isLoggedIn && navigate ) {
 				navigate( 'intro' );
 			}
 			// eslint-disable-next-line react-hooks/exhaustive-deps
 		}, [ isLoggedIn ] );
-
-		return { state: AssertConditionState.SUCCESS };
 	},
 
 	useStepNavigation( _currentStepSlug, navigate ) {

--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -1,14 +1,11 @@
 import { DOMAIN_TRANSFER } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
-import { useEffect } from 'react';
-import { useSelector } from 'react-redux';
 import {
 	clearSignupDestinationCookie,
 	setSignupCompleteSlug,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { USER_STORE } from '../stores';
 import { useLoginUrl } from '../utils/path';
 import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';

--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -10,10 +10,10 @@ import { USER_STORE } from '../stores';
 import { useLoginUrl } from '../utils/path';
 import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 import { STEPS } from './internals/steps';
-import { Flow } from './internals/types';
+import { FlowV2 } from './internals/types';
 import type { UserSelect } from '@automattic/data-stores';
 
-const domainTransfer: Flow = {
+const domainTransfer: FlowV2 = {
 	name: DOMAIN_TRANSFER,
 	get title() {
 		return translate( 'Bulk domain transfer' );
@@ -39,7 +39,7 @@ const domainTransfer: Flow = {
 			pageTitle: 'Bulk Transfer',
 		} );
 
-		const submit: ReturnType< Flow[ 'useStepNavigation' ] >[ 'submit' ] = (
+		const submit: ReturnType< FlowV2[ 'useStepNavigation' ] >[ 'submit' ] = (
 			providedDependencies = {}
 		) => {
 			switch ( currentStepSlug ) {

--- a/client/landing/stepper/declarative-flow/hundred-year-domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain-transfer.ts
@@ -3,12 +3,8 @@ import { translate } from 'i18n-calypso';
 import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
 import { setSignupCompleteFlowName, setSignupCompleteSlug } from 'calypso/signup/storageUtils';
 import domainTransfer from './domain-transfer';
-import {
-	AssertConditionResult,
-	AssertConditionState,
-	Flow,
-	ProvidedDependencies,
-} from './internals/types';
+import { STEPS } from './internals/steps';
+import { Flow, ProvidedDependencies } from './internals/types';
 
 const hundredYearDomainTransfer: Flow = {
 	...domainTransfer,
@@ -20,18 +16,24 @@ const hundredYearDomainTransfer: Flow = {
 	// Always start on the "domains" step, as we don't need what comes before it for the 100-year domain transfer flow.
 	// It doesn't make sense to show it as it contains additional cluttering information that doesn't matter
 	// specifically under the 100-year domain context - they'll also come from a different entry point.
-	useSteps() {
-		const transferSteps = domainTransfer.useSteps();
-		const domainsStepIndex = transferSteps.findIndex( ( step ) => step.slug === 'domains' );
-		return [
-			transferSteps[ domainsStepIndex ],
-			...stepsWithRequiredLogin( transferSteps.slice( domainsStepIndex ) ),
-		];
-	},
+	async initialize() {
+		const transferSteps = await domainTransfer.initialize();
 
-	// Always allow the user to proceed with the transfer, as we assert that the user is logged in later.
-	useAssertConditions(): AssertConditionResult {
-		return { state: AssertConditionState.SUCCESS };
+		if ( transferSteps === false ) {
+			// Forwarding returning the `false` value, as it's a signal to kill the app.
+			return false;
+		}
+
+		const domainsStepIndex = transferSteps.findIndex(
+			( step ) => step.slug === STEPS.DOMAIN_TRANSFER_DOMAINS.slug
+		);
+
+		if ( domainsStepIndex > -1 ) {
+			// If the needed step was not found, abort the flow.
+			return false;
+		}
+
+		return [ ...stepsWithRequiredLogin( transferSteps.slice( domainsStepIndex ) ) ];
 	},
 
 	useStepNavigation( _currentStepSlug, navigate ) {

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -348,6 +348,14 @@ export const STEPS = {
 				/* webpackChunkName: 'async-step-use-my-domain' */ './steps-repository/use-my-domain'
 			),
 	},
+	DOMAIN_TRANSFER_INTRO: {
+		slug: 'intro',
+		asyncComponent: () => import( './steps-repository/domain-transfer-intro' ),
+	},
+	DOMAIN_TRANSFER_DOMAINS: {
+		slug: 'domains',
+		asyncComponent: () => import( './steps-repository/domain-transfer-domains' ),
+	},
 } satisfies Record< string, StepperStep >;
 
 /**

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -232,11 +232,7 @@ export type FlowV2 = {
 	 *
 	 * Returning false will kill the app.
 	 */
-	initialize():
-		| false
-		| Promise< false >
-		| Promise< readonly StepperStep[] >
-		| readonly StepperStep[];
+	initialize(): false | readonly StepperStep[] | Promise< false | readonly StepperStep[] >;
 	useStepNavigation: UseStepNavigationHook< StepperStep[] >;
 	/**
 	 * A hook that is called in the flow's root at every render. You can use this hook to setup side-effects, call other hooks, etc..


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/97998
Related to pdDR7T-22t-p2

## Proposed Changes

- Migrate the "domain transfers" stepper flow from v1 to v2
- Mostly `useAssertConditions` => `useSideEffect` and `useSteps` => `initialize`, plus some other tweaks

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* v1 flows are deprecated and we should migrate all flows to v2 format

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit `/setup/domains-transfer` and make sure it behaves as on `trunk`:
- the initial step is `/setup/domains-transfer/intro`
- Visit `/setup/domain-transfer/domains` as logged out, and make sure that:
  - you get redirected to the login
  - when logged in, you get redirected back to the domains step


> [!note]
> During my testing, I noticed the following:
> - Visit `/setup/domains-transfer/domains` as a logged in user
> - Notice how you can go back (to `/intro` step) and forward again (to `/domains` step) without issues
> - In a separate tab, log out
> - In the `/setup/domains-transfer/domains` tab, you can continue to go back/forward and the "logged in" check will continue to pass, even if the user logged out in a separate tab
> 
> This behavior can be reproduced on `trunk`  too, but it feels like something that should be fixed?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?