### PR TITLE
Stats: Traffic page line chart adds visitors line

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -31,15 +31,46 @@ const ChartTabShape = PropTypes.shape( {
 	legendOptions: PropTypes.arrayOf( PropTypes.string ),
 } );
 
-const transformChartDataToLineFormat = ( chartData, activeLegend ) => {
-	return activeLegend.map( ( legend ) => ( {
-		label: legend,
+// data validation for line chart
+const transformChartDataToLineFormat = ( chartData ) => {
+	if ( ! Array.isArray( chartData ) ) {
+		return [];
+	}
+
+	// Create the first data series for views
+	const viewsSeries = {
+		label: 'Views',
 		options: {},
-		data: chartData.map( ( record ) => ( {
-			date: new Date( record.data.period ),
-			value: record.data[ legend ] || 0,
-		} ) ),
-	} ) );
+		data: chartData
+			.map( ( record ) => {
+				const date = new Date( record.data.period );
+				const value = record.data.views;
+				if ( isNaN( date.getTime() ) || typeof value !== 'number' ) {
+					return null;
+				}
+				return { date, value };
+			} )
+			.filter( Boolean ),
+	};
+
+	// Create the second data series for visitors
+	const visitorsSeries = {
+		label: 'Visitors',
+		options: {},
+		data: chartData
+			.map( ( record ) => {
+				const date = new Date( record.data.period );
+				const value = record.data.visitors;
+				if ( isNaN( date.getTime() ) || typeof value !== 'number' ) {
+					return null;
+				}
+				return { date, value };
+			} )
+			.filter( Boolean ),
+	};
+
+	// Return both series
+	return [ viewsSeries, visitorsSeries ];
 };
 
 class StatModuleChartTabs extends Component {
@@ -174,7 +205,7 @@ class StatModuleChartTabs extends Component {
 					<AsyncLoad
 						require="calypso/my-sites/stats/components/line-chart"
 						className="stats-chart-tabs__line-chart"
-						chartData={ transformChartDataToLineFormat( chartData, this.props.activeLegend ) }
+						chartData={ transformChartDataToLineFormat( chartData ) }
 						height={ 200 }
 						moment={ moment }
 					/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-roadmap/issues/2336

## Proposed Changes

* This PR adds a second data set to the traffic page linechart for visitors
* This does **not update** the activeLegend to toggle on/off the visitors line. This needs to be added back in a followup PR

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso live branch
* Navigate to `/stats/day/{URL}`
* Check you cannot see anything unusual
* Append feature flag `flags=stats/chart-library`
* Check that now the toggle button appears
* Click on the toggle, and make sure it toggles to the line chart. 
* Ensure the line chart is now showing two lines, one for `views` and one for `visitors`

![image](https://github.com/user-attachments/assets/f7001513-8353-4f5e-83a3-e54bdbf04fbd)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
