### PR TITLE
Masterbar tabs: Remove fade.

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -209,7 +209,6 @@ body.is-mobile-app-view {
 	padding: 0 8px;
 	text-decoration: none;
 	cursor: default;
-	transition: all 0.2s ease-in-out;
 	justify-content: center;
 
 	&.masterbar__reader {
@@ -596,7 +595,6 @@ body.is-mobile-app-view {
 			height: var(--masterbar-item-active-border-radius);
 			background-color: var(--color-sidebar-background);
 			opacity: 0;
-			transition: opacity 0.2s ease-in-out;
 			bottom: 0;
 			z-index: 1;
 			pointer-events: none;


### PR DESCRIPTION
Fixes #100257.

## Proposed Changes

Remove the fade effect from the masterbar tabs.

## Why are these changes being made?

As outlined in 100257, the little round bottom corners do not fade in sync with the tabs themselves. This is because they are pseudo elements, separately styled, so for some reason that's creating a little race condition both in occasional activation but also occasional deactivation states:

![fades](https://github.com/user-attachments/assets/9485e1a5-1c48-47fc-9be4-b53194d371ee)

Removing the fade fixes it and kinda makes it feel faster too:

![fixed](https://github.com/user-attachments/assets/03a7b5a3-2087-4d58-a9ca-32b301e63722)

## Testing Instructions

Test masterbar tabs like reader, sites, profile.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
