### PR TITLE
A4A > WooPayments: Add WooPayments to site API integration

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -53,6 +53,7 @@ export const A4A_AGENCY_TIER_LINK = '/agency-tier';
 export const A4A_WOOPAYMENTS_LINK = '/woopayments';
 export const A4A_WOOPAYMENTS_DASHBOARD_LINK = `${ A4A_WOOPAYMENTS_LINK }/dashboard`;
 export const A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK = `${ A4A_WOOPAYMENTS_LINK }/payment-settings`;
+export const A4A_WOOPAYMENTS_SITE_SETUP_LINK = `${ A4A_WOOPAYMENTS_LINK }/site-setup`;
 
 // Client
 export const A4A_CLIENT_LANDING_LINK = '/client/landing';

--- a/client/a8c-for-agencies/hooks/use-install-plugin-to-site.ts
+++ b/client/a8c-for-agencies/hooks/use-install-plugin-to-site.ts
@@ -16,23 +16,14 @@ function mutationInstallPluginToSite( {
 	siteId,
 	pluginSlug,
 }: InstallPluginToSiteMutationOptions ): Promise< void > {
-	const isAPIEnabled = false; // FIXME: Remove this once the API is enabled
-	return isAPIEnabled
-		? wpcom.req.post(
-				{
-					path: `/jetpack-blogs/${ siteId }/rest-api`,
-					apiNamespace: 'rest/v1.1',
-				},
-				{
-					path: '/wp/v2/plugins/',
-					body: JSON.stringify( {
-						slug: pluginSlug,
-						status: 'active',
-					} ),
-					json: true,
-				}
-		  )
-		: Promise.resolve();
+	return wpcom.req.post( {
+		apiNamespace: 'wp/v2',
+		path: `/sites/${ siteId }/plugins`,
+		body: {
+			slug: pluginSlug,
+			status: 'active',
+		},
+	} );
 }
 
 export default function useInstallPluginToSiteMutation< TContext = unknown >(

--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -47,6 +47,7 @@ import {
 	A4A_WOOPAYMENTS_LINK,
 	A4A_WOOPAYMENTS_DASHBOARD_LINK,
 	A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK,
+	A4A_WOOPAYMENTS_SITE_SETUP_LINK,
 } from '../components/sidebar-menu/lib/constants';
 import type { Agency } from 'calypso/state/a8c-for-agencies/types';
 
@@ -100,6 +101,7 @@ const MEMBER_ACCESSIBLE_PATHS: Record< string, string[] > = {
 	[ A4A_WOOPAYMENTS_LINK ]: [ 'a4a_read_referrals' ],
 	[ A4A_WOOPAYMENTS_DASHBOARD_LINK ]: [ 'a4a_read_referrals' ],
 	[ A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK ]: [ 'a4a_read_referrals' ],
+	[ A4A_WOOPAYMENTS_SITE_SETUP_LINK ]: [ 'a4a_read_referrals' ],
 };
 
 const MEMBER_ACCESSIBLE_DYNAMIC_PATHS: Record< string, string[] > = {

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/hooks/use-issue-and-assign-licenses.tsx
@@ -84,6 +84,7 @@ type UseIssueAndAssignLicensesOptions = {
 	onSuccess?: () => void;
 	onIssueError?: ( ( error: APIError ) => void ) | ( () => void );
 	onAssignError?: ( ( error: Error ) => void ) | ( () => void );
+	redirectTo?: string;
 };
 function useIssueAndAssignLicenses(
 	selectedSite?: { ID: number; domain: string } | null,
@@ -204,6 +205,11 @@ function useIssueAndAssignLicenses(
 				dispatch( successNotice( message, { displayOnNextPage: true } ) );
 
 				page.redirect( A4A_SITES_LINK );
+				return;
+			}
+
+			if ( options.redirectTo ) {
+				page.redirect( options.redirectTo );
 				return;
 			}
 

--- a/client/a8c-for-agencies/sections/migrations/hooks/use-fetch-all-managed-sites.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/use-fetch-all-managed-sites.ts
@@ -49,6 +49,7 @@ export const useFetchAllManagedSites = () => {
 						id: site.a4a_site_id,
 						site: urlToSlug( site.url ),
 						date: foundSite.options?.created_at || '',
+						rawSite: site,
 				  }
 				: null;
 		} )

--- a/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/add-site-table.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/add-site-table.tsx
@@ -9,11 +9,13 @@ import FormRadio from 'calypso/components/forms/form-radio';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useFetchAllManagedSites } from '../../migrations/hooks/use-fetch-all-managed-sites';
+import { Site } from '../../sites/types';
 
 export type WooPaymentsSiteItem = {
 	id: number;
 	site: string;
 	date: string;
+	rawSite: Site;
 };
 
 const AddWooPaymentsToSiteTable = ( {
@@ -78,7 +80,7 @@ const AddWooPaymentsToSiteTable = ( {
 	}, [ onSelectSite, selectedSite?.id, translate ] );
 
 	const { data: allSites, paginationInfo } = useMemo( () => {
-		return filterSortAndPaginate( availableSites, dataViewsState, fields );
+		return filterSortAndPaginate( availableSites as WooPaymentsSiteItem[], dataViewsState, fields );
 	}, [ availableSites, dataViewsState, fields ] );
 
 	return (

--- a/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/modal.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/modal.tsx
@@ -1,41 +1,34 @@
 import { Button } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import A4AModal from 'calypso/a8c-for-agencies/components/a4a-modal';
-import useAddWooPaymentsToSiteMutation from 'calypso/a8c-for-agencies/hooks/use-install-plugin-to-site';
-import { useDispatch } from 'calypso/state';
-import { errorNotice } from 'calypso/state/notices/actions';
+import { A4A_WOOPAYMENTS_SITE_SETUP_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useIssueAndAssignLicenses from 'calypso/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses';
 import AddWooPaymentsToSiteTable, { type WooPaymentsSiteItem } from './add-site-table';
 
 const AddWooPaymentsToSiteModal = ( { onClose }: { onClose: () => void } ) => {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
 
 	const [ selectedSite, setSelectedSite ] = useState< WooPaymentsSiteItem | null >( null );
 
-	const {
-		mutate: addWooPaymentsToSite,
-		status,
-		error,
-		isPending,
-	} = useAddWooPaymentsToSiteMutation();
-
-	useEffect( () => {
-		if ( status === 'success' ) {
-			onClose();
-		} else if ( status === 'error' ) {
-			dispatch(
-				errorNotice( error.message ?? translate( 'Something went wrong. Please try again.' ) )
-			);
+	const { issueAndAssignLicenses, isReady: isIssueAndAssignReady } = useIssueAndAssignLicenses(
+		selectedSite ? { ID: selectedSite.rawSite.blog_id, domain: selectedSite.site } : null,
+		{
+			redirectTo: addQueryArgs( A4A_WOOPAYMENTS_SITE_SETUP_LINK, {
+				site_id: selectedSite?.rawSite.blog_id,
+			} ),
 		}
-	}, [ status, onClose, error, dispatch, translate ] );
+	);
 
 	const handleAddSite = () => {
 		if ( selectedSite ) {
-			addWooPaymentsToSite( {
-				siteId: selectedSite.id,
-				pluginSlug: 'woocommerce-payments',
-			} );
+			issueAndAssignLicenses( [
+				{
+					slug: 'woocommerce-woopayments',
+					quantity: 1,
+				},
+			] );
 		}
 	};
 
@@ -52,8 +45,8 @@ const AddWooPaymentsToSiteModal = ( { onClose }: { onClose: () => void } ) => {
 				<Button
 					variant="primary"
 					onClick={ handleAddSite }
-					disabled={ isPending || ! selectedSite }
-					isBusy={ isPending }
+					disabled={ ! selectedSite || ! isIssueAndAssignReady }
+					isBusy={ ! isIssueAndAssignReady }
 				>
 					{ translate( 'Add WooPayments to selected site' ) }
 				</Button>

--- a/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/modal.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/modal.tsx
@@ -4,7 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import A4AModal from 'calypso/a8c-for-agencies/components/a4a-modal';
 import { A4A_WOOPAYMENTS_SITE_SETUP_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import useIssueAndAssignLicenses from 'calypso/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses';
+import useIssueAndAssignLicenses from 'calypso/a8c-for-agencies/sections/marketplace/products-overview-v2/hooks/use-issue-and-assign-licenses';
 import AddWooPaymentsToSiteTable, { type WooPaymentsSiteItem } from './add-site-table';
 
 const AddWooPaymentsToSiteModal = ( { onClose }: { onClose: () => void } ) => {

--- a/client/a8c-for-agencies/sections/woopayments/controller.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/controller.tsx
@@ -3,6 +3,7 @@ import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-t
 import WooPaymentsSidebar from 'calypso/a8c-for-agencies/components/sidebar-menu/woopayments';
 import ReferralsBankDetails from '../referrals/primary/bank-details';
 import WooPaymentsDashboard from './primary/woopayments-dashboard';
+import WooPaymentsSiteSetup from './primary/woopayments-site-setup';
 
 export const woopaymentsDashboardContext: Callback = ( context, next ) => {
 	context.primary = (
@@ -20,6 +21,19 @@ export const woopaymentsPaymentSettingsContext: Callback = ( context, next ) => 
 		<>
 			<PageViewTracker title="WooPayments > Payment Settings" path={ context.path } />
 			<ReferralsBankDetails isAutomatedReferral />
+		</>
+	);
+	context.secondary = <WooPaymentsSidebar path={ context.path } />;
+	next();
+};
+
+export const woopaymentsSiteSetupContext: Callback = ( context, next ) => {
+	const siteId = context.query.site_id;
+
+	context.primary = (
+		<>
+			<PageViewTracker title="WooPayments > Site Setup" path={ context.path } />
+			<WooPaymentsSiteSetup siteId={ siteId } />
 		</>
 	);
 	context.secondary = <WooPaymentsSidebar path={ context.path } />;

--- a/client/a8c-for-agencies/sections/woopayments/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/index.tsx
@@ -3,10 +3,15 @@ import {
 	A4A_WOOPAYMENTS_DASHBOARD_LINK,
 	A4A_WOOPAYMENTS_LINK,
 	A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK,
+	A4A_WOOPAYMENTS_SITE_SETUP_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { woopaymentsDashboardContext, woopaymentsPaymentSettingsContext } from './controller';
+import {
+	woopaymentsDashboardContext,
+	woopaymentsPaymentSettingsContext,
+	woopaymentsSiteSetupContext,
+} from './controller';
 
 export default function () {
 	page(
@@ -20,6 +25,13 @@ export default function () {
 		A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK,
 		requireAccessContext,
 		woopaymentsPaymentSettingsContext,
+		makeLayout,
+		clientRender
+	);
+	page(
+		A4A_WOOPAYMENTS_SITE_SETUP_LINK,
+		requireAccessContext,
+		woopaymentsSiteSetupContext,
 		makeLayout,
 		clientRender
 	);

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-site-setup/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-site-setup/index.tsx
@@ -1,0 +1,214 @@
+import page from '@automattic/calypso-router';
+import { SiteDetails } from '@automattic/data-stores';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { A4A_WOOPAYMENTS_DASHBOARD_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import StepSection from 'calypso/a8c-for-agencies/components/step-section';
+import StepSectionItem from 'calypso/a8c-for-agencies/components/step-section-item';
+import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
+import useInstallPluginToSiteMutation from 'calypso/a8c-for-agencies/hooks/use-install-plugin-to-site';
+import LayoutBody from 'calypso/layout/hosting-dashboard/body';
+import LayoutHeader, {
+	LayoutHeaderBreadcrumb as Breadcrumb,
+	LayoutHeaderActions as Actions,
+} from 'calypso/layout/hosting-dashboard/header';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getSites from 'calypso/state/selectors/get-sites';
+
+import './style.scss';
+
+const WooPaymentsSiteSetup = ( { siteId }: { siteId: string } ) => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const sites = useSelector( getSites );
+
+	const { mutateAsync: installPluginToSite, isPending } = useInstallPluginToSiteMutation();
+	const [ error, setError ] = useState( false );
+	const [ isInstalled, setIsInstalled ] = useState( false );
+
+	const [ selectedSite, setSelectedSite ] = useState< SiteDetails | null | undefined >( null );
+
+	const title = translate( 'WooPayments Site Setup' );
+
+	const onInstallPluginClick = async () => {
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_woopayments_site_setup_install_plugin_click', {
+				status: isInstalled ? 'installed' : 'not_installed',
+			} )
+		);
+
+		const wooSetupUrl = `${ selectedSite?.URL }/wp-admin/admin.php?page=wc-admin&path=/payments/connect`;
+
+		if ( isInstalled ) {
+			window.open( wooSetupUrl, '_blank' );
+			return;
+		}
+
+		// TODO: We need to check if the WooCommerce plugin is already installed
+		const plugins = [ 'woocommerce', 'woocommerce-payments' ];
+
+		// Install plugins sequentially
+		try {
+			for ( const plugin of plugins ) {
+				await installPluginToSite( {
+					siteId: parseInt( siteId ),
+					pluginSlug: plugin,
+				} );
+				if ( plugin === 'woocommerce-payments' ) {
+					window.open( wooSetupUrl, '_blank' );
+					setIsInstalled( true );
+					return;
+				}
+			}
+		} catch {
+			setError( true );
+		}
+	};
+
+	useEffect( () => {
+		// Redirect to dashboard if no siteId
+		if ( ! siteId ) {
+			page.redirect( A4A_WOOPAYMENTS_DASHBOARD_LINK );
+			return;
+		}
+
+		// Find matching site
+		const site = sites.find( ( site ) => site?.ID === parseInt( siteId ) );
+
+		if ( site ) {
+			// Set selected site and remove site_id param
+			setSelectedSite( site );
+			return;
+		}
+	}, [ siteId, sites ] );
+
+	return (
+		<Layout className="woopayments-site-setup" title={ title } wide>
+			<LayoutTop>
+				<LayoutHeader>
+					<Breadcrumb
+						hideOnMobile
+						items={ [
+							{
+								label: translate( 'WooPayments Commissions' ),
+								href: A4A_WOOPAYMENTS_DASHBOARD_LINK,
+							},
+							{
+								label: translate( 'Site setup' ),
+							},
+						] }
+					/>
+					<Actions>
+						<MobileSidebarNavigation />
+					</Actions>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody>
+				{ ! selectedSite ? (
+					<>
+						<TextPlaceholder />
+						<TextPlaceholder />
+						<TextPlaceholder />
+					</>
+				) : (
+					<>
+						<h2 className="woopayments-site-setup__page-title">
+							{ translate( 'WooPayments is now ready to be configured on %s', {
+								args: selectedSite?.domain,
+							} ) }
+						</h2>
+						<div className="woopayments-site-setup__page-description">
+							{ translate(
+								'Follow the steps below to complete the process so you can earn commissions.'
+							) }
+						</div>
+						<StepSection heading={ translate( 'Next steps' ) }>
+							<StepSectionItem
+								isNewLayout
+								heading={ translate( 'Install and activate the plugin on WP-Admin' ) }
+								description={
+									<>
+										<div>
+											{ translate(
+												"Click the button and we'll automatically install and activate the plugin for you. Then we'll launch WP-Admin so you can configure the final steps."
+											) }
+										</div>
+										{ error ? (
+											<>
+												<div className="woopayments-site-setup__error">
+													{ translate(
+														"We're sorry, we weren't able to install WooPayments on your site. Visit your WP-Admin to set up."
+													) }
+												</div>
+												<Button
+													variant="primary"
+													href={ `${ selectedSite.URL }/wp-admin/plugin-install.php?s=woopayments&tab=search&type=term` }
+													target="_blank"
+													rel="noopener noreferrer"
+													onClick={ () => {
+														dispatch(
+															recordTracksEvent(
+																'calypso_a4a_woopayments_site_setup_install_plugin_error_click'
+															)
+														);
+													} }
+												>
+													{ translate( 'Visit WP-Admin ↗' ) }
+												</Button>
+											</>
+										) : (
+											<Button
+												disabled={ isPending }
+												isBusy={ isPending }
+												variant="primary"
+												onClick={ onInstallPluginClick }
+											>
+												{ isInstalled
+													? translate( 'View WooPayments ↗' )
+													: translate( 'Install and activate the plugin ↗' ) }
+											</Button>
+										) }
+									</>
+								}
+							/>
+							<StepSectionItem
+								isNewLayout
+								heading={ translate( 'Earn commissions' ) }
+								description={
+									<>
+										<div>
+											{ translate(
+												"Once the plugin is installed and configured, each time a transaction occurs, you'll earn commisions!"
+											) }
+										</div>
+										<Button
+											variant="secondary"
+											onClick={ () => {
+												dispatch(
+													recordTracksEvent(
+														'calypso_a4a_woopayments_site_setup_view_commissions_click'
+													)
+												);
+											} }
+											href={ A4A_WOOPAYMENTS_DASHBOARD_LINK }
+										>
+											{ translate( 'View WooPayments Commissions' ) }
+										</Button>
+									</>
+								}
+							/>
+						</StepSection>
+					</>
+				) }
+			</LayoutBody>
+		</Layout>
+	);
+};
+
+export default WooPaymentsSiteSetup;

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-site-setup/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-site-setup/style.scss
@@ -1,0 +1,38 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
+.woopayments-site-setup .hosting-dashboard-layout__body-wrapper {
+	max-width: 900px;
+	padding-block-start: calc(24px + 48px);
+
+	.step-section .step-section__header .step-section__step-heading {
+		@include heading-large;
+	}
+
+	.step-section-item__description {
+		.components-button {
+			margin-block-start: 16px;
+		}
+	}
+
+	.a4a-text-placeholder {
+		margin-block-end: 32px;
+		height: 100px;
+	}
+}
+
+.woopayments-site-setup__page-title {
+	@include heading-x-large;
+	margin-block-end: 8px;
+}
+
+.woopayments-site-setup__page-description {
+	@include body-large;
+	margin-block-end: 40px;
+}
+
+.woopayments-site-setup__error {
+	@include body-small;
+	margin-block-start: 16px;
+	color: var(--color-error);
+}

--- a/client/sections.js
+++ b/client/sections.js
@@ -914,7 +914,12 @@ const sections = [
 	},
 	{
 		name: 'a8c-for-agencies-woopayments',
-		paths: [ '/woopayments', '/woopayments/dashboard', '/woopayments/payment-settings' ],
+		paths: [
+			'/woopayments',
+			'/woopayments/dashboard',
+			'/woopayments/payment-settings',
+			'/woopayments/site-setup',
+		],
 		module: 'calypso/a8c-for-agencies/sections/woopayments',
 		group: 'a8c-for-agencies',
 	},


### PR DESCRIPTION

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1850

## Proposed Changes

This PR:

- Integrates issue/assign WooPayments license to a Site API endpoint to the initial setup
- Adds site setup page for next steps
- Integrates the API endpoint to install and activate WooCommerce & WooPayments
- Handles error
- Redirects to WooPayments setup on WP-Admin after the WooPayments is activated on a site. 

Note: 

- We will check if WooCommerce is installed first before installing which will be done in another PR.
- Please ignore any design and button texts, we will do a final fix later.

## Why are these changes being made?

* To Assign a WooPayments license to the site and then install and activate it.

## Testing Instructions

* Open the A4A live link
* First, head to Marketplace, issue any license, and verify it works as expected to test regression.
* Please keep the network tab open
* Go to WooPayments: Dashboard > Click the "Add WooPayments to site" button on the layout top-right > Select a site that doesn't have both WooCommerce and WooPayments installed > Click the "Add WooPayments to selected site" button. Verify that the API calls to issue and assign a license to a site is done.

<img width="1728" alt="Screenshot 2025-02-26 at 1 04 56 PM" src="https://github.com/user-attachments/assets/7773c96c-87f7-4b43-83c7-4a324258c304" />

* Verify that you are redirected to a site setup page as shown below. Click the "Install and activate the plugin ↗" button > Verify that the plugin is installed, activated, and you are redirected to WooPayments setup on WP-Admin. Close the page.

<img width="1728" alt="Screenshot 2025-02-26 at 12 50 06 PM" src="https://github.com/user-attachments/assets/061e5baa-d533-4c9c-b616-d70db3c4bd83" />

* Verify the button text is changed > Click the button `View WooPayments ↗` and verify you are redirected to WooPayments setup on WP-Admin.

<img width="1728" alt="Screenshot 2025-02-26 at 12 50 33 PM" src="https://github.com/user-attachments/assets/877019e3-3d41-4346-8d07-6c0b6d92cb34" />

* Now refresh the page and click the "Install and activate the plugin ↗" button > Verify the below error is shown.

<img width="1728" alt="Screenshot 2025-02-26 at 12 50 59 PM" src="https://github.com/user-attachments/assets/2764f924-df2f-4b60-8f85-eb3ec6af5d54" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
