### PR TITLE
A4A: Remove Automated referrals feature flag and conditional flows.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -44,35 +44,21 @@ const useMainMenuItems = ( path: string ) => {
 	const agency = useSelector( getActiveAgency );
 
 	const menuItems = useMemo( () => {
-		const isAutomatedReferralsEnabled = config.isEnabled( 'a4a-automated-referrals' );
-
 		let referralItems = [] as any[];
 
 		if ( isSectionNameEnabled( 'a8c-for-agencies-referrals' ) ) {
-			referralItems = isAutomatedReferralsEnabled
-				? [
-						{
-							icon: reusableBlock,
-							path: A4A_REFERRALS_LINK,
-							link: A4A_REFERRALS_DASHBOARD,
-							title: translate( 'Referrals' ),
-							trackEventProps: {
-								menu_item: 'Automattic for Agencies / Referrals',
-							},
-							withChevron: true,
-						},
-				  ]
-				: [
-						{
-							icon: reusableBlock,
-							path: '/',
-							link: A4A_REFERRALS_LINK,
-							title: translate( 'Referrals' ),
-							trackEventProps: {
-								menu_item: 'Automattic for Agencies / Referrals',
-							},
-						},
-				  ];
+			referralItems = [
+				{
+					icon: reusableBlock,
+					path: A4A_REFERRALS_LINK,
+					link: A4A_REFERRALS_DASHBOARD,
+					title: translate( 'Referrals' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Referrals',
+					},
+					withChevron: true,
+				},
+			];
 		}
 
 		const migrationMenuItem = isSectionNameEnabled( 'a8c-for-agencies-migrations' )

--- a/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -16,8 +15,6 @@ import './style.scss';
 const PREFERENCE_NAME = 'a4a-marketplace-referral-guide-seen';
 
 const ReferralToggle = () => {
-	const isAutomatedReferrals = isEnabled( 'a4a-automated-referrals' );
-
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const { marketplaceType, toggleMarketplaceType } = useContext( MarketplaceTypeContext );
@@ -35,10 +32,6 @@ const ReferralToggle = () => {
 			openGuide();
 		}
 	}, [ dispatch, guideModalSeen, marketplaceType, openGuide ] );
-
-	if ( ! isAutomatedReferrals ) {
-		return null;
-	}
 
 	return (
 		<div className="a4a-marketplace__toggle-marketplace-type">

--- a/client/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-type.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-type.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { ComponentType, useState } from 'react';
 import { MarketplaceTypeContext } from '../context';
 import { MarketplaceType } from '../types';
@@ -15,14 +14,11 @@ function withMarketplaceType< T >(
 	WrappedComponent: ComponentType< T & ContextProps >
 ): ComponentType< T & ContextProps > {
 	return ( props ) => {
-		const isAutomatedReferrals = isEnabled( 'a4a-automated-referrals' );
-
-		const usedMarketplaceType =
+		const defaultType =
 			props.defaultMarketplaceType ??
 			( sessionStorage.getItem( MARKETPLACE_TYPE_SESSION_STORAGE_KEY ) as MarketplaceType ) ??
 			MARKETPLACE_TYPE_REGULAR;
 
-		const defaultType = isAutomatedReferrals ? usedMarketplaceType : MARKETPLACE_TYPE_REGULAR;
 		const [ marketplaceType, setMarketplaceType ] = useState( defaultType );
 
 		const updateMarketplaceType = ( type: MarketplaceType ) => {
@@ -31,9 +27,6 @@ function withMarketplaceType< T >(
 		};
 
 		const toggleMarketplaceType = () => {
-			if ( ! isAutomatedReferrals ) {
-				return;
-			}
 			const nextType =
 				marketplaceType === MARKETPLACE_TYPE_REGULAR
 					? MARKETPLACE_TYPE_REFERRAL

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Card, Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -47,8 +46,6 @@ export default function LicenseDetails( {
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
 
 	const pressablePlan = useGetPressablePlanByProductId( { product_id: license.productId } );
-
-	const isAutomatedReferralsEnabled = config.isEnabled( 'a4a-automated-referrals' );
 
 	return (
 		<Card
@@ -100,7 +97,7 @@ export default function LicenseDetails( {
 					</li>
 				) }
 
-				{ isAutomatedReferralsEnabled && referral && (
+				{ referral && (
 					<li className="license-details__list-item-small">
 						<h4 className="license-details__label">{ translate( 'Owned by' ) }</h4>
 						{ referral.client.email }
@@ -130,7 +127,7 @@ export default function LicenseDetails( {
 				licenseType={ licenseType }
 				hasDownloads={ hasDownloads }
 				isChildLicense={ isChildLicense }
-				isClientLicense={ !! ( isAutomatedReferralsEnabled && referral ) }
+				isClientLicense={ !! referral }
 			/>
 		</Card>
 	);

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Badge, Button, Gridicon } from '@automattic/components';
@@ -70,8 +69,6 @@ export default function LicensePreview( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const isAutomatedReferralsEnabled = config.isEnabled( 'a4a-automated-referrals' );
-
 	const site = useSelector( ( state ) => getSite( state, blogId as number ) );
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
 	const isWPCOMLicense = isWPCOMHostingProduct( licenseKey );
@@ -99,7 +96,7 @@ export default function LicensePreview( {
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const domain = siteUrl && ! isPressableLicense ? getUrlParts( siteUrl ).hostname || siteUrl : '';
 
-	const isClientLicense = isAutomatedReferralsEnabled && referral;
+	const isClientLicense = referral;
 
 	const assign = useCallback( () => {
 		const redirectUrl = isWPCOMLicense

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -96,13 +96,11 @@ export default function LicensePreview( {
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const domain = siteUrl && ! isPressableLicense ? getUrlParts( siteUrl ).hostname || siteUrl : '';
 
-	const isClientLicense = referral;
-
 	const assign = useCallback( () => {
 		const redirectUrl = isWPCOMLicense
 			? A4A_SITES_LINK_NEEDS_SETUP
 			: addQueryArgs( { key: licenseKey }, '/marketplace/assign-license' );
-		if ( paymentMethodRequired && ! isClientLicense ) {
+		if ( paymentMethodRequired && ! referral ) {
 			const noticeLinkHref = addQueryArgs(
 				{
 					return: redirectUrl,
@@ -125,7 +123,7 @@ export default function LicensePreview( {
 		}
 
 		page.redirect( redirectUrl );
-	}, [ isWPCOMLicense, licenseKey, paymentMethodRequired, isClientLicense, translate, dispatch ] );
+	}, [ isWPCOMLicense, licenseKey, paymentMethodRequired, referral, translate, dispatch ] );
 
 	useEffect( () => {
 		if ( isHighlighted ) {
@@ -251,13 +249,13 @@ export default function LicensePreview( {
 					<span className="license-preview__product">
 						<div className="license-preview__product-title">
 							{ productTitle }
-							{ isClientLicense && (
+							{ referral && (
 								<Badge className="license-preview__client-badge" type="info">
 									{ translate( 'Referral' ) }
 								</Badge>
 							) }
 						</div>
-						{ isClientLicense && (
+						{ referral && (
 							<div className="license-preview__client-email">
 								<ClientSite referral={ referral } />
 							</div>
@@ -375,7 +373,7 @@ export default function LicensePreview( {
 							revokedAt={ revokedAt }
 							licenseType={ licenseType }
 							isChildLicense={ isChildLicense }
-							isClientLicense={ !! isClientLicense }
+							isClientLicense={ !! referral }
 						/>
 					) : (
 						/*

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -66,7 +66,7 @@ export default function NeedSetup( { licenseKey }: Props ) {
 	// Filter out sites that have a referral
 	const availableSites =
 		allAvailableSites.filter(
-			( { features }: NeedsSetupSite ) => features.wpcom_atomic.referral
+			( { features }: NeedsSetupSite ) => ! features.wpcom_atomic.referral
 		) ?? [];
 
 	// Find the site license by license key

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -50,8 +49,6 @@ export default function NeedSetup( { licenseKey }: Props ) {
 
 	const closeModal = () => setCurrentSiteConfigurationId( null );
 
-	const isAutomatedReferralsEnabled = config.isEnabled( 'a4a-automated-referrals' );
-
 	const title = translate( 'Sites' );
 
 	const { data: pendingSites, isFetching, refetch: refetchPendingSites } = useFetchPendingSites();
@@ -68,8 +65,8 @@ export default function NeedSetup( { licenseKey }: Props ) {
 
 	// Filter out sites that have a referral
 	const availableSites =
-		allAvailableSites.filter( ( { features }: NeedsSetupSite ) =>
-			isAutomatedReferralsEnabled ? ! features.wpcom_atomic.referral : true
+		allAvailableSites.filter(
+			( { features }: NeedsSetupSite ) => features.wpcom_atomic.referral
 		) ?? [];
 
 	// Find the site license by license key
@@ -77,17 +74,14 @@ export default function NeedSetup( { licenseKey }: Props ) {
 		( { features }: NeedsSetupSite ) => features.wpcom_atomic.license_key === licenseKey
 	);
 
-	const hasReferral =
-		isAutomatedReferralsEnabled && !! foundSiteLicenseByLicenseKey?.features.wpcom_atomic.referral;
+	const hasReferral = !! foundSiteLicenseByLicenseKey?.features.wpcom_atomic.referral;
 
 	// Filter out the site license we found by license key
-	const otherReferralSites = isAutomatedReferralsEnabled
-		? allAvailableSites.filter(
-				( { features }: NeedsSetupSite ) =>
-					!! features.wpcom_atomic.referral &&
-					( hasReferral ? features.wpcom_atomic.license_key !== licenseKey : true )
-		  )
-		: [];
+	const otherReferralSites = allAvailableSites.filter(
+		( { features }: NeedsSetupSite ) =>
+			!! features.wpcom_atomic.referral &&
+			( hasReferral ? features.wpcom_atomic.license_key !== licenseKey : true )
+	);
 
 	const availablePlans: AvailablePlans[] = [
 		// If the site license we found by license key has a referral, we should show it first

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -38,7 +38,6 @@
 		"oauth": true,
 		"a4a/site-details-pane": true,
 		"a4a/site-migration": true,
-		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
 		"a4a-dev-sites": true,
 		"a4a-migrations-page-v2": true,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -31,7 +31,6 @@
 		"oauth": false,
 		"a4a/site-details-pane": true,
 		"a4a/site-migration": true,
-		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
 		"a4a-dev-sites": true,
 		"a4a-migrations-page-v2": true,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -31,7 +31,6 @@
 		"a8c-for-agencies": true,
 		"cookie-banner": true,
 		"oauth": true,
-		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
 		"a4a-dev-sites": true,
 		"a4a-migrations-page-v2": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -33,7 +33,6 @@
 		"cookie-banner": false,
 		"oauth": true,
 		"a4a/site-migration": false,
-		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
 		"a4a-dev-sites": true,
 		"a4a-migrations-page-v2": true,


### PR DESCRIPTION
This PR removes the 'a4a-automated-referrals' feature flag and all conditional flows that reference it.

## Proposed Changes

* Remove the `a4a-automated-referrals` feature flag.
* Remove all references to the flag.

## Why are these changes being made?

* This makes our code more maintainable.

## Testing Instructions

* Verify the changes and test if there is no regression on the referral flow and pages.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
