### PR TITLE
Reader profile - fix the id fallback case of the username route.

### DIFF
--- a/client/state/reader/users/actions.js
+++ b/client/state/reader/users/actions.js
@@ -25,9 +25,9 @@ export function requestUser( userLoginOrId, findById = false ) {
 			dispatch( {
 				type: READER_USER_REQUEST_SUCCESS,
 				// If we find by ID, setting by user_login allows a quick redirect to the normal
-				// route without needing to re-fetch the user. However, for the standard route we
-				// will set by the original requested input to continue being able to handle a
-				// the fallback case of the ID being used in the username route.
+				// route prettified by username without needing to re-fetch the user. However, for
+				// the standard use we must set by the original requested input to continue being
+				// able to handle the fallback case of the ID being used in the username route.
 				userLogin: findById ? userData.user_login : userLoginOrId,
 				userData,
 			} );

--- a/client/state/reader/users/actions.js
+++ b/client/state/reader/users/actions.js
@@ -24,7 +24,11 @@ export function requestUser( userLoginOrId, findById = false ) {
 			requestsInFlight.delete( userLoginOrId );
 			dispatch( {
 				type: READER_USER_REQUEST_SUCCESS,
-				userLogin: userData.user_login,
+				// If we find by ID, setting by user_login allows a quick redirect to the normal
+				// route without needing to re-fetch the user. However, for the standard route we
+				// will set by the original requested input to continue being able to handle a
+				// the fallback case of the ID being used in the username route.
+				userLogin: findById ? userData.user_login : userLoginOrId,
 				userData,
 			} );
 		} catch ( error ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/pull/100098#issuecomment-2675107183 and introduced from https://github.com/Automattic/wp-calypso/pull/100096 

## Proposed Changes

Fixes a bug where the `/reader/users/{username||id-fallback}` route wasnt properly rendering with the id fallback.
* Updates the action dispatch for the user data to continue using what it did before this when we are not specifically requesting by ID.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* I done made more regressions 🙈 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the user profile as much as you can to make sure it works.
* Try `/reader/users/{username||id-fallback}, both with your username and ID, make sure they both work.
* Make sure `/reader/users/id/{userId}` continues to work as expected. 
* Test unfindable values in all of the above (non existant usernames and ids).
* Test the lists tab.
* Test anything else you can think of around user profile.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
