### PR TITLE
i18n: Update i18n-calypso README. Include format-currency et al.

### DIFF
--- a/packages/i18n-calypso/README.md
+++ b/packages/i18n-calypso/README.md
@@ -205,26 +205,6 @@ const content3 = i18n.translate( 'post', {
 
 See the [test cases](test/test.jsx) for more example usage.
 
-## numberFormat Method (and variants)
-
-The numberFormat method is also available to format numbers using the loaded locale settings (i.e., locale-specific thousands and decimal separators). You pass in the number (integer or float) and (optionally) the number of decimal places you want (or an options object), and a string is returned with the proper formatting for the currently-loaded locale. You can also override the locale settings for a particular number if necessary by expanding the second argument into an object with the attributes you want to override.
-
-### Variants
-
-The following variants exist:
-
-- `numberFormatCompact` will format and localise a number using compact notation with 1 decimal point e.g. 1K, 1.5M, etc. It works identical to `numberFormat` (same number and order of arguments).
-
-### Examples
-
-```js
-// These examples assume a 'de' (German) locale to demonstrate
-// locale-formatted numbers
-i18n.numberFormat( 2500.25 ); // '2.500'
-i18n.numberFormat( 2500.1, 2 ); // '2.500,10'
-i18n.numberFormat( 2500.33, { decimals: 3 } ); // '2.500,330'
-```
-
 ## fixMe Method
 
 Using the method `fixMe` you can apply a translation (`newCopy` parameter) only when a certain text has been translated or the locale is English (`en`, `en-gb`), otherwise apply the fallback translation (`oldCopy` parameter). This is a common pattern in the codebase for new translations that we need to ship straight away, and the function is meant to save a few inline conditions.
@@ -416,3 +396,135 @@ Note that when generating the jed file, all possible strings need to be taken in
 ## Extracting Translatable Strings From JavaScript Sources
 
 There is a companion [i18n-calypso-cli](https://npmjs.com/package/i18n-calypso-cli) package that provides a tool to extract `translate()`-d strings from your JavaScript code and generate a POT or PHP translation file.
+
+## Number Formatters (including currencies, percentages, etc.)
+
+### numberFormat Method (and variants)
+
+The numberFormat method is used for formatting numbers using the loaded locale settings (i.e., locale-specific thousands and decimal separators). You pass in the number (integer or float) and (optionally) the number of decimal places you want (or an options object), and a string is returned with the proper formatting for the currently-loaded locale. You can also override the locale settings for a particular number if necessary by expanding the second argument into an object with the attributes you want to override.
+
+#### Variants
+
+The following variants exist:
+
+- `numberFormatCompact` will format and localise a number using compact notation with 1 decimal point e.g. 1K, 1.5M, etc. It works identical to `numberFormat` (same number and order of arguments).
+
+#### Examples
+
+```js
+// These examples assume a 'de' (German) locale to demonstrate
+// locale-formatted numbers
+i18n.numberFormat( 2500.25 ); // '2.500'
+i18n.numberFormat( 2500.1, 2 ); // '2.500,10'
+i18n.numberFormat( 2500.33, { decimals: 3 } ); // '2.500,330'
+```
+
+### geolocateCurrencySymbol()
+
+`geolocateCurrencySymbol(): Promise<void>`
+
+This will attempt to make an unauthenticated network request to `https://public-api.wordpress.com/geo/`. This is to determine the country code to provide better USD formatting. By default, the currency symbol for USD will be based on the locale (unlike other currency codes which use a hard-coded list of overrides); for `en-US`/`en` it will be `$` and for all other locales it will be `US$`. However, if the geolocation determines that the country is not inside the US, the USD symbol will be `US$` regardless of locale. This is to prevent confusion for users in non-US countries using an English locale.
+
+In the US, users will expect to see USD prices rendered with the currency symbol `$`. However, there are many other currencies which use `$` as their currency symbol (eg: `CAD`). This package tries to prevent confusion between these symbols by using an international version of the symbol when the locale does not match the currency. So if your locale is `en-CA`, USD prices will be rendered with the symbol `US$`.
+
+However, this relies on the user having set their interface language to something other than `en-US`/`en`, and many English-speaking non-US users still have that interface language (eg: there's no English locale available in our settings for Argentinian English so such users would probably still have `en`). As a result, those users will see a price with `$` and could be misled about what currency is being displayed. `geolocateCurrencySymbol()` helps prevent that from happening by showing `US$` for those users.
+
+### formatCurrency()
+
+#### Why does this API exist?
+
+Formatting currency amounts can be surprisingly complex. Most people assume that the currency itself is the main thing that defines how to write an amount of money but it is actually more affected by locale and a number of options.
+
+Technically this package just provides a wrapper for `Intl.NumberFormat`, but it handles a lot of things automatically to make things simple and provide consistency. Here's what the functions of this package provide:
+
+- A cached number formatter for performance, keyed by currency and locale as well as any other options which must be passed to the `Intl` formatter (whether to show non-zero decimals, and whether to display a `+` sign for positive amounts).
+- The locale is set from WordPress, if available, but also falls back to the browser’s locale, and can be set explicitly if WordPress is not available (eg: for a logged-out pricing page).
+- This uses a forced latin character set to make sure we always display latin numbers for consistency.
+- We override currency codes with a hard-coded list. This is for consistency and so that some currencies seem less confusing when viewed in EN locales, since those are the default locales for many users (eg: always use `C$` for CAD instead of `CA$` or just `$` which are the CLDR standard depending on locale since `$` might imply CAD and it might imply USD).
+- We always show `US$` for USD when the user’s geolocation is not inside the US. This is important because other currencies use `$` for their currency and are surprised sometimes if they are actually charged in USD (which is the default for many users). We can’t safely display `US$` for everyone because we've found that US users are confused by that style and it decreases confidence in the product.
+- An option to format currency from the currency’s smallest unit (eg: cents in USD, yen in JPY). This is important because doing price math with floating point numbers in code produces unexpected rounding errors, so most currency amounts should be provided and manipulated as integers.
+- An optional API to return the formatted pieces of a price separately, so the consumer can decide how best to render them (eg: this is used to wrap different HTML tags around prices and currency symbols). JS already includes this feature as `Intl.NumberFormat.formatToParts()` but our API must also include the other features listed here and extra information like the position of the currency symbol (before or after the number).
+
+#### Usage
+
+`formatCurrency( number: number, code: string, options: FormatCurrencyOptions = {} ): string`
+
+Formats money with a given currency code.
+
+The currency will define the properties to use for this formatting, but those properties can be overridden using the options. Be careful when doing this.
+
+For currencies that include decimals, this will always return the amount with decimals included, even if those decimals are zeros. To exclude the zeros, use the `stripZeros` option. For example, the function will normally format `10.00` in `USD` as `$10.00` but when this option is true, it will return `$10` instead.
+
+Since rounding errors are common in floating point math, sometimes a price is provided as an integer in the smallest unit of a currency (eg: cents in USD or yen in JPY). Set the `isSmallestUnit` to change the function to operate on integer numbers instead. If this option is not set or false, the function will format the amount `1025` in `USD` as `$1,025.00`, but when the option is true, it will return `$10.25` instead.
+
+### getCurrencyObject()
+
+`getCurrencyObject( number: number, code: string, options: FormatCurrencyOptions = {} ): CurrencyObject`
+
+Returns a formatted price object. See below for the details of that object's properties.
+
+The currency will define the properties to use for this formatting, but those properties can be overridden using the options. Be careful when doing this.
+
+For currencies that include decimals, this will always return the amount with decimals included, even if those decimals are zeros. To exclude the zeros, use the `stripZeros` option. For example, the function will normally format `10.00` in `USD` as `$10.00` but when this option is true, it will return `$10` instead. Alternatively, you can use the `hasNonZeroFraction` return value to decide if the decimal section should be displayed.
+
+Since rounding errors are common in floating point math, sometimes a price is provided as an integer in the smallest unit of a currency (eg: cents in USD or yen in JPY). Set the `isSmallestUnit` to change the function to operate on integer numbers instead. If this option is not set or false, the function will format the amount `1025` in `USD` as `$1,025.00`, but when the option is true, it will return `$10.25` instead.
+
+### FormatCurrencyOptions
+
+An object with the following properties:
+
+#### `precision?: number`
+
+The number of decimal places to display.
+
+Will be set automatically by the currency code.
+
+#### `locale?: string`
+
+The locale to use for the formatting. Defaults to using the browser's current locale unless `setDefaultLocale()` has been called.
+
+#### `stripZeros?: boolean`
+
+Forces any decimal zeros to be hidden if set.
+
+For example, the function will normally format `10.00` in `USD` as `$10.00` but when this option is true, it will return `$10` instead.
+
+For currencies without decimals (eg: JPY), this has no effect.
+
+#### `isSmallestUnit?: boolean`
+
+Changes function to treat number as an integer in the currency's smallest unit.
+
+Since rounding errors are common in floating point math, sometimes a price is provided as an integer in the smallest unit of a currency (eg: cents in USD or yen in JPY). If this option is false, the function will format the amount `1025` in `USD` as `$1,025.00`, but when the option is true, it will return `$10.25` instead.
+
+#### `signForPositive?: boolean`
+
+If the number is greater than 0, setting this to true will include its sign (eg: `+$35.00`). Has no effect on negative numbers or 0.
+
+### CurrencyObject
+
+An object with the following properties:
+
+#### `sign: '-' | '+' | ''`
+
+The negative sign for the price, if it is negative, or the positive sign if `signForPositive` is set.
+
+#### `symbol: string`
+
+The currency symbol (eg: `$` for USD).
+
+#### `integer: string`
+
+The integer part of a decimal currency. Note that this is not a number, but a locale-formatted string that includes any symbols used for separating the thousands groups (eg: commas, periods, or spaces).
+
+#### `fraction: string`
+
+The decimal part of a decimal currency. Note that this is not a number, but a locale-formatted string that includes the decimal separator that may be a comma or a period.
+
+#### `symbolPosition: 'before' | 'after'`
+
+The position of the currency symbol relative to the numeric price. If this is `'before'`, the symbol should be placed before the price like `US $ 10`; if this is `'after'`, the symbol should be placed after the price like `10 US $`.
+
+#### `hasNonZeroFraction: boolean`
+
+True if the price has a decimal part and that decimal's value is greater than zero. This can be useful to mimic the `stripZeros` option behavior (hiding decimal places if the decimal is zero) without having to specify that option.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

- Updates the README to include the latest format-currency components introduced.
- Moves everything under a `Number Formatters` section. Also easier to extract later

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Maintenance/docs

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

No functional changes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
