### PR TITLE
Enable Focused Launchpad for all onboarding users

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -16,7 +16,7 @@ import { urlToSlug } from 'calypso/lib/url';
 import { useSelector, useDispatch } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
-import { useShouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
+import { shouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
 import { useQuery } from '../../../../hooks/use-query';
 import StepContent from './step-content';
 import { areLaunchpadTasksCompleted } from './task-helper';
@@ -92,11 +92,8 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 		}
 	}, [ verifiedParam, translate, dispatch ] );
 
-	const [ loadingShouldShowLaunchpadFirst, shouldShowLaunchpadFirst ] =
-		useShouldShowLaunchpadFirst( site );
-
 	// Avoid screen flickering when redirecting to other paths
-	if ( ! site?.options || loadingShouldShowLaunchpadFirst ) {
+	if ( ! site?.options ) {
 		return null;
 	}
 
@@ -105,7 +102,7 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 		return null;
 	}
 
-	if ( shouldShowLaunchpadFirst ) {
+	if ( shouldShowLaunchpadFirst( site ) ) {
 		window.location.replace( `/home/${ siteSlug }` );
 		return null;
 	}

--- a/client/my-sites/customer-home/main.tsx
+++ b/client/my-sites/customer-home/main.tsx
@@ -5,16 +5,13 @@ import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { useShouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
+import { shouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
 import CelebrateLaunchModal from './components/celebrate-launch-modal';
 import { FullScreenLaunchpad } from './components/full-screen-launchpad';
 import HomeContent from './components/home-content';
 import type { SiteDetails } from '@automattic/data-stores';
 
 export default function CustomerHome( { site }: { site: SiteDetails } ) {
-	const [ isLoadingShouldShowLaunchpadFirst, shouldShowLaunchpadFirst ] =
-		useShouldShowLaunchpadFirst( site );
-
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
 
 	const [ isFullLaunchpadDismissed, setIsFullLaunchpadDismissed ] = useState(
@@ -35,9 +32,9 @@ export default function CustomerHome( { site }: { site: SiteDetails } ) {
 		<Main wideLayout>
 			<PageViewTracker path="/home/:site" title={ translate( 'My Home' ) } />
 			<DocumentHead title={ translate( 'My Home' ) } />
-			{ ! isLoadingShouldShowLaunchpadFirst && (
+			{ site.options && (
 				<>
-					{ shouldShowLaunchpadFirst && ! isFullLaunchpadDismissed ? (
+					{ shouldShowLaunchpadFirst( site ) && ! isFullLaunchpadDismissed ? (
 						<FullScreenLaunchpad
 							onClose={ () => setIsFullLaunchpadDismissed( true ) }
 							onSiteLaunch={ () => {

--- a/client/state/selectors/should-show-launchpad-first.ts
+++ b/client/state/selectors/should-show-launchpad-first.ts
@@ -1,6 +1,4 @@
 import { SiteDetails, Onboard } from '@automattic/data-stores';
-import { useEffect, useState } from 'react';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
 
 const SiteIntent = Onboard.SiteIntent;
 
@@ -9,58 +7,13 @@ const SiteIntent = Onboard.SiteIntent;
  * @param site Site object
  * @returns Whether launchpad should be shown first
  */
-export const shouldShowLaunchpadFirst = async ( site: SiteDetails ): Promise< boolean > => {
+export const shouldShowLaunchpadFirst = ( site: SiteDetails ): boolean => {
 	const wasSiteCreatedOnboardingFlow = site.options?.site_creation_flow === 'onboarding';
-	const createdAfterExperimentStart =
-		( site.options?.created_at ?? '' ) > '2025-02-03T10:22:45+00:00'; // If created_at is null then this expression is false
 	const isBigSkyIntent = site?.options?.site_intent === SiteIntent.AIAssembler;
 
-	if ( isBigSkyIntent || ! wasSiteCreatedOnboardingFlow || ! createdAfterExperimentStart ) {
+	if ( isBigSkyIntent || ! wasSiteCreatedOnboardingFlow ) {
 		return false;
 	}
 
-	const assignment = await loadExperimentAssignment(
-		'calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131'
-	);
-
-	return assignment?.variationName === 'treatment_cumulative';
-};
-
-export const useShouldShowLaunchpadFirst = ( site?: SiteDetails | null ): [ boolean, boolean ] => {
-	const [ state, setState ] = useState< boolean | 'loading' >( 'loading' );
-
-	useEffect( () => {
-		let cancel = false;
-
-		const getResponse = async () => {
-			if ( ! site ) {
-				return;
-			}
-
-			try {
-				setState( 'loading' );
-				const result = await shouldShowLaunchpadFirst( site );
-				if ( ! cancel ) {
-					setState( result );
-				}
-			} catch ( err ) {
-				if ( ! cancel ) {
-					setState( false );
-				}
-			}
-		};
-
-		getResponse();
-
-		return () => {
-			cancel = true;
-		};
-	}, [ site ] );
-
-	if ( ! site ) {
-		// If the site isn't available yet we'll assume we're still loading
-		return [ true, false ];
-	}
-
-	return [ state === 'loading', state === 'loading' ? false : state ];
+	return true;
 };

--- a/client/state/selectors/test/should-show-launchpad-first.ts
+++ b/client/state/selectors/test/should-show-launchpad-first.ts
@@ -1,12 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-import { act, renderHook, waitFor } from '@testing-library/react';
 import { loadExperimentAssignment } from 'calypso/lib/explat';
-import {
-	shouldShowLaunchpadFirst,
-	useShouldShowLaunchpadFirst,
-} from '../should-show-launchpad-first';
+import { shouldShowLaunchpadFirst } from '../should-show-launchpad-first';
 import type { SiteDetails } from '@automattic/data-stores';
 
 jest.mock( 'calypso/lib/explat', () => ( {
@@ -25,27 +21,12 @@ describe( 'shouldShowLaunchpadFirst', () => {
 		const site = {
 			options: {
 				site_creation_flow: 'onboarding',
-				created_at: '2025-02-18T00:00:00+00:00',
 			},
 		} as SiteDetails;
 
 		expect( await shouldShowLaunchpadFirst( site ) ).toBe( true );
 	} );
 
-	it( 'should return false when site was created via onboarding flow but assigned to control', async () => {
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
-			variationName: 'control',
-		} );
-		const site = {
-			options: {
-				site_creation_flow: 'onboarding',
-				created_at: '2025-02-18T00:00:00+00:00',
-			},
-		} as SiteDetails;
-
-		expect( await shouldShowLaunchpadFirst( site ) ).toBe( false );
-	} );
-
 	it( 'should return false when site was not created via onboarding flow', async () => {
 		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
 			variationName: 'treatment_cumulative',
@@ -53,7 +34,6 @@ describe( 'shouldShowLaunchpadFirst', () => {
 		const site = {
 			options: {
 				site_creation_flow: 'other',
-				created_at: '2025-02-18T00:00:00+00:00',
 			},
 		} as SiteDetails;
 
@@ -65,107 +45,9 @@ describe( 'shouldShowLaunchpadFirst', () => {
 			variationName: 'treatment_cumulative',
 		} );
 		const site = {
-			options: {
-				created_at: '2025-02-18T00:00:00+00:00',
-			},
+			options: {},
 		} as SiteDetails;
 
 		expect( await shouldShowLaunchpadFirst( site ) ).toBe( false );
 	} );
 } );
-
-describe( 'useShouldShowLaunchpadFirst', () => {
-	it( 'returns loading state until promise resolves', async () => {
-		const { promise, resolve } = promiseWithResolvers();
-		( loadExperimentAssignment as jest.Mock ).mockReturnValue( promise );
-		const site = {
-			options: {
-				site_creation_flow: 'onboarding',
-				created_at: '2025-02-18T00:00:00+00:00',
-			},
-		} as SiteDetails;
-
-		const { result } = renderHook( () => useShouldShowLaunchpadFirst( site ) );
-
-		expect( result.current[ 0 ] ).toBe( true );
-
-		await act( () => resolve( { variationName: 'treatment_cumulative' } ) );
-
-		expect( result.current ).toEqual( [ false, true ] );
-	} );
-
-	it( 'should return true when site was created via onboarding flow and assigned to experiment', async () => {
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
-			variationName: 'treatment_cumulative',
-		} );
-		const site = {
-			options: {
-				site_creation_flow: 'onboarding',
-				created_at: '2025-02-18T00:00:00+00:00',
-			},
-		} as SiteDetails;
-
-		const { result } = renderHook( () => useShouldShowLaunchpadFirst( site ) );
-
-		await waitFor( () => expect( result.current ).toEqual( [ false, true ] ) );
-	} );
-
-	it( 'should return false when site was created via onboarding flow but assigned to control', async () => {
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
-			variationName: 'control',
-		} );
-		const site = {
-			options: {
-				site_creation_flow: 'onboarding',
-				created_at: '2025-02-18T00:00:00+00:00',
-			},
-		} as SiteDetails;
-
-		const { result } = renderHook( () => useShouldShowLaunchpadFirst( site ) );
-
-		await waitFor( () => expect( result.current ).toEqual( [ false, false ] ) );
-	} );
-
-	it( 'should return false when site was not created via onboarding flow', async () => {
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
-			variationName: 'treatment_cumulative',
-		} );
-		const site = {
-			options: {
-				site_creation_flow: 'other',
-				created_at: '2025-02-18T00:00:00+00:00',
-			},
-		} as SiteDetails;
-
-		const { result } = renderHook( () => useShouldShowLaunchpadFirst( site ) );
-
-		await waitFor( () => expect( result.current ).toEqual( [ false, false ] ) );
-	} );
-
-	it( 'should return false when site has no creation flow information', async () => {
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
-			variationName: 'treatment_cumulative',
-		} );
-		const site = {
-			options: {
-				created_at: '2025-02-18T00:00:00+00:00',
-			},
-		} as SiteDetails;
-
-		const { result } = renderHook( () => useShouldShowLaunchpadFirst( site ) );
-
-		await waitFor( () => expect( result.current ).toEqual( [ false, false ] ) );
-	} );
-} );
-
-// Our TS Config doesn't know the standard Promise.withResolvers is available
-// in our version of Node.
-function promiseWithResolvers() {
-	let resolve;
-	let reject;
-	const promise = new Promise( ( res, rej ) => {
-		resolve = res;
-		reject = rej;
-	} );
-	return { promise, resolve, reject };
-}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up of: https://github.com/Automattic/wp-calypso/pull/99914
Related to: https://github.com/Automattic/wp-calypso/issues/99879

## Proposed Changes

* We ended the experiment and Focused Launchpad was tied to `treatment_cumulative` group. Now we're releasing it to all onboarding users.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is primarily a cosmetic change, and we decided to have it available to all onboarding users. 
Slack thread: p1740604199288619-slack-C057AH42XQD

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Remove any cache you may have, or use an incognito tab
* Go to [/setup/onboarding](http://calypso.localhost:3000/setup/onboarding)
* Finish the onboarding, and you should see the Focused Launchpad:
![Screenshot 2025-02-26 at 19 03 16](https://github.com/user-attachments/assets/d04ffe24-5b2f-431b-8f5b-a81ef3c7da7b)


* When navigating back and forth on the /home page, you should keep seeing it until you either dismiss or launch your site.

* Make sure flows like [/start/personal/](http://calypso.localhost:3000/start/personal/) still use the old launchpad:

**Note**: Asked here to see if we should enable it to all flows: p1740608836896969/1740604199.288619-slack-C057AH42XQD


![image](https://github.com/user-attachments/assets/d4e553ba-6859-40fd-bdcc-a356932161e7)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?