### PR TITLE
Social | Update the scheduled-actions endpoint

### DIFF
--- a/client/state/sharing/publicize/publicize-actions/actions.js
+++ b/client/state/sharing/publicize/publicize-actions/actions.js
@@ -24,14 +24,14 @@ export function fetchPostShareActionsScheduled( siteId, postId ) {
 			postId,
 		} );
 
-		const getScheduledPath = `/sites/${ siteId }/posts/${ postId }/publicize/scheduled-actions`;
+		const getScheduledPath = `/sites/${ siteId }/publicize/scheduled-actions/posts/${ postId }`;
 		return wpcom.req.get(
 			{
 				path: getScheduledPath,
 				apiNamespace: 'wpcom/v2',
 			},
 			( error, data ) => {
-				if ( error || ! data.items ) {
+				if ( error || ! data ) {
 					return dispatch( {
 						type: PUBLICIZE_SHARE_ACTIONS_SCHEDULED_REQUEST_FAILURE,
 						siteId,
@@ -41,7 +41,7 @@ export function fetchPostShareActionsScheduled( siteId, postId ) {
 				}
 
 				const actions = {};
-				data.items.forEach( ( action ) => ( actions[ action.ID ] = action ) );
+				data.forEach( ( action ) => ( actions[ action.ID ] = action ) );
 				dispatch( {
 					type: PUBLICIZE_SHARE_ACTIONS_SCHEDULED_REQUEST_SUCCESS,
 					siteId,
@@ -100,7 +100,7 @@ export function deletePostShareAction( siteId, postId, actionId ) {
 			actionId,
 		} );
 
-		const deleteActionPath = `/sites/${ siteId }/posts/${ postId }/publicize/scheduled-actions/${ actionId }`;
+		const deleteActionPath = `/sites/${ siteId }/publicize/scheduled-actions/posts/${ postId }/${ actionId }`;
 		return wpcom.req.get(
 			{
 				path: deleteActionPath,
@@ -136,7 +136,7 @@ export function schedulePostShareAction( siteId, postId, message, share_date, co
 		return Promise.all(
 			connections.map( ( connection_id ) =>
 				wpcom.req.post( {
-					path: `/sites/${ siteId }/posts/${ postId }/publicize/scheduled-actions/`,
+					path: `/sites/${ siteId }/publicize/scheduled-actions/posts/${ postId }/`,
 					body: { message, share_date, connection_id },
 					apiNamespace: 'wpcom/v2',
 				} )


### PR DESCRIPTION
## Proposed Changes

* Update the post list page share post section to use the updated `publicize/scheduled-actions` endpoint

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The `publicize/scheduled-actions` is being moved to Jetpack with some slight improvements.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply 175318-ghe-Automattic/wpcom to your sandbox
* Then apply https://github.com/Automattic/jetpack/pull/42136 to your sandbox on top of the above branch instead of on trunk
* Point the public API and your site to your sandbox
* Enable Calypso UI - p7DVsv-m73-p2
* Use the Calypso Live links below or run this PR locally
* Goto `/posts/:site`
* For any post click on the options menu (3 dots)
* Click on Share
* Veridy in the Network tab that the request goes to `wpcom/v2/sites/:site/publicize/scheduled-actions/posts/:post`
* Schedule a share for some social networks
* Confirm that the POST request is sent to `wpcom/v2/sites/:site/publicize/scheduled-actions/posts/:post` and is successful
* Confirm that the number of scheduled shares is reflected correctly
* Reload the page
* Confirm that the details are still correct
* Delete a scheduled share
* Confirm that the request is sent to `wpcom/v2/sites/:site/publicize/scheduled-actions/posts/:post/:actionId`
* Confirm that it works fine.
* Now remove sandboxing of the public API
* Goto `wordpress.com/posts/:site`
* Confirm that you see the shares scheduled above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?