### PR TITLE
desktop: Bump version to 8.1.0-beta2

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "8.1.0-beta1",
+	"version": "8.1.0-beta2",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/",


### PR DESCRIPTION
Routine PR to track the latest beta build for WordPress Desktop on `trunk`.

Reminder: The beta itself is distributed independently from this PR being merged. It depends on the `desktop-v8.1.0-beta2` tag. This PR is simply to ensure the version in `package.json` is up to date.

**Note:**
We're using `beta2` because the version was modified to `beta1` in #99742. We're just bumping it to be able to create this PR. So this is called `beta2`, but it's the first beta of 8.1.0 that will be released.
