### PR TITLE
Help Center: Removed unused tailored posts on frontend

### DIFF
--- a/packages/help-center/README.md
+++ b/packages/help-center/README.md
@@ -83,16 +83,8 @@ Example
 
 ### Suggest specific articles per page/route
 
-In [tailored-post-ids-mapping.json](https://github.com/Automattic/wp-calypso/blob/add/tailored_posts_help_center/packages/help-center/src/tailored-post-ids-mapping.json), there is a JSON structure where you can specify which post id ( one or many ) from which blog ( just one blog ) should be displayed
-
-```
-// This will fetch posts `"post_ids": [ 248292, 150414 ]` from `"blog_id": 9619154` and display them on `/home`
-"/home/": [ { "locale": "en", "post_ids": [ 248292, 150414 ], "blog_id": 9619154 } ],
-
-// This will fetch posts `"post_ids": [  99385, 99879, 99982 ]` from `"blog_id": 33534099` and display them on `{site}/wp-admin/post-new.php`
-"/wp-admin/post-new.php": [
-		{ "locale": "en", "post_ids": [ 99385, 99879, 99982 ], "blog_id": 33534099 }
-	]
-```
+When you open the Help Center, a call to /help/search is made.
+We can pass a `section` parameter to the search query, and it will fetch posts tailored from that section on the backend, on the `WPCOM_Help_Search` class.
+If needed, add a new section there, with a list of post ids.
 
 Tailored articles have priority in the results, meaning they appear on top. If any search query is provided by the user, tailored articles are not considered.

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -14,90 +14,44 @@ export interface SearchResult {
 	source?: string;
 }
 
-interface TailoredArticles {
-	post_ids: Array< number >;
-	blog_id: number;
-}
-
 interface APIFetchOptions {
 	global: boolean;
 	path: string;
 }
 
-const filterOutDuplicatedItems = (
-	articlesResponse: SearchResult[],
-	searchResultResponse: SearchResult[]
-) => {
-	const articlesIds = articlesResponse.map( ( result ) => result.post_id );
-	return searchResultResponse.filter(
-		( searchResult ) => ! articlesIds.includes( searchResult.post_id )
-	);
-};
-
 const fetchArticlesAPI = async (
 	search: string,
 	locale: string,
-	sectionName: string,
-	articles?: TailoredArticles
+	sectionName: string
 ): Promise< SearchResult[] > => {
-	let queryString;
-	let articlesResponse: SearchResult[] = [];
 	let searchResultResponse: SearchResult[] = [];
 
-	if ( articles ) {
-		const { post_ids, blog_id } = articles;
-		queryString = buildQueryString( {
-			blog_id: blog_id,
-			post_ids: `${ post_ids.join( ',' ) }`,
-		} );
-		if ( canAccessWpcomApis() ) {
-			articlesResponse = ( await wpcomRequest( {
-				path: `help/articles?${ queryString }`,
-				apiNamespace: 'wpcom/v2/',
-				apiVersion: '2',
-			} ) ) as SearchResult[];
-		} else {
-			articlesResponse = ( await apiFetch( {
-				global: true,
-				path: `/help-center/articles?${ queryString }`,
-			} as APIFetchOptions ) ) as SearchResult[];
-		}
+	const queryString = buildQueryString( { query: search, locale, section: sectionName } );
+	if ( canAccessWpcomApis() ) {
+		searchResultResponse = ( await wpcomRequest( {
+			path: `help/search/wpcom?${ queryString }`,
+			apiNamespace: 'wpcom/v2/',
+			apiVersion: '2',
+		} ) ) as SearchResult[];
+	} else {
+		searchResultResponse = ( await apiFetch( {
+			global: true,
+			path: `/help-center/search?${ queryString }`,
+		} as APIFetchOptions ) ) as SearchResult[];
 	}
 
-	// If less than 5 tailored articles are returned, fetch search results.
-	if ( articlesResponse?.length < 5 ) {
-		queryString = buildQueryString( { query: search, locale, section: sectionName } );
-		if ( canAccessWpcomApis() ) {
-			searchResultResponse = ( await wpcomRequest( {
-				path: `help/search/wpcom?${ queryString }`,
-				apiNamespace: 'wpcom/v2/',
-				apiVersion: '2',
-			} ) ) as SearchResult[];
-		} else {
-			searchResultResponse = ( await apiFetch( {
-				global: true,
-				path: `/help-center/search?${ queryString }`,
-			} as APIFetchOptions ) ) as SearchResult[];
-		}
-		// Remove articles that are already in the tailored articles.
-		searchResultResponse = filterOutDuplicatedItems( articlesResponse, searchResultResponse );
-	}
-
-	//Add tailored results first then add search results.
-	const combinedResults = [ ...articlesResponse, ...searchResultResponse ];
-	return combinedResults.slice( 0, 5 );
+	return searchResultResponse.slice( 0, 5 );
 };
 
 export const useHelpSearchQuery = (
 	search: string,
 	locale = 'en',
 	sectionName = '',
-	tailoredArticles?: TailoredArticles,
 	queryOptions: Record< string, unknown > = {}
 ) => {
 	return useQuery< any >( {
-		queryKey: [ 'help-center-search', search, locale, sectionName, tailoredArticles ],
-		queryFn: () => fetchArticlesAPI( search, locale, sectionName, tailoredArticles ),
+		queryKey: [ 'help-center-search', search, locale, sectionName ],
+		queryFn: () => fetchArticlesAPI( search, locale, sectionName ),
 		refetchOnWindowFocus: false,
 		...queryOptions,
 	} );

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -49,12 +49,6 @@ export interface Article {
 	is_external?: boolean;
 }
 
-export interface TailoredArticles {
-	post_ids: Array< number >;
-	blog_id: number;
-	locale: string;
-}
-
 export interface FeatureFlags {
 	loadNextStepsTutorial: boolean;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

We moved the tailored posts for the Help Center recommended articles to the backend a while ago. There was some cleanup to do.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check this and prod on various pages
* List of articles shown should be the same