### PR TITLE
Manage domains: Support screen reader

### DIFF
--- a/packages/domains-table/src/domains-table/domains-table-expires-renews-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-expires-renews-cell.tsx
@@ -87,7 +87,10 @@ export const DomainsTableExpiresRenewsOnCell = ( {
 						/>
 					) }
 
-					{ getNotice( { expiryDate, isAutoRenewing, isExpired, isHundredYearDomain } ) }
+					{ /* eslint-disable jsx-a11y/no-noninteractive-tabindex */ }
+					<span tabIndex={ 0 }>
+						{ getNotice( { expiryDate, isAutoRenewing, isExpired, isHundredYearDomain } ) }
+					</span>
 				</>
 			) : (
 				'-'

--- a/packages/domains-table/src/domains-table/domains-table-status-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-status-cell.tsx
@@ -43,6 +43,8 @@ export const DomainsTableStatusCell = ( {
 		);
 	};
 
+	const domainStatusText = domainStatus?.status ?? translate( 'Unknown status' );
+
 	return (
 		<Element
 			className={ clsx( 'domains-table-row__status-cell', {
@@ -50,7 +52,17 @@ export const DomainsTableStatusCell = ( {
 					!! domainStatus?.statusClass,
 			} ) }
 		>
-			{ domainStatus?.status ?? translate( 'Unknown status' ) }
+			{ /* eslint-disable jsx-a11y/no-noninteractive-tabindex */ }
+			<span
+				tabIndex={ 0 }
+				aria-label={
+					translate( 'Status: %(status)s', {
+						args: { status: domainStatusText },
+					} ) as string
+				}
+			>
+				{ domainStatusText }
+			</span>
 			{ pendingUpdates.length > 0 && (
 				<StatusPopover popoverTargetElement={ <Spinner size={ spinnerSize } /> }>
 					<div className="domains-bulk-update-status-popover">


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/79413

## Proposed Changes

* Screen reader support of two cells: `Expires / Renews On` and `Status`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Accessibility support

## Testing Instructions

- Start at `/domains/manage`
- Turn on the screen reader. For example, if you are on Chrome, install the "Screen Reader" extension.
- Navigate through the elements on the page.
- Check if the screen reader can read the domain's status and expiration date.

![Screen Capture on 2025-02-25 at 23-18-57](https://github.com/user-attachments/assets/2814dbdc-8ab8-47f7-a53c-527073cc7281)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
