### PR TITLE
Add custom domain: Fix the final destination of the add domain flow

### DIFF
--- a/client/my-sites/domains/domain-search/index.tsx
+++ b/client/my-sites/domains/domain-search/index.tsx
@@ -3,6 +3,7 @@ import page from '@automattic/calypso-router';
 import { Gridicon } from '@automattic/components';
 import { BackButton } from '@automattic/onboarding';
 import { UseShoppingCart, withShoppingCart } from '@automattic/shopping-cart';
+import { addQueryArgs, getQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { localize, useTranslate } from 'i18n-calypso';
 import moment from 'moment';
@@ -24,7 +25,6 @@ import {
 	ObjectWithProducts,
 } from 'calypso/lib/cart-values/cart-items';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
-import { addQueryArgs } from 'calypso/lib/url';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import DomainAndPlanPackageNavigation from 'calypso/my-sites/domains/components/domain-and-plan-package/navigation';
 import NewDomainsRedirectionNoticeUpsell from 'calypso/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell';
@@ -193,6 +193,7 @@ class DomainSearch extends Component< DomainSearchProps > {
 	}
 
 	async addDomain( suggestion: DomainSuggestion, position: number ) {
+		const queryArgs = getQueryArgs( window.location.href );
 		const {
 			domain_name: domain,
 			product_slug: productSlug,
@@ -225,14 +226,12 @@ class DomainSearch extends Component< DomainSearchProps > {
 			const intervalTypePath = this.props.isSiteOnMonthlyPlan ? 'yearly/' : '';
 			const nextStepLink =
 				! this.props.isSiteOnFreePlan && ! this.props.isSiteOnMonthlyPlan
-					? `/checkout/${ this.props.selectedSiteSlug }`
-					: addQueryArgs(
-							{
-								domainAndPlanPackage: true,
-								domain: this.props.isDomainUpsell ? domain : undefined,
-							},
-							`/plans/${ intervalTypePath }${ this.props.selectedSiteSlug }`
-					  );
+					? addQueryArgs( `/checkout/${ this.props.selectedSiteSlug }`, queryArgs )
+					: addQueryArgs( `/plans/${ intervalTypePath }${ this.props.selectedSiteSlug }`, {
+							...queryArgs,
+							domainAndPlanPackage: true,
+							domain: this.props.isDomainUpsell ? domain : undefined,
+					  } );
 			page( nextStepLink );
 			return;
 		}
@@ -243,7 +242,7 @@ class DomainSearch extends Component< DomainSearchProps > {
 			// Nothing needs to be done here. CartMessages will display the error to the user.
 			return;
 		}
-		page( domainAddEmailUpsell( this.props.selectedSiteSlug, domain ) );
+		page( addQueryArgs( domainAddEmailUpsell( this.props.selectedSiteSlug, domain ), queryArgs ) );
 	}
 
 	removeDomain( suggestion: DomainSuggestion ) {
@@ -313,12 +312,9 @@ class DomainSearch extends Component< DomainSearchProps > {
 		const { domainRegistrationMaintenanceEndTime } = this.state;
 
 		const hasPlanInCart = hasPlan( cart );
-		const hrefForDecideLater = addQueryArgs(
-			{
-				domainAndPlanPackage: true,
-			},
-			`/plans/yearly/${ selectedSiteSlug }`
-		);
+		const hrefForDecideLater = addQueryArgs( `/plans/yearly/${ selectedSiteSlug }`, {
+			domainAndPlanPackage: true,
+		} );
 
 		let content;
 

--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -5,6 +5,7 @@ import {
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
+import { addQueryArgs, getQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { stringify } from 'qs';
@@ -185,6 +186,8 @@ const EmailProvidersStackedComparison = ( {
 		);
 	};
 
+	const queryArgs = getQueryArgs( window.location.href );
+
 	if ( hasLoadedDomains && ! domain && ! isDomainInCart ) {
 		return null;
 	}
@@ -242,8 +245,8 @@ const EmailProvidersStackedComparison = ( {
 
 			{ ! hideNavigation && isDomainInCart && (
 				<EmailUpsellNavigation
-					backUrl={ domainAddNew( selectedSite?.slug ) }
-					skipUrl={ `/checkout/${ selectedSite?.slug }` }
+					backUrl={ addQueryArgs( domainAddNew( selectedSite?.slug ), queryArgs ) }
+					skipUrl={ addQueryArgs( `/checkout/${ selectedSite?.slug }`, queryArgs ) }
 				/>
 			) }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100680

## Proposed Changes

* Forward the query arguments to
  * Fix the `< Back` behavior when you select a domain and then want to go back to the Settings page
  * Fix the destination after the checkout. Now the page will be redirected back to the Settings page. However, it seems a bit confusing as there is no change on the Settings page or a success notice after adding a custom domain 🤔

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The back behavior is broken after you select a domain
* The final thank you page has a broken button

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `https://wordpress.com/domains/add/<your_site>?redirect_to=https://<your_site>/wp-admin/options-general.php` manually
* Select a domain
* Click the `< Back` button twice and ensure you can go back to the Settings page
* Repeat the step 1
* Now finish the add new domain flow
* Ensure you go back to the Settings page after the checkout

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
