### PR TITLE
Hosting Overview: Fix the renew domain on the Active domains card

### DIFF
--- a/client/sites/overview/components/active-domains-card.tsx
+++ b/client/sites/overview/components/active-domains-card.tsx
@@ -11,6 +11,7 @@ import {
 	HostingCardLinkButton,
 } from 'calypso/components/hosting-card';
 import { fetchSiteDomains } from 'calypso/my-sites/domains/domain-management/domains-table-fetch-functions';
+import { usePurchaseActions } from 'calypso/my-sites/domains/domain-management/list/use-purchase-actions';
 import { filterOutWpcomDomains } from 'calypso/my-sites/domains/domain-management/list/utils';
 import { isNotAtomicJetpack } from 'calypso/sites-dashboard/utils';
 import { useSelector, useDispatch } from 'calypso/state';
@@ -44,6 +45,8 @@ const ActiveDomainsCard: FC = () => {
 	const hasNonWpcomDomains = useMemo( () => {
 		return filterOutWpcomDomains( data?.domains ?? [] ).length > 0;
 	}, [ data ] );
+
+	const purchaseActions = usePurchaseActions();
 
 	// Do not render for self hosted jetpack sites, since they cannot manage domains with us.
 	if ( isJetpackNotAtomic ) {
@@ -81,6 +84,7 @@ const ActiveDomainsCard: FC = () => {
 				isHostingOverview
 				useMobileCards={ forceMobile }
 				siteSlug={ site?.slug ?? null }
+				domainStatusPurchaseActions={ purchaseActions }
 				userCanSetPrimaryDomains={ userCanSetPrimaryDomains }
 				hasConnectableSites={ hasConnectableSites }
 				onDomainAction={ ( action, domain ) => {

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -166,7 +166,7 @@ export const DomainsTableRowActions = ( {
 				<MenuItemLink
 					key="renewDomain"
 					onClick={ () => {
-						domainStatusPurchaseActions?.onRenewNowClick?.( domain.domain ?? '', domain );
+						domainStatusPurchaseActions?.onRenewNowClick?.( siteSlug ?? '', domain );
 						onClose?.();
 					} }
 				>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fix the "Renew now" action under the Active domains table doesn't work

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select any site that has a expiring domain
* Click the `...` on the Active domain cards
* Click the `Renew now` button
* Ensure it opens the checkout page to renew the domain 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
