### PR TITLE
Untangling: show breadcrumbs under feature flag only

### DIFF
--- a/client/sites/hooks/use-breadcrumbs.ts
+++ b/client/sites/hooks/use-breadcrumbs.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useRemoveDuplicateViewsExperimentEnabled } from 'calypso/lib/remove-duplicate-views-experiment';
 import { useSelector } from 'calypso/state';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
@@ -6,11 +7,16 @@ export default function useBreadcrumbs() {
 	const breadcrumbs = useSelector( getBreadcrumbs );
 	const isRemoveDuplicateViewsExperimentEnabled = useRemoveDuplicateViewsExperimentEnabled();
 
+	const shouldShowBreadcrumbs =
+		isRemoveDuplicateViewsExperimentEnabled &&
+		config.isEnabled( 'untangling/settings-i2' ) &&
+		breadcrumbs.length >= 3;
+
 	return {
 		// In sites dashboard, the components are rendered from the innermost level,
 		// and so the breadcrumb items are added in reversed order.
 		// Here we reverse them again so that they are shown in the correct order.
 		breadcrumbs: [ ...breadcrumbs ].reverse(),
-		shouldShowBreadcrumbs: isRemoveDuplicateViewsExperimentEnabled && breadcrumbs.length >= 3,
+		shouldShowBreadcrumbs,
 	};
 }

--- a/client/sites/settings/administration/tools/delete-site/index.jsx
+++ b/client/sites/settings/administration/tools/delete-site/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { isFreePlanProduct } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
@@ -240,7 +241,9 @@ class DeleteSite extends Component {
 
 		return (
 			<Panel className="settings-administration__delete-site">
-				{ ! isUntangled && <HeaderCakeBack icon="chevron-left" onClick={ this._goBack } /> }
+				{ ! ( isUntangled && config.isEnabled( 'untangling/settings-i2' ) ) && (
+					<HeaderCakeBack icon="chevron-left" onClick={ this._goBack } />
+				) }
 				<NavigationHeader
 					compactBreadcrumb={ false }
 					navigationItems={ [] }

--- a/client/sites/settings/administration/tools/reset-site/index.jsx
+++ b/client/sites/settings/administration/tools/reset-site/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button, FormLabel } from '@automattic/components';
 import {
 	useSiteResetContentSummaryQuery,
@@ -320,7 +321,7 @@ function SiteResetCard( {
 	return (
 		<Panel className="settings-administration__reset-site">
 			{ ! isLoading && <Interval onTick={ checkStatus } period={ EVERY_FIVE_SECONDS } /> }
-			{ ! isUntangled && (
+			{ ! ( isUntangled && config.isEnabled( 'untangling/settings-i2' ) ) && (
 				<HeaderCakeBack icon="chevron-left" href={ `${ source }/${ selectedSiteSlug }` } />
 			) }
 			<NavigationHeader

--- a/client/sites/settings/administration/tools/transfer-site/site-transfer-card.tsx
+++ b/client/sites/settings/administration/tools/transfer-site/site-transfer-card.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import HeaderCakeBack from 'calypso/components/header-cake/back';
@@ -40,7 +41,9 @@ export function SiteTransferCard( {
 
 	return (
 		<Panel className="settings-administration__transfer-site">
-			{ ! isUntangled && <HeaderCakeBack icon="chevron-left" onClick={ onClick } /> }
+			{ ! ( isUntangled && config.isEnabled( 'untangling/settings-i2' ) ) && (
+				<HeaderCakeBack icon="chevron-left" onClick={ onClick } />
+			) }
 			<NavigationHeader
 				title={ title }
 				subtitle={ translate(


### PR DESCRIPTION
Related to p1740137069914119-slack-C029GN3KD

## Proposed Changes

This PR put this previous PR:

- https://github.com/Automattic/wp-calypso/pull/99998

under the `untangling/settings-i2` feature flag.

## Why are these changes being made?

The original PR has a bug (see the linked Slack channel above), so we will hide it under feature flag.

## Testing Instructions

1. Verify that the breadcrumbs are shown by following the instructions from https://github.com/Automattic/wp-calypso/pull/99998
2. Append `?flags=-untangling/settings-i2` and verify that the breadcrumbs are not shown anymore.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?