### PR TITLE
E2E Tests: Fix the Welcome Guide checks in the I18N tests

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-welcome-guide-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-welcome-guide-component.ts
@@ -37,4 +37,34 @@ export class EditorWelcomeGuideComponent {
 		const closeBtn = editorParent.locator( selectors.welcomeGuideCloseButton );
 		await closeBtn.click();
 	}
+
+	/**
+	 * Force showing of the welcome guide.
+	 */
+	async forceShowWelcomeGuide(): Promise< void > {
+		const editorParent = await this.editor.parent();
+		const editorFrame = await ( await editorParent.elementHandle() )?.ownerFrame();
+		if ( ! editorFrame ) {
+			return;
+		}
+
+		await editorFrame.waitForFunction( async () => {
+			const editPostSelector = ( window as any )?.wp?.data?.select( 'core/edit-post' );
+			const editPostDispatcher = ( window as any )?.wp?.data?.dispatch( 'core/edit-post' );
+
+			if ( typeof editPostSelector?.isFeatureActive !== 'function' ) {
+				return false;
+			}
+
+			if ( typeof editPostDispatcher?.toggleFeature !== 'function' ) {
+				return false;
+			}
+
+			if ( ! editPostSelector.isFeatureActive( 'welcomeGuide' ) ) {
+				editPostDispatcher.toggleFeature( 'welcomeGuide' );
+			}
+
+			return true;
+		} );
+	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-welcome-guide-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-welcome-guide-component.ts
@@ -49,19 +49,19 @@ export class EditorWelcomeGuideComponent {
 		}
 
 		await editorFrame.waitForFunction( async () => {
-			const editPostSelector = ( window as any )?.wp?.data?.select( 'core/edit-post' );
-			const editPostDispatcher = ( window as any )?.wp?.data?.dispatch( 'core/edit-post' );
+			const editPostSelectors = ( window as any )?.wp?.data?.select( 'core/edit-post' );
+			const editPostActions = ( window as any )?.wp?.data?.dispatch( 'core/edit-post' );
 
-			if ( typeof editPostSelector?.isFeatureActive !== 'function' ) {
+			if ( typeof editPostSelectors?.isFeatureActive !== 'function' ) {
 				return false;
 			}
 
-			if ( typeof editPostDispatcher?.toggleFeature !== 'function' ) {
+			if ( typeof editPostActions?.toggleFeature !== 'function' ) {
 				return false;
 			}
 
-			if ( ! editPostSelector.isFeatureActive( 'welcomeGuide' ) ) {
-				editPostDispatcher.toggleFeature( 'welcomeGuide' );
+			if ( ! editPostSelectors.isFeatureActive( 'welcomeGuide' ) ) {
+				editPostActions.toggleFeature( 'welcomeGuide' );
 			}
 
 			return true;

--- a/test/e2e/specs/i18n/i18n__editor.ts
+++ b/test/e2e/specs/i18n/i18n__editor.ts
@@ -9,7 +9,7 @@ import {
 	getTestAccountByFeature,
 	envToFeatureKey,
 	RestAPIClient,
-	EditorWelcomeTourComponent,
+	EditorWelcomeGuideComponent,
 	EditorComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser, Locator } from 'playwright';
@@ -294,14 +294,14 @@ describe( 'I18N: Editor', function () {
 
 				// @TODO Consider moving this to EditorPage.
 				const editor = new EditorComponent( page );
-				const editorWelcomeTourComponent = new EditorWelcomeTourComponent( page, editor );
+				const editorWelcomeGuideComponent = new EditorWelcomeGuideComponent( page, editor );
 
 				// We know these are all defined because of the filtering above. Non-null asserting is safe here.
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				const etkTranslations = translations[ locale ]!.etkPlugin!;
 
 				// Ensure the Welcome Guide component is shown.
-				await editorWelcomeTourComponent.forceShowWelcomeTour();
+				await editorWelcomeGuideComponent.forceShowWelcomeGuide();
 
 				const editorParent = await editorPage.getEditorParent();
 

--- a/test/e2e/specs/i18n/i18n__editor.ts
+++ b/test/e2e/specs/i18n/i18n__editor.ts
@@ -17,12 +17,10 @@ import type { LanguageSlug } from '@automattic/languages';
 
 type Translations = {
 	[ language in LanguageSlug ]?: Partial< {
-		etkPlugin: {
-			welcomeGuide: {
-				openGuideSelector: string;
-				welcomeTitleSelector: string;
-				closeButtonSelector: string;
-			};
+		welcomeGuide: {
+			welcomeTitleSelector: string;
+			nextButtonSelector: string;
+			closeButtonSelector: string;
 		};
 		blocks: {
 			blockName: string;
@@ -34,14 +32,11 @@ type Translations = {
 };
 const translations: Translations = {
 	en: {
-		etkPlugin: {
-			welcomeGuide: {
-				openGuideSelector:
-					'.interface-more-menu-dropdown__content button:has-text("Welcome Guide")',
-				welcomeTitleSelector:
-					'.wpcom-tour-kit-step-card__heading:has-text("Welcome to WordPress!")',
-				closeButtonSelector: '.wpcom-tour-kit button[aria-label="Close Tour"]',
-			},
+		welcomeGuide: {
+			welcomeTitleSelector: '.edit-post-welcome-guide__heading:has-text("Welcome to the editor")',
+			nextButtonSelector:
+				'.components-guide__footer button.components-guide__forward-button:has-text("Next")',
+			closeButtonSelector: '.edit-post-welcome-guide button[aria-label="Close"]',
 		},
 		blocks: [
 			// Core
@@ -103,14 +98,12 @@ const translations: Translations = {
 		],
 	},
 	fr: {
-		etkPlugin: {
-			welcomeGuide: {
-				openGuideSelector:
-					'.interface-more-menu-dropdown__content button:has-text("Guide de bienvenue")',
-				welcomeTitleSelector:
-					'.wpcom-tour-kit-step-card__heading:has-text("Bienvenue dans WordPress !")',
-				closeButtonSelector: '.wpcom-tour-kit button[aria-label="Fermer la visite"]',
-			},
+		welcomeGuide: {
+			welcomeTitleSelector:
+				'.edit-post-welcome-guide__heading:has-text("Bienvenue dans l\'éditeur")',
+			nextButtonSelector:
+				'.components-guide__footer button.components-guide__forward-button:has-text("Suivant")',
+			closeButtonSelector: '.edit-post-welcome-guide button[aria-label="Fermer"]',
 		},
 		blocks: [
 			// Core
@@ -174,14 +167,11 @@ const translations: Translations = {
 		],
 	},
 	he: {
-		etkPlugin: {
-			welcomeGuide: {
-				openGuideSelector:
-					'.interface-more-menu-dropdown__content button:has-text("מדריך ברוכים הבאים")',
-				welcomeTitleSelector:
-					'.wpcom-tour-kit-step-card__heading:has-text("ברוך בואך ל-WordPress!")',
-				closeButtonSelector: '.wpcom-tour-kit button[aria-label="לסגור את הסיור"]',
-			},
+		welcomeGuide: {
+			welcomeTitleSelector: '.edit-post-welcome-guide__heading:has-text("ברוך בואך לעורך")',
+			nextButtonSelector:
+				'.components-guide__footer button.components-guide__forward-button:has-text("לשלב הבא")',
+			closeButtonSelector: '.edit-post-welcome-guide button[aria-label="סגור"]',
 		},
 		blocks: [
 			// Core
@@ -298,15 +288,15 @@ describe( 'I18N: Editor', function () {
 
 				// We know these are all defined because of the filtering above. Non-null asserting is safe here.
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				const etkTranslations = translations[ locale ]!.etkPlugin!;
+				const welcomeGuideTranslations = translations[ locale ]!.welcomeGuide!;
 
 				// Ensure the Welcome Guide component is shown.
 				await editorWelcomeGuideComponent.forceShowWelcomeGuide();
 
 				const editorParent = await editorPage.getEditorParent();
 
-				await editorParent.locator( etkTranslations.welcomeGuide.welcomeTitleSelector ).waitFor();
-				await editorParent.locator( etkTranslations.welcomeGuide.closeButtonSelector ).click();
+				await editorParent.locator( welcomeGuideTranslations.welcomeTitleSelector ).waitFor();
+				await editorParent.locator( welcomeGuideTranslations.closeButtonSelector ).click();
 			} );
 		} );
 

--- a/test/e2e/specs/i18n/i18n__editor.ts
+++ b/test/e2e/specs/i18n/i18n__editor.ts
@@ -330,6 +330,8 @@ describe( 'I18N: Editor', function () {
 				} );
 
 				it( 'Render block title translations', async function () {
+					await editorPage.openSettings();
+
 					// If on block insertion, one of the sub-blocks are selected, click on
 					// the first button in the floating toolbar which selects the overall
 					// block.

--- a/test/e2e/specs/i18n/i18n__editor.ts
+++ b/test/e2e/specs/i18n/i18n__editor.ts
@@ -18,7 +18,7 @@ import type { LanguageSlug } from '@automattic/languages';
 type Translations = {
 	[ language in LanguageSlug ]?: Partial< {
 		welcomeGuide: {
-			welcomeTitleSelector: string;
+			welcomeTextSelector: string;
 			nextButtonSelector: string;
 			closeButtonSelector: string;
 		};
@@ -33,7 +33,8 @@ type Translations = {
 const translations: Translations = {
 	en: {
 		welcomeGuide: {
-			welcomeTitleSelector: '.edit-post-welcome-guide__heading:has-text("Welcome to the editor")',
+			welcomeTextSelector:
+				'.edit-post-welcome-guide__text:has-text("In the WordPress editor, each paragraph")',
 			nextButtonSelector:
 				'.components-guide__footer button.components-guide__forward-button:has-text("Next")',
 			closeButtonSelector: '.edit-post-welcome-guide button[aria-label="Close"]',
@@ -99,8 +100,8 @@ const translations: Translations = {
 	},
 	fr: {
 		welcomeGuide: {
-			welcomeTitleSelector:
-				'.edit-post-welcome-guide__heading:has-text("Bienvenue dans l\'éditeur")',
+			welcomeTextSelector:
+				'.edit-post-welcome-guide__text:has-text("Dans l’éditeur de WordPress, chaque paragraphe")',
 			nextButtonSelector:
 				'.components-guide__footer button.components-guide__forward-button:has-text("Suivant")',
 			closeButtonSelector: '.edit-post-welcome-guide button[aria-label="Fermer"]',
@@ -168,7 +169,7 @@ const translations: Translations = {
 	},
 	he: {
 		welcomeGuide: {
-			welcomeTitleSelector: '.edit-post-welcome-guide__heading:has-text("ברוך בואך לעורך")',
+			welcomeTextSelector: '.edit-post-welcome-guide__text:has-text("בעורך של וורדפרס כל פסקה")',
 			nextButtonSelector:
 				'.components-guide__footer button.components-guide__forward-button:has-text("לשלב הבא")',
 			closeButtonSelector: '.edit-post-welcome-guide button[aria-label="סגור"]',
@@ -295,7 +296,7 @@ describe( 'I18N: Editor', function () {
 
 				const editorParent = await editorPage.getEditorParent();
 
-				await editorParent.locator( welcomeGuideTranslations.welcomeTitleSelector ).waitFor();
+				await editorParent.locator( welcomeGuideTranslations.welcomeTextSelector ).waitFor();
 				await editorParent.locator( welcomeGuideTranslations.closeButtonSelector ).click();
 			} );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Use Core's Welcome Guide in the tests, instead of Jetpack's Welcome Guide.
  * Add `forceShowWelcomeGuide` to `EditorWelcomeGuideComponent`, similar to `EditorWelcomeTourComponent::forceShowWelcomeTour`.
* Add selectors and translations to check Core's Welcome Guide.
* Add the `editorPage.openSettings` call back in.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The tests freeze because it waits indefinitely for Jetpack's Welcome Guide.

* A month ago, Jetpack's Welcome Guide was deprecated in favor of Core's (https://github.com/Automattic/jetpack/pull/41258).
* Without the `editorPage.openSettings` call, the tests appear to freeze because the settings panel is not open. This effectively reverts PR
https://github.com/Automattic/wp-calypso/pull/96828.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Trigger a custom build of the I18N E2E tests for this PR's branch in TeamCity.
* Verify that the build still fails, but that it continued past the welcome guide by checking the recorded video in the artifacts. (It should freeze while checking the French translations of the Image block, which is to be solved separately.)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
