### PR TITLE
E2E: update string in Forms test

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
@@ -93,9 +93,7 @@ export class FormPatternsFlow implements BlockFlow {
 		// There must be some slow-ish Editor rerender that is dismissing the dialog.
 		// This wait, although "against the rules", has proved to be the most reliable approach so far.
 		await context.page.waitForTimeout( 2 * 1000 );
-		await context.addedBlockLocator
-			.getByRole( 'button', { name: 'Explore Form Patterns' } )
-			.click();
+		await context.addedBlockLocator.getByRole( 'button', { name: 'Browse form patterns' } ).click();
 
 		const editorParent = await context.editorPage.getEditorParent();
 		await editorParent


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Matches changes done in https://github.com/Automattic/jetpack/pull/42141

Fixes:

```
======= Failed test run #1 ==========
  locator.click: Timeout 10000ms exceeded.
  Call log:
    - waiting for locator('iframe[src*="calypsoify"]').contentFrame().locator('body.block-editor-page').locator('#block-25e01a2a-0aa1-4057-ad86-a2425ca7d30a').getByRole('button', { name: 'Explore Form Patterns' })
  at FormPatternsFlow.click (/home/teamcity-4/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts:98:5)
      at FormPatternsFlow.configure (/home/teamcity-4/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts:45:3)
      at Object.<anonymous> (/home/teamcity-4/buildAgent/work/c4a9d5b38c1dacde/test/e2e/specs/blocks/shared/block-smoke-testing.ts:88:7)
======= Failed test run #2 ==========
  locator.click: Timeout 10000ms exceeded.
  Call log:
    - waiting for locator('iframe[src*="calypsoify"]').contentFrame().locator('body.block-editor-page').locator('#block-8ec1d576-165a-4200-bacd-af40dc3f6dec').getByRole('button', { name: 'Explore Form Patterns' })
  at FormPatternsFlow.click (/home/teamcity-4/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts:98:5)
      at FormPatternsFlow.configure (/home/teamcity-4/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts:45:3)
      at Object.<anonymous> (/home/teamcity-4/buildAgent/work/c4a9d5b38c1dacde/test/e2e/specs/blocks/shared/block-smoke-testing.ts:88:7)
```

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
