### PR TITLE
Launch Button: Remove from the calypso bar of a4a sites

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -416,9 +416,10 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderLaunchButton() {
-		const { isUnlaunchedSite, siteId, translate, isManageSiteOptionsEnabled } = this.props;
+		const { isA4ADevSite, isUnlaunchedSite, siteId, translate, isManageSiteOptionsEnabled } =
+			this.props;
 
-		if ( ! isUnlaunchedSite || ! isManageSiteOptionsEnabled ) {
+		if ( ! isUnlaunchedSite || ! isManageSiteOptionsEnabled || isA4ADevSite ) {
 			return null;
 		}
 
@@ -667,6 +668,7 @@ export default connect(
 			isManageSiteOptionsEnabled: canCurrentUserManageSiteOptions( state, siteId ),
 			isNotificationsShowing: isNotificationsOpen( state ),
 			isEcommerce: isEcommercePlan( sitePlanSlug ),
+			isA4ADevSite: site?.is_a4a_dev_site,
 			siteId: siteId,
 			siteSlug: getSiteSlug( state, siteId ),
 			siteTitle: getSiteTitle( state, siteId ),


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/98918#issuecomment-2674403504

## Proposed Changes

Launching A4A development websites triggers billing for the agencies. For this reason we want to have a different flow for launching sites and avoid a too prominent launch button in the header. This PR just hides that button for A4A sites.

## Testing Instructions

- Create an a4a dev site
- Use an a4a account to login to Calypso
- Click the site in question and ensure there's no "launch button" in the master bar.