### PR TITLE
Create Course Goal:  Automatically install sensei when the user selects "create course" goal

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-install-by-goal/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-install-by-goal/index.tsx
@@ -1,0 +1,45 @@
+import { StepContainer } from '@automattic/onboarding';
+import { useI18n } from '@wordpress/react-i18n';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { usePluginAutoInstallation } from 'calypso/landing/stepper/hooks/use-plugin-auto-installation';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+import './style.scss';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+
+const BundleInstallByGoal: Step = ( { navigation } ) => {
+	const { goBack } = navigation;
+	const { __ } = useI18n();
+	const site = useSite();
+
+	const { status } = usePluginAutoInstallation(
+		{
+			slug: 'sensei',
+			name: 'Sensei LMS',
+		},
+		site?.ID
+	);
+
+	console.log( 'SITE', site );
+
+	return (
+		<StepContainer
+			stepName="bundle-confirm"
+			goBack={ goBack }
+			hideSkip
+			isHorizontalLayout
+			formattedHeader={
+				<FormattedHeader
+					id="bundle-confirm-title-header"
+					headerText={ __( 'Install plugins' ) }
+					subHeaderText={ __( 'Install plugins to create your course goal' ) }
+					align="left"
+				/>
+			}
+			stepContent={ <div>Hello</div> }
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default BundleInstallByGoal;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-install-by-goal/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-install-by-goal/style.scss
@@ -1,0 +1,135 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+body.is-section-stepper {
+	// Two column layout.
+	.step-container.bundle-confirm {
+		@media (min-width: 660px) {
+			display: flex;
+		}
+
+		.step-container__header {
+			@media (min-width: 660px) {
+				margin-top: 0 !important;
+			}
+
+			.formatted-header {
+				text-align: inherit;
+
+				@media (min-width: 1024px) {
+					margin-left: 24px;
+				}
+
+				.formatted-header__title {
+					text-align: inherit;
+
+					@media (max-width: 660px) {
+						padding: 0 10px 0 0;
+					}
+				}
+
+				.formatted-header__subtitle {
+					@media (max-width: 660px) {
+						margin-top: 8px;
+						padding: 0 10px 0 0;
+					}
+
+					margin-top: 20px;
+					text-align: inherit;
+					max-width: 448px;
+				}
+			}
+		}
+
+		.step-container__content {
+			@media (min-width: 660px) {
+				display: flex;
+				margin: 0 24px;
+			}
+
+			.bundle-confirm__instructions-container {
+				font-size: 0.875rem;
+				letter-spacing: -0.16px;
+				color: var(--studio-gray-60);
+				flex-direction: column;
+				max-width: 520px;
+
+				@media (max-width: 660px) {
+					max-width: 90vw;
+				}
+
+				p {
+					margin-top: 16px;
+				}
+
+				.bundle-confirm__upgrade-required {
+					margin-top: 1rem;
+				}
+
+				.components-base-control {
+					font-size: $default-font-size;
+					line-height: $default-line-height;
+					margin-bottom: $grid-unit-30;
+
+					.components-base-control__label,
+					.components-input-control__label {
+						font-size: $editor-font-size;
+						margin-bottom: $grid-unit;
+						padding: 0;
+					}
+
+					.components-checkbox-control__label,
+					.components-select-control__input,
+					.components-text-control__input,
+					.components-combobox-control__input {
+						color: var(--color-neutral-70);
+					}
+
+					.components-combobox-control__suggestions-container,
+					.components-select-control__input,
+					.components-text-control__input {
+						line-height: 18px;
+						padding: $grid-unit-15 $grid-unit-20;
+					}
+
+					.components-select-control__input {
+						box-sizing: initial;
+						height: auto;
+						line-height: 20px;
+						min-height: auto;
+					}
+
+					.components-combobox-control__input {
+						padding: 0;
+					}
+				}
+
+				.components-text-control__input {
+					box-sizing: border-box;
+				}
+			}
+		}
+	}
+}
+
+.site-setup.bundle-confirm {
+	.bundle-confirm__loading-container,
+	.bundle-confirm__info-section {
+		display: flex;
+		justify-content: center;
+	}
+
+	.bundle-confirm__loading-container {
+		margin-top: 25vh;
+
+		@include break-small {
+			margin-top: 45vh;
+		}
+
+		.wpcom__loading-ellipsis {
+			display: block;
+			margin: 0 auto;
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx
@@ -36,6 +36,7 @@ export const transferStates = {
 const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
 
 const BundleTransfer: Step = function BundleTransfer( { navigation, flow } ) {
+	console.log( 'BundleTransfer' );
 	const { submit } = navigation;
 	const { setPendingAction, setProgress } = useDispatch( ONBOARD_STORE );
 	const { requestAtomicSoftwareStatus, requestLatestAtomicTransfer, initiateAtomicTransfer } =

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/check-for-plugins/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/check-for-plugins/index.tsx
@@ -15,7 +15,7 @@ const CheckForPlugins: Step = function CheckForPlugins( { navigation } ) {
 
 	useEffect( () => {
 		if ( ! site || ! checkForActivePlugins ) {
-			return;
+			submit?.( { hasPlugins: false } );
 		}
 
 		const checkForPlugins = async () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-theme-software-sets/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/get-current-theme-software-sets/index.tsx
@@ -34,7 +34,7 @@ const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep(
 	const [ hasRequested, setHasRequested ] = useState( false );
 
 	const reduxDispatch = useReduxDispatch();
-	const { goNext } = navigation;
+	const { goNext, submit } = navigation;
 	useEffect( () => {
 		if ( site?.ID && ! hasRequested ) {
 			debug( 'Dispatching requests for active theme and features' );
@@ -65,7 +65,7 @@ const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep(
 	useQueryTheme( 'wpcom', currentThemeId );
 
 	useEffect( () => {
-		debug(
+		console.log(
 			'Deciding to redirect, proceed, or wait',
 			JSON.stringify( { hasRequested, isRequestingActiveTheme, currentThemeId: currentTheme?.id } )
 		);
@@ -81,6 +81,7 @@ const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep(
 						siteSlug,
 					} )
 				);
+				console.log( 'GO NEXT' );
 				goNext?.();
 			} else {
 				debug(
@@ -92,8 +93,7 @@ const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep(
 					} )
 				);
 
-				// Current theme has no bundled plugins; they shouldn't be in this flow
-				window.location.replace( `/home/${ siteSlug }` );
+				submit?.( { hasNoBundledSoftware: true } );
 			}
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -115,7 +115,7 @@ const GetCurrentThemeSoftwareSets: Step = function GetCurrentBundledPluginsStep(
 					hasLoadedSiteFeatures,
 				} )
 			);
-			window.location.replace( `/home/${ siteSlug }` );
+			// window.location.replace( `/home/${ siteSlug }` );
 		}
 	}, [
 		isPluginBundleEligible,

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -1,4 +1,4 @@
-import { Onboard, getThemeIdFromStylesheet } from '@automattic/data-stores';
+import { Onboard, getThemeIdFromStylesheet, useSiteIntent } from '@automattic/data-stores';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useDispatch as reduxDispatch } from 'calypso/state';
 import { WRITE_INTENT_DEFAULT_DESIGN } from '../constants';
@@ -9,6 +9,7 @@ import { useSitePluginSlug } from '../hooks/use-site-plugin-slug';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { useCanUserManageOptions } from '../hooks/use-user-can-manage-options';
 import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../stores';
+import BundleInstallByGoal from './internals/steps-repository/bundle-install-by-goal';
 import { redirect } from './internals/steps-repository/import/util';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
 import {
@@ -42,19 +43,20 @@ const pluginBundleFlow: FlowV1 = {
 
 	useSteps() {
 		const pluginSlug = useSitePluginSlug();
+		console.log( 'PLUGIN SLUG', pluginSlug );
 
 		let bundlePluginSteps: StepperStep[] = [];
 
-		if ( pluginSlug && bundleStepsSettings.hasOwnProperty( pluginSlug ) ) {
-			bundlePluginSteps = [
-				...beforeCustomBundleSteps,
-				...bundleStepsSettings[ pluginSlug ].customSteps,
-				...afterCustomBundleSteps,
-			];
-		}
+		bundlePluginSteps = [
+			...beforeCustomBundleSteps,
+			...( bundleStepsSettings[ pluginSlug ]?.customSteps || [] ),
+			{ slug: 'bundle-install-by-goal', component: BundleInstallByGoal },
+			...afterCustomBundleSteps,
+		];
 		return [ ...initialBundleSteps, ...bundlePluginSteps ];
 	},
 	useStepNavigation( currentStep, navigate ) {
+		console.log( 'USE STEP NAVIGATION', currentStep );
 		const steps = this.useSteps();
 		const intent = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
@@ -134,7 +136,9 @@ const pluginBundleFlow: FlowV1 = {
 						);
 					}
 
-					Promise.all( pendingActions ).then( () => window.location.assign( to ) );
+					Promise.all( pendingActions ).then( () => {
+						return window.location.assign( to );
+					} );
 				} );
 			} );
 
@@ -145,6 +149,7 @@ const pluginBundleFlow: FlowV1 = {
 		};
 
 		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
+			console.log( 'SUBMIT', currentStep );
 			let defaultExitDest = `/home/${ siteSlug }`;
 
 			if ( siteDetails?.options?.theme_slug ) {
@@ -170,6 +175,15 @@ const pluginBundleFlow: FlowV1 = {
 			}
 
 			switch ( currentStep ) {
+
+				case 'checkForPlugins': {
+					console.log( 'CHECK FOR PLUGINS', providedDependencies );
+					if ( providedDependencies?.hasPlugins ) {
+						return exitFlow( defaultExitDest );
+					}
+
+					return navigate( 'bundleTransfer' );
+				}
 				case 'bundleConfirm': {
 					const [ checkoutUrl ] = params;
 
@@ -179,6 +193,20 @@ const pluginBundleFlow: FlowV1 = {
 
 					return navigate( 'bundleTransfer' );
 				}
+				case 'getCurrentThemeSoftwareSets': {
+					const { hasNoBundledSoftware } = providedDependencies as {
+						hasNoBundledSoftware: boolean;
+					};
+
+					console.log( { hasNoBundledSoftware, intent } );
+					if ( ! hasNoBundledSoftware || intent === SiteIntent.CreateCourseGoal ) {
+						return navigate( 'bundleConfirm' );
+					}
+
+					return navigate( nextStep! );
+				}
+
+
 				case 'processing': {
 					const processingResult = params[ 0 ] as ProcessingResult;
 
@@ -193,6 +221,12 @@ const pluginBundleFlow: FlowV1 = {
 						}
 
 						return exitFlow( `/post/${ siteSlug }` );
+					}
+
+					console.log( 'INTENT', intent );
+					if ( intent === SiteIntent.CreateCourseGoal ) {
+						console.log( 'Navigating to bundle-install-by-goal' );
+						return navigate( 'bundle-install-by-goal' );
 					}
 
 					// Custom end of flow.
@@ -236,6 +270,7 @@ const pluginBundleFlow: FlowV1 = {
 		};
 
 		const goNext = () => {
+			console.log( 'GO NEXT 2', currentStep );
 			switch ( currentStep ) {
 				// TODO - Do we need anything here?
 				default:
@@ -287,20 +322,21 @@ const pluginBundleFlow: FlowV1 = {
 			};
 		}
 
-		const { canManageOptions, isLoading } = useCanUserManageOptions();
-		if ( isLoading ) {
-			result = {
-				state: AssertConditionState.CHECKING,
-			};
-		} else if ( canManageOptions === false ) {
-			redirect( '/start' );
-			result = {
-				state: AssertConditionState.FAILURE,
-				message:
-					'site-setup the user needs to have the manage_options capability to go through the flow.',
-			};
-		}
+		// const { canManageOptions, isLoading } = useCanUserManageOptions();
+		// if ( isLoading ) {
+		// 	result = {
+		// 		state: AssertConditionState.CHECKING,
+		// 	};
+		// } else if ( canManageOptions === false ) {
+		// 	redirect( '/start' );
+		// 	result = {
+		// 		state: AssertConditionState.FAILURE,
+		// 		message:
+		// 			'site-setup the user needs to have the manage_options capability to go through the flow.',
+		// 	};
+		// }
 
+		// console.log( 'ASSERT CONDITIONS', result, canManageOptions, isLoading );
 		return result;
 	},
 };

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -295,6 +295,11 @@ const siteSetupFlow: FlowV1 = {
 						return exitFlow( `/setup/plugin-bundle/?siteSlug=${ siteSlug }` );
 					}
 
+					console.log( 'Site setup flow', { intent } );
+					if ( intent === SiteIntent.CreateCourseGoal ) {
+						return exitFlow( `/setup/plugin-bundle/?siteSlug=${ siteSlug }` );
+					}
+
 					if ( isLaunchpadIntent( intent ) ) {
 						initializeLaunchpadState( { siteId, siteSlug } );
 						const url = getPostFlowUrl( { flow: intent, siteId, siteSlug } );

--- a/client/landing/stepper/hooks/use-user-can-manage-options.ts
+++ b/client/landing/stepper/hooks/use-user-can-manage-options.ts
@@ -1,15 +1,18 @@
+import { useSelect } from '@wordpress/data';
 import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import { useSiteData } from './use-site-data';
+import { useSite } from './use-site';
 
 export function useCanUserManageOptions() {
-	const { site, siteSlugOrId } = useSiteData();
-	const canManageOptions = useSelector( ( state ) =>
-		canCurrentUser( state, site?.ID, 'manage_options' )
+	const site = useSite();
+	const canManageOptions = useSelect(
+		( state ) => ( site ? canCurrentUser( state, site?.ID, 'manage_options' ) : null ),
+		[ site?.ID ]
 	);
+	console.log( { site } );
 
 	return {
 		canManageOptions,
-		isLoading: siteSlugOrId && ! site,
+		isLoading: ! site,
 	};
 }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -171,9 +171,7 @@ export function useThemesThankYouData(
 	// Redirect to the plugin bundle flow after the activation.
 	useEffect( () => {
 		if ( isActive && continueWithPluginBundle ) {
-			page(
-				`/setup/plugin-bundle/getCurrentThemeSoftwareSets?siteId=${ siteId }&siteSlug=${ siteSlug }`
-			);
+			page( `/setup/plugin-bundle/?siteId=${ siteId }&siteSlug=${ siteSlug }` );
 		}
 	}, [ isActive, continueWithPluginBundle, siteId, siteSlug ] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
