### PR TITLE
Fix domain price on the top suggestions looking broken in the search results

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -226,11 +226,14 @@
 	word-break: normal;
 }
 
+.domain-suggestion__action-container {
+	height: 40px;
+}
+
 .domain-suggestion__price-container,
 .domain-suggestion__action-container {
 	flex: 0 0 auto;
 	width: 100%;
-	height: 40px;
 
 	@include break-mobile {
 		width: auto;

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -328,6 +328,9 @@
 	}
 }
 
+.domain-product-price {
+	max-width: 100%;
+}
 
 body.is-section-stepper,
 body.is-section-signup {

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -135,13 +135,17 @@
 		}
 		&.is-free-domain {
 			padding-left: 0;
-			margin-top: 12px;
 			display: flex;
 			flex-direction: column-reverse;
 			@include break-mobile {
 				flex-direction: column;
 			}
 		}
+	}
+
+	.domain-suggestion__price-container {
+		flex-grow: 1;
+		display: flex;
 	}
 
 	.domain-registration-suggestion__badges {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100673

## Proposed Changes

* Fixed the styles to make sure the price in the price section of domains in the search result doesn't look broken

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix stylings

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Purchase any annual plan like Business
- Go to "https://wordpress.com/domains/add/"
- Search for a domain
- Make sure Tthe prices of the top suggested domains do not look broken like the "Before" image attached below
- Also check `https://wordpress.com/setup/onboarding/domains` to make sure nothing looks broken there
- Check both of the screens above in mobile screen sizes as well to make sure nothing looks broken
- Try the same for free plans and make sure the style is not broken there either
- Try to find more places where it can effect and check those places as well

| Before | After |
|--------|--------|
| <img width="1742" alt="Screenshot 2025-03-01 at 4 07 13 AM" src="https://github.com/user-attachments/assets/c2a240d0-48db-47cc-a165-a94fbf17e100" /> | <img width="1742" alt="Screenshot 2025-03-03 at 8 28 05 AM" src="https://github.com/user-attachments/assets/32a3cba8-8a18-4242-b281-58948956d8d9" /> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
