### PR TITLE
Fix site card hover / sizing issues

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -255,7 +255,7 @@ class Site extends Component {
 						defaultIcon={ layout }
 						site={ site }
 						// eslint-disable-next-line no-nested-ternary
-						size={ this.props.compact ? 24 : 50 }
+						size={ this.props.compact ? 24 : 32 }
 					/>
 					<div className="site__info">
 						{ ! this.props.showChevronDownIcon ? (

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Gridicon } from '@automattic/components';
-import { Icon, chevronDown, layout } from '@wordpress/icons';
+import { Icon, chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -252,7 +252,11 @@ class Site extends Component {
 					}
 				>
 					<SiteIcon
-						defaultIcon={ layout }
+						defaultIcon={
+							this.props.defaultIcon || (
+								<Gridicon icon="globe" size={ this.props.compact ? 20 : 28 } />
+							)
+						}
 						site={ site }
 						// eslint-disable-next-line no-nested-ternary
 						size={ this.props.compact ? 24 : 32 }

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -273,8 +273,8 @@ class Site extends Component {
 						) : (
 							<>
 								{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
-								{ this.renderSiteBadges() }
 								{ this.renderSiteDomain() }
+								{ this.renderSiteBadges() }
 							</>
 						) }
 

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -21,10 +21,10 @@
 		align-self: flex-start;
 		margin-right: 8px;
 		flex: 0 0 auto;
-		background-color: var(--color-neutral-0);
+		background-color: var(--color-neutral-10);
 		svg {
 			transform: scale(0.65);
-			fill: var(--color-neutral-50);
+			fill: var(--color-neutral-0);
 		}
 	}
 

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -80,16 +80,17 @@ exports[`JetpackAuthorize renders as expected 1`] = `
               >
                 <div
                   class="site-icon is-blank"
-                  style="height: 50px; width: 50px; line-height: 50px; font-size: 50px;"
+                  style="height: 32px; width: 32px; line-height: 32px; font-size: 32px;"
                 >
                   <svg
-                    aria-hidden="true"
-                    focusable="false"
+                    class="gridicon gridicons-globe"
+                    height="28"
                     viewBox="0 0 24 24"
+                    width="28"
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M18 5.5H6a.5.5 0 00-.5.5v3h13V6a.5.5 0 00-.5-.5zm.5 5H10v8h8a.5.5 0 00.5-.5v-7.5zm-10 0h-3V18a.5.5 0 00.5.5h2.5v-8zM6 4h12a2 2 0 012 2v12a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2z"
+                    <use
+                      xlink:href="gridicons.svg#gridicons-globe"
                     />
                   </svg>
                 </div>

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -78,16 +78,17 @@ exports[`JetpackSignup should render 1`] = `
             >
               <div
                 class="site-icon is-blank"
-                style="height: 50px; width: 50px; line-height: 50px; font-size: 50px;"
+                style="height: 32px; width: 32px; line-height: 32px; font-size: 32px;"
               >
                 <svg
-                  aria-hidden="true"
-                  focusable="false"
+                  class="gridicon gridicons-globe"
+                  height="28"
                   viewBox="0 0 24 24"
+                  width="28"
                   xmlns="http://www.w3.org/2000/svg"
                 >
-                  <path
-                    d="M18 5.5H6a.5.5 0 00-.5.5v3h13V6a.5.5 0 00-.5-.5zm.5 5H10v8h8a.5.5 0 00.5-.5v-7.5zm-10 0h-3V18a.5.5 0 00.5.5h2.5v-8zM6 4h12a2 2 0 012 2v12a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2z"
+                  <use
+                    xlink:href="gridicons.svg#gridicons-globe"
                   />
                 </svg>
               </div>
@@ -376,16 +377,17 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
             >
               <div
                 class="site-icon is-blank"
-                style="height: 50px; width: 50px; line-height: 50px; font-size: 50px;"
+                style="height: 32px; width: 32px; line-height: 32px; font-size: 32px;"
               >
                 <svg
-                  aria-hidden="true"
-                  focusable="false"
+                  class="gridicon gridicons-globe"
+                  height="28"
                   viewBox="0 0 24 24"
+                  width="28"
                   xmlns="http://www.w3.org/2000/svg"
                 >
-                  <path
-                    d="M18 5.5H6a.5.5 0 00-.5.5v3h13V6a.5.5 0 00-.5-.5zm.5 5H10v8h8a.5.5 0 00.5-.5v-7.5zm-10 0h-3V18a.5.5 0 00.5.5h2.5v-8zM6 4h12a2 2 0 012 2v12a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2z"
+                  <use
+                    xlink:href="gridicons.svg#gridicons-globe"
                   />
                 </svg>
               </div>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/100325

## Proposed Changes

* Re-applies the reskin values removed by https://github.com/Automattic/wp-calypso/pull/99690

## Testing Instructions

Before

<img width=350 src=https://github.com/user-attachments/assets/3327881b-99cb-4beb-9532-eefdeb9605a9 />

After

<img width=350 src=https://github.com/user-attachments/assets/af9313cb-37b8-42e1-a1a0-a8db0b61e5d3 />


Before Before for reference

<img width=350 src=https://github.com/user-attachments/assets/45033187-44a0-4116-a361-479dda296851 />

Snapshots:
```
yarn run test-client client/jetpack-connect/test --updateSnapshot --testPathPattern ./client/jetpack-connnect/test
```