### PR TITLE
Add RDV checks to command palette for updated hosting-config routes

### DIFF
--- a/apps/command-palette-wp-admin/src/index.js
+++ b/apps/command-palette-wp-admin/src/index.js
@@ -5,7 +5,6 @@ import { render } from 'react-dom';
 import setLocale from './set-locale';
 import { useCommandsWpAdmin } from './use-commands';
 import { useSites } from './use-sites';
-
 function CommandPaletteApp() {
 	if ( ! window.commandPaletteConfig ) {
 		// Can't load the command palette without a config.
@@ -17,6 +16,7 @@ function CommandPaletteApp() {
 		isAtomic = false,
 		isSimple = false,
 		capabilities,
+		removeDuplicateViewsExperimentEnabled = false,
 	} = window?.commandPaletteConfig || {};
 
 	if ( ! isSimple && ! isAtomic ) {
@@ -41,6 +41,7 @@ function CommandPaletteApp() {
 				currentSiteId={ siteId }
 				useSites={ useSites }
 				userCapabilities={ userCapabilities }
+				removeDuplicateViewsExperimentEnabled={ removeDuplicateViewsExperimentEnabled }
 			/>
 		</QueryClientProvider>
 	);

--- a/client/layout/command-palette.tsx
+++ b/client/layout/command-palette.tsx
@@ -1,6 +1,7 @@
 import CommandPalette from '@automattic/command-palette';
 import { useSiteExcerptsSorted } from 'calypso/data/sites/use-site-excerpts-sorted';
 import { navigate } from 'calypso/lib/navigate';
+import { useRemoveDuplicateViewsExperimentEnabled } from 'calypso/lib/remove-duplicate-views-experiment';
 import { useCommandsCalypso } from 'calypso/sites-dashboard/components/wpcom-smp-commands';
 import { useDispatch, useSelector } from 'calypso/state';
 import { closeCommandPalette } from 'calypso/state/command-palette/actions';
@@ -28,7 +29,7 @@ const CalypsoCommandPalette = () => {
 	const currentSiteId = useSelector( getSelectedSiteId );
 	const userCapabilities = useSelector( getCurrentUserCapabilities );
 	const onClose = () => dispatch( closeCommandPalette() );
-
+	const removeDuplicateViewsExperimentEnabled = useRemoveDuplicateViewsExperimentEnabled();
 	return (
 		<CommandPalette
 			currentRoute={ currentRoutePattern }
@@ -39,6 +40,7 @@ const CalypsoCommandPalette = () => {
 			useCommands={ useCommandsCalypso }
 			useSites={ useSiteExcerptsSorted }
 			userCapabilities={ userCapabilities }
+			removeDuplicateViewsExperimentEnabled={ removeDuplicateViewsExperimentEnabled }
 		/>
 	);
 };

--- a/packages/command-palette/src/commands.tsx
+++ b/packages/command-palette/src/commands.tsx
@@ -57,6 +57,7 @@ export interface CommandCallBackParams {
 	navigate: ( url: string, openInNewTab?: boolean ) => void;
 	site?: SiteExcerptData;
 	currentRoute: string;
+	removeDuplicateViewsExperimentEnabled?: boolean;
 }
 
 export enum SiteType {
@@ -168,7 +169,12 @@ export function useCommands() {
 			clearCache: {
 				name: 'clearCache',
 				label: __( 'Clear cache', __i18n_text_domain__ ),
-				callback: commandNavigation( '/hosting-config/:site#cache' ),
+				callback: ( params ) => {
+					if ( params.removeDuplicateViewsExperimentEnabled ) {
+						return commandNavigation( '/sites/settings/performance/:site' )( params );
+					}
+					return commandNavigation( '/hosting-config/:site#cache' )( params );
+				},
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select a site to clear cache', __i18n_text_domain__ ),
 				...siteFilters.hostingEnabled,
@@ -177,7 +183,12 @@ export function useCommands() {
 			enableEdgeCache: {
 				name: 'enableEdgeCache',
 				label: __( 'Enable edge cache', __i18n_text_domain__ ),
-				callback: commandNavigation( '/hosting-config/:site#edge' ),
+				callback: ( params ) => {
+					if ( params.removeDuplicateViewsExperimentEnabled ) {
+						return commandNavigation( '/sites/settings/performance/:site' )( params );
+					}
+					return commandNavigation( '/hosting-config/:site#edge' )( params );
+				},
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select a site to enable edge cache', __i18n_text_domain__ ),
 				...siteFilters.hostingEnabledAndPublic,
@@ -186,7 +197,12 @@ export function useCommands() {
 			disableEdgeCache: {
 				name: 'disableEdgeCache',
 				label: __( 'Disable edge cache', __i18n_text_domain__ ),
-				callback: commandNavigation( '/hosting-config/:site#edge' ),
+				callback: ( params ) => {
+					if ( params.removeDuplicateViewsExperimentEnabled ) {
+						return commandNavigation( '/sites/settings/performance/:site' )( params );
+					}
+					return commandNavigation( '/hosting-config/:site#edge' )( params );
+				},
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select a site to disable edge cache', __i18n_text_domain__ ),
 				...siteFilters.hostingEnabledAndPublic,
@@ -195,7 +211,12 @@ export function useCommands() {
 			manageCacheSettings: {
 				name: 'manageCacheSettings',
 				label: __( 'Manage cache settings', __i18n_text_domain__ ),
-				callback: commandNavigation( '/hosting-config/:site#cache' ),
+				callback: ( params ) => {
+					if ( params.removeDuplicateViewsExperimentEnabled ) {
+						return commandNavigation( '/sites/settings/performance/:site' )( params );
+					}
+					return commandNavigation( '/hosting-config/:site#cache' )( params );
+				},
 				searchLabel: [
 					_x(
 						'manage cache settings',
@@ -290,7 +311,12 @@ export function useCommands() {
 			openHostingConfiguration: {
 				name: 'openHostingConfiguration',
 				label: __( 'Open server settings', __i18n_text_domain__ ),
-				callback: commandNavigation( '/hosting-config/:site' ),
+				callback: ( params ) => {
+					if ( params.removeDuplicateViewsExperimentEnabled ) {
+						return commandNavigation( '/sites/settings/server/:site' )( params );
+					}
+					return commandNavigation( '/hosting-config/:site' )( params );
+				},
 				searchLabel: [
 					_x(
 						'open hosting configuration',
@@ -348,7 +374,12 @@ export function useCommands() {
 			openPHPmyAdmin: {
 				name: 'openPHPmyAdmin',
 				label: __( 'Open database in phpMyAdmin', __i18n_text_domain__ ),
-				callback: commandNavigation( '/hosting-config/:site#database-access' ),
+				callback: ( params ) => {
+					if ( params.removeDuplicateViewsExperimentEnabled ) {
+						return commandNavigation( '/sites/settings/database/:site' )( params );
+					}
+					return commandNavigation( '/hosting-config/:site#database-access' )( params );
+				},
 				searchLabel: [
 					_x(
 						'open database in phpmyadmin',
@@ -642,7 +673,12 @@ export function useCommands() {
 			copySshConnectionString: {
 				name: 'copySshConnectionString',
 				label: __( 'Copy SSH connection string', __i18n_text_domain__ ),
-				callback: commandNavigation( '/hosting-config/:site#sftp-credentials' ),
+				callback: ( params ) => {
+					if ( params.removeDuplicateViewsExperimentEnabled ) {
+						return commandNavigation( '/sites/settings/sftp-ssh/:site' )( params );
+					}
+					return commandNavigation( '/hosting-config/:site#sftp-credentials' )( params );
+				},
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to copy SSH connection string', __i18n_text_domain__ ),
 				...siteFilters.hostingEnabled,
@@ -651,7 +687,12 @@ export function useCommands() {
 			openSshCredentials: {
 				name: 'openSshCredentials',
 				label: __( 'Open SFTP/SSH credentials', __i18n_text_domain__ ),
-				callback: commandNavigation( '/hosting-config/:site#sftp-credentials' ),
+				callback: ( params ) => {
+					if ( params.removeDuplicateViewsExperimentEnabled ) {
+						return commandNavigation( '/sites/settings/sftp-ssh/:site' )( params );
+					}
+					return commandNavigation( '/hosting-config/:site#sftp-credentials' )( params );
+				},
 				...siteFilters.hostingEnabled,
 				icon: keyIcon,
 				siteSelector: true,
@@ -660,7 +701,12 @@ export function useCommands() {
 			resetSshSftpPassword: {
 				name: 'resetSshSftpPassword',
 				label: __( 'Reset SFTP/SSH password', __i18n_text_domain__ ),
-				callback: commandNavigation( '/hosting-config/:site#sftp-credentials' ),
+				callback: ( params ) => {
+					if ( params.removeDuplicateViewsExperimentEnabled ) {
+						return commandNavigation( '/sites/settings/sftp-ssh/:site' )( params );
+					}
+					return commandNavigation( '/hosting-config/:site#sftp-credentials' )( params );
+				},
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to reset SFTP/SSH password', __i18n_text_domain__ ),
 				...siteFilters.hostingEnabled,
@@ -883,7 +929,12 @@ export function useCommands() {
 			changePHPVersion: {
 				name: 'changePHPVersion',
 				label: __( 'Change PHP version', __i18n_text_domain__ ),
-				callback: commandNavigation( '/hosting-config/:site#web-server-settings' ),
+				callback: ( params ) => {
+					if ( params.removeDuplicateViewsExperimentEnabled ) {
+						return commandNavigation( '/sites/settings/server/:site' )( params );
+					}
+					return commandNavigation( '/hosting-config/:site#web-server-settings' )( params );
+				},
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to change PHP version', __i18n_text_domain__ ),
 				...siteFilters.hostingEnabled,

--- a/packages/command-palette/src/context.tsx
+++ b/packages/command-palette/src/context.tsx
@@ -21,6 +21,7 @@ export interface CommandPaletteContext
 	setEmptyListNotice: ( message: string ) => void;
 	setFooterMessage: ( message: string | JSX.Element ) => void;
 	setSelectedCommandName: ( name: string ) => void;
+	removeDuplicateViewsExperimentEnabled?: boolean;
 }
 
 const CommandPaletteContext = createContext< CommandPaletteContext | undefined >( undefined );
@@ -44,6 +45,7 @@ export const CommandPaletteContextProvider: FC< PropsWithChildren< CommandPalett
 	setSearch,
 	setSelectedCommandName,
 	isOpen,
+	removeDuplicateViewsExperimentEnabled,
 } ) => {
 	return (
 		<CommandPaletteContext.Provider
@@ -65,6 +67,7 @@ export const CommandPaletteContextProvider: FC< PropsWithChildren< CommandPalett
 				setSearch,
 				setSelectedCommandName,
 				isOpen,
+				removeDuplicateViewsExperimentEnabled,
 			} }
 		>
 			{ children }

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -103,6 +103,7 @@ export function CommandMenuGroup() {
 		currentRoute,
 		currentSiteId,
 		useSites,
+		removeDuplicateViewsExperimentEnabled,
 	} = useCommandPaletteContext();
 	const { commands, filterNotice, emptyListNotice, inSiteContext } = useCommandPalette();
 	const { __ } = useI18n();
@@ -167,6 +168,7 @@ export function CommandMenuGroup() {
 								command,
 								navigate,
 								currentRoute,
+								removeDuplicateViewsExperimentEnabled,
 							} )
 						}
 						id={ cleanForSlug( itemValue ) }
@@ -261,6 +263,7 @@ export interface CommandPaletteProps {
 	selectedCommand?: PaletteCommand;
 	onBack?: () => void;
 	shouldCloseOnClickOutside?: boolean;
+	removeDuplicateViewsExperimentEnabled?: boolean;
 }
 
 const COMMAND_PALETTE_MODAL_OPEN_CLASSNAME = 'command-palette-modal-open';
@@ -285,6 +288,7 @@ const CommandPalette = ( {
 	selectedCommand,
 	onBack,
 	shouldCloseOnClickOutside,
+	removeDuplicateViewsExperimentEnabled,
 }: CommandPaletteProps ) => {
 	const [ placeHolderOverride, setPlaceholderOverride ] = useState( '' );
 	const [ search, setSearch ] = useState( '' );
@@ -423,6 +427,7 @@ const CommandPalette = ( {
 			setPlaceholderOverride={ setPlaceholderOverride }
 			setSearch={ setSearch }
 			setSelectedCommandName={ setSelectedCommandName }
+			removeDuplicateViewsExperimentEnabled={ removeDuplicateViewsExperimentEnabled }
 		>
 			<Modal
 				className="commands-command-menu"


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/10467

## Proposed Changes

* Add RDV checks to command palette for updated hosting-config routes

## Testing Instructions

Test hosting-config route changes in the PR across:

- [ ] Calypso
- [ ] Wp-admin with the app update, without JP update
- [ ] Wp-admin with the app update, with JP update

Repeat for simple and atomic sites.
