### PR TITLE
Fix goals step showing up again after a partner theme purchased on newish sites

### DIFF
--- a/client/state/themes/actions/add-external-managed-theme-to-cart.tsx
+++ b/client/state/themes/actions/add-external-managed-theme-to-cart.tsx
@@ -10,6 +10,7 @@ import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import 'calypso/state/themes/init';
 import { marketplaceThemeProduct } from 'calypso/lib/cart-values/cart-items';
 import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
+import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
 import { getProductsByBillingSlug } from 'calypso/state/products-list/selectors';
 import { getProductBillingSlugByThemeId } from 'calypso/state/products-list/selectors/get-product-billing-slug-by-theme-id';
 import { getSitePlanSlug, getSiteSlug } from 'calypso/state/sites/selectors';
@@ -107,6 +108,11 @@ export function addExternalManagedThemeToCart( themeId: string, siteId: number )
 			.forCartKey( cartKey )
 			.actions.addProductsToCart( cartItems )
 			.then( () => {
+				// If there's been a site created recently then this cookie will still contain
+				// the post-checkout destination from that site-creation flow. We don't want
+				// that flow's destination to be used here.
+				clearSignupDestinationCookie();
+
 				page( `/checkout/${ siteSlug }` );
 			} )
 			.finally( () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #100246

## Proposed Changes

* Clear `wpcom_signup_complete_destination` before purchasing partner theme

This allows the default post checkout behaviour for partner themes to run i.e. transferring to atomic

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See https://github.com/Automattic/wp-calypso/issues/100246#issuecomment-2689789201

In short the signup flow stores it's post-checkout destination in a cookie. If the user purchases a partner theme from `/themes` within 24 hours of the site being created, then that cookie will still be there. The cookie will override the post-checkout behaviour.

Deleting the cookie when we know the user wants to purchase a partner theme might not be an elegant fix, but it fixes the user's problem.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site with `/setup/onboarding`, or start with a simple site that's under 24 hours old
* Head to `/themes/:siteSlug` purchase a partner theme along with business plan (e.g. STAX)
* Complete checkout
* Post checkout there should be a progress bar while the site goes atomic
* Now test it with a site that started with a premium plan
* Now test it with a simple site that has business plan already
* Now test it with a brand new user

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
