### PR TITLE
Newsletter Sub Importer: update translation calls

### DIFF
--- a/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
@@ -3,10 +3,8 @@ import { Subscriber } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { createInterpolateElement } from '@wordpress/element';
 import { external } from '@wordpress/icons';
-import { useI18n } from '@wordpress/react-i18n';
-import i18n from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef } from 'react';
 import exportSubstackSubscribersImg from 'calypso/assets/images/importer/export-substack-subscribers.png';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -23,7 +21,7 @@ export default function StepInitial( {
 	engine,
 	setAutoFetchData,
 }: SubscribersStepProps ) {
-	const { __ } = useI18n();
+	const translate = useTranslate();
 	const { importSelector } = useSelect( ( select ) => {
 		const subscriber = select( Subscriber.store );
 		return {
@@ -41,37 +39,41 @@ export default function StepInitial( {
 
 	return (
 		<Card>
-			<h2>{ __( 'Step 1: Export your subscribers from Substack' ) }</h2>
+			<h2>{ translate( 'Step 1: Export your subscribers from Substack' ) }</h2>
 			<p>
-				{ createInterpolateElement(
-					// @ts-expect-error - fixMe method is not typed in the package. Once types are added upstream, remove this.
-					i18n.fixMe( {
-						text: `Generate a CSV of your Substack subscribers. In Substack, go to Subscribers, click Export under "All subscribers," then upload the CSV in the next step. On the free plan, you can import up to 100 subscribers.`,
-						newCopy: __(
-							`Generate a CSV of your Substack subscribers. In Substack, go to <strong>Subscribers</strong>, click <strong>Export</strong> under "All subscribers," then upload the CSV in the next step. On the free plan, <supportLink>you can import up to 100 subscribers.</supportLink>`
-						),
-						oldCopy: __(
-							`Generate a CSV file of all your Substack subscribers. On Substack, go to the <strong>Subscribers</strong> tab and click the <strong>Export</strong> button you’ll find on top of the table. Then, upload the downloaded CSV in the next step.`
-						),
-					} ),
-					{
-						strong: <strong />,
-						supportLink: (
-							<InlineSupportLink
-								noWrap={ false }
-								showIcon={ false }
-								supportLink={ localizeUrl(
-									'https://wordpress.com/support/import-subscribers-to-a-newsletter/#troubleshooting-subscriber-imports'
-								) }
-								supportPostId={ 220199 }
-							/>
-						),
-					}
-				) }
+				{ i18n.fixMe( {
+					text: `Generate a CSV of your Substack subscribers. In Substack, go to Subscribers, click Export under "All subscribers," then upload the CSV in the next step. On the free plan, you can import up to 100 subscribers.`,
+					newCopy: translate(
+						`Generate a CSV of your Substack subscribers. In Substack, go to {{strong}}Subscribers{{/strong}}, click {{strong}}Export{{/strong}} under "All subscribers," then upload the CSV in the next step. On the free plan, {{supportLink}}you can import up to 100 subscribers.{{/supportLink}}`,
+						{
+							components: {
+								strong: <strong />,
+								supportLink: (
+									<InlineSupportLink
+										noWrap={ false }
+										showIcon={ false }
+										supportLink={ localizeUrl(
+											'https://wordpress.com/support/import-subscribers-to-a-newsletter/#troubleshooting-subscriber-imports'
+										) }
+										supportPostId={ 220199 }
+									/>
+								),
+							},
+						}
+					),
+					oldCopy: translate(
+						`Generate a CSV file of all your Substack subscribers. On Substack, go to the {{strong}}Subscribers{{/strong}} tab and click the {{strong}}Export{{/strong}} button you’ll find on top of the table. Then, upload the downloaded CSV in the next step.`,
+						{
+							components: {
+								strong: <strong />,
+							},
+						}
+					),
+				} ) }
 			</p>
 			<img
 				src={ exportSubstackSubscribersImg }
-				alt={ __( 'Export Substack subscribers' ) }
+				alt={ translate( 'Export Substack subscribers' ) }
 				className="export-subscribers"
 			/>
 			<Button
@@ -82,10 +84,10 @@ export default function StepInitial( {
 				iconPosition="right"
 				variant="primary"
 			>
-				{ __( 'Open Substack subscribers' ) }
+				{ translate( 'Open Substack subscribers' ) }
 			</Button>
 			<hr />
-			<h2>{ __( 'Step 2: Import your subscribers' ) }</h2>
+			<h2>{ translate( 'Step 2: Import your subscribers' ) }</h2>
 			{ selectedSite.ID && (
 				<SubscriberUploadForm
 					siteId={ selectedSite.ID }

--- a/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
@@ -3,6 +3,7 @@ import { Subscriber } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
 import { external } from '@wordpress/icons';
 import i18n, { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef } from 'react';
@@ -61,12 +62,12 @@ export default function StepInitial( {
 							},
 						}
 					),
-					oldCopy: translate(
-						`Generate a CSV file of all your Substack subscribers. On Substack, go to the {{strong}}Subscribers{{/strong}} tab and click the {{strong}}Export{{/strong}} button you’ll find on top of the table. Then, upload the downloaded CSV in the next step.`,
+					oldCopy: createInterpolateElement(
+						translate(
+							`Generate a CSV file of all your Substack subscribers. On Substack, go to the <strong>Subscribers</strong> tab and click the <strong>Export</strong> button you’ll find on top of the table. Then, upload the downloaded CSV in the next step.`
+						),
 						{
-							components: {
-								strong: <strong />,
-							},
+							strong: <strong />,
 						}
 					),
 				} ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #100478 and #100532

**I checked to see if the new text has been translated so we could remove this but it has not**

## Proposed Changes

* Removes ts-expected-error check

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*  Types have been merged upstream

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to users -> subscribers
* Click "Add Subscribers"
* Choose "Import from Substack"
* Follow steps until you get to step 2, "Subscribers"
* Check that the new copy from #100478 is present
* Change your language in account settings
* Check that translation of the old text is still present

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
