### PR TITLE
Reader: Add from param while sending verification email

### DIFF
--- a/client/blocks/follow-button/index.jsx
+++ b/client/blocks/follow-button/index.jsx
@@ -15,7 +15,7 @@ function FollowButtonContainer( props ) {
 	const following = useSelector( ( state ) => isFollowing( state, { feedUrl: props.siteUrl } ) );
 
 	const dispatch = useDispatch();
-	const resendEmailVerification = useResendEmailVerification();
+	const resendEmailVerification = useResendEmailVerification( { from: 'wpcom-reader' } );
 	const translate = useTranslate();
 
 	const handleFollowToggle = ( followingSite ) => {

--- a/client/landing/stepper/hooks/use-resend-email-verification.ts
+++ b/client/landing/stepper/hooks/use-resend-email-verification.ts
@@ -1,12 +1,17 @@
 import { useTranslate } from 'i18n-calypso';
+import {
+	ResendEmailVerificationBody,
+	useSendEmailVerification,
+} from 'calypso/landing/stepper/hooks/use-send-email-verification';
 import { useDispatch } from 'calypso/state';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
-import { useSendEmailVerification } from './use-send-email-verification';
 
-export function useResendEmailVerification() {
+export function useResendEmailVerification(
+	body: ResendEmailVerificationBody
+): () => Promise< void > {
 	const resendEmailNotice = 'resend-verification-email';
 	const dispatch = useDispatch();
-	const resendEmail = useSendEmailVerification();
+	const resendEmail = useSendEmailVerification( body );
 	const translate = useTranslate();
 
 	return async () => {

--- a/client/landing/stepper/hooks/use-send-email-verification.ts
+++ b/client/landing/stepper/hooks/use-send-email-verification.ts
@@ -1,7 +1,14 @@
 import wpcom from 'calypso/lib/wp';
 
-export function useSendEmailVerification() {
+export interface ResendEmailVerificationBody {
+	from: string; // Helps decide the url of the page after confirmation.
+}
+
+export function useSendEmailVerification( body: ResendEmailVerificationBody ) {
 	return async () => {
-		return wpcom.req.post( '/me/send-verification-email', { apiVersion: '1.1' } );
+		return wpcom.req.post( '/me/send-verification-email', {
+			apiVersion: '1.1',
+			...body,
+		} );
 	};
 }

--- a/client/landing/stepper/hooks/use-send-email-verification.ts
+++ b/client/landing/stepper/hooks/use-send-email-verification.ts
@@ -1,10 +1,10 @@
 import wpcom from 'calypso/lib/wp';
 
 export interface ResendEmailVerificationBody {
-	from: string; // Helps decide the url of the page after confirmation.
+	from?: string; // Helps decide the url of the page after confirmation.
 }
 
-export function useSendEmailVerification( body: ResendEmailVerificationBody ) {
+export function useSendEmailVerification( body: ResendEmailVerificationBody = {} ) {
 	return async () => {
 		return wpcom.req.post( '/me/send-verification-email', {
 			apiVersion: '1.1',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98434

## Proposed Changes

Add `from` param while sending request for email verification. This param will help us decide the url of the page after confirmation which in our case will be https://wordpress.com/reader.

**Note:** The Backend PR of this change is in progress so for now just test the changes via Network panel.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve experience for the new users of Reader.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout PR. Create an unverified account or changed [this line](https://github.com/Automattic/wp-calypso/blob/7c1b26a3ed40dc934fb79c3cdb6702893bebf302/client/state/current-user/selectors.js#L141) to 
```javascript
export const isCurrentUserEmailVerified = () => false;
```
* Go to reader. Click on Ellipsis menu on any post. Select "Subscribe" or "Unsubsribe".
* On Notification click on "Resend Email".
* Verify that body of `POST me/send-verification-email` endpoint now have `from` param.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
