### PR TITLE
Stats: Enable Realtime prototype in staging

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -122,7 +122,7 @@
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,
-		"stats/real-time-tab": false,
+		"stats/real-time-tab": true,
 		"subscriber-importer": true,
 		"subscribers-dataviews": true,
 		"themes/block-theme-previews-premium-and-woo": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -155,7 +155,7 @@
 		"stats/locations": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
-		"stats/real-time-tab": false,
+		"stats/real-time-tab": true,
 		"subscriber-importer": true,
 		"subscribers-dataviews": true,
 		"themes/block-theme-previews-premium-and-woo": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -163,7 +163,7 @@
 		"stats/locations": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
-		"stats/real-time-tab": false,
+		"stats/real-time-tab": true,
 		"subscriber-importer": true,
 		"subscribers-dataviews": true,
 		"themes/block-theme-previews-premium-and-woo": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: https://github.com/Automattic/red-team/issues/110

## Proposed Changes

Release the Realtime prototype tab to all environments except production to allow for internal testing and feedback.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See above.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Stats → Traffic page.
* Confirm the Realtime tab is visible in staging. ie: When visiting WordPress.com when proxied.
* Confirm the tab is not present on production. ie: Non-a12n, non-proxied.
* Have a look at the tab and confirm the chart and modules are working.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
