### PR TITLE
Stats: Line Chart Component: Update Views to Value in naming

### DIFF
--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -48,7 +48,7 @@ function StatsLineChart( {
 	const maxValue = useMemo(
 		() =>
 			Math.max(
-				...chartData.map( ( serires ) => Math.max( ...serires.data.map( ( d ) => d.value ) ) )
+				...chartData.map( ( series ) => Math.max( ...series.data.map( ( d ) => d.value ) ) )
 			),
 		[ chartData ]
 	);

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -39,13 +39,13 @@ function StatsLineChart( {
 				} );
 		  };
 
-	const formatViews = ( value: number ) => {
+	const formatValue = ( value: number ) => {
 		return value.toFixed( 0 ).toString();
 	};
 
 	const isEmpty = ( chartData?.[ 0 ].data || [] ).length === 0;
 
-	const maxViews = useMemo(
+	const maxValue = useMemo(
 		() =>
 			Math.max(
 				...chartData.map( ( serires ) => Math.max( ...serires.data.map( ( d ) => d.value ) ) )
@@ -82,7 +82,7 @@ function StatsLineChart( {
 						options={ {
 							yScale: {
 								type: 'linear',
-								...( fixedDomain && { domain: [ 0, maxViews ] } ),
+								...( fixedDomain && { domain: [ 0, maxValue ] } ),
 								zero: zeroBaseline,
 							},
 							axis: {
@@ -91,8 +91,8 @@ function StatsLineChart( {
 								},
 								y: {
 									orientation: 'right',
-									tickFormat: formatViews,
-									numTicks: maxViews > 4 ? 4 : 1,
+									tickFormat: formatValue,
+									numTicks: maxValue > 4 ? 4 : 1,
 								},
 							},
 						} }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-roadmap/issues/2332

## Proposed Changes

* Updates naming of variables from `views` to `value` as it's more generic and can include all kinds of chart values, not just views. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso live branch
* Navigate to `/stats/day/{URL}`
* Check you cannot see anything unusual
* Append feature flag flags=stats/chart-library
* Check that now the toggle button appears
* Click on the toggle, and make sure it toggles between the bar chart and the line chart.
* Make sure nothing is broken or missing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
