### PR TITLE
Stepper: migrate hundred-year-domain-transfer flow to use built in authentication

### DIFF
--- a/client/landing/stepper/declarative-flow/hundred-year-domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain-transfer.ts
@@ -16,6 +16,7 @@ const hundredYearDomainTransfer: Flow = {
 	get title() {
 		return translate( '100-Year Domain' );
 	},
+	__experimentalUseBuiltinAuth: true,
 
 	// Always start on the "domains" step, as we don't need what comes before it for the 100-year domain transfer flow.
 	// It doesn't make sense to show it as it contains additional cluttering information that doesn't matter


### PR DESCRIPTION
This moves hundred-year-domain-transfer flow to use built in authentication of Stepper.

### Why?

**This gives the flow a significant performance boost. Because:**

1. The user will not go through any hard redirects until they reach checkout. This saves you at least two hard redirects.
2. Stepper will own the whole narrative, giving it the ability to preload the next steps.
3. The flow state will remain intact before and after the authentication.
4. It's just simpler.

### Testing steps

1. You can visit the flow by going to /setup/hundred-year-domain-transfer.
2. Please test the flow while incognito and signing **up**.
3. Please test the flow while incognito and signing **in**.
4. Please test the flow while signed in.

