### PR TITLE
Newsletter importer: Post import url on reset

### DIFF
--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -86,13 +86,12 @@ export const usePaidNewsletterQuery = (
 	engine: string,
 	currentStep: StepId,
 	siteId?: number,
-	autoRefresh?: boolean,
-	fromSite?: string
+	autoRefresh?: boolean
 ) => {
 	return useQuery( {
-		enabled: !! siteId && !! fromSite,
+		enabled: !! siteId,
 		// eslint-disable-next-line @tanstack/query/exhaustive-deps
-		queryKey: [ 'paid-newsletter-importer', siteId, engine, fromSite ],
+		queryKey: [ 'paid-newsletter-importer', siteId, engine ],
 		queryFn: (): Promise< PaidNewsletterData > => {
 			return wp.req.get(
 				{
@@ -102,7 +101,6 @@ export const usePaidNewsletterQuery = (
 				{
 					engine: engine,
 					current_step: currentStep,
-					import_url: fromSite,
 				}
 			);
 		},

--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -86,12 +86,13 @@ export const usePaidNewsletterQuery = (
 	engine: string,
 	currentStep: StepId,
 	siteId?: number,
-	autoRefresh?: boolean
+	autoRefresh?: boolean,
+	fromSite?: string
 ) => {
 	return useQuery( {
-		enabled: !! siteId,
+		enabled: !! siteId && !! fromSite,
 		// eslint-disable-next-line @tanstack/query/exhaustive-deps
-		queryKey: [ 'paid-newsletter-importer', siteId, engine ],
+		queryKey: [ 'paid-newsletter-importer', siteId, engine, fromSite ],
 		queryFn: (): Promise< PaidNewsletterData > => {
 			return wp.req.get(
 				{
@@ -101,6 +102,7 @@ export const usePaidNewsletterQuery = (
 				{
 					engine: engine,
 					current_step: currentStep,
+					import_url: fromSite,
 				}
 			);
 		},

--- a/client/data/paid-newsletter/use-reset-mutation.ts
+++ b/client/data/paid-newsletter/use-reset-mutation.ts
@@ -21,18 +21,16 @@ export const useResetMutation = (
 	const queryClient = useQueryClient();
 	const mutation = useMutation( {
 		mutationFn: async ( { siteId, engine, currentStep, import_url }: MutationVariables ) => {
-			const params = {
-				engine,
-				current_step: currentStep,
-				...( import_url && { import_url } ),
-			};
-
 			const response = await wp.req.post(
 				{
 					path: `/sites/${ siteId }/site-importer/paid-newsletter/reset`,
 					apiNamespace: 'wpcom/v2',
 				},
-				params
+				{
+					engine: engine,
+					current_step: currentStep,
+					...( import_url && { import_url } ),
+				}
 			);
 
 			if ( ! response.current_step ) {

--- a/client/data/paid-newsletter/use-reset-mutation.ts
+++ b/client/data/paid-newsletter/use-reset-mutation.ts
@@ -21,16 +21,18 @@ export const useResetMutation = (
 	const queryClient = useQueryClient();
 	const mutation = useMutation( {
 		mutationFn: async ( { siteId, engine, currentStep, import_url }: MutationVariables ) => {
+			const params = {
+				engine,
+				current_step: currentStep,
+				...( import_url && { import_url } ),
+			};
+
 			const response = await wp.req.post(
 				{
 					path: `/sites/${ siteId }/site-importer/paid-newsletter/reset`,
 					apiNamespace: 'wpcom/v2',
 				},
-				{
-					engine: engine,
-					current_step: currentStep,
-					import_url: import_url,
-				}
+				params
 			);
 
 			if ( ! response.current_step ) {
@@ -52,7 +54,12 @@ export const useResetMutation = (
 
 	const resetPaidNewsletter = useCallback(
 		( siteId: number, engine: string, currentStep: StepId, import_url?: string ) =>
-			mutate( { siteId, engine, currentStep, import_url } ),
+			mutate( {
+				siteId,
+				engine,
+				currentStep,
+				...( import_url && { import_url } ),
+			} ),
 		[ mutate ]
 	);
 

--- a/client/data/paid-newsletter/use-reset-mutation.ts
+++ b/client/data/paid-newsletter/use-reset-mutation.ts
@@ -12,6 +12,7 @@ interface MutationVariables {
 	siteId: number;
 	engine: string;
 	currentStep: StepId;
+	import_url?: string;
 }
 
 export const useResetMutation = (
@@ -19,7 +20,7 @@ export const useResetMutation = (
 ) => {
 	const queryClient = useQueryClient();
 	const mutation = useMutation( {
-		mutationFn: async ( { siteId, engine, currentStep }: MutationVariables ) => {
+		mutationFn: async ( { siteId, engine, currentStep, import_url }: MutationVariables ) => {
 			const response = await wp.req.post(
 				{
 					path: `/sites/${ siteId }/site-importer/paid-newsletter/reset`,
@@ -28,6 +29,7 @@ export const useResetMutation = (
 				{
 					engine: engine,
 					current_step: currentStep,
+					import_url: import_url,
 				}
 			);
 
@@ -49,8 +51,8 @@ export const useResetMutation = (
 	const { mutate } = mutation;
 
 	const resetPaidNewsletter = useCallback(
-		( siteId: number, engine: string, currentStep: StepId ) =>
-			mutate( { siteId, engine, currentStep } ),
+		( siteId: number, engine: string, currentStep: StepId, import_url?: string ) =>
+			mutate( { siteId, engine, currentStep, import_url } ),
 		[ mutate ]
 	);
 

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -76,7 +76,8 @@ export default function NewsletterImporter( {
 		engine,
 		step,
 		selectedSite?.ID,
-		autoFetchData
+		autoFetchData,
+		fromSite
 	);
 
 	useEffect( () => {

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -76,8 +76,7 @@ export default function NewsletterImporter( {
 		engine,
 		step,
 		selectedSite?.ID,
-		autoFetchData,
-		fromSite
+		autoFetchData
 	);
 
 	useEffect( () => {
@@ -124,7 +123,7 @@ export default function NewsletterImporter( {
 	useEffect( () => {
 		if ( urlData?.platform === engine ) {
 			if ( selectedSite && shouldResetImport && validFromSite === false ) {
-				resetPaidNewsletter( selectedSite.ID, engine, stepSlugs[ 0 ] );
+				resetPaidNewsletter( selectedSite.ID, engine, stepSlugs[ 0 ], fromSite );
 				setShouldResetImport( false );
 				window.history.replaceState(
 					null,

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -60,7 +60,7 @@ export default function Summary( {
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite.ID ) );
 	const siteAdmminUrl = useSelector( ( state ) => getSiteAdminUrl( state, selectedSite.ID ) );
 
-	const resetImporter = () => resetPaidNewsletter( selectedSite.ID, engine, 'content' );
+	const resetImporter = () => resetPaidNewsletter( selectedSite.ID, engine, 'content', fromSite );
 	const paidSubscribersCount = parseInt(
 		steps.subscribers.content?.meta?.paid_subscribed_count || '0'
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/479

## Proposed Changes

* Post the user-entered import url to the endpoint on reset, so that it's available for import logging.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To enhance the information available during the import.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/import/newsletter/substack/{site url}`
* Open your browser's Network tab.
* Enter a Substack URL. Let me know if you need one to test.
* Click to continue.
* Check that the reset POST request payload includes the URL.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
