### PR TITLE
Reader Quick Edit: Add success message

### DIFF
--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -33,6 +33,7 @@ export default function QuickPost() {
 	const hasLoaded = useSelector( hasLoadedSites );
 	const [ selectedSiteId, setSelectedSiteId ] = useState< number | null >( null );
 	const editorRef = useRef< HTMLDivElement >( null );
+	const [ showSuccessMessage, setShowSuccessMessage ] = useState( false );
 
 	// Set initial selected site once sites are loaded.
 	useEffect( () => {
@@ -45,11 +46,19 @@ export default function QuickPost() {
 		setEditorKey( ( key ) => key + 1 );
 	};
 
+	const callShowSuccessMessage = () => {
+		setShowSuccessMessage( true );
+		setTimeout( () => {
+			setShowSuccessMessage( false );
+		}, 5000 );
+	};
+
 	const handleSubmit = () => {
 		if ( ! postContent.trim() || ! selectedSiteId || isSubmitting ) {
 			return;
 		}
 
+		setShowSuccessMessage( false );
 		setIsSubmitting( true );
 
 		wpcom
@@ -63,6 +72,7 @@ export default function QuickPost() {
 			.then( () => {
 				recordReaderTracksEvent( 'calypso_reader_quick_post_submitted' );
 				clearEditor();
+				callShowSuccessMessage();
 				// TODO: Update the stream with the new post (if they're subscribed?) to signal success.
 			} )
 			.catch( () => {
@@ -133,6 +143,15 @@ export default function QuickPost() {
 				</div>
 			</div>
 			<div className="quick-post-input__actions">
+				<div
+					className={ `quick-post-input__success-message ${
+						showSuccessMessage ? 'is-visible' : ''
+					}` }
+					aria-hidden={ ! showSuccessMessage }
+				>
+					<p>{ translate( 'Post successful! Your message will appear in the feed soon.' ) }</p>
+				</div>
+
 				<Button
 					onClick={ handleCancel }
 					disabled={ isDisabled }

--- a/client/reader/components/quick-post/style.scss
+++ b/client/reader/components/quick-post/style.scss
@@ -30,6 +30,23 @@
 		color: var( --color-text-subtle );
 	}
 
+	&__success-message {
+		padding-left: 5px;
+		color: rgb( 0, 128, 0 );
+		display: flex;
+		align-items: center;
+		opacity: 0;
+		transition: opacity 0.3s ease-in-out;
+
+		&.is-visible {
+			opacity: 1;
+		}
+
+		p {
+			margin: 0;
+		}
+	}
+
     .verbum-editor-wrapper {
         .editor__header {
             border-color: var(--color-border-subtle);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/527

## Proposed Changes

Adds a simple success message with fade animation after successfully publishing a post.

<img width="748" alt="Screenshot 2025-02-27 at 18 05 11" src="https://github.com/user-attachments/assets/4668e285-b2e6-48de-921c-b427e5719aaf" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We should provide some kind of visual feedback when a user successfully publishes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit `/reader?flags=reader/quick-post`
- Add a post using the Quick Post editor
- Verify that the success message appears and that it disappears after a few seconds
- Verify that submitting another post immediately will also cause the message to disappear

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
