### PR TITLE
Potential fix for code scanning alert no. 197: Unvalidated dynamic method call

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -92,7 +92,7 @@ async function main() {
 	const flowName = getFlowFromURL();
 	const flowLoader = availableFlows[ flowName ];
 
-	if ( ! flowLoader || typeof flowLoader !== 'function' ) {
+	if ( typeof flowLoader !== 'function' ) {
 		// If the URL can't be traced back to an existing flow, stop the boot
 		// process and redirect to the default flow.
 		window.location.href = `/setup/${ DEFAULT_FLOW }${ window.location.search }`;

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -92,7 +92,7 @@ async function main() {
 	const flowName = getFlowFromURL();
 	const flowLoader = availableFlows[ flowName ];
 
-	if ( ! flowLoader ) {
+	if ( ! flowLoader || typeof flowLoader !== 'function' ) {
 		// If the URL can't be traced back to an existing flow, stop the boot
 		// process and redirect to the default flow.
 		window.location.href = `/setup/${ DEFAULT_FLOW }${ window.location.search }`;


### PR DESCRIPTION
Potential fix for [https://github.com/Automattic/wp-calypso/security/code-scanning/197](https://github.com/Automattic/wp-calypso/security/code-scanning/197)

To fix the problem, we need to ensure that the `flowLoader` is a valid function before invoking it. This can be achieved by adding a check to confirm that `flowLoader` is a function. If it is not, we should handle the error gracefully, such as by redirecting to the default flow.

1. Add a check to verify that `flowLoader` is a function before calling it.
2. If `flowLoader` is not a function, redirect to the default flow or handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


@ciampo, check this out! AI caught this. I thought it was wrong and almost dismissed it but it's actually right. You can see the bug if you visit `https://wordpress.com/setup/__proto__`
