### PR TITLE
Stepper: migrate write flow to use built in authentication

### DIFF
--- a/client/landing/stepper/declarative-flow/write.ts
+++ b/client/landing/stepper/declarative-flow/write.ts
@@ -1,31 +1,26 @@
 import { WRITE_FLOW } from '@automattic/onboarding';
-import { useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
-import { useEffect } from 'react';
-import { useFlowLocale } from 'calypso/landing/stepper/hooks/use-flow-locale';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
-import { USER_STORE } from '../stores';
-import { getLoginUrl } from '../utils/path';
+import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 import { STEPS } from './internals/steps';
-import {
-	AssertConditionResult,
-	AssertConditionState,
-	Flow,
-	ProvidedDependencies,
-} from './internals/types';
-import type { UserSelect } from '@automattic/data-stores';
+import { Flow, ProvidedDependencies } from './internals/types';
 
-const WRITE_FLOW_STEPS = [ STEPS.LAUNCHPAD, STEPS.SUBSCRIBERS, STEPS.PROCESSING ];
+const WRITE_FLOW_STEPS = stepsWithRequiredLogin( [
+	STEPS.LAUNCHPAD,
+	STEPS.SUBSCRIBERS,
+	STEPS.PROCESSING,
+] );
 
 const write: Flow = {
 	name: WRITE_FLOW,
 	get title() {
 		return translate( 'Write' );
 	},
+	__experimentalUseBuiltinAuth: true,
 	isSignupFlow: false,
 	useSteps() {
 		return WRITE_FLOW_STEPS;
@@ -79,70 +74,6 @@ const write: Flow = {
 		};
 
 		return { goNext, goToStep, submit };
-	},
-
-	useAssertConditions(): AssertConditionResult {
-		const userIsLoggedIn = useSelect(
-			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
-			[]
-		);
-		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
-
-		const queryParams = new URLSearchParams( window.location.search );
-		const flowName = this.name;
-
-		const locale = useFlowLocale();
-
-		const flags = queryParams.get( 'flags' );
-		const siteSlug = queryParams.get( 'siteSlug' );
-
-		const getStartUrl = () => {
-			let hasFlowParams = false;
-			const flowParams = new URLSearchParams();
-
-			if ( siteSlug ) {
-				flowParams.set( 'siteSlug', siteSlug );
-				hasFlowParams = true;
-			}
-
-			if ( locale && locale !== 'en' ) {
-				flowParams.set( 'locale', locale );
-				hasFlowParams = true;
-			}
-
-			const redirectTarget =
-				window?.location?.pathname +
-				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
-
-			const logInUrl = getLoginUrl( {
-				variationName: flowName,
-				redirectTo: redirectTarget,
-				locale,
-			} );
-
-			return logInUrl + ( flags ? `&flags=${ flags }` : '' );
-		};
-
-		// Despite sending a CHECKING state, this function gets called again with the
-		// /setup/write/launchpad route which has no locale in the path so we need to
-		// redirect off of the first render.
-		// This effects both /setup/write/<locale> starting points and /setup/write/launchpad/<locale> urls.
-		// The double call also hapens on urls without locale.
-		useEffect( () => {
-			if ( ! userIsLoggedIn ) {
-				const logInUrl = getStartUrl();
-				window.location.assign( logInUrl );
-			}
-		}, [] );
-
-		if ( ! userIsLoggedIn ) {
-			result = {
-				state: AssertConditionState.FAILURE,
-				message: 'write-flow requires a logged in user',
-			};
-		}
-
-		return result;
 	},
 };
 


### PR DESCRIPTION
This moves write flow to use built in authentication of Stepper.

### Why?

**This gives the flow a significant performance boost. Because:**

1. The user will not go through any hard redirects until they reach checkout. This saves you at least two hard redirects.
2. Stepper will own the whole narrative, giving it the ability to preload the next steps.
3. The flow state will remain intact before and after the authentication.
4. It's just simpler.

### Testing steps

1. You can visit the flow by going to /setup/write.
2. Please test the flow while incognito and signing **up**.
3. Please test the flow while incognito and signing **in**.
4. Please test the flow while signed in.

