### PR TITLE
Stepper: migrate hundred-year-domain flow to use built in authentication

### DIFF
--- a/client/landing/stepper/declarative-flow/hundred-year-domain.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-domain.ts
@@ -19,6 +19,7 @@ const steps = [ STEPS.DOMAINS, ...stepsWithRequiredLogin( [ STEPS.PROCESSING ] )
 const HundredYearDomainFlow: Flow = {
 	name: HUNDRED_YEAR_DOMAIN_FLOW,
 	isSignupFlow: true,
+	__experimentalUseBuiltinAuth: true,
 
 	get title() {
 		return translate( '100-Year Domain' );


### PR DESCRIPTION
This moves hundred-year-domain flow to use built in authentication of Stepper.

### Why?

**This gives the flow a significant performance boost. Because:**

1. The user will not go through any hard redirects until they reach checkout. This saves you at least two hard redirects.
2. Stepper will own the whole narrative, giving it the ability to preload the next steps.
3. The flow state will remain intact before and after the authentication.
4. It's just simpler.

### Testing steps

1. You can visit the flow by going to /setup/hundred-year-domain.
2. Please test the flow while incognito and signing **up**.
3. Please test the flow while incognito and signing **in**.
4. Please test the flow while signed in.

