### PR TITLE
query-site-purchases: avoid calls for negative site ids

### DIFF
--- a/client/components/data/query-site-purchases/index.jsx
+++ b/client/components/data/query-site-purchases/index.jsx
@@ -19,6 +19,13 @@ export const useQuerySitePurchases = ( siteId ) => {
 		if ( siteId === previousSiteId.current ) {
 			return;
 		}
+
+		// No need to request /rest/v1.1/sites/-1/purchases.
+		const siteIdNumber = Number( siteId );
+		if ( ! isNaN( siteIdNumber ) && siteIdNumber < 0 ) {
+			return;
+		}
+
 		debug(
 			`siteId "${ siteId }" has changed from previous "${ previousSiteId.current }"; fetching site purchases`
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* When fetching purchases, don't bother if the site is negative.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* I noticed there were 6000 calls to `https://public-api.wordpress.com/rest/v1.1/sites/-1/purchases?http_envelope=1` in the last hour, which are pointless. They all return
```
{"code":404,"headers":[{"name":"Content-Type","value":"application\/json"}],"body":{"error":"unknown_blog","message":"Unknown blog"}}
```

## Testing Instructions

Add debugging like
```diff
diff --git a/client/components/data/query-site-purchases/index.jsx b/client/components/data/query-site-purchases/index.jsx
index 19a58b8c7e3..557378a1712 100644
--- a/client/components/data/query-site-purchases/index.jsx
+++ b/client/components/data/query-site-purchases/index.jsx
@@ -23,8 +23,10 @@ export const useQuerySitePurchases = ( siteId ) => {
                // No need to request /rest/v1.1/sites/-1/purchases.
                const siteIdNumber = Number( siteId );
                if ( ! isNaN( siteIdNumber ) && siteIdNumber < 0 ) {
+                       console.warn( `siteId "${ siteId }" failed gate :(` );
                        return;
                }
+               console.warn( `siteId "${ siteId }" PASSED gate :)` );

                debug(
                        `siteId "${ siteId }" has changed from previous "${ previousSiteId.current }"; fetching site purchases`
```

* Visit http://calypso.localhost:3000/setup/onboarding/domains
  * Expect to see: Failed gate message and no longer a request to /sites/-1/purchases
* Visit a page like `http://calypso.localhost:3000/plans/<oneofyoursites>`
  * Expect to see: Passed gate message and still requesting purchases

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
