### PR TITLE
Downsize the domain status progress icon

### DIFF
--- a/client/my-sites/domains/domain-management/dataviews/dataviews-fields/domain-status-field.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/dataviews-fields/domain-status-field.tsx
@@ -60,6 +60,7 @@ const DomainStatusField = ( props: Props ) => {
 			domainStatus={ domainStatus }
 			pendingUpdates={ pendingUpdates }
 			as="div"
+			spinnerSize={ 14 }
 		/>
 	);
 };

--- a/packages/domains-table/src/domains-table/domains-table-status-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-status-cell.tsx
@@ -10,12 +10,14 @@ interface DomainsTableStatusCellProps {
 	domainStatus: ResolveDomainStatusReturn | null;
 	pendingUpdates: DomainUpdateStatus[];
 	as?: 'td' | 'div';
+	spinnerSize?: number;
 }
 
 export const DomainsTableStatusCell = ( {
 	domainStatus,
 	pendingUpdates,
 	as: Element = 'div',
+	spinnerSize = 16,
 }: DomainsTableStatusCellProps ) => {
 	const translate = useTranslate();
 	const locale = useLocale();
@@ -50,7 +52,7 @@ export const DomainsTableStatusCell = ( {
 		>
 			{ domainStatus?.status ?? translate( 'Unknown status' ) }
 			{ pendingUpdates.length > 0 && (
-				<StatusPopover popoverTargetElement={ <Spinner size={ 16 } /> }>
+				<StatusPopover popoverTargetElement={ <Spinner size={ spinnerSize } /> }>
 					<div className="domains-bulk-update-status-popover">
 						<span> { translate( 'Pending updates' ) }</span>
 						{ pendingUpdates.map( ( update, index ) => (


### PR DESCRIPTION
Related to #99904 

The icon was larger than the text size. So the appearance and disappearance of the icon caused some UI jumps. 

## Proposed Changes

* Downsize the domain status progress icon to avoid UI jumps.

## Why are these changes being made?

* Part of addressing CfT feedback.

## Testing Instructions

* For testing, you need to have a couple of domains you **own**.
* Turn on feature flags in your browser's console: `window.sessionStorage.setItem('flags',  'calypso/domains-dataviews'])`
* Go to http://calypso.localhost:3000/domains/manage
* Check domains you own, and choose Manage auto-renew bulk action.
* Apply either "on" or "off".
* Make sure the spinner icon that appears in the domain status column next to the status title doesn't affect the row's height.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
