### PR TITLE
Subscriptions: update newsletter landing page link

### DIFF
--- a/client/my-sites/stats/const.js
+++ b/client/my-sites/stats/const.js
@@ -11,8 +11,8 @@ export const JETPACK_SUPPORT_URL_SUBSCRIBERS =
 
 // eslint-disable-next-line wpcalypso/i18n-unlocalized-url
 export const SUBSCRIBERS_SUPPORT_URL = 'https://wordpress.com/support/subscribers/';
-export const SUBSCRIBERS_NEWSLETTER_LANDING_PAGE_URL =
-	'https://wordpress.com/learn/courses/newsletters-101/start-here/';
+// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
+export const NEWSLETTER_SUPPORT_URL = 'https://wordpress.com/support/newsletter/';
 export const INSIGHTS_SUPPORT_URL =
 	// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
 	'https://wordpress.com/support/stats/learn-insights-about-your-website/';

--- a/client/my-sites/stats/const.js
+++ b/client/my-sites/stats/const.js
@@ -11,6 +11,8 @@ export const JETPACK_SUPPORT_URL_SUBSCRIBERS =
 
 // eslint-disable-next-line wpcalypso/i18n-unlocalized-url
 export const SUBSCRIBERS_SUPPORT_URL = 'https://wordpress.com/support/subscribers/';
+export const SUBSCRIBERS_NEWSLETTER_LANDING_PAGE_URL =
+	'https://wordpress.com/learn/courses/newsletters-101/start-here/';
 export const INSIGHTS_SUPPORT_URL =
 	// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
 	'https://wordpress.com/support/stats/learn-insights-about-your-website/';

--- a/client/my-sites/stats/features/modules/shared/stats-empty-action-email.tsx
+++ b/client/my-sites/stats/features/modules/shared/stats-empty-action-email.tsx
@@ -38,7 +38,8 @@ const StatsEmptyActionEmail: React.FC< StatsEmptyActionProps > = ( { from } ) =>
 					redirectUrl = localizeUrl( JETPACK_SUPPORT_NEWSLETTER_URL );
 				}
 
-				setTimeout( () => ( window.location.href = redirectUrl ), 250 );
+				// open in new tab
+				setTimeout( () => window.open( redirectUrl, '_blank' ), 250 );
 			} }
 		/>
 	);

--- a/client/my-sites/stats/features/modules/shared/stats-empty-action-email.tsx
+++ b/client/my-sites/stats/features/modules/shared/stats-empty-action-email.tsx
@@ -3,16 +3,25 @@ import { mail } from '@automattic/components/src/icons';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
+import { useSelector } from 'react-redux';
 import EmptyStateAction from 'calypso/my-sites/stats/components/empty-state-action';
 import {
 	JETPACK_SUPPORT_NEWSLETTER_URL,
 	JETPACK_NEWSLETTER_LANDING_PAGE_URL,
+	SUBSCRIBERS_NEWSLETTER_LANDING_PAGE_URL,
 } from 'calypso/my-sites/stats/const';
