### PR TITLE
remove sub header from use a domain i own step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -5,17 +5,14 @@ import {
 	ONBOARDING_FLOW,
 	StepContainer,
 	isStartWritingFlow,
-	isOnboardingFlow,
 } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
-import { useI18n } from '@wordpress/react-i18n';
 import { getQueryArg } from '@wordpress/url';
 import { useLocation } from 'react-router';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { useMyDomainInputMode as inputMode } from 'calypso/components/domains/connect-domain-step/constants';
 import UseMyDomainComponent from 'calypso/components/domains/use-my-domain';
-import FormattedHeader from 'calypso/components/formatted-header';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { domainMapping, domainTransfer } from 'calypso/lib/cart-values/cart-items';
@@ -25,7 +22,6 @@ import type { Step } from '../../types';
 import './style.scss';
 
 const UseMyDomain: Step = function UseMyDomain( { navigation, flow } ) {
-	const { __ } = useI18n();
 	const { setHideFreePlan, setDomainCartItem } = useDispatch( ONBOARD_STORE );
 	const { goNext, goBack, submit } = navigation;
 	const getDefaultStepContent = () => <h1>Choose a domain step</h1>;
@@ -115,19 +111,6 @@ const UseMyDomain: Step = function UseMyDomain( { navigation, flow } ) {
 		}
 	};
 
-	const getFormattedHeader = () => {
-		if ( isOnboardingFlow( flow ) ) {
-			return (
-				<FormattedHeader
-					id="choose-a-domain-onboarding-header"
-					headerText=""
-					subHeaderText={ __( 'Find and claim one or more domain names' ) }
-					align="center"
-				/>
-			);
-		}
-	};
-
 	return (
 		<>
 			<QueryProductsList />
@@ -141,7 +124,6 @@ const UseMyDomain: Step = function UseMyDomain( { navigation, flow } ) {
 				isLargeSkipLayout={ false }
 				stepContent={ getStepContent() }
 				recordTracksEvent={ recordTracksEvent }
-				formattedHeader={ getFormattedHeader() }
 			/>
 		</>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #99928 

Note: The issue also mentions a font size issue, that I couldn't replicate locally.

## Proposed Changes

* Removes the `Find and claim one or more domain names` from the header

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We should remove the line "Find and claim one or more domain names" in the domain transfer screen. That copy only makes sense for the domain step, where you can add multiple domains to cart.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Logged in user
* In a logged-in account, add a second site by visiting /start
* In the domain step, click "Use a domain I own".
* Validate the titles

2. New user
* Register a new user
* In the domain step, click "Use a domain I own".
* Validate the titles

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/470c6de5-169e-4f7a-8e26-9507812fa244) | ![image](https://github.com/user-attachments/assets/8ccc00b8-73d3-41ae-a431-fffe3f15a4ab) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
