### PR TITLE
Notifications - add links to users reader profile (round 2)

### DIFF
--- a/apps/notifications/src/panel/templates/block-user.jsx
+++ b/apps/notifications/src/panel/templates/block-user.jsx
@@ -162,15 +162,30 @@ export class UserBlock extends Component {
 			);
 		}
 
+		const userId = this.props.block?.meta?.ids?.user;
+		const readerProfileUrl = userId
+			? `https://wordpress.com/reader/users/id/${ userId }`
+			: home_url;
+
 		if ( home_url ) {
 			return (
 				<div className="wpnc__user">
-					<a className="wpnc__user__site" href={ home_url } target="_blank" rel="noreferrer">
+					<a
+						className="wpnc__user__site"
+						href={ readerProfileUrl }
+						target="_blank"
+						rel="noreferrer"
+					>
 						<img src={ grav.url } height={ grav.height } width={ grav.width } alt="Avatar" />
 					</a>
 					<div>
 						<span className="wpnc__user__username">
-							<a className="wpnc__user__home" href={ home_url } target="_blank" rel="noreferrer">
+							<a
+								className="wpnc__user__home"
+								href={ readerProfileUrl }
+								target="_blank"
+								rel="noreferrer"
+							>
 								{ this.props.block.text }
 							</a>
 						</span>

--- a/apps/notifications/src/panel/templates/summary-in-single.jsx
+++ b/apps/notifications/src/panel/templates/summary-in-single.jsx
@@ -16,7 +16,13 @@ class UserHeader extends Component {
 	render() {
 		const grav = this.props.user.media[ 0 ];
 		const grav_tag = <img src={ grav.url } height={ grav.height } width={ grav.width } alt="" />;
-		const home_url = this.props.user.ranges[ 0 ].url;
+		const base_home_url = this.props.user.ranges[ 0 ].url;
+		// Some site notifications populate Id with the siteId, so consider the userId falsy in this
+		// case.
+		const userId =
+			this.props.user.ranges[ 0 ].id !== this.props.user.ranges[ 0 ].site_id &&
+			this.props.user.ranges[ 0 ].id;
+		const home_url = userId ? `https://wordpress.com/reader/users/id/${ userId }` : base_home_url;
 		const note = this.props.note;
 
 		const get_home_link = function ( classNames, children ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #  Automattic/loop#369
this is a re-ship of https://github.com/Automattic/wp-calypso/pull/99946, using the `reader/users/id/{userid}` route instead of `reader/users/{username||id-fallback}` route.

## Proposed Changes
We initially reverted this due to a rare (but exposed due to some prominent figures) edge case with the `/reader/users/{username||id-fallback}` not linking to the correct profile when there was a conflict with a fully numeric username. To resolve this we added an option on the users endpoint to allow specifically finding a user by ID, and updated calypso to have[ a new route to enable this](https://github.com/Automattic/wp-calypso/pull/100096). We should now be ready to reship this linking to the new id route.


Copying/pasting all of the below from https://github.com/Automattic/wp-calypso/pull/99946

Updates the notifications panel to link to a users reader profile instead of home_url for the avatar images and usernames shown in the flyout panel.

The site links still uses the pre-existing home_urls.

BEFORE
![Screenshot 2025-02-18 at 10 16 49 AM](https://github.com/user-attachments/assets/b0453ddd-24f1-45af-99af-120e6b71071a)

All of these links would go to the corresponding users home_url. 


AFTER
![Screenshot 2025-02-18 at 10 17 29 AM](https://github.com/user-attachments/assets/ba63a3bc-ef56-4877-8037-c06bbb782b53)
![Screenshot 2025-02-18 at 10 17 10 AM](https://github.com/user-attachments/assets/0d8e0e21-19bd-4657-af4a-90ff7e50a739)


Only this links to the corresponding users home_url, while the others circled in before (profile image and name) link to the user profile in the reader.



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The new reader profile page is a better option for these links now that it has been released.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test in calypso:
* Open notification in calypso.
* Verify these links noted above open the users profile page where expected.
* Verify other site and home_url links continue to go where expected.

Test in standalone app:
* use the auto generated comment below to install notifications on your sandbox. You will need to sandbox wordpress.com (if not seeing the change, you may need to also sandbox the test site and widgets).
* Test notifications on a simple site wp-admin screen or a p2, verify these links work as expected.
    * NOTE - when sandboxing wordpress.com, the links to the user profile will 404 since you are sandboxing wordpress.com and it is not running calypso. You can verify the urls are correct, or replace the domain with localhost calypso.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
