### PR TITLE
Design Picker: Implement useRedirectDesignSetupOldSlug hook

### DIFF
--- a/client/landing/stepper/declarative-flow/helpers/use-redirect-design-setup-old-slug.ts
+++ b/client/landing/stepper/declarative-flow/helpers/use-redirect-design-setup-old-slug.ts
@@ -1,13 +1,17 @@
 import { useEffect } from 'react';
+import { getStepOldSlug } from './helpers/get-step-old-slug';
 import type { StepperStep, Navigate } from '../internals/types';
+
+const DESIGN_SETUP_SLUG = 'design-setup';
 
 export function useRedirectDesignSetupOldSlug(
 	currentStep: string,
 	navigate: Navigate< StepperStep[] >
 ) {
+	const oldSlug = getStepOldSlug( DESIGN_SETUP_SLUG );
 	useEffect( () => {
-		if ( currentStep === 'designSetup' ) {
-			navigate( 'design-setup' );
+		if ( currentStep === oldSlug ) {
+			navigate( DESIGN_SETUP_SLUG );
 		}
-	}, [ currentStep, navigate ] );
+	}, [ currentStep, navigate, oldSlug ] );
 }

--- a/client/landing/stepper/declarative-flow/helpers/use-redirect-design-setup-old-slug.ts
+++ b/client/landing/stepper/declarative-flow/helpers/use-redirect-design-setup-old-slug.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { getStepOldSlug } from './helpers/get-step-old-slug';
+import { getStepOldSlug } from './get-step-old-slug';
 import type { StepperStep, Navigate } from '../internals/types';
 
 const DESIGN_SETUP_SLUG = 'design-setup';

--- a/client/landing/stepper/declarative-flow/helpers/use-redirect-design-setup-old-slug.ts
+++ b/client/landing/stepper/declarative-flow/helpers/use-redirect-design-setup-old-slug.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+import type { StepperStep, Navigate } from '../internals/types';
+
+export function useRedirectDesignSetupOldSlug(
+	currentStep: string,
+	navigate: Navigate< StepperStep[] >
+) {
+	useEffect( () => {
+		if ( currentStep === 'designSetup' ) {
+			navigate( 'design-setup' );
+		}
+	}, [ currentStep, navigate ] );
+}

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -12,6 +12,7 @@ import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-pa
 import { ONBOARD_STORE, USER_STORE } from 'calypso/landing/stepper/stores';
 import { ImporterMainPlatform } from 'calypso/lib/importer/types';
 import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
+import { useRedirectDesignSetupOldSlug } from './helpers/use-redirect-design-setup-old-slug';
 import { STEPS } from './internals/steps';
 import {
 	AssertConditionState,
@@ -116,6 +117,8 @@ const importFlow: Flow = {
 			);
 		};
 
