### PR TITLE
Pricing comparison grid: Add AI Assistant feature

### DIFF
--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -443,6 +443,7 @@ export const FEATURE_SUPPORT_FROM_EXPERTS = 'support-from-experts';
 export const FEATURE_UPLOAD_VIDEO = 'upload-video';
 export const FEATURE_STATS_BASIC_20250206 = 'stats-basic-20250206';
 export const FEATURE_STATS_ADVANCED_20250206 = 'stats-advanced-20250206';
+export const FEATURE_AI_ASSISTANT = 'ai-assistant';
 
 // Woo Express Features
 export const FEATURE_WOOCOMMERCE_STORE = 'woocommerce-store'; // WooCommerce store

--- a/packages/calypso-products/src/feature-group-plan-map.ts
+++ b/packages/calypso-products/src/feature-group-plan-map.ts
@@ -143,6 +143,7 @@ import {
 	FEATURE_STATS_ADVANCED_20250206,
 	FEATURE_SUPPORT,
 	FEATURE_SUPPORT_FROM_EXPERTS,
+	FEATURE_AI_ASSISTANT,
 } from './constants';
 import { FeatureGroupMap } from './types';
 
@@ -272,6 +273,7 @@ export const featureGroups: Partial< FeatureGroupMap > = {
 		slug: FEATURE_GROUP_MARKETING_GROWTH_AND_MONETIZATION_TOOLS,
 		getTitle: () => i18n.translate( 'Growth and monetization tools' ),
 		getFeatures: () => [
+			FEATURE_AI_ASSISTANT,
 			FEATURE_NEWSLETTERS_RSS,
 			FEATURE_AD_FREE_EXPERIENCE,
 			FEATURE_WORDADS,

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -334,6 +334,7 @@ import {
 	FEATURE_STATS_ADVANCED_20250206,
 	FEATURE_SUPPORT,
 	FEATURE_SUPPORT_FROM_EXPERTS,
+	FEATURE_AI_ASSISTANT,
 } from './constants';
 import type { FeatureList } from './types';
 
@@ -2499,6 +2500,12 @@ const FEATURES_LIST: FeatureList = {
 		getTitle: () => i18n.translate( 'Premium stats' ),
 		getDescription: () =>
 			i18n.translate( 'Unlock all stats, including UTM tracking and device insights.' ),
+	},
+	[ FEATURE_AI_ASSISTANT ]: {
+		getSlug: () => FEATURE_AI_ASSISTANT,
+		getTitle: () => i18n.translate( 'AI Assistant' ),
+		getDescription: () =>
+			i18n.translate( 'Enhance your content creation with AI-powered writing, images and more.' ),
 	},
 	/* END: 2023 Pricing Grid Features */
 

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -445,6 +445,7 @@ import {
 	FEATURE_STATS_ADVANCED_20250206,
 	FEATURE_SUPPORT,
 	FEATURE_SUPPORT_FROM_EXPERTS,
+	FEATURE_AI_ASSISTANT,
 } from './constants';
 import { isBigSkyOnboarding } from './is-big-sky-onboarding';
 import { isGlobalStylesOnPersonalEnabled } from './is-global-styles-on-personal-enabled';
@@ -581,6 +582,7 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 
 	get2023PlanComparisonFeatureOverride: () => {
 		return [
+			FEATURE_AI_ASSISTANT,
 			FEATURE_BEAUTIFUL_THEMES,
 			FEATURE_PAGES,
 			FEATURE_USERS,
@@ -626,6 +628,7 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 		const baseFeatures = {
 			[ FEATURE_SHARES_SOCIAL_MEDIA_JP ]: i18n.translate( '%d shares per month', { args: [ 30 ] } ),
 			[ FEATURE_COMMISSION_FEE_STANDARD_FEATURES ]: i18n.translate( '10%' ),
+			[ FEATURE_AI_ASSISTANT ]: i18n.translate( 'Limited to 20 requests' ),
 		};
 
 		return isStatsFeatureTranslated()


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add AI Assistant feature to the commparison grid.

<img width="1646" alt="Screenshot 2025-02-28 at 4 36 49 PM" src="https://github.com/user-attachments/assets/87b8f7fb-ae63-4f96-92ac-ce9d00f5bd01" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix https://github.com/Automattic/martech/issues/3685 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/setup/onboarding/plans` and verify that you see the AI Assistant feature in the comparison grid.

