### PR TITLE
Subscribers popover: Return null instead of false, to prevent destructuring error

### DIFF
--- a/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
@@ -72,16 +72,16 @@ const SubscribersHeaderPopover = ( {
 				className="subscriber-popover"
 				focusOnShow={ false }
 			>
-				{ hasSubscribers && (
+				{ hasSubscribers ? (
 					<PopoverMenuItem href={ downloadCsvLink } onClick={ onDownloadCsvClick }>
 						{ translate( 'Download subscribers as CSV' ) }
 					</PopoverMenuItem>
-				) }
-				{ hasMultipleSites && (
+				) : null }
+				{ hasMultipleSites ? (
 					<PopoverMenuItem onClick={ openMigrateSubscribersModal }>
 						{ translate( 'Migrate subscribers from another WordPress.com site' ) }
 					</PopoverMenuItem>
-				) }
+				) : null }
 			</PopoverMenu>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Return `null` instead of `false` so that React doesn't attempt to destructure non-existing props.

Before:

<img width="1915" alt="Screen Shot 2025-02-20 at 1 49 30 PM" src="https://github.com/user-attachments/assets/3ae99e3f-dcfc-4e76-a7a4-434667e8cfd2" />

After:

<img width="1632" alt="Screen Shot 2025-02-20 at 1 49 41 PM" src="https://github.com/user-attachments/assets/c9b6e87e-e86e-4ac1-8f0c-d9cddd3a9412" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix a bug.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Tricky to test, I'm only seeing it on one test site. It's definitely on /subscribers when there are no subscribers.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
