### PR TITLE
Reader Quick Edit: Update success message to use Notice component

### DIFF
--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -22,7 +22,7 @@ export default function GlobalNotices( { id = 'overlay-notices' } ) {
 	const noticesList = storeNotices.map(
 		// We'll rest/spread props to notice so arbitrary props can be passed to `Notice`.
 		// Be sure to destructure any props that aren't for at `Notice`, e.g. `button`.
-		( { button, buttonOptions, href, noticeId, onClick, onDismissClick, ...notice } ) => (
+		( { button, noticeActionProps, href, noticeId, onClick, onDismissClick, ...notice } ) => (
 			<Notice
 				{ ...notice }
 				key={ noticeId }
@@ -30,7 +30,7 @@ export default function GlobalNotices( { id = 'overlay-notices' } ) {
 				theme="dark"
 			>
 				{ button && (
-					<NoticeAction href={ href } onClick={ onClick } { ...buttonOptions }>
+					<NoticeAction href={ href } onClick={ onClick } { ...noticeActionProps }>
 						{ button }
 					</NoticeAction>
 				) }

--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -22,7 +22,7 @@ export default function GlobalNotices( { id = 'overlay-notices' } ) {
 	const noticesList = storeNotices.map(
 		// We'll rest/spread props to notice so arbitrary props can be passed to `Notice`.
 		// Be sure to destructure any props that aren't for at `Notice`, e.g. `button`.
-		( { button, href, noticeId, onClick, onDismissClick, ...notice } ) => (
+		( { button, buttonOptions, href, noticeId, onClick, onDismissClick, ...notice } ) => (
 			<Notice
 				{ ...notice }
 				key={ noticeId }
@@ -30,7 +30,7 @@ export default function GlobalNotices( { id = 'overlay-notices' } ) {
 				theme="dark"
 			>
 				{ button && (
-					<NoticeAction href={ href } onClick={ onClick }>
+					<NoticeAction href={ href } onClick={ onClick } { ...buttonOptions }>
 						{ button }
 					</NoticeAction>
 				) }

--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -12,6 +12,7 @@ import { useState, useRef } from 'react';
 import { useSelector, useDispatch, connect } from 'react-redux';
 import SitesDropdown from 'calypso/components/sites-dropdown';
 import { stripHTML } from 'calypso/lib/formatting';
+import Notice from 'calypso/components/notice';
 import wpcom from 'calypso/lib/wp';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
@@ -62,13 +63,6 @@ function QuickPost( {
 		setEditorKey( ( key ) => key + 1 );
 	};
 
-	const callShowSuccessMessage = () => {
-		setShowSuccessMessage( true );
-		setTimeout( () => {
-			setShowSuccessMessage( false );
-		}, 5000 );
-	};
-
 	const handleSubmit = () => {
 		if ( ! postContent.trim() || ! selectedSiteId || isSubmitting ) {
 			return;
@@ -95,7 +89,9 @@ function QuickPost( {
 			.then( ( postData: PostItem ) => {
 				recordReaderTracksEvent( 'calypso_reader_quick_post_submitted' );
 				clearEditor();
-				callShowSuccessMessage();
+
+				setShowSuccessMessage( true );
+				// TODO: Update the stream with the new post (if they're subscribed?) to signal success.
 
 				if ( config.isEnabled( 'reader/quick-post-v2' ) ) {
 					receivePosts( [ postData ] ).then( () => {
@@ -149,6 +145,11 @@ function QuickPost( {
 
 	return (
 		<div className="quick-post-input">
+			{ showSuccessMessage && (
+				<Notice status="is-success" onDismissClick={ () => setShowSuccessMessage( false ) }>
+					{ translate( 'Post successful! Your message will appear in the feed soon.' ) }
+				</Notice>
+			) }
 			<label htmlFor="quick-post-site-select" className="quick-post-input__label">
 				{ translate( 'Publish a post to' ) }
 			</label>
@@ -171,15 +172,6 @@ function QuickPost( {
 				</div>
 			</div>
 			<div className="quick-post-input__actions">
-				<div
-					className={ `quick-post-input__success-message ${
-						showSuccessMessage ? 'is-visible' : ''
-					}` }
-					aria-hidden={ ! showSuccessMessage }
-				>
-					<p>{ translate( 'Post successful! Your message will appear in the feed soon.' ) }</p>
-				</div>
-
 				<Button
 					onClick={ handleCancel }
 					disabled={ isDisabled }

--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -93,7 +93,7 @@ function QuickPost( {
 
 				successNotice( translate( 'Post successful! Your post will appear in the feed soon.' ), {
 					button: translate( 'View Post.' ),
-					buttonOptions: {
+					noticeActionProps: {
 						external: true,
 					},
 					href: postData.URL,

--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -12,9 +12,9 @@ import { useState, useRef } from 'react';
 import { useSelector, useDispatch, connect } from 'react-redux';
 import SitesDropdown from 'calypso/components/sites-dropdown';
 import { stripHTML } from 'calypso/lib/formatting';
-import Notice from 'calypso/components/notice';
 import wpcom from 'calypso/lib/wp';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { successNotice } from 'calypso/state/notices/actions';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
 import { receivePosts } from 'calypso/state/reader/posts/actions';
 import { receiveNewPost } from 'calypso/state/reader/streams/actions';
@@ -36,14 +36,17 @@ interface PostItem {
 	site_ID: number;
 	title: string;
 	content: string;
+	URL: string;
 }
 
 function QuickPost( {
 	primarySiteId,
 	receivePosts,
+	successNotice,
 }: {
 	primarySiteId: number | null;
 	receivePosts: ( posts: PostItem[] ) => Promise< void >;
+	successNotice: ( message: string, options: object ) => void;
 } ) {
 	const translate = useTranslate();
 	const locale = useLocale();
@@ -57,7 +60,6 @@ function QuickPost( {
 	const currentUser = useSelector( getCurrentUser );
 	const hasLoaded = useSelector( hasLoadedSites );
 	const hasSites = ( currentUser?.site_count ?? 0 ) > 0;
-	const [ showSuccessMessage, setShowSuccessMessage ] = useState( false );
 
 	const clearEditor = () => {
 		setEditorKey( ( key ) => key + 1 );
@@ -68,7 +70,6 @@ function QuickPost( {
 			return;
 		}
 
-		setShowSuccessMessage( false );
 		setIsSubmitting( true );
 
 		wpcom
@@ -90,7 +91,13 @@ function QuickPost( {
 				recordReaderTracksEvent( 'calypso_reader_quick_post_submitted' );
 				clearEditor();
 
-				setShowSuccessMessage( true );
+				successNotice( translate( 'Post successful! Your message will appear in the feed soon.' ), {
+					button: translate( 'View Post.' ),
+					buttonOptions: {
+						external: true,
+					},
+					href: postData.URL,
+				} );
 				// TODO: Update the stream with the new post (if they're subscribed?) to signal success.
 
 				if ( config.isEnabled( 'reader/quick-post-v2' ) ) {
@@ -145,11 +152,6 @@ function QuickPost( {
 
 	return (
 		<div className="quick-post-input">
-			{ showSuccessMessage && (
-				<Notice status="is-success" onDismissClick={ () => setShowSuccessMessage( false ) }>
-					{ translate( 'Post successful! Your message will appear in the feed soon.' ) }
-				</Notice>
-			) }
 			<label htmlFor="quick-post-site-select" className="quick-post-input__label">
 				{ translate( 'Publish a post to' ) }
 			</label>
@@ -196,6 +198,7 @@ export default connect(
 		primarySiteId: getPrimarySiteId( state ),
 	} ),
 	{
+		successNotice: ( message: string, options: object ) => successNotice( message, options ),
 		receivePosts: ( posts: PostItem[] ) => receivePosts( posts ) as Promise< void >,
 	}
 )( QuickPost );

--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -91,7 +91,7 @@ function QuickPost( {
 				recordReaderTracksEvent( 'calypso_reader_quick_post_submitted' );
 				clearEditor();
 
-				successNotice( translate( 'Post successful! Your message will appear in the feed soon.' ), {
+				successNotice( translate( 'Post successful! Your post will appear in the feed soon.' ), {
 					button: translate( 'View Post.' ),
 					buttonOptions: {
 						external: true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/527
Context: p1740679031588599/1740670158.331929-slack-C083J8DHLLD

## Proposed Changes

Replace the success message with a notice

### Before

<img width="748" alt="Screenshot 2025-02-27 at 18 05 11" src="https://github.com/user-attachments/assets/4668e285-b2e6-48de-921c-b427e5719aaf" />

### After

<img width="795" alt="Screenshot 2025-02-27 at 19 18 54" src="https://github.com/user-attachments/assets/847107b8-3c3b-4c81-bd96-ffdf30300ac0" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Improvements to Quick Edit experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit `/reader?flags=reader/quick-post`
- Add a post using the Quick Post editor
- Verify that the success message appears
- Verify that submitting another post will cause the message to disappear

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?