### PR TITLE
Stats: smooths chart lines for better readability

### DIFF
--- a/client/components/chart-uplot/index.tsx
+++ b/client/components/chart-uplot/index.tsx
@@ -83,6 +83,16 @@ export default function UplotChart( {
 
 		const seriesSet = data.length === 3 ? [ mainSeries, subSeries ] : [ mainSeries ];
 
+		// Add padding to y-axis range to smoothen chart visualization when
+		// there's little variation in data. This prevents the chart from
+		// exaggerating small changes.
+		const subscribersData = data[ 1 ] as number[];
+		const min = Math.min( ...subscribersData );
+		const max = Math.max( ...subscribersData );
+		const range = Math.max( 10, max - min );
+		const y_min = Math.max( 0, min - range );
+		const y_max = max + range;
+
 		const defaultOptions: uPlot.Options = {
 			class: 'calypso-uplot-chart',
 			...DEFAULT_DIMENSIONS,
@@ -134,6 +144,12 @@ export default function UplotChart( {
 							: ( stroke as CanvasRenderingContext2D[ 'strokeStyle' ] );
 					},
 					fill: () => '#fff',
+				},
+			},
+			scales: {
+				y: {
+					min: y_min,
+					max: y_max,
 				},
 			},
 			series: [


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #98859.

## Proposed Changes

Softens the Subscribers chart curve for a smoother visual representation of growth, avoiding the reported big slumps.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Automattic/jetpack-roadmap#1818

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Access the Calypso Live link below.
- Go to the Subscribers Stats for a site that has meaningful data, like `/stats/subscribers/week/jetpack.com`
- Click on the arrow to go back 1-2 weeks.
- The subscriber growth should show a smoother growth curve.

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/b64191e6-186b-43cb-805c-0e1fcea6d0fb) | ![image](https://github.com/user-attachments/assets/5cb76bf3-df91-4a01-8ee9-fcc0366819a8) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
