### PR TITLE
A4A: Make services and products required in signup

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/hooks/use-personalization-form-validation.ts
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/hooks/use-personalization-form-validation.ts
@@ -4,6 +4,8 @@ import { AgencyDetailsSignupPayload } from 'calypso/a8c-for-agencies/sections/si
 
 type ValidationState = {
 	country?: string;
+	servicesOffered?: string;
+	productsOffered?: string;
 };
 
 const usePersonalizationFormValidation = () => {
@@ -20,6 +22,14 @@ const usePersonalizationFormValidation = () => {
 
 			if ( payload.country === '' ) {
 				newValidationError.country = translate( `Please select your country` );
+			}
+
+			if ( ! payload.servicesOffered || payload.servicesOffered?.length < 1 ) {
+				newValidationError.servicesOffered = translate( `Please select services you offer` );
+			}
+
+			if ( ! payload.productsOffered || payload.productsOffered.length < 1 ) {
+				newValidationError.productsOffered = translate( `Please select products you offer` );
 			}
 
 			if ( Object.keys( newValidationError ).length > 0 ) {

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -49,6 +49,7 @@ export default function PersonalizationForm( { onContinue, goBack, initialFormDa
 			...prev,
 			servicesOffered: services.value,
 		} ) );
+		updateValidationError( { servicesOffered: undefined } );
 	};
 
 	const handleSetProductsOffered = ( products: { value: string[] } ) => {
@@ -56,6 +57,7 @@ export default function PersonalizationForm( { onContinue, goBack, initialFormDa
 			...prev,
 			productsOffered: products.value,
 		} ) );
+		updateValidationError( { productsOffered: undefined } );
 	};
 
 	const servicesOfferedOptions = useMemo(
@@ -77,6 +79,7 @@ export default function PersonalizationForm( { onContinue, goBack, initialFormDa
 			{ value: 'Jetpack', label: translate( 'Jetpack' ) },
 			{ value: 'Pressable', label: translate( 'Pressable' ) },
 			{ value: 'WordPress VIP', label: translate( 'WordPress VIP' ) },
+			{ value: 'None', label: translate( 'None' ) },
 		],
 		[ translate ]
 	);
@@ -164,7 +167,11 @@ export default function PersonalizationForm( { onContinue, goBack, initialFormDa
 						</FormFieldset>
 
 						<FormFieldset className="signup-personalization-form__checkbox">
-							<FormField label={ translate( 'What services do you offer?' ) }>
+							<FormField
+								error={ validationError.servicesOffered }
+								label={ translate( 'What services do you offer?' ) }
+								isRequired
+							>
 								<MultiCheckbox
 									id="services_offered"
 									name="services_offered"
@@ -177,9 +184,11 @@ export default function PersonalizationForm( { onContinue, goBack, initialFormDa
 
 						<FormFieldset className="signup-personalization-form__checkbox">
 							<FormField
+								error={ validationError.productsOffered }
 								label={ translate(
 									'What Automattic products do you currently offer your clients?'
 								) }
+								isRequired
 							>
 								<MultiCheckbox
 									id="products_offered"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1740012477536129/1739997856.108619-slack-C03Q2D22DGV

## Proposed Changes

We are making fields required on WC Asia signup flow
<img width="623" alt="Screenshot 2025-02-19 at 5 03 08 PM" src="https://github.com/user-attachments/assets/0fb22f3a-a8ce-4165-9620-5f047f73030a" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Use this WPCOM branch 174186-ghe-Automattic/wpcom
- Using live link, test `/signup/wc-asia` signup flow and verify changes described above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?