### PR TITLE
Admin bar: add subitems to the top-left WP.com icon menu

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -44,6 +44,7 @@ import {
 } from 'calypso/state/sites/selectors';
 import canCurrentUserManageSiteOptions from 'calypso/state/sites/selectors/can-current-user-manage-site-options';
 import canCurrentUserUseCustomerHome from 'calypso/state/sites/selectors/can-current-user-use-customer-home';
+import isSimpleSite from 'calypso/state/sites/selectors/is-simple-site';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { activateNextLayoutFocus, setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
@@ -247,7 +248,15 @@ class MasterbarLoggedIn extends Component {
 
 	// will render as back button on mobile and in editor
 	renderMySites() {
-		const { domainOnlySite, siteSlug, translate, section, currentRoute } = this.props;
+		const {
+			domainOnlySite,
+			siteSlug,
+			translate,
+			section,
+			currentRoute,
+			isGlobalSidebarVisible,
+			siteAdminUrl,
+		} = this.props;
 
 		const mySitesUrl = domainOnlySite
 			? domainManagementList( siteSlug, currentRoute, true )
@@ -259,12 +268,42 @@ class MasterbarLoggedIn extends Component {
 			return <Item icon={ icon } className="masterbar__item-no-sites" disabled />;
 		}
 
+		const subItems = isGlobalSidebarVisible
+			? null
+			: [
+					[
+						{
+							label: translate( 'Sites' ),
+							url: '/sites',
+						},
+						{
+							label: translate( 'Domains' ),
+							url: '/domains/manage',
+						},
+					],
+					...( this.props.isSimpleSite
+						? []
+						: [
+								[
+									{
+										label: translate( 'About WordPress' ),
+										url: `${ siteAdminUrl }about.php`,
+									},
+									{
+										label: translate( 'Get Involved' ),
+										url: `${ siteAdminUrl }contribute.php`,
+									},
+								],
+						  ] ),
+			  ];
+
 		return (
 			<Item
 				className="masterbar__item-my-sites"
 				url={ mySitesUrl }
 				tipTarget="my-sites"
 				icon={ icon }
+				subItems={ subItems }
 				onClick={ this.clickMySites }
 				isActive={ this.isMySitesActive() }
 				tooltip={ translate( 'Manage your sites' ) }
@@ -704,6 +743,7 @@ export default connect(
 			isClassicView,
 			currentSelectedSiteSlug: siteId ? getSiteSlug( state, siteId ) : undefined,
 			previousPath: getPreviousRoute( state ),
+			isSimpleSite: isSimpleSite( state, siteId ),
 			isJetpackNotAtomic: isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ),
 			currentLayoutFocus: getCurrentLayoutFocus( state ),
 			currentRoute: getCurrentRoute( state ),


### PR DESCRIPTION
(The same as https://github.com/Automattic/wp-calypso/pull/100617 but it got corrupted due to bad push 🤦 )

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

- https://github.com/Automattic/wp-calypso/issues/98079

## Proposed Changes

|Simple|Atomic|
|-|-|
|<img width="160" alt="image" src="https://github.com/user-attachments/assets/408f40d7-42a8-4b31-8773-0c3f8903c42d" />|<img width="161" alt="image" src="https://github.com/user-attachments/assets/37fb33d2-7950-41ac-aac9-d4a44e95f90f" />|

- Brought back the menu items on hover.
- Add `Sites` and `Domains` items pointing to the global view.
- On Atomic, Brought back Core's `About WordPress` and `Get Involved` menu.
   - On Simple sites, those links are not valid / hidden by opers.
- These changes DO NOT apply to the global view; only on site-specific view.

## Testing Instructions


Test this PR in a Simple and Atomic site, and verify the submenu items as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
