### PR TITLE
A4A > Agency Tier: Update the feature announcement modal content

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -15,7 +15,6 @@ import {
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { isPathAllowed } from 'calypso/a8c-for-agencies/lib/permission';
-import Badge from 'calypso/components/badge';
 import { isSectionNameEnabled } from 'calypso/sections-filter';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -190,7 +189,6 @@ const useMainMenuItems = ( path: string ) => {
 							path: '/',
 							link: A4A_AGENCY_TIER_LINK,
 							title: translate( 'Agency Tier' ),
-							extraContent: <Badge type="info-blue">{ translate( 'beta' ) }</Badge>,
 							trackEventProps: {
 								menu_item: 'Automattic for Agencies / Agency Tier',
 							},

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/celebration-modal/feature-announcement.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/celebration-modal/feature-announcement.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import EmergingPartnerBackground from 'calypso/assets/images/a8c-for-agencies/agency-tier/announcement-background.svg';
+import { preventWidows } from 'calypso/lib/formatting';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
@@ -38,14 +39,16 @@ const AgencyTierFeatureAnnouncement = () => {
 	return (
 		<AgencyTierCelebrationModalContent
 			celebrationModal={ {
-				title: translate( "We've just launched Agency Tiers in beta!" ),
-				description: translate(
-					"We're granting you early access to our new Agency Tier experience! While the official launch of our tiers is set for January 2025, you can explore and progress on your tier today."
+				title: translate( 'Take a look at Agency Tiers!' ),
+				description: preventWidows(
+					translate(
+						'Agency Tiers reward your engagement with Automattic—offering directory listings, co-marketing opportunities, growth resources, client leads, and other exciting tools to help you grow your agency depending on Agency Partner level.'
+					)
 				),
 				video:
 					'https://automattic.com/wp-content/uploads/2024/11/agency_tiers_feature_announcement.mp4',
 				image: EmergingPartnerBackground,
-				cta: translate( 'Learn more' ),
+				cta: translate( 'Take a deeper look' ),
 			} }
 			handleOnClose={ handleOnClose }
 			handleClickExploreBenefits={ handleClickExploreBenefits }


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1796
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1797

## Proposed Changes

This PR:
 
- Updates the Agency Tier feature announcement modal content
- Removes the `beta` badge from the Agency Tier menu item

## Testing Instructions

* Use the Agency MC tool and set the Agency Tier to `Emerging Partner`
* Open the A4A live link
* Reset the preference `a4a-agency-tier-announcement-modal-dismissed` using the Calypso dev tool

<img width="335" alt="Screenshot 2025-02-20 at 12 52 51 PM" src="https://github.com/user-attachments/assets/ed52a867-85dc-498d-b11d-badc51e9fcb9" />

* Refresh the Overview page and verify the modal is displayed as shown below:

<img width="785" alt="Screenshot 2025-02-20 at 12 45 55 PM" src="https://github.com/user-attachments/assets/6eb8cdb1-4e9f-4eab-a1e4-d92016bed259" />
 
* Verify the `beta` badge on the Agency Tier is removed

<img width="268" alt="Screenshot 2025-02-20 at 1 56 59 PM" src="https://github.com/user-attachments/assets/2cb194cd-41b4-493f-9d63-fc31e93e6568" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
