### PR TITLE
i18n: Fix missing thousandth separator in `/people/team/:site` member counts

### DIFF
--- a/client/my-sites/people/team-members/index.tsx
+++ b/client/my-sites/people/team-members/index.tsx
@@ -1,7 +1,7 @@
 import { Card, Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Icon } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import { ReactElement } from 'react';
 import InfiniteList from 'calypso/components/infinite-list';
 import NoResults from 'calypso/my-sites/no-results';
@@ -75,10 +75,14 @@ function TeamMembers( props: Props ) {
 			);
 		}
 
-		return translate( 'You have %(number)d user', 'You have %(number)d users', {
-			args: { number: membersTotal as number, searchTerm: search as string },
-			count: membersTotal as number,
-		} );
+		return translate(
+			'You have %(membersTotalCount)s user',
+			'You have %(membersTotalCount)s users',
+			{
+				args: { membersTotalCount: numberFormat( membersTotal as number ) },
+				count: membersTotal as number,
+			}
+		);
 	}
 
 	function renderSSOMessageWrapper( key: number, children: ReactElement ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/i18n-issues/issues/945

## Proposed Changes

Fixes missing number formatting under `/people/team/:site`

Confirmed string similarity between old/new to be ~0.6, which won't lead to a fuzzy translation.

## Media

### Before 

<img width="700" alt="Screenshot 2025-02-28 at 11 26 41 AM" src="https://github.com/user-attachments/assets/4abeea7e-ce53-4708-80a9-22df5185afae" />

### After

<img width="700" alt="Screenshot 2025-02-28 at 11 25 32 AM" src="https://github.com/user-attachments/assets/8dbf36d8-55d9-4621-9ab2-cc811fe26bcc" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Address https://github.com/Automattic/i18n-issues/issues/945

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Switch locale to EL/DE
- Go to `/people/team/:site` and confirm number of members renders with correct thousandth separator (`.` for EL). 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
