### PR TITLE
Desktop app: Set the rememberme field when logging in with oauth token

### DIFF
--- a/client/login/desktop-login/finalize.tsx
+++ b/client/login/desktop-login/finalize.tsx
@@ -55,6 +55,7 @@ export default function DesktopLoginFinalize( props: Props ) {
 			log={ username }
 			authorization={ 'Bearer ' + accessToken }
 			redirectTo={ window.location.href }
+			rememberMe
 		/>
 	);
 }

--- a/client/signup/wpcom-login-form/index.jsx
+++ b/client/signup/wpcom-login-form/index.jsx
@@ -39,7 +39,7 @@ export default function WpcomLoginForm( {
 			<input type="hidden" name="pwd" value={ pwd } />
 			<input type="hidden" name="authorization" value={ authorization } />
 			<input type="hidden" name="redirect_to" value={ redirectTo } />
-			{ rememberMe ? <input type="hidden" name="rememberme" value="true" /> : undefined }
+			{ rememberMe ? <input type="hidden" name="rememberme" value="forever" /> : undefined }
 		</form>
 	);
 }

--- a/client/signup/wpcom-login-form/index.jsx
+++ b/client/signup/wpcom-login-form/index.jsx
@@ -20,7 +20,13 @@ function getFormAction( redirectTo ) {
 	return `https://${ subdomain }wordpress.com/wp-login.php`;
 }
 
-export default function WpcomLoginForm( { redirectTo, authorization, pwd = '', log } ) {
+export default function WpcomLoginForm( {
+	redirectTo,
+	authorization,
+	pwd = '',
+	log,
+	rememberMe = false,
+} ) {
 	const form = useRef();
 
 	useEffect( () => {
@@ -33,6 +39,7 @@ export default function WpcomLoginForm( { redirectTo, authorization, pwd = '', l
 			<input type="hidden" name="pwd" value={ pwd } />
 			<input type="hidden" name="authorization" value={ authorization } />
 			<input type="hidden" name="redirect_to" value={ redirectTo } />
+			{ rememberMe ? <input type="hidden" name="rememberme" value="true" /> : undefined }
 		</form>
 	);
 }


### PR DESCRIPTION
## Proposed Changes
In #98345 we introduced a new OAuth login flow for the desktop app. This OAuth flow is disabled at the moment, it will be enabled in #99742. However, there's currently an issue that causes the user to be logged-out when they close and reopen the app.

This PR fixes that issue by setting the `rememberme` field when submitting the login form, after the user has done the OAuth authentication flow in their browser. If the `rememberme` is not set, the cookie will be a session cookie, so it will expire immediately when the app is closed.

## Why are these changes being made?
This fix is being made in a separate PR than #99742 because it needs to be deployed separately, so that we can test the fix in #99742.

## Testing Instructions

This fix should have no impact because the OAuth flow is not in use yet in the desktop app. Thus, these changes will be tested in #99742.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
