### PR TITLE
Domain-To-Plan Credit: Hide free-domain messaging on /domains/manage

### DIFF
--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -9,6 +9,7 @@ import { domainAddNew, domainUseMyDomain } from 'calypso/my-sites/domains/paths'
 import { useSelector } from 'calypso/state';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { hasPurchasedDomain } from 'calypso/state/purchases/selectors';
+import { isFetchingUserPurchases } from 'calypso/state/purchases/selectors/fetching';
 import { EmptyDomainsListCardSkeleton } from './empty-domains-list-card-skeleton';
 
 import './empty-domains-list-card-styles.scss';
@@ -21,6 +22,8 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 		selectedSite?.plan?.product_slug && ! isFreePlan( selectedSite.plan.product_slug );
 
 	const siteHasHundredYearPlan = selectedSite?.plan?.product_slug === PLAN_100_YEARS;
+
+	const isLoadingUserPurchases = useSelector( isFetchingUserPurchases );
 
 	const siteHasPurchasedDomain = !! useSelector(
 		( state ) => selectedSite?.ID && hasPurchasedDomain( state, selectedSite?.ID )
@@ -41,6 +44,10 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 		getProductBySlug( state, domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION )
 	);
 	const domainProductCost = domainRegistrationProduct?.combined_cost_display;
+
+	if ( isLoadingUserPurchases ) {
+		return null;
+	}
 
 	if ( isEnabled( 'domain-to-plan-credit' ) && ! siteHasPaidPlan && siteHasPurchasedDomain ) {
 		return null;

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { PLAN_100_YEARS, domainProductSlugs, isFreePlan } from '@automattic/calypso-products';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import clsx from 'clsx';
@@ -41,7 +42,7 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 	);
 	const domainProductCost = domainRegistrationProduct?.combined_cost_display;
 
