### PR TITLE
Revert "Enable Focused Launchpad for all onboarding users"

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -16,7 +16,7 @@ import { urlToSlug } from 'calypso/lib/url';
 import { useSelector, useDispatch } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
-import { shouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
+import { useShouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
 import { useQuery } from '../../../../hooks/use-query';
 import StepContent from './step-content';
 import { areLaunchpadTasksCompleted } from './task-helper';
@@ -92,8 +92,11 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 		}
 	}, [ verifiedParam, translate, dispatch ] );
 
+	const [ loadingShouldShowLaunchpadFirst, shouldShowLaunchpadFirst ] =
+		useShouldShowLaunchpadFirst( site );
+
 	// Avoid screen flickering when redirecting to other paths
-	if ( ! site?.options ) {
+	if ( ! site?.options || loadingShouldShowLaunchpadFirst ) {
 		return null;
 	}
 
@@ -102,7 +105,7 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 		return null;
 	}
 
-	if ( shouldShowLaunchpadFirst( site ) ) {
+	if ( shouldShowLaunchpadFirst ) {
 		window.location.replace( `/home/${ siteSlug }` );
 		return null;
 	}

--- a/client/my-sites/customer-home/main.tsx
+++ b/client/my-sites/customer-home/main.tsx
@@ -5,13 +5,16 @@ import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { shouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
+import { useShouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
 import CelebrateLaunchModal from './components/celebrate-launch-modal';
 import { FullScreenLaunchpad } from './components/full-screen-launchpad';
 import HomeContent from './components/home-content';
 import type { SiteDetails } from '@automattic/data-stores';
 
 export default function CustomerHome( { site }: { site: SiteDetails } ) {
+	const [ isLoadingShouldShowLaunchpadFirst, shouldShowLaunchpadFirst ] =
+		useShouldShowLaunchpadFirst( site );
+
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
 
 	const [ isFullLaunchpadDismissed, setIsFullLaunchpadDismissed ] = useState(
@@ -32,9 +35,9 @@ export default function CustomerHome( { site }: { site: SiteDetails } ) {
 		<Main wideLayout>
 			<PageViewTracker path="/home/:site" title={ translate( 'My Home' ) } />
 			<DocumentHead title={ translate( 'My Home' ) } />
-			{ site.options && (
+			{ ! isLoadingShouldShowLaunchpadFirst && (
 				<>
-					{ shouldShowLaunchpadFirst( site ) && ! isFullLaunchpadDismissed ? (
+					{ shouldShowLaunchpadFirst && ! isFullLaunchpadDismissed ? (
 						<FullScreenLaunchpad
 							onClose={ () => setIsFullLaunchpadDismissed( true ) }
 							onSiteLaunch={ () => {

--- a/client/my-sites/customer-home/test/customer-home.tsx
+++ b/client/my-sites/customer-home/test/customer-home.tsx
@@ -5,12 +5,24 @@ import { screen, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 import nock from 'nock';
 import React, { act } from 'react';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { reducer as ui } from 'calypso/state/ui/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import CustomerHome from '../main';
 import type { SiteDetails } from '@automattic/data-stores';
 
 jest.mock( '@wordpress/api-fetch' );
+
+let mockUseExperimentResult = [ false, true ];
+
+jest.mock( 'calypso/lib/explat', () => ( {
+	loadExperimentAssignment: jest.fn( ( slug ) =>
+		slug === 'calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131'
+			? Promise.resolve( { variationName: 'treatment_cumulative' } )
+			: Promise.reject( new Error( `Unmocked experiment slug: ${ slug }` ) )
+	),
+	useExperiment: jest.fn( () => mockUseExperimentResult ),
+} ) );
 
 jest.mock( '../components/home-content', () => () => (
 	<div data-testid="home-content">Home Content</div>
@@ -149,5 +161,34 @@ describe( 'CustomerHome', () => {
 		act( () => launchSiteButton.click() );
 
 		expect( await screen.findByText( 'Congrats, your site is live!' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows home content when site would be eligible to show launchpad, but user is in control group', async () => {
+		const testSite = makeTestSite( {
+			launch_status: 'unlaunched',
+			options: { site_creation_flow: 'onboarding', launchpad_screen: false },
+		} );
+		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( { variationName: 'control' } );
+
+		renderWithProvider( <CustomerHome site={ testSite } /> );
+
+		await waitFor( () => expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument() );
+		expect( screen.queryByTestId( 'launchpad-first' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows home content when site would be eligible to show launchpad, but user is in treatment_frozen group', async () => {
+		mockUseExperimentResult = [ false, false ];
+		const testSite = makeTestSite( {
+			launch_status: 'unlaunched',
+			options: { site_creation_flow: 'onboarding', launchpad_screen: false },
+		} );
+		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
+			variationName: 'treatment_frozen',
+		} );
+
+		renderWithProvider( <CustomerHome site={ testSite } /> );
+
+		await waitFor( () => expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument() );
+		expect( screen.queryByTestId( 'launchpad-first' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/state/selectors/should-show-launchpad-first.ts
+++ b/client/state/selectors/should-show-launchpad-first.ts
@@ -1,4 +1,6 @@
 import { SiteDetails, Onboard } from '@automattic/data-stores';
+import { useEffect, useState } from 'react';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 
 const SiteIntent = Onboard.SiteIntent;
 
@@ -7,13 +9,58 @@ const SiteIntent = Onboard.SiteIntent;
  * @param site Site object
  * @returns Whether launchpad should be shown first
  */
-export const shouldShowLaunchpadFirst = ( site: SiteDetails ): boolean => {
+export const shouldShowLaunchpadFirst = async ( site: SiteDetails ): Promise< boolean > => {
 	const wasSiteCreatedOnboardingFlow = site.options?.site_creation_flow === 'onboarding';
+	const createdAfterExperimentStart =
+		( site.options?.created_at ?? '' ) > '2025-02-03T10:22:45+00:00'; // If created_at is null then this expression is false
 	const isBigSkyIntent = site?.options?.site_intent === SiteIntent.AIAssembler;
 
-	if ( isBigSkyIntent || ! wasSiteCreatedOnboardingFlow ) {
+	if ( isBigSkyIntent || ! wasSiteCreatedOnboardingFlow || ! createdAfterExperimentStart ) {
 		return false;
 	}
 
-	return true;
+	const assignment = await loadExperimentAssignment(
+		'calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131'
+	);
+
+	return assignment?.variationName === 'treatment_cumulative';
+};
+
+export const useShouldShowLaunchpadFirst = ( site?: SiteDetails | null ): [ boolean, boolean ] => {
+	const [ state, setState ] = useState< boolean | 'loading' >( 'loading' );
+
+	useEffect( () => {
+		let cancel = false;
+
+		const getResponse = async () => {
+			if ( ! site ) {
+				return;
+			}
+
+			try {
+				setState( 'loading' );
+				const result = await shouldShowLaunchpadFirst( site );
+				if ( ! cancel ) {
+					setState( result );
+				}
+			} catch ( err ) {
+				if ( ! cancel ) {
+					setState( false );
+				}
+			}
+		};
+
+		getResponse();
+
+		return () => {
+			cancel = true;
+		};
+	}, [ site ] );
+
+	if ( ! site ) {
+		// If the site isn't available yet we'll assume we're still loading
+		return [ true, false ];
+	}
+
+	return [ state === 'loading', state === 'loading' ? false : state ];
 };

--- a/client/state/selectors/test/should-show-launchpad-first.ts
+++ b/client/state/selectors/test/should-show-launchpad-first.ts
@@ -1,8 +1,12 @@
 /**
  * @jest-environment jsdom
  */
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { loadExperimentAssignment } from 'calypso/lib/explat';
-import { shouldShowLaunchpadFirst } from '../should-show-launchpad-first';
+import {
+	shouldShowLaunchpadFirst,
+	useShouldShowLaunchpadFirst,
+} from '../should-show-launchpad-first';
 import type { SiteDetails } from '@automattic/data-stores';
 
 jest.mock( 'calypso/lib/explat', () => ( {
@@ -21,10 +25,25 @@ describe( 'shouldShowLaunchpadFirst', () => {
 		const site = {
 			options: {
 				site_creation_flow: 'onboarding',
+				created_at: '2025-02-18T00:00:00+00:00',
 			},
 		} as SiteDetails;
 
 		expect( await shouldShowLaunchpadFirst( site ) ).toBe( true );
+	} );
+
+	it( 'should return false when site was created via onboarding flow but assigned to control', async () => {
+		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
+			variationName: 'control',
+		} );
+		const site = {
+			options: {
+				site_creation_flow: 'onboarding',
+				created_at: '2025-02-18T00:00:00+00:00',
+			},
+		} as SiteDetails;
+
+		expect( await shouldShowLaunchpadFirst( site ) ).toBe( false );
 	} );
 
 	it( 'should return false when site was not created via onboarding flow', async () => {
@@ -34,6 +53,7 @@ describe( 'shouldShowLaunchpadFirst', () => {
 		const site = {
 			options: {
 				site_creation_flow: 'other',
+				created_at: '2025-02-18T00:00:00+00:00',
 			},
 		} as SiteDetails;
 
@@ -45,9 +65,107 @@ describe( 'shouldShowLaunchpadFirst', () => {
 			variationName: 'treatment_cumulative',
 		} );
 		const site = {
-			options: {},
+			options: {
+				created_at: '2025-02-18T00:00:00+00:00',
+			},
 		} as SiteDetails;
 
 		expect( await shouldShowLaunchpadFirst( site ) ).toBe( false );
 	} );
 } );
+
+describe( 'useShouldShowLaunchpadFirst', () => {
+	it( 'returns loading state until promise resolves', async () => {
+		const { promise, resolve } = promiseWithResolvers();
+		( loadExperimentAssignment as jest.Mock ).mockReturnValue( promise );
+		const site = {
+			options: {
+				site_creation_flow: 'onboarding',
+				created_at: '2025-02-18T00:00:00+00:00',
+			},
+		} as SiteDetails;
+
+		const { result } = renderHook( () => useShouldShowLaunchpadFirst( site ) );
+
+		expect( result.current[ 0 ] ).toBe( true );
+
+		await act( () => resolve( { variationName: 'treatment_cumulative' } ) );
+
+		expect( result.current ).toEqual( [ false, true ] );
+	} );
+
+	it( 'should return true when site was created via onboarding flow and assigned to experiment', async () => {
+		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
+			variationName: 'treatment_cumulative',
+		} );
+		const site = {
+			options: {
+				site_creation_flow: 'onboarding',
+				created_at: '2025-02-18T00:00:00+00:00',
+			},
+		} as SiteDetails;
+
+		const { result } = renderHook( () => useShouldShowLaunchpadFirst( site ) );
+
+		await waitFor( () => expect( result.current ).toEqual( [ false, true ] ) );
+	} );
+
+	it( 'should return false when site was created via onboarding flow but assigned to control', async () => {
+		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
+			variationName: 'control',
+		} );
+		const site = {
+			options: {
+				site_creation_flow: 'onboarding',
+				created_at: '2025-02-18T00:00:00+00:00',
+			},
+		} as SiteDetails;
+
+		const { result } = renderHook( () => useShouldShowLaunchpadFirst( site ) );
+
+		await waitFor( () => expect( result.current ).toEqual( [ false, false ] ) );
+	} );
+
+	it( 'should return false when site was not created via onboarding flow', async () => {
+		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
+			variationName: 'treatment_cumulative',
+		} );
+		const site = {
+			options: {
+				site_creation_flow: 'other',
+				created_at: '2025-02-18T00:00:00+00:00',
+			},
+		} as SiteDetails;
+
+		const { result } = renderHook( () => useShouldShowLaunchpadFirst( site ) );
+
+		await waitFor( () => expect( result.current ).toEqual( [ false, false ] ) );
+	} );
+
+	it( 'should return false when site has no creation flow information', async () => {
+		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
+			variationName: 'treatment_cumulative',
+		} );
+		const site = {
+			options: {
+				created_at: '2025-02-18T00:00:00+00:00',
+			},
+		} as SiteDetails;
+
+		const { result } = renderHook( () => useShouldShowLaunchpadFirst( site ) );
+
+		await waitFor( () => expect( result.current ).toEqual( [ false, false ] ) );
+	} );
+} );
+
+// Our TS Config doesn't know the standard Promise.withResolvers is available
+// in our version of Node.
+function promiseWithResolvers() {
+	let resolve;
+	let reject;
+	const promise = new Promise( ( res, rej ) => {
+		resolve = res;
+		reject = rej;
+	} );
+	return { promise, resolve, reject };
+}


### PR DESCRIPTION
Just in case.

Reverts Automattic/wp-calypso#100526