### PR TITLE
Stepper: migrate newsletter flow to use built in authentication

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -28,6 +28,12 @@
 		margin-left: auto;
 	}
 
+	// Hide the back button in the user step.
+	// This is unfortunate as it works perfectly, but it classes with the flow title.
+	button.navigation-link {
+		display: none;
+	}
+
 	.signup-header .wordpress-logo {
 		position: absolute;
 		inset-inline-start: 20px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -1,7 +1,6 @@
 @import "../style";
 
 .newsletter-setup {
-
 	.step-container {
 		padding-top: 20px;
 		@include break-medium {
@@ -9,7 +8,8 @@
 		}
 	}
 
-	.step-container__content {
+	// repeat to increase specificity.
+	.step-container__content.step-container__content {
 		display: flex;
 		justify-content: center;
 

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -25,6 +25,7 @@ import type { Flow } from './internals/types';
 
 const newsletter: Flow = {
 	name: NEWSLETTER_FLOW,
+	__experimentalUseBuiltinAuth: true,
 	get title() {
 		return translate( 'Newsletter' );
 	},


### PR DESCRIPTION
This moves newsletter flow to use built in authentication of Stepper.

### Why?

**This gives the flow a significant performance boost. Because:**

1. The user will not go through any hard redirects until they reach checkout. This saves you at least two hard redirects.
2. Stepper will own the whole narrative, giving it the ability to preload the next steps.
3. The flow state will remain intact before and after the authentication.
4. It's just simpler.

### Testing steps

1. You can visit the flow by going to /setup/newsletter
2. Please test the flow while incognito and signing **up**.
3. Please test the flow while incognito and signing **in**.
4. Please test the flow while signed in.

