### PR TITLE
Subscribers totals: Update to use translate plural args and numberFormat

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-totals/index.tsx
+++ b/client/my-sites/subscribers/components/subscriber-totals/index.tsx
@@ -1,5 +1,5 @@
 import { Spinner } from '@wordpress/components';
-import { translate } from 'i18n-calypso';
+import { translate, numberFormat } from 'i18n-calypso';
 import { SubscribersFilterBy } from '../../constants';
 import './style.scss';
 
@@ -19,35 +19,54 @@ const getFilterLabel = ( filters: SubscribersFilterBy[], count: number ): string
 	switch ( filterKey ) {
 		// Single filter cases.
 		case SubscribersFilterBy.Paid:
-			return count === 1 ? translate( 'paid subscriber' ) : translate( 'paid subscribers' );
+			return translate( 'paid subscriber', 'paid subscribers', {
+				count,
+				args: { count },
+			} ) as string;
 		case SubscribersFilterBy.Free:
-			return count === 1 ? translate( 'free subscriber' ) : translate( 'free subscribers' );
+			return translate( 'free subscriber', 'free subscribers', {
+				count,
+				args: { count },
+			} ) as string;
 		case SubscribersFilterBy.EmailSubscriber:
-			return count === 1 ? translate( 'email subscriber' ) : translate( 'email subscribers' );
+			return translate( 'email subscriber', 'email subscribers', {
+				count,
+				args: { count },
+			} ) as string;
 		case SubscribersFilterBy.ReaderSubscriber:
-			return count === 1 ? translate( 'reader subscriber' ) : translate( 'reader subscribers' );
+			return translate( 'reader subscriber', 'reader subscribers', {
+				count,
+				args: { count },
+			} ) as string;
 
 		// Two filter combinations.
 		case SubscribersFilterBy.EmailSubscriber + ',' + SubscribersFilterBy.Paid:
-			return count === 1
-				? translate( 'paid email subscriber' )
-				: translate( 'paid email subscribers' );
+			return translate( 'paid email subscriber', 'paid email subscribers', {
+				count,
+				args: { count },
+			} ) as string;
 		case SubscribersFilterBy.Paid + ',' + SubscribersFilterBy.ReaderSubscriber:
-			return count === 1
-				? translate( 'paid reader subscriber' )
-				: translate( 'paid reader subscribers' );
+			return translate( 'paid reader subscriber', 'paid reader subscribers', {
+				count,
+				args: { count },
+			} ) as string;
 		case SubscribersFilterBy.EmailSubscriber + ',' + SubscribersFilterBy.Free:
-			return count === 1
-				? translate( 'free email subscriber' )
-				: translate( 'free email subscribers' );
+			return translate( 'free email subscriber', 'free email subscribers', {
+				count,
+				args: { count },
+			} ) as string;
 		case SubscribersFilterBy.Free + ',' + SubscribersFilterBy.ReaderSubscriber:
-			return count === 1
-				? translate( 'free reader subscriber' )
-				: translate( 'free reader subscribers' );
+			return translate( 'free reader subscriber', 'free reader subscribers', {
+				count,
+				args: { count },
+			} ) as string;
 
 		// Default case.
 		default:
-			return count === 1 ? translate( 'subscriber' ) : translate( 'subscribers' );
+			return translate( 'subscriber', 'subscribers', {
+				count,
+				args: { count },
+			} ) as string;
 	}
 };
 
