### PR TITLE
Reader Editor - Update Quick Post Titles

### DIFF
--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -10,6 +10,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import SitesDropdown from 'calypso/components/sites-dropdown';
+import { stripHTML } from 'calypso/lib/formatting';
 import wpcom from 'calypso/lib/wp';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
@@ -58,7 +59,14 @@ export default function QuickPost() {
 			.site( selectedSiteId )
 			.post()
 			.add( {
-				title: postContent.split( '\n' )[ 0 ], // Use first line as title.
+				title:
+					(
+						stripHTML( postContent )
+							.split( '\n' )
+							.find( ( line ) => line.trim() ) || ''
+					)
+						.substring( 0, 57 )
+						.trim() + '...',
 				content: postContent,
 				status: 'publish',
 			} )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/526

## Proposed Changes

* Extract a quick post title by applying: trim, strip HTML tags (this will include Gutenberg markup), select the first non-empty line, truncate it to 57 chars, and add '...' to the end.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The original quick post code simply used the first full line as a title, but this was always Gutenberg markup.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live and go to /reader?flags=reader/quick-post
* Create a new post and observe that the generated title looks acceptable for a v1.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
