### PR TITLE
Subscriber Line Chart: Fix line chart tick formatting

### DIFF
--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -68,7 +68,7 @@ function StatsLineChart( {
 						withTooltips
 						withGradientFill
 						height={ height }
-						margin={ { left: 20, top: 20, bottom: 20 } }
+						margin={ { left: 15, top: 20, bottom: 20 } }
 						options={ {
 							yScale: {
 								type: 'linear',

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -53,16 +53,6 @@ function StatsLineChart( {
 		[ chartData ]
 	);
 
-	// TODO: we should have this in charts lib.
-	const chartDataSorted = useMemo(
-		() =>
-			chartData.map( ( series ) => ( {
-				...series,
-				data: series.data.sort( ( a, b ) => a.date.getTime() - b.date.getTime() ),
-			} ) ),
-		[ chartData ]
-	);
-
 	return (
 		<div className={ clsx( 'stats-line-chart', className ) }>
 			{ isEmpty && (
@@ -74,7 +64,7 @@ function StatsLineChart( {
 			{ ! isEmpty && (
 				<ThemeProvider theme={ jetpackTheme }>
 					<LineChart
-						data={ chartDataSorted }
+						data={ chartData }
 						withTooltips
 						withGradientFill
 						height={ height }

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -43,8 +43,7 @@ function StatsLineChart( {
 		return value.toFixed( 0 ).toString();
 	};
 
-	const dataLength = ( chartData?.[ 0 ].data || [] ).length;
-	const isEmpty = dataLength === 0;
+	const isEmpty = ( chartData?.[ 0 ].data || [] ).length === 0;
 
 	const maxValue = useMemo(
 		() =>
@@ -79,7 +78,6 @@ function StatsLineChart( {
 							axis: {
 								x: {
 									tickFormat: formatTime,
-									numTicks: dataLength < 5 ? dataLength : undefined,
 								},
 								y: {
 									orientation: 'right',

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -1,6 +1,6 @@
 import { LineChart, ThemeProvider, jetpackTheme } from '@automattic/charts';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
+import { numberFormat, useTranslate } from 'i18n-calypso';
 import { Moment } from 'moment';
 import { useMemo } from 'react';
 import StatsEmptyState from '../../stats-empty-state';
@@ -40,7 +40,9 @@ function StatsLineChart( {
 		  };
 
 	const formatValue = ( value: number ) => {
-		return value.toFixed( 0 );
+		return value < 100_000
+			? value.toFixed( 0 )
+			: numberFormat( value, { numberFormatOptions: { notation: 'compact' }, decimals: 1 } );
 	};
 
 	const isEmpty = ( chartData?.[ 0 ].data || [] ).length === 0;
@@ -72,7 +74,7 @@ function StatsLineChart( {
 							left: 15,
 							top: 20,
 							bottom: 20,
-							right: Math.max( maxValue.toFixed().length * 10, 40 ),
+							right: Math.max( formatValue( maxValue ).length * 10, 40 ), //TODO: we should support this from the lib.
 						} }
 						options={ {
 							yScale: {

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -43,7 +43,8 @@ function StatsLineChart( {
 		return value.toFixed( 0 ).toString();
 	};
 
-	const isEmpty = ( chartData?.[ 0 ].data || [] ).length === 0;
+	const dataLength = ( chartData?.[ 0 ].data || [] ).length;
+	const isEmpty = dataLength === 0;
 
 	const maxValue = useMemo(
 		() =>
@@ -68,7 +69,7 @@ function StatsLineChart( {
 						withTooltips
 						withGradientFill
 						height={ height }
-						margin={ { left: 15, top: 20, bottom: 20 } }
+						margin={ { left: 20, top: 20, bottom: 20 } }
 						options={ {
 							yScale: {
 								type: 'linear',
@@ -78,6 +79,7 @@ function StatsLineChart( {
 							axis: {
 								x: {
 									tickFormat: formatTime,
+									numTicks: dataLength < 5 ? dataLength : undefined,
 								},
 								y: {
 									orientation: 'right',

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -31,8 +31,8 @@ function StatsLineChart( {
 
 	const formatTime = formatTimeTick
 		? formatTimeTick
-		: ( value: number ) => {
-				const date = new Date( value );
+		: ( timestamp: number ) => {
+				const date = new Date( timestamp );
 				return date.toLocaleDateString( undefined, {
 					month: 'short',
 					day: 'numeric',
@@ -40,7 +40,7 @@ function StatsLineChart( {
 		  };
 
 	const formatValue = ( value: number ) => {
-		return value.toFixed( 0 ).toString();
+		return value.toFixed( 0 );
 	};
 
 	const isEmpty = ( chartData?.[ 0 ].data || [] ).length === 0;
@@ -68,7 +68,12 @@ function StatsLineChart( {
 						withTooltips
 						withGradientFill
 						height={ height }
-						margin={ { left: 15, top: 20, bottom: 20 } }
+						margin={ {
+							left: 15,
+							top: 20,
+							bottom: 20,
+							right: Math.max( maxValue.toFixed().length * 10, 40 ),
+						} }
 						options={ {
 							yScale: {
 								type: 'linear',

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -136,7 +136,6 @@ const RealtimeChart = ( { siteId }: { siteId: number } ) => {
 	const chartDataSeries = [
 		{
 			label: 'Views',
-			options: {}, //TODO: remove this after fixing chart lib typings.
 			data: chartData,
 		},
 	];

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -121,6 +121,33 @@ export default function SubscribersChartSection( {
 	const legendRef = useRef< HTMLDivElement >( null );
 	const translate = useTranslate();
 
+	const formatTimeTick = useCallback(
+		( timestamp: number ) => {
+			const date = new Date( timestamp );
+			switch ( period ) {
+				case 'week':
+				case 'day':
+					return new Date( timestamp ).toLocaleDateString( undefined, {
+						month: 'short',
+						day: 'numeric',
+					} );
+				case 'month':
+					return date.toLocaleDateString( undefined, {
+						month: 'short',
+						year: 'numeric',
+					} );
+				case 'year':
+					return date.getFullYear().toString();
+				default:
+					return date.toLocaleDateString( undefined, {
+						month: 'short',
+						day: 'numeric',
+					} );
+			}
+		},
+		[ period ]
+	);
+
 	const {
 		isLoading,
 		isError,
@@ -240,6 +267,7 @@ export default function SubscribersChartSection( {
 							height={ 300 }
 							EmptyState={ () => null }
 							zeroBaseline={ false }
+							formatTimeTick={ formatTimeTick }
 						/>
 					) : (
 						<UplotChart

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/calypso-razorpay": "workspace:^",
 		"@automattic/calypso-router": "workspace:^",
-		"@automattic/charts": "^0.8.2",
+		"@automattic/charts": "^0.8.3",
 		"@automattic/color-studio": "^3.0.1",
 		"@automattic/command-palette": "workspace:^",
 		"@automattic/components": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -565,9 +565,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/charts@npm:^0.8.2":
-  version: 0.8.2
-  resolution: "@automattic/charts@npm:0.8.2"
+"@automattic/charts@npm:^0.8.3":
+  version: 0.8.3
+  resolution: "@automattic/charts@npm:0.8.3"
   dependencies:
     "@babel/runtime": "npm:7.26.0"
     "@react-spring/web": "npm:9.7.3"
@@ -589,7 +589,7 @@ __metadata:
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-  checksum: 1cc176d865d356dc3900d7502a327f8822b6b503a90c4494a99637cd9806bef185abc62fd377f420105b8ae3acec6d9b58c1afe957b88dde6d7ac25c6f75cbd1
+  checksum: 003d54ea7e93ee6562e4a182ffb153745d9397552d908306467444762244ba8f6e7c9f4ae0859f26b599c8124ddb7c57cb772415ac30c02d0e5bf453858f10f1
   languageName: node
   linkType: hard
 
@@ -35928,7 +35928,7 @@ __metadata:
     "@automattic/calypso-razorpay": "workspace:^"
     "@automattic/calypso-router": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
-    "@automattic/charts": "npm:^0.8.2"
+    "@automattic/charts": "npm:^0.8.3"
     "@automattic/color-studio": "npm:^3.0.1"
     "@automattic/command-palette": "workspace:^"
     "@automattic/components": "workspace:^"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Updated charts lib to `0.8.3`
* Added different tick formatting for different period
* Remove unnecessary code after lib upgrade

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Better tick format 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `http://calypso.localhost:3000/stats/subscribers/day/your-site.com?flags=stats/chart-library`
* Ensure the ticks are formatted like `Jan 29` for Days and Weeks
* Formatted like `Dec 2024` for Months
* Formatted like `2024` for Years

| Before | After |
|---|---|
| <img width="954" alt="image" src="https://github.com/user-attachments/assets/49aced94-c912-4d50-adb4-b5dfb210c113" />| <img width="1193" alt="image" src="https://github.com/user-attachments/assets/17611a6a-3696-4b0d-9a0b-a12b4d02e6de" />|







## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
