### PR TITLE
Themes: Use the new REST API for /themes

### DIFF
--- a/client/state/themes/actions/request-themes.js
+++ b/client/state/themes/actions/request-themes.js
@@ -52,7 +52,7 @@ export function requestThemes( siteId, query = {}, locale ) {
 					Object.assign(
 						{
 							...query,
-							apiVersion: '1.2',
+							apiNamespace: 'wpcom/v2',
 							// We should keep the blank-canvas-3 stay hidden according to below discussion
 							// https://github.com/Automattic/wp-calypso/issues/71911#issuecomment-1381284172
 							// User can be redirected to PatternAssembler flow using the PatternAssemblerCTA on theme-list

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -212,7 +212,7 @@ describe( 'actions', () => {
 		describe( 'with a wpcom site', () => {
 			let nockScope;
 			useNock( ( nock ) => {
-				const url = '/rest/v1.2/themes?include_blankcanvas_theme=';
+				const url = '/wpcom/v2/themes?include_blankcanvas_theme=';
 				nockScope = nock( 'https://public-api.wordpress.com:443' )
 					.get( url )
 					.reply( 200, {

--- a/packages/design-picker/src/hooks/use-theme-designs-query.ts
+++ b/packages/design-picker/src/hooks/use-theme-designs-query.ts
@@ -32,7 +32,7 @@ export function useThemeDesignsQuery(
 				number: 50,
 				tier,
 				filter,
-				apiVersion: '1.2',
+				apiNamespace: 'wpcom/v2',
 			} ),
 		// Our theme offering doesn't change that often, we don't need to
 		// re-fetch until the next page refresh.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* I recently created a new /themes REST API endpoint in the WordPress REST API. This PR switches Calypso to use the new endpoint instead of the old one.
* See 173632-ghe-Automattic/wpcom to see where the new endpoint was added.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
* The old WordPress.com REST API should be retired in favour of the core WordPress REST API

## Testing Instructions
* Go to /themes/[site] and check that you can load themes, and filter themes as before.
* Also go through signup and check that the themes load.
* Also check that themes load in the design picker ( http://calypso.localhost:3000/setup/site-setup/design-setup?siteSlug=[siteslug]&categories=blog )
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?