### PR TITLE
[SiteAdmin]: Introduce the first batch of core-copy components

### DIFF
--- a/packages/site-admin/CHANGELOG.md
+++ b/packages/site-admin/CHANGELOG.md
@@ -1,4 +1,4 @@
 ## Next
 
 - Introduce package. Create skeleton.
-- Expose [getMeta()](./src/utils/meta/README.md)
+- Added new sidebar navigation components ported from Gutenberg core

--- a/packages/site-admin/package.json
+++ b/packages/site-admin/package.json
@@ -60,6 +60,7 @@
 		"@wordpress/base-styles": "^5.17.0",
 		"@wordpress/components": "^29.4.0",
 		"@wordpress/core-data": "^7.17.0",
+		"@wordpress/element": "^6.18.0",
 		"@wordpress/i18n": "^5.17.0",
 		"@wordpress/icons": "^10.17.0",
 		"clsx": "^2.1.1"

--- a/packages/site-admin/package.json
+++ b/packages/site-admin/package.json
@@ -58,6 +58,7 @@
 	},
 	"dependencies": {
 		"@wordpress/base-styles": "^5.17.0",
+		"@wordpress/components": "^29.4.0",
 		"@wordpress/core-data": "^7.17.0",
 		"@wordpress/i18n": "^5.17.0",
 		"@wordpress/icons": "^10.17.0",

--- a/packages/site-admin/package.json
+++ b/packages/site-admin/package.json
@@ -60,6 +60,7 @@
 		"@wordpress/base-styles": "^5.17.0",
 		"@wordpress/components": "^29.4.0",
 		"@wordpress/core-data": "^7.17.0",
+		"@wordpress/dom": "4.16.0",
 		"@wordpress/element": "^6.18.0",
 		"@wordpress/i18n": "^5.17.0",
 		"@wordpress/icons": "^10.17.0",

--- a/packages/site-admin/package.json
+++ b/packages/site-admin/package.json
@@ -63,6 +63,7 @@
 		"@wordpress/element": "^6.18.0",
 		"@wordpress/i18n": "^5.17.0",
 		"@wordpress/icons": "^10.17.0",
+		"@wordpress/router": "^1.16.0",
 		"clsx": "^2.1.1"
 	}
 }

--- a/packages/site-admin/src/components/sidebar-button/index.js
+++ b/packages/site-admin/src/components/sidebar-button/index.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+
+export default function SidebarButton( props ) {
+	return (
+		<Button
+			size="compact"
+			{ ...props }
+			className={ clsx( 'edit-site-sidebar-button', props.className ) }
+		/>
+	);
+}

--- a/packages/site-admin/src/components/sidebar-button/style.scss
+++ b/packages/site-admin/src/components/sidebar-button/style.scss
@@ -1,0 +1,24 @@
+.edit-site-sidebar-button {
+	color: $gray-200;
+	flex-shrink: 0;
+
+	// Focus (resets default button focus and use focus-visible).
+	&:focus:not(:disabled) {
+		box-shadow: none;
+		outline: none;
+	}
+	&:focus-visible:not(:disabled) {
+		box-shadow:
+			0 0 0 var(--wp-admin-border-width-focus)
+			var(--wp-admin-theme-color);
+		outline: 3px solid transparent;
+	}
+
+	&:hover:not(:disabled,[aria-disabled="true"]),
+	&:focus-visible,
+	&:focus,
+	&:not(:disabled,[aria-disabled="true"]):active,
+	&[aria-expanded="true"] {
+		color: $gray-100;
+	}
+}

