### PR TITLE
Fix profile submenu hover background color

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -354,20 +354,22 @@ body.is-mobile-app-view {
 		padding-top: 4px;
 	}
 
+	&:hover,
+	&.is-open,
+	&:has(+ .masterbar__item-subitems:hover) {
+		& + .masterbar__item-subitems {
+			display: block;
+			z-index: 99999;
+		}
+	}
+
 	// The hover colors are supposed to be the same as those in wp-admin.
 	&:hover,
-	&:has(+ .masterbar__item-subitems:hover),
 	&.is-open {
 		svg path,
 		.gridicon {
 			fill: var(--color-masterbar-highlight);
 		}
-
-		& + .masterbar__item-subitems {
-			display: block;
-			z-index: 99999;
-		}
-
 
 		@include breakpoint-deprecated( ">480px" ) {
 			background: var(--color-masterbar-item-hover-background);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #100614

## Proposed Changes

Separates hover styles for masterbar items to prevent background color from showing when only the submenu is being hovered:

before

https://github.com/user-attachments/assets/1e3085cc-d90d-499d-ad08-58524e9ef186

after

[![Image from Gyazo](https://i.gyazo.com/9291d4fa3ccd1ad1546b9837693936cf.gif)](https://gyazo.com/9291d4fa3ccd1ad1546b9837693936cf)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This issue stems from https://github.com/Automattic/wp-calypso/pull/98510/commits/abd76a2957b203583f9985ee9960bb39ae3ef396. While this maintained submenu visibility, it had an unintended side effect of also preserving the parent item's background color styles during submenu hover.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Go to /sites
	- Hover over a masterbar item and observe nothing breaks
	- Hover over "Howdy..." link and submenu, observe nothing breaks
- Go to /me
	- Hover over "Howdy..." link and submenu, observe nothing breaks
	- Hover over a masterbar item and observe nothing breaks

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
