### PR TITLE
Server configuration: always show the save button

### DIFF
--- a/client/sites/settings/server/server-configuration-form.scss
+++ b/client/sites/settings/server/server-configuration-form.scss
@@ -1,11 +1,5 @@
 @import "@automattic/typography/styles/variables";
 
-.web-server-settings-card__wp-set-version,
-.web-server-settings-card__php-set-version,
-.web-server-settings-card__static-file-404-set-setting {
-	margin-top: 16px;
-}
-
 .web-server-settings-card__static-file-404-select {
 	width: 100%;
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/10443

## Proposed Changes

This PR proposes to always show the Save button in the Server Configuration form in Server Settings. 

#### Before

A "save button" is shown next to individual fields whenever the value is changed:

|WP|PHP|404|
|-|-|-|
|<img width="731" alt="image" src="https://github.com/user-attachments/assets/5c85b153-77ae-411f-b178-a0ac95da78fe" />|<img width="726" alt="image" src="https://github.com/user-attachments/assets/479edf51-1528-4fcf-99ab-d1805f35f389" />|<img width="727" alt="image" src="https://github.com/user-attachments/assets/29d2f8f6-c6fa-4293-be77-3514dca78fd5" />|

#### After

A proper Save button is always displayed at the bottom:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/55ef7b07-39f0-44c9-9d5a-f88953c43aff" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

pbxlJb-6TO-p2

## Testing Instructions

1. Go to /sites
2. Pick an Atomic staging site (staging so that the PHP version can be changed)
3. Go to Server Settings (or Settings -> Server)
4. Try to update the values and verify that the fields can be saved.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?