### PR TITLE
Reader profile - add support for a route via userId

### DIFF
--- a/client/reader/index.ts
+++ b/client/reader/index.ts
@@ -100,6 +100,17 @@ export default async function (): Promise< void > {
 		);
 
 		page(
+			`/reader/users/id/:user_id`,
+			blogDiscoveryByFeedId,
+			redirectLoggedOutToSignup,
+			updateLastRoute,
+			sidebar,
+			userPosts,
+			makeLayout,
+			clientRender
+		);
+
+		page(
 			getUserProfileBasePath( 'lists' ),
 			blogDiscoveryByFeedId,
 			redirectLoggedOutToSignup,

--- a/client/reader/user-profile/controller.tsx
+++ b/client/reader/user-profile/controller.tsx
@@ -6,7 +6,8 @@ import { getUserProfileBasePath } from 'calypso/reader/user-profile/user-profile
 
 interface UserPostsContext extends Context {
 	params: {
-		user_login: string;
+		user_login?: string;
+		user_id?: string;
 	};
 	primary: ReactElement;
 }
@@ -16,6 +17,7 @@ const analyticsPageTitle = 'Reader';
 export function userPosts( ctx: Context, next: () => void ): void {
 	const context = ctx as UserPostsContext;
 	const userLogin = context.params.user_login;
+	const userId = context.params.user_id;
 	const basePath = getUserProfileBasePath();
 	const fullAnalyticsPageTitle = analyticsPageTitle + ' > User > ' + userLogin + ' > Posts';
 	const mcKey = 'user_posts';
@@ -31,6 +33,7 @@ export function userPosts( ctx: Context, next: () => void ): void {
 			require="calypso/reader/user-profile"
 			key={ 'user-posts-' + userLogin }
 			userLogin={ userLogin }
+			userId={ userId }
 			trackScrollPage={ trackScrollPage.bind(
 				null,
 				basePath,
@@ -40,6 +43,7 @@ export function userPosts( ctx: Context, next: () => void ): void {
 			) }
 			showBack={ !! ctx.lastRoute }
 			handleBack={ goBack }
+			path={ context.path }
 		/>
 	);
 	next();

--- a/client/reader/user-profile/index.tsx
+++ b/client/reader/user-profile/index.tsx
@@ -99,7 +99,7 @@ export default connect(
 	( state: UserProfileState, ownProps: UserProfileProps ) => ( {
 		// The following logic works because userLogin and userId are mutually exclusive via the
 		// routes.
-		user1: getReaderUser(
+		user: getReaderUser(
 			state,
 			ownProps.userLogin || ownProps.userId,
 			ownProps.userLogin ? false : true

--- a/client/reader/user-profile/index.tsx
+++ b/client/reader/user-profile/index.tsx
@@ -97,9 +97,13 @@ export function UserProfile( props: UserProfileProps ): JSX.Element | null {
 
 export default connect(
 	( state: UserProfileState, ownProps: UserProfileProps ) => ( {
-		user: ownProps.userLogin
-			? getReaderUser( state, ownProps.userLogin )
-			: getReaderUser( state, ownProps.userId, true ),
+		// The following logic works because userLogin and userId are mutually exclusive via the
+		// routes.
+		user1: getReaderUser(
+			state,
+			ownProps.userLogin || ownProps.userId,
+			ownProps.userLogin ? false : true
+		),
 		isLoading: state.reader.users.requesting[ ownProps.userLogin || ownProps.userId ] ?? false,
 	} ),
 	{ requestUser }

--- a/client/reader/user-profile/index.tsx
+++ b/client/reader/user-profile/index.tsx
@@ -9,13 +9,16 @@ import { getUserProfileUrl } from 'calypso/reader/user-profile/user-profile.util
 import UserLists from 'calypso/reader/user-profile/views/lists';
 import UserPosts from 'calypso/reader/user-profile/views/posts';
 import { requestUser } from 'calypso/state/reader/users/actions';
+import getReaderUser from 'calypso/state/selectors/get-reader-user';
 import './style.scss';
 
 interface UserProfileProps {
 	userLogin: string;
-	user: UserData;
+	userId: string;
+	user: UserData | undefined;
+	path: string;
 	isLoading: boolean;
-	requestUser: ( userLogin: string ) => Promise< void >;
+	requestUser: ( userLogin: string, findById?: boolean ) => Promise< void >;
 	showBack: boolean;
 	handleBack: () => void;
 }
@@ -30,12 +33,25 @@ type UserProfileState = {
 };
 
 export function UserProfile( props: UserProfileProps ): JSX.Element | null {
-	const { userLogin, requestUser, user, isLoading, showBack, handleBack } = props;
+	const { userLogin, userId, path, requestUser, user, isLoading, showBack, handleBack } = props;
 	const translate = useTranslate();
 
 	useEffect( () => {
-		requestUser( userLogin );
-	}, [ userLogin, requestUser ] );
+		if ( ! user ) {
+			if ( userLogin ) {
+				requestUser( userLogin );
+			}
+			if ( userId ) {
+				requestUser( userId, true );
+			}
+		}
+	}, [ userLogin, requestUser, userId, user ] );
+
+	useEffect( () => {
+		if ( path.startsWith( '/reader/users/id/' ) && user ) {
+			page.replace( `/reader/users/${ user.user_login }` );
+		}
+	}, [ path, user ] );
 
 	if ( isLoading ) {
 		return <></>;
@@ -81,7 +97,9 @@ export function UserProfile( props: UserProfileProps ): JSX.Element | null {
 
 export default connect(
 	( state: UserProfileState, ownProps: UserProfileProps ) => ( {
-		user: state.reader.users.items[ ownProps.userLogin ],
+		user: ownProps.userLogin
+			? getReaderUser( state, ownProps.userLogin )
+			: getReaderUser( state, ownProps.userId, true ),
 		isLoading: state.reader.users.requesting[ ownProps.userLogin ] ?? false,
 	} ),
 	{ requestUser }

--- a/client/reader/user-profile/index.tsx
+++ b/client/reader/user-profile/index.tsx
@@ -100,7 +100,7 @@ export default connect(
 		user: ownProps.userLogin
 			? getReaderUser( state, ownProps.userLogin )
 			: getReaderUser( state, ownProps.userId, true ),
-		isLoading: state.reader.users.requesting[ ownProps.userLogin ] ?? false,
+		isLoading: state.reader.users.requesting[ ownProps.userLogin || ownProps.userId ] ?? false,
 	} ),
 	{ requestUser }
 )( UserProfile );

--- a/client/state/reader/users/actions.js
+++ b/client/state/reader/users/actions.js
@@ -8,28 +8,30 @@ import {
 import 'calypso/state/reader/init';
 
 const requestsInFlight = new Set();
-export function requestUser( userLogin ) {
+export function requestUser( userLoginOrId, findById = false ) {
 	return async ( dispatch ) => {
-		if ( requestsInFlight.has( userLogin ) ) {
+		if ( requestsInFlight.has( userLoginOrId ) ) {
 			return;
 		}
 
-		dispatch( { type: READER_USER_REQUEST, userLogin } );
-		requestsInFlight.add( userLogin );
+		dispatch( { type: READER_USER_REQUEST, userLoginOrId } );
+		requestsInFlight.add( userLoginOrId );
 
 		try {
-			const userData = await wpcom.req.get( `/users/${ encodeURIComponent( userLogin ) }/` );
-			requestsInFlight.delete( userLogin );
+			const userData = await wpcom.req.get(
+				`/users/${ encodeURIComponent( userLoginOrId ) }/${ findById ? '?find_by_id=true' : '' }`
+			);
+			requestsInFlight.delete( userLoginOrId );
 			dispatch( {
 				type: READER_USER_REQUEST_SUCCESS,
-				userLogin,
+				userLogin: userData.user_login,
 				userData,
 			} );
 		} catch ( error ) {
-			requestsInFlight.delete( userLogin );
+			requestsInFlight.delete( userLoginOrId );
 			dispatch( {
 				type: READER_USER_REQUEST_FAILURE,
-				userLogin,
+				userLogin: userLoginOrId,
 				error,
 			} );
 		}

--- a/client/state/reader/users/actions.js
+++ b/client/state/reader/users/actions.js
@@ -14,7 +14,7 @@ export function requestUser( userLoginOrId, findById = false ) {
 			return;
 		}
 
-		dispatch( { type: READER_USER_REQUEST, userLoginOrId } );
+		dispatch( { type: READER_USER_REQUEST, userLogin: userLoginOrId } );
 		requestsInFlight.add( userLoginOrId );
 
 		try {

--- a/client/state/selectors/get-reader-user.ts
+++ b/client/state/selectors/get-reader-user.ts
@@ -14,9 +14,11 @@ export default function getReaderUser(
 	findById?: boolean | undefined
 ): UserData | undefined {
 	if ( findById ) {
-		return ( Object.values( state.reader.users.items ) as UserData[] ).find( ( user ) => {
-			return Number( user.ID ) === Number( userIdOrLogin );
-		} );
+		return (
+			( Object.values( state.reader.users.items ) as ( UserData | null )[] ).find( ( user ) => {
+				return Number( user?.ID ) === Number( userIdOrLogin );
+			} ) ?? undefined
+		);
 	}
 	return state.reader.users.items[ userIdOrLogin ];
 }

--- a/client/state/selectors/get-reader-user.ts
+++ b/client/state/selectors/get-reader-user.ts
@@ -1,0 +1,22 @@
+import { UserData } from 'calypso/lib/user/user';
+import { AppState } from 'calypso/types';
+
+/**
+ * Get the progress details of a restore for a specified site
+ * @param {AppState} state Global state tree
+ * @param {number | string} userIdOrLogin id or login of user
+ * @param {?boolean} findById if true, find the user by id
+ * @returns {UserData} User details
+ */
+export default function getReaderUser(
+	state: AppState,
+	userIdOrLogin: number | string,
+	findById?: boolean | undefined
+): UserData | undefined {
+	if ( findById ) {
+		return ( Object.values( state.reader.users.items ) as UserData[] ).find( ( user ) => {
+			return Number( user.ID ) === Number( userIdOrLogin );
+		} );
+	}
+	return state.reader.users.items[ userIdOrLogin ];
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/loop/issues/369

## Proposed Changes

Allows use of a `/reader/users/id/{userId}` route that will then replace with `/reader/users/{username}` once the data is retrieved for the user.
* updates the action for `requestUser` to optionally request by id.
* creates a selector for the get-reader-user and uses this in the connect function of the user profile page.
* other related changes to accomadate this

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So we can easily link to a reader profile from places where we don't easily have access to user_login but have the id.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the reader profile works as it did before.
* Verify there are no flashes of 'user not found' in the loading state.
* Verify going to /reader/users/id/{userId} directs to the correct user, loads properly, and replaces the url state in history with the updated login route value. (eg try /reader/users/5 vs. /reader/users/id/5)
* Verify there are no issues with trying inputs that will have an error response (e.g. /reader/users/id/foobar).
* Try to break it, test around.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
