### PR TITLE
Plan Grid: Vertically align storage labels in plans grid

### DIFF
--- a/packages/plans-grid-next/src/_shared.scss
+++ b/packages/plans-grid-next/src/_shared.scss
@@ -11,7 +11,7 @@ $mobile-card-max-width: 440px;
 
 .plans-grid-next-storage-feature-label__container {
 	display: flex;
-	gap: 5px;
+	gap: 10px;
 	flex-direction: column;
 	align-items: baseline;
 
@@ -76,14 +76,19 @@ $mobile-card-max-width: 440px;
 	margin-left: 4px;
 }
 
+// Height of the <CustomSelectControl /> component defined here: https://github.com/WordPress/gutenberg/blob/7c02f292165c182ffc126134b82e01074db6f631/packages/components/src/custom-select-control-v2/styles.ts#L40
+$storage-feature-dropdown-height: 40px;
+$storage-feature-label-y-padding: 4px;
+
 .plans-grid-next-storage-feature-label__volume {
 	color: var(--studio-gray-90);
-	padding: 4px 0;
+	padding: $storage-feature-label-y-padding 0;
 	font-weight: 400;
-	line-height: 20px;
+	line-height: $storage-feature-dropdown-height - 2 * $storage-feature-label-y-padding;
 	font-size: $font-body-extra-small;
 
 	&.is-badge {
+		line-height: 20px;
 		background: #f2f2f2;
 		/* stylelint-disable-next-line */
 		border-radius: 5px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/100221

## Proposed Changes

* Adjust line height of plan storage labels of low tier plans so that they align with storage labels of the high tier plans in combo boxes
* Adjust the storage add-on labels (which appear below the standard storage labels) so they vertically align

The font in the dropdown and in the label have different weights, so ideally the text would use `baseline` alignment. Due to the limitations of styling this within `<table>` elements, vertical alignment should be good enough 🤞 

Another approach I tried (since we're using `<table>`s) was `vertical-align: middle`. This has the advantage that the text element itself doesn't take up any more space than it naturally would. The downside it doesn't work when the user opens the dropdown of higher-tier plans; the row height increases and now `vertical-align: middle` doesn't align with the dropdown text. That's why I went with the line height approach. The minor downside is when you select the text it appears to have a super big selection box (see the gif below).

<img src="https://private-user-images.githubusercontent.com/1500769/418477848-4a2a3be0-0fa7-4f77-9457-de673e009550.gif?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDA5ODg2MjgsIm5iZiI6MTc0MDk4ODMyOCwicGF0aCI6Ii8xNTAwNzY5LzQxODQ3Nzg0OC00YTJhM2JlMC0wZmE3LTRmNzctOTQ1Ny1kZTY3M2UwMDk1NTAuZ2lmP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDMwMyUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTAzMDNUMDc1MjA4WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9MTFlNzMxYzFlOWM1YTcyNmFmZWJiNTU5MTFjMzJkZTNmYjg2ZjgwMTQ0Y2FmN2UxNjY1OWJkZGY0MzQxZTkxMSZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.6URSkhdarwtN6Yuln0i1BDiyy5Tp2axfeOc_YRjz7fI" alt="CleanShot 2025-03-03 at 20 51 15" style="max-width: 100%; display: inline-block;" data-target="animated-image.originalImage" width="20%">

#### No current add-ons, no dropdown item selected
| Before | After |
| --- | --- |
| ![CleanShot 2025-03-03 at 20 56 24@2x](https://github.com/user-attachments/assets/7508612c-0695-494f-ae5b-f5fe3509dfaa) | ![CleanShot 2025-03-03 at 20 54 39@2x](https://github.com/user-attachments/assets/0211ffaa-ff78-471b-b253-181b1ee0826f) |

#### No current add-ons, dropdown item selected
| Before | After |
| --- | --- |
| ![CleanShot 2025-03-03 at 20 57 47@2x](https://github.com/user-attachments/assets/c60bde97-202e-4a91-bbb7-7146068a45ff) | ![CleanShot 2025-03-03 at 20 58 57@2x](https://github.com/user-attachments/assets/6f9f9c13-b186-49c3-ab15-5a4f24f6a065) |

#### Site has existing storage add-on, no dropdown item selected
| Before | After |
| --- | --- |
| ![CleanShot 2025-03-03 at 21 02 08@2x](https://github.com/user-attachments/assets/ee618139-5293-429c-a616-d8072046e47a) | ![CleanShot 2025-03-03 at 21 03 39@2x](https://github.com/user-attachments/assets/53577f7d-e9d9-4d7b-8233-23c8ae487111) |

#### Site has existing storage add-on, dropdown item selected
| Before | After |
| --- | --- |
| ![CleanShot 2025-03-03 at 21 04 42@2x](https://github.com/user-attachments/assets/3d9e462a-1484-4f18-824e-3a60d605c3e9) | ![CleanShot 2025-03-03 at 21 05 17@2x](https://github.com/user-attachments/assets/79653a63-3795-47c2-a141-a7f302ad283b) |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is a fit an finish fix. When everything else in the grid lines up perfectly, having these storage labels unaligned feels jarring.

<img width="1377" alt="Image" src="https://github.com/user-attachments/assets/12a791d7-3811-4205-834a-94b32699f296" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To have the "+ $X/month" text appear in the Personal and Premium plan columns you need to have an existing site (it doesn't happen in onboarding afaict) and the existing site must have purchased a storage add-on. You can do that at `/add-ons/:siteSlug`
* The same price grid appears in `/setup/onboarding` and `/plans/:siteSlug`. Test in both locations
* Confirm everything still looks correct on mobile layout and the narrower screen, two-rows-of-plans, layout
* As far as I know one of the plans grid columns always includes a dropdown i.e. there's no scenario to test where none of the plans have a storage dropdown. The dropdown appears because of the `plans/upgradeable-storage` feature flag, which is enabled in all environments, and the as far as I know ever plan grid includes at least one of Business or Commerce.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
