### PR TITLE
Signup: remove unused domain-transfer flow

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1,6 +1,6 @@
 import { getTracksAnonymousUserId, recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
-import { WPCOM_DIFM_LITE, PRODUCT_1GB_SPACE, isDomainTransfer } from '@automattic/calypso-products';
+import { WPCOM_DIFM_LITE, PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Site, AddOns } from '@automattic/data-stores';
 import { STORAGE_ADD_ONS } from '@automattic/data-stores/src/add-ons';
@@ -1271,7 +1271,7 @@ export function maybeAddStorageAddonToCart( stepName, defaultDependencies, nextP
 }
 
 export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
-	const { isPaidPlan, sitePlanSlug, submitSignupStep, flowName, signupDependencies } = nextProps;
+	const { isPaidPlan, sitePlanSlug, submitSignupStep } = nextProps;
 	const fulfilledDependencies = [];
 	const dependenciesFromDefaults = {};
 
@@ -1280,11 +1280,6 @@ export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 		fulfilledDependencies.push( 'themeSlugWithRepo' );
 		dependenciesFromDefaults.themeSlugWithRepo = defaultDependencies.themeSlugWithRepo;
 	}
-
-	const isTransferSelectedInDomainTransferFlow =
-		'domain-transfer' === flowName &&
-		signupDependencies?.domainItem &&
-		isDomainTransfer( signupDependencies.domainItem );
 
 	if ( isPaidPlan ) {
 		const cartItems = undefined;
@@ -1301,14 +1296,6 @@ export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 			{ cartItems, ...dependenciesFromDefaults }
 		);
 		recordExcludeStepEvent( stepName, defaultDependencies.cartItem );
-		fulfilledDependencies.push( 'cartItems' );
-	} else if ( isTransferSelectedInDomainTransferFlow ) {
-		const cartItems = null;
-		submitSignupStep(
-			{ stepName, cartItems, wasSkipped: true },
-			{ cartItems, ...dependenciesFromDefaults }
-		);
-		recordExcludeStepEvent( stepName, sitePlanSlug );
 		fulfilledDependencies.push( 'cartItems' );
 	}
 

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -216,32 +216,6 @@ describe( 'isPlanFulfilled()', () => {
 		expect( flows.excludeStep ).toHaveBeenCalledWith( stepName );
 	} );
 
-	test( 'should remove a step when a domain transfer is selected in the `domain-transfer` flow', () => {
-		const stepName = 'plans';
-		const nextProps = {
-			isPaidPlan: false,
-			sitePlanSlug: 'sitePlanSlug',
-			flowName: 'domain-transfer',
-			signupDependencies: {
-				domainItem: {
-					product_slug: 'domain_transfer',
-				},
-			},
-			submitSignupStep,
-		};
-
-		expect( flows.excludeStep ).not.toHaveBeenCalled();
-		expect( submitSignupStep ).not.toHaveBeenCalled();
-
-		isPlanFulfilled( stepName, undefined, nextProps );
-
-		expect( submitSignupStep ).toHaveBeenCalledWith(
-			{ stepName, cartItems: null, wasSkipped: true },
-			{ cartItems: null }
-		);
-		expect( flows.excludeStep ).toHaveBeenCalledWith( stepName );
-	} );
-
 	test( 'should not remove unfulfilled step', () => {
 		const stepName = 'plans';
 		const nextProps = {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -187,16 +187,6 @@ export function generateFlows( {
 			hideProgressIndicator: true,
 		},
 		{
-			name: 'domain-transfer',
-			steps: [ userSocialStep, 'domains', 'plans' ],
-			destination: ( dependencies ) => `/domains/manage/${ dependencies.siteSlug }`,
-			description:
-				'Onboarding flow specifically for domain transfers. Read more in https://wp.me/pdhack-Hk.',
-			lastModified: '2023-10-11',
-			showRecaptcha: true,
-			hideProgressIndicator: true,
-		},
-		{
 			name: 'onboarding-pm',
 			steps: [ userSocialStep, 'domains', 'plans' ],
 			destination: getSignupDestination,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1182,7 +1182,7 @@ export class RenderDomainsStep extends Component {
 			return translate( 'Find and claim one or more domain names' );
 		}
 
-		if ( ! stepSectionName && 'domain-transfer' !== flowName ) {
+		if ( ! stepSectionName ) {
 			return translate( 'Enter some descriptive keywords to get started' );
 		}
 
@@ -1194,7 +1194,7 @@ export class RenderDomainsStep extends Component {
 	getHeaderText() {
 		const { headerText, isAllDomains, stepSectionName, translate, flowName } = this.props;
 
-		if ( stepSectionName === 'use-your-domain' || 'domain-transfer' === flowName ) {
+		if ( stepSectionName === 'use-your-domain' ) {
 			return '';
 		}
 
@@ -1232,11 +1232,6 @@ export class RenderDomainsStep extends Component {
 			sideContent = this.getSideContent();
 		}
 
-		if ( 'domain-transfer' === this.props.flowName && ! this.props.stepSectionName ) {
-			content = this.useYourDomainForm();
-			sideContent = null;
-		}
-
 		if ( this.props.step && 'invalid' === this.props.step.status ) {
 			content = (
 				<div className="domains__step-section-wrapper">
@@ -1263,10 +1258,7 @@ export class RenderDomainsStep extends Component {
 	}
 
 	getPreviousStepUrl() {
-		if (
-			'use-your-domain' !== this.props.stepSectionName &&
-			'domain-transfer' !== this.props.flowName
-		) {
+		if ( 'use-your-domain' !== this.props.stepSectionName ) {
 			return null;
 		}
 
@@ -1352,9 +1344,6 @@ export class RenderDomainsStep extends Component {
 		} else if ( isAllDomains ) {
 			backUrl = domainManagementRoot();
 			backLabelText = translate( 'Back to All Domains' );
-		} else if ( ! previousStepBackUrl && 'domain-transfer' === flowName ) {
-			backUrl = null;
-			backLabelText = null;
 		} else if ( 'domain-for-gravatar' === flowName ) {
 			backUrl = null;
 			backLabelText = null;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/78948

## Proposed Changes

Remove unused `domain-transfer` flow from the Signup framework

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The flow is not in use anymore, replaced by an equivalent `/setup` flow: see https://github.com/Automattic/wp-calypso/pull/78948

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit `/start/domain-transfer`
- Both on `trunk` and on this PR, notice that the page is redirected to `/setup/domain-transfer`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
