### PR TITLE
Stats: add event handler for line chart

### DIFF
--- a/apps/odyssey-stats/package.json
+++ b/apps/odyssey-stats/package.json
@@ -33,7 +33,6 @@
 		"@automattic/calypso-polyfills": "workspace:^",
 		"@automattic/calypso-router": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
-		"@automattic/charts": "^0.9.0",
 		"@automattic/components": "workspace:^",
 		"@tanstack/react-query": "^5.15.5",
 		"@wordpress/base-styles": "^5.16.0",

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -213,6 +213,7 @@ class StatModuleChartTabs extends Component {
 						chartData={ transformChartDataToLineFormat( chartData ) }
 						height={ 200 }
 						moment={ moment }
+						onClick={ this.props.barClick }
 					/>
 				) }
 

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/calypso-razorpay": "workspace:^",
 		"@automattic/calypso-router": "workspace:^",
-		"@automattic/charts": "^0.8.4",
+		"@automattic/charts": "^0.9.0",
 		"@automattic/color-studio": "^3.0.1",
 		"@automattic/command-palette": "workspace:^",
 		"@automattic/components": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1546,7 +1546,6 @@ __metadata:
     "@automattic/calypso-polyfills": "workspace:^"
     "@automattic/calypso-router": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
-    "@automattic/charts": "npm:^0.9.0"
     "@automattic/components": "workspace:^"
     "@automattic/languages": "workspace:^"
     "@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -565,34 +565,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/charts@npm:^0.8.4":
-  version: 0.8.4
-  resolution: "@automattic/charts@npm:0.8.4"
-  dependencies:
-    "@babel/runtime": "npm:7.26.0"
-    "@react-spring/web": "npm:9.7.3"
-    "@visx/axis": "npm:^3.12.0"
-    "@visx/curve": "npm:3.12.0"
-    "@visx/event": "npm:^3.8.0"
-    "@visx/gradient": "npm:3.12.0"
-    "@visx/grid": "npm:^3.12.0"
-    "@visx/group": "npm:^3.12.0"
-    "@visx/legend": "npm:^3.12.0"
-    "@visx/responsive": "npm:3.12.0"
-    "@visx/scale": "npm:^3.12.0"
-    "@visx/shape": "npm:^3.12.0"
-    "@visx/text": "npm:3.12.0"
-    "@visx/tooltip": "npm:^3.8.0"
-    "@visx/xychart": "npm:3.12.0"
-    clsx: "npm:2.1.1"
-    tslib: "npm:2.5.0"
-  peerDependencies:
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-  checksum: 3bc71ac84e3d44afbbeab1abb8d27b6d11ab43b5fdb8b05f6024a467f9fc001e3d143c958d1c4106b6915a977abeeacdb9cc61b480a5c83793fe2fb23680ebe4
-  languageName: node
-  linkType: hard
-
 "@automattic/charts@npm:^0.9.0":
   version: 0.9.0
   resolution: "@automattic/charts@npm:0.9.0"
@@ -35887,7 +35859,7 @@ __metadata:
     "@automattic/calypso-razorpay": "workspace:^"
     "@automattic/calypso-router": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
-    "@automattic/charts": "npm:^0.8.4"
+    "@automattic/charts": "npm:^0.9.0"
     "@automattic/color-studio": "npm:^3.0.1"
     "@automattic/command-palette": "workspace:^"
     "@automattic/components": "workspace:^"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Integrate with the click behavior of period navigating

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Task

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `http://calypso.localhost:3000/stats/day/yousite.com?flags=stats/chart-library`
* Switch to line chart
* Click a data point
* Ensure you are taken to hourly view
* Choose last 12 months
* Choose period to 'Month'
* Try drilling down to hourly stats

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
