### PR TITLE
Admin bar: bring back updates and comments menu

### DIFF
--- a/client/components/data/query-site-admin-menu/index.js
+++ b/client/components/data/query-site-admin-menu/index.js
@@ -1,0 +1,18 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { useSelector } from 'calypso/state';
+import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
+
+export default function QuerySiteAdminMenu( { siteId } ) {
+	const dispatch = useDispatch();
+	const siteDomain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
+	const locale = useLocale();
+
+	useEffect( () => {
+		siteId && dispatch( requestAdminMenu( siteId ) );
+	}, [ dispatch, siteId, siteDomain, locale ] );
+
+	return null;
+}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -14,6 +14,7 @@ import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryPreferences from 'calypso/components/data/query-preferences';
 import QuerySiteAdminColor from 'calypso/components/data/query-site-admin-color';
+import QuerySiteAdminMenu from 'calypso/components/data/query-site-admin-menu';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import QuerySiteSelectedEditor from 'calypso/components/data/query-site-selected-editor';
 import QuerySites from 'calypso/components/data/query-sites';
@@ -365,6 +366,7 @@ class Layout extends Component {
 				) }
 				<QueryPreferences />
 				<QuerySiteFeatures siteIds={ [ this.props.siteId ] } />
+				<QuerySiteAdminMenu siteId={ this.props.siteId } />
 				<QuerySiteAdminColor siteId={ this.props.siteId } />
 				{ config.isEnabled( 'layout/query-selected-editor' ) && (
 					<QuerySiteSelectedEditor siteId={ this.props.siteId } />

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -14,6 +14,8 @@ import wpcom from 'calypso/lib/wp';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { preload } from 'calypso/sections-helper';
 import { siteUsesWpAdminInterface } from 'calypso/sites-dashboard/utils';
+import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
+import { getAdminMenu } from 'calypso/state/admin-menu/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUser, getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
@@ -297,6 +299,65 @@ class MasterbarLoggedIn extends Component {
 				shouldClearCartWhenLeaving={ ! isCheckoutFailed }
 				loadHelpCenterIcon={ loadHelpCenterIcon }
 			/>
+		);
+	}
+
+	renderUpdatesMenu() {
+		const { adminMenu } = this.props;
+		if ( ! adminMenu ) {
+			return null;
+		}
+
+		let updatesCount = 0;
+		let updatesUrl = '';
+		for ( const menu of adminMenu ) {
+			for ( const menuItem of menu.children || [] ) {
+				if ( menuItem.slug === 'update-core-php' ) {
+					updatesCount = menuItem.count;
+					updatesUrl = menuItem.url;
+					break;
+				}
+			}
+		}
+
+		if ( updatesCount ) {
+			return (
+				<Item
+					className="masterbar__item-updates"
+					url={ updatesUrl }
+					icon={ <span className="dashicons-before dashicons-update" /> }
+				>
+					{ updatesCount }
+				</Item>
+			);
+		}
+		return null;
+	}
+
+	renderCommentsMenu() {
+		const { adminMenu } = this.props;
+		if ( ! adminMenu ) {
+			return null;
+		}
+
+		let commentsCount = 0;
+		let commentsUrl = '';
+		for ( const menu of adminMenu ) {
+			if ( menu.icon === 'dashicons-admin-comments' ) {
+				commentsCount = menu.count || 0;
+				commentsUrl = menu.url;
+				break;
+			}
+		}
+
+		return (
+			<Item
+				className="masterbar__item-comments"
+				url={ commentsUrl }
+				icon={ <span className="dashicons-before dashicons-admin-comments" /> }
+			>
+				<span className={ commentsCount === 0 ? 'count-0' : '' }>{ commentsCount }</span>
+			</Item>
 		);
 	}
 
@@ -632,6 +693,8 @@ class MasterbarLoggedIn extends Component {
 					{ this.renderSidebarMobileMenu() }
 					{ this.renderMySites() }
 					{ this.renderSiteMenu() }
+					{ this.renderUpdatesMenu() }
+					{ this.renderCommentsMenu() }
 					{ this.renderSiteActionMenu() }
 					{ this.renderLanguageSwitcher() }
 					{ this.renderLaunchButton() }
@@ -675,6 +738,7 @@ export default connect(
 			siteUrl: getSiteUrl( state, siteId ),
 			siteAdminUrl: getSiteAdminUrl( state, siteId ),
 			siteHomeUrl: getSiteHomeUrl( state, siteId ),
+			adminMenu: getAdminMenu( state, siteId ),
 			sectionGroup,
 			domainOnlySite: isDomainOnlySite( state, siteId ),
 			hasNoSites: siteCount === 0,
@@ -701,6 +765,7 @@ export default connect(
 		updateSiteMigrationMeta,
 		activateNextLayoutFocus,
 		savePreference,
+		requestAdminMenu,
 		redirectToLogout,
 		launchSiteOrRedirectToLaunchSignupFlow,
 	}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -522,6 +522,13 @@ body.is-mobile-app-view {
 			}
 		}
 
+		.dashicons-update {
+			&::before {
+				font-size: 40px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				top: 3px;
+			}
+		}
+
 		.dashicons-menu-alt {
 			padding-top: 0;
 			position: relative;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -216,7 +216,9 @@ body.is-mobile-app-view {
 	}
 
 	&.masterbar__item-my-site,
-	&.masterbar__item-my-site-actions {
+	&.masterbar__item-my-site-actions,
+	&.masterbar__item-updates,
+	&.masterbar__item-comments {
 		padding-left: 7px;
 		gap: 6px;
 	}
@@ -351,6 +353,13 @@ body.is-mobile-app-view {
 	}
 	.dashicons-plus {
 		padding-top: 4px;
+	}
+	.dashicons-admin-comments {
+		padding-top: 2px;
+
+		& + span .count-0 {
+			opacity: .5;
+		}
 	}
 
 	&:hover,
@@ -525,6 +534,11 @@ body.is-mobile-app-view {
 		}
 	}
 
+	@media only screen and (max-width: 600px) {
+		&.masterbar__item-updates {
+			display: none;
+		}
+	}
 
 	@media only screen and (max-width: 480px) {
 		// reset flex value on mobile

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -1,7 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { useLocale } from '@automattic/i18n-utils';
-import { useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useCurrentRoute } from 'calypso/components/route';
 import domainOnlyFallbackMenu from 'calypso/my-sites/sidebar/static-data/domain-only-fallback-menu';
 import { getAdminMenu } from 'calypso/state/admin-menu/selectors';
@@ -17,14 +15,12 @@ import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getSiteDomain, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { requestAdminMenu } from '../../state/admin-menu/actions';
 import allSitesMenu from './static-data/all-sites-menu';
 import buildFallbackResponse from './static-data/fallback-menu';
 import globalSidebarMenu from './static-data/global-sidebar-menu';
 import jetpackMenu from './static-data/jetpack-fallback-menu';
 
 const useSiteMenuItems = () => {
-	const dispatch = useDispatch();
 	const currentRoute = useSelector( ( state ) => getCurrentRoute( state ) );
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const siteDomain = useSelector( ( state ) => getSiteDomain( state, selectedSiteId ) );
@@ -33,17 +29,11 @@ const useSiteMenuItems = () => {
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, selectedSiteId ) );
 	const isStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, selectedSiteId ) );
 	const isPlanExpired = useSelector( ( state ) => !! getSelectedSite( state )?.plan?.expired );
-	const locale = useLocale();
 	const isAllDomainsView = '/domains/manage' === currentRoute;
 	const { currentSection } = useCurrentRoute();
 	const shouldShowGlobalSidebar = useSelector( ( state ) => {
 		return getShouldShowGlobalSidebar( state, selectedSiteId, currentSection?.group );
 	} );
-	useEffect( () => {
-		if ( selectedSiteId && siteDomain ) {
-			dispatch( requestAdminMenu( selectedSiteId ) );
-		}
-	}, [ dispatch, selectedSiteId, siteDomain, locale ] );
 
 	/**
 	 * As a general rule we allow fallback data to remain as static as possible.


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/issues/98079

## Proposed Changes

This PR tries to simulate Core's updates (Atomic only) and unread comments icons in the admin bar.

This is done by parsing the response of the `wpcom/v2/sites/:siteId/admin-menu` endpoint, and picking the badge counts of the `Dashboard/My Home -> Updates` and `Comments` from the sidebar.

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/d5f678c9-a09a-42ce-9254-0b90a9678bd3)|![image](https://github.com/user-attachments/assets/883ee0ee-d536-4377-822b-97a43422eb20)|


## Testing Instructions

Test all the combinations of {Simple, Atomic} x {Default, Classic} and verify that you can see the icons.

Use sites that have comments, and pending updates (Atomic only).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
