### PR TITLE
Stepper: migrate domain-user-transfer flow to use built in authentication

### DIFF
--- a/client/landing/stepper/declarative-flow/domain-user-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-user-transfer.ts
@@ -1,20 +1,11 @@
-import { useEffect } from '@wordpress/element';
-import { translate } from 'i18n-calypso';
 import { STEPS } from 'calypso/landing/stepper/declarative-flow/internals/steps';
-import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
 import {
-	AssertConditionResult,
-	AssertConditionState,
 	Flow,
 	ProvidedDependencies,
 } from 'calypso/landing/stepper/declarative-flow/internals/types';
-import { useDomainParams } from 'calypso/landing/stepper/hooks/use-domain-params';
-import { useFlowLocale } from 'calypso/landing/stepper/hooks/use-flow-locale';
-import { useSelector } from 'calypso/state';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { useLoginUrl } from '../utils/path';
+import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 
-const DOMAIN_USER_TRANSFER_STEPS = [ STEPS.DOMAIN_CONTACT_INFO ];
+const DOMAIN_USER_TRANSFER_STEPS = stepsWithRequiredLogin( [ STEPS.DOMAIN_CONTACT_INFO ] );
 
 const domainUserTransfer: Flow = {
 	name: 'domain-user-transfer',
@@ -22,7 +13,7 @@ const domainUserTransfer: Flow = {
 	useSteps() {
 		return DOMAIN_USER_TRANSFER_STEPS;
 	},
-
+	__experimentalUseBuiltinAuth: true,
 	useStepNavigation( currentStep, navigate ) {
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( currentStep ) {
@@ -47,39 +38,6 @@ const domainUserTransfer: Flow = {
 		};
 
 		return { goNext, goBack, goToStep, submit };
-	},
-
-	useAssertConditions(): AssertConditionResult {
-		const flowName = this.name;
-		const isLoggedIn = useSelector( isUserLoggedIn );
-
-		const locale = useFlowLocale();
-
-		const { domain } = useDomainParams();
-
-		const logInUrl = useLoginUrl( {
-			variationName: flowName,
-			redirectTo: `/setup/${ flowName }?domain=${ domain }`,
-			pageTitle: translate( 'Receive domain' ),
-			locale,
-		} );
-
-		useEffect( () => {
-			if ( ! isLoggedIn ) {
-				redirect( logInUrl );
-			}
-		}, [] );
-
-		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
-
-		if ( ! isLoggedIn ) {
-			result = {
-				state: AssertConditionState.CHECKING,
-				message: `${ flowName } requires a logged in user`,
-			};
-		}
-
-		return result;
 	},
 };
 


### PR DESCRIPTION
This moves domain-user-transfer flow to use built in authentication of Stepper.

### Why?

**This gives the flow a significant performance boost. Because:**

1. The user will not go through any hard redirects until they reach checkout. This saves you at least two hard redirects.
2. Stepper will own the whole narrative, giving it the ability to preload the next steps.
3. The flow state will remain intact before and after the authentication.
4. It's just simpler.

### Testing steps

1. You can visit the flow by going to /setup/domain-user-transfer?domain=YOUR_DOMAIN.
2. Please test the flow while incognito and signing **up**.
3. Please test the flow while incognito and signing **in**.
4. Please test the flow while signed in.

