### PR TITLE
i18n: add types for fixMe method

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-toggle.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-toggle.tsx
@@ -27,7 +27,6 @@ const NewsletterCategoriesToggle = ( {
 				label={ translate( 'Enable newsletter categories' ) }
 			/>
 			<FormSettingExplanation>
-				{ /* @ts-expect-error - fixMe method is not typed in the package. Once types are added upstream, remove this. */ }
 				{ i18n.fixMe( {
 					text: "Newsletter categories let you select the content that's emailed to subscribers. When enabled, only posts in the selected categories will be sent as newsletters. By default, subscribers can choose from your selected categories, or you can pre-select categories using the subscribe block.",
 					newCopy: translate(

--- a/packages/i18n-calypso/CHANGELOG.md
+++ b/packages/i18n-calypso/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.4.0
+
+- Add type for `fixMe` method
+
 ## 7.3.0
 
 - `formatCurrency` and `getCurrencyObject` methods added. Migrated from `format-currency` package

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "i18n-calypso",
-	"version": "7.3.0",
+	"version": "7.4.0",
 	"description": "I18n JavaScript library on top of Tannin originally used in Calypso.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/i18n-calypso/src/types/index.d.ts
+++ b/packages/i18n-calypso/src/types/index.d.ts
@@ -164,6 +164,29 @@ export interface I18N {
 	on( eventName: string, listener: EventListener ): void;
 	off( eventName: string, listener: EventListener ): void;
 	emit( eventName: string, ...payload: any ): void;
+
+	/**
+	 * Returns `newCopy` if given `text` is translated or locale is English, otherwise returns the `oldCopy`.
+	 *
+	 * `newCopy` prop should be an actual `i18n.translate()` call from the consuming end.
+	 * This is the only way currently to ensure that it is picked up by our string extraction mechanism
+	 * and propagate into GlotPress for translation.
+	 * @param options
+	 * @param options.text - The text to check for translation.
+	 * @param options.newCopy - The translation to return if the text is translated.
+	 * @param options.oldCopy - The fallback to return if the text is not translated.
+	 * @example
+	 * i18n.fixMe( {
+	 * 	text: 'new copy',
+	 * 	newCopy: i18n.translate( 'new copy' ),
+	 * 	oldCopy: i18n.translate( 'old copy' ),
+	 * } );
+	 */
+	fixMe( options: {
+		text: string;
+		newCopy: ExistingReactNode;
+		oldCopy?: ExistingReactNode;
+	} ): ExistingReactNode | null;
 }
 
 declare const i18n: I18N;
@@ -188,6 +211,7 @@ export declare const registerComponentUpdateHook: typeof i18n.registerComponentU
 export declare const on: typeof i18n.on;
 export declare const off: typeof i18n.off;
 export declare const emit: typeof i18n.emit;
+export declare const fixMe: typeof i18n.fixMe;
 
 export interface LocalizeProps {
 	locale: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Adds types for the `fixMe` method

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* tsc will error when attempting to use this method in a TS file because there is no type information. Adding these types will allow it to be used in TS files.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Easiest way to test would be to check this branch out locally and use the method in a TS context.
* Make sure the types are correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
