### PR TITLE
A4A > Signup: Improve WC Asia mobile screen padding and field alignment.

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/style.scss
@@ -25,6 +25,7 @@
 		cursor: pointer;
 		text-decoration: underline;
 		color: var(--color-primary);
+		text-align: left;
 	}
 
 
@@ -35,8 +36,12 @@
 
 .signup-multi-step-form__name-fields {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
 	gap: 16px;
+
+	@include break-medium {
+		flex-direction: row;
+	}
 
     > * {
         flex-grow: 1;

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/style.scss
@@ -39,7 +39,7 @@
     flex-direction: column;
 	gap: 16px;
 
-	@include break-medium {
+	@include break-small {
 		flex-direction: row;
 	}
 

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/signup-wrapper/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/signup-wrapper/style.scss
@@ -9,7 +9,7 @@
 	margin: -16px;
 
 
-	@include break-medium {
+	@include break-small {
 		padding: 16px;
 		margin: 16px;
 	}

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/signup-wrapper/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/signup-wrapper/style.scss
@@ -3,13 +3,13 @@
 
 .signup-wrapper {
     display: flex;
-    height: 90vh;
     background-color: var(--color-surface);
     border-radius: 16px; //stylelint-disable-line scales/radii
 
 	@include break-small {
 		padding: 16px;
 		margin: 16px;
+		height: 90vh;
 	}
 
   .signup-wrapper__left {

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/signup-wrapper/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/signup-wrapper/style.scss
@@ -5,9 +5,14 @@
     display: flex;
     height: 90vh;
     background-color: var(--color-surface);
-    padding: 16px;
-    margin: 16px;
     border-radius: 16px; //stylelint-disable-line scales/radii
+	margin: -16px;
+
+
+	@include break-medium {
+		padding: 16px;
+		margin: 16px;
+	}
 
   .signup-wrapper__left {
     display: none;

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/signup-wrapper/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/signup-wrapper/style.scss
@@ -6,8 +6,6 @@
     height: 90vh;
     background-color: var(--color-surface);
     border-radius: 16px; //stylelint-disable-line scales/radii
-	margin: -16px;
-
 
 	@include break-small {
 		padding: 16px;


### PR DESCRIPTION
This PR adds Mobile UI improvements on the WC Asia signup form.

Context: p1740117620574839-slack-C07TTQGJ2UW

## Proposed Changes

| Description | Before | After |
|--------|--------|--------|
| Reduce the paddings when on mobile view. | <img width="395" alt="Screenshot 2025-02-21 at 2 52 08 PM" src="https://github.com/user-attachments/assets/d9ac2372-8824-4d45-a5fd-2dece58eda7d" /> | <img width="408" alt="Screenshot 2025-02-21 at 2 52 43 PM" src="https://github.com/user-attachments/assets/79e8f619-f067-4538-9ef1-9f192586083a" /> |
| Collapse name fields to two lines when in mobile view. | <img width="393" alt="Screenshot 2025-02-21 at 2 53 25 PM" src="https://github.com/user-attachments/assets/f1a763c6-ee64-4be6-9ae4-66891d22dc3d" /> | <img width="452" alt="Screenshot 2025-02-21 at 2 53 31 PM" src="https://github.com/user-attachments/assets/cfd1e1f9-6409-47dd-b41c-8aefeea00810" /> |
| Align TOS link to left. | <img width="354" alt="Screenshot 2025-02-21 at 2 54 08 PM" src="https://github.com/user-attachments/assets/e2e07ff7-b145-4640-9c16-7a26cedd0495" /> | <img width="438" alt="Screenshot 2025-02-21 at 2 54 25 PM" src="https://github.com/user-attachments/assets/8e16f723-4852-4879-b25d-1e78ad3365bd" /> | 

## Why are these changes being made?

* This improves user experience on our Signup page when on Mobile devices.

## Testing Instructions

* Use the A4A live link and go to the `/signup/wc-asia` page.
* Set your browser to mobile view.
* Confirm the changes are working above.
* Also test the view on Desktop mode and confirm nothing is broken.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?