### PR TITLE
Ecommerce free trial: Fix broken launch store task URL path

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-tasks.ts
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-tasks.ts
@@ -26,7 +26,7 @@ export const getConfirmationTasks = ( { translate, hasWCPay }: ConfirmationTasks
 			title: translate( 'Launch your store' ),
 			subtitle: translate( 'Share your store with the world and start accepting orders.' ),
 			getActionUrl: ( { wooAdminUrl }: GetActionUrlProps ) =>
-				`${ wooAdminUrl }&path=launch-your-store`,
+				`${ wooAdminUrl }&path=%2Flaunch-your-store`,
 		},
 		{
 			id: 'promote-products',

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-tasks.ts
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-tasks.ts
@@ -25,7 +25,8 @@ export const getConfirmationTasks = ( { translate, hasWCPay }: ConfirmationTasks
 			illustration: launch,
 			title: translate( 'Launch your store' ),
 			subtitle: translate( 'Share your store with the world and start accepting orders.' ),
-			getActionUrl: ( { wooAdminUrl }: GetActionUrlProps ) => `${ wooAdminUrl }&task=launch_site`,
+			getActionUrl: ( { wooAdminUrl }: GetActionUrlProps ) =>
+				`${ wooAdminUrl }&path=launch-your-store`,
 		},
 		{
 			id: 'promote-products',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/98894

## Proposed Changes

* Update the link in wordpress.com/plans/my-plan/trial-upgraded/{SITE_URL} to launch task URL, {SITE_URL}/wp-admin/admin.php?page=wc-admin&path=%2Flaunch-your-store

 
## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The link is broken

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Set up a free trial site in https://wordpress.com/setup/entrepreneur
2. Upgrade the site to e-commerce plan
3. After the purchase, on the Checkout Upgraded page, change the site host to your local calypso
4. Click on Launch your store
5. Observe that it shows the LYS page


https://github.com/user-attachments/assets/9a650f78-71f4-4225-b10d-878d36466d61


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
