### PR TITLE
time-since: useRelativeTime: stop crash on invalid dates

### DIFF
--- a/packages/components/src/time-since/index.tsx
+++ b/packages/components/src/time-since/index.tsx
@@ -71,6 +71,10 @@ function useRelativeTime( date: string, dateFormat = 'll' ) {
  * Format a date using Intl.DateTimeFormat
  */
 function formatDate( date: Date, format: string ): string {
+	if ( ! date || isNaN( date.getTime() ) ) {
+		return '';
+	}
+
 	// Map moment-style formats to Intl options
 	const formatOptions: Intl.DateTimeFormatOptions = {
 		// Default to medium date format


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* fix this crash

![screenshot_2025-02-28_at_10 37 17___am](https://github.com/user-attachments/assets/0725b11e-82f2-4ccf-9f69-80ee9fbf502e)

seems to be caused by #100287 + a date of '0000-00-00 00:00:00'

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

apply
```diff
diff --git a/packages/components/src/time-since/index.tsx b/packages/components/src/time-since/index.tsx
index 438401c2b8c..a7e50b7f9a1 100644
--- a/packages/components/src/time-since/index.tsx
+++ b/packages/components/src/time-since/index.tsx
@@ -97,6 +97,7 @@ function formatDate( date: Date, format: string ): string {
 }

 function TimeSince( { className, date, dateFormat = 'll' }: TimeSinceProps ) {
+       date = '0000-00-00 00:00:00';
        const humanDate = useRelativeTime( date, dateFormat );
        const fullDate = formatDate( new Date( date ), 'llll' );

```

visit http://calypso.localhost:3000/sites

crash should stop happening

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