--- a/packages/site-admin/src/components/sidebar-navigation-item/index.js
+++ b/packages/site-admin/src/components/sidebar-navigation-item/index.js
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import {
+	__experimentalItem as Item,
+	__experimentalHStack as HStack,
+	FlexBlock,
+} from '@wordpress/components';
+import { useContext } from '@wordpress/element';
+import { isRTL } from '@wordpress/i18n';
+import { chevronRightSmall, chevronLeftSmall, Icon } from '@wordpress/icons';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import clsx from 'clsx';
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import { SidebarNavigationContext } from '../sidebar';
+
+const { useHistory, useLink } = unlock( routerPrivateApis );
+
+export default function SidebarNavigationItem( {
+	className,
+	icon,
+	withChevron = false,
+	suffix,
+	uid,
+	to,
+	onClick,
+	children,
+	...props
+} ) {
+	const history = useHistory();
+	const { navigate } = useContext( SidebarNavigationContext );
+	// If there is no custom click handler, create one that navigates to `params`.
+	function handleClick( e ) {
+		if ( onClick ) {
+			onClick( e );
+			navigate( 'forward' );
+		} else if ( to ) {
+			e.preventDefault();
+			history.navigate( to );
+			navigate( 'forward', `[id="${ uid }"]` );
+		}
+	}
+	const linkProps = useLink( to );
+
+	return (
+		<Item
+			className={ clsx(
+				'edit-site-sidebar-navigation-item',
+				{ 'with-suffix': ! withChevron && suffix },
+				className
+			) }
+			id={ uid }
+			onClick={ handleClick }
+			href={ to ? linkProps.href : undefined }
+			{ ...props }
+		>
+			<HStack justify="flex-start">
+				{ icon && <Icon style={ { fill: 'currentcolor' } } icon={ icon } size={ 24 } /> }
+				<FlexBlock>{ children }</FlexBlock>
+				{ withChevron && (
+					<Icon
+						icon={ isRTL() ? chevronLeftSmall : chevronRightSmall }
+						className="edit-site-sidebar-navigation-item__drilldown-indicator"
+						size={ 24 }
+					/>
+				) }
+				{ ! withChevron && suffix }
+			</HStack>
+		</Item>
+	);
+}

--- a/packages/site-admin/src/components/sidebar-navigation-item/style.scss
+++ b/packages/site-admin/src/components/sidebar-navigation-item/style.scss
@@ -1,0 +1,41 @@
+.edit-site-sidebar-navigation-item.components-item {
+	color: $gray-600;
+	// 6px right padding to align with + button
+	padding: $grid-unit-10 6px $grid-unit-10 $grid-unit-20;
+	border: none;
+	min-height: $grid-unit-50;
+
+	&:hover,
+	&:focus,
+	&[aria-current="true"] {
+		color: $gray-200;
+
+		.edit-site-sidebar-navigation-item__drilldown-indicator {
+			fill: $gray-200;
+		}
+	}
+
+	&[aria-current="true"] {
+		background: $gray-800;
+		color: $white;
+		font-weight: $font-weight-medium;
+	}
+
+	// Make sure the focus style is drawn on top of the current item background.
+	&:focus-visible {
+		transform: translateZ(0);
+	}
+
+	.edit-site-sidebar-navigation-item__drilldown-indicator {
+		fill: $gray-600;
+	}
+
+	&.with-suffix {
+		padding-right: $grid-unit-20;
+	}
+}
+
+.edit-site-sidebar-navigation-screen__content .block-editor-list-view-block-select-button {
+	cursor: grab;
+	padding: $grid-unit-10 $grid-unit-10 $grid-unit-10 0;
+}

