### PR TITLE
Receive query params from page context and pass to components

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain-dashboard-layout.tsx
+++ b/client/my-sites/domains/domain-management/components/domain-dashboard-layout.tsx
@@ -3,6 +3,7 @@ import Layout from 'calypso/layout/hosting-dashboard';
 import LayoutColumn from 'calypso/layout/hosting-dashboard/column';
 import DomainManagement from 'calypso/my-sites/domains/domain-management';
 import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
+import { QueryParams } from '../dataviews/query-params';
 
 // Add Dotcom specific styles
 import 'calypso/sites/components/dotcom-style.scss';
@@ -11,6 +12,7 @@ type DomainDashboardLayoutProps = {
 	innerContent: React.ReactNode;
 	selectedDomainName: string;
 	selectedFeature: string;
+	queryParams: QueryParams;
 };
 
 function DomainDashboardLayout( props: DomainDashboardLayoutProps ) {
@@ -29,6 +31,7 @@ function DomainDashboardLayout( props: DomainDashboardLayoutProps ) {
 					sidebarMode
 					selectedDomainName={ props.selectedDomainName }
 					selectedFeature={ props.selectedFeature }
+					queryParams={ props.queryParams }
 				/>
 			</LayoutColumn>
 			<LayoutColumn className="domains-overview__details" wide>

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -29,6 +29,7 @@ import {
 import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getQueryParams } from './dataviews/query-params';
 import { getSubpageParams } from './subpage-wrapper/subpages';
 import DomainManagement from '.';
 
@@ -66,6 +67,7 @@ export default {
 				<DomainManagement.BulkAllDomains
 					analyticsPath={ domainManagementRoot() }
 					analyticsTitle="Domain Management > All Domains"
+					queryParams={ getQueryParams( pageContext ) }
 				/>
 			</>
 		);
@@ -356,6 +358,7 @@ export default {
 				innerContent={ pageContext.primary }
 				selectedDomainName={ selectedDomainName }
 				selectedFeature={ selectedFeature }
+				queryParams={ getQueryParams( pageContext ) }
 			/>
 		);
 
@@ -395,6 +398,7 @@ export default {
 					siteSlug={ siteSlug }
 					site={ site }
 					inSiteContext={ pageContext.inSiteContext }
+					queryParams={ getQueryParams( pageContext ) }
 				/>
 			);
 

--- a/client/my-sites/domains/domain-management/dataviews/domains-dataviews.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/domains-dataviews.tsx
@@ -12,7 +12,7 @@ import {
 	DEFAULT_SORT_FIELD,
 	DEFAULT_SORT_DIRECTION,
 	buildPathWithQueryParams,
-	getQueryParams,
+	QueryParams,
 } from './query-params';
 import { useActions } from './use-actions';
 import { useDomainsDataViewsContext } from './use-context';
@@ -26,6 +26,7 @@ type Props = {
 	isLoading: boolean;
 	sidebarMode?: boolean;
 	selectedDomainName?: string;
+	queryParams: QueryParams;
 };
 
 export const DomainsDataViews = ( {
@@ -33,11 +34,11 @@ export const DomainsDataViews = ( {
 	isLoading,
 	sidebarMode,
 	selectedDomainName,
+	queryParams,
 }: Props ) => {
 	const translate = useTranslate();
 	const { isDesktop, getSiteSlug, selectedFeature } = useDomainsDataViewsContext();
 
-	const queryParams = getQueryParams();
 	const [ view, setView ] = useState( () =>
 		initializeViewState( isDesktop, queryParams, sidebarMode )
 	);
@@ -86,7 +87,7 @@ export const DomainsDataViews = ( {
 		const siteSlug = getSiteSlug( item );
 		const domainManagementLink = ! item.wpcom_domain
 			? addQueryArgs(
-					getQueryParams(),
+					queryParams,
 					getDomainManagementLink( item, siteSlug, true, selectedFeature )
 			  )
 			: '';

--- a/client/my-sites/domains/domain-management/dataviews/domains-dataviews.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/domains-dataviews.tsx
@@ -81,6 +81,14 @@ export const DomainsDataViews = ( {
 		} );
 	}, [ view.search, view.page, view.perPage, view.sort?.field, view.sort?.direction ] );
 
+	useEffect( () => {
+		setView( ( previousView ) => ( {
+			...previousView,
+			page: queryParams.page,
+			perPage: queryParams.perPage,
+		} ) );
+	}, [ queryParams.page, queryParams.perPage ] );
+
 	const layout = sidebarMode ? { list: {} } : { table: {} };
 
 	const onClickDomain = ( item: PartialDomainData ) => {

--- a/client/my-sites/domains/domain-management/dataviews/domains-dataviews.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/domains-dataviews.tsx
@@ -85,9 +85,8 @@ export const DomainsDataViews = ( {
 		setView( ( previousView ) => ( {
 			...previousView,
 			page: queryParams.page,
-			perPage: queryParams.perPage,
 		} ) );
-	}, [ queryParams.page, queryParams.perPage ] );
+	}, [ queryParams.page ] );
 
 	const layout = sidebarMode ? { list: {} } : { table: {} };
 

--- a/client/my-sites/domains/domain-management/dataviews/query-params.ts
+++ b/client/my-sites/domains/domain-management/dataviews/query-params.ts
@@ -1,3 +1,5 @@
+import { Context } from '@automattic/calypso-router';
+
 export const DEFAULT_PAGE = 1;
 export const DEFAULT_PER_PAGE = 50;
 export const DEFAULT_SORT_FIELD = 'domain_name';
@@ -19,22 +21,16 @@ const getDefaultParams = () => ( {
 	sortDirection: DEFAULT_SORT_DIRECTION,
 } );
 
-export function getQueryParams() {
-	const queryParams = new URLSearchParams( window.location.search );
+export function getQueryParams( context: Context ) {
 	return {
 		...getDefaultParams(),
-		page: queryParams.get( 'page' )?.length
-			? parseInt( queryParams.get( 'page' ) as string, 10 )
-			: DEFAULT_PAGE,
-		perPage: queryParams.get( 'perPage' )?.length
-			? parseInt( queryParams.get( 'perPage' ) as string, 10 )
-			: DEFAULT_PER_PAGE,
-		search: queryParams.get( 'search' ),
-		sortField: queryParams.get( 'sortField' ) || DEFAULT_SORT_FIELD,
+		page: context.query.page ? parseInt( context.query.page, 10 ) : DEFAULT_PAGE,
+		perPage: context.query.perPage ? parseInt( context.query.perPage, 10 ) : DEFAULT_PER_PAGE,
+		search: context.query.search,
+		sortField: context.query.sortField || DEFAULT_SORT_FIELD,
 		sortDirection:
-			queryParams.get( 'sortDirection' ) &&
-			[ 'asc', 'desc' ].includes( queryParams.get( 'sortDirection' ) as string )
-				? queryParams.get( 'sortDirection' )
+			context.query.sortDirection && [ 'asc', 'desc' ].includes( context.query.sortDirection )
+				? context.query.sortDirection
 				: DEFAULT_SORT_DIRECTION,
 	} as QueryParams;
 }

--- a/client/my-sites/domains/domain-management/dataviews/types.ts
+++ b/client/my-sites/domains/domain-management/dataviews/types.ts
@@ -9,6 +9,7 @@ import { SiteDomainsQueryFnData } from '@automattic/data-stores/src/queries/use-
 import { DomainStatusPurchaseActions, ResponseDomain } from '@automattic/domains-table';
 import { DomainAction } from '@automattic/domains-table/src/domains-table/domains-table-row-actions';
 import { SiteExcerptData } from '@automattic/sites';
+import { QueryParams } from './query-params';
 
 /**
  * Utility type for domain action descriptions.
@@ -65,6 +66,7 @@ interface BaseDomainsDataViewsProps {
 	currentUserCanBulkUpdateContactInfo?: boolean;
 	hasConnectableSites?: boolean;
 	context?: DomainsDataViewUsage;
+	queryParams: QueryParams;
 }
 
 /**

--- a/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
@@ -11,7 +11,7 @@ import { addQueryArgs } from 'calypso/lib/url';
 import * as paths from 'calypso/my-sites/domains/paths';
 import SiteIcon from 'calypso/sites/components/sites-dataviews/site-icon';
 import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
-import { getQueryParams } from '../dataviews/query-params';
+import { QueryParams } from '../dataviews/query-params';
 import {
 	FEATURE_TO_ROUTE_MAP,
 	DOMAIN_OVERVIEW,
@@ -32,6 +32,7 @@ interface Props {
 	siteSlug: string;
 	site: SiteExcerptData;
 	inSiteContext?: boolean;
+	queryParams: QueryParams;
 }
 
 export function showDomainManagementPage( route: string ) {
@@ -67,6 +68,7 @@ const DomainOverviewPane = ( {
 	siteSlug,
 	site,
 	inSiteContext,
+	queryParams,
 }: Props ) => {
 	const itemData: ItemData = {
 		title: selectedDomain,
@@ -136,7 +138,7 @@ const DomainOverviewPane = ( {
 								.replace( ':domain', selectedDomain )
 								.replace( ':site', siteSlug );
 
-							showDomainManagementPage( addQueryArgs( getQueryParams(), featureUrl ) );
+							showDomainManagementPage( addQueryArgs( queryParams, featureUrl ) );
 						}
 					},
 				},
@@ -144,7 +146,14 @@ const DomainOverviewPane = ( {
 				preview: enabled ? selectedDomainPreview : null,
 			};
 		} );
-	}, [ selectedFeature, selectedDomainPreview, inSiteContext, selectedDomain, siteSlug ] );
+	}, [
+		selectedFeature,
+		selectedDomainPreview,
+		inSiteContext,
+		selectedDomain,
+		siteSlug,
+		queryParams,
+	] );
 
 	const navigationItems = useMemo( () => {
 		if ( ! inSiteContext ) {
@@ -191,7 +200,7 @@ const DomainOverviewPane = ( {
 				closeItemView={ () => {
 					inSiteContext
 						? page.show( '/sites' )
-						: page.show( addQueryArgs( getQueryParams(), paths.domainManagementRoot() ) );
+						: page.show( addQueryArgs( queryParams, paths.domainManagementRoot() ) );
 				} }
 				features={ features }
 				enforceTabsView

--- a/client/my-sites/domains/domain-management/domain-overview-pane/test/index.test.tsx
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/test/index.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
+import { QueryParams } from '../../dataviews/query-params';
 import { DOMAIN_OVERVIEW } from '../constants';
 import DomainOverviewPane, { showDomainManagementPage } from '../index';
 
@@ -88,6 +89,14 @@ describe( 'DomainOverviewPane', () => {
 		},
 	};
 
+	const queryParams: QueryParams = {
+		page: undefined,
+		perPage: undefined,
+		sortField: undefined,
+		sortDirection: undefined,
+		search: undefined,
+	};
+
 	beforeEach( () => {
 		global.window.location = new URL( 'https://wordpress.com' ) as any;
 		jest.clearAllMocks();
@@ -98,7 +107,7 @@ describe( 'DomainOverviewPane', () => {
 		const store = mockStore( createState() );
 		return render(
 			<Provider store={ store }>
-				<DomainOverviewPane { ...defaultProps } { ...props } />
+				<DomainOverviewPane { ...defaultProps } { ...props } queryParams={ queryParams } />
 			</Provider>
 		);
 	};
@@ -132,16 +141,14 @@ describe( 'DomainOverviewPane', () => {
 		renderComponent();
 		fireEvent.click( screen.getByText( 'Email' ) );
 		expect( page.show ).toHaveBeenCalledWith(
-			'/domains/manage/all/email/example.com/example.wordpress.com?page=1&perPage=50&sortField=domain_name&sortDirection=asc'
+			'/domains/manage/all/email/example.com/example.wordpress.com'
 		);
 	} );
 
 	it( 'handles close button click', () => {
 		renderComponent();
 		fireEvent.click( screen.getByText( 'Close' ) );
-		expect( page.show ).toHaveBeenCalledWith(
-			'/domains/manage?page=1&perPage=50&sortField=domain_name&sortDirection=asc'
-		);
+		expect( page.show ).toHaveBeenCalledWith( '/domains/manage' );
 	} );
 } );
 

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -17,6 +17,7 @@ import { canAnySiteConnectDomains } from 'calypso/state/selectors/can-any-site-c
 import { isSupportSession } from 'calypso/state/support/selectors';
 import DomainHeader, { NavigationItem } from '../components/domain-header';
 import DotcomDomainsDataViews from '../dataviews';
+import { type QueryParams } from '../dataviews/query-params';
 import {
 	createBulkAction,
 	deleteBulkActionStatus,
@@ -37,6 +38,7 @@ interface BulkAllDomainsProps {
 	sidebarMode?: boolean;
 	selectedDomainName?: string;
 	selectedFeature?: string;
+	queryParams: QueryParams;
 }
 
 const domainsDataViewsGlobalStyles = css`
@@ -439,6 +441,7 @@ type RendererProps = {
 	hasConnectableSites?: boolean;
 	domains: PartialDomainData[];
 	isLoading?: boolean;
+	queryParams: QueryParams;
 };
 
 function DomainsTableRenderer( {
@@ -482,6 +485,7 @@ function DomainsDataViewsRenderer( {
 	domains,
 	isLoading,
 	hasConnectableSites,
+	queryParams,
 }: RendererProps ) {
 	return (
 		<DotcomDomainsDataViews
@@ -499,6 +503,7 @@ function DomainsDataViewsRenderer( {
 			selectedFeature={ selectedFeature }
 			hasConnectableSites={ hasConnectableSites }
 			context="domains"
+			queryParams={ queryParams }
 		/>
 	);
 }
@@ -563,6 +568,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 						item={ item }
 						domains={ domains }
 						isLoading={ isLoading }
+						queryParams={ props.queryParams }
 					/>
 				) : (
 					<div className="bulk-domains-empty-state">

--- a/client/my-sites/domains/domain-management/test/controller.test.tsx
+++ b/client/my-sites/domains/domain-management/test/controller.test.tsx
@@ -156,6 +156,13 @@ describe( 'domainManagementPaneView', () => {
 			},
 			primary: <div>Previous Content</div>,
 			store: testStore,
+			query: {
+				page: undefined,
+				perPage: undefined,
+				search: undefined,
+				sortField: undefined,
+				sortDirection: undefined,
+			},
 		};
 
 		const paneViewHandler = domainController.domainManagementPaneView( DOMAIN_OVERVIEW );
@@ -193,6 +200,13 @@ describe( 'domainManagementPaneView', () => {
 			},
 			primary: <div>Previous Content</div>,
 			store: testStore,
+			query: {
+				page: undefined,
+				perPage: undefined,
+				search: undefined,
+				sortField: undefined,
+				sortDirection: undefined,
+			},
 		};
 
 		const paneViewHandler = domainController.domainManagementPaneView( DOMAIN_OVERVIEW );


### PR DESCRIPTION
Related to #99910 and #99909 

The dependency on document.location.search didn't work well


## Proposed Changes

* Use query params from the page context and pass them to components.
* Update page when it has changed in query params.

## Why are these changes being made?

* Addressing CfT feedback

## Testing Instructions

* Turn on feature flags in your browser's console: `window.sessionStorage.setItem('flags',  'calypso/domains-dataviews'])`
* Go to http://calypso.localhost:3000/domains/manage
* Try to play with pagination settings and click on domains. Then use the browser's back button.
* Make sure the changes on the screen reflect the changes in the URL.
* Now go to http://calypso.localhost:3000/domains/manage
* Go to DataViews settings (the cog above the table) and set 10 domains per page.
* With the domains we normally get in dev/staging, there should be two pages now.
* Go to the second page.
* Click on Domains in the left navigation.
* Make sure current page is now the first one.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
