### PR TITLE
i18n: `format-currency` - bring `getCurrencyObject` method to i18n-calypso. Update all references.

### DIFF
--- a/client/blocks/reader-site-subscription/helpers.tsx
+++ b/client/blocks/reader-site-subscription/helpers.tsx
@@ -1,5 +1,5 @@
 import { Reader } from '@automattic/data-stores';
-import { getCurrencyObject } from '@automattic/format-currency';
+import { getCurrencyObject } from 'i18n-calypso';
 import moment from 'moment';
 import {
 	PLAN_YEARLY_FREQUENCY,

--- a/client/my-sites/promote-post-i2/utils/index.ts
+++ b/client/my-sites/promote-post-i2/utils/index.ts
@@ -1,8 +1,8 @@
 import config from '@automattic/calypso-config';
 import { SiteDetails } from '@automattic/data-stores';
-import { getCurrencyObject } from '@automattic/format-currency';
 import { InfiniteData } from '@tanstack/react-query';
 import { __, _x } from '@wordpress/i18n';
+import { getCurrencyObject } from 'i18n-calypso';
 import moment from 'moment';
 import {
 	BlazablePost,

--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -1,9 +1,8 @@
 import { Popover } from '@automattic/components';
-import { getCurrencyObject } from '@automattic/format-currency';
 import { Card } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, getCurrencyObject } from 'i18n-calypso';
 import { useRef, useState } from 'react';
 import { COMPONENT_CLASS_NAME } from './stats-purchase-consts';
 import StatsPurchasePreviewImage from './stats-purchase-preview-image';

--- a/client/my-sites/subscribers/hooks/use-subscription-plans.ts
+++ b/client/my-sites/subscribers/hooks/use-subscription-plans.ts
@@ -1,5 +1,4 @@
-import { getCurrencyObject } from '@automattic/format-currency';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, getCurrencyObject } from 'i18n-calypso';
 import { ReactNode, useMemo } from 'react';
 import {
 	PLAN_YEARLY_FREQUENCY,

--- a/packages/components/src/plan-price/index.tsx
+++ b/packages/components/src/plan-price/index.tsx
@@ -1,6 +1,5 @@
-import { getCurrencyObject } from '@automattic/format-currency';
 import clsx from 'clsx';
-import { useTranslate, TranslateResult } from 'i18n-calypso';
+import { useTranslate, TranslateResult, getCurrencyObject } from 'i18n-calypso';
 import { Component, createElement } from 'react';
 import { Badge } from '../';
 

--- a/packages/components/src/plan-price/test/index.tsx
+++ b/packages/components/src/plan-price/test/index.tsx
@@ -1,8 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-import { geolocateCurrencySymbol, setDefaultLocale } from '@automattic/format-currency';
 import { render, screen } from '@testing-library/react';
+import i18n, { geolocateCurrencySymbol } from 'i18n-calypso';
 import React from 'react';
 import PlanPrice from '../index';
 
@@ -10,7 +10,11 @@ describe( 'PlanPrice', () => {
 	const originalFetch = globalThis.fetch;
 
 	beforeEach( () => {
-		setDefaultLocale( 'en-US' );
+		i18n.setLocale( {
+			'': {
+				localeSlug: 'en-US',
+			},
+		} );
 		globalThis.fetch = originalFetch;
 	} );
 
@@ -365,13 +369,23 @@ describe( 'PlanPrice', () => {
 	} );
 
 	it( 'renders the symbol to the left of the integer when symbolPosition is "before"', () => {
-		setDefaultLocale( 'en-US' );
+		i18n.setLocale( {
+			'': {
+				localeSlug: 'en',
+				localeVariant: 'en-US',
+			},
+		} );
 		render( <PlanPrice rawPrice={ 48 } currencyCode="CAD" /> );
 		expect( document.body ).toHaveTextContent( 'C$48' );
 	} );
 
 	it( 'renders the symbol to the right of the integer when symbolPosition is "after"', () => {
-		setDefaultLocale( 'fr-CA' );
+		i18n.setLocale( {
+			'': {
+				localeVariant: 'fr-CA',
+				localeSlug: 'fr',
+			},
+		} );
 		render( <PlanPrice rawPrice={ 48 } currencyCode="CAD" /> );
 		expect( document.body ).toHaveTextContent( '48C$' );
 	} );

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -9,6 +9,7 @@ import {
 	__DO_NOT_IMPORT__numberFormat,
 	__DO_NOT_IMPORT__numberFormatCompact,
 	__DO_NOT_IMPORT__numberFormatCurrency,
+	__DO_NOT_IMPORT__getCurrencyObject,
 } from './number-formatters';
 
 const GEO_LOCATION_ENDPOINT_URL = 'https://public-api.wordpress.com/geo/';
@@ -283,6 +284,35 @@ I18N.prototype.formatCurrency = function (
 	}
 
 	return __DO_NOT_IMPORT__numberFormatCurrency( {
+		number,
+		currency,
+		browserSafeLocale,
+		stripZeros,
+		isSmallestUnit,
+		signForPositive,
+		geoLocation,
+		forceLatin,
+	} );
+};
+
+I18N.prototype.getCurrencyObject = function (
+	number,
+	currency,
+	{ stripZeros = false, isSmallestUnit = false, signForPositive = false, forceLatin = true } = {}
+) {
+	const browserSafeLocale = this.getBrowserSafeLocale();
+	const geoLocation = this.geoLocation;
+
+	/**
+	 * TS will flag this as an error, but best to check for undefined here for older usages
+	 * `Intl.NumberFormat` will return NaN for undefined values, which is not helpful. Null becomes 0, also potentially risky.
+	 */
+	if ( typeof number === 'undefined' || number === null ) {
+		warn( 'getCurrencyObject() requires a defined and non-null value as the first argument' );
+		return number;
+	}
+
+	return __DO_NOT_IMPORT__getCurrencyObject( {
 		number,
 		currency,
 		browserSafeLocale,

--- a/packages/i18n-calypso/src/index.ts
+++ b/packages/i18n-calypso/src/index.ts
@@ -13,6 +13,7 @@ export default i18n;
 export const numberFormat = i18n.numberFormat.bind( i18n );
 export const numberFormatCompact = i18n.numberFormatCompact.bind( i18n );
 export const formatCurrency = i18n.formatCurrency.bind( i18n );
+export const getCurrencyObject = i18n.getCurrencyObject.bind( i18n );
 export const geolocateCurrencySymbol = i18n.geolocateCurrencySymbol.bind( i18n );
 export const translate = i18n.translate.bind( i18n );
 export const configure = i18n.configure.bind( i18n );

--- a/packages/i18n-calypso/src/number-formatters/index.ts
+++ b/packages/i18n-calypso/src/number-formatters/index.ts
@@ -1,5 +1,4 @@
 import { getCachedFormatter } from './get-cached-formatter';
-import { __DO_NOT_IMPORT__numberFormatCurrency } from './number-format-currency';
 import type { NumberFormat } from './types';
 
 /**
@@ -47,7 +46,8 @@ const numberFormatCompact: NumberFormat = ( { numberFormatOptions = {}, ...param
 export {
 	numberFormat as __DO_NOT_IMPORT__numberFormat,
 	numberFormatCompact as __DO_NOT_IMPORT__numberFormatCompact,
-	__DO_NOT_IMPORT__numberFormatCurrency,
 };
+
+export * from './number-format-currency';
 
 export * from './types';

--- a/packages/i18n-calypso/src/number-formatters/test/number-format-currency.ts
+++ b/packages/i18n-calypso/src/number-formatters/test/number-format-currency.ts
@@ -1,4 +1,7 @@
-import { __DO_NOT_IMPORT__numberFormatCurrency } from '../number-format-currency';
+import {
+	__DO_NOT_IMPORT__numberFormatCurrency,
+	__DO_NOT_IMPORT__getCurrencyObject,
+} from '../number-format-currency';
 
 const browserSafeLocale = 'en-US';
 
@@ -10,6 +13,24 @@ describe( '__DO_NOT_IMPORT__numberFormatCurrency default export', () => {
 			browserSafeLocale,
 		} );
 		expect( money ).toBe( '$99.32' );
+	} );
+} );
+
+describe( '__DO_NOT_IMPORT__getCurrencyObject default export', () => {
+	test( 'handles negative values', () => {
+		const money = __DO_NOT_IMPORT__getCurrencyObject( {
+			number: -1234.56789,
+			currency: 'USD',
+			browserSafeLocale,
+		} );
+		expect( money ).toEqual( {
+			symbol: '$',
+			symbolPosition: 'before',
+			integer: '1,234',
+			fraction: '.57',
+			sign: '-',
+			hasNonZeroFraction: true,
+		} );
 	} );
 } );
 
@@ -399,6 +420,287 @@ describe( '__DO_NOT_IMPORT__numberFormatCurrency', () => {
 				isSmallestUnit: true,
 			} );
 			expect( money ).toBe( 'Rp 1.072.800,00' );
+		} );
+	} );
+} );
+
+describe( '__DO_NOT_IMPORT__getCurrencyObject()', () => {
+	test( 'handles zero', () => {
+		const money = __DO_NOT_IMPORT__getCurrencyObject( {
+			number: 0,
+			currency: 'USD',
+			browserSafeLocale,
+		} );
+		expect( money ).toEqual( {
+			symbol: '$',
+			symbolPosition: 'before',
+			integer: '0',
+			fraction: '.00',
+			sign: '',
+			hasNonZeroFraction: false,
+		} );
+	} );
+
+	test( 'handles negative values', () => {
+		const money = __DO_NOT_IMPORT__getCurrencyObject( {
+			number: -1234.56789,
+			currency: 'USD',
+			browserSafeLocale,
+		} );
+		expect( money ).toEqual( {
+			symbol: '$',
+			symbolPosition: 'before',
+			integer: '1,234',
+			fraction: '.57',
+			sign: '-',
+			hasNonZeroFraction: true,
+		} );
+	} );
+
+	test( 'handles values that round up', () => {
+		const money = __DO_NOT_IMPORT__getCurrencyObject( {
+			number: 9.99876,
+			currency: 'USD',
+			browserSafeLocale,
+		} );
+		expect( money ).toEqual( {
+			symbol: '$',
+			symbolPosition: 'before',
+			integer: '10',
+			fraction: '.00',
+			sign: '',
+			hasNonZeroFraction: false,
+		} );
+	} );
+
+	test( 'handles values that round down', () => {
+		const money = __DO_NOT_IMPORT__getCurrencyObject( {
+			number: 9.99432,
+			currency: 'USD',
+			browserSafeLocale,
+		} );
+		expect( money ).toEqual( {
+			symbol: '$',
+			symbolPosition: 'before',
+			integer: '9',
+			fraction: '.99',
+			sign: '',
+			hasNonZeroFraction: true,
+		} );
+	} );
+
+	test( 'handles a number in the smallest unit', () => {
+		const money = __DO_NOT_IMPORT__getCurrencyObject( {
+			number: 9932,
+			currency: 'USD',
+			browserSafeLocale,
+			isSmallestUnit: true,
+		} );
+		expect( money ).toEqual( {
+			symbol: '$',
+			symbolPosition: 'before',
+			integer: '99',
+			fraction: '.32',
+			sign: '',
+			hasNonZeroFraction: true,
+		} );
+	} );
+
+	test( 'handles a number in the smallest unit for non-decimal currency', () => {
+		const money = __DO_NOT_IMPORT__getCurrencyObject( {
+			number: 9932,
+			currency: 'JPY',
+			browserSafeLocale,
+			isSmallestUnit: true,
+		} );
+		expect( money ).toEqual( {
+			symbol: '¥',
+			symbolPosition: 'before',
+			integer: '9,932',
+			fraction: '',
+			sign: '',
+			hasNonZeroFraction: false,
+		} );
+	} );
+
+	test( 'handles the number as rounded if the number is a float and smallest unit is set', () => {
+		const money = __DO_NOT_IMPORT__getCurrencyObject( {
+			number: 9932.1,
+			currency: 'USD',
+			browserSafeLocale,
+			isSmallestUnit: true,
+		} );
+		expect( money ).toEqual( {
+			symbol: '$',
+			symbolPosition: 'before',
+			integer: '99',
+			fraction: '.32',
+			sign: '',
+			hasNonZeroFraction: true,
+		} );
+	} );
+
+	describe( 'specific currencies', () => {
+		test( 'USD', () => {
+			const money = __DO_NOT_IMPORT__getCurrencyObject( {
+				number: 9800900.32,
+				currency: 'USD',
+				browserSafeLocale,
+			} );
+			expect( money ).toEqual( {
+				symbol: '$',
+				symbolPosition: 'before',
+				integer: '9,800,900',
+				fraction: '.32',
+				sign: '',
+				hasNonZeroFraction: true,
+			} );
+		} );
+
+		test( 'USD with signForPositive set', () => {
+			const money = __DO_NOT_IMPORT__getCurrencyObject( {
+				number: 9800900.32,
+				currency: 'USD',
+				browserSafeLocale,
+				signForPositive: true,
+			} );
+			expect( money ).toEqual( {
+				symbol: '$',
+				symbolPosition: 'before',
+				integer: '9,800,900',
+				fraction: '.32',
+				sign: '+',
+				hasNonZeroFraction: true,
+			} );
+		} );
+
+		test( 'USD with signForPositive set and negative number', () => {
+			const money = __DO_NOT_IMPORT__getCurrencyObject( {
+				number: -9800900.32,
+				currency: 'USD',
+				browserSafeLocale,
+				signForPositive: true,
+			} );
+			expect( money ).toEqual( {
+				symbol: '$',
+				symbolPosition: 'before',
+				integer: '9,800,900',
+				fraction: '.32',
+				sign: '-',
+				hasNonZeroFraction: true,
+			} );
+		} );
+
+		test( 'USD in Canadian English', () => {
+			const money = __DO_NOT_IMPORT__getCurrencyObject( {
+				number: 9800900.32,
+				currency: 'USD',
+				browserSafeLocale: 'en-CA',
+			} );
+			expect( money ).toEqual( {
+				symbol: 'US$',
+				symbolPosition: 'before',
+				integer: '9,800,900',
+				fraction: '.32',
+				sign: '',
+				hasNonZeroFraction: true,
+			} );
+		} );
+
+		test( 'AUD', () => {
+			const money = __DO_NOT_IMPORT__getCurrencyObject( {
+				number: 9800900.32,
+				currency: 'AUD',
+				browserSafeLocale,
+			} );
+			expect( money ).toEqual( {
+				symbol: 'A$',
+				symbolPosition: 'before',
+				integer: '9,800,900',
+				fraction: '.32',
+				sign: '',
+				hasNonZeroFraction: true,
+			} );
+		} );
+
+		test( 'CAD', () => {
+			const money = __DO_NOT_IMPORT__getCurrencyObject( {
+				number: 9800900.32,
+				currency: 'CAD',
+				browserSafeLocale,
+			} );
+			expect( money ).toEqual( {
+				symbol: 'C$',
+				symbolPosition: 'before',
+				integer: '9,800,900',
+				fraction: '.32',
+				sign: '',
+				hasNonZeroFraction: true,
+			} );
+		} );
+
+		test( 'EUR', () => {
+			const money = __DO_NOT_IMPORT__getCurrencyObject( {
+				number: 9800900.32,
+				currency: 'EUR',
+				browserSafeLocale: 'de-DE',
+			} );
+			expect( money ).toEqual( {
+				symbol: '€',
+				symbolPosition: 'after',
+				integer: '9.800.900',
+				fraction: ',32',
+				sign: '',
+				hasNonZeroFraction: true,
+			} );
+		} );
+
+		test( 'GBP', () => {
+			const money = __DO_NOT_IMPORT__getCurrencyObject( {
+				number: 9800900.32,
+				currency: 'GBP',
+				browserSafeLocale,
+			} );
+			expect( money ).toEqual( {
+				symbol: '£',
+				symbolPosition: 'before',
+				integer: '9,800,900',
+				fraction: '.32',
+				sign: '',
+				hasNonZeroFraction: true,
+			} );
+		} );
+
+		test( 'JPY', () => {
+			const money = __DO_NOT_IMPORT__getCurrencyObject( {
+				number: 9800900.32,
+				currency: 'JPY',
+				browserSafeLocale,
+			} );
+			expect( money ).toEqual( {
+				symbol: '¥',
+				symbolPosition: 'before',
+				integer: '9,800,900',
+				fraction: '',
+				sign: '',
+				hasNonZeroFraction: false,
+			} );
+		} );
+
+		test( 'BRL', () => {
+			const money = __DO_NOT_IMPORT__getCurrencyObject( {
+				number: 9800900.32,
+				currency: 'BRL',
+				browserSafeLocale: 'pt-BR',
+			} );
+			expect( money ).toEqual( {
+				symbol: 'R$',
+				symbolPosition: 'before',
+				integer: '9.800.900',
+				fraction: ',32',
+				sign: '',
+				hasNonZeroFraction: true,
+			} );
 		} );
 	} );
 } );

--- a/packages/i18n-calypso/src/number-formatters/types.ts
+++ b/packages/i18n-calypso/src/number-formatters/types.ts
@@ -82,5 +82,48 @@ export interface NumberFormatCurrencyParams {
 	signForPositive?: boolean;
 }
 
+export interface CurrencyObject {
+	/**
+	 * The negative sign for the price, if it is negative, or the positive sign
+	 * if `signForPositive` is set.
+	 */
+	sign: '-' | '+' | '';
+
+	/**
+	 * The currency symbol for the formatted price.
+	 *
+	 * Note that the symbol's position depends on the `symbolPosition` property,
+	 * and keep RTL locales in mind.
+	 */
+	symbol: string;
+
+	/**
+	 * The position of the currency symbol relative to the formatted price.
+	 */
+	symbolPosition: 'before' | 'after';
+
+	/**
+	 * The section of the formatted price before the decimal.
+	 *
+	 * Note that this is not a number, but a locale-formatted string which may
+	 * include symbols like spaces, commas, or periods as group separators.
+	 */
+	integer: string;
+
+	/**
+	 * The section of the formatted price after and including the decimal.
+	 *
+	 * Note that this is not a number, but a locale-formatted string which may
+	 * include symbols like spaces, commas, or periods as the decimal separator.
+	 */
+	fraction: string;
+
+	/**
+	 * True if the formatted number has a non-0 decimal part.
+	 */
+	hasNonZeroFraction: boolean;
+}
+
 export type NumberFormat = ( params: NumberFormatParams ) => string;
 export type NumberFormatCurrency = ( params: NumberFormatCurrencyParams ) => string;
+export type GetCurrencyObject = ( params: NumberFormatCurrencyParams ) => CurrencyObject;

--- a/packages/i18n-calypso/src/types/index.d.ts
+++ b/packages/i18n-calypso/src/types/index.d.ts
@@ -2,7 +2,11 @@
 // Project: i18n-calypso
 
 import * as React from 'react';
-import type { NumberFormatParams, NumberFormatCurrencyParams } from '../number-formatters';
+import type {
+	NumberFormatParams,
+	NumberFormatCurrencyParams,
+	CurrencyObject,
+} from '../number-formatters';
 
 type LocaleData = Record< string, unknown >;
 type NormalizedTranslateArgs =
@@ -107,6 +111,11 @@ export interface I18N {
 	numberFormat( number: number, options?: NumberFormatOptions ): string;
 	numberFormatCompact( number: number, options?: NumberFormatOptions ): string;
 	formatCurrency( number: number, currency: string, options?: FormatCurrencyOptions ): string;
+	getCurrencyObject(
+		number: number,
+		currency: string,
+		options?: FormatCurrencyOptions
+	): CurrencyObject;
 
 	setLocale( localeData: LocaleData ): void;
 	addTranslations( localeData: LocaleData ): void;
@@ -163,6 +172,7 @@ export declare const translate: typeof i18n.translate;
 export declare const numberFormat: typeof i18n.numberFormat;
 export declare const numberFormatCompact: typeof i18n.numberFormatCompact;
 export declare const formatCurrency: typeof i18n.formatCurrency;
+export declare const getCurrencyObject: typeof i18n.getCurrencyObject;
 export declare const geolocateCurrencySymbol: typeof i18n.geolocateCurrencySymbol;
 export declare const setLocale: typeof i18n.setLocale;
 export declare const addTranslations: typeof i18n.addTranslations;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/939

## Proposed Changes

- We bring the `getCurrencyObject` method to i18n-calypso to begin centralizing with the other number-formatters.
- We update all references to use the new i18n-calypso method
- Unit tests carried from format-currency package for the base methods in `number-formatters` and new ones added for the i18n-calypso wrapper (similar to `formatCurrency`'s)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is part of addressing https://github.com/Automattic/i18n-issues/issues/939, which aims at unifying number & currency-number formatting

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- unit tests
- try with different locale and currency settings for the cases/refs affected e.g. use EL and USD (expect `123 US$`). Examples below:

### `PlanPrice`

This is used in many places. It uses `getCurrencyObject` to tailor the design/placement of elements. 

- under `/devdocs/blocks/plan-price`

<img width="400" alt="Screenshot 2025-02-25 at 6 42 38 PM" src="https://github.com/user-attachments/assets/b04de43f-cb9d-445c-a3eb-a09ee110fff0" />

- go to `/start/plans` and `/plans/:site`. The header prices are rendered through `PlanPrice` component

<img width="800" alt="Screenshot 2025-02-25 at 6 44 00 PM" src="https://github.com/user-attachments/assets/69eff5d8-2b1b-4d37-9451-af50d301f331" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