--- a/packages/site-admin/src/components/sidebar-navigation-screen/index.js
+++ b/packages/site-admin/src/components/sidebar-navigation-screen/index.js
@@ -1,0 +1,118 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalHeading as Heading,
+} from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { useContext } from '@wordpress/element';
+import { isRTL, __, sprintf } from '@wordpress/i18n';
+import { chevronRight, chevronLeft } from '@wordpress/icons';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import clsx from 'clsx';
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import { store as editSiteStore } from '../../store';
+import { isPreviewingTheme, currentlyPreviewingTheme } from '../../utils/is-previewing-theme';
+import { SidebarNavigationContext } from '../sidebar';
+import SidebarButton from '../sidebar-button';
+
+const { useHistory, useLocation } = unlock( routerPrivateApis );
+
+export default function SidebarNavigationScreen( {
+	isRoot,
+	title,
+	actions,
+	content,
+	footer,
+	description,
+	backPath: backPathProp,
+} ) {
+	const { dashboardLink, dashboardLinkText, previewingThemeName } = useSelect( ( select ) => {
+		const { getSettings } = unlock( select( editSiteStore ) );
+		const currentlyPreviewingThemeId = currentlyPreviewingTheme();
+		return {
+			dashboardLink: getSettings().__experimentalDashboardLink,
+			dashboardLinkText: getSettings().__experimentalDashboardLinkText,
+			// Do not call `getTheme` with null, it will cause a request to
+			// the server.
+			previewingThemeName: currentlyPreviewingThemeId
+				? select( coreStore ).getTheme( currentlyPreviewingThemeId )?.name?.rendered
+				: undefined,
+		};
+	}, [] );
+	const location = useLocation();
+	const history = useHistory();
+	const { navigate } = useContext( SidebarNavigationContext );
+	const backPath = backPathProp ?? location.state?.backPath;
+	const icon = isRTL() ? chevronRight : chevronLeft;
+
+	return (
+		<>
+			<VStack
+				className={ clsx( 'edit-site-sidebar-navigation-screen__main', {
+					'has-footer': !! footer,
+				} ) }
+				spacing={ 0 }
+				justify="flex-start"
+			>
+				<HStack
+					spacing={ 3 }
+					alignment="flex-start"
+					className="edit-site-sidebar-navigation-screen__title-icon"
+				>
+					{ ! isRoot && (
+						<SidebarButton
+							onClick={ () => {
+								history.navigate( backPath );
+								navigate( 'back' );
+							} }
+							icon={ icon }
+							label={ __( 'Back' ) }
+							showTooltip={ false }
+						/>
+					) }
+					{ isRoot && (
+						<SidebarButton
+							icon={ icon }
+							label={ dashboardLinkText || __( 'Go to the Dashboard' ) }
+							href={ dashboardLink }
+						/>
+					) }
+					<Heading
+						className="edit-site-sidebar-navigation-screen__title"
+						color={ '#e0e0e0' /* $gray-200 */ }
+						level={ 1 }
+						size={ 20 }
+					>
+						{ ! isPreviewingTheme()
+							? title
+							: sprintf(
+									/* translators: 1: theme name. 2: title */
+									__( 'Previewing %1$s: %2$s' ),
+									previewingThemeName,
+									title
+							  ) }
+					</Heading>
+					{ actions && (
+						<div className="edit-site-sidebar-navigation-screen__actions">{ actions }</div>
+					) }
+				</HStack>
+				<div className="edit-site-sidebar-navigation-screen__content">
+					{ description && (
+						<div className="edit-site-sidebar-navigation-screen__description">{ description }</div>
+					) }
+					{ content }
+				</div>
+			</VStack>
+			{ footer && (
+				<footer className="edit-site-sidebar-navigation-screen__footer">{ footer }</footer>
+			) }
+		</>
+	);
+}

--- a/packages/site-admin/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/site-admin/src/components/sidebar-navigation-screen/style.scss
@@ -1,0 +1,115 @@
+.edit-site-sidebar-navigation-screen {
+	display: flex;
+	flex-direction: column;
+	overflow-x: unset !important;
+	position: relative;
+}
+
+.edit-site-sidebar-navigation-screen__main {
+	// Ensure the sidebar is always at least as tall as the viewport.
+	// This allows the footer section to be sticky at the bottom of the viewport.
+	flex-grow: 1;
+	margin-bottom: $grid-unit-20;
+	&.has-footer {
+		margin-bottom: 0;
+	}
+}
+
+.edit-site-sidebar-navigation-screen__content {
+	padding: 0 $grid-unit-20;
+
+	.components-text {
+		color: $gray-400;
+	}
+
+	.components-heading {
+		margin-bottom: $grid-unit-10;
+	}
+}
+
+.edit-site-sidebar-navigation-screen__title-icon {
+	position: sticky;
+	top: 0;
+	background: $gray-900;
+	padding-top: $grid-unit-60;
+	margin-bottom: $grid-unit-10;
+	padding-bottom: $grid-unit-10;
+	z-index: z-index(".edit-site-sidebar-navigation-screen__title-icon");
+}
+
+.edit-site-sidebar-navigation-screen__title {
+	flex-grow: 1;
+	overflow-wrap: break-word;
+
+	&#{&},
+	&#{&} .edit-site-sidebar-navigation-screen__title {
+		line-height: $font-line-height-x-large;
+	}
+}
+
+.edit-site-sidebar-navigation-screen__actions {
+	display: flex;
+	flex-shrink: 0;
+}
+
+.edit-site-sidebar-navigation-screen__content .edit-site-global-styles-variations_item {
+
+	// Use a white outline to provide contrast with the dark background.
+	.edit-site-global-styles-variations_item-preview {
+		outline-color: rgba($white, 0.05);
+	}
+
+	&:not(.is-active):hover .edit-site-global-styles-variations_item-preview {
+		outline-color: rgba($white, 0.15);
+	}
+
+	&.is-active .edit-site-global-styles-variations_item-preview {
+		outline-color: $white;
+	}
+
+	&:focus-visible .edit-site-global-styles-variations_item-preview {
+		outline-color: var(--wp-admin-theme-color);
+	}
+}
+
+.edit-site-sidebar-navigation-screen__footer {
+	position: sticky;
+	bottom: 0;
+	background-color: $gray-900;
+	gap: 0;
+	padding: $grid-unit-10 $grid-unit-20;
+	margin: $grid-unit-20 0 0;
+	border-top: 1px solid $gray-800;
+
+	.edit-site-sidebar-navigation-screen-details-footer {
+		margin-left: -$grid-unit-20;
+		margin-right: -$grid-unit-20;
+	}
+}
+
+/* In general style overrides are discouraged.
+ * This is a temporary solution to override the InputControl component's styles.
+ * The `Theme` component will potentially be the more appropriate approach
+ * once that component is stabilized.
+ * See: packages/components/src/theme
+ */
+.edit-site-sidebar-navigation-screen__input-control {
+	width: 100%;
+	.components-input-control__container {
+		background: $gray-800;
+
+		.components-button {
+			color: $gray-200 !important;
+		}
+	}
+	.components-input-control__input {
+		color: $gray-200 !important;
+		background: $gray-800 !important;
+	}
+	.components-input-control__backdrop {
+		border: 4px !important;
+	}
+	.components-base-control__help {
+		color: $gray-600;
+	}
+}

