### PR TITLE
A4A: Update Missing payment details for referral commission.

### DIFF
--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -11,6 +11,7 @@
 .a4a-layout__banner {
 	margin-inline: 0;
 	max-height: 100%;
+	margin-block-end: 24px;
 
 	> * {
 		padding-inline: 16px;

--- a/client/a8c-for-agencies/components/pending-payment-notification/style.scss
+++ b/client/a8c-for-agencies/components/pending-payment-notification/style.scss
@@ -1,9 +1,5 @@
 
 .pending-payment-notification {
-	.notice-banner {
-		margin-block-end: 24px;
-	}
-
 	.components-button {
 		margin-block-start: 1rem;
 

--- a/client/a8c-for-agencies/components/pressable-usage-limit-notice/style.scss
+++ b/client/a8c-for-agencies/components/pressable-usage-limit-notice/style.scss
@@ -1,8 +1,4 @@
 .pressable-usage-limit-notice {
-	.notice-banner {
-		margin-block-end: 24px;
-	}
-
 	.components-button {
 		margin-block-start: 1rem;
 

--- a/client/a8c-for-agencies/sections/overview/overview.tsx
+++ b/client/a8c-for-agencies/sections/overview/overview.tsx
@@ -10,6 +10,7 @@ import LayoutHeader, {
 	LayoutHeaderActions as Actions,
 	LayoutHeaderTitle as Title,
 } from 'calypso/layout/hosting-dashboard/header';
+import { MissingPaymentSettingsNotice } from '../referrals/common/missing-payment-settings-notice';
 import OverviewBody from './body';
 import OverviewHeaderActions from './header-actions';
 import PartnerDirectoryOnboardingCard from './partner-directory-onboarding-card';
@@ -24,8 +25,10 @@ export default function Overview() {
 	return (
 		<Layout title={ title } wide>
 			<LayoutTop>
+				<MissingPaymentSettingsNotice />
 				<A4AAgencyApprovalNotice />
 				<PressableUsageLimitNotice />
+
 				<LayoutHeader className="a4a-overview-header">
 					<Title>{ title }</Title>
 					<Actions className="a4a-overview__header-actions">

--- a/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/index.tsx
@@ -1,30 +1,42 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
+import useFetchReferrals from '../../hooks/use-fetch-referrals';
+import useGetTipaltiPayee from '../../hooks/use-get-tipalti-payee';
 
 import './style.scss';
 
-type Props = {
-	onClose: () => void;
-};
-
-export const MissingPaymentSettingsNotice = ( { onClose }: Props ) => {
+export const MissingPaymentSettingsNotice = () => {
 	const translate = useTranslate();
+
+	const { data: tipaltiData } = useGetTipaltiPayee();
+	const isPayable = tipaltiData?.IsPayable;
+
+	const { data: referrals } = useFetchReferrals( true );
+
+	const hasReferrals = !! referrals?.length;
+
+	if ( isPayable || ! hasReferrals ) {
+		return null;
+	}
+
 	return (
 		<LayoutBanner
 			level="warning"
-			title={ translate( 'Your payment settings require action' ) }
-			onClose={ onClose }
+			title={ translate( 'Add your payment information to get paid' ) }
 			className="missing-payment-settings-notice"
+			hideCloseButton
 		>
 			<div>
-				{ translate( 'Please confirm your details before referring products to your clients.' ) }
+				{ translate(
+					"You've successfully made a client referral and will be due future commissions. Add your payment details to get paid."
+				) }
 			</div>
 			<Button
 				className="missing-payment-settings-notice__button is-dark"
 				href="/referrals/payment-settings"
 			>
-				{ translate( 'Go to payment settings' ) }
+				{ translate( 'Add your payment information' ) }
 			</Button>
 		</LayoutBanner>
 	);

--- a/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/style.scss
@@ -1,8 +1,4 @@
 .missing-payment-settings-notice {
-	.notice-banner {
-		padding: 24px;
-	}
-
 	.missing-payment-settings-notice__button {
 		margin-block-start: 1rem;
 	}

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -31,7 +31,6 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import MissingPaymentSettingsNotice from '../../common/missing-payment-settings-notice';
 import useFetchReferrals from '../../hooks/use-fetch-referrals';
 import useGetTipaltiPayee from '../../hooks/use-get-tipalti-payee';
-import { getAccountStatus } from '../../lib/get-account-status';
 import ReferralDetails from '../../referral-details';
 import ReferralsFooter from '../footer';
 import AutomatedReferralComingSoonBanner from './automated-referral-coming-soon-banner';
@@ -55,7 +54,6 @@ export default function ReferralsOverview( {
 		fields: [ 'completed-orders', 'pending-orders', 'commissions', 'subscription-status' ],
 		titleField: 'client',
 	} );
-	const [ requiredNoticeClose, setRequiredNoticeClosed ] = useState( false );
 
 	const { value: referralEmail, setValue: setReferralEmail } = useUrlQueryParam(
 		REFERRAL_EMAIL_QUERY_PARAM_KEY
@@ -73,7 +71,6 @@ export default function ReferralsOverview( {
 			: translate( 'Referrals' );
 
 	const { data: tipaltiData, isFetching } = useGetTipaltiPayee();
-	const accountStatus = getAccountStatus( tipaltiData, translate );
 
 	const wrapperRef = useRef< HTMLButtonElement | null >( null );
 
@@ -84,9 +81,6 @@ export default function ReferralsOverview( {
 	} = useFetchReferrals( isAutomatedReferral );
 
 	const hasReferrals = !! referrals?.length;
-
-	const actionRequiredNotice =
-		hasReferrals && accountStatus?.actionRequired && ! requiredNoticeClose;
 
 	const makeAReferral = useCallback( () => {
 		sessionStorage.setItem( MARKETPLACE_TYPE_SESSION_STORAGE_KEY, MARKETPLACE_TYPE_REFERRAL );
@@ -115,11 +109,8 @@ export default function ReferralsOverview( {
 							onClose={ () => setReferralEmail( '' ) }
 						/>
 					) }
-					{ actionRequiredNotice && (
-						<div className="referrals-overview__notice">
-							<MissingPaymentSettingsNotice onClose={ () => setRequiredNoticeClosed( true ) } />
-						</div>
-					) }
+
+					<MissingPaymentSettingsNotice />
 
 					{ ! isAutomatedReferral && <AutomatedReferralComingSoonBanner /> }
 


### PR DESCRIPTION
The new update on unrestricted referrals requires us to revise the missing payment details banner to match the updated flow.

<img width="1566" alt="Screenshot 2025-02-20 at 7 23 09 PM" src="https://github.com/user-attachments/assets/47ceabef-d91f-4ac3-ad11-36e6d94e0e13" />


Depends on https://github.com/Automattic/wp-calypso/pull/99937
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1809

## Proposed Changes

* Revise the text on the Current Payment details banner to match the updated flow. Additionally, ensure the banner cannot be dismissed.
* Show the banner on the Overview page and modify the logic so it only appears when there are no payment details available and a referral exists.
* **Additional**: Standardize Notice banner spacing.

## Why are these changes being made?

This contributes to the initiative aimed at boosting the Agency's referral rate.

## Testing Instructions


* Create a referral without payment details. You can follow https://github.com/Automattic/wp-calypso/pull/99937 for instructions.
* Use the A4A live link and go to the `/overview` and `/referrals/dashboard`.
* Confirm that you see the banner.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
