### PR TITLE
A4A > WooPayments: Add WooPayments to site initial implementation

### DIFF
--- a/client/a8c-for-agencies/hooks/use-install-plugin-to-site.ts
+++ b/client/a8c-for-agencies/hooks/use-install-plugin-to-site.ts
@@ -1,0 +1,45 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+interface InstallPluginToSiteMutationOptions {
+	siteId: number;
+	pluginSlug: string;
+}
+
+interface APIError {
+	status: number;
+	code: string | null;
+	message: string;
+}
+
+function mutationInstallPluginToSite( {
+	siteId,
+	pluginSlug,
+}: InstallPluginToSiteMutationOptions ): Promise< void > {
+	const isAPIEnabled = false; // FIXME: Remove this once the API is enabled
+	return isAPIEnabled
+		? wpcom.req.post(
+				{
+					path: `/jetpack-blogs/${ siteId }/rest-api`,
+					apiNamespace: 'rest/v1.1',
+				},
+				{
+					path: '/wp/v2/plugins/',
+					body: JSON.stringify( {
+						slug: pluginSlug,
+						status: 'active',
+					} ),
+					json: true,
+				}
+		  )
+		: Promise.resolve();
+}
+
+export default function useInstallPluginToSiteMutation< TContext = unknown >(
+	options?: UseMutationOptions< void, APIError, InstallPluginToSiteMutationOptions, TContext >
+): UseMutationResult< void, APIError, InstallPluginToSiteMutationOptions, TContext > {
+	return useMutation< void, APIError, InstallPluginToSiteMutationOptions, TContext >( {
+		...options,
+		mutationFn: mutationInstallPluginToSite,
+	} );
+}

--- a/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/add-site-table.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/add-site-table.tsx
@@ -1,0 +1,107 @@
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useMemo, useState } from 'react';
+import A4ATablePlaceholder from 'calypso/a8c-for-agencies/components/a4a-table-placeholder';
+import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
+import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import FormRadio from 'calypso/components/forms/form-radio';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { useFetchAllManagedSites } from '../../migrations/hooks/use-fetch-all-managed-sites';
+
+export type WooPaymentsSiteItem = {
+	id: number;
+	site: string;
+	date: string;
+};
+
+const AddWooPaymentsToSiteTable = ( {
+	selectedSite,
+	setSelectedSite,
+	excludedSites,
+}: {
+	selectedSite: WooPaymentsSiteItem | null;
+	setSelectedSite: ( site: WooPaymentsSiteItem | null ) => void;
+	excludedSites: WooPaymentsSiteItem[] | null;
+} ) => {
+	const translate = useTranslate();
+
+	const dispatch = useDispatch();
+
+	const { items, isLoading } = useFetchAllManagedSites();
+
+	const excludedSitesIds = useMemo(
+		() => excludedSites?.map( ( site ) => site.id ) || [],
+		[ excludedSites ]
+	);
+
+	// Filter out sites that are already tagged
+	const availableSites = useMemo( () => {
+		return items.filter( ( item ) => ! excludedSitesIds.includes( item.id ) );
+	}, [ items, excludedSitesIds ] );
+
+	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
+		...initialDataViewsState,
+		fields: [ 'site' ],
+	} );
+
+	const onSelectSite = useCallback(
+		( item: WooPaymentsSiteItem ) => {
+			setSelectedSite( item );
+			dispatch( recordTracksEvent( 'calypso_a8c_woopayments_add_site_table_select_site_click' ) );
+		},
+		[ dispatch, setSelectedSite ]
+	);
+
+	const fields = useMemo( () => {
+		const siteColumn = {
+			id: 'site',
+			label: translate( 'Site' ),
+			getValue: () => '-',
+			render: ( { item }: { item: WooPaymentsSiteItem } ) => (
+				<div>
+					<FormRadio
+						htmlFor={ `site-${ item.id }` }
+						id={ `site-${ item.id }` }
+						checked={ selectedSite?.id === item.id }
+						onChange={ () => onSelectSite( item ) }
+						label={ item.site }
+					/>
+				</div>
+			),
+			enableHiding: false,
+			enableSorting: false,
+		};
+
+		return [ siteColumn ];
+	}, [ onSelectSite, selectedSite?.id, translate ] );
+
+	const { data: allSites, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( availableSites, dataViewsState, fields );
+	}, [ availableSites, dataViewsState, fields ] );
+
+	return (
+		<div className="redesigned-a8c-table show-overflow-overlay">
+			{ isLoading ? (
+				<A4ATablePlaceholder />
+			) : (
+				<ItemsDataViews
+					data={ {
+						items: allSites,
+						fields,
+						getItemId: ( item ) => `${ item.id }`,
+						pagination: paginationInfo,
+						enableSearch: false,
+						actions: [],
+						dataViewsState: dataViewsState,
+						setDataViewsState: setDataViewsState,
+						defaultLayouts: { table: {} },
+					} }
+				/>
+			) }
+		</div>
+	);
+};
+
+export default AddWooPaymentsToSiteTable;

--- a/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/index.tsx
@@ -1,0 +1,30 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import AddWooPaymentsToSiteModal from './modal';
+
+const AddWooPaymentsToSite = () => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	const handleOpenModal = () => {
+		setIsOpen( true );
+		dispatch( recordTracksEvent( 'calypso_a4a_woopayments_add_site_button_click' ) );
+	};
+
+	return (
+		<>
+			<Button variant="primary" onClick={ handleOpenModal }>
+				{ translate( 'Add WooPayments to site' ) }
+			</Button>
+
+			{ isOpen && <AddWooPaymentsToSiteModal onClose={ () => setIsOpen( false ) } /> }
+		</>
+	);
+};
+
+export default AddWooPaymentsToSite;

