### PR TITLE
Podcasting: Update privacy settings link based on RDV flag

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/private-site.tsx
+++ b/client/my-sites/site-settings/podcasting-details/private-site.tsx
@@ -1,6 +1,7 @@
 import { localize, LocalizeProps } from 'i18n-calypso';
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { useRemoveDuplicateViewsExperimentEnabled } from 'calypso/lib/remove-duplicate-views-experiment';
 import { IAppState } from 'calypso/state/types';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
@@ -14,6 +15,12 @@ const PodcastingPrivateSiteMessage: React.FC< Props > = function PodcastingPriva
 	translate,
 	isComingSoon,
 }: Props ) {
+	const isRemoveDuplicateViewsExperimentEnabled = useRemoveDuplicateViewsExperimentEnabled();
+
+	const privacySettingsUrl = isRemoveDuplicateViewsExperimentEnabled
+		? `/sites/settings/site/${ siteSlug }#site-privacy-settings`
+		: `/settings/general/${ siteSlug }#site-privacy-settings`;
+
 	return (
 		<div className="podcasting-details__private-site">
 			<p>
@@ -43,9 +50,7 @@ const PodcastingPrivateSiteMessage: React.FC< Props > = function PodcastingPriva
 				) }
 			</p>
 			<p>
-				<a href={ '/settings/general/' + siteSlug + '#site-privacy-settings' }>
-					{ translate( 'Go to Privacy settings' ) }
-				</a>
+				<a href={ privacySettingsUrl }>{ translate( 'Go to Privacy settings' ) }</a>
 			</p>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR ensures the Privacy settings link goes to /sites/settings/site if the RDV is enabled.

<img width="794" alt="Screenshot 2025-02-20 at 15 57 37" src="https://github.com/user-attachments/assets/bbbf9e2b-5500-4c66-a7af-812184e76699" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- Without this change, the Privacy settings link directs to /settings/general, which redirects to options-general.php if RDV is enabled. However, Privacy settings are not available on options-general.php.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

treatment

- Prepare a Default site with the site visibility set to Private
- Go to Settings > Podcasting (/settings/podcasting)
- Click "Go to Privacy settings"
- Observe it redirects to /sites/settings/site

control

- Prepare a Default site with the site visibility set to Private
- Go to Settings > Podcasting (/settings/podcasting)
- Click "Go to Privacy settings"
- Observe it redirects to /settings/general

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
