### PR TITLE
State: Return stable empty object in `getThemeTierForTheme`

### DIFF
--- a/client/state/themes/selectors/get-theme-tier-for-theme.tsx
+++ b/client/state/themes/selectors/get-theme-tier-for-theme.tsx
@@ -1,7 +1,9 @@
 import { getTheme } from 'calypso/state/themes/selectors';
 import type { AppState } from 'calypso/types';
 
+const EMPTY_OBJECT = {};
+
 export function getThemeTierForTheme( state: AppState, themeId: string ) {
 	const theme = getTheme( state, 'wpcom', themeId ) || getTheme( state, 'wporg', themeId );
-	return theme?.theme_tier || {};
+	return theme?.theme_tier || EMPTY_OBJECT;
 }


### PR DESCRIPTION
## Proposed Changes

Fixes a warning for potential unnecessary rerenders:

![Screenshot 2025-02-20 at 14 03 44](https://github.com/user-attachments/assets/7da2df42-af88-45a5-8bc5-4b87c95d5c70)


## Why are these changes being made?

Found while working on #100057.

## Testing Instructions

* Go to `/setup/update-design/designSetup?siteSlug=SITESLUG&flowToReturnTo=design-first&categories=blog&theme=twentytwentyfive` where SITESLUG is the slug of a WP.com simple site.
* Verify the warning is gone.