### PR TITLE
Stepper: Migrate hosted site flow to use built in auth

### DIFF
--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -2,7 +2,7 @@ import { isFreeHostingTrial, isDotComPlan } from '@automattic/calypso-products';
 import { NEW_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
-import { useEffect, useLayoutEffect } from 'react';
+import { useEffect } from 'react';
 import { recordFreeHostingTrialStarted } from 'calypso/lib/analytics/ad-tracking/ad-track-trial-start';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
@@ -166,17 +166,17 @@ const hosting: Flow = {
 		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
 		const query = useQuery();
 		const isEligible = useSelector( isUserEligibleForFreeHostingTrial );
+		// Support for FlowV1 and V2, remove useSteps once FlowV1 is removed.
+		const steps = 'useSteps' in this ? this.useSteps() : this.getSteps?.();
 
 		const queryParams = Object.fromEntries( query );
 
-		useLayoutEffect( () => {
-			if ( currentStepSlug === 'trialAcknowledge' && ! isEligible ) {
+		useEffect( () => {
+			if ( currentStepSlug === 'trialAcknowledge' && ! isEligible && steps?.[ 0 ] ) {
 				// Go to the first step if the user is not eligible for a free hosting trial
-				// If domains is not the first, Stepper will figure it out.
-				// This automatically preserves the query params.
-				navigate( 'domains' );
+				navigate( steps[ 0 ].slug );
 			}
-		}, [ isEligible, currentStepSlug, navigate ] );
+		}, [ isEligible, currentStepSlug, navigate, steps ] );
 
 		useEffect( () => {
 			if ( queryParams.studioSiteId ) {

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -31,6 +31,7 @@ function useShowDomainStep(): boolean {
 
 const hosting: Flow = {
 	name: NEW_HOSTED_SITE_FLOW,
+	__experimentalUseBuiltinAuth: true,
 	isSignupFlow: true,
 	useSteps() {
 		const showDomainStep = useShowDomainStep();

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -17,7 +17,7 @@ import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-us
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { useQuery } from '../hooks/use-query';
 import { ONBOARD_STORE, USER_STORE } from '../stores';
-import { useLoginUrl } from '../utils/path';
+import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 import { STEPS } from './internals/steps';
 import { Flow, ProvidedDependencies } from './internals/types';
 import type { OnboardSelect, UserSelect } from '@automattic/data-stores';
@@ -35,13 +35,13 @@ const hosting: Flow = {
 	isSignupFlow: true,
 	useSteps() {
 		const showDomainStep = useShowDomainStep();
-		return [
+		return stepsWithRequiredLogin( [
 			...( showDomainStep ? [ STEPS.DOMAINS ] : [] ),
 			STEPS.PLANS,
 			STEPS.TRIAL_ACKNOWLEDGE,
 			STEPS.SITE_CREATION_STEP,
 			STEPS.PROCESSING,
-		];
+		] );
 	},
 	useStepNavigation( _currentStepSlug, navigate ) {
 		const { setPlanCartItem, resetCouponCode } = useDispatch( ONBOARD_STORE );
@@ -161,8 +161,7 @@ const hosting: Flow = {
 			submit,
 		};
 	},
-	useSideEffect( currentStepSlug ) {
-		const flowName = this.name;
+	useSideEffect( currentStepSlug, navigate ) {
 		const dispatch = reduxUseDispatch();
 		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
 		const query = useQuery();
@@ -174,27 +173,13 @@ const hosting: Flow = {
 
 		const queryParams = Object.fromEntries( query );
 
-		const logInUrl = useLoginUrl( {
-			variationName: flowName,
-			redirectTo: addQueryArgs( `/setup/${ flowName }`, { ...queryParams } ),
-		} );
-
 		useLayoutEffect( () => {
-			const urlWithQueryParams = addQueryArgs( '/setup/new-hosted-site', queryParams );
-
-			if ( ! userIsLoggedIn ) {
-				window.location.assign(
-					addQueryArgs( logInUrl, {
-						...queryParams,
-						flow: 'new-hosted-site',
-					} )
-				);
-			}
+			const urlWithQueryParams = addQueryArgs( 'setup/new-hosted-site', queryParams );
 
 			if ( currentStepSlug === 'trialAcknowledge' && ! isEligible ) {
-				window.location.assign( urlWithQueryParams );
+				navigate( urlWithQueryParams );
 			}
-		}, [ userIsLoggedIn, isEligible, currentStepSlug, queryParams, logInUrl ] );
+		}, [ userIsLoggedIn, isEligible, currentStepSlug, queryParams, navigate ] );
 
 		useEffect( () => {
 			if ( queryParams.studioSiteId ) {

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -16,11 +16,11 @@ import { useDispatch as reduxUseDispatch, useSelector } from 'calypso/state';
 import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { useQuery } from '../hooks/use-query';
-import { ONBOARD_STORE, USER_STORE } from '../stores';
+import { ONBOARD_STORE } from '../stores';
 import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 import { STEPS } from './internals/steps';
 import { Flow, ProvidedDependencies } from './internals/types';
-import type { OnboardSelect, UserSelect } from '@automattic/data-stores';
+import type { OnboardSelect } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import './internals/new-hosted-site-flow.scss';
 
@@ -166,20 +166,17 @@ const hosting: Flow = {
 		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
 		const query = useQuery();
 		const isEligible = useSelector( isUserEligibleForFreeHostingTrial );
-		const userIsLoggedIn = useSelect(
-			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
-			[]
-		);
 
 		const queryParams = Object.fromEntries( query );
 
 		useLayoutEffect( () => {
-			const urlWithQueryParams = addQueryArgs( 'setup/new-hosted-site', queryParams );
-
 			if ( currentStepSlug === 'trialAcknowledge' && ! isEligible ) {
-				navigate( urlWithQueryParams );
+				// Go to the first step if the user is not eligible for a free hosting trial
+				// If domains is not the first, Stepper will figure it out.
+				// This automatically preserves the query params.
+				navigate( 'domains' );
 			}
-		}, [ userIsLoggedIn, isEligible, currentStepSlug, queryParams, navigate ] );
+		}, [ isEligible, currentStepSlug, navigate ] );
 
 		useEffect( () => {
 			if ( queryParams.studioSiteId ) {


### PR DESCRIPTION
## Proposed Changes

This migrates the new-hosted-site flow to use built-in Stepper auth. This is much faster to load and makes all the navigations SPA-style. It also enables preloading of the following steps in the flow. 


## Why are these changes being made?
Mostly performance.

## Testing Instructions

1. Please test the flow thoroughly around auth.
2. Try to use it while logged in.
3. Try to use it while logged out by signing up.
4. Try to use it while logged out by signing in.
