### PR TITLE
Design Picker: Shuffle Best Matching Themes section

### DIFF
--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -222,7 +222,7 @@ const DesignCardGroup = ( {
 	const shuffleSeed = useMemo(
 		() =>
 			selectedCategories
-				.join( '' )
+				.join( ',' )
 				.split( '' )
 				.reduce( ( acc, char ) => acc + char.charCodeAt( 0 ), 0 ),
 		[ selectedCategories ]
@@ -238,7 +238,7 @@ const DesignCardGroup = ( {
 		if ( category === 'best' ) {
 			return [
 				...shuffleDesigns( boosted, shuffleSeed ),
-				...shuffleDesigns( remaining, shuffleSeed ),
+				...shuffleDesigns( remaining, shuffleSeed * 31 ), // Prime number for better distribution.
 			];
 		}
 

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -16,6 +16,7 @@ import {
 	isDefaultGlobalStylesVariationSlug,
 	isFeatureCategory,
 	isLockedStyleVariation,
+	shuffleDesigns,
 } from '../utils';
 import DesignPickerCategoryFilter from './design-picker-category-filter';
 import DesignPreviewImage from './design-preview-image';
@@ -216,21 +217,40 @@ const DesignCardGroup = ( {
 }: DesignCardGroup ) => {
 	const translate = useTranslate();
 	const [ isCollapsed, setIsCollapsed ] = useState( !! categoryName || false );
+	const { selectedCategories } = useDesignPickerFilters();
+
+	const shuffleSeed = useMemo(
+		() =>
+			selectedCategories
+				.join( '' )
+				.split( '' )
+				.reduce( ( acc, char ) => acc + char.charCodeAt( 0 ), 0 ),
+		[ selectedCategories ]
+	);
 
 	const visibleDesigns = useMemo( () => {
 		const free = designs.filter( ( design ) => design.design_tier === FREE_THEME );
 		const boosted = free.slice( 0, FREE_DESIGNS_BOOSTED_COUNT );
 		const remaining = designs.filter( ( design ) => ! boosted.includes( design ) );
 
-		if ( ! isCollapsed ) {
-			return [ ...boosted, ...remaining ];
+		// Ensure Best Matching Themes changes whenever selected categories are updated.
+		// This provides visual feedback so that users notice that the results have changed.
+		if ( category === 'best' ) {
+			return [
+				...shuffleDesigns( boosted, shuffleSeed ),
+				...shuffleDesigns( remaining, shuffleSeed ),
+			];
 		}
 
-		return [
-			...boosted,
-			...remaining.slice( 0, COLLAPSED_DESIGNS_VISIBLE_COUNT - boosted.length ),
-		];
-	}, [ isCollapsed, designs ] );
+		if ( isCollapsed ) {
+			return [
+				...boosted,
+				...remaining.slice( 0, COLLAPSED_DESIGNS_VISIBLE_COUNT - boosted.length ),
+			];
+		}
+
+		return [ ...boosted, ...remaining ];
+	}, [ isCollapsed, designs, category, shuffleSeed ] );
 
 	const content = (
 		<div className="design-picker__grid">

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -79,14 +79,11 @@ export const getThemeIdFromDesign = ( design: Design ) => {
 };
 
 export const shuffleDesigns = ( designs: Design[], seed: number ) => {
-	const designsToShuffle = [ ...designs ];
-	for ( let i = designsToShuffle.length - 1; i > 0; i-- ) {
-		const j = ( i + seed + designsToShuffle.length ) % i;
-		[ designsToShuffle[ i ], designsToShuffle[ j ] ] = [
-			designsToShuffle[ j ],
-			designsToShuffle[ i ],
-		];
+	const shuffled = [ ...designs ];
+	for ( let i = shuffled.length - 1; i > 0; i-- ) {
+		const j = ( i + seed + shuffled.length ) % ( i + 1 );
+		[ shuffled[ i ], shuffled[ j ] ] = [ shuffled[ j ], shuffled[ i ] ];
 	}
 
-	return designsToShuffle;
+	return shuffled;
 };

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -77,3 +77,16 @@ export const getThemeIdFromDesign = ( design: Design ) => {
 	}
 	return null;
 };
+
+export const shuffleDesigns = ( designs: Design[], seed: number ) => {
+	const designsToShuffle = [ ...designs ];
+	for ( let i = designsToShuffle.length - 1; i > 0; i-- ) {
+		const j = ( i + seed + designsToShuffle.length ) % i;
+		[ designsToShuffle[ i ], designsToShuffle[ j ] ] = [
+			designsToShuffle[ j ],
+			designsToShuffle[ i ],
+		];
+	}
+
+	return designsToShuffle;
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/10244

## Proposed Changes

The PR updates the ordering of the Best Matching Themes section so that every time users update category filters, the ordering of the section will be different even if the themes remain the same. This is to provide clear visual feedback from users interacting with category filters.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://github.com/Automattic/wp-calypso/pull/98205#pullrequestreview-2547627544 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Design Picker
* Try different category combinations and ensure that the Best Matching Themes section changes every time
* For instance, Blog + Podcast + Business and Blog + Podcast + Business + About have the same Best Matching Theme results

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
