### PR TITLE
Sites dashboard: initialize breadcrumbs when first rendering sites dashboard

### DIFF
--- a/client/sites/components/sites-dashboard.tsx
+++ b/client/sites/components/sites-dashboard.tsx
@@ -34,6 +34,7 @@ import { useSelector } from 'calypso/state';
 import { shouldShowSiteDashboard } from 'calypso/state/global-sidebar/selectors';
 import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { useInitializeBreadcrumbs } from '../hooks/use-initialize-breadcrumbs';
 import { useInitializeDataViewsPage } from '../hooks/use-initialize-dataviews-page';
 import { useShowSiteCreationNotice } from '../hooks/use-show-site-creation-notice';
 import { useShowSiteTransferredNotice } from '../hooks/use-show-site-transferred-notice';
@@ -314,6 +315,7 @@ const SitesDashboard = ( {
 
 	const onboardingTours = useOnboardingTours();
 
+	useInitializeBreadcrumbs( selectedSite?.ID );
 	useInitializeDataViewsPage( dataViewsState, setDataViewsState );
 
 	// Update URL with view control params on change.

--- a/client/sites/hooks/use-initialize-breadcrumbs.ts
+++ b/client/sites/hooks/use-initialize-breadcrumbs.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'calypso/state';
+import { resetBreadcrumbs } from 'calypso/state/breadcrumb/actions';
+
+export function useInitializeBreadcrumbs( siteId: number | undefined ) {
+	const dispatch = useDispatch();
+	useEffect( () => {
+		if ( ! siteId ) {
+			dispatch( resetBreadcrumbs() );
+		}
+	}, [ siteId, dispatch ] );
+}

--- a/client/sites/hooks/use-set-feature-breadcrumb.ts
+++ b/client/sites/hooks/use-set-feature-breadcrumb.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'calypso/state';
+import { resetBreadcrumbs, updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
+
+export function useSetFeatureBreadcrumb( {
+	siteId,
+	title,
+}: {
+	siteId: number | undefined;
+	title: string;
+} ) {
+	const dispatch = useDispatch();
+	useEffect( () => {
+		dispatch(
+			updateBreadcrumbs( [
+				{
+					id: 'feature',
+					label: title,
+				},
+			] )
+		);
+		return () => {
+			dispatch( resetBreadcrumbs() );
+		};
+	}, [ siteId, title ] ); // eslint-disable-line react-hooks/exhaustive-deps
+}
+
+export function FeatureBreadcrumb( {
+	siteId,
+	title,
+}: {
+	siteId: number | undefined;
+	title: string;
+} ) {
+	useSetFeatureBreadcrumb( { siteId, title } );
+	return null;
+}

--- a/client/sites/settings/administration/tools/delete-site/index.jsx
+++ b/client/sites/settings/administration/tools/delete-site/index.jsx
@@ -17,6 +17,7 @@ import { Panel, PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import withP2HubP2Count from 'calypso/data/p2/with-p2-hub-p2-count';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSettingsSource } from 'calypso/my-sites/site-settings/site-tools/utils';
+import { FeatureBreadcrumb } from 'calypso/sites/hooks/use-set-feature-breadcrumb';
 import { resetBreadcrumbs, updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
 import { getRemoveDuplicateViewsExperimentAssignment } from 'calypso/state/explat-experiments/actions';
 import { getIsRemoveDuplicateViewsExperimentEnabled } from 'calypso/state/explat-experiments/selectors';
@@ -178,17 +179,6 @@ class DeleteSite extends Component {
 		page( `${ source }/${ siteSlug }` );
 	};
 
-	refreshBreadcrumbs( prevProps ) {
-		if ( this.props.siteId && this.props.siteId !== prevProps?.siteId ) {
-			this.props.updateBreadcrumbs( [
-				{
-					id: 'subtab',
-					label: translate( 'Delete site' ),
-				},
-			] );
-		}
-	}
-
 	componentDidUpdate( prevProps ) {
 		const { siteId, siteExists, useSitesAsLandingPage } = this.props;
 
@@ -200,17 +190,10 @@ class DeleteSite extends Component {
 				page.redirect( '/' );
 			}
 		}
-
-		this.refreshBreadcrumbs( prevProps );
 	}
 
 	componentDidMount() {
 		this.props.getRemoveDuplicateViewsExperimentAssignment();
-		this.refreshBreadcrumbs( undefined );
-	}
-
-	componentWillUnmount() {
-		this.props.resetBreadcrumbs();
 	}
 
 	_checkSiteLoaded = ( event ) => {
@@ -244,6 +227,7 @@ class DeleteSite extends Component {
 				{ ! ( isUntangled && config.isEnabled( 'untangling/settings-i2' ) ) && (
 					<HeaderCakeBack icon="chevron-left" onClick={ this._goBack } />
 				) }
+				<FeatureBreadcrumb siteId={ siteId } title={ strings.deleteSite } />
 				<NavigationHeader
 					compactBreadcrumb={ false }
 					navigationItems={ [] }

--- a/client/sites/settings/administration/tools/reset-site/index.jsx
+++ b/client/sites/settings/administration/tools/reset-site/index.jsx
@@ -9,7 +9,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import { createInterpolateElement, useState } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { localize } from 'i18n-calypso';
-import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -23,11 +22,11 @@ import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
 import { useRemoveDuplicateViewsExperimentEnabled } from 'calypso/lib/remove-duplicate-views-experiment';
 import { getSettingsSource } from 'calypso/my-sites/site-settings/site-tools/utils';
 import { useDispatch, useSelector } from 'calypso/state';
-import { resetBreadcrumbs, updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { getSite, getSiteDomain, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { useSetFeatureBreadcrumb } from '../../../../hooks/use-set-feature-breadcrumb';
 import { DIFMUpsell } from '../../../components/difm-upsell-banner';
 
 import './style.scss';
@@ -54,19 +53,7 @@ function SiteResetCard( {
 	const title = isUntangled ? translate( 'Reset site' ) : translate( 'Site Reset' );
 	const source = isUntangled ? '/sites/settings/site' : getSettingsSource();
 
-	useEffect( () => {
-		dispatch(
-			updateBreadcrumbs( [
-				{
-					id: 'subtab',
-					label: title,
-				},
-			] )
-		);
-		return () => {
-			dispatch( resetBreadcrumbs() );
-		};
-	}, [ siteId, title ] ); // eslint-disable-line react-hooks/exhaustive-deps
+	useSetFeatureBreadcrumb( { siteId, title } );
 
 	const checkStatus = async () => {
 		if ( status?.status !== 'completed' && isAtomic ) {

--- a/client/sites/settings/administration/tools/transfer-site/site-transfer-card.tsx
+++ b/client/sites/settings/administration/tools/transfer-site/site-transfer-card.tsx
@@ -1,14 +1,12 @@
 import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
 import HeaderCakeBack from 'calypso/components/header-cake/back';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { Panel, PanelCard } from 'calypso/components/panel';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useRemoveDuplicateViewsExperimentEnabled } from 'calypso/lib/remove-duplicate-views-experiment';
-import { useDispatch } from 'calypso/state';
-import { resetBreadcrumbs, updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
+import { useSetFeatureBreadcrumb } from 'calypso/sites/hooks/use-set-feature-breadcrumb';
 
 export function SiteTransferCard( {
 	children,
@@ -23,21 +21,7 @@ export function SiteTransferCard( {
 	const isUntangled = useRemoveDuplicateViewsExperimentEnabled();
 	const title = isUntangled ? translate( 'Transfer site' ) : translate( 'Site Transfer' );
 
-	const dispatch = useDispatch();
-
-	useEffect( () => {
-		dispatch(
-			updateBreadcrumbs( [
-				{
-					id: 'subtab',
-					label: title,
-				},
-			] )
-		);
-		return () => {
-			dispatch( resetBreadcrumbs() );
-		};
-	}, [ siteId, title ] ); // eslint-disable-line react-hooks/exhaustive-deps
+	useSetFeatureBreadcrumb( { siteId, title } );
 
 	return (
 		<Panel className="settings-administration__transfer-site">


### PR DESCRIPTION
Fixes p1740137069914119-slack-C029GN3KD

## Proposed Changes

This PR proposes to reset/reinitializes breadcrumbs when we go to site-specific view in the sites dashboard.

This PR also takes the opportunity to refactor the logic of appending individual feature breadcrumb item into a new hook.

## Why are these changes being made?

Fixes a regression stated in the Slack message above.

## Testing Instructions

1. Go to /sites.
2. Click Plugins
3. Click a plugin
4. Click the back button to go back to /sites
5. Click a site
6. Verify that you don't see any breadcrumb (unlike the video shown in the linked Slack message)
7. Go to Settings
8. Try going to {Reset site, Transfer site, Delete site} and verify you can see the breadcrumbs as per normal.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?