### PR TITLE
Realtime: remove highlight cards + some fixes for real time chart

### DIFF
--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -147,6 +147,8 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 				] }
 				maxViews={ maxViews }
 				formatTimeTick={ formatTimeTick }
+				xAxisNumTicks={ 6 }
+				fixedDomain
 			/>
 		</div>
 	);

--- a/client/my-sites/stats/pages/realtime/index.jsx
+++ b/client/my-sites/stats/pages/realtime/index.jsx
@@ -88,7 +88,7 @@ function StatsRealtime() {
 				<NavigationHeader
 					className="stats__section-header modernized-header"
 					title={ STATS_PRODUCT_NAME }
-					subtitle={ translate( "View your site's traffic in real-time." ) }
+					subtitle={ translate( "[Experimental] View your site's traffic in real-time." ) }
 					screenReader={ navItems.realtime?.label }
 					navigationItems={ [] }
 				></NavigationHeader>

--- a/client/my-sites/stats/pages/realtime/index.jsx
+++ b/client/my-sites/stats/pages/realtime/index.jsx
@@ -14,7 +14,6 @@ import StatsModuleTopPosts from 'calypso/my-sites/stats/features/modules/stats-t
 import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import { requestSiteStats } from 'calypso/state/stats/lists/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import AnnualHighlightsSection from '../../sections/annual-highlights-section';
 import PageViewTracker from '../../stats-page-view-tracker';
 import statsStrings from '../../stats-strings';
 import StatsModuleListing from '../shared/stats-module-listing';
@@ -89,12 +88,11 @@ function StatsRealtime() {
 				<NavigationHeader
 					className="stats__section-header modernized-header"
 					title={ STATS_PRODUCT_NAME }
-					subtitle={ translate( "View your site's performance and learn from trends." ) }
+					subtitle={ translate( "View your site's traffic in real-time." ) }
 					screenReader={ navItems.realtime?.label }
 					navigationItems={ [] }
 				></NavigationHeader>
 				<StatsNavigation selectedItem="realtime" siteId={ siteId } slug={ siteSlug } />
-				<AnnualHighlightsSection siteId={ siteId } />
 				<RealtimeChart siteId={ siteId } />
 				<StatsModuleListing className="stats__module-list--insights" siteId={ siteId }>
 					<StatsModuleTopPosts


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related: https://github.com/Automattic/wp-calypso/pull/99712/

## Proposed Changes

* remove highlight cards + some fixes for real time chart

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Address a couple of small issues together

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `http://calypso.localhost:3000/stats/realtime/xxx.com`
* Ensure the zero line is not in the middle of the chart
* Ensure highlight cards are gone

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
