### PR TITLE
Transferring Hosted Site: Add values to progress bar

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
@@ -14,7 +14,7 @@ import type { OnboardSelect } from '@automattic/data-stores';
 const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 	const [ searchParams ] = useSearchParams();
 	const { submit } = navigation;
-	const { setPendingAction } = useDispatch( ONBOARD_STORE );
+	const { setPendingAction, setProgress } = useDispatch( ONBOARD_STORE );
 	const site = useSite();
 
 	let siteId = site?.ID as number;
@@ -58,10 +58,15 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 		}
 
 		setPendingAction( async () => {
+			setProgress( 10 );
 			await waitForInitiateTransfer();
+			setProgress( 25 );
 			await waitForTransfer();
+			setProgress( 50 );
 			await waitForFeature();
+			setProgress( 75 );
 			await waitForLatestSiteData();
+			setProgress( 100 );
 
 			return {
 				finishedWaitingForAtomic: true,

--- a/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
@@ -1,13 +1,12 @@
 import { SiteSelect } from '@automattic/data-stores';
 import { SITE_STORE } from '@automattic/launchpad/src/launchpad';
 import { TRANSFERRING_HOSTED_SITE_FLOW } from '@automattic/onboarding';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import { useSelector } from 'calypso/state';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 import { isAdminInterfaceWPAdmin } from 'calypso/state/sites/selectors';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
-import { ONBOARD_STORE } from '../stores';
 import { STEPS } from './internals/steps';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
 import type { Flow, ProvidedDependencies } from './internals/types';
@@ -20,10 +19,6 @@ const transferringHostedSite: Flow = {
 
 	useSteps() {
 		return TRANSFERRING_HOSTED_SITE_STEPS;
-	},
-	useSideEffect() {
-		const { setProgress } = useDispatch( ONBOARD_STORE );
-		setProgress( 0 );
 	},
 	useStepNavigation( currentStep, navigate ) {
 		const siteId = useSiteIdParam();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Set values for the progress bar during the Processing step in the transferring-hosted-site flow.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The progress was set to 0 in the flow and never changed, so the bar remained empty during the whole process.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the transferring-hosted-site flow.

