### PR TITLE
Help Center: Fix last message check

### DIFF
--- a/packages/help-center/src/components/help-center-chat-history.tsx
+++ b/packages/help-center/src/components/help-center-chat-history.tsx
@@ -63,7 +63,7 @@ const Conversations = ( {
 			{ conversations.map( ( conversation ) => {
 				const lastMessage = getLastMessage( { conversation } );
 				const lastSupportInteraction = supportInteractions.find(
-					( interaction ) => interaction.uuid === conversation.metadata.supportInteractionId
+					( interaction ) => interaction.uuid === conversation?.metadata.supportInteractionId
 				);
 
 				if ( lastMessage ) {

--- a/packages/help-center/src/components/help-center-recent-conversations.tsx
+++ b/packages/help-center/src/components/help-center-recent-conversations.tsx
@@ -73,7 +73,7 @@ const HelpCenterRecentConversations: React.FC = () => {
 			const lastConversation = lastUnreadConversation || conversations[ 0 ];
 			const lastMessage = lastConversation?.messages[ lastConversation?.messages.length - 1 ];
 			const lastSupportInteraction = supportInteractions.find(
-				( interaction ) => interaction.uuid === lastConversation.metadata.supportInteractionId
+				( interaction ) => interaction.uuid === lastConversation?.metadata.supportInteractionId
 			);
 
 			setLastSupportInteraction( lastSupportInteraction );


### PR DESCRIPTION
## Proposed Changes

Make sure last message is not null before accessing its metadata.

## Why are these changes being made?
To handle null values in case of missing last message or during its loading.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
