### PR TITLE
Stepper: do not load the Help Center unless logged in

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/help-center/async.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/help-center/async.tsx
@@ -1,16 +1,26 @@
-import { HelpCenter, User as UserStore } from '@automattic/data-stores';
+import { HelpCenter } from '@automattic/data-stores';
 import { useDispatch } from '@wordpress/data';
 import { useCallback } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
+import { useSelector } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import type { User as UserStore } from '@automattic/data-stores';
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
 const AsyncHelpCenter: React.FC< { user: UserStore.CurrentUser | undefined } > = ( { user } ) => {
+	const isLoggedIn = useSelector( isUserLoggedIn );
+
 	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
 
 	const handleClose = useCallback( () => {
 		setShowHelpCenter( false );
 	}, [ setShowHelpCenter ] );
+
+	// The Help Center only works if you're logged in. Don't waste time loading it if you're not.
+	if ( ! isLoggedIn ) {
+		return null;
+	}
 
 	/**
 	 * The stepper query parameter ensures Webpack treats this Help Center as separate from the one in the main client app.


### PR DESCRIPTION
Break out from https://github.com/Automattic/wp-calypso/pull/99352/files#r1963025714


## Proposed Changes

Currently, Stepper loads the Help Center too early for no reason. This PR delays loading to when the user is logged in. There is more room for optimization (further delaying the HC), but this is quick and safe because the Help Center doesn't work unless you are logged in, anyway.

## Why are these changes being made?
To speed up Stepper.

## Testing Instructions

1. Create a Jurassic site ([jurassic.ninja](https://jurassic.ninja/)).
2. Go to /setup/hosted-site-migration.
3. Import the Jurassic site.
4. Reach the site-migration-upgrade-plan and click to upgrade your plan.
5. During checkout, click on Visit Help Center, it should open just fine.
