### PR TITLE
Reader: Fix back button styles in site stream

### DIFF
--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -385,6 +385,12 @@
 	}
 }
 
+body.is-section-reader div.layout.is-global-sidebar-visible .is-site-stream .back-button button.is-compact.is-borderless {
+	@media ( max-width: 1300px ) {
+		margin-bottom: 24px;
+	}
+}
+
 // Featured Image/Video
 .reader__post-featured-image,
 .reader__post-featured-video {

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -1090,23 +1090,3 @@ body.is-section-reader div.layout.is-global-sidebar-visible .is-site-stream .bac
 		min-width: 200px;
 	}
 }
-
-.user-profile__content-wrapper {
-	.back-button {
-		border: none;
-		position: fixed;
-		top: calc(var(--masterbar-height) + 29px);
-		left: var(--sidebar-width-max);
-		background-color: transparent;
-		z-index: z-index(".masterbar", ".reader-back");
-	
-		button.is-compact.is-borderless {
-			padding: 20px 0 0 20px;
-		}
-	
-		@media ( max-width: 1280px ) {
-			position: unset;
-			display: flex;
-		}
-	}
-}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100089

## Proposed Changes

- Adds a style to override the margin in the site stream component.
- Removes unused back button style for user profile.

### Before

<img width="795" alt="Screenshot 2025-02-24 at 19 28 24" src="https://github.com/user-attachments/assets/abe3d219-d0cf-4850-a948-7e1a5d749d12" />

<img width="514" alt="Screenshot 2025-02-24 at 19 28 40" src="https://github.com/user-attachments/assets/a60b58b0-d64e-4ee5-9034-28325c33bc0b" />

### After

<img width="800" alt="Screenshot 2025-02-24 at 19 28 15" src="https://github.com/user-attachments/assets/39aafd5f-e1cf-4b15-9cda-2b515b782a2f" />

<img width="514" alt="Screenshot 2025-02-24 at 19 28 55" src="https://github.com/user-attachments/assets/8ce175c2-2a01-4e81-958e-8dd177b9f944" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- The Back button styles on site stream pages look sloppy.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Navigate to a site stream such that the Back button appears (you can do this using the Recent sidebar)
- Ensure the Back button has a bottom margin at widths below 1300px
- Smoke test the user profile page and other pages to make sure the Back button hasn't broken anywhere else

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
