### PR TITLE
Stats: add custom tooltips to line charts

### DIFF
--- a/apps/odyssey-stats/package.json
+++ b/apps/odyssey-stats/package.json
@@ -33,6 +33,7 @@
 		"@automattic/calypso-polyfills": "workspace:^",
 		"@automattic/calypso-router": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
+		"@automattic/charts": "^0.9.0",
 		"@automattic/components": "workspace:^",
 		"@tanstack/react-query": "^5.15.5",
 		"@wordpress/base-styles": "^5.16.0",

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -21,7 +21,7 @@ function StatsLineChart( {
 }: {
 	chartData: Array< {
 		label: string;
-		icon: JSX.Element;
+		icon?: JSX.Element;
 		options: object;
 		data: Array< { date: Date; value: number } >;
 	} >;
@@ -91,10 +91,8 @@ function StatsLineChart( {
 		() =>
 			Object.fromEntries(
 				chartData
-					.map( ( series ) => {
-						return series.icon && [ series.label, series.icon ];
-					} )
-					.filter( Boolean )
+					.filter( ( series ) => series.icon !== undefined )
+					.map( ( series ) => [ series.label, series.icon ] as const )
 			),
 		[ chartData ]
 	);
@@ -105,7 +103,7 @@ function StatsLineChart( {
 		}: {
 			tooltipData?: {
 				nearestDatum?: {
-					datum: DataPointDate & { tooltipData: object[] };
+					datum: DataPointDate;
 					key: string;
 				};
 				datumByKey?: { [ key: string ]: { datum: DataPointDate } };

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -3,47 +3,12 @@ import { DataPointDate } from '@automattic/charts/src/types';
 import clsx from 'clsx';
 import { numberFormat, useTranslate } from 'i18n-calypso';
 import { Moment } from 'moment';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import ChartBarTooltip from 'calypso/components/chart/bar-tooltip';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import StatsEmptyState from '../../stats-empty-state';
 
 import './styles.scss';
-
-const renderTooltip = ( {
-	tooltipData,
-}: {
-	tooltipData?: {
-		nearestDatum?: {
-			datum: DataPointDate;
-			key: string;
-		};
-		datumByKey?: { [ key: string ]: { datum: DataPointDate } };
-	};
-} ) => {
-	const nearestDatum = tooltipData?.nearestDatum?.datum;
-	if ( ! nearestDatum ) {
-		return null;
-	}
-	const tooltipPoints = Object.entries( tooltipData?.datumByKey || {} )
-		.map( ( [ key, { datum } ] ) => ( {
-			key,
-			value: datum.value as number,
-		} ) )
-		.sort( ( a, b ) => b.value - a.value );
-
-	return (
-		<div className="stats-line-chart-tooltip">
-			<div className="module-content-list-item is-date-label">
-				{ nearestDatum.date?.toLocaleDateString() }
-			</div>
-			<ul>
-				{ tooltipPoints.map( ( point ) => (
-					<ChartBarTooltip key={ point.key } label={ point.key } value={ point.value } />
-				) ) }
-			</ul>
-		</div>
-	);
-};
 
 function StatsLineChart( {
 	chartData = [],
@@ -56,6 +21,7 @@ function StatsLineChart( {
 }: {
 	chartData: Array< {
 		label: string;
+		icon: JSX.Element;
 		options: object;
 		data: Array< { date: Date; value: number } >;
 	} >;
@@ -68,6 +34,7 @@ function StatsLineChart( {
 	fixedDomain?: boolean;
 } ) {
 	const translate = useTranslate();
+	const moment = useLocalizedMoment();
 
 	const formatTime = formatTimeTick
 		? formatTimeTick
@@ -119,6 +86,62 @@ function StatsLineChart( {
 
 		return 'linear';
 	}, [ chartData ] );
+
+	const seriesIcons = useMemo(
+		() =>
+			Object.fromEntries(
+				chartData
+					.map( ( series ) => {
+						return series.icon && [ series.label, series.icon ];
+					} )
+					.filter( Boolean )
+			),
+		[ chartData ]
+	);
+
+	const renderTooltip = useCallback(
+		( {
+			tooltipData,
+		}: {
+			tooltipData?: {
+				nearestDatum?: {
+					datum: DataPointDate & { tooltipData: object[] };
+					key: string;
+				};
+				datumByKey?: { [ key: string ]: { datum: DataPointDate } };
+			};
+		} ) => {
+			const nearestDatum = tooltipData?.nearestDatum?.datum;
+			if ( ! nearestDatum ) {
+				return null;
+			}
+			const tooltipPoints = Object.entries( tooltipData?.datumByKey || {} ).map(
+				( [ key, { datum } ] ) => ( {
+					key,
+					value: datum.value as number,
+				} )
+			);
+
+			return (
+				<div className="stats-line-chart-tooltip">
+					<div className="module-content-list-item is-date-label">
+						{ nearestDatum.date && moment( nearestDatum.date ).format( 'LL' ) }
+					</div>
+					<ul>
+						{ tooltipPoints.map( ( point ) => (
+							<ChartBarTooltip
+								key={ point.key }
+								label={ point.key }
+								value={ point.value }
+								icon={ seriesIcons[ point.key ] }
+							/>
+						) ) }
+					</ul>
+				</div>
+			);
+		},
+		[ moment ]
+	);
 
 	return (
 		<div className={ clsx( 'stats-line-chart', className ) }>

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -1,9 +1,49 @@
 import { LineChart, ThemeProvider, jetpackTheme } from '@automattic/charts';
+import { DataPointDate } from '@automattic/charts/src/types';
 import clsx from 'clsx';
 import { numberFormat, useTranslate } from 'i18n-calypso';
 import { Moment } from 'moment';
 import { useMemo } from 'react';
+import ChartBarTooltip from 'calypso/components/chart/bar-tooltip';
 import StatsEmptyState from '../../stats-empty-state';
+
+import './styles.scss';
+
+const renderTooltip = ( {
+	tooltipData,
+}: {
+	tooltipData?: {
+		nearestDatum?: {
+			datum: DataPointDate;
+			key: string;
+		};
+		datumByKey?: { [ key: string ]: { datum: DataPointDate } };
+	};
+} ) => {
+	const nearestDatum = tooltipData?.nearestDatum?.datum;
+	if ( ! nearestDatum ) {
+		return null;
+	}
+	const tooltipPoints = Object.entries( tooltipData?.datumByKey || {} )
+		.map( ( [ key, { datum } ] ) => ( {
+			key,
+			value: datum.value as number,
+		} ) )
+		.sort( ( a, b ) => b.value - a.value );
+
+	return (
+		<div className="stats-line-chart-tooltip">
+			<div className="module-content-list-item is-date-label">
+				{ nearestDatum.date?.toLocaleDateString() }
+			</div>
+			<ul>
+				{ tooltipPoints.map( ( point ) => (
+					<ChartBarTooltip key={ point.key } label={ point.key } value={ point.value } />
+				) ) }
+			</ul>
+		</div>
+	);
+};
 
 function StatsLineChart( {
 	chartData = [],
@@ -118,6 +158,7 @@ function StatsLineChart( {
 								},
 							},
 						} }
+						renderTooltip={ renderTooltip }
 					/>
 				</ThemeProvider>
 			) }

--- a/client/my-sites/stats/components/line-chart/styles.scss
+++ b/client/my-sites/stats/components/line-chart/styles.scss
@@ -1,0 +1,67 @@
+.stats-line-chart-tooltip {
+	color: var(--color-text-inverted);
+	background: var(--color-neutral-100);
+	font-size: $font-body-small;
+	padding: 16px 24px;
+
+	// Default tooltip is 230px wide. We need a bit more room
+	// to account for longer date labels and post titles.
+	width: fit-content;
+	min-width: 230px;
+	max-width: 300px;
+
+	ul {
+		li {
+			font-size: $font-body-small;
+			font-weight: 500;
+			line-height: 20px;
+			letter-spacing: -0.24px;
+			margin-bottom: 10px;
+			text-transform: none;
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+
+			.value {
+				color: inherit;
+			}
+
+			.gridicon {
+				margin-right: 12px;
+			}
+		}
+	}
+
+	.module-content-list-item {
+		&.is-date-label {
+			font-weight: 600;
+			border-bottom: 0;
+		}
+
+		&.is-published {
+			margin-bottom: 4px;
+		}
+
+		&.is-published-item {
+			height: auto;
+			font-size: $font-body-extra-small;
+			margin-bottom: 0;
+			padding-left: 30px;
+
+			.label {
+				height: auto;
+				line-height: 20px;
+				color: inherit;
+				letter-spacing: inherit;
+				word-break: break-word;
+			}
+
+			// Override the default gradient.
+			.value::before {
+				background: none;
+			}
+		}
+	}
+
+}

--- a/client/my-sites/stats/components/line-chart/styles.scss
+++ b/client/my-sites/stats/components/line-chart/styles.scss
@@ -1,67 +1,97 @@
-.stats-line-chart-tooltip {
-	color: var(--color-text-inverted);
-	background: var(--color-neutral-100);
-	font-size: $font-body-small;
-	padding: 16px 24px;
+.visx-tooltip {
+	background-color: transparent !important;
+	border: none !important;
+	box-shadow: none !important;
 
-	// Default tooltip is 230px wide. We need a bit more room
-	// to account for longer date labels and post titles.
-	width: fit-content;
-	min-width: 230px;
-	max-width: 300px;
+	.stats-line-chart-tooltip {
+		color: var(--color-text-inverted);
+		background: var(--color-neutral-100);
+		border-radius: 4px;
+		font-size: $font-body-small;
+		padding: 16px 24px;
 
-	ul {
-		li {
-			font-size: $font-body-small;
-			font-weight: 500;
-			line-height: 20px;
-			letter-spacing: -0.24px;
-			margin-bottom: 10px;
-			text-transform: none;
+		// Default tooltip is 230px wide. We need a bit more room
+		// to account for longer date labels and post titles.
+		width: fit-content;
+		min-width: 230px;
+		max-width: 300px;
 
-			&:last-child {
-				margin-bottom: 0;
-			}
+		ul {
+			list-style: none;
+			margin: 0;
+			padding: 0;
 
-			.value {
-				color: inherit;
-			}
-
-			.gridicon {
-				margin-right: 12px;
-			}
-		}
-	}
-
-	.module-content-list-item {
-		&.is-date-label {
-			font-weight: 600;
-			border-bottom: 0;
-		}
-
-		&.is-published {
-			margin-bottom: 4px;
-		}
-
-		&.is-published-item {
-			height: auto;
-			font-size: $font-body-extra-small;
-			margin-bottom: 0;
-			padding-left: 30px;
-
-			.label {
-				height: auto;
+			li {
+				font-size: $font-body-small;
+				font-weight: 500;
 				line-height: 20px;
-				color: inherit;
-				letter-spacing: inherit;
-				word-break: break-word;
-			}
+				letter-spacing: -0.24px;
+				margin-bottom: 10px;
+				text-transform: none;
 
-			// Override the default gradient.
-			.value::before {
-				background: none;
+				.wrapper {
+					display: block;
+					line-height: 24px;
+					clear: both;
+				}
+
+				.value {
+					color: inherit;
+					text-align: right;
+					float: right;
+					min-width: 22px;
+				}
+
+				.label {
+					display: block;
+					overflow: hidden;
+					word-break: break-all;
+					vertical-align: baseline;
+				}
+
+				.gridicon {
+					margin-right: 12px;
+					vertical-align: middle;
+					margin-top: -3px;
+				}
+
+				&:last-child {
+					margin-bottom: 0;
+				}
 			}
 		}
+
+		.module-content-list-item {
+			&.is-date-label {
+				font-weight: 600;
+				border-bottom: 0;
+			}
+
+			&.is-published {
+				margin-bottom: 4px;
+			}
+
+			&.is-published-item {
+				height: auto;
+				font-size: $font-body-extra-small;
+				margin-bottom: 0;
+				padding-left: 30px;
+
+				.label {
+					height: auto;
+					line-height: 20px;
+					color: inherit;
+					letter-spacing: inherit;
+					word-break: break-word;
+				}
+
+				// Override the default gradient.
+				.value::before {
+					background: none;
+				}
+			}
+		}
+
 	}
 
 }

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -1,3 +1,5 @@
+import { eye } from '@automattic/components/src/icons';
+import { Icon, people } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize, translate } from 'i18n-calypso';
 import { flowRight } from 'lodash';
@@ -40,8 +42,9 @@ const transformChartDataToLineFormat = ( chartData ) => {
 
 	// Create the first data series for views
 	const viewsSeries = {
-		label: 'Views',
+		label: translate( 'Views' ),
 		options: {},
+		icon: <Icon className="gridicon" icon={ eye } />,
 		data: chartData
 			.map( ( record ) => {
 				const date = parseLocalDate( record.data.period );
@@ -56,8 +59,9 @@ const transformChartDataToLineFormat = ( chartData ) => {
 
 	// Create the second data series for visitors
 	const visitorsSeries = {
-		label: 'Visitors',
+		label: translate( 'Visitors' ),
 		options: {},
+		icon: <Icon className="gridicon" icon={ people } />,
 		data: chartData
 			.map( ( record ) => {
 				const date = parseLocalDate( record.data.period );

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { UseQueryResult } from '@tanstack/react-query';
+import { Icon, people, currencyDollar } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Intervals from 'calypso/blocks/stats-navigation/intervals';
@@ -199,6 +200,7 @@ export default function SubscribersChartSection( {
 	const lineChartData = [
 		{
 			label: translate( 'Subscribers' ),
+			icon: <Icon className="gridicon" icon={ people } />,
 			options: {
 				stroke: '#069e08',
 			},
@@ -206,6 +208,7 @@ export default function SubscribersChartSection( {
 		},
 		{
 			label: translate( 'Paid Subscribers' ),
+			icon: <Icon className="gridicon" icon={ currencyDollar } />,
 			options: {
 				stroke: 'rgb(230, 139, 40)',
 			},

--- a/yarn.lock
+++ b/yarn.lock
@@ -593,6 +593,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@automattic/charts@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "@automattic/charts@npm:0.9.0"
+  dependencies:
+    "@babel/runtime": "npm:7.26.0"
+    "@react-spring/web": "npm:9.7.3"
+    "@visx/axis": "npm:^3.12.0"
+    "@visx/curve": "npm:3.12.0"
+    "@visx/event": "npm:^3.8.0"
+    "@visx/gradient": "npm:3.12.0"
+    "@visx/grid": "npm:^3.12.0"
+    "@visx/group": "npm:^3.12.0"
+    "@visx/legend": "npm:^3.12.0"
+    "@visx/responsive": "npm:3.12.0"
+    "@visx/scale": "npm:^3.12.0"
+    "@visx/shape": "npm:^3.12.0"
+    "@visx/text": "npm:3.12.0"
+    "@visx/tooltip": "npm:^3.8.0"
+    "@visx/xychart": "npm:3.12.0"
+    clsx: "npm:2.1.1"
+    tslib: "npm:2.5.0"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+  checksum: 50d8555f2c815aee82d45f673c791d9a0ae02a62a1ae82a8461921e2e0d8250482faf4b39cc64c4e2c1891eb6518288ad1414520477c29b2e544e12239c21723
+  languageName: node
+  linkType: hard
+
 "@automattic/color-studio@npm:^3.0.1":
   version: 3.0.1
   resolution: "@automattic/color-studio@npm:3.0.1"
@@ -1566,6 +1594,7 @@ __metadata:
     "@automattic/calypso-polyfills": "workspace:^"
     "@automattic/calypso-router": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
+    "@automattic/charts": "npm:^0.9.0"
     "@automattic/components": "workspace:^"
     "@automattic/languages": "workspace:^"
     "@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Add in Jetpack Stats styled tooltips for line chart
* Update charts to `0.9.0`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Task

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `http://calypso.localhost:3000/stats/day/yoursite.au.ngrok.io?flags=stats/chart-library`
* Switch to line chart
* Hover over the lines
* Ensure the tooltip looks like the screenshot below (It doesn't have posts and views per visitors data yet)
* Open `http://calypso.localhost:3000/stats/subscribers/yoursite.au.ngrok.io?flags=stats/chart-library`
* * Ensure the tooltip looks like the screenshot below (ignore the fact that paid is greater than total in my screenshot please)


<img width="731" alt="image" src="https://github.com/user-attachments/assets/2464004c-fb55-4406-b288-d5a13ee5bfaa" />

<img width="734" alt="image" src="https://github.com/user-attachments/assets/86715592-af95-4337-abba-b677818634dc" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
