### PR TITLE
Employ the use_goals parameter when fetching launchpad tasks

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -169,16 +169,6 @@ const siteSetupFlow: FlowV1 = {
 			);
 		};
 
-		const getEnableFeaturesForGoals = () => {
-			const featuresForGoals: Onboard.SiteGoal[] = [];
-
-			if ( configApi.isEnabled( 'onboarding/enable-write-goal-features' ) ) {
-				featuresForGoals.push( Onboard.SiteGoal.Write );
-			}
-
-			return featuresForGoals.length > 0 ? featuresForGoals : undefined;
-		};
-
 		const exitFlow = ( to: string, options: ExitFlowOptions = {} ) => {
 			setPendingAction( () => {
 				/**
@@ -235,7 +225,7 @@ const siteSetupFlow: FlowV1 = {
 
 					formData.push( [ 'settings', JSON.stringify( settings ) ] );
 
-					const enableFeaturesForGoals = getEnableFeaturesForGoals();
+					const enableFeaturesForGoals = Onboard.utils.getEnableFeaturesForGoals( configApi );
 
 					if ( enableFeaturesForGoals ) {
 						formData.push( [

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -1,4 +1,6 @@
+import configApi from '@automattic/calypso-config';
 import { Button, CircularProgressBar, Gridicon } from '@automattic/components';
+import { Onboard } from '@automattic/data-stores';
 import { Launchpad } from '@automattic/launchpad';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -88,6 +90,10 @@ const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( {
 				checklistSlug={ checklistSlug }
 				launchpadContext={ launchpadContext }
 				onSiteLaunched={ onSiteLaunched }
+				options={ {
+					useGoals: true,
+					enableFeaturesForGoals: Onboard.utils.getEnableFeaturesForGoals( configApi ),
+				} }
 			/>
 		</div>
 	);

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,5 +1,6 @@
+import configApi from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { fetchLaunchpad } from '@automattic/data-stores';
+import { Onboard, fetchLaunchpad } from '@automattic/data-stores';
 import { areLaunchpadTasksCompleted } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper';
 import { isRemovedFlow } from 'calypso/landing/stepper/utils/flow-redirect-handler';
 import { getQueryArgs } from 'calypso/lib/query-args';
@@ -88,7 +89,10 @@ export async function maybeRedirect( context, next ) {
 			launchpad_screen: launchpadScreenOption,
 			site_intent: siteIntentOption,
 			checklist: launchpadChecklist,
-		} = await fetchLaunchpad( slug );
+		} = await fetchLaunchpad( slug, null, null, {
+			useGoals: true,
+			enableFeaturesForGoals: Onboard.utils.getEnableFeaturesForGoals( configApi ),
+		} );
 
 		const shouldShowLaunchpad = ! isRemovedFlow( siteIntentOption );
 

--- a/packages/data-stores/src/onboard/utils.ts
+++ b/packages/data-stores/src/onboard/utils.ts
@@ -1,3 +1,4 @@
+import { ConfigApi } from '@automattic/create-calypso-config';
 import { SiteGoal, SiteIntent } from './constants';
 
 interface Flags {
@@ -58,4 +59,14 @@ export const serializeGoals = ( goals: SiteGoal[] ): string => {
 	return ( firstGoal ? [ firstGoal ] : [] )
 		.concat( goals.filter( ( goal ) => goal !== firstGoal ).sort() )
 		.join( ',' );
+};
+
+export const getEnableFeaturesForGoals = ( configApi: ConfigApi ) => {
+	const featuresForGoals: SiteGoal[] = [];
+
+	if ( configApi.isEnabled( 'onboarding/enable-write-goal-features' ) ) {
+		featuresForGoals.push( SiteGoal.Write );
+	}
+
+	return featuresForGoals.length > 0 ? featuresForGoals : undefined;
 };

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import { Onboard } from '..';
 
 interface APIFetchOptions {
 	global: boolean;
@@ -59,12 +60,18 @@ type LaunchpadUpdateSettings = {
 
 export type UseLaunchpadOptions = {
 	onSuccess?: ( data: LaunchpadResponse ) => LaunchpadResponse;
-};
+} & FetchLaunchpadOptions;
+
+interface FetchLaunchpadOptions {
+	useGoals?: boolean;
+	enableFeaturesForGoals?: Onboard.SiteGoal[];
+}
 
 export const fetchLaunchpad = (
 	siteSlug: SiteSlug,
 	checklistSlug?: string | null,
-	launchpadContext?: string
+	launchpadContext?: string,
+	options: FetchLaunchpadOptions = {}
 ): Promise< LaunchpadResponse > => {
 	const slug = encodeURIComponent( siteSlug as string );
 	const checklistSlugEncoded = checklistSlug ? encodeURIComponent( checklistSlug ) : null;
@@ -73,6 +80,10 @@ export const fetchLaunchpad = (
 		_locale: 'user',
 		...( checklistSlug && { checklist_slug: checklistSlugEncoded } ),
 		...( launchpadContext && { launchpad_context: launchpadContextEncoded } ),
+		...( options.useGoals && { use_goals: true } ),
+		...( options.enableFeaturesForGoals && {
+			enable_features_for_goals: options.enableFeaturesForGoals,
+		} ),
 	};
 
 	return canAccessWpcomApis()
@@ -117,16 +128,15 @@ type SiteSlug = string | number | null;
 export const useLaunchpad = (
 	siteSlug: SiteSlug,
 	checklistSlug?: string | null,
-	options?: UseLaunchpadOptions,
+	{ onSuccess = defaultSuccessCallback, ...options }: UseLaunchpadOptions = {},
 	launchpad_context?: string | undefined
 ) => {
 	const key = getKey( siteSlug, checklistSlug );
-	const onSuccessCallback = options?.onSuccess || defaultSuccessCallback;
 
 	return useQuery( {
 		queryKey: key,
 		queryFn: () =>
-			fetchLaunchpad( siteSlug, checklistSlug, launchpad_context ).then( onSuccessCallback ),
+			fetchLaunchpad( siteSlug, checklistSlug, launchpad_context, options ).then( onSuccess ),
 		retry: 3,
 		initialData: {
 			site_intent: '',

--- a/packages/launchpad/src/launchpad.tsx
+++ b/packages/launchpad/src/launchpad.tsx
@@ -4,6 +4,7 @@ import {
 	type SiteSelect,
 	sortLaunchpadTasksByCompletionStatus,
 	useSortedLaunchpadTasks,
+	UseLaunchpadOptions,
 } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
 import { useState } from 'react';
@@ -22,6 +23,7 @@ type LaunchpadProps = {
 	onTaskClick?: EventHandlers[ 'onTaskClick' ];
 	onPostFilterTasks?: ( tasks: Task[] ) => Task[];
 	highlightNextAction?: boolean;
+	options?: UseLaunchpadOptions;
 };
 
 const Launchpad = ( {
@@ -32,6 +34,7 @@ const Launchpad = ( {
 	onTaskClick,
 	onPostFilterTasks,
 	highlightNextAction,
+	options,
 }: LaunchpadProps ) => {
 	const {
 		data: { checklist },
@@ -76,6 +79,7 @@ const Launchpad = ( {
 
 	const launchpadOptions = {
 		onSuccess: sortLaunchpadTasksByCompletionStatus,
+		...options,
 	};
 
 	if ( ! launchpadContext ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