@@ -75,28 +94,28 @@ const SubscriberTotals: React.FC< SubscriberTotalsProps > = ( {
 				<>
 					<span className="subscriber-totals__filtered-count">
 						{ searchTerm
-							? translate( '%(count)d matching result', '%(count)d matching results', {
-									count: filteredCount,
-									args: { count: filteredCount },
+							? translate( '%(count)s matching result', '%(count)s matching results', {
+									count: filteredCount || 2,
+									args: { count: numberFormat( filteredCount ) },
 							  } )
-							: translate( '%(count)d %(filterLabel)s', {
+							: translate( '%(count)s %(filterLabel)s', {
 									args: {
-										count: filteredCount,
+										count: numberFormat( filteredCount ),
 										filterLabel,
 									},
 							  } ) }
 					</span>
 					<span className="subscriber-totals__total">
-						{ translate( 'out of %(total)d total subscribers', {
-							args: { total: totalSubscribers },
+						{ translate( 'out of %(total)s total subscribers', {
+							args: { total: numberFormat( totalSubscribers ) },
 						} ) }
 					</span>
 				</>
 			) : (
 				<span className="subscriber-totals__total-count">
-					{ translate( '%(count)d total subscriber', '%(count)d total subscribers', {
+					{ translate( '%(count)s total subscriber', '%(count)s total subscribers', {
 						count: totalSubscribers,
-						args: { count: totalSubscribers },
+						args: { count: numberFormat( totalSubscribers ) },
 					} ) }
 				</span>
 			) }

--- a/client/my-sites/subscribers/components/subscriber-totals/index.tsx
+++ b/client/my-sites/subscribers/components/subscriber-totals/index.tsx
@@ -94,29 +94,37 @@ const SubscriberTotals: React.FC< SubscriberTotalsProps > = ( {
 				<>
 					<span className="subscriber-totals__filtered-count">
 						{ searchTerm
-							? translate( '%(count)s matching result', '%(count)s matching results', {
-									count: filteredCount || 2,
-									args: { count: numberFormat( filteredCount ) },
-							  } )
-							: translate( '%(count)s %(filterLabel)s', {
+							? translate(
+									'%(matchingSubscriberCount)s matching result',
+									'%(matchingSubscriberCount)s matching results',
+									{
+										count: filteredCount,
+										args: { matchingSubscriberCount: numberFormat( filteredCount ) },
+									}
+							  )
+							: translate( '%(filteredSubscriberCount)s %(filterLabel)s', {
 									args: {
-										count: numberFormat( filteredCount ),
+										filteredSubscriberCount: numberFormat( filteredCount ),
 										filterLabel,
 									},
 							  } ) }
 					</span>
 					<span className="subscriber-totals__total">
-						{ translate( 'out of %(total)s total subscribers', {
-							args: { total: numberFormat( totalSubscribers ) },
+						{ translate( 'out of %(totalSubscriberCount)s total subscribers', {
+							args: { totalSubscriberCount: numberFormat( totalSubscribers ) },
 						} ) }
 					</span>
 				</>
 			) : (
 				<span className="subscriber-totals__total-count">
-					{ translate( '%(count)s total subscriber', '%(count)s total subscribers', {
-						count: totalSubscribers,
-						args: { count: numberFormat( totalSubscribers ) },
-					} ) }
+					{ translate(
+						'%(subscriberCount)s total subscriber',
+						'%(subscriberCount)s total subscribers',
+						{
+							count: totalSubscribers,
+							args: { subscriberCount: numberFormat( totalSubscribers ) },
+						}
+					) }
 				</span>
 			) }
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Use the `translate` singular/plural form and `numberFormat`, requested here: https://github.com/Automattic/wp-calypso/pull/99177#discussion_r1964339765

Here's how a large number currently looks on a non-EN site:

<img width="486" alt="Screen Shot 2025-02-28 at 11 57 18 PM" src="https://github.com/user-attachments/assets/4225fdc1-00e1-4224-9a5f-939ff7e2de93" />

More examples of the copy to be translated:

<img width="489" alt="Screen Shot 2025-03-04 at 9 57 52 AM" src="https://github.com/user-attachments/assets/f31cc5a6-79d0-47e3-9152-7a4402c290db" />
<img width="474" alt="Screen Shot 2025-03-04 at 9 57 37 AM" src="https://github.com/user-attachments/assets/c0557cd0-edbf-4540-ab10-5b468530c480" />
<img width="498" alt="Screen Shot 2025-03-04 at 9 57 23 AM" src="https://github.com/user-attachments/assets/f3fad810-dfc2-4602-a0f9-eba58017366a" />
<img width="470" alt="Screen Shot 2025-03-04 at 9 57 10 AM" src="https://github.com/user-attachments/assets/441d60c0-68ec-48d7-9366-bae76e001588" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Request from i18n team.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /subscribers/{ site url} and see the total update as you filter and search.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