--- a/packages/site-admin/src/components/sidebar/index.js
+++ b/packages/site-admin/src/components/sidebar/index.js
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import { focus } from '@wordpress/dom';
+import { createContext, useContext, useState, useRef, useLayoutEffect } from '@wordpress/element';
+import clsx from 'clsx';
+
+export const SidebarNavigationContext = createContext( () => {} );
+// Focus a sidebar element after a navigation. The element to focus is either
+// specified by `focusSelector` (when navigating back) or it is the first
+// tabbable element (usually the "Back" button).
+function focusSidebarElement( el, direction, focusSelector ) {
+	let elementToFocus;
+	if ( direction === 'back' && focusSelector ) {
+		elementToFocus = el.querySelector( focusSelector );
+	}
+	if ( direction !== null && ! elementToFocus ) {
+		const [ firstTabbable ] = focus.tabbable.find( el );
+		elementToFocus = firstTabbable ?? el;
+	}
+	elementToFocus?.focus();
+}
+
+// Navigation state that is updated when navigating back or forward. Helps us
+// manage the animations and also focus.
+function createNavState() {
+	let state = {
+		direction: null,
+		focusSelector: null,
+	};
+
+	return {
+		get() {
+			return state;
+		},
+		navigate( direction, focusSelector = null ) {
+			state = {
+				direction,
+				focusSelector:
+					direction === 'forward' && focusSelector ? focusSelector : state.focusSelector,
+			};
+		},
+	};
+}
+
+function SidebarContentWrapper( { children, shouldAnimate } ) {
+	const navState = useContext( SidebarNavigationContext );
+	const wrapperRef = useRef();
+	const [ navAnimation, setNavAnimation ] = useState( null );
+
+	useLayoutEffect( () => {
+		const { direction, focusSelector } = navState.get();
+		focusSidebarElement( wrapperRef.current, direction, focusSelector );
+		setNavAnimation( direction );
+	}, [ navState ] );
+
+	const wrapperCls = clsx(
+		'edit-site-sidebar__screen-wrapper',
+		/*
+		 * Some panes do not have sub-panes and therefore
+		 * should not animate when clicked on.
+		 */
+		shouldAnimate
+			? {
+					'slide-from-left': navAnimation === 'back',
+					'slide-from-right': navAnimation === 'forward',
+			  }
+			: {}
+	);
+
+	return (
+		<div ref={ wrapperRef } className={ wrapperCls }>
+			{ children }
+		</div>
+	);
+}
+
+export default function SidebarContent( { routeKey, shouldAnimate, children } ) {
+	const [ navState ] = useState( createNavState );
+
+	return (
+		<SidebarNavigationContext.Provider value={ navState }>
+			<div className="edit-site-sidebar__content">
+				<SidebarContentWrapper shouldAnimate={ shouldAnimate } key={ routeKey }>
+					{ children }
+				</SidebarContentWrapper>
+			</div>
+		</SidebarNavigationContext.Provider>
+	);
+}

