### PR TITLE
bilmur: Always add data-site-tz="Etc/UTC" to tag

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -235,6 +235,7 @@ class Document extends Component {
 							data-provider="wordpress.com"
 							data-service="calypso"
 							data-customproperties={ `{"route_name": "${ sectionName }"}` }
+							data-site-tz="Etc/UTC"
 						/>
 					) }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Always set the site timezone as Etc/UTC for bilmur (our rum library).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We have decided to populate a site_time column in our rum data, allowing for proper daily division of stats. For Calypso, the rum data covers people visiting wordpress.com URLs and not actual site URLs, so we want to keep it simple and only use UTC as the site timezone.

## Testing Instructions


* Visit any calypso page and use the inspect panel to find the bilmur tag.

Note: You will have to force it to be enabled in dev
```diff
diff --git a/client/document/utils/bilmur.js b/client/document/utils/bilmur.js
index ecbdb74e163..d6296ed68a6 100644
--- a/client/document/utils/bilmur.js
+++ b/client/document/utils/bilmur.js
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';

 export function isBilmurEnabled() {
+       return true;
        return config.isEnabled( 'bilmur-script' );
 }

```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
