### PR TITLE
Stepper: Add .create-site class to processing styles in global.scss

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -102,7 +102,8 @@ button {
 .hundred-year-domain,
 .entrepreneur,
 .generate-content,
-.processing {
+.processing,
+.create-site {
 	box-sizing: border-box;
 
 	&.step-route {

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -106,6 +106,10 @@ button {
 .create-site {
 	box-sizing: border-box;
 
+	.wpcom-loading__boot {
+		margin-top: 32vh;
+	}
+
 	&.step-route {
 		padding: 60px 0 0;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/wp-calypso/issues/100496

## Proposed Changes

* Update jump in loading position when transitioning through `create-site` step

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix loading state

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/setup/onboarding` and complete the flow with a free plan and site.
* Verify there are no jumps in the loading component positioning as they change ( check if its moving up, down, etc.)