--- a/packages/site-admin/src/components/sidebar/style.scss
+++ b/packages/site-admin/src/components/sidebar/style.scss
@@ -1,0 +1,63 @@
+.edit-site-sidebar__content {
+	flex-grow: 1;
+	overflow-y: auto;
+	// Prevents horizontal overflow while animating screen transitions
+	overflow-x: hidden;
+	// Mark this section of the DOM as isolated, providing performance benefits
+	// by limiting calculations of layout, style and paint to a DOM subtree rather
+	// than the entire page.
+	contain: content;
+}
+
+@keyframes local--slide-from-right {
+	from {
+		transform: translateX(50px);
+		opacity: 0;
+	}
+	to {
+		transform: none;
+		opacity: 1;
+	}
+}
+
+@keyframes local--slide-from-left {
+	from {
+		transform: translateX(-50px);
+		opacity: 0;
+	}
+	to {
+		transform: none;
+		opacity: 1;
+	}
+}
+
+.edit-site-sidebar__screen-wrapper {
+	overflow-x: auto;
+	@include custom-scrollbars-on-hover(transparent, $gray-700);
+	scrollbar-gutter: stable;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	max-height: 100%;
+
+	// This matches the logo padding
+	padding: 0 $grid-unit-15;
+
+	// Animation
+	animation-duration: 0.14s;
+	animation-timing-function: ease-in-out;
+	will-change: transform, opacity;
+
+	@media ( prefers-reduced-motion: reduce ) {
+		animation-duration: 0s;
+	}
+
+	&.slide-from-left {
+		animation-name: local--slide-from-left;
+	}
+
+	&.slide-from-right {
+		animation-name: local--slide-from-right;
+	}
+
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1850,6 +1850,7 @@ __metadata:
     "@wordpress/element": "npm:^6.18.0"
     "@wordpress/i18n": "npm:^5.17.0"
     "@wordpress/icons": "npm:^10.17.0"
+    "@wordpress/router": "npm:^1.16.0"
     clsx: "npm:^2.1.1"
     copyfiles: "npm:^2.4.1"
     postcss: "npm:^8.4.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1847,6 +1847,7 @@ __metadata:
     "@wordpress/base-styles": "npm:^5.17.0"
     "@wordpress/components": "npm:^29.4.0"
     "@wordpress/core-data": "npm:^7.17.0"
+    "@wordpress/element": "npm:^6.18.0"
     "@wordpress/i18n": "npm:^5.17.0"
     "@wordpress/icons": "npm:^10.17.0"
     clsx: "npm:^2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1845,6 +1845,7 @@ __metadata:
     "@storybook/cli": "npm:^7.6.20"
     "@storybook/react": "npm:^7.6.20"
     "@wordpress/base-styles": "npm:^5.17.0"
+    "@wordpress/components": "npm:^29.4.0"
     "@wordpress/core-data": "npm:^7.17.0"
     "@wordpress/i18n": "npm:^5.17.0"
     "@wordpress/icons": "npm:^10.17.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1847,6 +1847,7 @@ __metadata:
     "@wordpress/base-styles": "npm:^5.17.0"
     "@wordpress/components": "npm:^29.4.0"
     "@wordpress/core-data": "npm:^7.17.0"
+    "@wordpress/dom": "npm:4.16.0"
     "@wordpress/element": "npm:^6.18.0"
     "@wordpress/i18n": "npm:^5.17.0"
     "@wordpress/icons": "npm:^10.17.0"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR introduces exact copies of components developed in Gutenberg core to enhance our site admin functionality.

## New Dependencies Added
- `@wordpress/dom` (version 4.16.0)
- `@wordpress/router` (version 1.16.0)
- `clsx` (version 2.1.1)

## New Components Added
1. **SidebarButton**
   - A customized button component for sidebar navigation with specialized styling and focus handling

2. **SidebarNavigationItem**
   - Navigation item component with chevron indicators and routing capabilities
   - Supports custom click handlers and navigation state management

3. **SidebarNavigationScreen**
   - Screen component for sidebar navigation with title, content, and footer sections
   - Supports back navigation and theme preview display

4. **Sidebar**
   - Core sidebar component with navigation context provider
   - Handles animations and focus management between navigation states
   - Includes utility functions for navigation state management

These components are direct ports from Gutenberg core, maintaining their original functionality while integrating with our site admin package. The implementation includes all necessary styling and interaction patterns to ensure consistent behavior with the Gutenberg editor experience.

Related to #

## Proposed Changes

* [SiteAdmin]: Introduce the first batch of core-copy components

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Since these components are not currently used in the application, testing this PR involves only a visual review of the code. We will adapt and utilize them in future PRs as we continue to enhance the sidebar navigation functionality.

At this stage, functional testing is not required. We are simply introducing the component structure that will serve as the foundation for upcoming features.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
