### PR TITLE
Reader profile - pass context path to reader profile lists tab page

### DIFF
--- a/client/reader/user-profile/controller.tsx
+++ b/client/reader/user-profile/controller.tsx
@@ -63,6 +63,7 @@ export function userLists( ctx: Context, next: () => void ): void {
 			require="calypso/reader/user-profile"
 			key={ 'user-lists-' + userLogin }
 			userLogin={ userLogin }
+			path={ context.path }
 		/>
 	);
 

--- a/client/reader/user-profile/index.tsx
+++ b/client/reader/user-profile/index.tsx
@@ -48,7 +48,7 @@ export function UserProfile( props: UserProfileProps ): JSX.Element | null {
 	}, [ userLogin, requestUser, userId, user ] );
 
 	useEffect( () => {
-		if ( path && path.startsWith( '/reader/users/id/' ) && user ) {
+		if ( path?.startsWith( '/reader/users/id/' ) && user ) {
 			page.replace( `/reader/users/${ user.user_login }` );
 		}
 	}, [ path, user ] );
@@ -70,11 +70,10 @@ export function UserProfile( props: UserProfileProps ): JSX.Element | null {
 		);
 	}
 
-	const currentPath = page.current;
 	const userProfileUrl = getUserProfileUrl( userLogin );
 
 	const renderContent = (): React.ReactNode => {
-		const basePath = currentPath.split( '?' )[ 0 ];
+		const basePath = path?.split( '?' )[ 0 ];
 		switch ( basePath ) {
 			case userProfileUrl:
 				return <UserPosts user={ user } />;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/pull/100149 

## Proposed Changes

Passes the context path as a prop through the userLists route middleware. The main tab and lists tab share a component but have different router middleware, a recent change passed a prop in one and not the other causing a breaking error on the lists page. We shipped a fix noted above to make sure the path is there before checking it, but this will ensure the path will be there from the lists page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* the component needs that prop.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test there are no regressions in the reader user profile tabs.
* test by id as well `/reader/user/id/{userId}`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