--- a/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/modal.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/modal.tsx
@@ -1,18 +1,42 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import A4AModal from 'calypso/a8c-for-agencies/components/a4a-modal';
+import useAddWooPaymentsToSiteMutation from 'calypso/a8c-for-agencies/hooks/use-install-plugin-to-site';
+import { useDispatch } from 'calypso/state';
+import { errorNotice } from 'calypso/state/notices/actions';
 import AddWooPaymentsToSiteTable, { type WooPaymentsSiteItem } from './add-site-table';
 
 const AddWooPaymentsToSiteModal = ( { onClose }: { onClose: () => void } ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const [ selectedSite, setSelectedSite ] = useState< WooPaymentsSiteItem | null >( null );
 
-	const isPending = false;
+	const {
+		mutate: addWooPaymentsToSite,
+		status,
+		error,
+		isPending,
+	} = useAddWooPaymentsToSiteMutation();
+
+	useEffect( () => {
+		if ( status === 'success' ) {
+			onClose();
+		} else if ( status === 'error' ) {
+			dispatch(
+				errorNotice( error.message ?? translate( 'Something went wrong. Please try again.' ) )
+			);
+		}
+	}, [ status, onClose, error, dispatch, translate ] );
 
 	const handleAddSite = () => {
-		// TODO: Add the site
+		if ( selectedSite ) {
+			addWooPaymentsToSite( {
+				siteId: selectedSite.id,
+				pluginSlug: 'woocommerce-payments',
+			} );
+		}
 	};
 
 	const excludedSites = null; // FIXME: Replace this with sites that already have WooPayments enabled

--- a/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/modal.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/modal.tsx
@@ -1,0 +1,47 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import A4AModal from 'calypso/a8c-for-agencies/components/a4a-modal';
+import AddWooPaymentsToSiteTable, { type WooPaymentsSiteItem } from './add-site-table';
+
+const AddWooPaymentsToSiteModal = ( { onClose }: { onClose: () => void } ) => {
+	const translate = useTranslate();
+
+	const [ selectedSite, setSelectedSite ] = useState< WooPaymentsSiteItem | null >( null );
+
+	const isPending = false;
+
+	const handleAddSite = () => {
+		// TODO: Add the site
+	};
+
+	const excludedSites = null; // FIXME: Replace this with sites that already have WooPayments enabled
+
+	return (
+		<A4AModal
+			title={ translate( 'Which site would you like to add WooPayments to?' ) }
+			subtile={ translate(
+				"If you don't see the site in the list, connect it first via the Sites Dashboard."
+			) }
+			onClose={ onClose }
+			extraActions={
+				<Button
+					variant="primary"
+					onClick={ handleAddSite }
+					disabled={ isPending || ! selectedSite }
+					isBusy={ isPending }
+				>
+					{ translate( 'Add WooPayments to selected site' ) }
+				</Button>
+			}
+		>
+			<AddWooPaymentsToSiteTable
+				setSelectedSite={ setSelectedSite }
+				selectedSite={ selectedSite }
+				excludedSites={ excludedSites }
+			/>
+		</A4AModal>
+	);
+};
+
+export default AddWooPaymentsToSiteModal;

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
@@ -7,6 +7,7 @@ import LayoutHeader, {
 	LayoutHeaderTitle as Title,
 	LayoutHeaderActions as Actions,
 } from 'calypso/layout/hosting-dashboard/header';
+import AddWooPaymentsToSite from '../../add-woopayments-to-site';
 
 const WooPaymentsDashboard = () => {
 	const translate = useTranslate();
@@ -26,6 +27,7 @@ const WooPaymentsDashboard = () => {
 					<Title>{ title }</Title>
 					<Actions>
 						<MobileSidebarNavigation />
+						<AddWooPaymentsToSite />
 					</Actions>
 				</LayoutHeader>
 			</LayoutTop>

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -609,7 +609,34 @@ html {
 		}
 	}
 
+	&.show-overflow-overlay {
+		overflow-y: auto;
+		margin-block: 24px;
+
+		&::after {
+			content: "";
+			position: absolute;
+			left: 0;
+			bottom: 80px;
+			width: 100%;
+			height: 5%;
+			display: inline-block;
+			background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(255, 255, 255, 1) 100%);
+			transition: opacity 0.3s ease-out;
+		}
+
+		.dataviews-view-table {
+			padding-block-end: 80px;
+			margin: 0 0 32px;
+
+			tr {
+				border-top: none;
+			}
+		}
+	}
 }
+
+
 
 .full-width-layout-with-table {
 	.hosting-dashboard-layout__body-wrapper {


### PR DESCRIPTION

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1849

## Proposed Changes

This PR does the initial implementation of the "Add WooPayments to site" functionality.

NOTE: API implementation will be done in another PR.

## Testing Instructions

* Open the A4A live link
* Go to WooPayments: Dashboard > Click the "Add WooPayments to site" button on the layout top-right 

<img width="1728" alt="Screenshot 2025-02-25 at 2 11 53 PM" src="https://github.com/user-attachments/assets/8d1d0b48-2688-44d8-8505-5ecd2f5fdc4c" />

* Verify the modal is displayed listing all the managed sites. We are not filtering the sites. This will be done in another PR. 
* Select a site and click the `Add WooPayments to selected site` button. Verify the modal is closed. The API implementation for this will be done in another PR

<img width="1728" alt="Screenshot 2025-02-25 at 2 12 18 PM" src="https://github.com/user-attachments/assets/ba15f518-e948-480a-961c-82ecbd6c23c6" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
