### PR TITLE
Hosting Overview: Fix the change theme link on simple sites with the paid plan

### DIFF
--- a/client/state/selectors/get-theme-install-url.ts
+++ b/client/state/selectors/get-theme-install-url.ts
@@ -1,8 +1,14 @@
+import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteAdminUrl, getSiteSlug, isAdminInterfaceWPAdmin } from '../sites/selectors';
 import type { AppState } from 'calypso/types';
 
 export default function getThemeInstallUrl( state: AppState, siteId?: number | null ) {
-	if ( ! isAdminInterfaceWPAdmin( state, siteId ) ) {
+	const canInstallTheme = siteHasFeature( state, siteId, FEATURE_INSTALL_THEMES );
+	const isWPCOMAtomicSite = isAtomicSite( state, siteId );
+
+	if ( ! isAdminInterfaceWPAdmin( state, siteId ) || ! canInstallTheme || ! isWPCOMAtomicSite ) {
 		const siteSlug = getSiteSlug( state, siteId );
 		return `/themes/${ siteSlug }`;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fix the change theme link on simple sites with the paid plan

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The `theme-install.php` is not available on simpel sites...

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Pick a simple site with the paid plan and classic interface style
* Click the `Change theme` button on the quick actions
* Ensure it opens the Theme Showcase

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
