### PR TITLE
Domains: Show more descriptive error when restoring default `www` CNAME with existing conflicting record

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
@@ -171,7 +171,20 @@ function DnsMenuOptionsButton( {
 	const restoreDefaultCnameRecord = useCallback( async () => {
 		dispatchUpdateDns( domainName, getDefaultCnameRecord(), getCnameRecordToRemove() )
 			.then( () => dispatchSuccessNotice( __( 'Default CNAME record restored' ) ) )
-			.catch( () => dispatchErrorNotice( __( 'Failed to restore the default CNAME record' ) ) );
+			.catch( ( e ) => {
+				// The backend error message when there's already an existing record for the `www` subdomain has the format:
+				// CNAME www.your-domain.com. conflicts with A www.your-domain.com.
+				if ( e.message.match( /^CNAME www\..+ conflicts with .*$/ ) ) {
+					return dispatchErrorNotice(
+						__(
+							'Failed to restore the default CNAME record. Please remove any DNS records you added for the “www” subdomain before restoring the default CNAME record.'
+						)
+					);
+				}
+
+				// Other DNS errors will be presented with a generic error message
+				return dispatchErrorNotice( __( 'Failed to restore the default CNAME record' ) );
+			} );
 	}, [
 		__,
 		dispatchErrorNotice,


### PR DESCRIPTION
Related to https://github.com/Automattic/nomado-issues/issues/1268

## Proposed Changes

This PR shows a more descriptive and actionable error message when users try to restore a domain's default `www` CNAME record and there's already a conflicting `www` record of another type. E.g. a domain has an `A` record on subdomain `www` pointing elsewhere, and the user tries to restore the default `www` CNAME record to point `www` to the root domain.

### Screenshots

| Before | After |
| --- | --- |
| <img width="1359" alt="Screenshot 2025-02-24 at 18 03 04" src="https://github.com/user-attachments/assets/a1ed815b-84d2-425f-b3f3-b1d3d3fdf129" /> | <img width="1373" alt="Screenshot 2025-02-24 at 17 49 59" src="https://github.com/user-attachments/assets/60ff5687-2326-4ed0-8a3a-8762d1974935" /> |

## Why are these changes being made?

There have been reports from users and HEs (p2MSmN-esV-p2) that the generic error message that's shown doesn't help users solve the problem. This improved message (hat tip to @dragstor 🙇) should hopefully guide users to know what they need to do to restore the default `www` CNAME record.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to the DNS management page of a domain you own
- Remove the default `www` CNAME record if it exists
- Add an A record (or any other DNS record type) for the `www` subdomain
- Click on the three-dots menu and select "Restore default CNAME record"
- Ensure the new, more descriptive message is shown instead of the old one

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?