### PR TITLE
A4A: Fix WooPayments featured badge color override.

### DIFF
--- a/client/a8c-for-agencies/sections/overview/sidebar/featured-woopayments/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/featured-woopayments/style.scss
@@ -45,7 +45,7 @@ $woocommerce-purple-50: #720EEC;
 	}
 }
 
-.overview__featured-woopayments-badge {
+.badge.overview__featured-woopayments-badge {
 	display: inline-block;
 	background-color: var(--color-surface);
 	color: $woocommerce-purple-50;


### PR DESCRIPTION
The featured badge on the WooPayments overview card appears to have a styled override. This PR ensures that this won't happen by adding a more specific CSS selector.

**Original** ✅ 
<img width="447" alt="Screenshot 2025-02-25 at 11 17 15 PM" src="https://github.com/user-attachments/assets/4c00fbb3-ffee-40fb-a60f-254bf76fc8db" />

**Override** ❌ 
<img width="461" alt="Screenshot 2025-02-25 at 11 13 55 PM" src="https://github.com/user-attachments/assets/f666ac5b-c90e-44d9-834b-d04022464bc3" />


## Proposed Changes

* Add `.badge` to the selector to increase specificity.

## Why are these changes being made?

* Ensure our branding colors are consistent.

## Testing Instructions

* Use the A4A live link and go to the `/overview` page.
* Click the Marketplace menu in the sidebar to go to the Marketplace page.
* Now go back to the Overview page.
* Confirm that the Featured badge color does not change color.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
