### PR TITLE
Clean up untangling/settings-i2 flag

### DIFF
--- a/client/hosting/overview/controller.tsx
+++ b/client/hosting/overview/controller.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page, { Context as PageJSContext } from '@automattic/calypso-router';
 import { removeQueryArgs } from '@wordpress/url';
 import i18n from 'i18n-calypso';
@@ -78,7 +77,7 @@ export async function redirectToServerSettingsIfDuplicatedView(
 ) {
 	const { getState, dispatch } = context.store;
 	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( getState, dispatch );
-	if ( isUntangled && config.isEnabled( 'untangling/settings-i2' ) ) {
+	if ( isUntangled ) {
 		const siteParam = context.params.site_id;
 		return page.redirect( `/sites/settings/server/${ siteParam }` );
 	}

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -175,7 +175,6 @@ const DotcomPreviewPane = ( {
 					SETTINGS_SFTP_SSH,
 					SETTINGS_DATABASE,
 					SETTINGS_PERFORMANCE,
-					...( ! config.isEnabled( 'untangling/settings-i2' ) ? [ DOTCOM_HOSTING_CONFIG ] : [] ),
 				],
 			},
 			{

--- a/client/sites/hooks/breadcrumbs/use-breadcrumbs.ts
+++ b/client/sites/hooks/breadcrumbs/use-breadcrumbs.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { useRemoveDuplicateViewsExperimentEnabled } from 'calypso/lib/remove-duplicate-views-experiment';
 import { useSelector } from 'calypso/state';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
@@ -7,10 +6,7 @@ export function useBreadcrumbs() {
 	const breadcrumbs = useSelector( getBreadcrumbs );
 	const isRemoveDuplicateViewsExperimentEnabled = useRemoveDuplicateViewsExperimentEnabled();
 
-	const shouldShowBreadcrumbs =
-		isRemoveDuplicateViewsExperimentEnabled &&
-		config.isEnabled( 'untangling/settings-i2' ) &&
-		breadcrumbs.length >= 3;
+	const shouldShowBreadcrumbs = isRemoveDuplicateViewsExperimentEnabled && breadcrumbs.length >= 3;
 
 	return {
 		// In sites dashboard, the components are rendered from the innermost level,

--- a/client/sites/settings/administration/tools/delete-site/index.jsx
+++ b/client/sites/settings/administration/tools/delete-site/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { isFreePlanProduct } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
@@ -224,9 +223,7 @@ class DeleteSite extends Component {
 
 		return (
 			<Panel className="settings-administration__delete-site">
-				{ ! ( isUntangled && config.isEnabled( 'untangling/settings-i2' ) ) && (
-					<HeaderCakeBack icon="chevron-left" onClick={ this._goBack } />
-				) }
+				{ ! isUntangled && <HeaderCakeBack icon="chevron-left" onClick={ this._goBack } /> }
 				<FeatureBreadcrumb siteId={ siteId } title={ strings.deleteSite } />
 				<NavigationHeader
 					compactBreadcrumb={ false }

--- a/client/sites/settings/administration/tools/reset-site/index.jsx
+++ b/client/sites/settings/administration/tools/reset-site/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button, FormLabel } from '@automattic/components';
 import {
 	useSiteResetContentSummaryQuery,
@@ -308,7 +307,7 @@ function SiteResetCard( {
 	return (
 		<Panel className="settings-administration__reset-site">
 			{ ! isLoading && <Interval onTick={ checkStatus } period={ EVERY_FIVE_SECONDS } /> }
-			{ ! ( isUntangled && config.isEnabled( 'untangling/settings-i2' ) ) && (
+			{ ! isUntangled && (
 				<HeaderCakeBack icon="chevron-left" href={ `${ source }/${ selectedSiteSlug }` } />
 			) }
 			<NavigationHeader

--- a/client/sites/settings/administration/tools/transfer-site/site-transfer-card.tsx
+++ b/client/sites/settings/administration/tools/transfer-site/site-transfer-card.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import HeaderCakeBack from 'calypso/components/header-cake/back';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -25,9 +24,7 @@ export function SiteTransferCard( {
 
 	return (
 		<Panel className="settings-administration__transfer-site">
-			{ ! ( isUntangled && config.isEnabled( 'untangling/settings-i2' ) ) && (
-				<HeaderCakeBack icon="chevron-left" onClick={ onClick } />
-			) }
+			{ ! isUntangled && <HeaderCakeBack icon="chevron-left" onClick={ onClick } /> }
 			<NavigationHeader
 				title={ title }
 				subtitle={ translate(

--- a/client/sites/settings/controller.tsx
+++ b/client/sites/settings/controller.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { __ } from '@wordpress/i18n';
 import { useSelector } from 'react-redux';
@@ -43,10 +42,7 @@ export function SettingsSidebar() {
 	return (
 		<Sidebar>
 			<SidebarItem href={ `/sites/settings/site/${ slug }` }>{ __( 'General' ) }</SidebarItem>
-			{ ! config.isEnabled( 'untangling/settings-i2' ) && areAdvancedHostingFeaturesSupported && (
-				<SidebarItem href={ `/hosting-config/${ slug }` }>{ __( 'Server' ) }</SidebarItem>
-			) }
-			{ config.isEnabled( 'untangling/settings-i2' ) && areAdvancedHostingFeaturesSupported && (
+			{ areAdvancedHostingFeaturesSupported && (
 				<>
 					<SidebarItem href={ `/sites/settings/server/${ slug }` }>{ __( 'Server' ) }</SidebarItem>
 					<SidebarItem href={ `/sites/settings/sftp-ssh/${ slug }` }>{ sftpSshTitle }</SidebarItem>
@@ -55,7 +51,7 @@ export function SettingsSidebar() {
 					</SidebarItem>
 				</>
 			) }
-			{ config.isEnabled( 'untangling/settings-i2' ) && areHostingFeaturesSupported && (
+			{ areHostingFeaturesSupported && (
 				<SidebarItem href={ `/sites/settings/performance/${ slug }` }>
 					{ __( 'Performance' ) }
 				</SidebarItem>
@@ -72,7 +68,7 @@ export async function redirectToHostingConfigIfDuplicatedViewsDisabled(
 	const isUntangled = await isRemoveDuplicateViewsExperimentEnabled( getState, dispatch );
 	const siteSlug = getSelectedSiteSlug( getState() );
 
-	if ( ! isUntangled || ! config.isEnabled( 'untangling/settings-i2' ) ) {
+	if ( ! isUntangled ) {
 		// Redirect command palette routes to the new hosting config page when not in the treatment group
 		const routes = {
 			[ `/sites/settings/server/${ siteSlug }` ]: `/hosting-config/${ siteSlug }`,

--- a/client/sites/settings/database/form.tsx
+++ b/client/sites/settings/database/form.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button, MaterialIcon } from '@automattic/components';
 import { PanelBody } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
@@ -71,8 +70,7 @@ export default function PhpMyAdminForm( { disabled }: PhpMyAdminFormProps ) {
 	const { openPhpMyAdmin, loading } = useOpenPhpMyAdmin();
 	const dispatch = useDispatch();
 
-	let isUntangled = useRemoveDuplicateViewsExperimentEnabled();
-	isUntangled = isUntangled && config.isEnabled( 'untangling/settings-i2' );
+	const isUntangled = useRemoveDuplicateViewsExperimentEnabled();
 
 	const form = (
 		<div className="phpmyadmin-card__wrapper">

--- a/client/sites/settings/performance/form.tsx
+++ b/client/sites/settings/performance/form.tsx
@@ -126,8 +126,7 @@ export default function CachingForm( { disabled }: CachingFormProps ) {
 				}
 		  );
 
-	let isUntangled = useRemoveDuplicateViewsExperimentEnabled();
-	isUntangled = isUntangled && config.isEnabled( 'untangling/settings-i2' );
+	const isUntangled = useRemoveDuplicateViewsExperimentEnabled();
 
 	return (
 		<HostingCard

--- a/client/sites/settings/sftp-ssh/sftp-form.tsx
+++ b/client/sites/settings/sftp-ssh/sftp-form.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { FEATURE_SFTP, FEATURE_SSH } from '@automattic/calypso-products';
 import { Button, FormLabel, Spinner, ExternalLink } from '@automattic/components';
 import { PanelBody, ToggleControl } from '@wordpress/components';
@@ -395,8 +394,7 @@ export const SftpForm = ( { disabled }: SftpFormProps ) => {
 		</div>
 	);
 
-	let isUntangled = useRemoveDuplicateViewsExperimentEnabled();
-	isUntangled = isUntangled && config.isEnabled( 'untangling/settings-i2' );
+	const isUntangled = useRemoveDuplicateViewsExperimentEnabled();
 
 	let ContainerComponent = HostingCard;
 	if ( isUntangled ) {

--- a/config/development.json
+++ b/config/development.json
@@ -204,7 +204,6 @@
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"untangling/hosting-menu": false,
-		"untangling/settings-i2": true,
 		"user-management-revamp": true,
 		"wpcom-user-bootstrap": false,
 		"yolo/command-palette": true

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -130,7 +130,6 @@
 		"themes/subscription-purchases": false,
 		"themes/text-search-lots": true,
 		"two-factor/enhanced-security": true,
-		"untangling/settings-i2": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/production.json
+++ b/config/production.json
@@ -165,7 +165,6 @@
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/text-search-lots": true,
-		"untangling/settings-i2": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -162,7 +162,6 @@
 		"themes/subscription-purchases": false,
 		"themes/text-search-lots": true,
 		"two-factor/enhanced-security": true,
-		"untangling/settings-i2": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/test.json
+++ b/config/test.json
@@ -118,7 +118,6 @@
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"themes/premium": true,
-		"untangling/settings-i2": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -174,7 +174,6 @@
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"untangling/hosting-menu": false,
-		"untangling/settings-i2": true,
 		"use-translation-chunks": true,
 		"user-management-revamp": true,
 		"wpcom-user-bootstrap": true,


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/pull/100322

## Proposed Changes

This PR cleans up the `untangling/settings-i2` flag; since it's true in all environment.

## Testing Instructions

1. Go to /sites
2. Open a Simple site
3. Go to Settings tab
4. Verify nothing is broken
2. Open an Atomic site
3. Go to Settings tab
4. Verify nothing is broken in all subtabs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
