### PR TITLE
Avoid state mutation and settings searchResults if unchanged in removeUnavailablePremiumDomain

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -781,14 +781,20 @@ class RegisterDomainStep extends Component {
 
 	removeUnavailablePremiumDomain = ( domainName ) => {
 		this.setState( ( state ) => {
-			const newPremiumDomains = { ...state.premiumDomains };
-			delete newPremiumDomains[ domainName ];
-			const searchResults = state.searchResults || [];
+			const newPremiumDomains = Object.fromEntries(
+				Object.entries( state.premiumDomains ).filter( ( [ key ] ) => key !== domainName )
+			);
+			if ( Array.isArray( state.searchResults ) ) {
+				const newSearchResults = state.searchResults.filter(
+					( suggestion ) => suggestion.domain_name !== domainName
+				);
+				return {
+					premiumDomains: newPremiumDomains,
+					searchResults: newSearchResults,
+				};
+			}
 			return {
 				premiumDomains: newPremiumDomains,
-				searchResults: searchResults.filter(
-					( suggestion ) => suggestion.domain_name !== domainName
-				),
 			};
 		} );
 	};

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -796,6 +796,7 @@ class RegisterDomainStep extends Component {
 			}
 			return {
 				premiumDomains,
+				searchResults,
 			};
 		} );
 	};

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -781,7 +781,7 @@ class RegisterDomainStep extends Component {
 
 	removeUnavailablePremiumDomain = ( domainName ) => {
 		this.setState( ( state ) => {
-			const newPremiumDomains = Object.fromEntries(
+			const premiumDomains = Object.fromEntries(
 				Object.entries( state.premiumDomains ).filter( ( [ key ] ) => key !== domainName )
 			);
 			if ( Array.isArray( state.searchResults ) ) {
@@ -789,12 +789,12 @@ class RegisterDomainStep extends Component {
 					( suggestion ) => suggestion.domain_name !== domainName
 				);
 				return {
-					premiumDomains: newPremiumDomains,
+					premiumDomains,
 					searchResults: newSearchResults,
 				};
 			}
 			return {
-				premiumDomains: newPremiumDomains,
+				premiumDomains,
 			};
 		} );
 	};

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -784,8 +784,9 @@ class RegisterDomainStep extends Component {
 			const premiumDomains = Object.fromEntries(
 				Object.entries( state.premiumDomains ).filter( ( [ key ] ) => key !== domainName )
 			);
-			if ( Array.isArray( state.searchResults ) ) {
-				const newSearchResults = state.searchResults.filter(
+			const { searchResults } = state;
+			if ( Array.isArray( searchResults ) ) {
+				const newSearchResults = searchResults.filter(
 					( suggestion ) => suggestion.domain_name !== domainName
 				);
 				return {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/99852

## Proposed Changes

* Use `Object.entries` to avoid `newPremiumDomains` mutations
* `filter` `state.searchResults` to avoid object mutations
* Update `searchResults` only if they were filtered

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The original implementation was mutating state, so I had to improve it. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* [Open this 100-year search result page](http://calypso.localhost:3000/setup/hundred-year-domain/domains?new=bero.blog&search=yes) and ensure it doesn't crash

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
