### PR TITLE
Stepper: Migrate onboarding flow to indexed steps

### DIFF
--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -103,27 +103,11 @@ const onboarding: Flow = {
 		const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 
 		const steps = stepsWithRequiredLogin( [
-			{
-				slug: 'domains',
-				asyncComponent: () => import( './internals/steps-repository/unified-domains' ),
-			},
-			{
-				slug: 'use-my-domain',
-				asyncComponent: () => import( './internals/steps-repository/use-my-domain' ),
-			},
-			{
-				slug: 'plans',
-				asyncComponent: () => import( './internals/steps-repository/unified-plans' ),
-			},
-			{
-				slug: 'create-site',
-				asyncComponent: () => import( './internals/steps-repository/create-site' ),
-			},
-			{
-				slug: 'processing',
-				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
-			},
-			STEPS.POST_CHECKOUT_ONBOARDING,
+			STEPS.UNIFIED_DOMAINS,
+			STEPS.USE_MY_DOMAIN,
+			STEPS.UNIFIED_PLANS,
+			STEPS.SITE_CREATION_STEP,
+			STEPS.PROCESSING,
 		] );
 
 		if ( isGoalsAtFrontExperiment ) {

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -108,6 +108,7 @@ const onboarding: Flow = {
 			STEPS.UNIFIED_PLANS,
 			STEPS.SITE_CREATION_STEP,
 			STEPS.PROCESSING,
+			STEPS.POST_CHECKOUT_ONBOARDING,
 		] );
 
 		if ( isGoalsAtFrontExperiment ) {


### PR DESCRIPTION

Related to https://github.com/Automattic/wp-calypso/pull/99352

## Proposed Changes

This migrates the onboarding flow to use the indexed steps.


## Why are these changes being made?
Because the indexed steps have the chunk names.

## Testing Instructions

Same testing steps as https://github.com/Automattic/wp-calypso/pull/99744