### PR TITLE
Reader Quick Edit: Set primary site as default selected site ID

### DIFF
--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -40,7 +40,7 @@ function QuickPost( {
 	primarySiteId,
 	receivePosts,
 }: {
-	primarySiteId: number;
+	primarySiteId: number | null;
 	receivePosts: ( posts: PostItem[] ) => Promise< void >;
 } ) {
 	const translate = useTranslate();

--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -86,11 +86,11 @@ function QuickPost( {
 			} )
 			.then( ( postData: PostItem ) => {
 				recordReaderTracksEvent( 'calypso_reader_quick_post_submitted' );
+				clearEditor();
+				callShowSuccessMessage();
 
 				if ( config.isEnabled( 'reader/quick-post-v2' ) ) {
 					receivePosts( [ postData ] ).then( () => {
-						clearEditor();
-						callShowSuccessMessage();
 						// Actual API response will update the stream with the real post data
 						dispatch(
 							receiveNewPost( {

--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -16,6 +16,7 @@ import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
 import { receivePosts } from 'calypso/state/reader/posts/actions';
 import { receiveNewPost } from 'calypso/state/reader/streams/actions';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
 
 import './style.scss';
@@ -35,14 +36,20 @@ interface PostItem {
 	content: string;
 }
 
-function QuickPost( { receivePosts }: { receivePosts: ( posts: PostItem[] ) => Promise< void > } ) {
+function QuickPost( {
+	primarySiteId,
+	receivePosts,
+}: {
+	primarySiteId: number;
+	receivePosts: ( posts: PostItem[] ) => Promise< void >;
+} ) {
 	const translate = useTranslate();
 	const locale = useLocale();
 	const recordReaderTracksEvent = useRecordReaderTracksEvent();
 	const [ postContent, setPostContent ] = useState( '' );
 	const [ editorKey, setEditorKey ] = useState( 0 );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
-	const [ selectedSiteId, setSelectedSiteId ] = useState< number | null >( null );
+	const [ selectedSiteId, setSelectedSiteId ] = useState< number | null >( primarySiteId ?? null );
 	const editorRef = useRef< HTMLDivElement >( null );
 	const dispatch = useDispatch();
 	const currentUser = useSelector( getCurrentUser );
@@ -184,6 +191,11 @@ function QuickPost( { receivePosts }: { receivePosts: ( posts: PostItem[] ) => P
 	);
 }
 
-export default connect( null, {
-	receivePosts: ( posts: PostItem[] ) => receivePosts( posts ) as Promise< void >,
-} )( QuickPost );
+export default connect(
+	( state: any ) => ( {
+		primarySiteId: getPrimarySiteId( state ),
+	} ),
+	{
+		receivePosts: ( posts: PostItem[] ) => receivePosts( posts ) as Promise< void >,
+	}
+)( QuickPost );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/537

## Proposed Changes

- Adds the primary site as props to the Quick Edit component
- This allows us to set the state with the siteID on initial load, making the submit button function as expected

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The submit button was broken on initial page load.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/reader?flags=reader/quick-post,reader/quick-post-v2`
- Try to submit a post using the Quick Editor
- See that the submit button works as intended

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
