### PR TITLE
A4A: Fix bug with Product overview page's header with notice banner.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/index.tsx
@@ -125,6 +125,11 @@ export function ProductsOverviewV2( {
 	);
 
 	const topRef = useRef< HTMLDivElement >( null );
+	const actionPanelRef = useRef< HTMLDivElement >( null );
+
+	const actionPanelStickyTopOffset = topRef.current?.offsetHeight ?? 0;
+	const productListingStickyTopOffset =
+		actionPanelStickyTopOffset + ( actionPanelRef.current?.offsetHeight ?? 0 );
 
 	return (
 		<Layout
@@ -188,23 +193,29 @@ export function ProductsOverviewV2( {
 				</LayoutTop>
 			</div>
 
-			<ProductActionPanel
-				stickyTopOffset={ topRef.current?.offsetHeight ?? 0 }
-				searchQuery={ productSearchQuery }
-				onSearchQueryChange={ setProductSearchQuery }
-				selectedFilters={ selectedFilters }
-				setSelectedFilters={ setSelectedFilters }
-				resetSelectedFilters={ resetFilters }
-				isReferralMode={ isReferralMode }
-				selectedBundleSize={ selectedBundleSize }
-				availableBundleSizes={ availableBundleSizes }
-				setSelectedBundleSize={ setSelectedBundleSize }
-			/>
+			<div
+				className="products-overview-v2__action-panel-wrapper"
+				ref={ actionPanelRef }
+				style={ { top: actionPanelStickyTopOffset } }
+			>
+				<ProductActionPanel
+					searchQuery={ productSearchQuery }
+					onSearchQueryChange={ setProductSearchQuery }
+					selectedFilters={ selectedFilters }
+					setSelectedFilters={ setSelectedFilters }
+					resetSelectedFilters={ resetFilters }
+					isReferralMode={ isReferralMode }
+					selectedBundleSize={ selectedBundleSize }
+					availableBundleSizes={ availableBundleSizes }
+					setSelectedBundleSize={ setSelectedBundleSize }
+				/>
+			</div>
 
 			<ShoppingCartContext.Provider value={ { setSelectedCartItems, selectedCartItems } }>
 				{
 					// we will remove this once we have the new product listing component
 					<ProductListing
+						stickyHeadingTopOffset={ productListingStickyTopOffset }
 						selectedSite={ selectedSite }
 						suggestedProduct={ suggestedProduct }
 						productBrand={ productBrand }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/index.tsx
@@ -3,7 +3,7 @@ import { SiteDetails } from '@automattic/data-stores';
 import { useBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useContext, useEffect, useLayoutEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
@@ -124,6 +124,8 @@ export function ProductsOverviewV2( {
 		[ dispatch, setSelectedFilters ]
 	);
 
+	const topRef = useRef< HTMLDivElement >( null );
+
 	return (
 		<Layout
 			className={ clsx( 'products-overview-v2', { 'is-compact': isCompact } ) }
@@ -133,58 +135,61 @@ export function ProductsOverviewV2( {
 		>
 			<GuidedTour defaultTourId="marketplaceWalkthrough" />
 
-			<LayoutTop>
-				<A4AAgencyApprovalNotice />
-				<LayoutHeader>
-					<Breadcrumb
-						items={ [
-							{
-								label: translate( 'Marketplace' ),
-								href: A4A_MARKETPLACE_LINK,
-							},
-							{
-								label: translate( 'Products' ),
-							},
-						] }
-						hideOnMobile
-					/>
-
-					<Actions className="a4a-marketplace__header-actions">
-						<MobileSidebarNavigation />
-						<div ref={ ( ref ) => setReferralToggleRef( ref as HTMLElement | null ) }>
-							<ReferralToggle />
-						</div>
-						<ShoppingCart
-							showCart={ showCart }
-							setShowCart={ setShowCart }
-							toggleCart={ toggleCart }
-							items={ selectedCartItems }
-							onRemoveItem={ onRemoveCartItem }
-							onCheckout={ () => {
-								page( A4A_MARKETPLACE_CHECKOUT_LINK );
-							} }
+			<div className="products-overview-v2__top" ref={ topRef }>
+				<LayoutTop>
+					<A4AAgencyApprovalNotice />
+					<LayoutHeader>
+						<Breadcrumb
+							items={ [
+								{
+									label: translate( 'Marketplace' ),
+									href: A4A_MARKETPLACE_LINK,
+								},
+								{
+									label: translate( 'Products' ),
+								},
+							] }
+							hideOnMobile
 						/>
 
-						<GuidedTourStep
-							className="a4a-marketplace__guided-tour"
-							id="marketplace-walkthrough-navigation"
-							tourId="marketplaceWalkthrough"
-							context={ sidebarRef }
-						/>
+						<Actions className="a4a-marketplace__header-actions">
+							<MobileSidebarNavigation />
+							<div ref={ ( ref ) => setReferralToggleRef( ref as HTMLElement | null ) }>
+								<ReferralToggle />
+							</div>
+							<ShoppingCart
+								showCart={ showCart }
+								setShowCart={ setShowCart }
+								toggleCart={ toggleCart }
+								items={ selectedCartItems }
+								onRemoveItem={ onRemoveCartItem }
+								onCheckout={ () => {
+									page( A4A_MARKETPLACE_CHECKOUT_LINK );
+								} }
+							/>
 
-						<GuidedTourStep
-							className="a4a-marketplace__guided-tour"
-							id="marketplace-walkthrough-referral-toggle"
-							tourId="marketplaceWalkthrough"
-							context={ referralToggleRef }
-						/>
-					</Actions>
-				</LayoutHeader>
+							<GuidedTourStep
+								className="a4a-marketplace__guided-tour"
+								id="marketplace-walkthrough-navigation"
+								tourId="marketplaceWalkthrough"
+								context={ sidebarRef }
+							/>
 
-				<ProductCategoryMenu onSelect={ onCategorySelected } />
-			</LayoutTop>
+							<GuidedTourStep
+								className="a4a-marketplace__guided-tour"
+								id="marketplace-walkthrough-referral-toggle"
+								tourId="marketplaceWalkthrough"
+								context={ referralToggleRef }
+							/>
+						</Actions>
+					</LayoutHeader>
+
+					<ProductCategoryMenu onSelect={ onCategorySelected } />
+				</LayoutTop>
+			</div>
 
 			<ProductActionPanel
+				stickyTopOffset={ topRef.current?.offsetHeight ?? 0 }
 				searchQuery={ productSearchQuery }
 				onSearchQueryChange={ setProductSearchQuery }
 				selectedFilters={ selectedFilters }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-action-panel/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-action-panel/index.tsx
@@ -20,7 +20,6 @@ type Props = {
 	selectedBundleSize: number;
 	availableBundleSizes: number[];
 	setSelectedBundleSize: ( value: number ) => void;
-	stickyTopOffset: number;
 };
 
 export default function ProductActionPanel( {
@@ -33,7 +32,6 @@ export default function ProductActionPanel( {
 	selectedBundleSize,
 	availableBundleSizes,
 	setSelectedBundleSize,
-	stickyTopOffset,
 }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -88,30 +86,28 @@ export default function ProductActionPanel( {
 	);
 
 	return (
-		<div className="product-action-panel" style={ { top: stickyTopOffset } }>
-			<LayoutSection>
-				<div className="product-action-panel__filter">
-					<SearchControl
-						label={ translate( 'Search' ) }
-						value={ searchQuery }
-						onChange={ handleSearchQueryChange }
-					/>
+		<LayoutSection className="product-action-panel">
+			<div className="product-action-panel__filter">
+				<SearchControl
+					label={ translate( 'Search' ) }
+					value={ searchQuery }
+					onChange={ handleSearchQueryChange }
+				/>
 
-					<ProductTypeFilter
-						selectedFilters={ selectedFilters }
-						setSelectedFilters={ handleSelectedFiltersChange }
-						resetFilters={ handleResetSelectedFilters }
-					/>
-				</div>
+				<ProductTypeFilter
+					selectedFilters={ selectedFilters }
+					setSelectedFilters={ handleSelectedFiltersChange }
+					resetFilters={ handleResetSelectedFilters }
+				/>
+			</div>
 
-				{ ! isReferralMode && (
-					<BundlePriceSelector
-						options={ availableBundleSizes }
-						value={ selectedBundleSize }
-						onChange={ handleSelectedBundleSizeChange }
-					/>
-				) }
-			</LayoutSection>
-		</div>
+			{ ! isReferralMode && (
+				<BundlePriceSelector
+					options={ availableBundleSizes }
+					value={ selectedBundleSize }
+					onChange={ handleSelectedBundleSizeChange }
+				/>
+			) }
+		</LayoutSection>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-action-panel/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-action-panel/index.tsx
@@ -20,6 +20,7 @@ type Props = {
 	selectedBundleSize: number;
 	availableBundleSizes: number[];
 	setSelectedBundleSize: ( value: number ) => void;
+	stickyTopOffset: number;
 };
 
 export default function ProductActionPanel( {
@@ -32,6 +33,7 @@ export default function ProductActionPanel( {
 	selectedBundleSize,
 	availableBundleSizes,
 	setSelectedBundleSize,
+	stickyTopOffset,
 }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -86,28 +88,30 @@ export default function ProductActionPanel( {
 	);
 
 	return (
-		<LayoutSection className="product-action-panel">
-			<div className="product-action-panel__filter">
-				<SearchControl
-					label={ translate( 'Search' ) }
-					value={ searchQuery }
-					onChange={ handleSearchQueryChange }
-				/>
+		<div className="product-action-panel" style={ { top: stickyTopOffset } }>
+			<LayoutSection>
+				<div className="product-action-panel__filter">
+					<SearchControl
+						label={ translate( 'Search' ) }
+						value={ searchQuery }
+						onChange={ handleSearchQueryChange }
+					/>
 
-				<ProductTypeFilter
-					selectedFilters={ selectedFilters }
-					setSelectedFilters={ handleSelectedFiltersChange }
-					resetFilters={ handleResetSelectedFilters }
-				/>
-			</div>
+					<ProductTypeFilter
+						selectedFilters={ selectedFilters }
+						setSelectedFilters={ handleSelectedFiltersChange }
+						resetFilters={ handleResetSelectedFilters }
+					/>
+				</div>
 
-			{ ! isReferralMode && (
-				<BundlePriceSelector
-					options={ availableBundleSizes }
-					value={ selectedBundleSize }
-					onChange={ handleSelectedBundleSizeChange }
-				/>
-			) }
-		</LayoutSection>
+				{ ! isReferralMode && (
+					<BundlePriceSelector
+						options={ availableBundleSizes }
+						value={ selectedBundleSize }
+						onChange={ handleSelectedBundleSizeChange }
+					/>
+				) }
+			</LayoutSection>
+		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-action-panel/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-action-panel/style.scss
@@ -2,29 +2,22 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.product-action-panel {
+.product-action-panel.hosting-dashboard-layout__body {
 	background: var( --color-surface );
+	padding-block: 16px;
+	margin-block-start: 16px;
 
-	.hosting-dashboard-layout__body {
-		padding-block: 16px;
-		margin-block-start: 16px;
+	.hosting-dashboard-layout__body-wrapper {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+		justify-content: center;
 
-		.hosting-dashboard-layout__body-wrapper {
-			display: flex;
-			flex-direction: column;
-			gap: 16px;
-			justify-content: center;
-
-			@include break-large {
-				flex-direction: row;
-				justify-content: space-between;
-			}
+		@include break-large {
+			flex-direction: row;
+			justify-content: space-between;
 		}
 	}
-}
-
-.products-overview-v2.main.hosting-dashboard-layout.is-compact .product-action-panel {
-	box-shadow: 0 2px 4px 0 rgba(0, 0, 0, .10);
 }
 
 .product-action-panel__filter {

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-action-panel/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-action-panel/style.scss
@@ -2,25 +2,28 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.product-action-panel.hosting-dashboard-layout__body {
+.product-action-panel {
 	background: var( --color-surface );
-	padding-block: 16px;
-	margin-block-start: 16px;
 
-	.hosting-dashboard-layout__body-wrapper {
-		display: flex;
-		flex-direction: column;
-		gap: 16px;
-		justify-content: center;
+	.hosting-dashboard-layout__body {
+		padding-block: 16px;
+		margin-block-start: 16px;
 
-		@include break-large {
-			flex-direction: row;
-			justify-content: space-between;
+		.hosting-dashboard-layout__body-wrapper {
+			display: flex;
+			flex-direction: column;
+			gap: 16px;
+			justify-content: center;
+
+			@include break-large {
+				flex-direction: row;
+				justify-content: space-between;
+			}
 		}
 	}
 }
 
-.products-overview-v2.main.hosting-dashboard-layout.is-compact .product-action-panel.hosting-dashboard-layout__body {
+.products-overview-v2.main.hosting-dashboard-layout.is-compact .product-action-panel {
 	box-shadow: 0 2px 4px 0 rgba(0, 0, 0, .10);
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/index.tsx
@@ -33,6 +33,7 @@ interface ProductListingProps {
 	isReferralMode: boolean;
 	selectedBundleSize: number;
 	selectedFilters: SelectedFilters;
+	stickyHeadingTopOffset?: number;
 }
 
 export default function ProductListing( {
@@ -42,6 +43,7 @@ export default function ProductListing( {
 	isReferralMode,
 	selectedBundleSize,
 	selectedFilters,
+	stickyHeadingTopOffset,
 }: ProductListingProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -258,7 +260,10 @@ export default function ProductListing( {
 			{ isEmptyList && <ProductListingEmpty /> }
 
 			{ featuredProducts.length > 0 && (
-				<ProductListingSection title={ translate( 'Featured products' ) }>
+				<ProductListingSection
+					title={ translate( 'Featured products' ) }
+					stickyHeadingTopOffset={ stickyHeadingTopOffset }
+				>
 					{ getProductCards( featuredProducts, true ) }
 				</ProductListingSection>
 			) }
@@ -270,6 +275,7 @@ export default function ProductListing( {
 					description={ translate(
 						"Explore the tools and integrations you need to grow your client's Woo store."
 					) }
+					stickyHeadingTopOffset={ stickyHeadingTopOffset }
 				>
 					{ getProductCards( wooExtensions ) }
 				</ProductListingSection>
@@ -282,6 +288,7 @@ export default function ProductListing( {
 					description={ translate(
 						'Save big with comprehensive bundles of Jetpack security, performance, and growth tools.'
 					) } // FIXME: Add proper description for A4A
+					stickyHeadingTopOffset={ stickyHeadingTopOffset }
 				>
 					{ getProductCards( jetpackPlans ) }
 				</ProductListingSection>
@@ -294,6 +301,7 @@ export default function ProductListing( {
 					description={ translate(
 						'Mix and match powerful security, performance, and growth tools for your sites.'
 					) }
+					stickyHeadingTopOffset={ stickyHeadingTopOffset }
 				>
 					{ getProductCards( jetpackProducts ) }
 				</ProductListingSection>
@@ -306,6 +314,7 @@ export default function ProductListing( {
 					description={ translate(
 						'Add additional storage to your current VaultPress Backup plans.'
 					) }
+					stickyHeadingTopOffset={ stickyHeadingTopOffset }
 				>
 					{ getProductCards( jetpackBackupAddons ) }
 				</ProductListingSection>

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/section.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/section.tsx
@@ -8,6 +8,7 @@ type Props = {
 	description?: string;
 	children: ReactNode;
 	extraContent?: ReactNode;
+	stickyHeadingTopOffset?: number;
 };
 
 export default function ProductListingSection( {
@@ -16,6 +17,7 @@ export default function ProductListingSection( {
 	description,
 	children,
 	extraContent,
+	stickyHeadingTopOffset,
 }: Props ) {
 	const sectionRef = useRef< HTMLDivElement >( null );
 	const [ isVisibleOnce, setIsVisibleOnce ] = useState( false );
@@ -53,7 +55,18 @@ export default function ProductListingSection( {
 
 	return (
 		<div className="product-listing-section" ref={ sectionRef }>
-			<div className="product-listing-section__header-wrapper">
+			<div
+				className="product-listing-section__header-wrapper"
+				style={
+					stickyHeadingTopOffset
+						? {
+								top: stickyHeadingTopOffset,
+								position: 'sticky',
+								paddingBlock: '16px',
+						  }
+						: undefined
+				}
+			>
 				<div className="product-listing-section__header">
 					{ icon }
 					<h2 className="product-listing-section__header-title">{ title }</h2>

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/style.scss
@@ -57,14 +57,9 @@ $header-compact-height-mobile: 128px;
 		height: 156px;
 	}
 
-	.product-action-panel {
+	.products-overview-v2__action-panel-wrapper {
 		position: sticky;
 		z-index: 2;
-	}
-
-	.product-listing-section__header-wrapper {
-		position: sticky;
-		padding-block: 16px;
 	}
 }
 
@@ -74,5 +69,9 @@ $header-compact-height-mobile: 128px;
 		height: 0;
 		opacity: 0;
 		margin: 0;
+	}
+
+	.products-overview-v2__action-panel-wrapper {
+		box-shadow: 0 2px 4px 0 rgba(0, 0, 0, .10);
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/style.scss
@@ -3,12 +3,8 @@
 @import "../variables";
 @import "../shared";
 
-$header-height: 300px;
-$header-height-mobile: 350px;
 $header-compact-height: 114px;
 $header-compact-height-mobile: 128px;
-$action-panel-height: 72px;
-$action-panel-height-mobile: 128px;
 
 .products-overview-v2.main.hosting-dashboard-layout {
 	.hosting-dashboard-layout__container {
@@ -17,7 +13,7 @@ $action-panel-height-mobile: 128px;
 		display: block;
 	}
 
-	.hosting-dashboard-layout__top-wrapper {
+	.products-overview-v2__top {
 		max-height: auto;
 		background: url( calypso/assets/images/a8c-for-agencies/marketplace-hosting-page-v3-bg.svg ) no-repeat top right $header-background-color;
         border-block-end: none;
@@ -25,13 +21,7 @@ $action-panel-height-mobile: 128px;
 		top: 0;
 		z-index: 100;
 		overflow: hidden;
-		transition: height .25s ease-out;
 		box-sizing: border-box;
-		height: $header-height-mobile;
-
-		@include break-medium {
-			height: $header-height;
-		}
     }
 
 	.hosting-dashboard-layout__header > * {
@@ -62,42 +52,27 @@ $action-panel-height-mobile: 128px;
 	}
 
 	.product-category-menu {
+		transition: height .25s ease-out;
 		opacity: 1;
-		transition: opacity .25s ease-out;
+		height: 156px;
 	}
 
 	.product-action-panel {
 		position: sticky;
-		top: $header-compact-height-mobile;
 		z-index: 2;
-
-		@include break-medium {
-			top: $header-compact-height;
-		}
 	}
 
 	.product-listing-section__header-wrapper {
 		position: sticky;
 		padding-block: 16px;
-
-		top: calc( $header-compact-height-mobile + $action-panel-height-mobile );
-
-		@include break-medium {
-			top: calc( $header-compact-height + $action-panel-height );
-		}
 	}
 }
 
 .products-overview-v2.main.hosting-dashboard-layout.is-compact {
-	.hosting-dashboard-layout__top-wrapper {
-		height: $header-compact-height-mobile;
-
-		@include break-medium {
-			height: $header-compact-height;
-		}
-	}
-
 	.product-category-menu {
+		overflow: hidden;
+		height: 0;
 		opacity: 0;
+		margin: 0;
 	}
 }


### PR DESCRIPTION
This PR addresses a bug where the Product category menu gets cut off due to the Notice banner.

| Before | After |
|--------|--------|
| <img width="1449" alt="Screenshot 2025-02-20 at 10 46 50 PM" src="https://github.com/user-attachments/assets/347fa53f-05e5-449c-8dba-8bd7b3b8144c" /> | <img width="1485" alt="Screenshot 2025-02-20 at 10 47 23 PM" src="https://github.com/user-attachments/assets/ad39484b-9bec-42c6-bd12-aecde97c428d" /> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1798

## Proposed Changes
The current approach for the Product category header and its sticky feature depends on hardcoded top offset values in our CSS rules. This hard-coded approach becomes problematic with the additional content in the header, leading to the bug described above.

To resolve this issue, we needed to refactor our implementation and handle the sticky behavior in React instead of leaving it in the CSS. This allows us to accurately calculate the top offset for our sticky elements since our header is sufficiently dynamic.

The positive aspect of this new approach is that it is not fragile and can accommodate various header sizes regardless of the content.

## Why are these changes being made?

* For new agencies that have yet to be approved, the Marketplace page provides a flawed experience.

## Testing Instructions

* To test this, you need to make a new agency that is not yet approved. You can also manually change your current agency status by updating the blog option.
* Use the A4A live link and go to the `/marketplace/products` page.
* Confirm that you see the banner and the category menu is not cut off. 
* Test that the sticky behavior is working as expected.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
