### PR TITLE
Stepper: migrate newsletter flow to use steps dictionary

### DIFF
--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -19,6 +19,7 @@ import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../stores';
 import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
+import { STEPS } from './internals/steps';
 import { ProvidedDependencies } from './internals/types';
 import type { Flow } from './internals/types';
 
@@ -32,41 +33,17 @@ const newsletter: Flow = {
 		const query = useQuery();
 		const isComingFromMarketingPage = query.get( 'ref' ) === 'newsletter-lp';
 
-		const publicSteps = [
-			...( ! isComingFromMarketingPage
-				? [
-						{ slug: 'intro', asyncComponent: () => import( './internals/steps-repository/intro' ) },
-				  ]
-				: [] ),
-		];
+		const publicSteps = [ ...( ! isComingFromMarketingPage ? [ STEPS.INTRO ] : [] ) ];
 
 		const privateSteps = stepsWithRequiredLogin( [
-			{
-				slug: 'newsletterSetup',
-				asyncComponent: () => import( './internals/steps-repository/newsletter-setup' ),
-			},
-			{
-				slug: 'newsletterGoals',
-				asyncComponent: () => import( './internals/steps-repository/newsletter-goals' ),
-			},
-			{ slug: 'domains', asyncComponent: () => import( './internals/steps-repository/domains' ) },
-			{ slug: 'plans', asyncComponent: () => import( './internals/steps-repository/plans' ) },
-			{
-				slug: 'processing',
-				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
-			},
-			{
-				slug: 'subscribers',
-				asyncComponent: () => import( './internals/steps-repository/subscribers' ),
-			},
-			{
-				slug: 'createSite',
-				asyncComponent: () => import( './internals/steps-repository/create-site' ),
-			},
-			{
-				slug: 'launchpad',
-				asyncComponent: () => import( './internals/steps-repository/launchpad' ),
-			},
+			STEPS.NEWSLETTER_SETUP,
+			STEPS.NEWSLETTER_GOALS,
+			STEPS.DOMAINS,
+			STEPS.PLANS,
+			STEPS.PROCESSING,
+			STEPS.SUBSCRIBERS,
+			STEPS.SITE_CREATION_STEP,
+			STEPS.LAUNCHPAD,
 		] );
 
 		return [ ...publicSteps, ...privateSteps ];


### PR DESCRIPTION
Related to: #100585 

This moves newsletter flow to use indexed steps for consistency.

### Testing steps

1. Smoke test the flow and make sure it works.
2. Make sure the steps in the index have the same slug as the ones that were removed from the flow.
3. Make sure TypeScript is happy.
