### PR TITLE
Users: use total user count, not the query count

### DIFF
--- a/client/data/users/use-users-query.js
+++ b/client/data/users/use-users-query.js
@@ -35,11 +35,19 @@ const useUsersQuery = ( siteId, fetchOptions = {}, queryOptions = {} ) => {
 			/* @TODO:
 			 * `uniqueBy` is necessary, because the API can return duplicates.
 			 * This is most commonly seen where a user has both a "regular" user role
-			 * such as Administrator and Editor, and has also been added as a "Viewer" .
+			 * such as Administrator and Editor, and has also been added as a "Viewer".
+			 * This is arguably a bug in the API, and should be deduped.
 			 */
 			const users = uniqueBy( extractPages( data.pages ), compareUnique );
 			return {
-				users: uniqueBy( extractPages( data.pages ), compareUnique ),
+				users,
+				/*
+				 * @TODO: The property name `total` is misleading.
+				 * The value `found` is the total number of users returned from the query,
+				 * not the total number of users on the site. It should be renamed to `found`,
+				 * and a `totalUsers` property should be added to the response.
+				 * See: https://github.com/Automattic/jetpack/pull/42170
+				 */
 				total: users?.length ?? data.pages[ 0 ].found,
 				...data,
 			};

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -17,7 +17,7 @@ import './style.scss';
 
 class PeopleListSectionHeader extends Component {
 	static propTypes = {
-		label: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),
+		label: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array, PropTypes.element ] ),
 		count: PropTypes.number,
 		isFollower: PropTypes.bool,
 		site: PropTypes.object,

--- a/client/my-sites/people/team-members/index.tsx
+++ b/client/my-sites/people/team-members/index.tsx
@@ -55,6 +55,11 @@ function TeamMembers( props: Props ) {
 		( obj ) => obj.linked_user_ID === false
 	);
 
+	/*
+	 * @TODO: The property name `total` is misleading.
+	 * It's value `found` is the total number of users returned from the query,
+	 * not the total number of users on the site.
+	 */
 	const membersTotal = data?.total;
 	const addTeamMemberLink = `/people/new/${ site?.slug }`;
 
@@ -76,8 +81,8 @@ function TeamMembers( props: Props ) {
 		}
 
 		return translate(
-			'You have %(membersTotalCount)s user',
-			'You have %(membersTotalCount)s users',
+			'Displaying %(membersTotalCount)s users',
+			'Displaying %(membersTotalCount)s users',
 			{
 				args: { membersTotalCount: numberFormat( membersTotal as number ) },
 				count: membersTotal as number,


### PR DESCRIPTION
## Proposed Changes

Resolves https://github.com/Automattic/wp-calypso/issues/100628 (partly)

This commit:

- Updates the "You have `n` users" to "Displaying `n` users" to reflect the poor state of the users backend.
- Fixes a React prop type error.
- Removes dupe call to `uniqueBy`.

This PR originally attempted to send the _real_ total number of viewers and users to the frontend, but it requires an investment in dev time to fix the buggy endpoint. See: https://github.com/Automattic/jetpack/pull/42170 

So for now we're trying not to be misleading by describing what we're showing to the user. 

> [!NOTE]
> Eventually, when time and a business case arise, it would be better to fix `/users` once and for all. It's buggy and doesn't abstract the separate sources of users and viewers. See: https://github.com/Automattic/jetpack/pull/42170 for WIP.


## Background

The "All users" view uses the `found` property value from the `/users` response. This value is inaccurate as it represents only the results "found" in the current query plus the total number of viewers.

Therefore, if a site has 100+ users, the heading will display `You have 100 team members` because that is the length of the query count. It has nothing to do with how many users a site has.

https://github.com/Automattic/jetpack/pull/42170  will fix it eventually, but it's been placed on hold pending priority adjustments.


## Testing Instructions

Load `http://calypso.localhost:3000/people/team/[YOUR_SITE]`

The number will correspond to the number of users shown, rather than the number of users of your site.

### Before


<img width="791" alt="Screenshot 2025-04-09 at 12 44 58 pm" src="https://github.com/user-attachments/assets/8fed785c-cccd-4e3e-ade0-7b0d8e47d3ce" />



### After




<img width="798" alt="Screenshot 2025-04-09 at 12 48 39 pm" src="https://github.com/user-attachments/assets/6dc5211e-2b84-4a39-944a-56c9173e26d7" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
