### PR TITLE
Stats: Update logic for commercial use checks

### DIFF
--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -12,6 +12,7 @@ import {
 	PRODUCT_JETPACK_STATS_YEARLY,
 } from '@automattic/calypso-products';
 import { createSelector } from '@automattic/state-utils';
+import moment from 'moment';
 import { ComponentClass, useMemo } from 'react';
 import { useSelector } from 'calypso/state';
 import {
@@ -29,14 +30,40 @@ import type { Purchase } from 'calypso/lib/purchases/types';
 const JETPACK_STATS_TIERED_BILLING_LIVE_DATE_2024_01_04 = '2024-01-04T05:30:00+00:00';
 const JETPACK_BUSINESS_PLANS = [ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY ];
 
+/**
+ * Checks if a purchase is valid.
+ *
+ * A purchase is considered valid if it is not expired or if it is within the grace period.
+ * The grace period accounts for timezones and auto-renewals.
+ * @param {Purchase} purchase - The purchase object to check.
+ * @returns {boolean} - Returns false if the purchase is both expired and outside the grace period, otherwise true.
+ */
+
+const isPurchaseValid = ( purchase: Purchase ) => {
+	if ( purchase.expiryStatus !== 'expired' ) {
+		return true;
+	}
+
+	if ( ! purchase.expiryDate ) {
+		return false;
+	}
+
+	// Allow for a grace period to account for timezones and auto-renewals.
+	const EXPIRY_THRESHOLD_DAYS = 2;
+	const expiryThreshold = moment().subtract( EXPIRY_THRESHOLD_DAYS, 'days' );
+	const isExpiredAndOld = moment( purchase.expiryDate ).isBefore( expiryThreshold );
+
+	return ! isExpiredAndOld;
+};
+
 const filterPurchasesByProducts = ( ownedPurchases: Purchase[], productSlugs: string[] ) => {
 	if ( ! ownedPurchases?.length ) {
 		return [];
 	}
 
+	// Filter purchases by both slug and validity.
 	return ownedPurchases.filter(
-		( purchase ) =>
-			purchase.expiryStatus !== 'expired' && productSlugs.includes( purchase.productSlug )
+		( purchase ) => isPurchaseValid( purchase ) && productSlugs.includes( purchase.productSlug )
 	);
 };
 

--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -34,7 +34,7 @@ const JETPACK_BUSINESS_PLANS = [ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MO
  * Checks if a purchase is valid.
  *
  * A purchase is considered valid if it is not expired or if it is within the grace period.
- * The grace period accounts for timezones and auto-renewals.
+ * The grace period accounts for time zones and auto-renewals.
  * @param {Purchase} purchase - The purchase object to check.
  * @returns {boolean} - Returns false if the purchase is both expired and outside the grace period, otherwise true.
  */
@@ -48,7 +48,7 @@ const isPurchaseValid = ( purchase: Purchase ) => {
 		return false;
 	}
 
-	// Allow for a grace period to account for timezones and auto-renewals.
+	// Allow for a grace period to account for time zones and auto-renewals.
 	const EXPIRY_THRESHOLD_DAYS = 2;
 	const expiryThreshold = moment().subtract( EXPIRY_THRESHOLD_DAYS, 'days' );
 	const isExpiredAndOld = moment( purchase.expiryDate ).isBefore( expiryThreshold );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Updates logic checking for valid/expired plans.

Due to time zone handling, a plan could show as expired in a users dashboard before an auto-renewal attempt was run. To work around this, we allow for a grace period when checking plan validity. ie: A plan will show as valid if it has expired less than `EXPIRY_THRESHOLD_DAYS` ago, currently set as 2 days.

Q: Should we set the threshold higher? Say 7 days to match auto-renewal cadence?
Q: Should we also test against the `active` field on the purchase? I'm not sure this is necessary as I don't think we get inactive plans via the `getSitePurchases()` selector.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

see above

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a new test site.
* Add a paid plan that supports Stats.
* Set the expiry date of the plan to yesterday (or today, if you're ahead of UTC) via the Store Admin tool.
* Visit the Traffic page and confirm the Devices and UTM modules are still accessible.
* Bump the expiry date to 3+ days ago.
* Refresh the Traffic page and confirm the modules are now gated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
