### PR TITLE
Launch site: Fix colors in WP-Admin

### DIFF
--- a/apps/command-palette-wp-admin/webpack.config.js
+++ b/apps/command-palette-wp-admin/webpack.config.js
@@ -36,11 +36,8 @@ function getWebpackConfig( env, argv ) {
 				requestToExternal( request ) {
 					// The extraction logic will only extract a dependency if requestToExternal
 					// explicitly returns undefined for the given request. Null shortcuts the
-					// logic such that @wordpress/commands styles and @wordpress/react-i18n are bundled.
-					if (
-						request === '@wordpress/commands/build-style/style.css' ||
-						request === '@wordpress/react-i18n'
-					) {
+					// logic such that @wordpress/react-i18n styles are bundled.
+					if ( request === '@wordpress/react-i18n' ) {
 						return null;
 					}
 				},

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -20,7 +20,6 @@ import { siteUsesWpAdminInterface } from './utils';
 import type { Command as PaletteCommand } from './commands';
 import type { SiteExcerptData } from '@automattic/sites';
 import './style.scss';
-import '@wordpress/commands/build-style/style.css';
 
 const StyledCommandsMenuContainer = styled.div( {
 	'[cmdk-root] > [cmdk-list]': {

--- a/packages/command-palette/src/style.scss
+++ b/packages/command-palette/src/style.scss
@@ -1,3 +1,7 @@
+@import "~@wordpress/base-styles/variables";
+@import "~@wordpress/base-styles/mixins";
+@import "~@wordpress/base-styles/breakpoints";
+
 .commands-command-menu__overlay {
 	z-index: z-index("root", ".commands-commands-menu__overlay");
 }
@@ -18,3 +22,5 @@ div.commands-command-menu {
 .commands-command-menu__header svg {
 	fill: #1e1e1e;
 }
+
+@import '~@wordpress/commands/src/style';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

The command palette build comes with color scheme variables that override the correct ones in WP-Admin. This PR removes those variables from the CSS build file. 

Related to https://github.com/Automattic/wp-calypso/issues/99971

## Proposed Changes

* Remove the color variables from the wpcom command palette build

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The command palette build for WP-Admin also contained color variables, overriding the correct ones

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Update your sandbox with the app
* Go to a Simple site in `wp-admin/edit.php`
* Notice that the "Launch site" button has the same blue color as in Calypso

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