+		useRedirectDesignSetupOldSlug( _currentStep, navigate );
+
 		const submit = ( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) => {
 			switch ( _currentStep ) {
 				case 'importList':
@@ -169,7 +172,6 @@ const importFlow: Flow = {
 					}
 				}
 
-				case 'designSetup':
 				case 'design-setup': {
 					return navigate( 'processing' );
 				}
@@ -306,7 +308,6 @@ const importFlow: Flow = {
 				case 'importReadyNot':
 				case 'importReadyWpcom':
 				case 'importReadyPreview':
-				case 'designSetup':
 				case 'design-setup':
 					return navigate( `import?siteSlug=${ siteSlugParam }` );
 

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -33,11 +33,6 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/design-setup' ),
 	},
 
-	DESIGN_SETUP_LEGACY: {
-		slug: 'designSetup',
-		asyncComponent: () => import( './steps-repository/design-setup' ),
-	},
-
 	DIFM_STARTING_POINT: {
 		slug: 'difmStartingPoint',
 		asyncComponent: () => import( './steps-repository/difm-starting-point' ),

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -31,6 +31,7 @@ import { getLoginUrl } from '../utils/path';
 import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 import { useBigSkyBeforePlans } from './helpers/use-bigsky-before-plans-experiment';
 import { useGoalsFirstExperiment } from './helpers/use-goals-first-experiment';
+import { useRedirectDesignSetupOldSlug } from './helpers/use-redirect-design-setup-old-slug';
 import { recordStepNavigation } from './internals/analytics/record-step-navigation';
 import { STEPS } from './internals/steps';
 import { AssertConditionState, Flow, ProvidedDependencies } from './internals/types';
@@ -117,7 +118,6 @@ const onboarding: Flow = {
 				STEPS.GOALS,
 				STEPS.DESIGN_CHOICES,
 				STEPS.DESIGN_SETUP,
-				STEPS.DESIGN_SETUP_LEGACY,
 				STEPS.DIFM_STARTING_POINT
 			);
 		}
@@ -166,6 +166,7 @@ const onboarding: Flow = {
 		} else if ( typeof window !== 'undefined' ) {
 			window.__a8cBigSkyOnboarding = false;
 		}
+
 		/**
 		 * Returns [destination, backDestination] for the post-checkout destination.
 		 */
@@ -199,6 +200,7 @@ const onboarding: Flow = {
 		};
 
 		clearUseMyDomainsQueryParams( currentStepSlug );
+		useRedirectDesignSetupOldSlug( currentStepSlug, navigate );
 
 		const submit = async ( providedDependencies: ProvidedDependencies = {} ) => {
 			switch ( currentStepSlug ) {
@@ -228,7 +230,6 @@ const onboarding: Flow = {
 					}
 				}
 
-				case 'designSetup':
 				case 'design-setup': {
 					return navigate( 'domains' );
 				}
@@ -428,7 +429,6 @@ const onboarding: Flow = {
 						}
 						return navigate( 'design-setup' );
 					}
-				case 'designSetup':
 				case 'design-setup':
 					if ( isDesignChoicesStepEnabled ) {
 						return navigate( 'design-choices' );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -21,6 +21,7 @@ import { useSiteData } from '../hooks/use-site-data';
 import { useCanUserManageOptions } from '../hooks/use-user-can-manage-options';
 import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../stores';
 import { shouldRedirectToSiteMigration } from './helpers';
+import { useRedirectDesignSetupOldSlug } from './helpers/use-redirect-design-setup-old-slug';
 import { useLaunchpadDecider } from './internals/hooks/use-launchpad-decider';
 import { STEPS } from './internals/steps';
 import { redirect } from './internals/steps-repository/import/util';
@@ -60,7 +61,6 @@ const siteSetupFlow: FlowV1 = {
 			STEPS.OPTIONS,
 			STEPS.DESIGN_CHOICES,
 			STEPS.DESIGN_SETUP,
-			STEPS.DESIGN_SETUP_LEGACY,
 			STEPS.BLOGGER_STARTING_POINT,
 			STEPS.COURSES,
 			STEPS.IMPORT,
@@ -272,6 +272,8 @@ const siteSetupFlow: FlowV1 = {
 			navigate,
 		} );
 
+		useRedirectDesignSetupOldSlug( currentStep, navigate );
+
 		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
 			switch ( currentStep ) {
 				case 'options': {
@@ -286,7 +288,6 @@ const siteSetupFlow: FlowV1 = {
 					return navigate( 'bloggerStartingPoint' );
 				}
 
-				case 'designSetup':
 				case 'design-setup': {
 					return navigate( 'processing' );
 				}
@@ -519,7 +520,6 @@ const siteSetupFlow: FlowV1 = {
 				case 'courses':
 					return navigate( 'bloggerStartingPoint' );
 
-				case 'designSetup':
 				case 'design-setup':
 					if ( intent === SiteIntent.DIFM ) {
 						return navigate( 'difmStartingPoint' );

--- a/client/landing/stepper/declarative-flow/update-design.ts
+++ b/client/landing/stepper/declarative-flow/update-design.ts
@@ -12,6 +12,7 @@ import { useQuery } from '../hooks/use-query';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../stores';
+import { useRedirectDesignSetupOldSlug } from './helpers/use-redirect-design-setup-old-slug';
 import { STEPS } from './internals/steps';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
 import { ProvidedDependencies } from './internals/types';
@@ -24,7 +25,7 @@ const updateDesign: Flow = {
 	},
 	isSignupFlow: false,
 	useSteps() {
-		return [ STEPS.DESIGN_SETUP, STEPS.DESIGN_SETUP_LEGACY, STEPS.PROCESSING, STEPS.ERROR ];
+		return [ STEPS.DESIGN_SETUP, STEPS.PROCESSING, STEPS.ERROR ];
 	},
 	useSideEffect() {
 		const { setIntent } = useDispatch( ONBOARD_STORE );
@@ -55,6 +56,8 @@ const updateDesign: Flow = {
 			navigate,
 		} );
 
+		useRedirectDesignSetupOldSlug( currentStep, navigate );
+
 		function submit( providedDependencies: ProvidedDependencies = {}, ...results: string[] ) {
 			switch ( currentStep ) {
 				case 'processing':
@@ -79,7 +82,6 @@ const updateDesign: Flow = {
 						} )
 					);
 
-				case 'designSetup':
 				case 'design-setup':
 					if ( providedDependencies?.goToCheckout ) {
 						const destination = `/setup/${ flowToReturnTo }/launchpad?siteSlug=${ providedDependencies.siteSlug }`;


### PR DESCRIPTION
## Proposed Changes

Follow-up of https://github.com/Automattic/wp-calypso/pull/100318. The PR implements the hook useRedirectDesignSetupOldSlug() which redirects the old design setup step slug to the new one, thus maintaining backwards compatibility.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Refactor.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure /setup/site-setup flow still works as intended
- Ensure /setup/onboarding flow still works as intended
- Ensure /setup/update-design flow still works as intended
- Ensure /setup/import-focused flow still works as intended
- In each of the flows above, replace design-setup with designSetup in the URL and ensure the flow still works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
