### PR TITLE
A4A > WooPayments: Initial implementation of section & pages

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -34,6 +34,7 @@ import {
 	A4A_TEAM_LINK,
 	A4A_AGENCY_TIER_LINK,
 	A4A_MIGRATIONS_OVERVIEW_LINK,
+	A4A_WOOPAYMENTS_LINK,
 } from '../lib/constants';
 import { createItem } from '../lib/utils';
 
@@ -191,6 +192,19 @@ const useMainMenuItems = ( path: string ) => {
 							title: translate( 'Agency Tier' ),
 							trackEventProps: {
 								menu_item: 'Automattic for Agencies / Agency Tier',
+							},
+						},
+				  ]
+				: [] ),
+			...( isSectionNameEnabled( 'a8c-for-agencies-woopayments' )
+				? [
+						{
+							icon: currencyDollar,
+							path: '/',
+							link: A4A_WOOPAYMENTS_LINK,
+							title: translate( 'WooPayments' ),
+							trackEventProps: {
+								menu_item: 'Automattic for Agencies / WooPayments',
 							},
 						},
 				  ]

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-woopayments-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-woopayments-menu-items.tsx
@@ -1,0 +1,70 @@
+import { category, cog } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
+import useGetTipaltiPayee from 'calypso/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-payee';
+import { getAccountStatus } from 'calypso/a8c-for-agencies/sections/referrals/lib/get-account-status';
+import {
+	A4A_WOOPAYMENTS_LINK,
+	A4A_WOOPAYMENTS_DASHBOARD_LINK,
+	A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK,
+} from '../lib/constants';
+import { createItem } from '../lib/utils';
+
+const useWooPaymentsMenuItems = ( path: string ) => {
+	const translate = useTranslate();
+
+	const { data } = useGetTipaltiPayee();
+	const accountStatus = getAccountStatus( data, translate );
+
+	const showIndicator = accountStatus?.actionRequired;
+
+	const menuItems = useMemo( () => {
+		return [
+			createItem(
+				{
+					icon: category,
+					path: A4A_WOOPAYMENTS_LINK,
+					link: A4A_WOOPAYMENTS_DASHBOARD_LINK,
+					title: translate( 'Dashboard' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / WooPayments / Dashboard',
+					},
+				},
+				path
+			),
+			createItem(
+				{
+					icon: cog,
+					path: A4A_WOOPAYMENTS_LINK,
+					link: A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK,
+					title: translate( 'Payment Settings' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / WooPayments / Payment Settings',
+					},
+					...( showIndicator && {
+						extraContent: (
+							<StatusBadge
+								statusProps={ {
+									children: 1,
+									type: accountStatus.statusType,
+									isRounded: true,
+									tooltip: accountStatus.statusReason,
+								} }
+							/>
+						),
+					} ),
+				},
+				path
+			),
+		]
+			.map( ( item ) => createItem( item, path ) )
+			.map( ( item ) => ( {
+				...item,
+				isSelected: item.link === path,
+			} ) );
+	}, [ accountStatus, path, showIndicator, translate ] );
+	return menuItems;
+};
+
+export default useWooPaymentsMenuItems;

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -50,6 +50,9 @@ export const A4A_TEAM_INVITE_LINK = '/team/invite';
 export const A4A_TEAM_ACCEPT_INVITE_LINK = '/team/invite/accept';
 export const EXTERNAL_A4A_KNOWLEDGE_BASE = 'http://automattic.com/for-agencies/help';
 export const A4A_AGENCY_TIER_LINK = '/agency-tier';
+export const A4A_WOOPAYMENTS_LINK = '/woopayments';
+export const A4A_WOOPAYMENTS_DASHBOARD_LINK = `${ A4A_WOOPAYMENTS_LINK }/dashboard`;
+export const A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK = `${ A4A_WOOPAYMENTS_LINK }/payment-settings`;
 
 // Client
 export const A4A_CLIENT_LANDING_LINK = '/client/landing';

--- a/client/a8c-for-agencies/components/sidebar-menu/woopayments.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/woopayments.tsx
@@ -1,0 +1,31 @@
+import page from '@automattic/calypso-router';
+import { chevronLeft } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import Sidebar from '../sidebar';
+import useWooPaymentsMenuItems from './hooks/use-woopayments-menu-items';
+import { A4A_OVERVIEW_LINK, A4A_WOOPAYMENTS_LINK } from './lib/constants';
+
+type Props = {
+	path: string;
+};
+
+export default function ( { path }: Props ) {
+	const translate = useTranslate();
+	const menuItems = useWooPaymentsMenuItems( path );
+
+	return (
+		<Sidebar
+			path={ A4A_WOOPAYMENTS_LINK }
+			title={ translate( 'WooPayments' ) }
+			backButtonProps={ {
+				label: translate( 'Back to overview' ),
+				icon: chevronLeft,
+				onClick: () => {
+					page( A4A_OVERVIEW_LINK );
+				},
+			} }
+			menuItems={ menuItems }
+			withUserProfileFooter
+		/>
+	);
+}

--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -44,6 +44,9 @@ import {
 	A4A_MIGRATIONS_PAYMENT_SETTINGS,
 	A4A_TEAM_INVITE_LINK,
 	A4A_AGENCY_TIER_LINK,
+	A4A_WOOPAYMENTS_LINK,
+	A4A_WOOPAYMENTS_DASHBOARD_LINK,
+	A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK,
 } from '../components/sidebar-menu/lib/constants';
 import type { Agency } from 'calypso/state/a8c-for-agencies/types';
 
@@ -93,6 +96,10 @@ const MEMBER_ACCESSIBLE_PATHS: Record< string, string[] > = {
 	[ A4A_TEAM_INVITE_LINK ]: [ 'a4a_edit_user_invites' ],
 	[ A4A_AGENCY_TIER_LINK ]: [ 'a4a_read_agency_tier' ],
 	[ A4A_PLUGINS_LINK ]: [ 'a4a_read_managed_sites' ],
+	// TODO: Add the correct capability for WooPayments
+	[ A4A_WOOPAYMENTS_LINK ]: [ 'a4a_read_referrals' ],
+	[ A4A_WOOPAYMENTS_DASHBOARD_LINK ]: [ 'a4a_read_referrals' ],
+	[ A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK ]: [ 'a4a_read_referrals' ],
 };
 
 const MEMBER_ACCESSIBLE_DYNAMIC_PATHS: Record< string, string[] > = {

--- a/client/a8c-for-agencies/sections/woopayments/controller.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/controller.tsx
@@ -1,0 +1,27 @@
+import { type Callback } from '@automattic/calypso-router';
+import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
+import WooPaymentsSidebar from 'calypso/a8c-for-agencies/components/sidebar-menu/woopayments';
+import ReferralsBankDetails from '../referrals/primary/bank-details';
+import WooPaymentsDashboard from './primary/woopayments-dashboard';
+
+export const woopaymentsDashboardContext: Callback = ( context, next ) => {
+	context.primary = (
+		<>
+			<PageViewTracker title="WooPayments > Dashboard" path={ context.path } />
+			<WooPaymentsDashboard />
+		</>
+	);
+	context.secondary = <WooPaymentsSidebar path={ context.path } />;
+	next();
+};
+
+export const woopaymentsPaymentSettingsContext: Callback = ( context, next ) => {
+	context.primary = (
+		<>
+			<PageViewTracker title="WooPayments > Payment Settings" path={ context.path } />
+			<ReferralsBankDetails isAutomatedReferral />
+		</>
+	);
+	context.secondary = <WooPaymentsSidebar path={ context.path } />;
+	next();
+};

--- a/client/a8c-for-agencies/sections/woopayments/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/index.tsx
@@ -1,0 +1,27 @@
+import page from '@automattic/calypso-router';
+import {
+	A4A_WOOPAYMENTS_DASHBOARD_LINK,
+	A4A_WOOPAYMENTS_LINK,
+	A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { woopaymentsDashboardContext, woopaymentsPaymentSettingsContext } from './controller';
+
+export default function () {
+	page(
+		A4A_WOOPAYMENTS_DASHBOARD_LINK,
+		requireAccessContext,
+		woopaymentsDashboardContext,
+		makeLayout,
+		clientRender
+	);
+	page(
+		A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK,
+		requireAccessContext,
+		woopaymentsPaymentSettingsContext,
+		makeLayout,
+		clientRender
+	);
+	page( A4A_WOOPAYMENTS_LINK, () => page.redirect( A4A_WOOPAYMENTS_DASHBOARD_LINK ) );
+}

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
@@ -1,0 +1,40 @@
+import { useTranslate } from 'i18n-calypso';
+import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import LayoutBody from 'calypso/layout/hosting-dashboard/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+	LayoutHeaderActions as Actions,
+} from 'calypso/layout/hosting-dashboard/header';
+
+const WooPaymentsDashboard = () => {
+	const translate = useTranslate();
+
+	const title = translate( 'WooPayments Commissions' );
+
+	const showEmptyState = false;
+
+	if ( showEmptyState ) {
+		// TODO: Add the empty state
+	}
+
+	return (
+		<Layout title={ title } wide>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ title }</Title>
+					<Actions>
+						<MobileSidebarNavigation />
+					</Actions>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody>
+				<>{ /* TODO: Add the content */ }</>
+			</LayoutBody>
+		</Layout>
+	);
+};
+
+export default WooPaymentsDashboard;

--- a/client/sections.js
+++ b/client/sections.js
@@ -912,6 +912,12 @@ const sections = [
 		module: 'calypso/a8c-for-agencies/sections/agency-tier',
 		group: 'a8c-for-agencies',
 	},
+	{
+		name: 'a8c-for-agencies-woopayments',
+		paths: [ '/woopayments', '/woopayments/dashboard', '/woopayments/payment-settings' ],
+		module: 'calypso/a8c-for-agencies/sections/woopayments',
+		group: 'a8c-for-agencies',
+	},
 ];
 
 module.exports = sections;

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -174,6 +174,7 @@
 		"a8c-for-agencies-client": false,
 		"a8c-for-agencies-team": false,
 		"a8c-for-agencies-agency-tier": false,
