### PR TITLE
Reader Default Home Page - Prevent blank screen flash and check for reader-lp ref

### DIFF
--- a/client/signup/steps/set-reader-landing/index.tsx
+++ b/client/signup/steps/set-reader-landing/index.tsx
@@ -13,7 +13,7 @@ interface Props {
 	};
 }
 
-const SetReaderLanding = ( { submitSignupStep, goToNextStep, initialContext }: Props ) => {
+const SetReaderLanding = ( { submitSignupStep, goToNextStep, initialContext }: Props ): null => {
 	const dispatch = useDispatch();
 	const refParam = initialContext?.query?.ref;
 
@@ -38,6 +38,8 @@ const SetReaderLanding = ( { submitSignupStep, goToNextStep, initialContext }: P
 		saveAndProceed();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
+
+	return null; // Non-interactive step.
 };
 
 export default SetReaderLanding;

--- a/client/signup/steps/set-reader-landing/index.tsx
+++ b/client/signup/steps/set-reader-landing/index.tsx
@@ -6,19 +6,28 @@ import { READER_AS_LANDING_PAGE_PREFERENCE } from 'calypso/state/sites/selectors
 interface Props {
 	submitSignupStep: ( args: { stepName: string } ) => void;
 	goToNextStep: () => void;
+	initialContext?: {
+		query?: {
+			ref?: string;
+		};
+	};
 }
 
-const SetReaderLanding = ( { submitSignupStep, goToNextStep }: Props ): null => {
+const SetReaderLanding = ( { submitSignupStep, goToNextStep, initialContext }: Props ): null => {
 	const dispatch = useDispatch();
+	const refParam = initialContext?.query?.ref;
 
 	useEffect( () => {
 		const saveAndProceed = async () => {
-			await dispatch(
-				savePreference( READER_AS_LANDING_PAGE_PREFERENCE, {
-					useReaderAsLandingPage: true,
-					updatedAt: Date.now(),
-				} )
-			);
+			if ( 'reader-lp' === refParam ) {
+				await dispatch(
+					savePreference( READER_AS_LANDING_PAGE_PREFERENCE, {
+						useReaderAsLandingPage: true,
+						updatedAt: Date.now(),
+					} )
+				);
+			}
+
 			submitSignupStep( { stepName: 'set-reader-landing' } );
 			goToNextStep();
 		};

--- a/client/signup/steps/set-reader-landing/index.tsx
+++ b/client/signup/steps/set-reader-landing/index.tsx
@@ -13,12 +13,16 @@ interface Props {
 	};
 }
 
-const SetReaderLanding = ( { submitSignupStep, goToNextStep, initialContext }: Props ): null => {
+const SetReaderLanding = ( { submitSignupStep, goToNextStep, initialContext }: Props ) => {
 	const dispatch = useDispatch();
 	const refParam = initialContext?.query?.ref;
 
 	useEffect( () => {
+		// Submit the step immediately to trigger the processing screen.
+		submitSignupStep( { stepName: 'set-reader-landing' } );
+
 		const saveAndProceed = async () => {
+			// Save the preference
 			if ( 'reader-lp' === refParam ) {
 				await dispatch(
 					savePreference( READER_AS_LANDING_PAGE_PREFERENCE, {
@@ -28,15 +32,12 @@ const SetReaderLanding = ( { submitSignupStep, goToNextStep, initialContext }: P
 				);
 			}
 
-			submitSignupStep( { stepName: 'set-reader-landing' } );
 			goToNextStep();
 		};
 
 		saveAndProceed();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
-
-	return null; // Non-interactive step.
 };
 
 export default SetReaderLanding;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1740763842468069-slack-C02T4NVL4JJ

## Proposed Changes

* Check for the `ref` URL paramter `reader-lp` to be more conservative with when we set the Reader as the default start page.
* Call `submitSignupStep` at the beginning of the call to trigger the loading screen immediately and prevent a blank white screen flash.

White flash in "before" seen around 11 seconds, right after the "Create your account" submit.
In the After, right after the "Create your account" submit, the loading screen is shown immediately.
Before | After
--|--
<video src="https://github.com/user-attachments/assets/b84c34e9-2d5b-47f6-986b-0f39e9a4008c" />  |  <video src="https://github.com/user-attachments/assets/d871aed3-c6de-4f72-8a34-1ec23962f6e9" />








## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /start/account/user-social?ref=reader-lp
* Sign up for an account using a new email address (you can use the username+whatever@gmail.com, it will count as a new email to WPCOM, but you will receive an emails at username@gmail.com). There should NOT be a blank screen flash between the account creation submit and the loading screen.
* Go to /me/account. Your default home page should be set to the Reader.
* Log out.
* Go to /start/account/user-social (without the ref parameter)
* Sign up for an account using a new email address.
* Go to /me/account. Your default home page should NOT be set to the Reader.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?