### PR TITLE
Newsletter Dashboard Widget: add newsletter-widget package

### DIFF
--- a/apps/newsletter/package.json
+++ b/apps/newsletter/package.json
@@ -28,9 +28,9 @@
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/wp-babel-makepot": "workspace:^",
 		"@wordpress/dependency-extraction-webpack-plugin": "^6.14.0",
-		"mkdirp": "^3.0.1",
-		"postcss": "^8.5.3",
-		"webpack": "^5.98.0"
+		"mkdirp": "^1.0.4",
+		"postcss": "^8.5.1",
+		"webpack": "^5.97.1"
 	},
 	"repository": {
 		"type": "git",

--- a/apps/newsletter/package.json
+++ b/apps/newsletter/package.json
@@ -1,10 +1,8 @@
 {
-	"name": "@automattic/newsletter",
+	"name": "@automattic/newsletter-app",
 	"version": "1.0.0",
 	"description": "The Newsletter widget.",
-	"calypso:src": "src/index.js",
-	"main": "dist/build.min.js",
-	"module": "dist/build.esm.js",
+	"main": "dist/newsletter.min.js",
 	"sideEffects": true,
 	"author": "Automattic Inc.",
 	"license": "GPL-2.0-or-later",
@@ -17,36 +15,26 @@
 		"build": "NODE_ENV=production yarn dev",
 		"build:newsletter": "calypso-build",
 		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/newsletter",
-		"teamcity:build-app": "yarn run build",
-		"translate": "rm -rf dist/strings && mkdirp dist && wp-babel-makepot '../../{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base '../../' --dir './dist/strings' --output './dist/whats-new-strings.pot' && build-app-languages --stringsFilePath='./dist/whats-new-strings.pot'"
+		"teamcity:build-app": "yarn run build && yarn run translate",
+		"translate": "rm -rf dist/strings && mkdirp dist && wp-babel-makepot '../../{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base '../../' --dir './dist/strings' --output './dist/newsletter-strings.pot' && build-app-languages --stringsFilePath='./dist/newsletter-strings.pot'"
 	},
 	"dependencies": {
-		"@automattic/newsletter": "workspace:^",
+		"@automattic/newsletter-widget": "workspace:^",
 		"@wordpress/element": "^6.16.0",
-		"@wordpress/i18n": "^5.16.0",
-		"i18n-calypso": "workspace:^",
-		"mkdirp": "npm:^3.0.1",
-		"postcss": "^8.5.2",
 		"react": "^18.2.0"
 	},
 	"devDependencies": {
 		"@automattic/calypso-apps-builder": "workspace:^",
 		"@automattic/calypso-build": "workspace:^",
-		"@automattic/calypso-typescript-config": "workspace:^",
 		"@automattic/wp-babel-makepot": "workspace:^",
 		"@wordpress/dependency-extraction-webpack-plugin": "^6.14.0",
-		"webpack": "^5.97.1"
+		"mkdirp": "^3.0.1",
+		"postcss": "^8.5.3",
+		"webpack": "^5.98.0"
 	},
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Automattic/wp-calypso.git",
-		"directory": "packages/your-package"
-	},
-	"publishConfig": {
-		"access": "public"
-	},
-	"files": [
-		"dist",
-		"src"
-	]
+		"directory": "apps/newsletter"
+	}
 }

--- a/apps/newsletter/src/index.js
+++ b/apps/newsletter/src/index.js
@@ -1,23 +1,9 @@
-/* global __i18n_text_domain__ */
-
+import { NewsletterWidget } from '@automattic/newsletter-widget';
 import { createRoot } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-
-function Newsletter() {
-	return (
-		<div className="flex items-center justify-center h-screen bg-gray-100">
-			<h1 className="text-4xl font-bold text-gray-800">
-				{ __( 'This is the placeholder for the newsletter widget', __i18n_text_domain__ ) }
-			</h1>
-		</div>
-	);
-}
 
 // Mount the React component to the DOM
 const container = document.getElementById( 'newsletter-widget-app' );
 if ( container ) {
 	const root = createRoot( container );
-	root.render( <Newsletter /> );
+	root.render( <NewsletterWidget /> );
 }
-
-export default Newsletter;

