### PR TITLE
Stats: add back paid subscribers

### DIFF
--- a/client/sites/marketing/traffic/traffic.js
+++ b/client/sites/marketing/traffic/traffic.js
@@ -86,13 +86,15 @@ const SiteSettingsTraffic = ( {
 				<CloudflareAnalyticsSettings />
 			) }
 
-			<JetpackSiteStats
-				handleAutosavingToggle={ handleAutosavingToggle }
-				setFieldValue={ setFieldValue }
-				isSavingSettings={ isSavingSettings }
-				isRequestingSettings={ isRequestingSettings }
-				fields={ fields }
-			/>
+			{ isJetpackAdmin && (
+				<JetpackSiteStats
+					handleAutosavingToggle={ handleAutosavingToggle }
+					setFieldValue={ setFieldValue }
+					isSavingSettings={ isSavingSettings }
+					isRequestingSettings={ isRequestingSettings }
+					fields={ fields }
+				/>
+			) }
 			{ isAdmin && <AnalyticsSettings /> }
 			{ isJetpackAdmin && (
 				<Shortlinks

--- a/client/sites/marketing/traffic/traffic.js
+++ b/client/sites/marketing/traffic/traffic.js
@@ -86,15 +86,13 @@ const SiteSettingsTraffic = ( {
 				<CloudflareAnalyticsSettings />
 			) }
 
-			{ isJetpackAdmin && (
-				<JetpackSiteStats
-					handleAutosavingToggle={ handleAutosavingToggle }
-					setFieldValue={ setFieldValue }
-					isSavingSettings={ isSavingSettings }
-					isRequestingSettings={ isRequestingSettings }
-					fields={ fields }
-				/>
-			) }
+			<JetpackSiteStats
+				handleAutosavingToggle={ handleAutosavingToggle }
+				setFieldValue={ setFieldValue }
+				isSavingSettings={ isSavingSettings }
+				isRequestingSettings={ isRequestingSettings }
+				fields={ fields }
+			/>
 			{ isAdmin && <AnalyticsSettings /> }
 			{ isJetpackAdmin && (
 				<Shortlinks


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Add back Paid Subscribers data

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Feature match

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a site with paid subscribers `http://calypso.localhost:3000/stats/subscribers/day/{your-site}?flags=stats/chart-library` (otherwise you have to fake some data like [this](https://github.com/Automattic/wp-calypso/pull/100313/files#r1968706265) 😅 ) 
* Ensure you see Paid Subscribers line along with the Subscribers

<img width="666" alt="image" src="https://github.com/user-attachments/assets/89489022-39a8-4fa6-a59c-633ac0027fe6" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
