### PR TITLE
A4A Dev Sites: Update all `Prepare for launch` links to lead to the Settings page

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
@@ -44,7 +44,7 @@ export default function useLicenseActions(
 		return [
 			{
 				name: translate( 'Prepare for launch' ),
-				href: `https://wordpress.com/settings/general/${ siteSlug }`,
+				href: `https://wordpress.com/sites/settings/site/${ siteSlug }`,
 				onClick: () => handleClickMenuItem( 'prepare_for_launch' ),
 				isExternalLink: true,
 				isEnabled: isDevSite,

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -85,7 +85,7 @@ export default function useSiteActions( {
 		return [
 			{
 				name: translate( 'Prepare for launch' ),
-				href: `https://wordpress.com/settings/general/${ blog_id }`,
+				href: `https://wordpress.com/sites/settings/site/${ blog_id }`,
 				onClick: () => handleClickMenuItem( 'prepare_for_launch' ),
 				isExternalLink: true,
 				isEnabled: isDevSite,
@@ -275,7 +275,7 @@ export function useSiteActionsDataViews( {
 					return canHaveActions( item ) && isDevSite( item );
 				},
 				callback( items: SiteData[] ) {
-					window.open( `https://wordpress.com/settings/general/${ getBlogId( items[ 0 ] ) }` );
+					window.open( `https://wordpress.com/sites/settings/site/${ getBlogId( items[ 0 ] ) }` );
 					dispatch(
 						recordTracksEvent( getActionEventName( 'prepare_for_launch', isLargeScreen ) )
 					);

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -164,7 +164,7 @@ const SitePerformanceContent = () => {
 	const onLaunchSiteClick = () => {
 		if ( site?.is_a4a_dev_site ) {
 			recordTracksEvent( 'calypso_performance_profiler_prepare_launch_cta_click' );
-			page( `/settings/general/${ site.slug }` );
+			page( `/sites/settings/site/${ site.slug }` );
 			return;
 		}
 		dispatch( launchSite( siteId! ) );

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -381,7 +381,7 @@ export function useActions( {
 				id: 'prepare-for-launch',
 				label: __( 'Prepare for launch' ),
 				callback: ( sites ) => {
-					page( `/settings/general/${ sites[ 0 ].ID }` );
+					page( `/sites/settings/site/${ sites[ 0 ].ID }` );
 					dispatch(
 						recordTracksEvent( 'calypso_sites_dashboard_site_action_prepare_for_launch_click' )
 					);

--- a/client/sites/overview/components/plan-card.tsx
+++ b/client/sites/overview/components/plan-card.tsx
@@ -48,7 +48,7 @@ const DevelopmentSiteActions = () => {
 					/>
 					<Action
 						icon={ <LaunchIcon /> }
-						href={ `/settings/general/${ site?.slug }` }
+						href={ `/sites/settings/site/${ site?.slug }` }
 						text={ translate( 'Prepare for launch' ) }
 					/>
 				</ul>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1836.

## Proposed Changes

* update all `Prepare to launch` links to lead to `https://wordpress.com/sites/settings/site/${ siteSlug }`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* please see the discussion: p1740103478447579/1739971240.373249-slack-C06JY8QL0TU

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start-a8c-for-agencies` (or use the related Automattic for Agencies Live [link below](https://github.com/Automattic/wp-calypso/pull/100136#issuecomment-2674166490)).
2. Head over to http://agencies.localhost:3000/sites/ and if you don't have any dev site, create one through the `Add sites` button.
3. Once the dev site is created, open the action menu on the side and click the `Prepare for launch` item. It should get you to `https://wordpress.com/sites/settings/site/${ siteSlug }`.
![Markup on 2025-02-21 at 11:38:09](https://github.com/user-attachments/assets/6d7baa30-1bea-4606-b10b-2442d098227b)

4. Similar button can be found on the Licenses page as well: https://agencies.automattic.com/purchases/licenses.
5. Now build the app with `yarn start` (or use the related Calypso Live [link below](https://github.com/Automattic/wp-calypso/pull/100136#issuecomment-2674166490)).
6. Test the `Prepare for launch` links also in: `http://calypso.localhost:3000/sites`
![Markup on 2025-02-21 at 11:49:45](https://github.com/user-attachments/assets/dbbecce1-c034-440f-8438-6e881a89ef64)

7. In `http://calypso.localhost:3000/overview/{site-slug}`:
![Markup on 2025-02-21 at 11:48:58](https://github.com/user-attachments/assets/a8a34ca3-8f03-4e39-aeb6-3f1a78d8e072)

8. And also in `http://calypso.localhost:3000/sites/performance/{site-slug}`:
![Markup on 2025-02-21 at 12:07:27](https://github.com/user-attachments/assets/6591ff4e-464e-4fa9-a6ca-705596b956b1)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?