### PR TITLE
Show a TSP banner for everyone

### DIFF
--- a/client/my-sites/promote-post-i2/main.tsx
+++ b/client/my-sites/promote-post-i2/main.tsx
@@ -209,9 +209,7 @@ export default function PromotedPosts( { tab }: Props ) {
 	const userHasCollapsedTspBanner = ( cookies[ TSP_BANNER_COLLAPSED_COOKIE ] ?? '0' ) === '1';
 
 	const showTspBanner = // TSP Banner has a higher priority than the regular banner
-		false && // TODO remove this false to make the banner display after we release tsp
-		( ( ! campaignsIsLoading && campaignsTspEligible ) ||
-			( ! postsIsLoading && postsTspEligible ) );
+		( ! campaignsIsLoading && campaignsTspEligible ) || ( ! postsIsLoading && postsTspEligible );
 
 	const [ isTspBannerCollapsed, setIsTspBannerCollapsed ] = useState( userHasCollapsedTspBanner );
 


### PR DESCRIPTION
Original issue is `3153-gh-Tumblr/a8c-dsp`


## Proposed Changes

* Remove temporary `false` that prevent a TSP banner from being shown for everyone

## Why are these changes being made?

We want to release the Super Native Ad Format (TSP Ads) in WP Blaze for everyone

## Testing Instructions

Even though CR is enough, 
feel free to create a Jurassic Ninja site, connect it to a non-admin user,
open advertising having `https://wordpress.com/advertising/YOUR-SITE-DOMAIN-NAME` in your address bar,
whenever you have TSP eligible posts (read, having Gutenberg blocks), you should see a TSP Banner

![Screenshot 2025-02-21 at 19 28 03](https://github.com/user-attachments/assets/95479c86-9140-4834-a146-9142cdd35f4b)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
