### PR TITLE
Stepper: migrate plugin-bundle flow to use built in authentication

### DIFF
--- a/client/landing/stepper/declarative-flow/migration-signup.ts
+++ b/client/landing/stepper/declarative-flow/migration-signup.ts
@@ -20,7 +20,7 @@ const FLOW_NAME = MIGRATION_SIGNUP_FLOW;
 const migrationSignup: Flow = {
 	name: FLOW_NAME,
 	isSignupFlow: true,
-	__experimentalUseBuiltinAuth: true,
+
 	useSteps() {
 		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
 

--- a/client/landing/stepper/declarative-flow/migration-signup.ts
+++ b/client/landing/stepper/declarative-flow/migration-signup.ts
@@ -20,7 +20,7 @@ const FLOW_NAME = MIGRATION_SIGNUP_FLOW;
 const migrationSignup: Flow = {
 	name: FLOW_NAME,
 	isSignupFlow: true,
-
+	__experimentalUseBuiltinAuth: true,
 	useSteps() {
 		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
 

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -39,7 +39,7 @@ const SiteIntent = Onboard.SiteIntent;
 const pluginBundleFlow: FlowV1 = {
 	name: 'plugin-bundle',
 	isSignupFlow: false,
-
+	__experimentalUseBuiltinAuth: true,
 	useSteps() {
 		const pluginSlug = useSitePluginSlug();
 

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -9,6 +9,7 @@ import { useSitePluginSlug } from '../hooks/use-site-plugin-slug';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { useCanUserManageOptions } from '../hooks/use-user-can-manage-options';
 import { ONBOARD_STORE, SITE_STORE } from '../stores';
+import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 import { redirect } from './internals/steps-repository/import/util';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
 import {

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -8,7 +8,7 @@ import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSitePluginSlug } from '../hooks/use-site-plugin-slug';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { useCanUserManageOptions } from '../hooks/use-user-can-manage-options';
-import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../stores';
+import { ONBOARD_STORE, SITE_STORE } from '../stores';
 import { redirect } from './internals/steps-repository/import/util';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
 import {
@@ -24,7 +24,7 @@ import {
 	afterCustomBundleSteps,
 	bundleStepsSettings,
 } from './plugin-bundle-data';
-import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-stores';
+import type { OnboardSelect, SiteSelect } from '@automattic/data-stores';
 
 const getNextStep = ( currentStep: string, steps: StepperStep[] ): string | undefined => {
 	const stepsIndex = steps.map( ( step ) => step.slug );
@@ -52,7 +52,7 @@ const pluginBundleFlow: FlowV1 = {
 				...afterCustomBundleSteps,
 			];
 		}
-		return [ ...initialBundleSteps, ...bundlePluginSteps ];
+		return stepsWithRequiredLogin( [ ...initialBundleSteps, ...bundlePluginSteps ] );
 	},
 	useStepNavigation( currentStep, navigate ) {
 		const steps = this.useSteps();
@@ -253,23 +253,11 @@ const pluginBundleFlow: FlowV1 = {
 	useAssertConditions(): AssertConditionResult {
 		const siteSlug = useSiteSlugParam();
 		const siteId = useSiteIdParam();
-		const userIsLoggedIn = useSelect(
-			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
-			[]
-		);
 		const fetchingSiteError = useSelect(
 			( select ) => ( select( SITE_STORE ) as SiteSelect ).getFetchingSiteError(),
 			[]
 		);
 		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
-
-		if ( ! userIsLoggedIn ) {
-			redirect( '/start' );
-			result = {
-				state: AssertConditionState.FAILURE,
-				message: 'site-setup requires a logged in user',
-			};
-		}
 
 		if ( ! siteSlug && ! siteId ) {
 			redirect( '/' );


### PR DESCRIPTION
This moves plugin-bundle flow to use built in authentication of Stepper.

### Why?

**This gives the flow a significant performance boost. Because:**

1. The user will not go through any hard redirects until they reach checkout. This saves you at least two hard redirects.
2. Stepper will own the whole narrative, giving it the ability to preload the next steps.
3. The flow state will remain intact before and after the authentication.
4. It's just simpler.

### Testing steps

1. You can visit the flow by going to /setup/plugin-bundle.
2. Please test the flow while incognito and signing **up**.
3. Please test the flow while incognito and signing **in**.
4. Please test the flow while signed in.

