### PR TITLE
Global Styles: Disabled Global Styles on Personal in all envs

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -66,7 +66,7 @@
 		"cookie-banner": false,
 		"google-drive": true,
 		"google-my-business": true,
-		"global-styles/on-personal-plan": true,
+		"global-styles/on-personal-plan": false,
 		"help": true,
 		"help/gpt-response": true,
 		"home/launchpad-first": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -33,7 +33,7 @@
 		"domain-to-plan-credit": false,
 		"cookie-banner": true,
 		"google-my-business": false,
-		"global-styles/on-personal-plan": true,
+		"global-styles/on-personal-plan": false,
 		"help": true,
 		"home/launchpad-first": false,
 		"home/layout-dev": true,

--- a/config/production.json
+++ b/config/production.json
@@ -45,7 +45,7 @@
 		"cookie-banner": true,
 		"domain-to-plan-credit": false,
 		"google-my-business": true,
-		"global-styles/on-personal-plan": true,
+		"global-styles/on-personal-plan": false,
 		"help": true,
 		"help/gpt-response": true,
 		"home/launchpad-first": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -45,7 +45,7 @@
 		"domain-to-plan-credit": false,
 		"cookie-banner": false,
 		"google-my-business": true,
-		"global-styles/on-personal-plan": true,
+		"global-styles/on-personal-plan": false,
 		"help": true,
 		"help/gpt-response": true,
 		"home/launchpad-first": false,

--- a/config/test.json
+++ b/config/test.json
@@ -46,7 +46,7 @@
 		"domain-to-plan-credit": false,
 		"cookie-banner": false,
 		"google-my-business": false,
-		"global-styles/on-personal-plan": true,
+		"global-styles/on-personal-plan": false,
 		"help": true,
 		"hosting-server-settings-enhancements": true,
 		"importers/newsletter": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -50,7 +50,7 @@
 		"email-accounts/enabled": true,
 		"cookie-banner": true,
 		"google-my-business": true,
-		"global-styles/on-personal-plan": true,
+		"global-styles/on-personal-plan": false,
 		"help": true,
 		"help/gpt-response": true,
 		"home/launchpad-first": true,

--- a/packages/calypso-products/src/feature-group-plan-map.ts
+++ b/packages/calypso-products/src/feature-group-plan-map.ts
@@ -471,10 +471,10 @@ export function resolveFeatureGroupsForFeaturesGrid( {
 			[ FEATURE_GROUP_ADS ]: featureGroups[ FEATURE_GROUP_ADS ],
 			[ FEATURE_GROUP_THEMES ]: featureGroups[ FEATURE_GROUP_THEMES ],
 			[ FEATURE_GROUP_SUPPORT ]: featureGroups[ FEATURE_GROUP_SUPPORT ],
-			[ FEATURE_GROUP_CUSTOMIZE_STYLE ]: featureGroups[ FEATURE_GROUP_CUSTOMIZE_STYLE ],
 			...( isStatsGroupTranslated() && {
 				[ FEATURE_GROUP_STATS ]: featureGroups[ FEATURE_GROUP_STATS ],
 			} ),
+			[ FEATURE_GROUP_CUSTOMIZE_STYLE ]: featureGroups[ FEATURE_GROUP_CUSTOMIZE_STYLE ],
 			[ FEATURE_GROUP_ANALYTICS ]: featureGroups[ FEATURE_GROUP_ANALYTICS ],
 			...( isUploadVideosTranslated() && {
 				[ FEATURE_GROUP_UPLOAD_VIDEOS ]: featureGroups[ FEATURE_GROUP_UPLOAD_VIDEOS ],

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -747,20 +747,22 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 				'Unlock unlimited, expert customer support via email.'
 		),
 	getPlanCompareFeatures: () =>
-		compact( [
-			// pay attention to ordering, shared features should align on /plan page
-			FEATURE_CUSTOM_DOMAIN,
-			FEATURE_HOSTING,
-			FEATURE_JETPACK_ESSENTIAL,
-			FEATURE_FAST_SUPPORT_FROM_EXPERTS,
-			FEATURE_FREE_THEMES,
-			isGlobalStylesOnPersonalEnabled() ? FEATURE_STYLE_CUSTOMIZATION : null,
-			FEATURE_6GB_STORAGE,
-			FEATURE_NO_ADS,
-			FEATURE_MEMBERSHIPS,
-			FEATURE_PREMIUM_CONTENT_BLOCK,
-			FEATURE_PAYMENT_TRANSACTION_FEES_8,
-		] ),
+		compact(
+			[
+				// pay attention to ordering, shared features should align on /plan page
+				FEATURE_CUSTOM_DOMAIN,
+				FEATURE_HOSTING,
+				FEATURE_JETPACK_ESSENTIAL,
+				FEATURE_FAST_SUPPORT_FROM_EXPERTS,
+				FEATURE_FREE_THEMES,
+				isGlobalStylesOnPersonalEnabled() ? FEATURE_STYLE_CUSTOMIZATION : null,
+				FEATURE_6GB_STORAGE,
+				FEATURE_NO_ADS,
+				FEATURE_MEMBERSHIPS,
+				FEATURE_PREMIUM_CONTENT_BLOCK,
+				FEATURE_PAYMENT_TRANSACTION_FEES_8,
+			].filter( ( feature ) => feature !== null )
+		),
 	getSignupFeatures: () => {
 		const baseFeatures = [
 			FEATURE_FREE_DOMAIN,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
## Proposed Changes

* Disabled the feature on all environments.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* After the Big Sky experiment has finished, we need to disable the Global Styles on Personal feature to re-run the Global Styles on Personal experiment.
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Apply this 174564-ghe-Automattic/wpcom to your sandbox
* Apply https://github.com/Automattic/jetpack/pull/41999
* Sandbox your API
* Test ALL the Global Styles flows.
* Test Upgrade Modals.
* Test Site Editor.
* Test Theme Showcase.
* Test Theme Details page.
* Test ALL pricing grid variations (new, upgrade, etc)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?