### PR TITLE
Reader User Profile: Update back button styles

### DIFF
--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -259,8 +259,8 @@
 	}
 }
 
-// X-Posts
 .is-reader-page {
+	// X-Posts
 	.reader__card.card.is-x-post {
 		margin: 0;
 		padding: 16px 0 32px;
@@ -303,6 +303,85 @@
 
 	.reader__card.card.is-x-post + .reader__card.card.is-x-post {
 		padding-top: 32px;
+	}
+
+	// Back Button
+	.back-button {
+		border: none;
+		position: fixed;
+		top: calc(var(--masterbar-height) + 29px);
+		left: var(--sidebar-width-max);
+		background-color: transparent;
+		z-index: z-index(".masterbar", ".reader-back");
+
+		button.is-compact.is-borderless {
+			@media ( max-width: 1180px ) {
+				margin: -5px 0 7px 0;
+				padding: 0;
+			}
+
+			@media ( max-width: 600px ) {
+				margin: 0 0 14px 14px;
+			}
+		}
+
+		@media ( max-width: 1180px ) {
+			position: unset;
+			display: flex;
+		}
+	}
+
+	// Styles to allow a temporary ovarlay positioned over
+	// the stream feed while loading and initial scrolling.
+	.main {
+		position: relative;
+
+		&.tag-stream__main {
+			.back-button {
+				button.is-compact.is-borderless {
+					@media ( max-width: 660px ) {
+						padding: 0 0 0 16px;
+					}
+					@media ( max-width: 600px ) {
+						padding: 0 0 8px 0;
+					}
+				}
+			}
+		}
+
+		&.reader-full-post {
+			.back-button {
+				button.is-compact.is-borderless {
+					@media ( max-width: 1180px ) {
+						margin: 7px 0 0 0;
+						padding: 0 0 0 24px;
+					}
+				}
+			}
+		}
+
+		&.search-stream {
+			.following {
+				.back-button {
+					display: none;
+				}
+			}
+		}
+
+		.stream__init-overlay {
+			display: none;
+
+			&.stream__init-overlay-enabled {
+				background: var( --studio-white );
+				position: absolute;
+				display: block;
+				left: 0;
+				right: 0;
+				top: 0;
+				bottom: 0;
+				z-index: z-index( 'root', '.stream__init-overlay-enabled' );
+			}
+		}
 	}
 }
 
@@ -1003,84 +1082,6 @@
 .following-manage__search-followed-input {
 	@include breakpoint-deprecated( '>960px' ) {
 		min-width: 200px;
-	}
-}
-
-// Styles to allow a temporary ovarlay positioned over the stream feed while loading and initial
-// scrolling.
-.is-reader-page .main {
-	position: relative;
-
-	.stream__init-overlay {
-		display: none;
-
-		&.stream__init-overlay-enabled {
-			background: var( --studio-white );
-			position: absolute;
-			display: block;
-			left: 0;
-			right: 0;
-			top: 0;
-			bottom: 0;
-			z-index: z-index( 'root', '.stream__init-overlay-enabled' );
-		}
-	}
-
-	.back-button {
-		border: none;
-		position: fixed;
-		top: calc(var(--masterbar-height) + 29px);
-		left: var(--sidebar-width-max);
-		background-color: transparent;
-		z-index: z-index(".masterbar", ".reader-back");
-	
-		button.is-compact.is-borderless {
-			@media ( max-width: 1180px ) {
-				margin: -5px 0 7px 0;
-				padding: 0;
-			}
-
-			@media ( max-width: 600px ) {
-				margin: 0 0 14px 14px;
-			}
-		}
-	
-		@media ( max-width: 1180px ) {
-			position: unset;
-			display: flex;
-		}
-	}
-
-	&.tag-stream__main {
-		.back-button {
-			button.is-compact.is-borderless {	
-				@media ( max-width: 660px ) {
-					padding: 0 0 0 16px;
-				}
-				@media ( max-width: 600px ) {
-					padding: 0 0 8px 0;
-				}
-			}
-		}
-	}
-
-	&.reader-full-post {
-		.back-button {
-			button.is-compact.is-borderless {
-				@media ( max-width: 1180px ) {
-					margin: 7px 0 0 0;
-					padding: 0 0 0 24px;
-				}
-			}
-		}
-	}
-
-	&.search-stream {
-		.following {
-			.back-button {
-				display: none;
-			}
-		}
 	}
 }
 

--- a/client/reader/user-profile/style.scss
+++ b/client/reader/user-profile/style.scss
@@ -13,8 +13,19 @@
 
 		div.user-profile__wrapper {
 
+			.back-button {
+
+				@media ( max-width: 1300px ) {
+					padding: 24px 24px 0;
+				}
+
+				@media ( max-width: 600px ) {
+					padding: 24px 0 0;
+				}
+			}
+
 			&-content {
-				padding-top: 36px;
+				padding-top: 24px;
 
 				@include breakpoint-deprecated( '<660px' ) {
 					padding-top: 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100089, https://github.com/Automattic/wp-calypso/issues/100095#top

## Proposed Changes

- Moves Reader-wide back button styles so they take effect on the profile page
- Update back button and other padding on profile page

### Before
<img width="1422" alt="Image" src="https://github.com/user-attachments/assets/6275162d-8fc5-460c-bfc3-8f6bb15e5398" />

<img width="1164" alt="Image" src="https://github.com/user-attachments/assets/2a131e6b-6b91-485f-90bc-697a5196eddc" />

<img width="698" alt="Image" src="https://github.com/user-attachments/assets/b5fab059-861f-49fd-95d0-a8942138dba1" />

### After

<img width="1432" alt="Screenshot 2025-02-21 at 19 30 52" src="https://github.com/user-attachments/assets/6e7370fc-06a8-4589-9405-1a7553f13b9c" />

<img width="1064" alt="Screenshot 2025-02-21 at 19 31 01" src="https://github.com/user-attachments/assets/ac53101f-ed65-482e-aaf5-11bb13dc70d0" />

<img width="489" alt="Screenshot 2025-02-21 at 19 31 13" src="https://github.com/user-attachments/assets/9c204b6d-2ec9-4f15-a542-3a76cfeee0dc" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Improving styling.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit `/reader/users/{username}`. Make sure styles appear properly at all browser widths.
- Also check the back button across the Reader:
  - Visible if the user has a back history.
  - Visible in the top left hand corner.
  - Moves to the left of the stream content when space is available, otherwise it will render above the Stream header title.
  - Visible as you scroll down the stream.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
