### PR TITLE
Stepper: migrate site-setup flow to use built in authentication

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -19,7 +19,7 @@ import { useActivateDesign } from '../hooks/use-activate-design';
 import { useIsPluginBundleEligible } from '../hooks/use-is-plugin-bundle-eligible';
 import { useSiteData } from '../hooks/use-site-data';
 import { useCanUserManageOptions } from '../hooks/use-user-can-manage-options';
-import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../stores';
+import { ONBOARD_STORE, SITE_STORE } from '../stores';
 import { shouldRedirectToSiteMigration } from './helpers';
 import { useRedirectDesignSetupOldSlug } from './helpers/use-redirect-design-setup-old-slug';
 import { useLaunchpadDecider } from './internals/hooks/use-launchpad-decider';
@@ -32,7 +32,7 @@ import {
 	FlowV1,
 	ProvidedDependencies,
 } from './internals/types';
-import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-stores';
+import type { OnboardSelect, SiteSelect } from '@automattic/data-stores';
 
 const SiteIntent = Onboard.SiteIntent;
 
@@ -51,7 +51,7 @@ function useGoalsAtFrontExperimentQueryParam() {
 const siteSetupFlow: FlowV1 = {
 	name: 'site-setup',
 	isSignupFlow: false,
-
+	__experimentalUseBuiltinAuth: true,
 	useSteps() {
 		const isGoalsAtFrontExperiment = useGoalsAtFrontExperimentQueryParam();
 
@@ -87,7 +87,7 @@ const siteSetupFlow: FlowV1 = {
 			return [ STEPS.PROCESSING, STEPS.ERROR ];
 		}
 
-		return steps;
+		return stepsWithRequiredLogin( steps );
 	},
 	useStepNavigation( currentStep, navigate ) {
 		const isGoalsAtFrontExperiment = useGoalsAtFrontExperimentQueryParam();
@@ -636,23 +636,11 @@ const siteSetupFlow: FlowV1 = {
 
 	useAssertConditions(): AssertConditionResult {
 		const { site, siteSlug, siteId } = useSiteData();
-		const userIsLoggedIn = useSelect(
-			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
-			[]
-		);
 		const fetchingSiteError = useSelect(
 			( select ) => ( select( SITE_STORE ) as SiteSelect ).getFetchingSiteError(),
 			[]
 		);
 		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
-
-		if ( ! userIsLoggedIn ) {
-			redirect( '/start' );
-			result = {
-				state: AssertConditionState.FAILURE,
-				message: 'site-setup requires a logged in user',
-			};
-		}
 
 		if ( ! siteSlug && ! siteId ) {
 			redirect( '/' );


### PR DESCRIPTION
This moves site-setup flow to use built in authentication of Stepper.

### Why?

**This gives the flow a significant performance boost. Because:**

1. The user will not go through any hard redirects until they reach checkout. This saves you at least two hard redirects.
2. Stepper will own the whole narrative, giving it the ability to preload the next steps.
3. The flow state will remain intact before and after the authentication.
4. It's just simpler.

### Testing steps

1. You can visit the flow by going to /setup/site-setup.
2. Please test the flow while incognito and signing **up**.
3. Please test the flow while incognito and signing **in**.
4. Please test the flow while signed in.

