### PR TITLE
A4A > WooPayments: Implement Sites list view

### DIFF
--- a/client/a8c-for-agencies/data/sites/use-fetch-sites-with-plugins.ts
+++ b/client/a8c-for-agencies/data/sites/use-fetch-sites-with-plugins.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+export default function useFetchSitesWithPlugins( plugins: string[] ) {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useQuery( {
+		queryKey: [ 'a4a-sites-with-plugins', agencyId, plugins ],
+		queryFn: () =>
+			wpcom.req.get(
+				{
+					apiNamespace: 'wpcom/v2',
+					path: `/agency/${ agencyId }/sites`,
+				},
+				{
+					filters: {
+						plugins,
+					},
+				}
+			),
+		enabled: !! agencyId,
+		refetchOnWindowFocus: false,
+		staleTime: 0,
+	} );
+}

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/index.tsx
@@ -1,0 +1,104 @@
+import { useState, useEffect, useCallback } from 'react';
+import useFetchLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-licenses';
+import useFetchSitesWithPlugins from 'calypso/a8c-for-agencies/data/sites/use-fetch-sites-with-plugins';
+import { LICENSES_PER_PAGE } from 'calypso/a8c-for-agencies/sections/purchases/lib/constants';
+import {
+	LicenseFilter,
+	LicenseSortField,
+	LicenseSortDirection,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import useFetchWooPaymentsData from '../hooks/use-fetch-woopayments-data';
+import SitesWithWooPayments from './sites-with-woopayments';
+import type { SitesWithWooPaymentsState, SitesWithWooPaymentsPlugins } from '../types';
+import type { License } from 'calypso/state/partner-portal/types';
+
+const sortByState = ( a: SitesWithWooPaymentsState, b: SitesWithWooPaymentsState ) => {
+	// Sites without state go first
+	if ( ! a.state && b.state ) {
+		return -1;
+	}
+	if ( a.state && ! b.state ) {
+		return 1;
+	}
+	return 0;
+};
+
+const WooPaymentsDashboardContent = () => {
+	const [ sitesWithPluginsStates, setSitesWithPluginsStates ] = useState<
+		SitesWithWooPaymentsState[]
+	>( [] );
+
+	const { data: licensesWithWooPayments, isLoading: isLoadingLicensesWithWooPayments } =
+		useFetchLicenses(
+			LicenseFilter.Attached,
+			'woopayments',
+			LicenseSortField.IssuedAt,
+			LicenseSortDirection.Descending,
+			1,
+			LICENSES_PER_PAGE
+		);
+
+	const { isLoading: isLoadingSitesWithPlugins, data: sitesWithPlugins } = useFetchSitesWithPlugins(
+		[ 'woocommerce-payments/woocommerce-payments' ]
+	);
+
+	const { data: woopaymentsData } = useFetchWooPaymentsData( {} );
+
+	const createInitialSiteState = useCallback(
+		( license: License ) => {
+			const sitePlugin = sitesWithPlugins.find(
+				( site: SitesWithWooPaymentsPlugins ) => site.blog_id === license.blogId
+			);
+
+			return {
+				blogId: license.blogId,
+				siteUrl: license.siteUrl,
+				state: sitePlugin?.state || null,
+				transactions: 0,
+			} as SitesWithWooPaymentsState;
+		},
+		[ sitesWithPlugins ]
+	);
+
+	const updateSitesWithTransactions = useCallback(
+		( currentStates: SitesWithWooPaymentsState[] ) =>
+			currentStates.map( ( site ) => ( {
+				...site,
+				transactions: woopaymentsData?.sites?.[ String( site.blogId ) ]?.tpv ?? 0,
+				payout: woopaymentsData?.sites?.[ String( site.blogId ) ]?.payout ?? 0,
+			} ) ),
+		[ woopaymentsData ]
+	);
+
+	// Initial setup of sites without transactions
+	useEffect( () => {
+		if ( ! sitesWithPlugins?.length || ! licensesWithWooPayments?.items ) {
+			return;
+		}
+
+		const states = licensesWithWooPayments.items.map( createInitialSiteState ).sort( sortByState );
+
+		setSitesWithPluginsStates( states );
+	}, [ sitesWithPlugins, licensesWithWooPayments, createInitialSiteState ] );
+
+	// Update transactions when woopaymentsData arrives
+	useEffect( () => {
+		if ( ! woopaymentsData || ! sitesWithPluginsStates.length ) {
+			return;
+		}
+
+		setSitesWithPluginsStates( updateSitesWithTransactions );
+	}, [ woopaymentsData, updateSitesWithTransactions, sitesWithPluginsStates.length ] );
+
+	if ( isLoadingLicensesWithWooPayments || isLoadingSitesWithPlugins ) {
+		return <div>Loading...</div>;
+	}
+
+	if ( ! sitesWithPluginsStates.length ) {
+		return <div>No sites with WooPayments</div>;
+	}
+
+	return <SitesWithWooPayments items={ sitesWithPluginsStates } />;
+};
+
+export default WooPaymentsDashboardContent;

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/mobile-view.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/mobile-view.tsx
@@ -1,0 +1,52 @@
+import { useTranslate } from 'i18n-calypso';
+import {
+	ListItemCards,
+	ListItemCard,
+	ListItemCardContent,
+} from 'calypso/a8c-for-agencies/components/list-item-cards';
+import {
+	SiteColumn,
+	WooPaymentsStatusColumn,
+	TransactionsColumn,
+	CommissionsPaidColumn,
+} from './site-columns';
+import type { SitesWithWooPaymentsState } from '../types';
+
+import './style.scss';
+
+export default function SitesWithWooPaymentsMobileView( {
+	items,
+}: {
+	items: SitesWithWooPaymentsState[];
+} ) {
+	const translate = useTranslate();
+
+	return (
+		<div className="sites-with-woopayments-list-mobile-view">
+			<ListItemCards>
+				{ items.map( ( item ) => (
+					<ListItemCard key={ item.blogId }>
+						<ListItemCardContent title={ translate( 'Site' ) }>
+							<div className="sites-with-woopayments-list-mobile-view__column">
+								<SiteColumn site={ item.siteUrl } />
+							</div>
+						</ListItemCardContent>
+						<ListItemCardContent title={ translate( 'Transactions' ) }>
+							<div className="sites-with-woopayments-list-mobile-view__column">
+								<TransactionsColumn transactions={ item.transactions } />
+							</div>
+						</ListItemCardContent>
+						<ListItemCardContent title={ translate( 'Commissions Paid' ) }>
+							<div className="sites-with-woopayments-list-mobile-view__column">
+								<CommissionsPaidColumn payout={ item.payout } />
+							</div>
+						</ListItemCardContent>
+						<ListItemCardContent title={ translate( 'Review status' ) }>
+							<WooPaymentsStatusColumn state={ item.state } siteUrl={ item.siteUrl } />
+						</ListItemCardContent>
+					</ListItemCard>
+				) ) }
+			</ListItemCards>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -1,0 +1,70 @@
+import { BadgeType, Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { useTranslate, formatCurrency } from 'i18n-calypso';
+import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
+import { urlToSlug } from 'calypso/lib/url/http-utils';
+
+export const SiteColumn = ( { site }: { site: string } ) => {
+	return urlToSlug( site );
+};
+
+export const TransactionsColumn = ( { transactions }: { transactions: number } ) => {
+	return transactions ?? <Gridicon icon="minus" />;
+};
+
+export const CommissionsPaidColumn = ( { payout }: { payout: number } ) => {
+	return payout ? formatCurrency( payout, 'USD', { stripZeros: true } ) : <Gridicon icon="minus" />;
+};
+
+export const WooPaymentsStatusColumn = ( {
+	state,
+	siteUrl,
+}: {
+	state: string;
+	siteUrl: string;
+} ) => {
+	const translate = useTranslate();
+
+	if ( ! state ) {
+		return (
+			<Button
+				variant="secondary"
+				href={ `${ siteUrl }/wp-admin/plugin-install.php?s=woopayments&tab=search&type=term` }
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				{ translate( 'Setup in WP-Admin ↗' ) }
+			</Button>
+		);
+	}
+
+	const getStatusProps = () => {
+		switch ( state ) {
+			case 'active':
+				return {
+					statusText: translate( 'Active' ),
+					statusType: 'success',
+				};
+			default:
+				return {
+					statusText: translate( 'Disconnected' ),
+					statusType: 'warning',
+				};
+		}
+	};
+
+	const statusProps = getStatusProps();
+
+	if ( ! statusProps ) {
+		return null;
+	}
+
+	return (
+		<StatusBadge
+			statusProps={ {
+				children: statusProps.statusText,
+				type: statusProps.statusType as BadgeType,
+			} }
+		/>
+	);
+};

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
@@ -1,0 +1,97 @@
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo, ReactNode, useState } from 'react';
+import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
+import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import SitesWithWooPaymentsMobileView from './mobile-view';
+import {
+	CommissionsPaidColumn,
+	SiteColumn,
+	TransactionsColumn,
+	WooPaymentsStatusColumn,
+} from './site-columns';
+import type { SitesWithWooPaymentsState } from '../types';
+import type { Field } from '@wordpress/dataviews';
+
+export default function SitesWithWooPayments( { items }: { items: SitesWithWooPaymentsState[] } ) {
+	const translate = useTranslate();
+
+	const isDesktop = useDesktopBreakpoint();
+
+	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
+		...initialDataViewsState,
+		fields: [ 'site', 'transactions', 'commissionsPaid', 'woopaymentsStatus' ],
+	} );
+
+	const fields: Field< any >[] = useMemo(
+		() => [
+			{
+				id: 'site',
+				label: translate( 'Site' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item }: { item: SitesWithWooPaymentsState } ): ReactNode => (
+					<SiteColumn site={ item.siteUrl } />
+				),
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'transactions',
+				label: translate( 'Transactions' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item } ): ReactNode => (
+					<TransactionsColumn transactions={ item.transactions } />
+				),
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'commissionsPaid',
+				label: translate( 'Commissions Paid' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item } ): ReactNode => <CommissionsPaidColumn payout={ item.payout } />,
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'woopaymentsStatus',
+				label: translate( 'WooPayments Status' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item } ): ReactNode => (
+					<WooPaymentsStatusColumn state={ item.state } siteUrl={ item.siteUrl } />
+				),
+				enableHiding: false,
+				enableSorting: false,
+			},
+		],
+		[ translate ]
+	);
+
+	const { data, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( items, dataViewsState, fields );
+	}, [ items, dataViewsState, fields ] );
+
+	if ( ! isDesktop ) {
+		return <SitesWithWooPaymentsMobileView items={ items } />;
+	}
+
+	return (
+		<div className="redesigned-a8c-table full-width">
+			<ItemsDataViews
+				data={ {
+					items: data,
+					getItemId: ( item: SitesWithWooPaymentsState ) => `${ item.blogId }`,
+					pagination: paginationInfo,
+					enableSearch: false,
+					fields,
+					actions: [],
+					setDataViewsState,
+					dataViewsState,
+					defaultLayouts: { table: {} },
+				} }
+			/>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/style.scss
@@ -1,0 +1,7 @@
+.sites-with-woopayments-list-mobile-view {
+	padding: 16px;
+}
+
+.sites-with-woopayments-list-mobile-view__column {
+	@include a4a-font-body-md;
+}

--- a/client/a8c-for-agencies/sections/woopayments/hooks/use-fetch-woopayments-data.ts
+++ b/client/a8c-for-agencies/sections/woopayments/hooks/use-fetch-woopayments-data.ts
@@ -37,6 +37,5 @@ export default function useFetchWooPaymentsData( {
 				: Promise.resolve( [] ),
 		enabled: !! agencyId,
 		refetchOnWindowFocus: false,
-		staleTime: 0,
 	} );
 }

