### PR TITLE
Stats: Add simple header to page content

### DIFF
--- a/client/my-sites/stats/pages/realtime/index.jsx
+++ b/client/my-sites/stats/pages/realtime/index.jsx
@@ -22,6 +22,21 @@ import RealtimeChart from './chart';
 
 import './style.scss';
 
+// TODO: Update header per design review.
+// Each page has slightly different headers so staying simple
+// and requesting feedback first.
+// Not traslating until until design is finalized.
+function StatsRealtimeHeader() {
+	return (
+		<div className="stats-realtime-header">
+			<h2 className="stats-realtime-header__title">Current views</h2>
+			<div className="stats-realtime-header__description">
+				<span>Updates once per minute</span>
+			</div>
+		</div>
+	);
+}
+
 function StatsRealtime() {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state, siteId ) );
@@ -94,6 +109,7 @@ function StatsRealtime() {
 					navigationItems={ [] }
 				></NavigationHeader>
 				<StatsNavigation selectedItem="realtime" siteId={ siteId } slug={ siteSlug } />
+				<StatsRealtimeHeader />
 				<RealtimeChart siteId={ siteId } />
 				<StatsModuleListing className="stats__module-list--insights" siteId={ siteId }>
 					<StatsModuleTopPosts

--- a/client/my-sites/stats/pages/realtime/style.scss
+++ b/client/my-sites/stats/pages/realtime/style.scss
@@ -26,3 +26,28 @@
 	}
 	/* Style the line chart svg using the user admin color scheme */
 }
+
+@import "@automattic/typography/styles/variables";
+
+.stats-realtime-header {
+	margin-top: 32px;
+}
+
+.stats-realtime-header__title {
+	font-family: $brand-serif;
+	// stylelint-disable-next-line declaration-property-unit-allowed-list
+	font-size: 32px;
+	font-style: normal;
+	font-weight: 400;
+	line-height: 40px;
+}
+
+.stats-realtime-header__description {
+	font-family: inherit;
+	// stylelint-disable-next-line declaration-property-unit-allowed-list
+	font-size: 14px;
+	font-style: normal;
+	font-weight: 400;
+	line-height: 16px;
+	color: var(--color-text-subtle);
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: https://github.com/Automattic/red-team/issues/110

## Proposed Changes

Adds a simple header to the Realtime content.

- Not translating strings yet as copy is likely to change.
- Tried to match layout/styles from Insights page.

Should be fine to ship this version for now. We can remove it if we decide to put the content header inside the bounds of the chart.

<img width="612" alt="SCR-20250222-qiur" src="https://github.com/user-attachments/assets/c36a0e24-5f68-4745-a258-714ea7fda450" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Temporary header pending feedback. This very simple header matches the style of the other pages, mostly. It seems they all have slightly different dimensions. Doesn't follow the initial design as that puts the header inside the chart which might not make it clear this applies to the entire page. Seeking design feedback on this one.

cc: @ederrengifo 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live link.
* Enable the flag: `flags=stats/real-time-tab`
* Visit the Realtime tab.
* Confirm the new header is present.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
