### PR TITLE
Design Picker: Rename step slug from designSetup to design-setup

### DIFF
--- a/client/blocks/importer/blogger/index.tsx
+++ b/client/blocks/importer/blogger/index.tsx
@@ -87,7 +87,7 @@ export const BloggerImporter: React.FunctionComponent< ImporterBaseProps > = ( p
 	function onSiteViewClick() {
 		if ( isEnabled( 'onboarding/import-redirect-to-themes' ) ) {
 			recordTracksEvent( 'calypso_site_importer_pick_a_design' );
-			stepNavigator?.navigate?.( 'designSetup' );
+			stepNavigator?.navigate?.( 'design-setup' );
 		} else {
 			recordTracksEvent( 'calypso_site_importer_view_site' );
 			stepNavigator?.goToSiteViewPage?.();

--- a/client/blocks/importer/medium/index.tsx
+++ b/client/blocks/importer/medium/index.tsx
@@ -87,7 +87,7 @@ export const MediumImporter: React.FunctionComponent< ImporterBaseProps > = ( pr
 	function onSiteViewClick() {
 		if ( isEnabled( 'onboarding/import-redirect-to-themes' ) ) {
 			recordTracksEvent( 'calypso_site_importer_pick_a_design' );
-			stepNavigator?.navigate?.( 'designSetup' );
+			stepNavigator?.navigate?.( 'design-setup' );
 		} else {
 			recordTracksEvent( 'calypso_site_importer_view_site' );
 			stepNavigator?.goToSiteViewPage?.();

--- a/client/blocks/importer/squarespace/index.tsx
+++ b/client/blocks/importer/squarespace/index.tsx
@@ -87,7 +87,7 @@ export const SquarespaceImporter: React.FunctionComponent< ImporterBaseProps > =
 	function onSiteViewClick() {
 		if ( isEnabled( 'onboarding/import-redirect-to-themes' ) ) {
 			recordTracksEvent( 'calypso_site_importer_pick_a_design' );
-			stepNavigator?.navigate?.( 'designSetup' );
+			stepNavigator?.navigate?.( 'design-setup' );
 		} else {
 			recordTracksEvent( 'calypso_site_importer_view_site' );
 			stepNavigator?.goToSiteViewPage?.();

--- a/client/blocks/importer/wix/index.tsx
+++ b/client/blocks/importer/wix/index.tsx
@@ -121,7 +121,7 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 	function onSiteViewClick() {
 		if ( isEnabled( 'onboarding/import-redirect-to-themes' ) ) {
 			recordTracksEvent( 'calypso_site_importer_pick_a_design' );
-			stepNavigator?.navigate?.( 'designSetup' );
+			stepNavigator?.navigate?.( 'design-setup' );
 		} else {
 			recordTracksEvent( 'calypso_site_importer_view_site' );
 			stepNavigator?.goToSiteViewPage?.();

--- a/client/blocks/importer/wordpress/import-content-only/index.tsx
+++ b/client/blocks/importer/wordpress/import-content-only/index.tsx
@@ -113,7 +113,7 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 			job?.importerFileType !== 'playground' &&
 			isEnabled( 'onboarding/import-redirect-to-themes' )
 		) {
-			stepNavigator?.navigate?.( 'designSetup' );
+			stepNavigator?.navigate?.( 'design-setup' );
 		} else {
 			stepNavigator?.goToSiteViewPage?.();
 		}

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -124,7 +124,7 @@ const designFirst: Flow = {
 						] );
 
 						return window.location.assign(
-							addQueryArgs( `/setup/update-design/designSetup`, {
+							addQueryArgs( `/setup/update-design/design-setup`, {
 								siteSlug: providedDependencies?.siteSlug,
 								flowToReturnTo: DESIGN_FIRST_FLOW,
 								theme: getQueryArg( window.location.href, 'theme' ),
@@ -163,7 +163,7 @@ const designFirst: Flow = {
 						}
 
 						return window.location.assign(
-							addQueryArgs( `/setup/update-design/designSetup`, {
+							addQueryArgs( `/setup/update-design/design-setup`, {
 								siteSlug: siteSlug,
 								flowToReturnTo: flowName,
 								theme: getQueryArg( window.location.href, 'theme' ),

--- a/client/landing/stepper/declarative-flow/helpers/get-step-old-slug.ts
+++ b/client/landing/stepper/declarative-flow/helpers/get-step-old-slug.ts
@@ -4,6 +4,7 @@
 export const getStepOldSlug = ( stepSlug: string ): string | undefined => {
 	const stepSlugMap: Record< string, string > = {
 		'create-site': 'site-creation-step',
+		'design-setup': 'designSetup',
 	};
 
 	return stepSlugMap[ stepSlug ];

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -169,7 +169,7 @@ const importFlow: Flow = {
 					}
 				}
 
-				case 'designSetup': {
+				case 'design-setup': {
 					return navigate( 'processing' );
 				}
 
@@ -305,7 +305,7 @@ const importFlow: Flow = {
 				case 'importReadyNot':
 				case 'importReadyWpcom':
 				case 'importReadyPreview':
-				case 'designSetup':
+				case 'design-setup':
 					return navigate( `import?siteSlug=${ siteSlugParam }` );
 
 				case 'verifyEmail':

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -169,6 +169,7 @@ const importFlow: Flow = {
 					}
 				}
 
+				case 'designSetup':
 				case 'design-setup': {
 					return navigate( 'processing' );
 				}
@@ -305,6 +306,7 @@ const importFlow: Flow = {
 				case 'importReadyNot':
 				case 'importReadyWpcom':
 				case 'importReadyPreview':
+				case 'designSetup':
 				case 'design-setup':
 					return navigate( `import?siteSlug=${ siteSlugParam }` );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-starting-point/starting-points.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-starting-point/starting-points.tsx
@@ -26,7 +26,7 @@ const useStartingPoints = () => {
 			title: translate( 'Choose a design' ),
 			description: <p>{ translate( 'Make your blog feel like home' ) }</p>,
 			icon: design,
-			value: 'designSetup',
+			value: 'design-setup',
 			actionText: translate( 'View designs' ),
 		},
 	];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
@@ -138,7 +138,7 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 									title={ translate( 'Choose a theme' ) }
 									description={ translate( 'Choose one of our professionally designed themes.' ) }
 									imageSrc={ themesIllustrationImage }
-									destination="designSetup"
+									destination="design-setup"
 									onSelect={ handleSubmit }
 								/>
 							) : (
@@ -148,7 +148,7 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 										'Choose a professionally designed theme and make it yours.'
 									) }
 									fgImageSrc={ themeChoiceFg }
-									destination="designSetup"
+									destination="design-setup"
 									onSelect={ handleSubmit }
 								/>
 							) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
@@ -101,7 +101,7 @@ const renderComponent = ( component, initialState = {} ) => {
 		...initialState,
 	} );
 
-	const initialEntries = [ `/setup/site-setup/designSetup?siteSlug=test.wordpress.com` ];
+	const initialEntries = [ `/setup/site-setup/design-setup?siteSlug=test.wordpress.com` ];
 
 	return render(
 		<Provider store={ store }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-light/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-light/index.tsx
@@ -112,7 +112,7 @@ const ImportLight: Step = function ImportStep( props ) {
 				return (
 					<Summary
 						colorsNum={ colors.length }
-						onContinueClick={ () => navigation.goToStep?.( 'designSetup' ) }
+						onContinueClick={ () => navigation.goToStep?.( 'design-setup' ) }
 					/>
 				);
 

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -29,7 +29,7 @@ export const STEPS = {
 	},
 
 	DESIGN_SETUP: {
-		slug: 'designSetup',
+		slug: 'design-setup',
 		asyncComponent: () => import( './steps-repository/design-setup' ),
 	},
 

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -33,6 +33,11 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/design-setup' ),
 	},
 
+	DESIGN_SETUP_LEGACY: {
+		slug: 'designSetup',
+		asyncComponent: () => import( './steps-repository/design-setup' ),
+	},
+
 	DIFM_STARTING_POINT: {
 		slug: 'difmStartingPoint',
 		asyncComponent: () => import( './steps-repository/difm-starting-point' ),

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -222,12 +222,12 @@ const onboarding: Flow = {
 							if ( isDesignChoicesStepEnabled ) {
 								return navigate( 'design-choices' );
 							}
-							return navigate( 'designSetup' );
+							return navigate( 'design-setup' );
 						}
 					}
 				}
 
-				case 'designSetup': {
+				case 'design-setup': {
 					return navigate( 'domains' );
 				}
 
@@ -424,9 +424,9 @@ const onboarding: Flow = {
 						if ( isBigSkyBeforePlansExperiment && createWithBigSky ) {
 							return navigate( 'design-choices' );
 						}
-						return navigate( 'designSetup' );
+						return navigate( 'design-setup' );
 					}
-				case 'designSetup':
+				case 'design-setup':
 					if ( isDesignChoicesStepEnabled ) {
 						return navigate( 'design-choices' );
 					}

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -117,6 +117,7 @@ const onboarding: Flow = {
 				STEPS.GOALS,
 				STEPS.DESIGN_CHOICES,
 				STEPS.DESIGN_SETUP,
+				STEPS.DESIGN_SETUP_LEGACY,
 				STEPS.DIFM_STARTING_POINT
 			);
 		}
@@ -227,6 +228,7 @@ const onboarding: Flow = {
 					}
 				}
 
+				case 'designSetup':
 				case 'design-setup': {
 					return navigate( 'domains' );
 				}
@@ -426,6 +428,7 @@ const onboarding: Flow = {
 						}
 						return navigate( 'design-setup' );
 					}
+				case 'designSetup':
 				case 'design-setup':
 					if ( isDesignChoicesStepEnabled ) {
 						return navigate( 'design-choices' );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -260,12 +260,12 @@ const siteSetupFlow: FlowV1 = {
 						 *
 						 * Instead of having the user manually choose between "Start simple" and "More power", we let them select a theme and use the theme choice to determine which path to take.
 						 */
-						return navigate( 'designSetup' );
+						return navigate( 'design-setup' );
 					}
 					return navigate( 'bloggerStartingPoint' );
 				}
 
-				case 'designSetup': {
+				case 'design-setup': {
 					return navigate( 'processing' );
 				}
 
@@ -344,7 +344,7 @@ const siteSetupFlow: FlowV1 = {
 							if ( isDesignChoicesStepEnabled ) {
 								return navigate( 'design-choices' );
 							}
-							return navigate( 'designSetup' );
+							return navigate( 'design-setup' );
 						}
 					}
 				}
@@ -368,7 +368,7 @@ const siteSetupFlow: FlowV1 = {
 							return exitFlow( `https://wordpress.com/home/${ siteId ?? siteSlug }` );
 						}
 						case 'build': {
-							return navigate( 'designSetup' );
+							return navigate( 'design-setup' );
 						}
 						case 'sell': {
 							return navigate( 'options' );
@@ -497,7 +497,7 @@ const siteSetupFlow: FlowV1 = {
 				case 'courses':
 					return navigate( 'bloggerStartingPoint' );
 
-				case 'designSetup':
+				case 'design-setup':
 					if ( intent === SiteIntent.DIFM ) {
 						return navigate( 'difmStartingPoint' );
 					}
@@ -580,7 +580,7 @@ const siteSetupFlow: FlowV1 = {
 			switch ( currentStep ) {
 				case 'options':
 					if ( intent === 'sell' ) {
-						return navigate( 'designSetup' );
+						return navigate( 'design-setup' );
 					}
 					return navigate( 'bloggerStartingPoint' );
 
@@ -591,7 +591,7 @@ const siteSetupFlow: FlowV1 = {
 					return navigate( 'importList' );
 
 				case 'difmStartingPoint':
-					return navigate( 'designSetup' );
+					return navigate( 'design-setup' );
 
 				default:
 					return navigate( 'intent' );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -59,6 +59,7 @@ const siteSetupFlow: FlowV1 = {
 			STEPS.OPTIONS,
 			STEPS.DESIGN_CHOICES,
 			STEPS.DESIGN_SETUP,
+			STEPS.DESIGN_SETUP_LEGACY,
 			STEPS.BLOGGER_STARTING_POINT,
 			STEPS.COURSES,
 			STEPS.IMPORT,
@@ -265,6 +266,7 @@ const siteSetupFlow: FlowV1 = {
 					return navigate( 'bloggerStartingPoint' );
 				}
 
+				case 'designSetup':
 				case 'design-setup': {
 					return navigate( 'processing' );
 				}
@@ -497,6 +499,7 @@ const siteSetupFlow: FlowV1 = {
 				case 'courses':
 					return navigate( 'bloggerStartingPoint' );
 
+				case 'designSetup':
 				case 'design-setup':
 					if ( intent === SiteIntent.DIFM ) {
 						return navigate( 'difmStartingPoint' );

--- a/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
@@ -78,7 +78,7 @@ describe( 'Onboarding Flow', () => {
 			expect( getFlowLocation().path ).toBe( '/difmStartingPoint' );
 		} );
 
-		it( 'should navigate to designSetup step for other intents', async () => {
+		it( 'should navigate to design-setup step for other intents', async () => {
 			const { runUseStepNavigationSubmit } = renderFlow( onboarding );
 
 			runUseStepNavigationSubmit( {
@@ -88,7 +88,7 @@ describe( 'Onboarding Flow', () => {
 				},
 			} );
 
-			expect( getFlowLocation().path ).toBe( '/designSetup' );
+			expect( getFlowLocation().path ).toBe( '/design-setup' );
 		} );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/update-design.ts
+++ b/client/landing/stepper/declarative-flow/update-design.ts
@@ -24,7 +24,7 @@ const updateDesign: Flow = {
 	},
 	isSignupFlow: false,
 	useSteps() {
-		return [ STEPS.DESIGN_SETUP, STEPS.PROCESSING, STEPS.ERROR ];
+		return [ STEPS.DESIGN_SETUP, STEPS.DESIGN_SETUP_LEGACY, STEPS.PROCESSING, STEPS.ERROR ];
 	},
 	useSideEffect() {
 		const { setIntent } = useDispatch( ONBOARD_STORE );
@@ -79,6 +79,7 @@ const updateDesign: Flow = {
 						} )
 					);
 
+				case 'designSetup':
 				case 'design-setup':
 					if ( providedDependencies?.goToCheckout ) {
 						const destination = `/setup/${ flowToReturnTo }/launchpad?siteSlug=${ providedDependencies.siteSlug }`;

--- a/client/landing/stepper/declarative-flow/update-design.ts
+++ b/client/landing/stepper/declarative-flow/update-design.ts
@@ -79,7 +79,7 @@ const updateDesign: Flow = {
 						} )
 					);
 
-				case 'designSetup':
+				case 'design-setup':
 					if ( providedDependencies?.goToCheckout ) {
 						const destination = `/setup/${ flowToReturnTo }/launchpad?siteSlug=${ providedDependencies.siteSlug }`;
 						persistSignupDestination( destination );

--- a/client/my-sites/customer-home/cards/launchpad/test/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/test/index.tsx
@@ -83,7 +83,7 @@ const DEFAULT_TAKS_RESPONSE = {
 			subtitle: '',
 			badge_text: '',
 			isLaunchTask: false,
-			calypso_path: '/setup/update-design/designSetup?siteSlug=gabrielcaires0.wordpress.com',
+			calypso_path: '/setup/update-design/design-setup?siteSlug=gabrielcaires0.wordpress.com',
 		},
 	],
 	is_enabled: false,

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -191,7 +191,7 @@ function getAllThemeOptions( { translate, isFSEActive, isGlobalStylesOnPersonal 
 			const slug = getSiteSlug( state, siteId );
 
 			const redirectTo = encodeURIComponent(
-				addQueryArgs( `${ origin }/setup/site-setup/designSetup`, {
+				addQueryArgs( `${ origin }/setup/site-setup/design-setup`, {
 					siteSlug: slug,
 					theme: themeId,
 					style_variation: options?.styleVariationSlug,

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -145,7 +145,7 @@ function getWithThemeDestination( {
 		! cartItems &&
 		[ DOT_ORG_THEME, PREMIUM_THEME, MARKETPLACE_THEME, BUNDLED_THEME ].includes( themeType )
 	) {
-		return `/setup/site-setup/designSetup?siteSlug=${ siteSlug }`;
+		return `/setup/site-setup/design-setup?siteSlug=${ siteSlug }`;
 	}
 
 	if ( DOT_ORG_THEME === themeType ) {
@@ -158,7 +158,7 @@ function getWithThemeDestination( {
 		return `/marketplace/thank-you/${ siteSlug }?onboarding=&themes=${ themeParameter }${ style }`;
 	}
 
-	return `/setup/site-setup/designSetup?siteSlug=${ siteSlug }&theme=${ themeParameter }${ style }`;
+	return `/setup/site-setup/design-setup?siteSlug=${ siteSlug }&theme=${ themeParameter }${ style }`;
 }
 
 function getWithPluginDestination( { siteSlug, pluginParameter, pluginBillingPeriod } ) {

--- a/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
@@ -9,7 +9,7 @@ export type StepName =
 	| 'goals'
 	| 'vertical'
 	| 'intent'
-	| 'designSetup'
+	| 'design-setup'
 	| 'options'
 	| 'designChoices';
 type WriteActions = 'Start writing' | 'Start learning' | 'View designs';
@@ -79,7 +79,7 @@ export class StartSiteFlow {
 			return 'intent';
 		}
 		if ( ( await this.page.locator( selectors.themePickerContainer ).count() ) > 0 ) {
-			return 'designSetup';
+			return 'design-setup';
 		}
 		if ( ( await this.page.locator( selectors.optionsStepContainer ).count() ) > 0 ) {
 			return 'options';
@@ -165,7 +165,7 @@ export class StartSiteFlow {
 			await this.page.waitForURL( /setup\/site-setup\/courses/ );
 		}
 		if ( action === 'View designs' ) {
-			await this.page.waitForURL( /setup\/site-setup\/designSetup/ );
+			await this.page.waitForURL( /setup\/site-setup\/design-setup/ );
 		}
 	}
 

--- a/packages/launchpad/src/msw/setup-free.ts
+++ b/packages/launchpad/src/msw/setup-free.ts
@@ -36,7 +36,7 @@ export default {
 			subtitle: '',
 			badge_text: '',
 			isLaunchTask: false,
-			calypso_path: '/setup/update-design/designSetup?siteSlug=site62798.wordpress.com',
+			calypso_path: '/setup/update-design/design-setup?siteSlug=site62798.wordpress.com',
 		},
 		{
 			id: 'domain_upsell',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/100206

## Proposed Changes

This PR replaces all instances of `designSetup` to `design-setup`. In addition, taking into account backwards compatibility, the following changes were also made:

1. Ensure Tracks event still triggers for the previous step slug.
```diff
export const getStepOldSlug = ( stepSlug: string ): string | undefined => {
	const stepSlugMap: Record< string, string > = {
		'create-site': 'site-creation-step',
+		'design-setup': 'designSetup',
	};

	return stepSlugMap[ stepSlug ];
```

2. Ensure previous URL is still accessible.
```diff
+	DESIGN_SETUP_LEGACY: {
+		slug: 'designSetup',
+		asyncComponent: () => import( './steps-repository/design-setup' ),
+	},
```

### /setup/onboarding flow

https://github.com/user-attachments/assets/ca4b849a-d355-48fb-b814-3404fbd5613a

### /setup/site-setup flow (head to /start?flags=-onboarding/force-goals-first)

https://github.com/user-attachments/assets/858d5e32-ee98-446a-8bc0-59ab89a22712

### /setup/update-design

https://github.com/user-attachments/assets/b7bb7058-00ce-45db-8a55-64b78184881a

### /setup/import-focused flow

https://github.com/user-attachments/assets/41fa8037-4253-4d5f-ae67-4452a1a1b848


> [!NOTE]
> We will follow up updating the URL in wpcom and Jetpack in later PRs.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Stepper step slug consistency.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure /setup/site-setup flow still works as intended
* Ensure /setup/onboarding flow still works as intended
* Ensure /setup/update-design flow still works as intended
* Ensure /setup/import-focused flow still works as intended
* In each of the flows above, replace design-setup with designSetup in the URL and ensure the flow still works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
