### PR TITLE
Create Course Goal: Install sensei plugin when selecting business plan and create course goal

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -28,6 +28,16 @@ const PostCheckoutOnboarding: Step = ( { navigation } ) => {
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	const { site, siteSlug } = useSiteData();
 
+	const intent = useSelect(
+		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
+		[]
+	);
+
+	const goals = useSelect(
+		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getGoals(),
+		[]
+	);
+
 	const selectedDesign = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
 		[]
@@ -57,8 +67,12 @@ const PostCheckoutOnboarding: Step = ( { navigation } ) => {
 	const { waitForInitiateTransfer, waitForTransfer, waitForFeature, waitForLatestSiteData } =
 		useWaitForAtomic( {} );
 
+	const { setIntentOnSite, setGoalsOnSite } = useDispatch( SITE_STORE );
+
 	const waitForAtomic = async () => {
 		await waitForTransfer();
+		await setIntentOnSite( siteSlug, intent );
+		await setGoalsOnSite( siteSlug, goals );
 		await waitForFeature();
 		await waitForLatestSiteData();
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -10,6 +10,19 @@ import { useWaitForAtomic } from '../../../../hooks/use-wait-for-atomic';
 import type { Step } from '../../types';
 import type { OnboardSelect, SiteSelect } from '@automattic/data-stores';
 
+const usePluginByGoal = () => {
+	const intent = useSelect(
+		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
+		[]
+	);
+
+	if ( intent === SiteIntent.CreateCourseGoal ) {
+		return 'sensei-lms';
+	}
+
+	return null;
+};
+
 const PostCheckoutOnboarding: Step = ( { navigation } ) => {
 	const { submit } = navigation;
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
@@ -17,11 +30,6 @@ const PostCheckoutOnboarding: Step = ( { navigation } ) => {
 
 	const selectedDesign = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
-		[]
-	);
-
-	const intent = useSelect(
-		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
 		[]
 	);
 
@@ -55,8 +63,21 @@ const PostCheckoutOnboarding: Step = ( { navigation } ) => {
 		await waitForLatestSiteData();
 	};
 
-	const hasPluginByGoal = intent === SiteIntent.CreateCourseGoal;
+	const pluginByGoal = usePluginByGoal();
+	const hasPluginByGoal = !! pluginByGoal;
 
+	/**
+	 * If an externally managed theme is selected, we need to check the following:
+	 * - Ensure the theme is available. If it's not, we do nothing, as the user may remove the theme product during checkout.
+	 * - Verify that the site is atomic, as the theme should be installed on the user's site.
+	 *
+	 * The atomic transfer will be initiated immediately after the user purchases an externally managed theme.
+	 * If it’s not initiated, we need to trigger the atomic transfer manually.
+	 *
+	 * Note that an externally managed theme is only available when both of the following conditions are met:
+	 * - The site must be subscribed to the theme.
+	 * - The site must be eligible for managed external themes.
+	 */
 	const hasExternalTheme =
 		selectedDesign?.is_externally_managed &&
 		isMarketplaceThemeSubscribed &&
@@ -83,22 +104,10 @@ const PostCheckoutOnboarding: Step = ( { navigation } ) => {
 				return providedDependencies;
 			}
 
-			/**
-			 * If an externally managed theme is selected, we need to check the following:
-			 * - Ensure the theme is available. If it's not, we do nothing, as the user may remove the theme product during checkout.
-			 * - Verify that the site is atomic, as the theme should be installed on the user's site.
-			 *
-			 * The atomic transfer will be initiated immediately after the user purchases an externally managed theme.
-			 * If it’s not initiated, we need to trigger the atomic transfer manually.
-			 *
-			 * Note that an externally managed theme is only available when both of the following conditions are met:
-			 * - The site must be subscribed to the theme.
-			 * - The site must be eligible for managed external themes.
-			 */
 			if ( siteTransferStatusData?.isTransferring ) {
 				await waitForAtomic();
 			} else if ( hasExternalTheme || hasPluginByGoal ) {
-				await waitForInitiateTransfer( 'sensei-lms' );
+				await waitForInitiateTransfer( pluginByGoal );
 				await waitForAtomic();
 			}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -1,3 +1,4 @@
+import { SiteIntent } from '@automattic/data-stores/src/onboard';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import Loading from 'calypso/components/loading';
@@ -16,6 +17,11 @@ const PostCheckoutOnboarding: Step = ( { navigation } ) => {
 
 	const selectedDesign = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
+		[]
+	);
+
+	const intent = useSelect(
+		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
 		[]
 	);
 
@@ -49,6 +55,13 @@ const PostCheckoutOnboarding: Step = ( { navigation } ) => {
 		await waitForLatestSiteData();
 	};
 
+	const hasPluginByGoal = intent === SiteIntent.CreateCourseGoal;
+
+	const hasExternalTheme =
+		selectedDesign?.is_externally_managed &&
+		isMarketplaceThemeSubscribed &&
+		isExternallyManagedThemeAvailable;
+
 	useEffect( () => {
 		if (
 			! site ||
@@ -60,7 +73,12 @@ const PostCheckoutOnboarding: Step = ( { navigation } ) => {
 		}
 
 		setPendingAction( async () => {
-			const providedDependencies = { siteSlug };
+			const providedDependencies = {
+				siteSlug,
+				hasExternalTheme,
+				hasPluginByGoal,
+			};
+
 			if ( isJetpackOrAtomic ) {
 				return providedDependencies;
 			}
@@ -79,12 +97,8 @@ const PostCheckoutOnboarding: Step = ( { navigation } ) => {
 			 */
 			if ( siteTransferStatusData?.isTransferring ) {
 				await waitForAtomic();
-			} else if (
-				selectedDesign?.is_externally_managed &&
-				isMarketplaceThemeSubscribed &&
-				isExternallyManagedThemeAvailable
-			) {
-				await waitForInitiateTransfer();
+			} else if ( hasExternalTheme || hasPluginByGoal ) {
+				await waitForInitiateTransfer( 'sensei-lms' );
 				await waitForAtomic();
 			}
 
@@ -102,6 +116,7 @@ const PostCheckoutOnboarding: Step = ( { navigation } ) => {
 		selectedDesign,
 		isMarketplaceThemeSubscribed,
 		isExternallyManagedThemeAvailable,
+		hasPluginByGoal,
 	] );
 
 	return <Loading className="wpcom-loading__boot" />;

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -171,7 +171,7 @@ const onboarding: Flow = {
 		 */
 		const getPostCheckoutDestination = (
 			providedDependencies: ProvidedDependencies
-		): [ string, string ] => {
+		): [ string, string | null ] => {
 			if ( createWithBigSky && isBigSkyBeforePlansExperiment && isGoalsAtFrontExperiment ) {
 				const destination = addQueryArgs(
 					withLocale( '/setup/site-setup/launch-big-sky', locale ),
@@ -188,6 +188,10 @@ const onboarding: Flow = {
 						isBigSkyBeforePlansFlow: true,
 					} ),
 				];
+			}
+
+			if ( ! providedDependencies.hasExternalTheme && providedDependencies.hasPluginByGoal ) {
+				return [ `/home/${ providedDependencies.siteSlug }`, null ];
 			}
 
 			const destination = addQueryArgs( withLocale( '/setup/site-setup', locale ), {

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -382,7 +382,7 @@ const onboarding: Flow = {
 									}
 								),
 								signup: 1,
-								checkoutBackUrl: pathToUrl( backDestination ),
+								checkoutBackUrl: pathToUrl( backDestination ?? '' ),
 								coupon,
 								...( createWithBigSky && isBigSkyBeforePlansExperiment && isGoalsAtFrontExperiment
 									? { [ 'big-sky-checkout' ]: 1 }

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -713,7 +713,7 @@ const siteSetupFlow: FlowV1 = {
 		const isPendingActionSet = useRef( false );
 
 		useEffect( () => {
-			if ( ! isGoalsAtFrontExperiment ) {
+			if ( ! isGoalsAtFrontExperiment || ! siteSlugOrId || ! siteId ) {
 				return;
 			}
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -709,13 +709,11 @@ const siteSetupFlow: FlowV1 = {
 		const dispatch = reduxDispatch();
 
 		const skippedCheckout = useQuery().get( 'skippedCheckout' );
-
 		const activateDesign = useActivateDesign();
-
 		const isPendingActionSet = useRef( false );
 
 		useEffect( () => {
-			if ( ! isGoalsAtFrontExperiment || ! siteSlugOrId || ! siteId ) {
+			if ( ! isGoalsAtFrontExperiment ) {
 				return;
 			}
 
@@ -729,7 +727,6 @@ const siteSetupFlow: FlowV1 = {
 				if ( ! selectedDesign ) {
 					return;
 				}
-
 				try {
 					await activateDesign( selectedDesign, {
 						styleVariation: selectedStyleVariation,

--- a/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
@@ -3,6 +3,7 @@
  */
 import { SiteIntent } from '@automattic/data-stores/src/onboard/constants';
 import { ONBOARDING_FLOW } from '@automattic/onboarding';
+import { addQueryArgs } from '@wordpress/url';
 import { STEPS } from '../internals/steps';
 import onboarding from '../onboarding';
 import { getFlowLocation, renderFlow } from './helpers';
@@ -89,6 +90,41 @@ describe( 'Onboarding Flow', () => {
 			} );
 
 			expect( getFlowLocation().path ).toBe( '/design-setup' );
+		} );
+	} );
+
+	describe( 'Processing step navigation', () => {
+		it( 'should redirect to home when hasPluginByGoal true and hasExternalTheme false', async () => {
+			const { runUseStepNavigationSubmit } = renderFlow( onboarding );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.PROCESSING.slug,
+				dependencies: {
+					hasExternalTheme: false,
+					hasPluginByGoal: true,
+					siteSlug: 'test-site.wordpress.com',
+				},
+			} );
+
+			expect( window.location.replace ).toHaveBeenCalledWith( '/home/test-site.wordpress.com' );
+		} );
+
+		it( 'should redirect to home when hasExternalTheme true', async () => {
+			const { runUseStepNavigationSubmit } = renderFlow( onboarding );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.PROCESSING.slug,
+				dependencies: {
+					hasExternalTheme: true,
+					siteSlug: 'test-site.wordpress.com',
+				},
+			} );
+
+			expect( window.location.replace ).toHaveBeenCalledWith(
+				addQueryArgs( '/setup/site-setup', {
+					siteSlug: 'test-site.wordpress.com',
+				} )
+			);
 		} );
 	} );
 } );

--- a/client/landing/stepper/hooks/use-wait-for-atomic.ts
+++ b/client/landing/stepper/hooks/use-wait-for-atomic.ts
@@ -54,7 +54,7 @@ export const useWaitForAtomic = ( {
 		[]
 	);
 
-	const waitForInitiateTransfer = async ( plugin?: string ) => {
+	const waitForInitiateTransfer = async ( plugin?: string | null ) => {
 		const initiateTransferContext = searchParams.get( 'initiate_transfer_context' );
 		if ( ! initiateTransferContext && ! plugin ) {
 			return;

--- a/client/landing/stepper/hooks/use-wait-for-atomic.ts
+++ b/client/landing/stepper/hooks/use-wait-for-atomic.ts
@@ -54,9 +54,9 @@ export const useWaitForAtomic = ( {
 		[]
 	);
 
-	const waitForInitiateTransfer = async () => {
+	const waitForInitiateTransfer = async ( plugin?: string ) => {
 		const initiateTransferContext = searchParams.get( 'initiate_transfer_context' );
-		if ( ! initiateTransferContext ) {
+		if ( ! initiateTransferContext && ! plugin ) {
 			return;
 		}
 
@@ -64,9 +64,9 @@ export const useWaitForAtomic = ( {
 			initiateThemeTransfer(
 				siteId,
 				null,
-				'',
+				plugin || '',
 				searchParams.get( 'initiate_transfer_geo_affinity' ) || '',
-				initiateTransferContext
+				initiateTransferContext || 'onboarding'
 			)
 		);
 	};


### PR DESCRIPTION
Related to #100023 

## Proposed Changes
* Update the `onboarding>post-checkout` step to start the site transfer using sensei.

## Why are these changes being made?
* We want to install sensei when the user selects the "create a course" goal and already has the business plan.*
*  This PR seeks to avoid introducing new flow steps that could worsen the user experience. 


## Testing Instructions
* Assign yourself to the goals first experiment 22180-explat-experiment (treatment_cumulative)
* Go to /start
* Select the goal "create a course" 
* Choose a business plan
* After the site site is finished, check if your new site already has sensei installed. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?