### PR TITLE
Stepper: avoid WSOD when visiting non-existing flows

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -99,7 +99,7 @@ function getSignupDestination( { domainItem, siteId, siteSlug, refParameter, flo
 		queryParam.ref = refParameter;
 	}
 
-	return addQueryArgs( queryParam, '/setup' );
+	return addQueryArgs( queryParam, '/setup/site-setup' );
 }
 
 function getLaunchDestination( dependencies ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/100397

## Proposed Changes

* Change the default "destination url" for Signup flows from `/setup` to `/setup/site-setup`
* Change how stepper handles URLs containing a flow slug that doesn't match any existing flows:
  * the fallback flow changes from `/setup/site-setup` to `/setup/onboarding`
  * the navigation to the fallback flow is done with a full page refresh, instead of only rendering the fallback flow without changing the URL of the page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- To address the WSOD bug described in https://github.com/Automattic/wp-calypso/issues/100397
- The Signup behavior doesn't really change in practice: redirecting to `/setup` was already causing the `/setup/site-setup` flow to render
- The added redirect in Stepper makes sure that the framework doesn't end up in a state where the URL and the flow being rendered don't match.
- Having the `/setup/onboarding` flow being the fallback flow is more aligned with the recent flows changes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the `/start/premium` signup flow. Make sure that, after the flow is completed, the user is correctly redirected to the `/setup/site-setup` flow, as it also happens on `trunk`
* Visit `/setup?siteSlug=[SITE_SLUG]`:
  * On `trunk`, the user is re-directed to the `/setup/site-setup` flow
  * On this PR, the user is re-directed to the `/setup/onboarding` flow
* Visit `/setup/non-existing-flow?siteSlug=[SITE_SLUG]`:
  * On `trunk`, the user sees a WSOD
  * On this PR, the user is re-directed to the `/setup/onboarding` flow
* Visit `/setup/site-setup?siteSlug=[SITE_SLUG]` (or any other valid Stepper flows), and make sure that the flow works as on `trunk`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
