### PR TITLE
Allow showing certain themes at the beginning of a category list

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -76,6 +76,7 @@ import {
 	recordSelectedDesign,
 	getVirtualDesignProps,
 } from '../../analytics/record-design';
+import { useCreateCourseGoalFeature } from '../../hooks/use-create-course-goal-feature';
 import { getCategorizationOptions } from './categories';
 import { STEP_NAME } from './constants';
 import DesignPickerDesignTitle from './design-picker-design-title';
@@ -111,6 +112,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const isSiteRequired = flow !== ONBOARDING_FLOW || ! isGoalsAtFrontExperiment;
 
 	const isUpdatedBadgeDesign = useIsUpdatedBadgeDesign();
+	const isIntentCreateCourseGoalEnabled = useCreateCourseGoalFeature();
 
 	const { isEligible: isBigSkyEligible } = useIsBigSkyEligible();
 
@@ -906,6 +908,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const stepContent = (
 		<>
 			<UnifiedDesignPicker
+				isIntentCreateCourseGoalEnabled={ isIntentCreateCourseGoalEnabled }
 				designs={ designs }
 				locale={ locale }
 				onDesignWithAI={ onDesignWithAI }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -76,7 +76,6 @@ import {
 	recordSelectedDesign,
 	getVirtualDesignProps,
 } from '../../analytics/record-design';
-import { useCreateCourseGoalFeature } from '../../hooks/use-create-course-goal-feature';
 import { getCategorizationOptions } from './categories';
 import { STEP_NAME } from './constants';
 import DesignPickerDesignTitle from './design-picker-design-title';
@@ -112,7 +111,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const isSiteRequired = flow !== ONBOARDING_FLOW || ! isGoalsAtFrontExperiment;
 
 	const isUpdatedBadgeDesign = useIsUpdatedBadgeDesign();
-	const isIntentCreateCourseGoalEnabled = useCreateCourseGoalFeature();
 
 	const { isEligible: isBigSkyEligible } = useIsBigSkyEligible();
 
@@ -905,11 +903,17 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		navigate( `/setup/site-setup/launch-big-sky?siteSlug=${ siteSlug }&siteId=${ site?.ID }` );
 	}
 