-	if ( ! siteHasPaidPlan && siteHasPurchasedDomain ) {
+	if ( isEnabled( 'domain-to-plan-credit' ) && ! siteHasPaidPlan && siteHasPurchasedDomain ) {
 		return null;
 	}
 

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -6,9 +6,9 @@ import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { domainAddNew, domainUseMyDomain } from 'calypso/my-sites/domains/paths';
+import { useDomainToPlanCreditsApplicable } from 'calypso/my-sites/plans-features-main/hooks/use-domain-to-plan-credits-applicable';
 import { useSelector } from 'calypso/state';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
-import { hasPurchasedDomain } from 'calypso/state/purchases/selectors';
 import { isFetchingUserPurchases } from 'calypso/state/purchases/selectors/fetching';
 import { EmptyDomainsListCardSkeleton } from './empty-domains-list-card-skeleton';
 
@@ -25,10 +25,6 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 
 	const isLoadingUserPurchases = useSelector( isFetchingUserPurchases );
 
-	const siteHasPurchasedDomain = !! useSelector(
-		( state ) => selectedSite?.ID && hasPurchasedDomain( state, selectedSite?.ID )
-	);
-
 	let title = translate( 'Get your free domain' );
 	let line = translate(
 		'Get a free one-year domain registration or transfer with any annual paid plan.'
@@ -44,12 +40,17 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 		getProductBySlug( state, domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION )
 	);
 	const domainProductCost = domainRegistrationProduct?.combined_cost_display;
+	const domainToPlanCreditsApplicable = useDomainToPlanCreditsApplicable( selectedSite?.ID );
 
 	if ( isLoadingUserPurchases ) {
 		return null;
 	}
 
-	if ( isEnabled( 'domain-to-plan-credit' ) && ! siteHasPaidPlan && siteHasPurchasedDomain ) {
+	if (
+		isEnabled( 'domain-to-plan-credit' ) &&
+		domainToPlanCreditsApplicable !== null &&
+		domainToPlanCreditsApplicable > 0
+	) {
 		return null;
 	}
 

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -7,6 +7,7 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import { domainAddNew, domainUseMyDomain } from 'calypso/my-sites/domains/paths';
 import { useSelector } from 'calypso/state';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
+import { hasPurchasedDomain } from 'calypso/state/purchases/selectors';
 import { EmptyDomainsListCardSkeleton } from './empty-domains-list-card-skeleton';
 
 import './empty-domains-list-card-styles.scss';
@@ -19,6 +20,10 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 		selectedSite?.plan?.product_slug && ! isFreePlan( selectedSite.plan.product_slug );
 
 	const siteHasHundredYearPlan = selectedSite?.plan?.product_slug === PLAN_100_YEARS;
+
+	const siteHasPurchasedDomain = !! useSelector(
+		( state ) => selectedSite?.ID && hasPurchasedDomain( state, selectedSite?.ID )
+	);
 
 	let title = translate( 'Get your free domain' );
 	let line = translate(
@@ -35,6 +40,10 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 		getProductBySlug( state, domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION )
 	);
 	const domainProductCost = domainRegistrationProduct?.combined_cost_display;
+
+	if ( ! siteHasPaidPlan && siteHasPurchasedDomain ) {
+		return null;
+	}
 
 	if ( siteHasPaidPlan && ! hasDomainCredit ) {
 		if ( hasNonWpcomDomains ) {

--- a/client/my-sites/domains/domain-management/list/test/empty-domains-list-card.test.tsx
+++ b/client/my-sites/domains/domain-management/list/test/empty-domains-list-card.test.tsx
@@ -2,9 +2,11 @@
  * @jest-environment jsdom
  */
 
+import config from '@automattic/calypso-config';
 import { PLAN_100_YEARS } from '@automattic/calypso-products';
 import { screen } from '@testing-library/react';
 import React from 'react';
+import { hasPurchasedDomain } from 'calypso/state/purchases/selectors';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import EmptyDomainsListCard from '../empty-domains-list-card';
 
@@ -18,7 +20,7 @@ jest.mock( 'calypso/state/products-list/selectors', () => ( {
 } ) );
 
 jest.mock( 'calypso/state/purchases/selectors', () => ( {
-	hasPurchasedDomain: () => false,
+	hasPurchasedDomain: jest.fn().mockReturnValue( false ),
 } ) );
 
 // Mock QueryProductsList component to prevent actual API calls
@@ -26,6 +28,13 @@ jest.mock( 'calypso/components/data/query-products-list', () => {
 	return function MockQueryProductsList() {
 		return null;
 	};
+} );
+
+// Mock isEnabled to control feature flags
+jest.mock( '@automattic/calypso-config', () => {
+	const config = () => {};
+	config.isEnabled = jest.fn().mockReturnValue( false );
+	return config;
 } );
 
 describe( 'EmptyDomainsListCard', () => {
@@ -57,10 +66,10 @@ describe( 'EmptyDomainsListCard', () => {
 			expect( screen.getByText( 'Just search for a domain' ) ).toBeInTheDocument();
 		} );
 
-		it( 'returns null if site has no paid plan but has purchased domain', () => {
-			jest
-				.spyOn( require( 'calypso/state/purchases/selectors' ), 'hasPurchasedDomain' )
-				.mockReturnValue( true );
+		it( 'returns null if feature flag is enabled, site is on free plan, and site has purchased a domain', () => {
+			config.isEnabled.mockImplementation( ( flag: unknown ): boolean => {
+				return flag === 'domain-to-plan-credit';
+			} );
 
 			const selectedSite = {
 				plan: {
@@ -69,6 +78,8 @@ describe( 'EmptyDomainsListCard', () => {
 				slug: 'example.com',
 				ID: 1,
 			};
+
+			hasPurchasedDomain.mockReturnValue( true );
 
 			const { container } = renderWithProvider(
 				<EmptyDomainsListCard

--- a/client/my-sites/domains/domain-management/list/test/empty-domains-list-card.test.tsx
+++ b/client/my-sites/domains/domain-management/list/test/empty-domains-list-card.test.tsx
@@ -23,6 +23,10 @@ jest.mock( 'calypso/state/purchases/selectors', () => ( {
 	hasPurchasedDomain: jest.fn().mockReturnValue( false ),
 } ) );
 
+jest.mock( 'calypso/state/purchases/selectors/fetching', () => ( {
+	isFetchingUserPurchases: jest.fn().mockReturnValue( false ),
+} ) );
+
 // Mock QueryProductsList component to prevent actual API calls
 jest.mock( 'calypso/components/data/query-products-list', () => {
 	return function MockQueryProductsList() {

--- a/client/my-sites/domains/domain-management/list/test/empty-domains-list-card.test.tsx
+++ b/client/my-sites/domains/domain-management/list/test/empty-domains-list-card.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { PLAN_100_YEARS } from '@automattic/calypso-products';
+import { screen } from '@testing-library/react';
+import React from 'react';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import EmptyDomainsListCard from '../empty-domains-list-card';
+
+const mockProduct = {
+	combined_cost_display: '$12/year',
+};
+
+// Mock the required selectors
+jest.mock( 'calypso/state/products-list/selectors', () => ( {
+	getProductBySlug: () => mockProduct,
+} ) );
+
+jest.mock( 'calypso/state/purchases/selectors', () => ( {
+	hasPurchasedDomain: () => false,
+} ) );
+
+// Mock QueryProductsList component to prevent actual API calls
+jest.mock( 'calypso/components/data/query-products-list', () => {
+	return function MockQueryProductsList() {
+		return null;
+	};
+} );
+
+describe( 'EmptyDomainsListCard', () => {
+	describe( 'Free plan scenarios', () => {
+		it( 'renders upgrade message for free plan sites', () => {
+			const selectedSite = {
+				plan: {
+					product_slug: 'free_plan',
+				},
+				slug: 'example.com',
+			};
+
+			renderWithProvider(
+				<EmptyDomainsListCard
+					selectedSite={ selectedSite }
+					hasDomainCredit={ false }
+					isCompact={ false }
+					hasNonWpcomDomains={ false }
+				/>
+			);
+
+			expect( screen.getByText( 'Get your free domain' ) ).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					'Get a free one-year domain registration or transfer with any annual paid plan.'
+				)
+			).toBeInTheDocument();
+			expect( screen.getByText( 'Upgrade to a plan' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Just search for a domain' ) ).toBeInTheDocument();
+		} );
+
+		it( 'returns null if site has no paid plan but has purchased domain', () => {
+			jest
+				.spyOn( require( 'calypso/state/purchases/selectors' ), 'hasPurchasedDomain' )
+				.mockReturnValue( true );
+
+			const selectedSite = {
+				plan: {
+					product_slug: 'free_plan',
+				},
+				slug: 'example.com',
+				ID: 1,
+			};
+
+			const { container } = renderWithProvider(
+				<EmptyDomainsListCard
+					selectedSite={ selectedSite }
+					hasDomainCredit={ false }
+					isCompact={ false }
+					hasNonWpcomDomains={ false }
+				/>
+			);
+
+			expect( container ).toBeEmptyDOMElement();
+		} );
+	} );
+
+	describe( 'Paid plan scenarios', () => {
+		it( 'renders add domain message for paid plan without domain credit', () => {
+			const selectedSite = {
+				plan: {
+					product_slug: 'value_bundle',
+				},
+				slug: 'example.com',
+			};
+
+			renderWithProvider(
+				<EmptyDomainsListCard
+					selectedSite={ selectedSite }
+					hasDomainCredit={ false }
+					isCompact={ false }
+					hasNonWpcomDomains={ false }
+				/>
+			);
+
+			expect( screen.getByText( 'Add your domain' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'You have no domains added to this site.' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Search for a domain' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Use a domain I own' ) ).toBeInTheDocument();
+		} );
+
+		it( 'returns null for paid plan without domain credit but with non-wpcom domains', () => {
+			const selectedSite = {
+				plan: {
+					product_slug: 'value_bundle',
+				},
+				slug: 'example.com',
+			};
+
+			const { container } = renderWithProvider(
+				<EmptyDomainsListCard
+					selectedSite={ selectedSite }
+					hasDomainCredit={ false }
+					isCompact={ false }
+					hasNonWpcomDomains
+				/>
+			);
+
+			expect( container ).toBeEmptyDOMElement();
+		} );
+
+		it( 'renders claim domain message for paid plan with domain credit', () => {
+			const selectedSite = {
+				plan: {
+					product_slug: 'value_bundle',
+				},
+				slug: 'example.com',
+			};
+
+			renderWithProvider(
+				<EmptyDomainsListCard
+					selectedSite={ selectedSite }
+					hasDomainCredit
+					isCompact={ false }
+					hasNonWpcomDomains={ false }
+				/>
+			);
+
+			expect( screen.getByText( 'Claim your free domain' ) ).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					'You have a free one-year domain registration or transfer included with your plan.'
+				)
+			).toBeInTheDocument();
+			expect( screen.getByText( 'Search for a domain' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Use a domain I own' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( '100 Year Plan scenarios', () => {
+		it( 'renders special message for 100 year plan with domain credit', () => {
+			const selectedSite = {
+				plan: {
+					product_slug: PLAN_100_YEARS,
+				},
+				slug: 'example.com',
+			};
+
+			renderWithProvider(
+				<EmptyDomainsListCard
+					selectedSite={ selectedSite }
+					hasDomainCredit
+					isCompact={ false }
+					hasNonWpcomDomains={ false }
+				/>
+			);
+
+			expect( screen.getByText( 'Claim your free domain' ) ).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					'You have a free domain registration or transfer included with your plan.'
+				)
+			).toBeInTheDocument();
+			expect( screen.getByText( 'Search for a domain' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Use a domain I own' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Styling', () => {
+		it( 'applies correct class when hasNonWpcomDomains is true', () => {
+			const selectedSite = {
+				plan: {
+					product_slug: 'value_bundle',
+				},
+				slug: 'example.com',
+			};
+
+			const { container } = renderWithProvider(
+				<EmptyDomainsListCard
+					selectedSite={ selectedSite }
+					hasDomainCredit
+					isCompact={ false }
+					hasNonWpcomDomains
+				/>
+			);
+
+			const element = container.querySelector( '.has-non-wpcom-domains' );
+			expect( element ).toBeInTheDocument();
+		} );
+
+		it( 'handles compact mode correctly', () => {
+			const selectedSite = {
+				plan: {
+					product_slug: 'value_bundle',
+				},
+				slug: 'example.com',
+			};
+
+			const { container } = renderWithProvider(
+				<EmptyDomainsListCard
+					selectedSite={ selectedSite }
+					hasDomainCredit
+					isCompact
+					hasNonWpcomDomains={ false }
+				/>
+			);
+
+			const element = container.querySelector( '.is-compact' );
+			expect( element ).toBeInTheDocument();
+		} );
+	} );
+} );

--- a/client/my-sites/domains/domain-management/list/test/empty-domains-list-card.test.tsx
+++ b/client/my-sites/domains/domain-management/list/test/empty-domains-list-card.test.tsx
@@ -10,14 +10,22 @@ import { hasPurchasedDomain } from 'calypso/state/purchases/selectors';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import EmptyDomainsListCard from '../empty-domains-list-card';
 
-const mockProduct = {
-	combined_cost_display: '$12/year',
+const freeSite = {
+	ID: 1,
+	plan: { product_slug: 'free_plan' },
+	slug: 'example.com',
 };
 
-// Mock the required selectors
-jest.mock( 'calypso/state/products-list/selectors', () => ( {
-	getProductBySlug: () => mockProduct,
-} ) );
+const paidSite = {
+	ID: 1,
+	plan: { product_slug: 'value_bundle' },
+	slug: 'example.com',
+};
+
+const hundredYearSite = {
+	plan: { product_slug: PLAN_100_YEARS },
+	slug: 'example.com',
+};
 
 jest.mock( 'calypso/state/purchases/selectors', () => ( {
 	hasPurchasedDomain: jest.fn().mockReturnValue( false ),
@@ -27,14 +35,12 @@ jest.mock( 'calypso/state/purchases/selectors/fetching', () => ( {
 	isFetchingUserPurchases: jest.fn().mockReturnValue( false ),
 } ) );
 
-// Mock QueryProductsList component to prevent actual API calls
 jest.mock( 'calypso/components/data/query-products-list', () => {
 	return function MockQueryProductsList() {
 		return null;
 	};
 } );
 
-// Mock isEnabled to control feature flags
 jest.mock( '@automattic/calypso-config', () => {
 	const config = () => {};
 	config.isEnabled = jest.fn().mockReturnValue( false );
@@ -43,55 +49,28 @@ jest.mock( '@automattic/calypso-config', () => {
 
 describe( 'EmptyDomainsListCard', () => {
 	describe( 'Free plan scenarios', () => {
-		it( 'renders upgrade message for free plan sites', () => {
-			const selectedSite = {
-				plan: {
-					product_slug: 'free_plan',
-				},
-				slug: 'example.com',
-			};
-
-			renderWithProvider(
-				<EmptyDomainsListCard
-					selectedSite={ selectedSite }
-					hasDomainCredit={ false }
-					isCompact={ false }
-					hasNonWpcomDomains={ false }
-				/>
-			);
+		it( "displays 'upgrade to a plan' message when site has no domain credit", () => {
+			renderWithProvider( <EmptyDomainsListCard selectedSite={ freeSite } /> );
 
 			expect( screen.getByText( 'Get your free domain' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Upgrade to a plan' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Just search for a domain' ) ).toBeInTheDocument();
 			expect(
 				screen.getByText(
 					'Get a free one-year domain registration or transfer with any annual paid plan.'
 				)
 			).toBeInTheDocument();
-			expect( screen.getByText( 'Upgrade to a plan' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Just search for a domain' ) ).toBeInTheDocument();
 		} );
 
-		it( 'returns null if feature flag is enabled, site is on free plan, and site has purchased a domain', () => {
+		it( 'displays empty if feature flag is enabled and site has purchased a domain', () => {
 			config.isEnabled.mockImplementation( ( flag: unknown ): boolean => {
 				return flag === 'domain-to-plan-credit';
 			} );
 
-			const selectedSite = {
-				plan: {
-					product_slug: 'free_plan',
-				},
-				slug: 'example.com',
-				ID: 1,
-			};
-
 			hasPurchasedDomain.mockReturnValue( true );
 
 			const { container } = renderWithProvider(
-				<EmptyDomainsListCard
-					selectedSite={ selectedSite }
-					hasDomainCredit={ false }
-					isCompact={ false }
-					hasNonWpcomDomains={ false }
-				/>
+				<EmptyDomainsListCard selectedSite={ freeSite } />
 			);
 
 			expect( container ).toBeEmptyDOMElement();
@@ -99,22 +78,31 @@ describe( 'EmptyDomainsListCard', () => {
 	} );
 
 	describe( 'Paid plan scenarios', () => {
-		it( 'renders add domain message for paid plan without domain credit', () => {
-			const selectedSite = {
-				plan: {
-					product_slug: 'value_bundle',
-				},
-				slug: 'example.com',
-			};
+		it( "displays 'claim free domain' and 'free registration or transfer' message when site has domain credit", () => {
+			renderWithProvider( <EmptyDomainsListCard selectedSite={ paidSite } hasDomainCredit /> );
 
+			expect( screen.getByText( 'Claim your free domain' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Search for a domain' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Use a domain I own' ) ).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					'You have a free one-year domain registration or transfer included with your plan.'
+				)
+			).toBeInTheDocument();
+		} );
+
+		it( "displays 'claim free domain' message when site has domain credit and non-wpcom domains", () => {
 			renderWithProvider(
-				<EmptyDomainsListCard
-					selectedSite={ selectedSite }
-					hasDomainCredit={ false }
-					isCompact={ false }
-					hasNonWpcomDomains={ false }
-				/>
+				<EmptyDomainsListCard selectedSite={ paidSite } hasDomainCredit hasNonWpcomDomains />
 			);
+
+			expect( screen.getByText( 'Claim your free domain' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Search for a domain' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Use a domain I own' ) ).toBeInTheDocument();
+		} );
+
+		it( "displays 'add your domain' and 'you have no domains' message when site has no domain credit", () => {
+			renderWithProvider( <EmptyDomainsListCard selectedSite={ paidSite } /> );
 
 			expect( screen.getByText( 'Add your domain' ) ).toBeInTheDocument();
 			expect( screen.getByText( 'You have no domains added to this site.' ) ).toBeInTheDocument();
@@ -122,124 +110,29 @@ describe( 'EmptyDomainsListCard', () => {
 			expect( screen.getByText( 'Use a domain I own' ) ).toBeInTheDocument();
 		} );
 
-		it( 'returns null for paid plan without domain credit but with non-wpcom domains', () => {
-			const selectedSite = {
-				plan: {
-					product_slug: 'value_bundle',
-				},
-				slug: 'example.com',
-			};
-
+		it( 'displays empty when site has no domain credit and non-wpcom domains', () => {
 			const { container } = renderWithProvider(
-				<EmptyDomainsListCard
-					selectedSite={ selectedSite }
-					hasDomainCredit={ false }
-					isCompact={ false }
-					hasNonWpcomDomains
-				/>
+				<EmptyDomainsListCard selectedSite={ paidSite } hasNonWpcomDomains />
 			);
 
 			expect( container ).toBeEmptyDOMElement();
 		} );
-
-		it( 'renders claim domain message for paid plan with domain credit', () => {
-			const selectedSite = {
-				plan: {
-					product_slug: 'value_bundle',
-				},
-				slug: 'example.com',
-			};
-
-			renderWithProvider(
-				<EmptyDomainsListCard
-					selectedSite={ selectedSite }
-					hasDomainCredit
-					isCompact={ false }
-					hasNonWpcomDomains={ false }
-				/>
-			);
-
-			expect( screen.getByText( 'Claim your free domain' ) ).toBeInTheDocument();
-			expect(
-				screen.getByText(
-					'You have a free one-year domain registration or transfer included with your plan.'
-				)
-			).toBeInTheDocument();
-			expect( screen.getByText( 'Search for a domain' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Use a domain I own' ) ).toBeInTheDocument();
-		} );
 	} );
 
 	describe( '100 Year Plan scenarios', () => {
-		it( 'renders special message for 100 year plan with domain credit', () => {
-			const selectedSite = {
-				plan: {
-					product_slug: PLAN_100_YEARS,
-				},
-				slug: 'example.com',
-			};
-
+		it( "displays 'claim free domain' and 'free registration or transfer' message when site has domain credit", () => {
 			renderWithProvider(
-				<EmptyDomainsListCard
-					selectedSite={ selectedSite }
-					hasDomainCredit
-					isCompact={ false }
-					hasNonWpcomDomains={ false }
-				/>
+				<EmptyDomainsListCard selectedSite={ hundredYearSite } hasDomainCredit />
 			);
 
 			expect( screen.getByText( 'Claim your free domain' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Search for a domain' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Use a domain I own' ) ).toBeInTheDocument();
 			expect(
 				screen.getByText(
 					'You have a free domain registration or transfer included with your plan.'
 				)
 			).toBeInTheDocument();
-			expect( screen.getByText( 'Search for a domain' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Use a domain I own' ) ).toBeInTheDocument();
-		} );
-	} );
-
-	describe( 'Styling', () => {
-		it( 'applies correct class when hasNonWpcomDomains is true', () => {
-			const selectedSite = {
-				plan: {
-					product_slug: 'value_bundle',
-				},
-				slug: 'example.com',
-			};
-
-			const { container } = renderWithProvider(
-				<EmptyDomainsListCard
-					selectedSite={ selectedSite }
-					hasDomainCredit
-					isCompact={ false }
-					hasNonWpcomDomains
-				/>
-			);
-
-			const element = container.querySelector( '.has-non-wpcom-domains' );
-			expect( element ).toBeInTheDocument();
-		} );
-
-		it( 'handles compact mode correctly', () => {
-			const selectedSite = {
-				plan: {
-					product_slug: 'value_bundle',
-				},
-				slug: 'example.com',
-			};
-
-			const { container } = renderWithProvider(
-				<EmptyDomainsListCard
-					selectedSite={ selectedSite }
-					hasDomainCredit
-					isCompact
-					hasNonWpcomDomains={ false }
-				/>
-			);
-
-			const element = container.querySelector( '.is-compact' );
-			expect( element ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/client/my-sites/domains/domain-management/list/test/empty-domains-list-card.test.tsx
+++ b/client/my-sites/domains/domain-management/list/test/empty-domains-list-card.test.tsx
@@ -6,7 +6,7 @@ import config from '@automattic/calypso-config';
 import { PLAN_100_YEARS } from '@automattic/calypso-products';
 import { screen } from '@testing-library/react';
 import React from 'react';
-import { hasPurchasedDomain } from 'calypso/state/purchases/selectors';
+import { useDomainToPlanCreditsApplicable } from 'calypso/my-sites/plans-features-main/hooks/use-domain-to-plan-credits-applicable';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import EmptyDomainsListCard from '../empty-domains-list-card';
 
@@ -27,10 +27,6 @@ const hundredYearSite = {
 	slug: 'example.com',
 };
 
-jest.mock( 'calypso/state/purchases/selectors', () => ( {
-	hasPurchasedDomain: jest.fn().mockReturnValue( false ),
-} ) );
-
 jest.mock( 'calypso/state/purchases/selectors/fetching', () => ( {
 	isFetchingUserPurchases: jest.fn().mockReturnValue( false ),
 } ) );
@@ -47,6 +43,13 @@ jest.mock( '@automattic/calypso-config', () => {
 	return config;
 } );
 
+jest.mock(
+	'calypso/my-sites/plans-features-main/hooks/use-domain-to-plan-credits-applicable',
+	() => ( {
+		useDomainToPlanCreditsApplicable: jest.fn().mockReturnValue( null ),
+	} )
+);
+
 describe( 'EmptyDomainsListCard', () => {
 	describe( 'Free plan scenarios', () => {
 		it( "displays 'upgrade to a plan' message when site has no domain credit", () => {
@@ -62,12 +65,12 @@ describe( 'EmptyDomainsListCard', () => {
 			).toBeInTheDocument();
 		} );
 
-		it( 'displays empty if feature flag is enabled and site has purchased a domain', () => {
+		it( 'displays empty if feature flag is enabled and site has domain-to-plan credit', () => {
 			config.isEnabled.mockImplementation( ( flag: unknown ): boolean => {
 				return flag === 'domain-to-plan-credit';
 			} );
 
-			hasPurchasedDomain.mockReturnValue( true );
+			useDomainToPlanCreditsApplicable.mockImplementationOnce( () => 1 );
 
 			const { container } = renderWithProvider(
 				<EmptyDomainsListCard selectedSite={ freeSite } />

--- a/client/my-sites/plans-features-main/components/plan-notice-domain-to-plan-credit.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice-domain-to-plan-credit.tsx
@@ -17,11 +17,7 @@ const PlanNoticeDomainToPlanCredit = ( {
 	visiblePlans,
 }: Props ) => {
 	const domainToPlanCreditsApplicable = useDomainToPlanCreditsApplicable( siteId, visiblePlans );
-	const showNotice =
-		visiblePlans &&
-		visiblePlans.length > 0 &&
-		domainToPlanCreditsApplicable !== null &&
-		domainToPlanCreditsApplicable > 0;
+	const showNotice = domainToPlanCreditsApplicable !== null && domainToPlanCreditsApplicable > 0;
 
 	return (
 		<>

--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -67,7 +67,7 @@ function useResolveNoticeType(
 		discountInformation &&
 		getDiscountByName( discountInformation.coupon, discountInformation.discountEndDate );
 	const planUpgradeCreditsApplicable = usePlanUpgradeCreditsApplicable( siteId, visiblePlans );
-	const domainToPlanCreditsApplicable = useDomainToPlanCreditsApplicable( siteId );
+	const domainToPlanCreditsApplicable = useDomainToPlanCreditsApplicable( siteId, visiblePlans );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
 	const sitePlanSlug = sitePlan?.product_slug ?? '';
 	const isCurrentPlanRetired = isProPlan( sitePlanSlug ) || isStarterPlan( sitePlanSlug );

--- a/client/my-sites/plans-features-main/hooks/test/use-domain-to-plan-credits-applicable.tsx
+++ b/client/my-sites/plans-features-main/hooks/test/use-domain-to-plan-credits-applicable.tsx
@@ -7,20 +7,10 @@ import { COST_OVERRIDE_REASONS } from '@automattic/data-stores/src/plans/constan
 import { UseQueryResult } from '@tanstack/react-query';
 import { useDomainToPlanCreditsApplicable } from 'calypso/my-sites/plans-features-main/hooks/use-domain-to-plan-credits-applicable';
 import { useMaxPlanUpgradeCredits } from 'calypso/my-sites/plans-features-main/hooks/use-max-plan-upgrade-credits';
-import { hasPurchasedDomain } from 'calypso/state/purchases/selectors/has-purchased-domain';
-import { isCurrentPlanPaid } from 'calypso/state/sites/selectors';
 import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
 
 jest.mock( 'calypso/my-sites/plans-features-main/hooks/use-max-plan-upgrade-credits', () => ( {
 	useMaxPlanUpgradeCredits: jest.fn(),
-} ) );
-
-jest.mock( 'calypso/state/purchases/selectors/has-purchased-domain', () => ( {
-	hasPurchasedDomain: jest.fn(),
-} ) );
-
-jest.mock( 'calypso/state/sites/selectors', () => ( {
-	isCurrentPlanPaid: jest.fn(),
 } ) );
 
 jest.mock( '@automattic/data-stores/src/plans/queries/use-site-plans', () => jest.fn() );
@@ -28,59 +18,47 @@ jest.mock( '@automattic/data-stores/src/plans/queries/use-site-plans', () => jes
 const mockUseMaxPlanUpgradeCredits = useMaxPlanUpgradeCredits as jest.MockedFunction<
 	typeof useMaxPlanUpgradeCredits
 >;
-const mockHasPurchasedDomain = hasPurchasedDomain as jest.MockedFunction<
-	typeof hasPurchasedDomain
->;
-const mockIsCurrentPlanPaid = isCurrentPlanPaid as jest.MockedFunction< typeof isCurrentPlanPaid >;
 const mockUseSitePlans = useSitePlans as jest.MockedFunction< typeof useSitePlans >;
 const siteId = 1;
 const overrideCode = COST_OVERRIDE_REASONS.RECENT_DOMAIN_PRORATION;
 
 describe( 'useDomainToPlanCreditsApplicable', () => {
 	beforeEach( () => {
-		jest.resetAllMocks();
-
-		mockUseMaxPlanUpgradeCredits.mockImplementation( () => 1000 );
-		mockHasPurchasedDomain.mockImplementation( () => true );
-		mockIsCurrentPlanPaid.mockImplementation( () => false );
 		mockUseSitePlans.mockImplementation(
 			() =>
 				( {
-					data: { free_plan: { pricing: { costOverrides: [ { overrideCode } ] } } },
-				} ) as unknown as UseQueryResult< { [ planSlug: string ]: SitePlan } >
+					data: {
+						free_plan: {
+							pricing: { costOverrides: [ { overrideCode } ] },
+						},
+					},
+				} ) as UseQueryResult< { free_plan: SitePlan } >
 		);
+		mockUseMaxPlanUpgradeCredits.mockImplementation( () => 0 );
 	} );
 
-	test( 'Returns the credit value for a site that is eligible (has a domain and is on the free plan)', () => {
+	test( 'Returns the credit value for a site that has domain-to-plan credit', () => {
+		mockUseMaxPlanUpgradeCredits.mockImplementation( () => 1000 );
 		const { result } = renderHookWithProvider( () => useDomainToPlanCreditsApplicable( siteId ) );
 		expect( result.current ).toEqual( 1000 );
 	} );
 
-	test( "Returns null when the site is not eligible because it doesn't have a domain)", () => {
-		mockHasPurchasedDomain.mockImplementation( () => false );
-		const { result } = renderHookWithProvider( () => useDomainToPlanCreditsApplicable( siteId ) );
-		expect( result.current ).toEqual( null );
-	} );
-
-	test( 'Returns null when the site is not eligible because it is on a paid plan', () => {
-		mockIsCurrentPlanPaid.mockImplementation( () => true );
-		const { result } = renderHookWithProvider( () => useDomainToPlanCreditsApplicable( siteId ) );
-		expect( result.current ).toEqual( null );
-	} );
-
-	test( 'Returns null when the site is not eligible because the upgrade credit is not for domain proration', () => {
+	test( 'Returns null for a site that has credit but not domain-to-plan credit', () => {
 		mockUseSitePlans.mockImplementation(
 			() =>
 				( {
-					data: { free_plan: { pricing: { costOverrides: [] } } },
-				} ) as unknown as UseQueryResult< { [ planSlug: string ]: SitePlan } >
+					data: {
+						free_plan: {
+							pricing: { costOverrides: [ { overrideCode: 'some-other-override' } ] },
+						},
+					},
+				} ) as UseQueryResult< { free_plan: SitePlan } >
 		);
 		const { result } = renderHookWithProvider( () => useDomainToPlanCreditsApplicable( siteId ) );
 		expect( result.current ).toEqual( null );
 	} );
 
-	test( 'Returns 0 (rather than null) for for a site that is eligible and has a credit value of 0', () => {
-		// ie. distinguishes between a site having zero credits, and a site being ineligible for credits (returning null)
+	test( 'Returns 0 (not null) for a site that has domain-to-plan credit value of 0', () => {
 		mockUseMaxPlanUpgradeCredits.mockImplementation( () => 0 );
 		const { result } = renderHookWithProvider( () => useDomainToPlanCreditsApplicable( siteId ) );
 		expect( result.current ).toEqual( 0 );

--- a/client/my-sites/plans-features-main/hooks/use-domain-to-plan-credits-applicable.ts
+++ b/client/my-sites/plans-features-main/hooks/use-domain-to-plan-credits-applicable.ts
@@ -1,39 +1,27 @@
 import { PlanSlug } from '@automattic/calypso-products';
 import { useSitePlans } from '@automattic/data-stores/src/plans';
 import { COST_OVERRIDE_REASONS } from '@automattic/data-stores/src/plans/constants';
-import { useSelector } from 'calypso/state';
-import { hasPurchasedDomain } from 'calypso/state/purchases/selectors';
-import { isCurrentPlanPaid } from 'calypso/state/sites/selectors';
 import { useMaxPlanUpgradeCredits } from './use-max-plan-upgrade-credits';
 
 /**
- * This hook provides the domain-to-plan credit value if the site is eligible,
- * or null if the site is not eligible
- * @param siteId The ID of the site
- * @param visiblePlans The plans that are visible to the user
- * @returns The credit value or null if the site is not eligible
+ * This hook returns the domain-to-plan credit for a site, or null if the site is not eligible.
+ * @param siteId
+ * @param planSlugs
+ * @returns The credit value or null
  */
 export function useDomainToPlanCreditsApplicable(
 	siteId?: number | null,
-	visiblePlans: PlanSlug[] = []
+	planSlugs?: PlanSlug[]
 ): number | null {
-	const isSiteOnFreePlan = !! useSelector(
-		( state ) => siteId && ! isCurrentPlanPaid( state, siteId )
-	);
-	const hasSitePurchasedDomain = !! useSelector(
-		( state ) => siteId && hasPurchasedDomain( state, siteId )
-	);
-	const isSiteEligible = isSiteOnFreePlan && hasSitePurchasedDomain;
-
 	const { data: sitePlans } = useSitePlans( { siteId, coupon: undefined } );
-	const isUpgradeCreditForDomainProration = Object.values( sitePlans || {} ).some(
+	const plans = planSlugs || ( Object.keys( sitePlans || {} ) as PlanSlug[] );
+	const isCreditForDomainToPlan = Object.values( sitePlans || {} ).some(
 		( plan ) =>
 			plan?.pricing?.costOverrides?.some(
 				( override ) => override.overrideCode === COST_OVERRIDE_REASONS.RECENT_DOMAIN_PRORATION
 			)
 	);
+	const credits = useMaxPlanUpgradeCredits( { siteId, plans } );
 
-	const creditsValue = useMaxPlanUpgradeCredits( { siteId, plans: visiblePlans } );
-
-	return isSiteEligible && isUpgradeCreditForDomainProration ? creditsValue : null;
+	return isCreditForDomainToPlan ? credits : null;
 }

--- a/client/sites/overview/components/plan-credit-notice.tsx
+++ b/client/sites/overview/components/plan-credit-notice.tsx
@@ -1,4 +1,3 @@
-import { useSitePlans } from '@automattic/data-stores/src/plans';
 import { Notice } from '@wordpress/components';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
@@ -6,16 +5,11 @@ import DomainToPlanCreditMessage from 'calypso/components/domain-to-plan-credit-
 import { useDomainToPlanCreditsApplicable } from 'calypso/my-sites/plans-features-main/hooks/use-domain-to-plan-credits-applicable';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import type { PlanSlug } from '@automattic/calypso-products';
 
 const PlanCreditNotice = () => {
 	const site = useSelector( getSelectedSite );
 	const { ID: siteId } = site || {};
-	const { data: sitePlans } = useSitePlans( { siteId, coupon: undefined } );
-	const domainToPlanCreditsApplicable = useDomainToPlanCreditsApplicable(
-		siteId,
-		Object.keys( sitePlans || {} ) as PlanSlug[]
-	);
+	const domainToPlanCreditsApplicable = useDomainToPlanCreditsApplicable( siteId );
 	const showNotice = domainToPlanCreditsApplicable !== null && domainToPlanCreditsApplicable > 0;
 
 	if ( ! siteId ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3701

## Proposed Changes

- Hides the 'Get your free domain' card on `/domains/manage/:blog` for free sites that have purchased a domain
- Centralises the display logic for any domain-to-plan credit UI using `useDomainToPlanCreditsApplicable`
- Adds tests for the `EmptyDomainsListCard` component

| Prod | PR |
| -- | -- |
|![CleanShot 2025-02-21 at 17 21 43@2x](https://github.com/user-attachments/assets/6f13b2b7-0e8e-4952-ae9e-0a70bd6f987e)|![CleanShot 2025-02-21 at 17 21 55@2x](https://github.com/user-attachments/assets/7f57239d-fd55-442e-8835-57c6a79a6889)|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We don't want to offer a free domain to users who have already purchased a domain and are on a free plan.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- With a free site that has purchased a domain:
  1. Navigate to `/domains/manage/:blog?flags=domain-to-plan-credit`
  2. Verify that the 'Get your free domain' card is not displayed

- With a free site that has not purchased a domain:
  1. Navigate to `/domains/manage/:blog?flags=domain-to-plan-credit`
  2. Verify that the 'Get your free domain' card is displayed

- With a site on a paid plan:
  1. Navigate to `/domains/manage/:blog?flags=domain-to-plan-credit`
  2. Verify that the 'Get your free domain' card is displayed


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
