### PR TITLE
Plans Comparison Grid: Keep the plan grid order in comparison table

### DIFF
--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -934,13 +934,14 @@ const ComparisonGrid = ( {
 	const { gridPlans, gridPlansIndex, featureGroupMap } = usePlansGridContext();
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
 	const [ visiblePlans, setVisiblePlans ] = useState< PlanSlug[] >( [] );
+	const isTruncated = visiblePlans.length !== gridPlans.length;
 
 	const displayedGridPlans = useMemo( () => {
-		return sortPlans( gridPlans, currentSitePlanSlug, 'small' === gridSize );
-	}, [ gridPlans, currentSitePlanSlug, gridSize ] );
+		return sortPlans( gridPlans, currentSitePlanSlug, isTruncated );
+	}, [ gridPlans, currentSitePlanSlug, isTruncated ] );
 
 	useEffect( () => {
-		setVisiblePlans( ( prev ) => {
+		setVisiblePlans( () => {
 			let visibleLength = displayedGridPlans.length;
 			switch ( gridSize ) {
 				case 'large':
@@ -955,27 +956,7 @@ const ComparisonGrid = ( {
 					break;
 			}
 
-			// visible length changed, update with the current gridPlans
-			// - we don't care about previous order
-			if ( prev.length !== visibleLength ) {
-				return displayedGridPlans.slice( 0, visibleLength ).map( ( { planSlug } ) => planSlug );
-			}
-
-			// prev state out of sync with current gridPlans (e.g. gridPlans updated to a different term)
-			// - we care about previous order
-			const isPrevStale = prev.some( ( planSlug ) => ! gridPlansIndex[ planSlug ] );
-			if ( isPrevStale ) {
-				return prev.map( ( planSlug ) => {
-					const gridPlan = displayedGridPlans.find(
-						( gridPlan ) => getPlanClass( gridPlan.planSlug ) === getPlanClass( planSlug )
-					);
-
-					return gridPlan?.planSlug ?? planSlug;
-				} );
-			}
-
-			// nothing to update
-			return prev;
+			return displayedGridPlans.slice( 0, visibleLength ).map( ( { planSlug } ) => planSlug );
 		} );
 	}, [ gridSize, displayedGridPlans, gridPlansIndex ] );
 

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -934,11 +934,10 @@ const ComparisonGrid = ( {
 	const { gridPlans, gridPlansIndex, featureGroupMap } = usePlansGridContext();
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
 	const [ visiblePlans, setVisiblePlans ] = useState< PlanSlug[] >( [] );
-	const isTruncated = visiblePlans.length !== gridPlans.length;
 
 	const displayedGridPlans = useMemo( () => {
-		return sortPlans( gridPlans, currentSitePlanSlug, isTruncated );
-	}, [ gridPlans, currentSitePlanSlug, isTruncated ] );
+		return sortPlans( gridPlans, currentSitePlanSlug );
+	}, [ gridPlans, currentSitePlanSlug ] );
 
 	useEffect( () => {
 		setVisiblePlans( () => {

--- a/packages/plans-grid-next/src/lib/sort-plan-properties.ts
+++ b/packages/plans-grid-next/src/lib/sort-plan-properties.ts
@@ -2,15 +2,14 @@ import type { GridPlan } from '../types';
 
 export function sortPlans(
 	gridPlans: GridPlan[],
-	currentSitePlanProductSlug?: string | null,
-	isTruncated?: boolean
+	currentSitePlanProductSlug?: string | null
 ): GridPlan[] {
 	// If we don't have plans to sort, return empty array
 	if ( ! gridPlans.length ) {
 		return [];
 	}
 	// If we have a current site plan and we're on mobile, sort to prioritize it
-	if ( currentSitePlanProductSlug && isTruncated ) {
+	if ( currentSitePlanProductSlug ) {
 		return [ ...gridPlans ].sort( ( planA, planB ) => {
 			// If planA is the current plan, it should come first (-1 moves it up)
 			if ( planA.planSlug === currentSitePlanProductSlug ) {

--- a/packages/plans-grid-next/src/lib/sort-plan-properties.ts
+++ b/packages/plans-grid-next/src/lib/sort-plan-properties.ts
@@ -1,46 +1,28 @@
-import { isFreePlan } from '@automattic/calypso-products';
-import { isPopularPlan } from '../hooks/data-store/is-popular-plan';
 import type { GridPlan } from '../types';
 
 export function sortPlans(
 	gridPlans: GridPlan[],
 	currentSitePlanProductSlug?: string | null,
-	isMobile?: boolean
+	isTruncated?: boolean
 ): GridPlan[] {
-	let firstPlanIndex = -1;
-
-	// Try to find the current paid plan in the plans list
-	if ( currentSitePlanProductSlug && ! isFreePlan( currentSitePlanProductSlug ) ) {
-		firstPlanIndex = gridPlans.findIndex( ( gridPlan ) => {
-			return gridPlan.planSlug === currentSitePlanProductSlug;
+	// If we don't have plans to sort, return empty array
+	if ( ! gridPlans.length ) {
+		return [];
+	}
+	// If we have a current site plan and we're on mobile, sort to prioritize it
+	if ( currentSitePlanProductSlug && isTruncated ) {
+		return [ ...gridPlans ].sort( ( planA, planB ) => {
+			// If planA is the current plan, it should come first (-1 moves it up)
+			if ( planA.planSlug === currentSitePlanProductSlug ) {
+				return -1;
+			}
+			// If planB is the current plan, it should come first (1 moves planA down)
+			if ( planB.planSlug === currentSitePlanProductSlug ) {
+				return 1;
+			}
+			// Otherwise, maintain original order
+			return 0;
 		} );
 	}
-
-	if ( firstPlanIndex < 0 ) {
-		// Site is on a free plan or the current plan is not in the list. Try to find the popular plan.
-		firstPlanIndex = gridPlans.findIndex( ( { planSlug } ) => {
-			return isPopularPlan( planSlug );
-		} );
-		// If the popular plan exists, on mobile, it will be second plan for comparison.
-		if ( firstPlanIndex > 0 && isMobile ) {
-			firstPlanIndex = firstPlanIndex - 1;
-		}
-	}
-
-	if ( firstPlanIndex < 0 ) {
-		return gridPlans;
-	}
-
-	return [
-		// The first plan
-		gridPlans[ firstPlanIndex ],
-		// Rest of the plans in default order
-		...gridPlans.slice( firstPlanIndex + 1 ),
-		// Leftover plans (before the first plan) in descending order of value
-		...gridPlans.slice( 0, firstPlanIndex ).sort( ( planA, planB ) => {
-			return (
-				( planB?.pricing.originalPrice.full || 0 ) - ( planA?.pricing.originalPrice.full || 0 )
-			);
-		} ),
-	].filter( ( gridPlan ) => Boolean( gridPlan ) );
+	return [ ...gridPlans ];
 }

--- a/packages/plans-grid-next/src/lib/test/sort-plan-properties.ts
+++ b/packages/plans-grid-next/src/lib/test/sort-plan-properties.ts
@@ -42,63 +42,81 @@ const planEcommerce = {
 const plansInDefaultOrder = [ planFree, planPersonal, planPremium, planBusiness, planEcommerce ];
 
 describe( 'sortPlans', () => {
-	it( 'should sort plans in descending order of value when current plan slug is personal', () => {
+	it( 'should return an empty array if no plans are provided', () => {
+		expect( sortPlans( [] ) ).toEqual( [] );
+	} );
+
+	it( 'should return the original order if no current plan is specified', () => {
+		expect( sortPlans( plansInDefaultOrder ) ).toEqual( plansInDefaultOrder );
+	} );
+
+	it( 'should return the original order if current plan is null', () => {
+		expect( sortPlans( plansInDefaultOrder, null ) ).toEqual( plansInDefaultOrder );
+	} );
+
+	it( 'should return the original order if current plan is undefined', () => {
+		expect( sortPlans( plansInDefaultOrder, undefined ) ).toEqual( plansInDefaultOrder );
+	} );
+
+	it( 'should return the original order if current plan is not found in the plans array', () => {
+		expect( sortPlans( plansInDefaultOrder, 'non-existent-plan' ) ).toEqual( plansInDefaultOrder );
+	} );
+
+	it( 'should prioritize the current plan when specified', () => {
+		// When personal plan is current
 		expect( sortPlans( plansInDefaultOrder, 'personal-bundle' ) ).toEqual( [
 			planPersonal,
+			planFree,
 			planPremium,
 			planBusiness,
 			planEcommerce,
-			planFree,
 		] );
-	} );
 
-	it( 'should sort plans in descending order of value when current plan slug is ecommerce', () => {
+		// When premium plan is current
+		expect( sortPlans( plansInDefaultOrder, 'value_bundle' ) ).toEqual( [
+			planPremium,
+			planFree,
+			planPersonal,
+			planBusiness,
+			planEcommerce,
+		] );
+
+		// When business plan is current
+		expect( sortPlans( plansInDefaultOrder, 'business-bundle' ) ).toEqual( [
+			planBusiness,
+			planFree,
+			planPersonal,
+			planPremium,
+			planEcommerce,
+		] );
+
+		// When ecommerce plan is current
 		expect( sortPlans( plansInDefaultOrder, 'ecommerce-bundle' ) ).toEqual( [
 			planEcommerce,
-			planBusiness,
-			planPremium,
-			planPersonal,
 			planFree,
-		] );
-	} );
-
-	it( 'should show the popular plan first if current plan slug is empty', () => {
-		expect( sortPlans( plansInDefaultOrder ) ).toEqual( [
+			planPersonal,
 			planPremium,
 			planBusiness,
-			planEcommerce,
-			planPersonal,
-			planFree,
 		] );
-	} );
 
-	it( 'should show the popular plan first when current plan slug is empty', () => {
-		expect( sortPlans( plansInDefaultOrder ) ).toEqual( [
-			planPremium,
-			planBusiness,
-			planEcommerce,
-			planPersonal,
-			planFree,
-		] );
-	} );
-
-	it( 'should show the popular plan first if current plan slug is the free plan', () => {
+		// When free plan is current
 		expect( sortPlans( plansInDefaultOrder, 'free_plan' ) ).toEqual( [
+			planFree,
+			planPersonal,
 			planPremium,
 			planBusiness,
 			planEcommerce,
-			planPersonal,
-			planFree,
 		] );
 	} );
 
-	it( 'should show the popular plan second if current plan slug is empty/free and user is on mobile', () => {
-		expect( sortPlans( plansInDefaultOrder, 'free_plan', true ) ).toEqual( [
-			planPersonal,
-			planPremium,
-			planBusiness,
-			planEcommerce,
-			planFree,
-		] );
+	it( 'should work with a single plan', () => {
+		const singlePlan = [ planFree ];
+		expect( sortPlans( singlePlan, 'free_plan' ) ).toEqual( [ planFree ] );
+	} );
+
+	it( 'should preserve the original array', () => {
+		const originalArray = [ ...plansInDefaultOrder ];
+		sortPlans( plansInDefaultOrder, 'personal-bundle' );
+		expect( plansInDefaultOrder ).toEqual( originalArray );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to  3714-gh-Automattic/martech

## Proposed Changes

This removes the special sorting so that the plans in the comparison table match the ones in the pricing grid. The current plan will be placed first.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want to avoid confusion by keeping the same plan order in both sections.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans`
* The order of the plans in the comparison table should match the one on top
<img width="320" alt="Screenshot 2025-02-28 at 11 20 59" src="https://github.com/user-attachments/assets/2a7eb6dc-92e0-42a5-9812-763ae3320867" />

* Go to `/plans` with a Free plan
* The current plan should be first, followed by the rest of the plans matching the order on top
<img width="320" alt="Screenshot 2025-02-28 at 11 15 28" src="https://github.com/user-attachments/assets/4f1384df-4cb5-4c7e-a238-9bf20e2cd265" />

* Go to `/plans` with any paid plan
* The current plan should be first, followed by the rest of the plans matching the order on top
<img width="320" alt="Screenshot 2025-02-28 at 11 15 18" src="https://github.com/user-attachments/assets/e1aeb849-153b-4a71-9898-06623b74128e" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
