### PR TITLE
Signup: Remove unused launch-only flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -363,18 +363,6 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 		{
-			name: 'launch-only',
-			steps: [ 'launch' ],
-			destination: getLaunchDestination,
-			description:
-				'Launch flow without domain or plan selected, used for sites that already have a paid plan and domain (e.g. via the launch banner in the site preview)',
-			lastModified: '2020-11-30',
-			get pageTitle() {
-				return translate( 'Launch your site' );
-			},
-			providesDependenciesInQuery: [ 'siteSlug' ],
-		},
-		{
 			name: 'business-monthly',
 			steps: [ userSocialStep, 'domains', 'plans-business-monthly' ],
 			destination: getSignupDestination,


### PR DESCRIPTION
## Proposed Changes

Remove the unused `launch-only` flow.

## Why are these changes being made?

Just cleaning up an unused signup flow. You can check the `calypso_signup_start` event with `flow`: `launch-only` to see that it hasn't been in use for the past month.

## Testing Instructions

* Verify removed code is not in use
* All checks should be green.