### PR TITLE
A4A > Signup: Fix WC Asia button alignment on mobile

### DIFF
--- a/client/a8c-for-agencies/components/form/footer/style.scss
+++ b/client/a8c-for-agencies/components/form/footer/style.scss
@@ -1,11 +1,30 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .a4a-form__footer {
 	margin-block-start: 8px;
 	padding-block: 24px;
 	border-block-start: 1px solid #C3C4C7;
-
 	display: flex;
-	gap: 24px;
+	flex-direction: column;
+	gap: 8px;
 
-	justify-content: space-between;
-	align-items: center;
+	div {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 8px;
+	}
+
+	@include break-small {
+		flex-direction: row;
+		gap: 24px;
+		justify-content: space-between;
+		align-items: center;
+
+		div {
+			display: block;
+			align-items: unset;
+		}
+	}
 }

--- a/client/a8c-for-agencies/components/form/footer/style.scss
+++ b/client/a8c-for-agencies/components/form/footer/style.scss
@@ -9,22 +9,10 @@
 	flex-direction: column;
 	gap: 8px;
 
-	div {
-		display: flex;
-		flex-direction: column;
-		align-items: flex-start;
-		gap: 8px;
-	}
-
 	@include break-small {
 		flex-direction: row;
 		gap: 24px;
 		justify-content: space-between;
 		align-items: center;
-
-		div {
-			display: block;
-			align-items: unset;
-		}
 	}
 }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/index.tsx
@@ -60,7 +60,7 @@ const ChoiceBlueprint: React.FC< Props > = ( { onContinue, onSkip, goBack } ) =>
 					{ translate( 'Back' ) }
 				</Button>
 
-				<div>
+				<div className="choice-blueprint__buttons">
 					<Button
 						className="choice-blueprint__cancel-button"
 						variant="tertiary"

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/choice-blueprint/style.scss
@@ -1,5 +1,18 @@
+@import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
+
+.choice-blueprint__buttons {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 8px;
+
+	@include break-small {
+		display: block;
+		align-items: unset;
+	}
+}
 
 .choice-blueprint__button {
 	width: 200px;


### PR DESCRIPTION
## Proposed Changes

* This PR fixes the WC Asia button alignment on mobile

## Testing Instructions

* Open the A4A live link
* Append the URL with /signup/wc-asia
* Switch to mobile view(<600px) and verify the button alignment is fixed as shown below. Also, verify the styles applied doesn't affect any screen >600px

<img width="401" alt="Screenshot 2025-02-21 at 12 14 16 PM" src="https://github.com/user-attachments/assets/1b86e8ac-b03b-420d-9789-56f6ac1e61cf" />
<img width="401" alt="Screenshot 2025-02-21 at 12 14 42 PM" src="https://github.com/user-attachments/assets/98b95f34-1195-45c6-b5dd-a19a904715d0" />
<img width="401" alt="Screenshot 2025-02-21 at 12 15 33 PM" src="https://github.com/user-attachments/assets/8b42be4a-6dab-497a-9218-f65d355c4f1c" />
<img width="401" alt="Screenshot 2025-02-21 at 12 15 38 PM" src="https://github.com/user-attachments/assets/2a4d70a2-2673-4442-83e8-be236c65a18e" />
<img width="401" alt="Screenshot 2025-02-21 at 12 15 42 PM" src="https://github.com/user-attachments/assets/0a8afdb9-5c3b-46d9-8040-2060f1990f7c" />
<img width="401" alt="Screenshot 2025-02-21 at 12 16 10 PM" src="https://github.com/user-attachments/assets/eb804776-edf0-4cab-aee9-402cfe155ad9" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
