### PR TITLE
Stepper: migrate new-hosted-site-flow to use steps dictionary

### DIFF
--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -83,7 +83,7 @@ const hosting: Flow = {
 						setPlanCartItem( {
 							product_slug: plan,
 						} );
-						return navigate( 'createSite' );
+						return navigate( 'create-site' );
 					}
 					return navigate( 'plans' );
 				}
@@ -105,14 +105,14 @@ const hosting: Flow = {
 					}
 
 					setSignupCompleteFlowName( flowName );
-					return navigate( 'createSite' );
+					return navigate( 'create-site' );
 				}
 
 				case 'trialAcknowledge': {
-					return navigate( 'createSite' );
+					return navigate( 'create-site' );
 				}
 
-				case 'createSite':
+				case 'create-site':
 					return navigate( 'processing' );
 
 				case 'processing': {

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -18,6 +18,7 @@ import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { useQuery } from '../hooks/use-query';
 import { ONBOARD_STORE, USER_STORE } from '../stores';
 import { useLoginUrl } from '../utils/path';
+import { STEPS } from './internals/steps';
 import { Flow, ProvidedDependencies } from './internals/types';
 import type { OnboardSelect, UserSelect } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
@@ -34,27 +35,11 @@ const hosting: Flow = {
 	useSteps() {
 		const showDomainStep = useShowDomainStep();
 		return [
-			...( showDomainStep
-				? [
-						{
-							slug: 'domains',
-							asyncComponent: () => import( './internals/steps-repository/domains' ),
-						},
-				  ]
-				: [] ),
-			{ slug: 'plans', asyncComponent: () => import( './internals/steps-repository/plans' ) },
-			{
-				slug: 'trialAcknowledge',
-				asyncComponent: () => import( './internals/steps-repository/trial-acknowledge' ),
-			},
-			{
-				slug: 'createSite',
-				asyncComponent: () => import( './internals/steps-repository/create-site' ),
-			},
-			{
-				slug: 'processing',
-				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
-			},
+			...( showDomainStep ? [ STEPS.DOMAINS ] : [] ),
+			STEPS.PLANS,
+			STEPS.TRIAL_ACKNOWLEDGE,
+			STEPS.SITE_CREATION_STEP,
+			STEPS.PROCESSING,
 		];
 	},
 	useStepNavigation( _currentStepSlug, navigate ) {


### PR DESCRIPTION
Related to: #100585 

This moves new-hosted-site-flow flow to use indexed steps for consistency.

### Testing steps

1. Smoke test the flow and make sure it works.
2. Make sure the steps in the index, have the same slug as the ones that were removed from the flow.