+		"a8c-for-agencies-woopayments": false,
 		"jetpack-cloud": false,
 		"jetpack-cloud-overview": false,
 		"jetpack-cloud-agency-dashboard": false,

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -65,7 +65,8 @@
 		"a8c-for-agencies-migrations": true,
 		"a8c-for-agencies-client": true,
 		"a8c-for-agencies-team": true,
-		"a8c-for-agencies-agency-tier": true
+		"a8c-for-agencies-agency-tier": true,
+		"a8c-for-agencies-woopayments": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -58,7 +58,8 @@
 		"a8c-for-agencies-migrations": true,
 		"a8c-for-agencies-client": true,
 		"a8c-for-agencies-team": true,
-		"a8c-for-agencies-agency-tier": true
+		"a8c-for-agencies-agency-tier": true,
+		"a8c-for-agencies-woopayments": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1842
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1843

## Proposed Changes

This PR implements the initial foundational work required for the WooPayments commissions on A4A, including:

- Adding a section and enabling it on Dev & Horizon environments
- Adding menu items
- Updating permissions
- Adding controller and pages

## Why are these changes being made?

* To lay the foundational work required to implement WooPayment commissions on A4A

## Testing Instructions

* Open the A4A live link
* Verify you can see the WooPayment menu item. Please ignore the icon.

<img width="1728" alt="Screenshot 2025-02-25 at 9 51 03 AM" src="https://github.com/user-attachments/assets/5108c5cf-7440-4521-b66c-07c89d35bd32" />


* Click the menu item > Verify you can see an empty page rendered  

<img width="1728" alt="Screenshot 2025-02-25 at 10 22 12 AM" src="https://github.com/user-attachments/assets/f88f112b-03b7-4540-932a-f0dcd81d0fdb" />


* Click the Payment Settings menu item > Verify you can see the payment setting page rendered. Please ignore the page title for now, we will update this in another PR.

<img width="1728" alt="Screenshot 2025-02-25 at 9 55 16 AM" src="https://github.com/user-attachments/assets/71861dde-585d-4f61-a5e6-13e21df8d297" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
