### PR TITLE
Decode entities found in Help Center article title

### DIFF
--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -6,6 +6,7 @@ import { clearHelpCenterZendeskConversationStarted } from '@automattic/odie-clie
 import { CardHeader, Button, Flex, ToggleControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useMemo, useCallback, useEffect, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 import { _n } from '@wordpress/i18n';
 import {
 	closeSmall,
@@ -41,7 +42,7 @@ export function ArticleTitle() {
 		<>
 			<Icon icon={ page } />
 			<span className="help-center-header__article-title">
-				{ ( post && post?.title ) ?? __( 'Help Center', __i18n_text_domain__ ) }
+				{ ( post && decodeEntities( post?.title ) ) ?? __( 'Help Center', __i18n_text_domain__ ) }
 			</span>
 		</>
 	);


### PR DESCRIPTION
Fixes #100131.

## Proposed Changes

* Wraps `post.title` with `decodeEntities()`.
* Follows convention used in [support article header](https://github.com/Automattic/wp-calypso/blob/8e071d56d0929ea15aefce22364cbb4b30e6a5c1/packages/help-center/src/components/help-center-support-article-header.tsx).

## Why are these changes being made?

* Corrects display of encoded entities in Help Center article modal titles. For instance, the curly apostrophe (`&#8217;` or `&rsquo;`) reported in the original issue.

## Testing Instructions

1. Go to `https://wordpress.com/domains/manage/{yoursite}` for a domain you can manage.
2. In the "Primary site address" box, click the "Learn more" link and observe the display of the Help Center article's title bar.
3. Optionally, hover over the truncated title and observe the tooltip.

### Before patch
<img width="581" alt="article title entities are not decoded" src="https://github.com/user-attachments/assets/66ff5dda-ee8c-4be8-9e5a-e230d4f47b4f" />

### After patch
<img width="538" alt="article title entities are decoded" src="https://github.com/user-attachments/assets/ce98f8f3-361a-4fd9-9b05-7c9802d819a1" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