+import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { StatsEmptyActionProps } from './';
 
 const StatsEmptyActionEmail: React.FC< StatsEmptyActionProps > = ( { from } ) => {
 	const translate = useTranslate();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	const siteId = useSelector( getSelectedSiteId );
+	const isAtomic = useSelector( ( state ) => isAtomicSite( state as any, siteId ) );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state as any, siteId ) );
+	const useJetpackLinks = isAtomic || isJetpack;
 
 	return (
 		<EmptyStateAction
@@ -25,9 +34,16 @@ const StatsEmptyActionEmail: React.FC< StatsEmptyActionProps > = ( { from } ) =>
 			onClick={ () => {
 				// analytics event tracting handled in EmptyStateAction component
 
-				const redirectUrl = isOdysseyStats
-					? localizeUrl( JETPACK_SUPPORT_NEWSLETTER_URL )
-					: localizeUrl( JETPACK_NEWSLETTER_LANDING_PAGE_URL );
+				// If the site is a Jetpack or Atomic site, use the Jetpack links.
+				// Otherwise, use the WordPress.com links.
+				let redirectUrl = localizeUrl( SUBSCRIBERS_NEWSLETTER_LANDING_PAGE_URL );
+				if ( useJetpackLinks ) {
+					if ( isOdysseyStats ) {
+						redirectUrl = localizeUrl( JETPACK_SUPPORT_NEWSLETTER_URL );
+					} else {
+						redirectUrl = localizeUrl( JETPACK_NEWSLETTER_LANDING_PAGE_URL );
+					}
+				}
 
 				setTimeout( () => ( window.location.href = redirectUrl ), 250 );
 			} }

--- a/client/my-sites/stats/features/modules/shared/stats-empty-action-email.tsx
+++ b/client/my-sites/stats/features/modules/shared/stats-empty-action-email.tsx
@@ -8,7 +8,7 @@ import EmptyStateAction from 'calypso/my-sites/stats/components/empty-state-acti
 import {
 	JETPACK_SUPPORT_NEWSLETTER_URL,
 	JETPACK_NEWSLETTER_LANDING_PAGE_URL,
-	SUBSCRIBERS_NEWSLETTER_LANDING_PAGE_URL,
+	NEWSLETTER_SUPPORT_URL,
 } from 'calypso/my-sites/stats/const';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -36,7 +36,7 @@ const StatsEmptyActionEmail: React.FC< StatsEmptyActionProps > = ( { from } ) =>
 
 				// If the site is a Jetpack or Atomic site, use the Jetpack links.
 				// Otherwise, use the WordPress.com links.
-				let redirectUrl = localizeUrl( SUBSCRIBERS_NEWSLETTER_LANDING_PAGE_URL );
+				let redirectUrl = localizeUrl( NEWSLETTER_SUPPORT_URL );
 				if ( useJetpackLinks ) {
 					if ( isOdysseyStats ) {
 						redirectUrl = localizeUrl( JETPACK_SUPPORT_NEWSLETTER_URL );

--- a/client/my-sites/stats/features/modules/shared/stats-empty-action-email.tsx
+++ b/client/my-sites/stats/features/modules/shared/stats-empty-action-email.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { mail } from '@automattic/components/src/icons';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
@@ -7,7 +6,6 @@ import { useSelector } from 'react-redux';
 import EmptyStateAction from 'calypso/my-sites/stats/components/empty-state-action';
 import {
 	JETPACK_SUPPORT_NEWSLETTER_URL,
-	JETPACK_NEWSLETTER_LANDING_PAGE_URL,
 	NEWSLETTER_SUPPORT_URL,
 } from 'calypso/my-sites/stats/const';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
@@ -17,7 +15,6 @@ import type { StatsEmptyActionProps } from './';
 
 const StatsEmptyActionEmail: React.FC< StatsEmptyActionProps > = ( { from } ) => {
 	const translate = useTranslate();
-	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const siteId = useSelector( getSelectedSiteId );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state as any, siteId ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state as any, siteId ) );
@@ -38,11 +35,7 @@ const StatsEmptyActionEmail: React.FC< StatsEmptyActionProps > = ( { from } ) =>
 				// Otherwise, use the WordPress.com links.
 				let redirectUrl = localizeUrl( NEWSLETTER_SUPPORT_URL );
 				if ( useJetpackLinks ) {
-					if ( isOdysseyStats ) {
-						redirectUrl = localizeUrl( JETPACK_SUPPORT_NEWSLETTER_URL );
-					} else {
-						redirectUrl = localizeUrl( JETPACK_NEWSLETTER_LANDING_PAGE_URL );
-					}
+					redirectUrl = localizeUrl( JETPACK_SUPPORT_NEWSLETTER_URL );
 				}
 
 				setTimeout( () => ( window.location.href = redirectUrl ), 250 );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/loop/issues/470

## Proposed Changes

* Redirects to WordPress.com newsletter landing page when on simple site
* Redirectes to Jetpack newsletter landing page if site is jetpack or atomic

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to calypso.live `stats/subscribers/{test site}` where test site is a simple site - confirm it goes to https://wordpress.com/learn/courses/newsletters-101/start-here/
* Go to calypso.live `stats/subscribers/{test site}` where test site is a jetpack/atomic site - confirm it goes to https://jetpack.com/newsletter/

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
