### PR TITLE
Line chart: use css variables for colors

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -195,7 +195,7 @@ $y-axis-padding: 0 20px;
 
 .chart__bar-section {
 	display: inline-block;
-	background-color: var(--color-primary-light);
+	background-color: var(--color-primary);
 	position: absolute;
 	right: 16%; // 1
 	bottom: 0; // 1
@@ -275,7 +275,7 @@ $y-axis-padding: 0 20px;
 	.chart__legend-color {
 		width: 20px;
 		height: 20px;
-		background: var(--color-primary-light);
+		background: var(--color-primary);
 		display: inline-block;
 		border-radius: 4px;
 		vertical-align: top;

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -195,7 +195,7 @@ $y-axis-padding: 0 20px;
 
 .chart__bar-section {
 	display: inline-block;
-	background-color: var(--color-primary);
+	background-color: var(--color-primary-light);
 	position: absolute;
 	right: 16%; // 1
 	bottom: 0; // 1
@@ -275,7 +275,7 @@ $y-axis-padding: 0 20px;
 	.chart__legend-color {
 		width: 20px;
 		height: 20px;
-		background: var(--color-primary);
+		background: var(--color-primary-light);
 		display: inline-block;
 		border-radius: 4px;
 		vertical-align: top;

--- a/client/my-sites/stats/hooks/use-css-variable.ts
+++ b/client/my-sites/stats/hooks/use-css-variable.ts
@@ -1,0 +1,73 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Custom hook to read CSS variables
+ *
+ * @param variableName - The CSS variable name (including the -- prefix)
+ * @param element - The element to read the variable from (defaults to :root)
+ * @param observe - Whether to observe for changes to the variable
+ * @returns The value of the CSS variable
+ *
+ * @example
+ * // Basic usage
+ * const primaryColor = useCssVariable('--primary-color');
+ *
+ * @example
+ * // Reading from a specific element and observing changes
+ * const headerHeight = useCssVariable('--header-height', headerRef.current, true);
+ */
+function useCssVariable(
+	variableName: string,
+	element: Element | null = typeof document !== 'undefined' ? document.documentElement : null,
+	observe: boolean = false
+): string {
+	const [ value, setValue ] = useState< string >( '' );
+
+	useEffect( () => {
+		// Check if we're in a browser environment
+		if ( typeof window === 'undefined' ) {
+			return;
+		}
+
+		// Make sure the element exists
+		if ( ! element ) {
+			return;
+		}
+
+		// Function to get the current value of the CSS variable
+		const updateValue = (): void => {
+			const styles = window.getComputedStyle( element );
+			const newValue = styles.getPropertyValue( variableName ).trim();
+			setValue( newValue );
+		};
+
+		// Get the initial value
+		setTimeout( updateValue, 200 );
+
+		// Set up observer for changes if requested
+		if ( observe ) {
+			const observer = new MutationObserver( ( mutations: MutationRecord[] ): void => {
+				mutations.forEach( ( mutation: MutationRecord ): void => {
+					if (
+						mutation.type === 'attributes' &&
+						( mutation.attributeName === 'style' || mutation.attributeName === 'class' )
+					) {
+						updateValue();
+					}
+				} );
+			} );
+
+			observer.observe( element, {
+				attributes: true,
+				attributeFilter: [ 'style', 'class' ],
+			} );
+
+			// Clean up observer when component unmounts
+			return () => observer.disconnect();
+		}
+	}, [ variableName, element, observe ] );
+
+	return value;
+}
+
+export default useCssVariable;

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -378,7 +378,7 @@ const connectComponent = connect(
 );
 
 const withCssColors = ( WrappedComponent ) => ( props ) => {
-	const primaryColor = useCssVariable( '--color-primary', document.body, true );
+	const primaryColor = useCssVariable( '--color-primary-light', document.body, true );
 	const secondaryColor = useCssVariable( '--color-primary-dark', document.body, true );
 	return (
 		<WrappedComponent

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -5,7 +5,7 @@ import { localize, translate } from 'i18n-calypso';
 import { flowRight } from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
+import { Component, useRef } from 'react';
 import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import Chart from 'calypso/components/chart';
@@ -103,6 +103,9 @@ class StatModuleChartTabs extends Component {
 		),
 		isActiveTabLoading: PropTypes.bool,
 		onChangeLegend: PropTypes.func.isRequired,
+		chartContainerRef: PropTypes.object,
+		primaryColor: PropTypes.string,
+		secondaryColor: PropTypes.string,
 	};
 
 	state = {
@@ -170,6 +173,7 @@ class StatModuleChartTabs extends Component {
 			countsComp,
 			primaryColor,
 			secondaryColor,
+			chartContainerRef,
 		} = this.props;
 		const { chartType } = this.state;
 
@@ -188,7 +192,7 @@ class StatModuleChartTabs extends Component {
 		];
 		/* pass bars count as `key` to disable transitions between tabs with different column count */
 		return (
-			<div className={ clsx( ...classes ) }>
+			<div className={ clsx( ...classes ) } ref={ chartContainerRef }>
 				<ChartHeader
 					activeLegend={ this.props.activeLegend }
 					activeTab={ this.props.activeTab }
@@ -377,14 +381,19 @@ const connectComponent = connect(
 	{ recordGoogleEvent, requestChartCounts }
 );
 
+// TODO: let's convert it to a function component and remove all the hassle.
 const withCssColors = ( WrappedComponent ) => ( props ) => {
-	const primaryColor = useCssVariable( '--color-primary-light', document.body, true );
-	const secondaryColor = useCssVariable( '--color-primary-dark', document.body, true );
+	const chartContainerRef = useRef( null );
+
+	const primaryColor = useCssVariable( '--color-primary-light', chartContainerRef.current );
+	const secondaryColor = useCssVariable( '--color-primary-dark', chartContainerRef.current );
+
 	return (
 		<WrappedComponent
 			{ ...props }
 			primaryColor={ primaryColor }
 			secondaryColor={ secondaryColor }
+			chartContainerRef={ chartContainerRef }
 		/>
 	);
 };

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -18,6 +18,7 @@ import { requestChartCounts } from 'calypso/state/stats/chart-tabs/actions';
 import { QUERY_FIELDS } from 'calypso/state/stats/chart-tabs/constants';
 import { getCountRecords, getLoadingTabs } from 'calypso/state/stats/chart-tabs/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import useCssVariable from '../hooks/use-css-variable';
 import StatsEmptyState from '../stats-empty-state';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatTabs from '../stats-tabs';
@@ -35,7 +36,7 @@ const ChartTabShape = PropTypes.shape( {
 } );
 
 // data validation for line chart
-const transformChartDataToLineFormat = ( chartData ) => {
+const transformChartDataToLineFormat = ( chartData, primaryColor, secondaryColor ) => {
 	if ( ! Array.isArray( chartData ) ) {
 		return [];
 	}
@@ -43,7 +44,7 @@ const transformChartDataToLineFormat = ( chartData ) => {
 	// Create the first data series for views
 	const viewsSeries = {
 		label: translate( 'Views' ),
-		options: {},
+		options: { stroke: primaryColor },
 		icon: <Icon className="gridicon" icon={ eye } />,
 		data: chartData
 			.map( ( record ) => {
@@ -60,7 +61,9 @@ const transformChartDataToLineFormat = ( chartData ) => {
 	// Create the second data series for visitors
 	const visitorsSeries = {
 		label: translate( 'Visitors' ),
-		options: {},
+		options: {
+			stroke: secondaryColor,
+		},
 		icon: <Icon className="gridicon" icon={ people } />,
 		data: chartData
 			.map( ( record ) => {
@@ -157,8 +160,17 @@ class StatModuleChartTabs extends Component {
 	};
 
 	render() {
-		const { siteId, slug, queryParams, selectedPeriod, isActiveTabLoading, className, countsComp } =
-			this.props;
+		const {
+			siteId,
+			slug,
+			queryParams,
+			selectedPeriod,
+			isActiveTabLoading,
+			className,
+			countsComp,
+			primaryColor,
+			secondaryColor,
+		} = this.props;
 		const { chartType } = this.state;
 
 		const chartData = this.props.chartData.map( ( record ) => {
@@ -210,7 +222,7 @@ class StatModuleChartTabs extends Component {
 					<AsyncLoad
 						require="calypso/my-sites/stats/components/line-chart"
 						className="stats-chart-tabs__line-chart"
-						chartData={ transformChartDataToLineFormat( chartData ) }
+						chartData={ transformChartDataToLineFormat( chartData, primaryColor, secondaryColor ) }
 						height={ 200 }
 						moment={ moment }
 					/>
@@ -365,7 +377,19 @@ const connectComponent = connect(
 	{ recordGoogleEvent, requestChartCounts }
 );
 
+const withCssColors = ( WrappedComponent ) => ( props ) => {
+	const primaryColor = useCssVariable( '--color-primary', document.body, true );
+	const secondaryColor = useCssVariable( '--color-primary-dark', document.body, true );
+	return (
+		<WrappedComponent
+			{ ...props }
+			primaryColor={ primaryColor }
+			secondaryColor={ secondaryColor }
+		/>
+	);
+};
+
 export default flowRight(
 	localize,
 	connectComponent
-)( withPerformanceTrackerStop( StatModuleChartTabs ) );
+)( withPerformanceTrackerStop( withCssColors( StatModuleChartTabs ) ) );

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -8,6 +8,7 @@ import AsyncLoad from 'calypso/components/async-load';
 import UplotChart from 'calypso/components/chart-uplot';
 import useSubscribersQuery from 'calypso/my-sites/stats/hooks/use-subscribers-query';
 import { useSelector } from 'calypso/state';
+import useCssVariable from '../hooks/use-css-variable';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsPeriodHeader from '../stats-period-header';
 import { parseLocalDate } from '../utils';
@@ -109,6 +110,7 @@ export default function SubscribersChartSection( {
 	slug?: string | null;
 	period?: PeriodType;
 } ) {
+	const containerRef = useRef< HTMLDivElement >( null );
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const isChartLibraryEnabled = config.isEnabled( 'stats/chart-library' );
 	const quantityDefault: QuantityDefaultType = {
@@ -179,6 +181,7 @@ export default function SubscribersChartSection( {
 		}
 	}, [ status, isError ] );
 
+	const primaryColor = useCssVariable( '--color-primary-dark', containerRef.current );
 	const products = useSelector( ( state ) => state.memberships?.productList?.items[ siteId ?? 0 ] );
 
 	// Products with an undefined value rather than an empty array means the API call has not been completed yet.
@@ -202,7 +205,7 @@ export default function SubscribersChartSection( {
 			label: translate( 'Subscribers' ),
 			icon: <Icon className="gridicon" icon={ people } />,
 			options: {
-				stroke: '#069e08',
+				stroke: primaryColor,
 			},
 			data: subscribersData,
 		},
@@ -229,7 +232,7 @@ export default function SubscribersChartSection( {
 		: `/subscribers/${ slug }`;
 
 	return (
-		<div className="subscribers-section">
+		<div ref={ containerRef } className="subscribers-section">
 			{ /* TODO: Remove highlight-cards class and use a highlight cards heading component instead. */ }
 			<div className="subscribers-section-heading highlight-cards">
 				<h1 className="highlight-cards-heading">

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -181,7 +181,7 @@ export default function SubscribersChartSection( {
 		}
 	}, [ status, isError ] );
 
-	const primaryColor = useCssVariable( '--color-primary-dark', containerRef.current );
+	const subscriberLineStroke = useCssVariable( '--color-primary-light', containerRef.current );
 	const products = useSelector( ( state ) => state.memberships?.productList?.items[ siteId ?? 0 ] );
 
 	// Products with an undefined value rather than an empty array means the API call has not been completed yet.
@@ -205,7 +205,7 @@ export default function SubscribersChartSection( {
 			label: translate( 'Subscribers' ),
 			icon: <Icon className="gridicon" icon={ people } />,
 			options: {
-				stroke: primaryColor,
+				stroke: subscriberLineStroke,
 			},
 			data: subscribersData,
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Introduced a hook to get css variables so that the chart could render the right colors
* Made Views color lighter for better visual differentiation

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Use colors in the theme

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `http://calypso.localhost:3000/stats/day/your-site.com?flags=stats/chart-library`
* Ensure the Bar chart looks good
* Switch to line chart
* Ensure lines have okay visual differentiation
* Open `http://calypso.localhost:3000/stats/subscribers/jasper1.au.ngrok.io?flags=stats/chart-library`
* Ensure the line chart looks okay

![image](https://github.com/user-attachments/assets/b3000821-cb35-4ef4-be43-f5979c596748)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
