### PR TITLE
Remove top margin from step container in launchpad styles

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -306,7 +306,6 @@
 		display: flex;
 		flex-direction: column;
 		align-items: center;
-		margin-top: 25vh;
 	}
 
 	.step-container__content {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/100269

## Proposed Changes

* Fix spacing above loading component on processing step on Launchpad.

Before: 
![image](https://github.com/user-attachments/assets/2f8494f2-b210-4be9-bda1-7e57f3a6b3d9)

After: 
![CleanShot 2025-02-25 at 12 52 22@2x](https://github.com/user-attachments/assets/7a7d35dd-7666-4efc-8089-c180468d1a13)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix and align styling

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Navigate to `/setup/onboarding` and complete the flow until you reach the launchpad (I chose the `Showcase work/portfolio` goal).
* Launch the site and verify the loading component on the processing screen is not aligned to the bottom of the screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
