### PR TITLE
Subscribers: Add Tracks events

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -203,12 +203,12 @@ const SubscriberDataViews = ( {
 
 	const handleViewChange = useCallback(
 		( newView: View ) => {
-			// Track search changes
+			// Track search changes.
 			if ( newView.search !== currentView.search && newView.search ) {
 				recordSubscriberSearch( { site_id: siteId, query: newView.search } );
 			}
 
-			// Track filter changes
+			// Track filter changes.
 			const newFilters = ( newView.filters?.map( ( f ) => f.value ).filter( Boolean ) ??
 				[] ) as SubscribersFilterBy[];
 			const currentFilters = ( currentView.filters?.map( ( f ) => f.value ).filter( Boolean ) ??
@@ -221,7 +221,7 @@ const SubscriberDataViews = ( {
 				} );
 			}
 
-			// Track sort changes
+			// Track sort changes.
 			if (
 				newView.sort?.field !== currentView.sort?.field ||
 				newView.sort?.direction !== currentView.sort?.direction
@@ -414,7 +414,7 @@ const SubscriberDataViews = ( {
 		setFilters( filterValues.length ? filterValues : [ SubscribersFilterBy.All ] );
 	}, [ currentView.search, currentView.filters ] );
 
-	// Remove the tracking useEffects and keep only the data and pagination memoization
+	// Memoize the data and pagination info.
 	const { data, paginationInfo } = useMemo( () => {
 		return {
 			data: subscribers,

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -17,6 +17,12 @@ import {
 	useSubscriberCountQuery,
 	useSubscriberDetailsQuery,
 } from '../../queries';
+import {
+	useRecordSubscriberClicked,
+	useRecordSubscriberSearch,
+	useRecordSubscriberFilter,
+	useRecordSubscriberSort,
+} from '../../tracks';
 import { Subscriber } from '../../types';
 import { EmptyListView } from '../empty-list-view';
 import { SubscriberDetails } from '../subscriber-details';
@@ -71,6 +77,10 @@ const SubscriberDataViews = ( {
 	isUnverified,
 }: SubscriberDataViewsProps ) => {
 	const isMobile = useBreakpoint( '<660px' );
+	const recordSubscriberClicked = useRecordSubscriberClicked();
+	const recordSubscriberSearch = useRecordSubscriberSearch();
+	const recordSubscriberFilter = useRecordSubscriberFilter();
+	const recordSubscriberSort = useRecordSubscriberSort();
 
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const [ filters, setFilters ] = useState< SubscribersFilterBy[] >( [ SubscribersFilterBy.All ] );
@@ -181,9 +191,51 @@ const SubscriberDataViews = ( {
 
 	const handleSubscriberOnClick = useCallback(
 		( subscriber: Subscriber ) => {
+			recordSubscriberClicked( 'row', {
+				site_id: siteId,
+				subscription_id: subscriber.subscription_id,
+				user_id: subscriber.user_id,
+			} );
 			handleSubscriberSelect( [ getSubscriberId( subscriber ) ] );
 		},
-		[ getSubscriberId, handleSubscriberSelect ]
+		[ getSubscriberId, handleSubscriberSelect, recordSubscriberClicked, siteId ]
+	);
+
+	const handleViewChange = useCallback(
+		( newView: View ) => {
+			// Track search changes
+			if ( newView.search !== currentView.search && newView.search ) {
+				recordSubscriberSearch( { site_id: siteId, query: newView.search } );
+			}
+
+			// Track filter changes
+			const newFilters = ( newView.filters?.map( ( f ) => f.value ).filter( Boolean ) ??
+				[] ) as SubscribersFilterBy[];
+			const currentFilters = ( currentView.filters?.map( ( f ) => f.value ).filter( Boolean ) ??
+				[] ) as SubscribersFilterBy[];
+			if ( JSON.stringify( newFilters ) !== JSON.stringify( currentFilters ) ) {
+				newFilters.forEach( ( filter ) => {
+					if ( filter ) {
+						recordSubscriberFilter( { site_id: siteId, filter } );
+					}
+				} );
+			}
+
+			// Track sort changes
+			if (
+				newView.sort?.field !== currentView.sort?.field ||
+				newView.sort?.direction !== currentView.sort?.direction
+			) {
+				recordSubscriberSort( {
+					site_id: siteId,
+					sort_field: newView.sort?.field as SubscribersSortBy,
+					sort_direction: newView.sort?.direction as 'asc' | 'desc',
+				} );
+			}
+
+			setCurrentView( newView );
+		},
+		[ currentView, recordSubscriberSearch, recordSubscriberFilter, recordSubscriberSort, siteId ]
 	);
 
 	const fields = useMemo(
@@ -279,6 +331,11 @@ const SubscriberDataViews = ( {
 				label: translate( 'View' ),
 				callback: ( items: Subscriber[] ) => {
 					if ( items[ 0 ] ) {
+						recordSubscriberClicked( 'row', {
+							site_id: siteId,
+							subscription_id: items[ 0 ].subscription_id,
+							user_id: items[ 0 ].user_id,
+						} );
 						handleSubscriberSelect( [ getSubscriberId( items[ 0 ] ) ] );
 					}
 				},
@@ -313,6 +370,8 @@ const SubscriberDataViews = ( {
 		onGiftSubscription,
 		couponsAndGiftsEnabled,
 		getSubscriberId,
+		recordSubscriberClicked,
+		siteId,
 	] );
 
 	useEffect( () => {
@@ -355,7 +414,7 @@ const SubscriberDataViews = ( {
 		setFilters( filterValues.length ? filterValues : [ SubscribersFilterBy.All ] );
 	}, [ currentView.search, currentView.filters ] );
 
-	// Memoize the data and pagination info.
+	// Remove the tracking useEffects and keep only the data and pagination memoization
 	const { data, paginationInfo } = useMemo( () => {
 		return {
 			data: subscribers,
@@ -392,7 +451,7 @@ const SubscriberDataViews = ( {
 							fields={ fields }
 							view={ currentView }
 							onClickItem={ handleSubscriberOnClick }
-							onChangeView={ setCurrentView }
+							onChangeView={ handleViewChange }
 							selection={
 								selectedSubscriber ? [ selectedSubscriber.subscription_id.toString() ] : undefined
 							}

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -201,43 +201,6 @@ const SubscriberDataViews = ( {
 		[ getSubscriberId, handleSubscriberSelect, recordSubscriberClicked, siteId ]
 	);
 
-	const handleViewChange = useCallback(
-		( newView: View ) => {
-			// Track search changes.
-			if ( newView.search !== currentView.search && newView.search ) {
-				recordSubscriberSearch( { site_id: siteId, query: newView.search } );
-			}
-
-			// Track filter changes.
-			const newFilters = ( newView.filters?.map( ( f ) => f.value ).filter( Boolean ) ??
-				[] ) as SubscribersFilterBy[];
-			const currentFilters = ( currentView.filters?.map( ( f ) => f.value ).filter( Boolean ) ??
-				[] ) as SubscribersFilterBy[];
-			if ( JSON.stringify( newFilters ) !== JSON.stringify( currentFilters ) ) {
-				newFilters.forEach( ( filter ) => {
-					if ( filter ) {
-						recordSubscriberFilter( { site_id: siteId, filter } );
-					}
-				} );
-			}
-
-			// Track sort changes.
-			if (
-				newView.sort?.field !== currentView.sort?.field ||
-				newView.sort?.direction !== currentView.sort?.direction
-			) {
-				recordSubscriberSort( {
-					site_id: siteId,
-					sort_field: newView.sort?.field as SubscribersSortBy,
-					sort_direction: newView.sort?.direction as 'asc' | 'desc',
-				} );
-			}
-
-			setCurrentView( newView );
-		},
-		[ currentView, recordSubscriberSearch, recordSubscriberFilter, recordSubscriberSort, siteId ]
-	);
-
 	const fields = useMemo(
 		() => [
 			{
@@ -373,6 +336,55 @@ const SubscriberDataViews = ( {
 		recordSubscriberClicked,
 		siteId,
 	] );
+
+	const handleViewChange = useCallback(
+		( newView: View ) => {
+			// Track search changes.
+			if ( newView.search !== currentView.search && newView.search ) {
+				recordSubscriberSearch( { site_id: siteId, query: newView.search } );
+			}
+
+			// Track filter changes.
+			const newFilters = newView.filters?.filter( Boolean ) ?? [];
+			const currentFilters = currentView.filters?.filter( Boolean ) ?? [];
+			if ( JSON.stringify( newFilters ) !== JSON.stringify( currentFilters ) ) {
+				newFilters.forEach( ( filter ) => {
+					if ( filter?.value ) {
+						const field = fields.find( ( f ) => f.id === filter.field );
+						const element = field?.elements?.find( ( e ) => e.value === filter.value );
+						recordSubscriberFilter( {
+							site_id: siteId,
+							filter: filter.value as SubscribersFilterBy,
+							filter_field: filter.field,
+							filter_label: element?.label ?? '',
+						} );
+					}
+				} );
+			}
+
+			// Track sort changes.
+			if (
+				newView.sort?.field !== currentView.sort?.field ||
+				newView.sort?.direction !== currentView.sort?.direction
+			) {
+				recordSubscriberSort( {
+					site_id: siteId,
+					sort_field: newView.sort?.field as SubscribersSortBy,
+					sort_direction: newView.sort?.direction as 'asc' | 'desc',
+				} );
+			}
+
+			setCurrentView( newView );
+		},
+		[
+			currentView,
+			recordSubscriberSearch,
+			recordSubscriberFilter,
+			recordSubscriberSort,
+			siteId,
+			fields,
+		]
+	);
 
 	useEffect( () => {
 		// If we're on mobile, we only want to show the name field.

--- a/client/my-sites/subscribers/tracks/index.ts
+++ b/client/my-sites/subscribers/tracks/index.ts
@@ -3,3 +3,6 @@ export { default as useRecordSubscriberRemoved } from './use-record-subscriber-r
 export { default as useRecordRemoveModal } from './use-record-remove-modal';
 export { default as useRecordExport } from './use-record-export';
 export { default as useRecordSubscriberClicked } from './use-record-subscriber-clicked';
+export { default as useRecordSubscriberSearch } from './use-record-subscriber-search';
+export { default as useRecordSubscriberFilter } from './use-record-subscriber-filter';
+export { default as useRecordSubscriberSort } from './use-record-subscriber-sort';

--- a/client/my-sites/subscribers/tracks/use-record-subscriber-clicked.ts
+++ b/client/my-sites/subscribers/tracks/use-record-subscriber-clicked.ts
@@ -4,10 +4,10 @@ const useRecordSubscriberClicked = () => {
 	const recordSubscribersTracksEvent = useRecordSubscriberTrackEvent();
 
 	return (
-		where: 'title' | 'icon',
+		where: 'title' | 'icon' | 'row',
 		tracksProps: { site_id?: number | null; subscription_id?: number; user_id?: number }
 	) => {
-		// Allows for calypso_subscribers_subscriber_title_clicked & calypso_subscribers_subscriber_icon_clicked
+		// Allows for calypso_subscribers_subscriber_title_clicked, calypso_subscribers_subscriber_icon_clicked & calypso_subscribers_subscriber_row_clicked
 		recordSubscribersTracksEvent(
 			`calypso_subscribers_subscriber_${ where }_clicked`,
 			tracksProps

--- a/client/my-sites/subscribers/tracks/use-record-subscriber-filter.ts
+++ b/client/my-sites/subscribers/tracks/use-record-subscriber-filter.ts
@@ -4,7 +4,12 @@ import useRecordSubscriberTrackEvent from './use-record-subscriber-tracks-event'
 const useRecordSubscriberFilter = () => {
 	const recordSubscribersTracksEvent = useRecordSubscriberTrackEvent();
 
-	return ( tracksProps: { site_id?: number | null; filter: SubscribersFilterBy } ) => {
+	return ( tracksProps: {
+		site_id?: number | null;
+		filter: SubscribersFilterBy;
+		filter_field: string;
+		filter_label: string;
+	} ) => {
 		recordSubscribersTracksEvent( 'calypso_subscribers_filter_applied', tracksProps );
 	};
 };

--- a/client/my-sites/subscribers/tracks/use-record-subscriber-filter.ts
+++ b/client/my-sites/subscribers/tracks/use-record-subscriber-filter.ts
@@ -1,0 +1,12 @@
+import { SubscribersFilterBy } from '../constants';
+import useRecordSubscriberTrackEvent from './use-record-subscriber-tracks-event';
+
+const useRecordSubscriberFilter = () => {
+	const recordSubscribersTracksEvent = useRecordSubscriberTrackEvent();
+
+	return ( tracksProps: { site_id?: number | null; filter: SubscribersFilterBy } ) => {
+		recordSubscribersTracksEvent( 'calypso_subscribers_filter_applied', tracksProps );
+	};
+};
+
+export default useRecordSubscriberFilter;

--- a/client/my-sites/subscribers/tracks/use-record-subscriber-search.ts
+++ b/client/my-sites/subscribers/tracks/use-record-subscriber-search.ts
@@ -1,0 +1,11 @@
+import useRecordSubscriberTrackEvent from './use-record-subscriber-tracks-event';
+
+const useRecordSubscriberSearch = () => {
+	const recordSubscribersTracksEvent = useRecordSubscriberTrackEvent();
+
+	return ( tracksProps: { site_id?: number | null; query: string } ) => {
+		recordSubscribersTracksEvent( 'calypso_subscribers_search_performed', tracksProps );
+	};
+};
+
+export default useRecordSubscriberSearch;

--- a/client/my-sites/subscribers/tracks/use-record-subscriber-sort.ts
+++ b/client/my-sites/subscribers/tracks/use-record-subscriber-sort.ts
@@ -1,0 +1,16 @@
+import { SubscribersSortBy } from '../constants';
+import useRecordSubscriberTrackEvent from './use-record-subscriber-tracks-event';
+
+const useRecordSubscriberSort = () => {
+	const recordSubscribersTracksEvent = useRecordSubscriberTrackEvent();
+
+	return ( tracksProps: {
+		site_id?: number | null;
+		sort_field: SubscribersSortBy;
+		sort_direction: 'asc' | 'desc';
+	} ) => {
+		recordSubscribersTracksEvent( 'calypso_subscribers_sort_changed', tracksProps );
+	};
+};
+
+export default useRecordSubscriberSort;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/381

## Proposed Changes

* Add Tracks events for clicking to view a subscriber, filtering, sorting, and searching.
* Use existing click tracking hook and add additional hooks.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To gain insight into how the new Subscribers is being used.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /subscribers/{site url}
* View tracks: PCYsg-nSS-p2
* Interact with the Subscribers table: click on subscribers, click on actions in the Actions column, sort, filter, and search.
* Check that you see the correct corresponding Tracks event, and no errors.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?