--- a/apps/newsletter/webpack.config.js
+++ b/apps/newsletter/webpack.config.js
@@ -23,6 +23,9 @@ function getWebpackConfig( env = {}, argv = {} ) {
 			filename: '[name].min.js',
 		},
 		plugins: [
+			...webpackConfig.plugins.filter(
+				( plugin ) => plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'
+			),
 			new webpack.DefinePlugin( {
 				__i18n_text_domain__: JSON.stringify( 'newsletter-widget' ),
 			} ),

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/languages": "workspace:^",
 		"@automattic/launchpad": "workspace:^",
+		"@automattic/newsletter-widget": "workspace:^",
 		"@automattic/plans-grid-next": "workspace:^",
 		"@automattic/privacy-toolset": "workspace:^",
 		"@automattic/typography": "workspace:^",

--- a/packages/newsletter-widget/README.md
+++ b/packages/newsletter-widget/README.md
@@ -1,0 +1,11 @@
+# Newsletter Widget
+
+Renders relevant newsletter data in a widget.
+
+## Usage
+
+```jsx
+import { NewsletterWidget } from '@automattic/newsletter-widget';
+
+<NewsletterWidget />;
+```

--- a/packages/newsletter-widget/package.json
+++ b/packages/newsletter-widget/package.json
@@ -1,0 +1,41 @@
+{
+	"name": "@automattic/newsletter-widget",
+	"version": "1.0.0",
+	"description": "Renders relevant newsletter data in a widget.",
+	"calypso:src": "src/index.ts",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"sideEffects": [
+		"*.css",
+		"*.scss"
+	],
+	"keywords": [
+		"wordpress",
+		"newsletters",
+		"widget"
+	],
+	"author": "Automattic Inc.",
+	"contributors": [],
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"license": "GPL-2.0-or-later",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/newsletter-widget"
+	},
+	"private": true,
+	"bugs": {
+		"url": "https://github.com/Automattic/wp-calypso/issues"
+	},
+	"types": "dist/types",
+	"scripts": {
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets",
+		"prepack": "yarn run clean && yarn run build",
+		"watch": "tsc --build ./tsconfig.json --watch"
+	},
+	"devDependencies": {
+		"@automattic/calypso-typescript-config": "workspace:^",
+		"typescript": "^5.7.3"
+	}
+}

--- a/packages/newsletter-widget/package.json
+++ b/packages/newsletter-widget/package.json
@@ -36,6 +36,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.7.3"
+		"typescript": "^5.3.3"
 	}
 }

--- a/packages/newsletter-widget/src/index.ts
+++ b/packages/newsletter-widget/src/index.ts
@@ -1,0 +1,1 @@
+export * from './newsletter-widget';

--- a/packages/newsletter-widget/src/newsletter-widget.tsx
+++ b/packages/newsletter-widget/src/newsletter-widget.tsx
@@ -1,0 +1,5 @@
+import './styles.scss';
+
+export const NewsletterWidget = () => {
+	return <h1 className="newsletter-widget">Hello Newsletters</h1>;
+};

--- a/packages/newsletter-widget/src/styles.scss
+++ b/packages/newsletter-widget/src/styles.scss
@@ -1,0 +1,3 @@
+.newsletter-widget {
+	color: #ff6347;
+}

--- a/packages/newsletter-widget/test/index.ts
+++ b/packages/newsletter-widget/test/index.ts
@@ -1,0 +1,7 @@
+import { NewsletterWidget } from '../src';
+
+describe( 'NewsletterWidget', () => {
+	it( 'should be defined', () => {
+		expect( NewsletterWidget ).toBeDefined();
+	} );
+} );

--- a/packages/newsletter-widget/tsconfig-cjs.json
+++ b/packages/newsletter-widget/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"outDir": "dist/cjs"
+	}
+}

