### PR TITLE
Sub Chart: fix year view for sub chart

### DIFF
--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -45,7 +45,7 @@ function StatsLineChart( {
 			: numberFormat( value, { numberFormatOptions: { notation: 'compact' }, decimals: 1 } );
 	};
 
-	const isEmpty = ( chartData?.[ 0 ].data || [] ).length === 0;
+	const isEmpty = ( chartData?.[ 0 ]?.data || [] ).length === 0;
 
 	const maxValue = useMemo(
 		() =>

--- a/client/my-sites/stats/utils.js
+++ b/client/my-sites/stats/utils.js
@@ -63,16 +63,16 @@ export const appendQueryStringForRedirection = ( pathname, query = {} ) => {
 
 /**
  * Parse a date string into a Date object
- * @param {string} dateString
+ * @param {string} dateString YYYY-MM-DD format
  * @returns
  */
 export const parseLocalDate = ( dateString ) => {
 	// Compatible with Date object.
-	const testDate = new Date( dateString );
-	if ( isNaN( testDate.getTime() ) ) {
-		return testDate;
+	const date = new Date( dateString );
+	if ( isNaN( date.getTime() ) ) {
+		return date;
 	}
-	const [ year, month, day ] = dateString.substring( 0, 10 ).split( '-' ).map( Number );
-	// Note: month is 0-indexed in JavaScript Date
-	return new Date( year, month - 1, day );
+
+	date.setMinutes( date.getMinutes() - date.getTimezoneOffset() );
+	return date;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Offset with browser offset instead

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix timezone issue with chart

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `http://calypso.localhost:3000/stats/subscribers/year/your-site.com`
* Ensure it doesn't crash anymore

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
