### PR TITLE
Line Chart: use local dates

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -19,6 +19,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import StatsEmptyState from '../stats-empty-state';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatTabs from '../stats-tabs';
+import { parseLocalDate } from '../utils';
 import ChartHeader from './chart-header';
 import { buildChartData, getQueryDate } from './utility';
 
@@ -43,7 +44,7 @@ const transformChartDataToLineFormat = ( chartData ) => {
 		options: {},
 		data: chartData
 			.map( ( record ) => {
-				const date = new Date( record.data.period );
+				const date = parseLocalDate( record.data.period );
 				const value = record.data.views;
 				if ( isNaN( date.getTime() ) || typeof value !== 'number' ) {
 					return null;

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -60,7 +60,7 @@ const transformChartDataToLineFormat = ( chartData ) => {
 		options: {},
 		data: chartData
 			.map( ( record ) => {
-				const date = new Date( record.data.period );
+				const date = parseLocalDate( record.data.period );
 				const value = record.data.visitors;
 				if ( isNaN( date.getTime() ) || typeof value !== 'number' ) {
 					return null;

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -9,6 +9,7 @@ import useSubscribersQuery from 'calypso/my-sites/stats/hooks/use-subscribers-qu
 import { useSelector } from 'calypso/state';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsPeriodHeader from '../stats-period-header';
+import { parseLocalDate } from '../utils';
 import { hideFractionNumber } from './chart-utils';
 import SubscribersNavigationArrows from './subscribers-navigation-arrows';
 import type uPlot from 'uplot';
@@ -78,7 +79,7 @@ const transformLineChartData = (
 	const subscribersData: ChartDataPoint[] = [];
 	const paidSubscribersData: ChartDataPoint[] = [];
 	data?.map( ( point ) => {
-		const dateObj = new Date( point.period );
+		const dateObj = parseLocalDate( point.period );
 		if ( isNaN( dateObj.getTime() ) ) {
 			return null;
 		}

--- a/client/my-sites/stats/utils.js
+++ b/client/my-sites/stats/utils.js
@@ -60,3 +60,14 @@ export const appendQueryStringForRedirection = ( pathname, query = {} ) => {
 
 	return `${ pathname }${ queryString ? '?' : '' }${ queryString }`;
 };
+
+/**
+ * Parse a date string into a Date object
+ * @param {string} dateString
+ * @returns
+ */
+export const parseLocalDate = ( dateString ) => {
+	const [ year, month, day ] = dateString.substring( 0, 10 ).split( '-' ).map( Number );
+	// Note: month is 0-indexed in JavaScript Date
+	return new Date( year, month - 1, day );
+};

--- a/client/my-sites/stats/utils.js
+++ b/client/my-sites/stats/utils.js
@@ -67,6 +67,11 @@ export const appendQueryStringForRedirection = ( pathname, query = {} ) => {
  * @returns
  */
 export const parseLocalDate = ( dateString ) => {
+	// Compatible with Date object.
+	const testDate = new Date( dateString );
+	if ( isNaN( testDate.getTime() ) ) {
+		return testDate;
+	}
 	const [ year, month, day ] = dateString.substring( 0, 10 ).split( '-' ).map( Number );
 	// Note: month is 0-indexed in JavaScript Date
 	return new Date( year, month - 1, day );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/100451#pullrequestreview-2643010326

## Proposed Changes

* Fix the issue when ticks and points on line don't match 



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug fix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Please ignore the fact that my paid sub is higher than total subs


| Before      | After |
| ----------- | ----------- |
| <img width="1182" alt="image" src="https://github.com/user-attachments/assets/04ed3863-32ba-4a41-ad8c-d40c3cdf7f7b" />      | <img width="1203" alt="image" src="https://github.com/user-attachments/assets/233a763f-ef70-4c8a-a744-38b45b3bf74e" />       |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
