### PR TITLE
Update manage contact info action icon

### DIFF
--- a/client/my-sites/domains/domain-management/dataviews/use-actions.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/use-actions.tsx
@@ -20,7 +20,7 @@ import {
 } from '@automattic/domains-table/src/utils/paths';
 import { shouldUpgradeToMakeDomainPrimary } from '@automattic/domains-table/src/utils/should-upgrade-to-make-domain-primary';
 import { Action } from '@wordpress/dataviews';
-import { Icon, drawerLeft, info, update } from '@wordpress/icons';
+import { Icon, commentAuthorAvatar, drawerLeft, update } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { navigate } from 'calypso/lib/navigate';
 import { AutoRenewDiolog } from './components/auto-renew-dialog';
@@ -102,7 +102,7 @@ export function useActions( viewType: 'table' | 'list' | 'grid', onClose?: () =>
 		},
 		{
 			id: 'manage-contact-info',
-			icon: <Icon icon={ info } />,
+			icon: commentAuthorAvatar,
 			callback: ( domains: Array< PartialDomainData > ) => {
 				if ( domains.length === 0 ) {
 					return;


### PR DESCRIPTION
Related to #99897

## Proposed Changes

* Use the same icon for Manage contact information action as is used in DomainTable.

## Why are these changes being made?

* Address CfT feedback.

## Testing Instructions

* For testing, you need to have a couple of domains you **own**.
* Turn on feature flags in your browser's console: `window.sessionStorage.setItem('flags',  'calypso/domains-dataviews'])`
* Go to http://calypso.localhost:3000/domains/manage
* Check domains you own.
* Make sure the Manage contact information bulk action icon looks similar to the image below:

![CleanShot 2025-02-19 at 22 34 01@2x](https://github.com/user-attachments/assets/513fa766-c434-4756-bdfe-fa3e6642efbe)

DomainsTable action icon:
![CleanShot 2025-02-19 at 22 33 43@2x](https://github.com/user-attachments/assets/f9b44b2d-8cec-49f1-82cc-b97590a96fc7)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
