### PR TITLE
Pricing comparison grid: "Display products by brand" update

### DIFF
--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1640,7 +1640,7 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 			[ FEATURE_PREMIUM_THEMES ]: i18n.translate( 'All premium themes' ),
 			[ FEATURE_PREMIUM_STORE_THEMES ]: i18n.translate( 'Available with plugins' ),
 			[ FEATURE_UNLIMITED_PRODUCTS ]: i18n.translate( 'Available with plugins' ),
-			[ FEATURE_DISPLAY_PRODUCTS_BRAND ]: i18n.translate( 'Available with paid plugins' ),
+			[ FEATURE_DISPLAY_PRODUCTS_BRAND ]: i18n.translate( 'Available with plugins' ),
 			[ FEATURE_PRODUCT_ADD_ONS ]: i18n.translate( 'Available with paid plugins' ),
 			[ FEATURE_ASSEMBLED_KITS ]: i18n.translate( 'Available with paid plugins' ),
 			[ FEATURE_MIN_MAX_ORDER_QUANTITY ]: i18n.translate( 'Available with paid plugins' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* Update "Display products by brand" feature in the comparison grid. The business plan should say "Available with plugin" instead of paid plugin.
* This PR is the Calypso change for the corresponding Landpack fix in 175325-ghe-Automattic/wpcom
* Fixes 3729-gh-Automattic/martech

### BEFORE
<img width="810" alt="Screenshot 2025-02-28 at 2 20 06 PM" src="https://github.com/user-attachments/assets/e555cd8f-a0e2-4ee8-a773-c3465dc3b9dd" />



### AFTER

<img width="834" alt="Screenshot 2025-02-28 at 2 19 37 PM" src="https://github.com/user-attachments/assets/74f72abd-9d82-4af7-b44d-cf34c2c4d77b" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/setup/onboarding/plans` and verify in the comparison grid that the changes shown in the screenshot are visible.
* Verify in non-EN that translations exist.

