### PR TITLE
Add context to "May" when referring to the abbreviation

### DIFF
--- a/client/my-sites/stats/stats-detail-months/index.jsx
+++ b/client/my-sites/stats/stats-detail-months/index.jsx
@@ -29,7 +29,7 @@ const StatsPostDetailMonths = ( props ) => {
 					<th>{ translate( 'Feb' ) }</th>
 					<th>{ translate( 'Mar' ) }</th>
 					<th>{ translate( 'Apr' ) }</th>
-					<th>{ translate( 'May' ) }</th>
+					<th>{ translate( 'May', { context: 'May abbreviation' } ) }</th>
 					<th>{ translate( 'Jun' ) }</th>
 					<th>{ translate( 'Jul' ) }</th>
 					<th>{ translate( 'Aug' ) }</th>

--- a/client/my-sites/stats/stats-views/months.jsx
+++ b/client/my-sites/stats/stats-views/months.jsx
@@ -190,7 +190,7 @@ const StatsViewsMonths = ( props ) => {
 						{ translate( 'Apr' ) }
 					</Month>
 					<Month value={ numberFormat( getMonthTotal( totals, 4 ) ) } isHeader>
-						{ translate( 'May' ) }
+						{ translate( 'May', { context: 'May abbreviation' } ) }
 					</Month>
 					<Month value={ numberFormat( getMonthTotal( totals, 5 ) ) } isHeader>
 						{ translate( 'Jun' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/i18n-issues#952

## Proposed Changes

* Add context to the month 'May' when used in a list of 3-letter abbreviations

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

In Jetpack stats, the string "May" is part of a list of months using the 3 letter abbreviation.

Since May is also the full month name, we need to add context here to specify that it's the 3-letter abbreviation.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
