### PR TITLE
Connected Applications: Prevent badges from linebreaking in webkit

### DIFF
--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -105,11 +105,10 @@ class ConnectedApplicationItem extends Component {
 
 		return (
 			<div>
-				<h2>
-					{ this.props.translate( 'Access scope' ) }
+				<div className="connected-application-item__access-scope">
+					<h2>{ this.props.translate( 'Access scope' ) }</h2>
 					{ this.renderAccessScopeBadge() }
-				</h2>
-
+				</div>
 				<p className="connected-application-item__connection-detail-description">{ message }</p>
 			</div>
 		);

--- a/client/me/connected-application-item/style.scss
+++ b/client/me/connected-application-item/style.scss
@@ -46,6 +46,11 @@
 	font-weight: normal;
 }
 
+.connected-application-item__access-scope {
+	display: flex;
+	align-items: center;
+}
+
 .connected-application-item__connection-detail-descriptions {
 	margin-left: 1.5em;
 	margin-top: 4px;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/100372

## Proposed Changes

* Prevents the access scope and similar badges from line breaking below the label on /me/security/connected-applications in webkit browsers.

## Testing

The authentication badge should appear inline with "Access Scope"

![Screenshot(110)](https://github.com/user-attachments/assets/e34ff9f6-5a9a-4caf-af80-d2fa42cabe34)
