### PR TITLE
Design Picker: Fix badge not showing the latest design

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-is-updated-badge-design.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-is-updated-badge-design.tsx
@@ -3,7 +3,7 @@ import { getStepFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url'
 
 const useIsUpdatedBadgeDesign = () => {
 	const step = useMemo( () => getStepFromURL(), [] );
-	return [ 'designsetup', 'design-setup' ].includes( step?.toLowerCase() );
+	return [ 'designsetup', 'design-setup' ].includes( step?.toLowerCase() ?? '' );
 };
 
 export default useIsUpdatedBadgeDesign;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-is-updated-badge-design.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-is-updated-badge-design.tsx
@@ -1,13 +1,9 @@
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useMemo } from 'react';
 import { getStepFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
 
 const useIsUpdatedBadgeDesign = () => {
 	const step = useMemo( () => getStepFromURL(), [] );
-	// TODO: Remove this after translations are completed
-	const hasEnTranslation = useHasEnTranslation();
-	const isEligible = hasEnTranslation( '%(planName)s + %(price)s/mo' );
-	return isEligible ? step?.toLowerCase() === 'designsetup' : false;
+	return [ 'designsetup', 'design-setup' ].includes( step?.toLowerCase() );
 };
 
 export default useIsUpdatedBadgeDesign;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR fixes a regression issue introduced by https://github.com/Automattic/wp-calypso/pull/100318 where the pricing badge in the Design Picker not showing the latest design.

| Old design | New design |
| --- | --- | 
| ![Screenshot 2025-02-26 at 3 30 00 PM](https://github.com/user-attachments/assets/acf9bac7-9f63-4637-9a35-f07b6449fa04) |  ![Screenshot 2025-02-26 at 3 30 19 PM](https://github.com/user-attachments/assets/67968a43-a90c-452a-860b-acbd9d2f0a51) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Design Picker
* Ensure that the pricing badge is using the latest design

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