--- a/client/a8c-for-agencies/sections/woopayments/hooks/use-fetch-woopayments-data.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/hooks/use-fetch-woopayments-data.tsx
@@ -1,0 +1,42 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+export default function useFetchWooPaymentsData( {
+	startDate,
+	endDate,
+	segment,
+}: {
+	/** Start date in YYYY-MM-DD format */
+	startDate?: string;
+	/** End date in YYYY-MM-DD format */
+	endDate?: string;
+	/** Time segment: 'day' | 'week' | 'month' | 'quarter' | 'year' */
+	segment?: 'day' | 'week' | 'month' | 'quarter' | 'year';
+} ) {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	const isApiEnabled = false;
+
+	return useQuery( {
+		queryKey: [ 'a4a-site-woopayments-data', agencyId, startDate, endDate, segment, isApiEnabled ],
+		queryFn: () =>
+			isApiEnabled
+				? wpcom.req.get(
+						{
+							apiNamespace: 'wpcom/v2',
+							path: `/agency/${ agencyId }/woopayments`,
+						},
+						{
+							...( startDate && { start_date: startDate } ),
+							...( endDate && { end_date: endDate } ),
+							...( segment && { segment } ),
+						}
+				  )
+				: Promise.resolve( [] ),
+		enabled: !! agencyId,
+		refetchOnWindowFocus: false,
+		staleTime: 0,
+	} );
+}

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
@@ -8,6 +8,9 @@ import LayoutHeader, {
 	LayoutHeaderActions as Actions,
 } from 'calypso/layout/hosting-dashboard/header';
 import AddWooPaymentsToSite from '../../add-woopayments-to-site';
