### PR TITLE
Subscribers: disable API calls if no selected subscriber

### DIFF
--- a/client/data/newsletter-categories/use-subscribed-newsletter-categories-query.tsx
+++ b/client/data/newsletter-categories/use-subscribed-newsletter-categories-query.tsx
@@ -6,6 +6,7 @@ type NewsletterCategoryQueryProps = {
 	siteId: number;
 	subscriptionId?: number;
 	userId?: number;
+	enabled?: boolean;
 };
 
 type NewsletterCategoryResponse = {
@@ -16,8 +17,9 @@ type NewsletterCategoryResponse = {
 export const getSubscribedNewsletterCategoriesKey = (
 	siteId?: string | number,
 	subscriptionId?: number,
-	userId?: number
-) => [ 'subscribed-newsletter-categories', siteId, subscriptionId, userId ];
+	userId?: number,
+	enabled?: boolean
+) => [ 'subscribed-newsletter-categories', siteId, subscriptionId, userId, enabled ];
 
 const convertNewsletterCategoryResponse = (
 	response: NewsletterCategoryResponse
@@ -30,6 +32,7 @@ const useSubscribedNewsletterCategories = ( {
 	siteId,
 	subscriptionId,
 	userId,
+	enabled = true,
 }: NewsletterCategoryQueryProps ): UseQueryResult< NewsletterCategories > => {
 	let path = `/sites/${ siteId }/newsletter-categories/subscriptions`;
 	if ( userId ) {
@@ -55,7 +58,7 @@ const useSubscribedNewsletterCategories = ( {
 				};
 			}
 		},
-		enabled: !! siteId && ( !! subscriptionId || !! userId ),
+		enabled: !! siteId && enabled,
 	} );
 };
 

--- a/client/data/newsletter-categories/use-subscribed-newsletter-categories-query.tsx
+++ b/client/data/newsletter-categories/use-subscribed-newsletter-categories-query.tsx
@@ -55,7 +55,7 @@ const useSubscribedNewsletterCategories = ( {
 				};
 			}
 		},
-		enabled: !! siteId,
+		enabled: !! siteId && ( !! subscriptionId || !! userId ),
 	} );
 };
 

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -139,6 +139,7 @@ const SubscriberDataViews = ( {
 			siteId: siteId as number,
 			subscriptionId: selectedSubscriber?.subscription_id,
 			userId: selectedSubscriber?.user_id,
+			enabled: !! selectedSubscriber,
 		} );
 
 	const { data: subscribersTotals } = useSubscriberCountQuery( siteId ?? null );

--- a/client/my-sites/subscribers/queries/use-subscriber-details-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscriber-details-query.tsx
@@ -19,7 +19,7 @@ const useSubscriberDetailsQuery = (
 					: `/sites/${ siteId }/subscribers/individual?subscription_id=${ subscriptionId }&type=${ type }`,
 				apiNamespace: 'wpcom/v2',
 			} ),
-		enabled: !! siteId,
+		enabled: !! siteId && ( !! subscriptionId || !! userId ),
 		placeholderData: keepPreviousData,
 	} );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/loop/issues/491

404s on subscribers page on Jetpack cloud

![Image](https://github.com/user-attachments/assets/5bee82f7-7aa2-4726-8130-29f65dc5f10c)

Its happening because there are API calls going out with missing or undefined params;
* `https://public-api.wordpress.com/wpcom/v2/sites/30429098/subscribers/individual?subscription_id=undefined&type=email`
* `https://public-api.wordpress.com/wpcom/v2/sites/30429098/newsletter-categories/subscriptions`

## Proposed Changes

* Disables API calls when no selected subscriber set - this avoid 404 responses with invalid params

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to jetpack cloud live link and look at `/subscribers` page, i.e. `/subscribers/{test site}?site={test site}`
* Confirm that 404's not showing up in console

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
