### PR TITLE
Design first Do not show designs which require Atomic in the goals-first flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -215,6 +215,19 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					design.style_variations = [];
 					return design;
 				} );
+		} else if ( isGoalsAtFrontExperiment ) {
+			// We don't need to clear style variations in the Goals First experiment
+			// because they don't block site creation and have in-product notifications
+			// that a plan is required. However we do need to hide themes that require
+			// Atomic, as the Goals First flow doesn't support transferring immediately
+			// post-checkout.
+			allDesigns.designs = allDesigns.designs.filter(
+				( design ) =>
+					! (
+						design?.design_tier === THEME_TIER_PARTNER ||
+						( design.software_sets && design.software_sets.length > 0 )
+					)
+			);
 		}
 
 		return allDesigns;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Raised in pbxlJb-6S8-p2
Related to #

## Proposed Changes

* Hides partner designs, and designs which require software (e.g. sensei or woo) from the goals-first design picker

**Before**
![CleanShot 2025-02-21 at 10 40 50@2x](https://github.com/user-attachments/assets/b55900ef-8c5f-4534-bf72-e9550e13a64c)

**After**
![CleanShot 2025-02-21 at 10 40 25@2x](https://github.com/user-attachments/assets/81c6c7e2-58d9-4ffa-a2c5-4697ff022d87)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?