### PR TITLE
Reader Editor: Add basic quick post behind feature flag

### DIFF
--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -1,0 +1,153 @@
+import { Spinner } from '@automattic/components';
+import { isLocaleRtl, useLocale } from '@automattic/i18n-utils';
+import {
+	Editor,
+	loadBlocksWithCustomizations,
+	loadTextFormatting,
+} from '@automattic/verbum-block-editor';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { ChangeEvent, useEffect, useState, useRef } from 'react';
+import { useSelector } from 'react-redux';
+import FormSelect from 'calypso/components/forms/form-select';
+import wpcom from 'calypso/lib/wp';
+import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
+import getSites from 'calypso/state/selectors/get-sites';
+import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
+import type { SiteDetails } from '@automattic/data-stores';
+
+import './style.scss';
+
+// Initialize the editor blocks and text formatting.
+loadBlocksWithCustomizations();
+loadTextFormatting();
+
+export default function QuickPost() {
+	const translate = useTranslate();
+	const locale = useLocale();
+	const recordReaderTracksEvent = useRecordReaderTracksEvent();
+	const [ postContent, setPostContent ] = useState( '' );
+	const [ editorKey, setEditorKey ] = useState( 0 );
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const sites = useSelector( getSites ).filter( ( site ): site is SiteDetails => site !== null );
+	const hasLoaded = useSelector( hasLoadedSites );
+	const [ selectedSiteId, setSelectedSiteId ] = useState< number | null >( null );
+	const editorRef = useRef< HTMLDivElement >( null );
+
+	// Set initial selected site once sites are loaded.
+	useEffect( () => {
+		if ( hasLoaded && sites.length > 0 && ! selectedSiteId ) {
+			setSelectedSiteId( sites[ 0 ].ID );
+		}
+	}, [ hasLoaded, sites, selectedSiteId ] );
+
+	const clearEditor = () => {
+		setEditorKey( ( key ) => key + 1 );
+	};
+
+	const handleSubmit = () => {
+		if ( ! postContent.trim() || ! selectedSiteId || isSubmitting ) {
+			return;
+		}
+
+		setIsSubmitting( true );
+
+		wpcom
+			.site( selectedSiteId )
+			.post()
+			.add( {
+				title: postContent.split( '\n' )[ 0 ], // Use first line as title.
+				content: postContent,
+				status: 'publish',
+			} )
+			.then( () => {
+				recordReaderTracksEvent( 'calypso_reader_quick_post_submitted' );
+				clearEditor();
+				// TODO: Update the stream with the new post (if they're subscribed?) to signal success.
+			} )
+			.catch( () => {
+				recordReaderTracksEvent( 'calypso_reader_quick_post_error' );
+				// TODO: Add error handling
+			} )
+			.finally( () => {
+				setIsSubmitting( false );
+			} );
+	};
+
+	const handleCancel = () => {
+		clearEditor();
+	};
+
+	const handleSiteChange = ( event: ChangeEvent< HTMLSelectElement > ) => {
+		setSelectedSiteId( Number( event.target.value ) );
+	};
+
+	const getButtonText = () => {
+		if ( isSubmitting ) {
+			return translate( 'Posting' );
+		}
+		return translate( 'Post' );
+	};
+
+	if ( ! hasLoaded ) {
+		return (
+			<div className="quick-post-input quick-post-input--loading">
+				<Spinner />
+			</div>
+		);
+	}
+
+	if ( ! sites.length ) {
+		return null; // Don't show QuickPost if user has no sites.
+	}
+
+	const isDisabled = isSubmitting;
+
+	return (
+		<div className="quick-post-input">
+			<label htmlFor="quick-post-site-select" className="quick-post-input__label">
+				{ translate( 'Publish a post to' ) }
+			</label>
+			<div className="quick-post-input__fields">
+				<FormSelect
+					id="quick-post-site-select"
+					value={ selectedSiteId || '' }
+					onChange={ handleSiteChange }
+					disabled={ isDisabled }
+					className="quick-post-input__site-select"
+				>
+					{ sites.map( ( site ) => (
+						<option key={ site.ID } value={ site.ID }>
+							{ site.name } ({ site.domain })
+						</option>
+					) ) }
+				</FormSelect>
+				<div className="verbum-editor-wrapper" ref={ editorRef }>
+					<Editor
+						key={ editorKey }
+						initialContent=""
+						onChange={ setPostContent }
+						isRTL={ isLocaleRtl( locale ) ?? false }
+						isDarkMode={ false }
+					/>
+				</div>
+			</div>
+			<div className="quick-post-input__actions">
+				<Button
+					onClick={ handleCancel }
+					disabled={ isDisabled }
+					className="quick-post-input__cancel"
+				>
+					{ translate( 'Cancel' ) }
+				</Button>
+				<Button
+					variant="primary"
+					onClick={ handleSubmit }
+					disabled={ ! postContent.trim() || isDisabled }
+				>
+					{ getButtonText() }
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/client/reader/components/quick-post/style.scss
+++ b/client/reader/components/quick-post/style.scss
@@ -1,0 +1,54 @@
+/* stylelint-disable scales/radii */
+.quick-post-input {
+	margin-bottom: 24px;
+
+	&--loading {
+		text-align: center;
+		padding: 24px;
+	}
+
+	&__fields {
+		margin-bottom: 16px;
+	}
+
+	&__site-select {
+		margin-bottom: 16px !important;
+		width: 100%;
+        border-color: var(--color-border-subtle);
+        border-style: solid;
+        border-radius: 6px;
+        border-width: 1px;
+	}
+
+    &__actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 8px;
+	}
+
+	&__cancel {
+		color: var( --color-text-subtle );
+	}
+
+    .verbum-editor-wrapper {
+        .editor__header {
+            border-color: var(--color-border-subtle);
+            border-style: solid;
+            border-radius: 6px 6px 0 0;
+            border-width: 1px;
+            border-bottom-width: 0;
+        }
+
+        .block-editor-block-contextual-toolbar {
+            background-color: transparent;
+        }
+
+        .editor__main {
+            border-color: var(--color-border-subtle);
+            border-style: solid;
+            border-radius: 0 0 6px 6px;
+            border-width: 1px;
+            border-top-width: 0;
+        }
+    }
+}

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -1,9 +1,11 @@
+import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import AsyncLoad from 'calypso/components/async-load';
 import BloganuaryHeader from 'calypso/components/bloganuary-header';
 import NavigationHeader from 'calypso/components/navigation-header';
 import withDimensions from 'calypso/lib/with-dimensions';
+import QuickPost from 'calypso/reader/components/quick-post';
 import ReaderOnboarding from 'calypso/reader/onboarding';
 import SuggestionProvider from 'calypso/reader/search-stream/suggestion-provider';
 import ReaderStream, { WIDE_DISPLAY_CUTOFF } from 'calypso/reader/stream';
@@ -52,6 +54,7 @@ function FollowingStream( { ...props } ) {
 					>
 						<ViewToggle />
 					</NavigationHeader>
+					{ config.isEnabled( 'reader/quick-post' ) && <QuickPost /> }
 					<ReaderOnboarding />
 				</ReaderStream>
 			) }

--- a/config/development.json
+++ b/config/development.json
@@ -166,6 +166,7 @@
 		"reader": true,
 		"reader/comment-polling": false,
 		"reader/full-errors": true,
+		"reader/quick-post": false,
 		"readymade-templates/showcase": true,
 		"redirect-fallback-browsers": false,
 		"rum-tracking/logstash": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pe7F0s-2x3-p2

## Proposed Changes

* Adds a basic functional "quick post" editor to the top of the /reader stream behind a `reader/quick-post` feature flag.

<img width="1246" alt="Screenshot 2025-02-25 at 12 09 36 PM" src="https://github.com/user-attachments/assets/f87c74a9-d66b-4642-afa8-0d3486f9a94b" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Kicking off the Reader Editor project to increase user engagement.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that this feature is behind the feature flag by loading Calypso Live and going to /reader. The quick post editor should not display, and everything should work as expected.
* On Calypso Live go to /reader?flags=reader/quick-post
* Select a test blog and submit a test post using the quick post feature. You must refresh the page to see the post show up in your stream. Note that Atomic sites seem to take longer to show up in the stream than simple sites. (We'll follow up on refreshing the stream without needing to refresh the page.)
* Smoke test and parse the code to ensure nothing is leaking outside the feature flag.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?