### PR TITLE
i18n: Fix missing number localisation in plugin ratings

### DIFF
--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -1,5 +1,5 @@
 import { ProgressBar } from '@automattic/components';
-import { localize, getLocaleSlug } from 'i18n-calypso';
+import { localize, getLocaleSlug, numberFormat } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import Rating from 'calypso/components/rating';
@@ -73,11 +73,11 @@ class PluginRatings extends Component {
 	renderDownloaded() {
 		let downloaded = this.props.downloaded;
 		if ( downloaded > 100000 ) {
-			downloaded = this.props.numberFormat( Math.floor( downloaded / 10000 ) * 10000 ) + '+';
+			downloaded = numberFormat( Math.floor( downloaded / 10000 ) * 10000 ) + '+';
 		} else if ( downloaded > 10000 ) {
-			downloaded = this.props.numberFormat( Math.floor( downloaded / 1000 ) * 1000 ) + '+';
+			downloaded = numberFormat( Math.floor( downloaded / 1000 ) * 1000 ) + '+';
 		} else {
-			downloaded = this.props.numberFormat( downloaded );
+			downloaded = numberFormat( downloaded );
 		}
 
 		return (
@@ -119,7 +119,9 @@ class PluginRatings extends Component {
 						</span>
 					) }
 					{ ! hideRatingNumber && rating > 0 && (
-						<span className="plugin-ratings__number">{ rating / 20 }</span>
+						<span className="plugin-ratings__number">
+							{ numberFormat( rating / 20, { decimals: 1 } ) }
+						</span>
 					) }
 				</div>
 				{ ! inlineNumRatings && numRatings && (

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -4,7 +4,7 @@ import { Badge, Gridicon } from '@automattic/components';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { Icon, info } from '@wordpress/icons';
 import clsx from 'clsx';
-import { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import { useMemo, useCallback, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -288,13 +288,13 @@ const PluginsBrowserListElement = ( props ) => {
 										color="#f0b849" // alert-yellow
 									/>
 									<span className="plugins-browser-item__rating-value">
-										{ ( plugin.rating / 20 ).toFixed( 1 ) }
+										{ numberFormat( plugin.rating / 20, { decimals: 1 } ) }
 									</span>
 									{ Number.isInteger( plugin.num_ratings ) && (
 										<span className="plugins-browser-item__number-of-ratings">
 											{ translate( '(%(number_of_ratings)s)', {
 												args: {
-													number_of_ratings: plugin.num_ratings.toLocaleString( getLocaleSlug() ),
+													number_of_ratings: numberFormat( plugin.num_ratings ),
 												},
 											} ) }
 										</span>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/i18n-issues/issues/946

## Proposed Changes

The ratings shown on `/plugins/:site` page are missing localisation. Other numbers and currencies on that page are, so it can feel like a bit of a soup.

## Media

### Before

<img width="800" alt="Screenshot 2025-02-28 at 5 26 04 PM" src="https://github.com/user-attachments/assets/52f04ed8-157f-4082-a8f7-2ca2b28aba29" />

### After

<img width="800" alt="Screenshot 2025-02-28 at 5 26 26 PM" src="https://github.com/user-attachments/assets/269777cc-8982-4323-acc0-4c4fcac913ed" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Addresses https://github.com/Automattic/i18n-issues/issues/946

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Switch locale to EL/DE
- Go to `/plugins/:site` and confirm the ratings render with correct decimals separator (`,` for EL).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
