### PR TITLE
Site default features: Apply changes at the end of site-setup

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -1,5 +1,4 @@
-import config from '@automattic/calypso-config';
-import { Site, Onboard } from '@automattic/data-stores';
+import { Site } from '@automattic/data-stores';
 import { FREE_THEME } from '@automattic/design-picker';
 import {
 	ENTREPRENEUR_FLOW,
@@ -29,7 +28,6 @@ import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import Loading from 'calypso/components/loading';
 import useAddEcommerceTrialMutation from 'calypso/data/ecommerce/use-add-ecommerce-trial-mutation';
-import { useGoalsFirstCumulativeExperience } from 'calypso/data/experiment/use-goals-first-cumulative-experience';
 import useAddTempSiteToSourceOptionMutation from 'calypso/data/site-migration/use-add-temp-site-mutation';
 import { useSourceMigrationStatusQuery } from 'calypso/data/site-migration/use-source-migration-status-query';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
@@ -97,7 +95,6 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 
 	const { mutateAsync: addEcommerceTrial } = useAddEcommerceTrialMutation( partnerBundle );
 	const [ , isGoalsFirstExperiment ] = useGoalsFirstExperiment();
-	const [ , isGoalsFirstCumulativeExperience ] = useGoalsFirstCumulativeExperience();
 
 	/**
 	 * Support singular and multiple domain cart items.
@@ -206,20 +203,6 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 
 		const siteIntent = isMigrationSignupFlow( flow ) ? 'migration' : '';
 
-		const getEnableFeaturesForGoals = () => {
-			if ( ! isGoalsFirstCumulativeExperience ) {
-				return undefined;
-			}
-
-			const featuresForGoals: Onboard.SiteGoal[] = [];
-
-			if ( config.isEnabled( 'onboarding/enable-write-goal-features' ) ) {
-				featuresForGoals.push( Onboard.SiteGoal.Write );
-			}
-
-			return featuresForGoals.length > 0 ? featuresForGoals : undefined;
-		};
-
 		const sourceSlug = hasSourceSlug( data ) ? data.sourceSlug : undefined;
 		const site = await createSiteWithCart(
 			flow,
@@ -240,8 +223,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 			domainItem,
 			sourceSlug,
 			siteIntent,
-			shouldSaveSiteGoals ? siteGoals : undefined,
-			getEnableFeaturesForGoals()
+			shouldSaveSiteGoals ? siteGoals : undefined
 		);
 
 		if ( preselectedThemeSlug && site?.siteSlug ) {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,3 +1,4 @@
+import configApi from '@automattic/calypso-config';
 import { Onboard, updateLaunchpadSettings } from '@automattic/data-stores';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from 'react';
@@ -167,6 +168,16 @@ const siteSetupFlow: FlowV1 = {
 			);
 		};
 
+		const getEnableFeaturesForGoals = () => {
+			const featuresForGoals: Onboard.SiteGoal[] = [];
+
+			if ( configApi.isEnabled( 'onboarding/enable-write-goal-features' ) ) {
+				featuresForGoals.push( Onboard.SiteGoal.Write );
+			}
+
+			return featuresForGoals.length > 0 ? featuresForGoals : undefined;
+		};
+
 		const exitFlow = ( to: string, options: ExitFlowOptions = {} ) => {
 			setPendingAction( () => {
 				/**
@@ -222,6 +233,15 @@ const siteSetupFlow: FlowV1 = {
 					}
 
 					formData.push( [ 'settings', JSON.stringify( settings ) ] );
+
+					const enableFeaturesForGoals = getEnableFeaturesForGoals();
+
+					if ( enableFeaturesForGoals ) {
+						formData.push( [
+							'enable_features_for_goals',
+							JSON.stringify( enableFeaturesForGoals ),
+						] );
+					}
 
 					pendingActions.push(
 						wpcomRequest( {

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -158,8 +158,7 @@ export const createSiteWithCart = async (
 	domainItem?: DomainSuggestion,
 	sourceSlug?: string,
 	siteIntent?: string,
-	siteGoals?: SiteGoal[],
-	enableFeaturesForGoals?: SiteGoal[]
+	siteGoals?: SiteGoal[]
 ) => {
 	const siteUrl = storedSiteUrl || domainItem?.domain_name;
 	const isFreeThemePreselected = startsWith( themeSlugWithRepo, 'pub' );
@@ -207,9 +206,6 @@ export const createSiteWithCart = async (
 					? { segmentation_survey_answers_anon_id: segmentationSurveyAnswersAnonId }
 					: {} ),
 				...( siteGoals && { site_goals: siteGoals } ),
-				...( enableFeaturesForGoals && {
-					enable_features_for_goals: enableFeaturesForGoals,
-				} ),
 			},
 		},
 	} );


### PR DESCRIPTION
Related to pdxWSz-26W-p2#comment-898.

## Proposed Changes

Moves the feature activation at the end of the onboarding flow instead of on site creation.

## Why are these changes being made?

Because we have two variations of the flow. Previously, we wanted to ship stuff only to the `treatment_cumulative` variant of the onboarding flow, which sees goals first. But now, the `control` variant of the goals-first experiment will win (p1740371895971309-slack-C085HCWCEDN), which means the user will only pick the goals after creating the site.

## Testing Instructions

1. Apply 174673-ghe-Automattic/wpcom to your sandbox and proxy yourself;
2. Checkout this branch and enable the `onboarding/enable-write-goal-features` feature flag.

### With the goals-first flow enabled...

1. Create a site with the `Publish a blog` goal selected;
2. Go through the onboarding, then visit Settings > Newsletter and verify that the "
Add the Subscribe Block at the end of each post" setting is turned ON.

### With the goals-first flow disabled...

1. Create a site with the `Publish a blog` goal selected;
2. Go through the onboarding, then visit Settings > Newsletter and verify that the "
Add the Subscribe Block at the end of each post" setting is turned ON.

### Without the `onboarding/enable-write-goal-features` feature flag

Create the site in any of the variations of the onboarding flow and notice the subscriber block setting is turned OFF.