### PR TITLE
fix smallPhone typo in radio button

### DIFF
--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -175,7 +175,7 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 			flex-direction: row;
 			align-items: center;
 			justify-content: space-between;
-			gap: 7px:
+			gap: 7px;
 		}
 }
 


### PR DESCRIPTION
A small issue in the @media of packages/composite-checkout/src/components/radio-button.tsx
There was ":" and should have been ";" at the end of the line 178
