### PR TITLE
Subscriber Dataview: remove flags from config

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -194,7 +194,6 @@
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": true,
 		"subscriber-importer": true,
-		"subscribers-dataviews": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -125,7 +125,6 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,
-		"subscribers-dataviews": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -78,7 +78,6 @@
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
-		"subscribers-dataviews": true,
 		"upgrades/redirect-payments": true,
 		"jetpack/pricing-page-cart": true,
 		"yolo/command-palette": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -71,7 +71,6 @@
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
-		"subscribers-dataviews": true,
 		"upgrades/redirect-payments": true,
 		"jetpack/pricing-page-cart": true,
 		"yolo/command-palette": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -75,7 +75,6 @@
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
-		"subscribers-dataviews": true,
 		"upgrades/redirect-payments": false,
 		"jetpack/pricing-page-cart": true,
 		"yolo/command-palette": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -75,7 +75,6 @@
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
-		"subscribers-dataviews": true,
 		"upgrades/redirect-payments": true,
 		"jetpack/pricing-page-cart": true,
 		"yolo/command-palette": false,

--- a/config/production.json
+++ b/config/production.json
@@ -162,7 +162,6 @@
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,
-		"subscribers-dataviews": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -158,7 +158,6 @@
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,
-		"subscribers-dataviews": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,

--- a/config/test.json
+++ b/config/test.json
@@ -117,7 +117,6 @@
 		"stats/chart-library": false,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
-		"subscribers-dataviews": true,
 		"themes/premium": true,
 		"untangling/settings-i2": true,
 		"upgrades/redirect-payments": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -166,7 +166,6 @@
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,
-		"subscribers-dataviews": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/99965
Related to https://github.com/Automattic/wp-calypso/pull/100133

## Proposed Changes

* Remove the config definitions

## Why are these changes being made?

Fully remove the Subscriber Dataview project stuff

## Testing Instructions

Smoke test, this shouldn't affect anything