### PR TITLE
Subscribers: fix height on iPhone

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -8,7 +8,6 @@ $padding-standard: 16px;
 body.is-section-subscribers,
 .theme-jetpack-cloud.is-group-jetpack-cloud.is-section-jetpack-subscribers
  {
-    overflow: hidden;
     
     .layout:not(.has-no-sidebar),
     .has-no-masterbar {

--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -45,7 +45,6 @@ body.is-section-subscribers,
             height: calc(
                 100vh - var(--masterbar-height) - #{$padding-standard * 2}
             );
-            overflow: hidden;
         
             @media ( max-width: $break-small ) {
                 padding: 0;


### PR DESCRIPTION
Fixes https://github.com/Automattic/loop/issues/508

## Proposed Changes

* Remove the overflow styling on dataviews

## Why are these changes being made?

This was causing issues with the floating pagination footer specifically on iPhone

| Before | After |
|--------|--------|
| <img width="1026" alt="Screen Shot 2025-02-24 at 23 02 22" src="https://github.com/user-attachments/assets/d6d63eda-39c1-42cd-a9c7-6fa12cbdddd3" /> | <img width="718" alt="Screen Shot 2025-02-24 at 23 01 19" src="https://github.com/user-attachments/assets/38644625-8bed-486c-aa6a-6f09a8247949" /> | 


## Testing Instructions

1. Check for regressions
2. Using either an iPhone or browserstack check out subscribers page on an iphone.
3. The pagination section should not be cut-off