--- a/packages/newsletter-widget/tsconfig.json
+++ b/packages/newsletter-widget/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "@automattic/calypso-typescript-config/ts-package.json",
+	"compilerOptions": {
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src"
+	},
+	"include": [ "src" ],
+	"exclude": [ "**/test/*" ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1424,23 +1424,29 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/newsletter@workspace:^, @automattic/newsletter@workspace:apps/newsletter":
+"@automattic/newsletter-app@workspace:apps/newsletter":
   version: 0.0.0-use.local
-  resolution: "@automattic/newsletter@workspace:apps/newsletter"
+  resolution: "@automattic/newsletter-app@workspace:apps/newsletter"
   dependencies:
     "@automattic/calypso-apps-builder": "workspace:^"
     "@automattic/calypso-build": "workspace:^"
-    "@automattic/calypso-typescript-config": "workspace:^"
-    "@automattic/newsletter": "workspace:^"
+    "@automattic/newsletter-widget": "workspace:^"
     "@automattic/wp-babel-makepot": "workspace:^"
     "@wordpress/dependency-extraction-webpack-plugin": "npm:^6.14.0"
     "@wordpress/element": "npm:^6.16.0"
-    "@wordpress/i18n": "npm:^5.16.0"
-    i18n-calypso: "workspace:^"
     mkdirp: "npm:^3.0.1"
-    postcss: "npm:^8.5.2"
+    postcss: "npm:^8.5.3"
     react: "npm:^18.2.0"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
+  languageName: unknown
+  linkType: soft
+
+"@automattic/newsletter-widget@workspace:^, @automattic/newsletter-widget@workspace:packages/newsletter-widget":
+  version: 0.0.0-use.local
+  resolution: "@automattic/newsletter-widget@workspace:packages/newsletter-widget"
+  dependencies:
+    "@automattic/calypso-typescript-config": "workspace:^"
+    typescript: "npm:^5.7.3"
   languageName: unknown
   linkType: soft
 
@@ -28501,7 +28507,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.2.4, postcss@npm:^8.3.11, postcss@npm:^8.3.5, postcss@npm:^8.4.21, postcss@npm:^8.4.33, postcss@npm:^8.4.5, postcss@npm:^8.5.1, postcss@npm:^8.5.2":
+"postcss@npm:^8.2.4, postcss@npm:^8.3.11, postcss@npm:^8.3.5, postcss@npm:^8.4.21, postcss@npm:^8.4.33, postcss@npm:^8.4.5, postcss@npm:^8.5.1":
   version: 8.5.2
   resolution: "postcss@npm:8.5.2"
   dependencies:
@@ -28509,6 +28515,17 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 3044d49bc725029ab62292e8bf9849741251b95f3b754e191bf8b4025414d40ec3b4ac05c5a563d4b50060b5c8e96683eb4d783d8d8fa3867eb7b763cbe66127
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.5.3":
+  version: 8.5.3
+  resolution: "postcss@npm:8.5.3"
+  dependencies:
+    nanoid: "npm:^3.3.8"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: b75510d7b28c3ab728c8733dd01538314a18c52af426f199a3c9177e63eb08602a3938bfb66b62dc01350b9aed62087eabbf229af97a1659eb8d3513cec823b3
   languageName: node
   linkType: hard
 
@@ -34289,6 +34306,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^5.7.3":
+  version: 5.7.3
+  resolution: "typescript@npm:5.7.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: b7580d716cf1824736cc6e628ab4cd8b51877408ba2be0869d2866da35ef8366dd6ae9eb9d0851470a39be17cbd61df1126f9e211d8799d764ea7431d5435afa
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>":
   version: 5.3.3
   resolution: "typescript@patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>::version=5.3.3&hash=e012d7"
@@ -34296,6 +34323,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 1d0a5f4ce496c42caa9a30e659c467c5686eae15d54b027ee7866744952547f1be1262f2d40de911618c242b510029d51d43ff605dba8fb740ec85ca2d3f9500
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^5.7.3#optional!builtin<compat/typescript>":
+  version: 5.7.3
+  resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=e012d7"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 3b56d6afa03d9f6172d0b9cdb10e6b1efc9abc1608efd7a3d2f38773d5d8cfb9bbc68dfb72f0a7de5e8db04fc847f4e4baeddcd5ad9c9feda072234f0d788896
   languageName: node
   linkType: hard
 
@@ -35643,6 +35680,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webpack@npm:^5.98.0":
+  version: 5.98.0
+  resolution: "webpack@npm:5.98.0"
+  dependencies:
+    "@types/eslint-scope": "npm:^3.7.7"
+    "@types/estree": "npm:^1.0.6"
+    "@webassemblyjs/ast": "npm:^1.14.1"
+    "@webassemblyjs/wasm-edit": "npm:^1.14.1"
+    "@webassemblyjs/wasm-parser": "npm:^1.14.1"
+    acorn: "npm:^8.14.0"
+    browserslist: "npm:^4.24.0"
+    chrome-trace-event: "npm:^1.0.2"
+    enhanced-resolve: "npm:^5.17.1"
+    es-module-lexer: "npm:^1.2.1"
+    eslint-scope: "npm:5.1.1"
+    events: "npm:^3.2.0"
+    glob-to-regexp: "npm:^0.4.1"
+    graceful-fs: "npm:^4.2.11"
+    json-parse-even-better-errors: "npm:^2.3.1"
+    loader-runner: "npm:^4.2.0"
+    mime-types: "npm:^2.1.27"
+    neo-async: "npm:^2.6.2"
+    schema-utils: "npm:^4.3.0"
+    tapable: "npm:^2.1.1"
+    terser-webpack-plugin: "npm:^5.3.11"
+    watchpack: "npm:^2.4.1"
+    webpack-sources: "npm:^3.2.3"
+  peerDependenciesMeta:
+    webpack-cli:
+      optional: true
+  bin:
+    webpack: bin/webpack.js
+  checksum: bee4fa77f444802f0beafb2ff30eb5454a606163ad7d3cc9a5dcc9d24033c62407bed04601b25dea49ea3969b352c1b530a86c753246f42560a4a084eefb094e
+  languageName: node
+  linkType: hard
+
 "websocket-driver@npm:>=0.5.1, websocket-driver@npm:^0.7.4":
   version: 0.7.4
   resolution: "websocket-driver@npm:0.7.4"
@@ -35938,6 +36011,7 @@ __metadata:
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/languages": "workspace:^"
     "@automattic/launchpad": "workspace:^"
+    "@automattic/newsletter-widget": "workspace:^"
     "@automattic/plans-grid-next": "workspace:^"
     "@automattic/privacy-toolset": "workspace:^"
     "@automattic/typography": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1434,10 +1434,10 @@ __metadata:
     "@automattic/wp-babel-makepot": "workspace:^"
     "@wordpress/dependency-extraction-webpack-plugin": "npm:^6.14.0"
     "@wordpress/element": "npm:^6.16.0"
-    mkdirp: "npm:^3.0.1"
-    postcss: "npm:^8.5.3"
+    mkdirp: "npm:^1.0.4"
+    postcss: "npm:^8.5.1"
     react: "npm:^18.2.0"
-    webpack: "npm:^5.98.0"
+    webpack: "npm:^5.97.1"
   languageName: unknown
   linkType: soft
 
@@ -26055,15 +26055,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "mkdirp@npm:3.0.1"
-  bin:
-    mkdirp: dist/cjs/src/bin.js
-  checksum: 9f2b975e9246351f5e3a40dcfac99fcd0baa31fbfab615fe059fb11e51f10e4803c63de1f384c54d656e4db31d000e4767e9ef076a22e12a641357602e31d57d
-  languageName: node
-  linkType: hard
-
 "mock-fs@npm:^5.4.1":
   version: 5.5.0
   resolution: "mock-fs@npm:5.5.0"
@@ -28515,17 +28506,6 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 3044d49bc725029ab62292e8bf9849741251b95f3b754e191bf8b4025414d40ec3b4ac05c5a563d4b50060b5c8e96683eb4d783d8d8fa3867eb7b763cbe66127
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.3":
-  version: 8.5.3
-  resolution: "postcss@npm:8.5.3"
-  dependencies:
-    nanoid: "npm:^3.3.8"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: b75510d7b28c3ab728c8733dd01538314a18c52af426f199a3c9177e63eb08602a3938bfb66b62dc01350b9aed62087eabbf229af97a1659eb8d3513cec823b3
   languageName: node
   linkType: hard
 
@@ -35677,42 +35657,6 @@ __metadata:
   bin:
     webpack: bin/webpack.js
   checksum: a12d3dc882ca582075f2c4bd88840be8307427245c90a8a0e0b372d73560df13fcf25a61625c9e7edc964981d16b5a8323640562eb48347cf9dd2f8bd1b39d35
-  languageName: node
-  linkType: hard
-
-"webpack@npm:^5.98.0":
-  version: 5.98.0
-  resolution: "webpack@npm:5.98.0"
-  dependencies:
-    "@types/eslint-scope": "npm:^3.7.7"
-    "@types/estree": "npm:^1.0.6"
-    "@webassemblyjs/ast": "npm:^1.14.1"
-    "@webassemblyjs/wasm-edit": "npm:^1.14.1"
-    "@webassemblyjs/wasm-parser": "npm:^1.14.1"
-    acorn: "npm:^8.14.0"
-    browserslist: "npm:^4.24.0"
-    chrome-trace-event: "npm:^1.0.2"
-    enhanced-resolve: "npm:^5.17.1"
-    es-module-lexer: "npm:^1.2.1"
-    eslint-scope: "npm:5.1.1"
-    events: "npm:^3.2.0"
-    glob-to-regexp: "npm:^0.4.1"
-    graceful-fs: "npm:^4.2.11"
-    json-parse-even-better-errors: "npm:^2.3.1"
-    loader-runner: "npm:^4.2.0"
-    mime-types: "npm:^2.1.27"
-    neo-async: "npm:^2.6.2"
-    schema-utils: "npm:^4.3.0"
-    tapable: "npm:^2.1.1"
-    terser-webpack-plugin: "npm:^5.3.11"
-    watchpack: "npm:^2.4.1"
-    webpack-sources: "npm:^3.2.3"
-  peerDependenciesMeta:
-    webpack-cli:
-      optional: true
-  bin:
-    webpack: bin/webpack.js
-  checksum: bee4fa77f444802f0beafb2ff30eb5454a606163ad7d3cc9a5dcc9d24033c62407bed04601b25dea49ea3969b352c1b530a86c753246f42560a4a084eefb094e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1446,7 +1446,7 @@ __metadata:
   resolution: "@automattic/newsletter-widget@workspace:packages/newsletter-widget"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    typescript: "npm:^5.7.3"
+    typescript: "npm:^5.3.3"
   languageName: unknown
   linkType: soft
 
@@ -34286,16 +34286,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.7.3":
-  version: 5.7.3
-  resolution: "typescript@npm:5.7.3"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: b7580d716cf1824736cc6e628ab4cd8b51877408ba2be0869d2866da35ef8366dd6ae9eb9d0851470a39be17cbd61df1126f9e211d8799d764ea7431d5435afa
-  languageName: node
-  linkType: hard
-
 "typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>":
   version: 5.3.3
   resolution: "typescript@patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>::version=5.3.3&hash=e012d7"
@@ -34303,16 +34293,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 1d0a5f4ce496c42caa9a30e659c467c5686eae15d54b027ee7866744952547f1be1262f2d40de911618c242b510029d51d43ff605dba8fb740ec85ca2d3f9500
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A^5.7.3#optional!builtin<compat/typescript>":
-  version: 5.7.3
-  resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=e012d7"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 3b56d6afa03d9f6172d0b9cdb10e6b1efc9abc1608efd7a3d2f38773d5d8cfb9bbc68dfb72f0a7de5e8db04fc847f4e4baeddcd5ad9c9feda072234f0d788896
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/loop#501

## Proposed Changes

* Adds a newsletter widget package to Calypso to be consumed by the Calypso app
* This provides the flexibility to use the widget in Calypso directly, as described in pdDR7T-1Gn-p2
* Made some updates to the app
  * Styles are now built correctly and will end up at `widgets.wp.com`
  * Corrected some copy pasta

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Creating a packages for the Newsletter widget provides a way to be used across Calypso and wp-admin on simple and atomic sites. See pdDR7T-1Gn-p2 for the pattern.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

It's probably easiest to test the package locally at this point but also test the app is consuming the package correctly. I'll link to those instructions

**Package**
- Checkout to this branch.
- `cd packages/newsletter-widget`
- Run `yarn && yarn build`
- The package should build without errors
- You can also test importing the package into a Calypso page and render it locally if you want to see it visually

**App**
- Follow the guide in this post: pg9MHR-ox-p2
- Nothing should have changed about this part. This PR just moves the widget code into a package that the app consumes.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