+import WooPaymentsDashboardContent from '../../dashboard-content';
+
+import './style.scss';
 
 const WooPaymentsDashboard = () => {
 	const translate = useTranslate();
@@ -21,7 +24,7 @@ const WooPaymentsDashboard = () => {
 	}
 
 	return (
-		<Layout title={ title } wide>
+		<Layout className="woopayments-dashboard" title={ title } wide>
 			<LayoutTop>
 				<LayoutHeader>
 					<Title>{ title }</Title>
@@ -33,7 +36,7 @@ const WooPaymentsDashboard = () => {
 			</LayoutTop>
 
 			<LayoutBody>
-				<>{ /* TODO: Add the content */ }</>
+				<WooPaymentsDashboardContent />
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/style.scss
@@ -1,0 +1,8 @@
+.woopayments-dashboard {
+	.hosting-dashboard-layout__header-actions {
+		display: flex;
+		flex-direction: column;
+		align-items: normal;
+		justify-content: normal;
+	}
+}

--- a/client/a8c-for-agencies/sections/woopayments/types.ts
+++ b/client/a8c-for-agencies/sections/woopayments/types.ts
@@ -1,0 +1,20 @@
+export interface SitesWithWooPayments {
+	id: number;
+	url: string;
+	blog_id: number;
+}
+
+export interface SitesWithWooPaymentsPlugins {
+	id: number;
+	url: string;
+	state: string;
+	blog_id: number;
+}
+
+export interface SitesWithWooPaymentsState {
+	blogId: number;
+	siteUrl: string;
+	state: string;
+	transactions: number;
+	payout: number;
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1852

## Proposed Changes

This PR:

- Implements table view for listing the sites with WooPayments
- Implements API integration to list the sites with WooPayments based on the Licenses API endpoint.
- Implements mobile view for listing the sites with WooPayments

Note: 

- Loading and Empty State view will be implemented in a different PR
- API integrations to show the commissions will be implemented in a different PR
- Any minor UI fixes/enhancements will be done in another PR.
- Pagination will be handled in a different PR

## Why are these changes being made?

* To show the list of sites that have Woopayments licenses(installed and not installed)

## Testing Instructions

* Open the A4A live link
* Issue and Assign WooPayments licenses to a few sites. Also, go to the respective WP-Admin of some sites (not all) and install and activate WooCommerce and WooPayments plugins.
* Visit WooPayments: Dashboard: Verify a list view is displayed and shown below. Also, verify the mobile view looks good. You should see a button: `Setup in WP-Admin ↗` on the status column if the WooPayments plugin is not installed or activated. It shows `Active` if everything is set.

<img width="1728" alt="Screenshot 2025-02-27 at 2 02 29 PM" src="https://github.com/user-attachments/assets/07b29654-8395-4024-9e10-cc1a04a0b249" />

<img width="377" alt="Screenshot 2025-02-27 at 2 09 07 PM" src="https://github.com/user-attachments/assets/8de8a9ed-41b9-45c7-891e-6932a8926514" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
