### PR TITLE
Site Migration: Fix site-migration-upgrade-plan header style issue

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/style.scss
@@ -1,4 +1,5 @@
-.is-step-site-migration-upgrade-plan-with-variants {
+
+:root .site-migration-upgrade-plan .is-step-site-migration-upgrade-plan-with-variants {
 	padding-bottom: 5rem;
 
 	@media ( min-width: 1040px ) {


### PR DESCRIPTION
Related to p1740050819242509-slack-C0Q664T29

## Proposed Changes
* Increase the step CSS specificity using the. :root selector


## Why are these changes being made?
There is a CSS conflict causing the header misalignment, as described by the https://specificity.keegan.st/ calculator

![CleanShot 2025-02-20 at 12 48 43@2x](https://github.com/user-attachments/assets/bb752d5f-3b39-465c-a884-e64da5499ff5)

0.4.1 (Global Style) > 0.4.0 (Step style)
I used the `:root` selector to increase the local style to 0.5.0
![CleanShot 2025-02-20 at 12 51 06@2x](https://github.com/user-attachments/assets/a90dc456-63e5-449d-93cb-38c957233e3d)

--- 
## Screenshots

Before
![CleanShot 2025-02-20 at 12 42 37@2x](https://github.com/user-attachments/assets/a5b6fe8c-300d-48cd-892b-c723298bfb95)

After 
![CleanShot 2025-02-20 at 12 43 15@2x](https://github.com/user-attachments/assets/45b0ba8a-db8b-43b7-9059-7032cf08ce9e)


## Testing Instructions

* Go to /setup/hosted-site-migration
* Select a free plan and choose the migrate option
* When you arrive on the `There is a plan for you` page, check if the header is centered as in the screenshot above.  


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?