### PR TITLE
Import: Replace LoadingEllipsis with Loading component and update styles

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -11,7 +11,7 @@ import { getImporterTypeForEngine } from 'calypso/blocks/importer/util';
 import { retrieveMigrationStatus } from 'calypso/blocks/importer/wordpress/utils';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySites from 'calypso/components/data/query-sites';
-import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import Loading from 'calypso/components/loading';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSaveHostingFlowPathStep } from 'calypso/landing/stepper/hooks/use-save-hosting-flow-path-step';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
@@ -171,7 +171,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 			if ( isLoading() ) {
 				return (
 					<div className="import-layout__center">
-						<LoadingEllipsis />
+						<Loading />
 					</div>
 				);
 			} else if ( ! siteSlug || ! site || ! siteId ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/style.scss
@@ -26,6 +26,10 @@
 			display: block;
 			margin: auto;
 		}
+
+		.wpcom__loading {
+			margin: 0 auto;
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Update progressbar for import screen

![CleanShot 2025-02-27 at 11 32 09@2x](https://github.com/user-attachments/assets/ca9fd4d6-20ad-4a31-8506-7f1cd0dd81ed)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Align loading state UX

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout or use live link
* Navigate to `/sites`, click the `Add new site` dropdown and select `Import`
* Click `pick your current platform from a list`
* Click any option such as `Blogger` and verify you see the loading progressbar before it transitiions to the import content page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
