### PR TITLE
Site migration check: Use Loading component

### DIFF
--- a/client/blocks/import/scanning/index.tsx
+++ b/client/blocks/import/scanning/index.tsx
@@ -1,23 +1,11 @@
-import { Title, SubTitle } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
-import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
-import type * as React from 'react';
-
-/* eslint-disable wpcalypso/jsx-classname-namespace */
+import Loading from 'calypso/components/loading';
 
 const ScanningStep: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 
 	return (
-		<div className="import-layout__center">
-			<div className="import__header scanning__header">
-				<div className="import__heading import__heading-center">
-					<Title>{ __( 'Scanning your site' ) }</Title>
-					<SubTitle>{ __( "We'll be done in no time." ) }</SubTitle>
-					<LoadingEllipsis />
-				</div>
-			</div>
-		</div>
+		<Loading title={ __( 'Scanning your site' ) } subtitle={ __( "We'll be done in no time." ) } />
 	);
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/100272

## Proposed Changes

Before

<img width="819" alt="Image" src="https://github.com/user-attachments/assets/24e23844-b6c4-4776-9c59-636accaea702" />

After

<img width="1046" alt="image" src="https://github.com/user-attachments/assets/1f8f3eda-9c69-4696-b638-ae37cb40a3a0" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start a new site
2. On the Goals screen, select 'Import or migrate an existing site' or alternatively visit [wordpress.com/setup/site-migration](https://wordpress.com/setup/site-migration/)
3. Add a valid domain and click "Check my site"