### PR TITLE
Reader: Update new subscription verify email notification

### DIFF
--- a/client/landing/subscriptions/components/add-sites-button/add-sites-button.tsx
+++ b/client/landing/subscriptions/components/add-sites-button/add-sites-button.tsx
@@ -1,8 +1,8 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { useResendEmailVerification } from 'calypso/landing/stepper/hooks/use-resend-email-verification';
 import { AddSitesModal } from 'calypso/landing/subscriptions/components/add-sites-modal';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -13,23 +13,20 @@ const AddSitesButton = () => {
 	const translate = useTranslate();
 	const [ isAddSitesModalVisible, setIsAddSitesModalVisible ] = useState( false );
 	const dispatch = useDispatch();
-	const resendEmailVerification = useResendEmailVerification();
 	const isEmailVerified = useSelector( isCurrentUserEmailVerified );
 
 	return (
 		<>
 			<Button
-				primary
-				className="subscriptions-add-sites__button"
+				variant="primary"
+				className="button subscriptions-add-sites__button"
 				onClick={ () => {
 					if ( ! isEmailVerified ) {
 						return dispatch(
-							errorNotice( translate( 'Your email has not been verified yet.' ), {
+							errorNotice( translate( 'Please verify your email before subscribing.' ), {
 								id: 'resend-verification-email',
-								button: translate( 'Resend Email' ),
-								onClick: () => {
-									resendEmailVerification();
-								},
+								button: translate( 'Account Settings' ),
+								href: '/me/account',
 							} )
 						);
 					}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/475

## Proposed Changes

* Update the /reader/subscriptions "New subscription" button email verification notification so it matches the notification we use on /discover/add-new.
* Refactor to replace the deprecated `Button` component with the newest version.

<img width="1266" alt="Screenshot 2025-02-25 at 4 47 45 PM" src="https://github.com/user-attachments/assets/1360d653-8bbf-420f-8ce7-aafe718bbc72" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Provides consistency with same feature found on /discover/add-new.
* The updated notification provides more context by linking the user to /me/account, which has more information on how to verify your email.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On an account with an unverified email, use Calypso Live and go to /reader/subscriptions.
* Click on "New subscription". You should see the new notification message.
* Click on the "Account Settings" button. It should take you /me/account.
* On an account with a verified email, use Calypso Live and go to /reader/subscriptions.
* Ensure it behaves just like production and there are no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
