### PR TITLE
A4A > Signup: WC Asia Signup page enhancements & fixes

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form-2/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form-2/index.tsx
@@ -84,6 +84,9 @@ const BlueprintForm2: React.FC< Props > = ( { onContinue, initialFormData, goBac
 			className="blueprint-form"
 			title={ preventWidows( translate( "Let's build your blueprint" ) ) }
 		>
+			<div className="field-mandatory-message">
+				{ translate( 'Fields marked with * are required' ) }
+			</div>
 			<FormField
 				label={ translate(
 					"How does your agency typically work with clients regarding Automattic's solutions?"

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/blueprint-form/index.tsx
@@ -99,6 +99,9 @@ const BlueprintForm: React.FC< Props > = ( { onContinue, initialFormData, goBack
 				"We'll send you a custom blueprint to grow your business based on your answers below."
 			) }
 		>
+			<div className="field-mandatory-message">
+				{ translate( 'Fields marked with * are required' ) }
+			</div>
 			<FormField
 				label={ translate( 'What is your top goal when partnering with a technology provider?' ) }
 				error={ validationError.topPartneringGoal }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
@@ -84,6 +84,9 @@ const SignupContactForm = ( { onContinue, initialFormData }: Props ) => {
 				)
 			) }
 		>
+			<div className="field-mandatory-message">
+				{ translate( 'Fields marked with * are required' ) }
+			</div>
 			<div className="signup-multi-step-form__name-fields">
 				<FormField
 					error={ validationError.firstName }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -114,6 +114,9 @@ export default function PersonalizationForm( { onContinue, goBack, initialFormDa
 				title={ translate( 'Personalize your experience' ) }
 				description={ translate( "We'll tailor the product and onboarding for you." ) }
 			>
+				<div className="field-mandatory-message">
+					{ translate( 'Fields marked with * are required' ) }
+				</div>
 				<FormFieldset>
 					<FormField
 						error={ validationError.country }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/step-progress/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/step-progress/index.tsx
@@ -26,7 +26,7 @@ const StepProgress = ( { steps }: Props ) => {
 							} ) }
 						>
 							<span className="step-progress__step-label">{ step.label }</span>
-							<ProgressBar value={ step.value ?? 0 } total={ 100 } />
+							<ProgressBar value={ step.value ?? 0 } total={ 100 } canGoBackwards />
 						</div>
 					) ) }
 				</div>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/step-progress/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/step-progress/style.scss
@@ -55,3 +55,7 @@
 	}
 }
 
+.field-mandatory-message {
+	@include a4a-font-body-sm;
+	padding-block-end: 8px;
+}

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/step-progress/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/step-progress/style.scss
@@ -58,4 +58,8 @@
 .field-mandatory-message {
 	@include a4a-font-body-sm;
 	padding-block-end: 8px;
+
+	@media (prefers-color-scheme: dark) {
+		color: var(--color-text-inverted);
+	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1827
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1826

## Proposed Changes

This PR:

- Adds “Fields marked with * are required” text on all the necessary steps
- Fixes an issue with the Progress Bar that doesn't change when going to previous steps.

## Testing Instructions

* Open the A4A live link
* Append the URL with /signup/wc-asia
* Verify 2 things: Progress Bar should change when going to previous steps and the steps have "Fields marked with * are required” text wherever neccessary.

<img width="1728" alt="Screenshot 2025-02-20 at 1 25 14 PM" src="https://github.com/user-attachments/assets/e7023581-1ccc-4932-b77f-1ef7b30efa61" />
<img width="1728" alt="Screenshot 2025-02-20 at 1 25 42 PM" src="https://github.com/user-attachments/assets/c7056821-8e72-49bd-8bcc-629d1741a670" />
<img width="1728" alt="Screenshot 2025-02-20 at 1 25 51 PM" src="https://github.com/user-attachments/assets/4491d228-161a-4d99-ac82-dce6b7487f7f" />
<img width="1728" alt="Screenshot 2025-02-20 at 1 25 59 PM" src="https://github.com/user-attachments/assets/9223de1d-6522-4e90-9a08-a4d405f7ba9b" />

<img width="1728" alt="Screenshot 2025-02-20 at 3 01 34 PM" src="https://github.com/user-attachments/assets/dbec4816-a5df-46db-b058-0fa5fecf8913" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
