### PR TITLE
Newsletter importer: Add optional chaining to prevent type errors

### DIFF
--- a/client/my-sites/importer/newsletter/utils.tsx
+++ b/client/my-sites/importer/newsletter/utils.tsx
@@ -28,7 +28,7 @@ export function getStepsProgress(
 ) {
 	const summaryStatus = getImporterStatus(
 		paidNewsletterData?.steps?.content?.status,
-		paidNewsletterData?.steps.subscribers.status
+		paidNewsletterData?.steps?.subscribers?.status
 	);
 
 	const result: ClickHandler[] = [
@@ -42,7 +42,7 @@ export function getStepsProgress(
 				);
 			},
 			show: 'onComplete',
-			indicator: getStepProgressIndicator( paidNewsletterData?.steps.subscribers.status ),
+			indicator: getStepProgressIndicator( paidNewsletterData?.steps?.subscribers?.status ),
 		},
 		{
 			message: __( 'Summary' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add optional chaining to prevent type errors I'm seeing when trying to go back and access the newsletter importer again. Or when there are no subscribers in the newsletter data.

Before:
<img width="1174" alt="Screen Shot 2025-02-21 at 12 58 36 PM" src="https://github.com/user-attachments/assets/44d31d17-4e3a-4861-bb5d-8a50ecde07d5" />

After:
<img width="994" alt="Screen Shot 2025-02-21 at 12 58 28 PM" src="https://github.com/user-attachments/assets/a6034c3f-ba8b-4b9f-8b83-26a29c0a54d6" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Prevent errors when re-accessing the newsletter importer.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Complete the content import for a site at /import/newsletter/substack/{site}
* Navigate away and then try to resume at the subscribers import.
* No type errors should be thrown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