+	// Use this to prioritize themes in certain categories.
+	// The specified theme will be shown first in the list.
+	const priorityThemes: Record< string, string > = {
+		education: 'course',
+	};
+
 	const stepContent = (
 		<>
 			<UnifiedDesignPicker
-				isIntentCreateCourseGoalEnabled={ isIntentCreateCourseGoalEnabled }
 				designs={ designs }
+				priorityThemes={ priorityThemes }
 				locale={ locale }
 				onDesignWithAI={ onDesignWithAI }
 				onPreview={ previewDesign }

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -349,6 +349,7 @@ interface DesignPickerProps {
 	showActiveThemeBadge?: boolean;
 	isMultiFilterEnabled?: boolean;
 	isBigSkyEligible?: boolean;
+	isIntentCreateCourseGoalEnabled?: boolean;
 }
 
 const DesignPicker: React.FC< DesignPickerProps > = ( {
@@ -367,6 +368,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	showActiveThemeBadge = false,
 	isMultiFilterEnabled = false,
 	isBigSkyEligible = false,
+	isIntentCreateCourseGoalEnabled = false,
 } ) => {
 	const translate = useTranslate();
 	const { selectedCategoriesWithoutDesignTier } = useDesignPickerFilters();
@@ -385,7 +387,14 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 		[ categorization?.categories ]
 	);
 
-	const { all, best, ...designsByGroup } = useFilteredDesignsByGroup( designs );
+	// Use this to prioritize themes in certain categories.
+	// The specified theme will be shown first in the list.
+	const priorityThemes: Record< string, string > = {};
+	if ( isIntentCreateCourseGoalEnabled ) {
+		priorityThemes[ 'education' ] = 'course';
+	}
+
+	const { all, best, ...designsByGroup } = useFilteredDesignsByGroup( designs, priorityThemes );
 
 	// Show no results only when no design matches the selected categories and tiers.
 	const showNoResults = Object.values( designsByGroup ).every(
@@ -509,6 +518,7 @@ export interface UnifiedDesignPickerProps {
 	showActiveThemeBadge?: boolean;
 	isMultiFilterEnabled?: boolean;
 	isBigSkyEligible?: boolean;
+	isIntentCreateCourseGoalEnabled?: boolean;
 }
 
 const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
@@ -529,6 +539,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	showActiveThemeBadge = false,
 	isMultiFilterEnabled = false,
 	isBigSkyEligible = false,
+	isIntentCreateCourseGoalEnabled,
 } ) => {
 	const hasCategories = !! ( categorization?.categories || [] ).length;
 
@@ -556,6 +567,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					showActiveThemeBadge={ showActiveThemeBadge }
 					isMultiFilterEnabled={ isMultiFilterEnabled }
 					isBigSkyEligible={ isBigSkyEligible }
+					isIntentCreateCourseGoalEnabled={ isIntentCreateCourseGoalEnabled }
 				/>
 				<InView onChange={ ( inView ) => inView && onViewAllDesigns() } />
 			</div>

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -349,7 +349,7 @@ interface DesignPickerProps {
 	showActiveThemeBadge?: boolean;
 	isMultiFilterEnabled?: boolean;
 	isBigSkyEligible?: boolean;
-	isIntentCreateCourseGoalEnabled?: boolean;
+	priorityThemes?: Record< string, string > | null;
 }
 
 const DesignPicker: React.FC< DesignPickerProps > = ( {
@@ -364,11 +364,11 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	getBadge,
 	getOptionsMenu,
 	oldHighResImageLoading,
+	priorityThemes = null,
 	siteActiveTheme = null,
 	showActiveThemeBadge = false,
 	isMultiFilterEnabled = false,
 	isBigSkyEligible = false,
-	isIntentCreateCourseGoalEnabled = false,
 } ) => {
 	const translate = useTranslate();
 	const { selectedCategoriesWithoutDesignTier } = useDesignPickerFilters();
@@ -386,13 +386,6 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 		() => categories.filter( ( { slug } ) => ! isFeatureCategory( slug ) ),
 		[ categorization?.categories ]
 	);
-
-	// Use this to prioritize themes in certain categories.
-	// The specified theme will be shown first in the list.
-	const priorityThemes: Record< string, string > = {};
-	if ( isIntentCreateCourseGoalEnabled ) {
-		priorityThemes[ 'education' ] = 'course';
-	}
 
 	const { all, best, ...designsByGroup } = useFilteredDesignsByGroup( designs, priorityThemes );
 
@@ -518,7 +511,7 @@ export interface UnifiedDesignPickerProps {
 	showActiveThemeBadge?: boolean;
 	isMultiFilterEnabled?: boolean;
 	isBigSkyEligible?: boolean;
-	isIntentCreateCourseGoalEnabled?: boolean;
+	priorityThemes?: Record< string, string >;
 }
 
 const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
@@ -539,7 +532,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	showActiveThemeBadge = false,
 	isMultiFilterEnabled = false,
 	isBigSkyEligible = false,
-	isIntentCreateCourseGoalEnabled,
+	priorityThemes = null,
 } ) => {
 	const hasCategories = !! ( categorization?.categories || [] ).length;
 
@@ -567,7 +560,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					showActiveThemeBadge={ showActiveThemeBadge }
 					isMultiFilterEnabled={ isMultiFilterEnabled }
 					isBigSkyEligible={ isBigSkyEligible }
-					isIntentCreateCourseGoalEnabled={ isIntentCreateCourseGoalEnabled }
+					priorityThemes={ priorityThemes }
 				/>
 				<InView onChange={ ( inView ) => inView && onViewAllDesigns() } />
 			</div>

--- a/packages/design-picker/src/hooks/use-filtered-designs.ts
+++ b/packages/design-picker/src/hooks/use-filtered-designs.ts
@@ -9,7 +9,7 @@ export const getFilteredDesignsByCategory = (
 	designs: Design[],
 	categorySlugs: string[] | null | undefined,
 	designTierSlugs: string[],
-	priorityThemes: Record< string, string >
+	priorityThemes: Record< string, string > | null
 ) => {
 	const filteredDesigns = designs.filter(
 		( design ) =>
@@ -99,7 +99,7 @@ export const getFilteredDesignsByCategory = (
 
 export const useFilteredDesignsByGroup = (
 	designs: Design[],
-	priorityThemes: Record< string, string >
+	priorityThemes: Record< string, string > | null
 ): { [ key: string ]: Design[] } => {
 	const { selectedCategoriesWithoutDesignTier, selectedDesignTiers } = useDesignPickerFilters();
 

--- a/packages/design-picker/src/hooks/use-filtered-designs.ts
+++ b/packages/design-picker/src/hooks/use-filtered-designs.ts
@@ -8,7 +8,8 @@ import type { Design } from '../types';
 export const getFilteredDesignsByCategory = (
 	designs: Design[],
 	categorySlugs: string[] | null | undefined,
-	designTierSlugs: string[]
+	designTierSlugs: string[],
+	priorityThemes: Record< string, string >
 ) => {
 	const filteredDesigns = designs.filter(
 		( design ) =>
@@ -74,10 +75,32 @@ export const getFilteredDesignsByCategory = (
 	// limit the best designs to 6
 	filteredDesignsByCategory.best = filteredDesignsByCategory.best.slice( 0, 6 );
 
+	// Prioritize themes based on the priorityThemes mapping
+	if ( categorySlugs && priorityThemes ) {
+		for ( const categorySlug of categorySlugs ) {
+			const priorityThemeSlug = priorityThemes[ categorySlug ];
+
+			if ( priorityThemeSlug && filteredDesignsByCategory[ categorySlug ] ) {
+				filteredDesignsByCategory[ categorySlug ].sort( ( a, b ) => {
+					if ( a.slug === priorityThemeSlug ) {
+						return -1;
+					}
+					if ( b.slug === priorityThemeSlug ) {
+						return 1;
+					}
+					return 0;
+				} );
+			}
+		}
+	}
+
 	return filteredDesignsByCategory;
 };
 
-export const useFilteredDesignsByGroup = ( designs: Design[] ): { [ key: string ]: Design[] } => {
+export const useFilteredDesignsByGroup = (
+	designs: Design[],
+	priorityThemes: Record< string, string >
+): { [ key: string ]: Design[] } => {
 	const { selectedCategoriesWithoutDesignTier, selectedDesignTiers } = useDesignPickerFilters();
 
 	const filteredDesigns = useMemo( () => {
@@ -85,14 +108,15 @@ export const useFilteredDesignsByGroup = ( designs: Design[] ): { [ key: string 
 			return getFilteredDesignsByCategory(
 				designs,
 				selectedCategoriesWithoutDesignTier,
-				selectedDesignTiers
+				selectedDesignTiers,
+				priorityThemes
 			);
 		}
 
 		return {
 			all: designs,
 		};
-	}, [ designs, selectedCategoriesWithoutDesignTier, selectedDesignTiers ] );
+	}, [ designs, selectedCategoriesWithoutDesignTier, selectedDesignTiers, priorityThemes ] );
 
 	return filteredDesigns;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #100015

## Proposed Changes

Allows us to prioritize a particular theme within in a category.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want to make sure the Course theme is listed first when the Education category is selected.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run locally or use the calypso.live url
* Go through `/start` until you reach the `designSetup step.
* The "Course" theme should appear first in the list.

<img width="1438" alt="CleanShot 2025-02-25 at 14 04 38@2x" src="https://github.com/user-attachments/assets/93a37f6a-f4ce-4a7a-86d7-82c9098dafd5" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
