### PR TITLE
Move the onboarding/create-course feature flag logic to a hook

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-create-course-goal-feature/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-create-course-goal-feature/index.tsx
@@ -1,0 +1,6 @@
+import config from '@automattic/calypso-config';
+
+export function useCreateCourseGoalFeature() {
+	// Feature flag approach can be replaced with experiment later
+	return config.isEnabled( 'onboarding/create-course' );
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
@@ -12,6 +11,7 @@ import { isGoalsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getQueryArgs } from 'calypso/lib/query-args';
+import { useCreateCourseGoalFeature } from '../../hooks/use-create-course-goal-feature';
 import DashboardIcon from './dashboard-icon';
 import { GoalsCaptureContainer } from './goals-capture-container';
 import SelectGoals from './select-goals';
@@ -62,8 +62,7 @@ const GoalsStep: Step = ( { navigation, flow } ) => {
 
 	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 	const [ , isIntentNewsletterGoalEnabled ] = useGoalsFirstCumulativeExperience();
-	// Use the experiment flag instead of the feature flag to ensure the experiment is running
-	const isIntentCreateCourseGoalEnabled = config.isEnabled( 'onboarding/create-course' );
+	const isIntentCreateCourseGoalEnabled = useCreateCourseGoalFeature();
 
 	useEffect( () => {
 		resetIntent();


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/100092

## Proposed Changes

As discussed here: p1740495443242809-slack-C0Q664T29
We are adding a reusable hook to control the onboarding/create-course feature flag.

This will give us a single source of truth if we replace with with an experiment.

## Testing Instructions

Follow the instructions of the previous PR and check if it still works as expected:
[Create Course Goal: Store the create-course goal based on the feature flag](https://github.com/Automattic/wp-calypso/pull/100001) 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?