### PR TITLE
use-wait-for-atomic: Fix atomic transfer wait on ecommerce trial

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -41,7 +41,7 @@ const PostCheckoutOnboarding: Step = ( { navigation } ) => {
 		useSiteTransferStatusQuery( site?.ID );
 
 	const { waitForInitiateTransfer, waitForTransfer, waitForFeature, waitForLatestSiteData } =
-		useWaitForAtomic();
+		useWaitForAtomic( {} );
 
 	const waitForAtomic = async () => {
 		await waitForTransfer();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
@@ -50,7 +50,7 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 	};
 
 	const { waitForInitiateTransfer, waitForTransfer, waitForFeature, waitForLatestSiteData } =
-		useWaitForAtomic( { handleTransferFailure } );
+		useWaitForAtomic( { handleTransferFailure, siteId } );
 
 	useEffect( () => {
 		if ( ! siteId ) {

--- a/client/landing/stepper/hooks/use-wait-for-atomic.ts
+++ b/client/landing/stepper/hooks/use-wait-for-atomic.ts
@@ -34,12 +34,13 @@ export const transferStates = {
 
 interface UseWaitForAtomicProps {
 	handleTransferFailure?: ( failureInfo: FailureInfo ) => void;
+	siteId?: number;
 }
 
 export const useWaitForAtomic = ( {
 	handleTransferFailure,
 	siteId: providedSiteId,
-}: UseWaitForAtomicProps & { siteId?: number } ) => {
+}: UseWaitForAtomicProps ) => {
 	const [ searchParams ] = useSearchParams();
 	const reduxDispatch = useReduxDispatch();
 

--- a/client/landing/stepper/hooks/use-wait-for-atomic.ts
+++ b/client/landing/stepper/hooks/use-wait-for-atomic.ts
@@ -36,10 +36,17 @@ interface UseWaitForAtomicProps {
 	handleTransferFailure?: ( failureInfo: FailureInfo ) => void;
 }
 
-export const useWaitForAtomic = ( { handleTransferFailure }: UseWaitForAtomicProps = {} ) => {
+export const useWaitForAtomic = ( {
+	handleTransferFailure,
+	siteId: providedSiteId,
+}: UseWaitForAtomicProps & { siteId?: number } ) => {
 	const [ searchParams ] = useSearchParams();
 	const reduxDispatch = useReduxDispatch();
-	const { siteId } = useSiteData();
+
+	const { siteId: hookSiteId } = useSiteData();
+	// Use provided siteId if available, otherwise fall back to hookSiteId
+	const siteId = providedSiteId || hookSiteId;
+
 	const { requestLatestAtomicTransfer } = useDispatch( SITE_STORE );
 	const { getSiteLatestAtomicTransfer, getSiteLatestAtomicTransferError } = useSelect(
 		( select ) => select( SITE_STORE ) as SiteSelect,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

**Issue**: When creating a new eCommerce trial site (e.g., via `https://wordpress.com/setup/entrepreneur/start/?ref=pricing-lp`), the signup flow breaks after receiving a `siteId` from `/new`. 

Subsequent requests (e.g., `/atomic/transfers/latest`) use `siteId=0` in the url and fail with "invalid site" errors due to the `siteId` not being properly propagated through the `wait-for-atomic` step. This regression was introduced in #99744.

**Fix**: Modified the `useWaitForAtomic` hook to accept an optional `siteId` parameter and explicitly pass the `siteId` from the `WaitForAtomic` component. 

This ensures the hook uses the correct `siteId` from the flow rather than relying on `useSiteData()`, which may not have the correct site data.

See also p1740410638840639-slack-C02FMH4G8

## Why are these changes being made?

* To unbreak ecommerce trial site creation

## Testing Instructions

1. Visit `calypso.localhost:3000/setup/entrepreneur/start/?ref=pricing-lp`.
2. Create a new eCommerce store with "Physical products".
3. Verify the flow completes, and you’re redirected to the new site’s dashboard (e.g., `https://<site-slug>.wordpress.com/wp-admin`).
4. Check network requests to confirm `/atomic/transfers/latest` uses the correct `siteId`.

**IMPORTANT**: Other atomic related flows need to keep working (not sure how to test?)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?