### PR TITLE
Stepper: migrate domain-transfer flow to use steps dictionary

### DIFF
--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -11,6 +11,7 @@ import {
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { USER_STORE } from '../stores';
 import { useLoginUrl } from '../utils/path';
+import { STEPS } from './internals/steps';
 import {
 	ProvidedDependencies,
 	AssertConditionResult,
@@ -19,6 +20,12 @@ import {
 } from './internals/types';
 import type { UserSelect } from '@automattic/data-stores';
 
+const DOMAIN_TRANSFER_STEPS = [
+	STEPS.DOMAIN_TRANSFER_INTRO,
+	STEPS.DOMAIN_TRANSFER_DOMAINS,
+	STEPS.PROCESSING,
+];
+
 const domainTransfer: FlowV1 = {
 	name: DOMAIN_TRANSFER,
 	get title() {
@@ -26,20 +33,7 @@ const domainTransfer: FlowV1 = {
 	},
 	isSignupFlow: false,
 	useSteps() {
-		return [
-			{
-				slug: 'intro',
-				asyncComponent: () => import( './internals/steps-repository/domain-transfer-intro' ),
-			},
-			{
-				slug: 'domains',
-				asyncComponent: () => import( './internals/steps-repository/domain-transfer-domains' ),
-			},
-			{
-				slug: 'processing',
-				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
-			},
-		];
+		return DOMAIN_TRANSFER_STEPS;
 	},
 
 	useAssertConditions( navigate ): AssertConditionResult {

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -38,6 +38,16 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/difm-starting-point' ),
 	},
 
+	DOMAIN_TRANSFER_INTRO: {
+		slug: 'intro',
+		asyncComponent: () => import( './steps-repository/domain-transfer-intro' ),
+	},
+
+	DOMAIN_TRANSFER_DOMAINS: {
+		slug: 'domains',
+		asyncComponent: () => import( './steps-repository/domain-transfer-domains' ),
+	},
+
 	DOMAINS: {
 		slug: 'domains',
 		asyncComponent: () => import( './steps-repository/domains' ),


### PR DESCRIPTION
Related to: #100585 

This moves domain-transfer flow to use indexed steps for consistency.

### Testing steps

1. Smoke test the flow and make sure it works.
2. Make sure the steps in the index have the same slug as the ones that were removed from the flow.
3. Make sure TypeScript is happy.

