### PR TITLE
Stepper: Unify site creation step slug

### DIFF
--- a/client/landing/stepper/declarative-flow/connect-domain.ts
+++ b/client/landing/stepper/declarative-flow/connect-domain.ts
@@ -119,9 +119,9 @@ const connectDomain: Flow = {
 			switch ( _currentStepSlug ) {
 				case 'plans':
 					clearSignupDestinationCookie();
-					return navigate( 'createSite' );
+					return navigate( 'create-site' );
 
-				case 'createSite':
+				case 'create-site':
 					return navigate( 'processing' );
 
 				case 'processing': {

--- a/client/landing/stepper/declarative-flow/example.ts
+++ b/client/landing/stepper/declarative-flow/example.ts
@@ -101,9 +101,9 @@ const newsletter: Flow = {
 					return navigate( 'plans' );
 
 				case 'plans':
-					return navigate( 'createSite' );
+					return navigate( 'create-site' );
 
-				case 'createSite':
+				case 'create-site':
 					return navigate( 'processing' );
 
 				case 'processing':

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow-user-included.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow-user-included.ts
@@ -32,7 +32,7 @@ const hosting: Flow = {
 				asyncComponent: () => import( './internals/steps-repository/trial-acknowledge' ),
 			},
 			{
-				slug: 'createSite',
+				slug: 'create-site',
 				asyncComponent: () => import( './internals/steps-repository/create-site' ),
 			},
 			{
@@ -75,14 +75,14 @@ const hosting: Flow = {
 						return navigate( 'trialAcknowledge' );
 					}
 
-					return navigate( 'createSite' );
+					return navigate( 'create-site' );
 				}
 
 				case 'trialAcknowledge': {
-					return navigate( 'createSite' );
+					return navigate( 'create-site' );
 				}
 
-				case 'createSite':
+				case 'create-site':
 					return navigate( 'processing' );
 
 				case 'processing': {

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -96,9 +96,9 @@ const newsletter: Flow = {
 					return navigate( 'plans' );
 
 				case 'plans':
-					return navigate( 'createSite' );
+					return navigate( 'create-site' );
 
-				case 'createSite':
+				case 'create-site':
 					return navigate( 'processing' );
 
 				case 'processing':

--- a/client/landing/stepper/declarative-flow/reblogging.ts
+++ b/client/landing/stepper/declarative-flow/reblogging.ts
@@ -37,9 +37,9 @@ const reblogging: Flow = {
 					return navigate( 'plans' );
 
 				case 'plans':
-					return navigate( 'createSite' );
+					return navigate( 'create-site' );
 
-				case 'createSite':
+				case 'create-site':
 					return navigate( 'processing' );
 
 				case 'processing': {


### PR DESCRIPTION
Some flows call it `create-site`, others `createSite`, this unifies it.