### PR TITLE
Stats: decouple real-time line charts

### DIFF
--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -14,7 +14,6 @@ function StatsLineChart( {
 	moment,
 	EmptyState = StatsEmptyState,
 	zeroBaseline = true,
-	xAxisNumTicks,
 	fixedDomain = false,
 }: {
 	chartData: Array< {
@@ -29,7 +28,6 @@ function StatsLineChart( {
 	moment: Moment;
 	EmptyState: typeof StatsEmptyState;
 	zeroBaseline?: boolean;
-	xAxisNumTicks?: number;
 	fixedDomain?: boolean;
 } ) {
 	const translate = useTranslate();
@@ -49,44 +47,45 @@ function StatsLineChart( {
 		return value.toFixed( 0 ).toString();
 	};
 
-	const dataSeries = chartData?.[ 0 ].data || [];
+	const isEmpty = ( chartData?.[ 0 ].data || [] ).length === 0;
 
 	return (
 		<div className={ clsx( 'stats-line-chart', className ) }>
-			{ dataSeries.length === 0 && (
+			{ isEmpty && (
 				<EmptyState
 					headingText={ translate( 'Real-time views' ) }
 					infoText={ translate( 'Collecting data… auto-refreshing in a minute…' ) }
 				/>
 			) }
-			<ThemeProvider theme={ jetpackTheme }>
-				<LineChart
-					data={ chartData }
-					withTooltips
-					withGradientFill
-					height={ height }
-					/** naturalCurve sometime goes off the grid :( */
-					margin={ { left: 15, top: 20, bottom: 20 } }
-					options={ {
-						yScale: {
-							type: 'linear',
-							...( fixedDomain && { domain: [ 0, maxViews ] } ),
-							zero: zeroBaseline,
-						},
-						axis: {
-							x: {
-								tickFormat: formatTime,
-								numTicks: xAxisNumTicks ?? dataSeries.length,
+			{ ! isEmpty && (
+				<ThemeProvider theme={ jetpackTheme }>
+					<LineChart
+						data={ chartData }
+						withTooltips
+						withGradientFill
+						height={ height }
+						/** naturalCurve sometime goes off the grid :( */
+						margin={ { left: 15, top: 20, bottom: 20 } }
+						options={ {
+							yScale: {
+								type: 'linear',
+								...( fixedDomain && { domain: [ 0, maxViews ] } ),
+								zero: zeroBaseline,
 							},
-							y: {
-								orientation: 'right',
-								tickFormat: formatViews,
-								numTicks: maxViews > 4 ? 4 : 1,
+							axis: {
+								x: {
+									tickFormat: formatTime,
+								},
+								y: {
+									orientation: 'right',
+									tickFormat: formatViews,
+									numTicks: maxViews > 4 ? 4 : 1,
+								},
 							},
-						},
-					} }
-				/>
-			</ThemeProvider>
+						} }
+					/>
+				</ThemeProvider>
+			) }
 		</div>
 	);
 }

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -2,11 +2,11 @@ import { LineChart, ThemeProvider, jetpackTheme } from '@automattic/charts';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { Moment } from 'moment';
+import { useMemo } from 'react';
 import StatsEmptyState from '../../stats-empty-state';
 
 function StatsLineChart( {
 	chartData = [],
-	maxViews = 1,
 	formatTimeTick,
 	className,
 	height = 400,
@@ -19,7 +19,6 @@ function StatsLineChart( {
 		options: object;
 		data: Array< { date: Date; value: number } >;
 	} >;
-	maxViews?: number;
 	formatTimeTick?: ( value: number ) => string;
 	className?: string;
 	height?: number;
@@ -45,6 +44,14 @@ function StatsLineChart( {
 	};
 
 	const isEmpty = ( chartData?.[ 0 ].data || [] ).length === 0;
+
+	const maxViews = useMemo(
+		() =>
+			Math.max(
+				...chartData.map( ( serires ) => Math.max( ...serires.data.map( ( d ) => d.value ) ) )
+			),
+		[ chartData ]
+	);
 
 	return (
 		<div className={ clsx( 'stats-line-chart', className ) }>
@@ -76,7 +83,7 @@ function StatsLineChart( {
 								y: {
 									orientation: 'right',
 									tickFormat: formatViews,
-									numTicks: maxViews > 4 ? 4 : 1,
+									numTicks: 4,
 								},
 							},
 						} }

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -92,7 +92,7 @@ function StatsLineChart( {
 								y: {
 									orientation: 'right',
 									tickFormat: formatViews,
-									numTicks: 4,
+									maxViews > 4 ? 4 : 1,
 								},
 							},
 						} }

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -53,6 +53,16 @@ function StatsLineChart( {
 		[ chartData ]
 	);
 
+	// TODO: we should have this in charts lib.
+	const chartDataSorted = useMemo(
+		() =>
+			chartData.map( ( series ) => ( {
+				...series,
+				data: series.data.sort( ( a, b ) => a.date.getTime() - b.date.getTime() ),
+			} ) ),
+		[ chartData ]
+	);
+
 	return (
 		<div className={ clsx( 'stats-line-chart', className ) }>
 			{ isEmpty && (
@@ -64,7 +74,7 @@ function StatsLineChart( {
 			{ ! isEmpty && (
 				<ThemeProvider theme={ jetpackTheme }>
 					<LineChart
-						data={ chartData }
+						data={ chartDataSorted }
 						withTooltips
 						withGradientFill
 						height={ height }

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -2,7 +2,6 @@ import { LineChart, ThemeProvider, jetpackTheme } from '@automattic/charts';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { Moment } from 'moment';
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import StatsEmptyState from '../../stats-empty-state';
 
 function StatsLineChart( {
@@ -11,7 +10,6 @@ function StatsLineChart( {
 	formatTimeTick,
 	className,
 	height = 400,
-	moment,
 	EmptyState = StatsEmptyState,
 	zeroBaseline = true,
 	fixedDomain = false,
@@ -36,10 +34,9 @@ function StatsLineChart( {
 		? formatTimeTick
 		: ( value: number ) => {
 				const date = new Date( value );
-				return new Date( date ).toLocaleTimeString( moment.locale(), {
-					hour: '2-digit',
-					minute: '2-digit',
-					hour12: true,
+				return date.toLocaleDateString( undefined, {
+					month: 'short',
+					day: 'numeric',
 				} );
 		  };
 
@@ -90,4 +87,4 @@ function StatsLineChart( {
 	);
 }
 
-export default withLocalizedMoment( StatsLineChart );
+export default StatsLineChart;

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -92,7 +92,7 @@ function StatsLineChart( {
 								y: {
 									orientation: 'right',
 									tickFormat: formatViews,
-									maxViews > 4 ? 4 : 1,
+									numTicks: maxViews > 4 ? 4 : 1,
 								},
 							},
 						} }

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -78,7 +78,6 @@ function StatsLineChart( {
 						withTooltips
 						withGradientFill
 						height={ height }
-						/** naturalCurve sometime goes off the grid :( */
 						margin={ { left: 15, top: 20, bottom: 20 } }
 						options={ {
 							yScale: {

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -1,12 +1,11 @@
+import { LineChart, ThemeProvider, jetpackTheme } from '@automattic/charts';
+import clsx from 'clsx';
 import moment from 'moment';
 import { useEffect, useState, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import AsyncLoad from 'calypso/components/async-load';
 import wpcom from 'calypso/lib/wp';
-import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { parseChartData } from 'calypso/state/stats/lists/utils';
-import PageLoading from '../shared/page-loading';
 
 type Unit = 'hour' | 'day' | 'week' | 'month' | 'year';
 
@@ -32,7 +31,6 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 	const gmtOffset = useSelector( ( state: object ) =>
 		getSiteOption( state, siteId, 'gmt_offset' )
 	) as number;
-	const momentSiteZone = useSelector( ( state: object ) => getMomentSiteZone( state, siteId ) );
 	const [ viewsData, setViewsData ] = useState( {} as chartMinuteDataTypes );
 	const [ initialViewsCount, setInitialViewsCount ] = useState< number | undefined >( undefined );
 
@@ -131,25 +129,47 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 		return `-${ diffMinutes }m`;
 	};
 
+	const formatViews = ( value: number ) => {
+		return value.toFixed( 0 ).toString();
+	};
+
+	const chartDataSeries = [
+		{
+			label: 'Views',
+			options: {}, //TODO: remove this after fixing chart lib typings.
+			data: chartData,
+		},
+	];
+
 	return (
-		<div>
-			<AsyncLoad
-				require="calypso/my-sites/stats/components/line-chart"
-				className="stats-realtime-chart"
-				height={ 425 }
-				placeholder={ PageLoading }
-				moment={ momentSiteZone }
-				chartData={ [
-					{
-						label: 'Views',
-						data: chartData,
-					},
-				] }
-				maxViews={ maxViews }
-				formatTimeTick={ formatTimeTick }
-				xAxisNumTicks={ 6 }
-				fixedDomain
-			/>
+		<div className={ clsx( 'stats-line-chart', 'stats-realtime-chart' ) }>
+			<ThemeProvider theme={ jetpackTheme }>
+				<LineChart
+					data={ chartDataSeries }
+					withTooltips
+					withGradientFill
+					height={ 425 }
+					/** naturalCurve sometime goes off the grid :( */
+					margin={ { left: 15, top: 20, bottom: 20 } }
+					options={ {
+						yScale: {
+							type: 'linear',
+							domain: [ 0, maxViews ],
+							zero: false,
+						},
+						axis: {
+							x: {
+								tickFormat: formatTimeTick,
+							},
+							y: {
+								orientation: 'right',
+								tickFormat: formatViews,
+								numTicks: maxViews > 4 ? 4 : 1,
+							},
+						},
+					} }
+				/>
+			</ThemeProvider>
 		</div>
 	);
 };

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -120,13 +120,10 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 	// Format the time in minute difference from now.
 	const formatTimeTick = ( value: number ) => {
 		const date = new Date( value );
-		const datetime = date.getTime();
-
-		const now = new Date();
-		const nowDatetime = now.getTime();
-		const diffMinutes = Math.floor( ( nowDatetime - datetime ) / 1000 / 60 );
-
-		return `-${ diffMinutes }m`;
+		return date.toLocaleDateString( undefined, {
+			month: 'short',
+			day: 'numeric',
+		} );
 	};
 
 	const formatViews = ( value: number ) => {

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -120,10 +120,13 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 	// Format the time in minute difference from now.
 	const formatTimeTick = ( value: number ) => {
 		const date = new Date( value );
-		return date.toLocaleDateString( undefined, {
-			month: 'short',
-			day: 'numeric',
-		} );
+		const datetime = date.getTime();
+
+		const now = new Date();
+		const nowDatetime = now.getTime();
+		const diffMinutes = Math.floor( ( nowDatetime - datetime ) / 1000 / 60 );
+
+		return `-${ diffMinutes }m`;
 	};
 
 	const formatViews = ( value: number ) => {

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -149,7 +149,6 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 					withTooltips
 					withGradientFill
 					height={ 425 }
-					/** naturalCurve sometime goes off the grid :( */
 					margin={ { left: 15, top: 20, bottom: 20 } }
 					options={ {
 						yScale: {

--- a/client/my-sites/stats/pages/realtime/index.jsx
+++ b/client/my-sites/stats/pages/realtime/index.jsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import { navItems } from 'calypso/blocks/stats-navigation/constants';
+import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
@@ -17,8 +18,8 @@ import { requestSiteStats } from 'calypso/state/stats/lists/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import PageViewTracker from '../../stats-page-view-tracker';
 import statsStrings from '../../stats-strings';
+import PageLoading from '../shared/page-loading';
 import StatsModuleListing from '../shared/stats-module-listing';
-import RealtimeChart from './chart';
 
 import './style.scss';
 
@@ -110,7 +111,11 @@ function StatsRealtime() {
 				></NavigationHeader>
 				<StatsNavigation selectedItem="realtime" siteId={ siteId } slug={ siteSlug } />
 				<StatsRealtimeHeader />
-				<RealtimeChart siteId={ siteId } />
+				<AsyncLoad
+					require="calypso/my-sites/stats/pages/realtime/chart"
+					siteId={ siteId }
+					placeholder={ PageLoading }
+				/>
 				<StatsModuleListing className="stats__module-list--insights" siteId={ siteId }>
 					<StatsModuleTopPosts
 						moduleStrings={ moduleStrings.posts }

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -20,7 +20,7 @@ import StatsEmptyState from '../stats-empty-state';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatTabs from '../stats-tabs';
 import ChartHeader from './chart-header';
-import { buildChartData, getQueryDate, formatDate } from './utility';
+import { buildChartData, getQueryDate } from './utility';
 
 import './style.scss';
 
@@ -177,7 +177,6 @@ class StatModuleChartTabs extends Component {
 						chartData={ transformChartDataToLineFormat( chartData, this.props.activeLegend ) }
 						height={ 200 }
 						moment={ moment }
-						formatTimeTick={ ( timestamp ) => formatDate( new Date( timestamp ), selectedPeriod ) }
 					/>
 				) }
 

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -178,7 +178,6 @@ class StatModuleChartTabs extends Component {
 						height={ 200 }
 						moment={ moment }
 						formatTimeTick={ ( timestamp ) => formatDate( new Date( timestamp ), selectedPeriod ) }
-						maxViews={ Math.max( ...chartData.map( ( d ) => d.value ) ) }
 					/>
 				) }
 

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -157,16 +157,6 @@ export default function SubscribersChartSection( {
 		},
 	];
 
-	// adds in a tick formatting function to pass to the linechart component
-	// this can be modified to add more date formats (eg. month, year, etc.)
-	const formatTimeTick = ( value: number ) => {
-		const date = new Date( value );
-		return date.toLocaleDateString( undefined, {
-			month: 'short',
-			day: 'numeric',
-		} );
-	};
-
 	const subscribers = {
 		label: 'Subscribers',
 		path: `/stats/subscribers/`,
@@ -220,7 +210,6 @@ export default function SubscribersChartSection( {
 							require="calypso/my-sites/stats/components/line-chart"
 							chartData={ lineChartData }
 							height={ 300 }
-							formatTimeTick={ formatTimeTick }
 							EmptyState={ () => null }
 							zeroBaseline={ false }
 						/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Decouple the usage of a shared line component on real-time page, because it's very different.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Maintenance

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `http://calypso.localhost:3000/stats/subscribers/day/yoursite.com?flags=stats/chart-library`
* Ensure chart look okay
* Open `http://calypso.localhost:3000/stats/realtime/yoursite.com`
* Ensure real-time chart still works like it was

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
