### PR TITLE
Design Picker: Update default categories for the write goal

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -3,7 +3,7 @@ import { CATEGORIES } from '@automattic/design-picker';
 import type { Category } from '@automattic/design-picker';
 
 const GOALS_TO_CATEGORIES: { [ key in Onboard.SiteGoal ]: string[] } = {
-	[ Onboard.SiteGoal.Write ]: [ CATEGORIES.BLOG, CATEGORIES.NEWSLETTER ],
+	[ Onboard.SiteGoal.Write ]: [ CATEGORIES.BLOG ],
 	[ Onboard.SiteGoal.Courses ]: [ CATEGORIES.EDUCATION ],
 	[ Onboard.SiteGoal.AnnounceEvents ]: [ CATEGORIES.EVENTS ],
 	[ Onboard.SiteGoal.Porfolio ]: [ CATEGORIES.PORTFOLIO ],


### PR DESCRIPTION
## Proposed Changes

This PR updates the default categories for the "Publish a blog" goal to be just the Blog category.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Internal feedback. 
pbxlJb-6S8-p2#comment-4137.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Head to /setup/onboarding
- Select the "Publish a blog" goal
- Ensure that only the Blog category is pre-selected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?