### PR TITLE
Try: Improve Google Analytics form.

### DIFF
--- a/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
@@ -100,6 +100,8 @@ const GoogleAnalyticsSimpleForm = ( {
 								{ translate(
 									'A free analytics tool that offers additional insights into your site.'
 								) }{ ' ' }
+							</p>
+							<p>
 								<a
 									onClick={ recordSupportLinkClick }
 									href={ analyticsSupportUrl }
@@ -175,7 +177,7 @@ const GoogleAnalyticsSimpleForm = ( {
 								checked={ displayForm }
 								disabled={ isRequestingSettings || isSavingSettings }
 								onChange={ handleFormToggle }
-								label={ translate( 'Add Google' ) }
+								label={ translate( 'Add Google Analytics' ) }
 							/>
 						</div>
 						<Button

--- a/client/my-sites/site-settings/analytics/style.scss
+++ b/client/my-sites/site-settings/analytics/style.scss
@@ -12,7 +12,7 @@
 .site-settings__analytics {
 	display: flex;
 	flex-direction: row;
-	align-items: flex-start;
+	align-items: center;
 	margin-bottom: 12px;
 	margin-top: 16px;
 	.support-info {
@@ -27,13 +27,14 @@
 	line-height: 1rem;
 }
 .site-settings__analytics-text p {
-	margin: 0;
+	margin-bottom: 0.5em;
 }
 
 .site-settings__analytics-illustration {
 	width: 50px;
 	img {
 		width: 100%;
+		display: block;
 	}
 }
 


### PR DESCRIPTION
Fixes #100498.

## Proposed Changes

Improves the layout of Google Analytics. Before:

![Screenshot 2025-02-27 at 15 58 01](https://github.com/user-attachments/assets/867ca06e-5b34-4969-a14f-bbc3345b6bf3)

After:

![Screenshot 2025-02-27 at 16 17 20](https://github.com/user-attachments/assets/93552058-d17b-490e-bb4b-1c26b07f22a0)

This is a light refresh. More could be done.

## Testing Instructions

Visit At https://wordpress.com/marketing/traffic/SITE or Tools → Marketing → Traffic on a premium plan.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
