### PR TITLE
Block Editor Tracking: Ignore blocks loaded async in inner blocks replacement

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -525,8 +525,8 @@ const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
 			name === 'core/post-content' ||
 			// Page List
 			name === 'core/page-list' ||
-			// Page List Item
-			name === 'core/page-list-item'
+			// Navigation
+			name === 'core/navigation'
 		) {
 			return;
 		}

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -522,7 +522,11 @@ const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
 			// Reusable Block
 			name === 'core/block' ||
 			// Post Content
-			name === 'core/post-content'
+			name === 'core/post-content' ||
+			// Page List
+			name === 'core/page-list' ||
+			// Page List Item
+			name === 'core/page-list-item'
 		) {
 			return;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79818

## Proposed Changes

This PR prevents the `wpcom_block_inserted` event from firing during navigation by applying the approach used in https://github.com/Automattic/wp-calypso/pull/53501: it ignores blocks that are loaded async.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To avoid false tracking: https://github.com/Automattic/wp-calypso/issues/79818

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Patch this change with `install-plugin.sh wpcom-block-editor fix/site-editor-track-event`: https://github.com/Automattic/wp-calypso/pull/100543#issuecomment-2687094018
- Open the Site Editor.
- Monitor track events (e.g., PCYsg-T9m-p2).
- Navigate through the sidebar and ensure that no wpcom_block_inserted events are fired.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?