### PR TITLE
Help Center: Add scroll tracking for Help Center article sections

### DIFF
--- a/packages/help-center/src/components/help-center-article.tsx
+++ b/packages/help-center/src/components/help-center-article.tsx
@@ -79,7 +79,8 @@ export const HelpCenterArticle = () => {
 								blog_id: post?.site_ID,
 								section_id: entry?.target?.id,
 							};
-							recordTracksEvent( 'calypso_helpcenter_article_section_scroll_viewed', tracksData );
+							recordTracksEvent( 'calypso_helpcenter_article_section_view', tracksData );
+							observer.unobserve( entry.target ); // Unobserve after first intersection
 						}
 					} );
 				},
@@ -90,7 +91,7 @@ export const HelpCenterArticle = () => {
 			h2Elements.forEach( ( h2 ) => observer.observe( h2 ) );
 
 			return () => {
-				h2Elements.forEach( ( h2 ) => observer.unobserve( h2 ) );
+				observer.disconnect();
 			};
 		}
 	}, [ elementRef, post?.ID, post?.URL, post?.site_ID ] );

--- a/packages/help-center/src/components/help-center-article.tsx
+++ b/packages/help-center/src/components/help-center-article.tsx
@@ -64,6 +64,37 @@ export const HelpCenterArticle = () => {
 		}
 	}, [ post, query, sectionName ] );
 
+	// Trigger event for each section scrolled into view
+	useEffect( () => {
+		if ( elementRef.current ) {
+			const observer = new IntersectionObserver(
+				( entries ) => {
+					entries.forEach( ( entry ) => {
+						if ( entry.isIntersecting ) {
+							const tracksData = {
+								force_site_id: true,
+								location: 'help-center',
+								post_url: post?.URL,
+								post_id: post?.ID,
+								blog_id: post?.site_ID,
+								section_id: entry?.target?.id,
+							};
+							recordTracksEvent( 'calypso_helpcenter_article_section_scroll_viewed', tracksData );
+						}
+					} );
+				},
+				{ threshold: 0.1 }
+			);
+
+			const h2Elements = elementRef.current.querySelectorAll( 'h2' );
+			h2Elements.forEach( ( h2 ) => observer.observe( h2 ) );
+
+			return () => {
+				h2Elements.forEach( ( h2 ) => observer.unobserve( h2 ) );
+			};
+		}
+	}, [ elementRef, post?.ID, post?.URL, post?.site_ID ] );
+
 	return (
 		<div className="help-center-article" ref={ elementRef }>
 			{ ! error && <ArticleContent post={ post } isLoading={ isLoading } /> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/wp-calypso/issues/99589


## Proposed Changes

* Trigger event data tracking when article sections are scrolled into view
* Event name: `calypso_helpcenter_article_section_view`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Gather data on most view sections and potentially useful sections of articles. One benefit is creating more concise articles based on the data.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Use the browser network tab and verify the `calypso_helpcenter_article_section_scroll_viewed` is triggered with correct values

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
