### PR TITLE
Improve auto-renew dialog

### DIFF
--- a/client/my-sites/domains/domain-management/dataviews/components/auto-renew-dialog.scss
+++ b/client/my-sites/domains/domain-management/dataviews/components/auto-renew-dialog.scss
@@ -42,7 +42,7 @@
 	&__actions {
 		display: flex;
 		justify-content: flex-end;
-		gap: 4px;
+		gap: 8px;
 	}
 }
 

--- a/client/my-sites/domains/domain-management/dataviews/components/auto-renew-dialog.scss
+++ b/client/my-sites/domains/domain-management/dataviews/components/auto-renew-dialog.scss
@@ -40,7 +40,9 @@
 	}
 
 	&__actions {
-		text-align: end;
+		display: flex;
+		justify-content: flex-end;
+		gap: 4px;
 	}
 }
 

--- a/client/my-sites/domains/domain-management/dataviews/components/auto-renew-dialog.scss
+++ b/client/my-sites/domains/domain-management/dataviews/components/auto-renew-dialog.scss
@@ -1,0 +1,46 @@
+.domains-dataviews-bulk-actions-dialog {
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+
+	&__icon {
+		margin-right: 4px;
+		vertical-align: text-top;
+	}
+
+	&__select.select-dropdown {
+		z-index: 1; // Needed for the dropdown to appear overtop of the checkboxes
+
+		width: 100%;
+		.select-dropdown__container {
+			min-width: 100%;
+		}
+
+		.select-dropdown__header {
+			height: var(--domains-table-toolbar-height);
+			font-weight: 400;
+			color: var(--studio-gray-70);
+		}
+
+		// Undo some dropdown styling that causes the items within the dropdown to be truncated with ellipsis.
+		.select-dropdown__item {
+			padding-right: 16px;
+			color: var(--studio-gray-70);
+		}
+		.select-dropdown__item::before {
+			content: "";
+		}
+		.select-dropdown__item-text {
+			position: static;
+		}
+	}
+
+	&__description {
+		margin: 0;
+	}
+
+	&__actions {
+		text-align: end;
+	}
+}
+

--- a/client/my-sites/domains/domain-management/dataviews/components/auto-renew-dialog.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/components/auto-renew-dialog.tsx
@@ -1,10 +1,13 @@
 import { SelectDropdown } from '@automattic/components';
 import { PartialDomainData } from '@automattic/data-stores';
 import transformIcon from '@automattic/domains-table/src/bulk-actions-toolbar/transform.svg';
+import { Button } from '@wordpress/components';
 import { RenderModalProps } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDomainsDataViewsContext } from '../use-context';
+
+import './auto-renew-dialog.scss';
 
 export const AutoRenewDiolog = ( {
 	items,
@@ -14,6 +17,7 @@ export const AutoRenewDiolog = ( {
 	const { handleAutoRenew } = useDomainsDataViewsContext();
 	const translate = useTranslate();
 	const [ controlKey, setControlKey ] = useState( 1 );
+	const [ value, setValue ] = useState< string | undefined >( undefined );
 
 	const enableLabel = translate( 'Turn {{strong}}on{{/strong}} auto-renew', {
 		components: { strong: <strong /> },
@@ -23,7 +27,7 @@ export const AutoRenewDiolog = ( {
 		components: { strong: <strong /> },
 	} );
 
-	const handleAutoRenewSelect = ( { value }: { value: string } ) => {
+	const onUpdateAutoRenew = () => {
 		if ( value === 'enable' ) {
 			handleAutoRenew( items, true );
 		} else if ( value === 'disable' ) {
@@ -39,9 +43,11 @@ export const AutoRenewDiolog = ( {
 		closeModal?.();
 	};
 
+	const updateButtonDisbled = [ undefined, 'button-label' ].includes( value );
+
 	return (
-		<div>
-			<p>
+		<div className="domains-dataviews-bulk-actions-dialog">
+			<p className="domains-dataviews-bulk-actions-dialog__description">
 				{ translate(
 					/* translators: domainCount will be the number of domains to update */
 					'Update auto-renew settings for %(domainCount)d domain',
@@ -56,17 +62,17 @@ export const AutoRenewDiolog = ( {
 			</p>
 			<SelectDropdown
 				key={ controlKey }
-				className="domains-table-bulk-actions-toolbar__select"
+				className="domains-dataviews-bulk-actions-dialog__select"
 				initialSelected="button-label"
 				showSelectedOption={ false }
-				onSelect={ handleAutoRenewSelect }
+				onSelect={ ( { value: v }: { value: string } ) => setValue( v ) }
 				options={ [
 					{
 						value: 'button-label',
 						label: translate( 'Choose new status…' ),
 						icon: (
 							<img
-								className="domains-table-bulk-actions-toolbar__icon"
+								className="domains-dataviews-bulk-actions-dialog__icon"
 								src={ transformIcon }
 								width={ 18 }
 								height={ 18 }
@@ -78,6 +84,15 @@ export const AutoRenewDiolog = ( {
 					{ value: 'disable', label: disableLabel },
 				] }
 			/>
+
+			<div className="domains-dataviews-bulk-actions-dialog__actions">
+				<Button variant="tertiary" onClick={ closeModal }>
+					{ translate( 'Cancel' ) }
+				</Button>
+				<Button variant="primary" onClick={ onUpdateAutoRenew } disabled={ updateButtonDisbled }>
+					{ translate( 'Update' ) }
+				</Button>
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
Related to #99900

## Proposed Changes

* Improve the auto-renew dialog:
  * Intorduce Cancel and Update buttons.
  * Submit on the click on the Update button, not on selecting an option in the dropdown.

## Why are these changes being made?

* Addressing CfT feedback.

## Testing Instructions

- You need to have at least two domains you __own__ to test bulk actions (if fact, it works even with one domain).
- Turn on feature flags in your browser's console: window.sessionStorage.setItem('flags',  'calypso/domains-dataviews'])
- Go to http://calypso.localhost:3000/domains/manage
- Tick domains.
- Click on the Auto-renew bulk action.
- Make sure the dialog looks like on screenshots below.
- Make sure the Update button remains disabled until you select a valid option.
- Make sure the Cancel button closes the modal.
- Make sure the Update button performs the action (you'll see a loader in the domain status column, then the notification should appear).
- Change the language of the [account](https://wordpress.com/me/account), and make sure the texts in the modal are translated (including buttons).

## Screenshots
![CleanShot 2025-02-25 at 15 55 05@2x](https://github.com/user-attachments/assets/d3acfe8e-c8b5-4bd0-ad2e-6ee1c64e5157)
![CleanShot 2025-02-25 at 15 55 14@2x](https://github.com/user-attachments/assets/94f76121-1a17-46de-8245-d5801f17f3f4)
![CleanShot 2025-02-25 at 15 55 20@2x](https://github.com/user-attachments/assets/05de266d-61c8-4e41-ab70-857bf9c4c18b)

Translated:
![CleanShot 2025-02-25 at 16 07 25@2x](https://github.com/user-attachments/assets/af0897f2-8390-4be7-b875-75ee58c96ae0)
![CleanShot 2025-02-25 at 16 07 35@2x](https://github.com/user-attachments/assets/4cdf4169-f887-449b-9fe4-a9a55e5f3ad0)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
