### PR TITLE
Staging Sites: Add error messages when the `Add staging site` button gets disabled

### DIFF
--- a/client/sites/staging-site/components/staging-site-card/card-content/new-staging-site-card-content.tsx
+++ b/client/sites/staging-site/components/staging-site-card/card-content/new-staging-site-card-content.tsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import Notice from 'calypso/components/notice';
 import { useSelector } from 'calypso/state';
 import isSiteStore from 'calypso/state/selectors/is-site-store';
 import { ExceedQuotaErrorContent } from './exceed-quota-error-content';
@@ -29,6 +30,8 @@ type CardContentProps = {
 	isButtonDisabled: boolean;
 	showQuotaError: boolean;
 	isDevelopmentSite?: boolean;
+	isSyncInProgress: boolean;
+	isPossibleJetpackConnectionProblem: boolean;
 };
 
 export const NewStagingSiteCardContent = ( {
@@ -37,6 +40,8 @@ export const NewStagingSiteCardContent = ( {
 	isButtonDisabled,
 	showQuotaError,
 	isDevelopmentSite,
+	isSyncInProgress,
+	isPossibleJetpackConnectionProblem,
 }: CardContentProps ) => {
 	{
 		const translate = useTranslate();
@@ -68,6 +73,20 @@ export const NewStagingSiteCardContent = ( {
 					<p>
 						{ translate( 'Staging sites are only available to sites launched in production.' ) }
 					</p>
+				) }
+				{ isSyncInProgress && (
+					<Notice status="is-error" showDismiss={ false }>
+						{ translate(
+							'Unable to create a new staging site. If the issue persists, please contact support.'
+						) }
+					</Notice>
+				) }
+				{ isPossibleJetpackConnectionProblem && (
+					<Notice status="is-error" showDismiss={ false }>
+						{ translate(
+							'Unable to create a new staging site. There is a site connection issue. If the issue persists, please contact support.'
+						) }
+					</Notice>
 				) }
 				<Button primary disabled={ isButtonDisabled } onClick={ onAddClick }>
 					<span>{ translate( 'Add staging site' ) }</span>

--- a/client/sites/staging-site/components/staging-site-card/card-content/new-staging-site-card-content.tsx
+++ b/client/sites/staging-site/components/staging-site-card/card-content/new-staging-site-card-content.tsx
@@ -72,14 +72,14 @@ export const NewStagingSiteCardContent = ( {
 						{ translate( 'Staging sites are only available to sites launched in production.' ) }
 					</p>
 				) }
-				<Button primary disabled={ isButtonDisabled } onClick={ onAddClick }>
-					<span>{ translate( 'Add staging site' ) }</span>
-				</Button>
 				{ isButtonDisabled && disabledMessage && (
 					<Notice status="is-error" showDismiss={ false }>
 						{ disabledMessage }
 					</Notice>
 				) }
+				<Button primary disabled={ isButtonDisabled } onClick={ onAddClick }>
+					<span>{ translate( 'Add staging site' ) }</span>
+				</Button>
 				{ showQuotaError && <ExceedQuotaErrorContent /> }
 			</>
 		);

--- a/client/sites/staging-site/components/staging-site-card/card-content/new-staging-site-card-content.tsx
+++ b/client/sites/staging-site/components/staging-site-card/card-content/new-staging-site-card-content.tsx
@@ -30,8 +30,7 @@ type CardContentProps = {
 	isButtonDisabled: boolean;
 	showQuotaError: boolean;
 	isDevelopmentSite?: boolean;
-	isSyncInProgress: boolean;
-	isPossibleJetpackConnectionProblem: boolean;
+	disabledMessage?: string;
 };
 
 export const NewStagingSiteCardContent = ( {
@@ -40,8 +39,7 @@ export const NewStagingSiteCardContent = ( {
 	isButtonDisabled,
 	showQuotaError,
 	isDevelopmentSite,
-	isSyncInProgress,
-	isPossibleJetpackConnectionProblem,
+	disabledMessage,
 }: CardContentProps ) => {
 	{
 		const translate = useTranslate();
@@ -74,23 +72,14 @@ export const NewStagingSiteCardContent = ( {
 						{ translate( 'Staging sites are only available to sites launched in production.' ) }
 					</p>
 				) }
-				{ isSyncInProgress && (
-					<Notice status="is-error" showDismiss={ false }>
-						{ translate(
-							'Unable to create a new staging site. If the issue persists, please contact support.'
-						) }
-					</Notice>
-				) }
-				{ isPossibleJetpackConnectionProblem && (
-					<Notice status="is-error" showDismiss={ false }>
-						{ translate(
-							'Unable to create a new staging site. There is a site connection issue. If the issue persists, please contact support.'
-						) }
-					</Notice>
-				) }
 				<Button primary disabled={ isButtonDisabled } onClick={ onAddClick }>
 					<span>{ translate( 'Add staging site' ) }</span>
 				</Button>
+				{ isButtonDisabled && disabledMessage && (
+					<Notice status="is-error" showDismiss={ false }>
+						{ disabledMessage }
+					</Notice>
+				) }
 				{ showQuotaError && <ExceedQuotaErrorContent /> }
 			</>
 		);

--- a/client/sites/staging-site/components/staging-site-card/index.js
+++ b/client/sites/staging-site/components/staging-site-card/index.js
@@ -506,13 +506,27 @@ export const StagingSiteCard = ( {
 			/>
 		);
 	} else if ( showAddStagingSiteCard ) {
+		const getDisabledMessage = () => {
+			if ( isSyncInProgress ) {
+				return translate(
+					'Unable to create a new staging site. If the issue persists, please contact support.'
+				);
+			}
+			if ( isPossibleJetpackConnectionProblem ) {
+				return translate(
+					'Unable to create a new staging site. There is a site connection issue. If the issue persists, please contact support.'
+				);
+			}
+			return null;
+		};
+
+		const disabledMessage = getDisabledMessage();
 		stagingSiteCardContent = (
 			<NewStagingSiteCardContent
 				siteId={ siteId }
 				onAddClick={ onAddClick }
 				isDevelopmentSite={ isDevelopmentSite }
-				isSyncInProgress={ isSyncInProgress }
-				isPossibleJetpackConnectionProblem={ isPossibleJetpackConnectionProblem }
+				disabledMessage={ disabledMessage }
 				isButtonDisabled={
 					disabled ||
 					isLoadingAddStagingSite ||

--- a/client/sites/staging-site/components/staging-site-card/index.js
+++ b/client/sites/staging-site/components/staging-site-card/index.js
@@ -511,6 +511,8 @@ export const StagingSiteCard = ( {
 				siteId={ siteId }
 				onAddClick={ onAddClick }
 				isDevelopmentSite={ isDevelopmentSite }
+				isSyncInProgress={ isSyncInProgress }
+				isPossibleJetpackConnectionProblem={ isPossibleJetpackConnectionProblem }
 				isButtonDisabled={
 					disabled ||
 					isLoadingAddStagingSite ||


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/90427.

## Proposed Changes

* display an error message when either `isSyncInProgress` or `isPossibleJetpackConnectionProblem` is `true`

![Markup on 2025-03-03 at 12:36:06](https://github.com/user-attachments/assets/8f00e7cb-bf06-4482-a591-e7681c177375)

(only one of the error messages can display at once; the screenshot above is just to show up both messages)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

There's an edge case that is preventing some users from creating staging sites. We haven't been able to reproduce the issue on our side yet and therefore the goal of this PR is to add two error messages that will help us to understand better where the issue could be coming from.

Please see the details in https://github.com/Automattic/wp-calypso/issues/90427#issuecomment-2688297418.

With the proposed changes in, when a user contacts us again, we will know where the issue is coming from and can ask the user for the recent actions they have taken with their site. This can then bring us closer to the root cause of the issue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Please review the proposed code change and check for regressions:

1. Apply the PR branch and build the app with `yarn start`.
2. Navigate to `http://calypso.localhost:3000/staging-site/{site-slug}` on an existing Atomic site.
3. If you haven't created a staging site for this production site yet, there should be an `Add staging site` button. When you click it, a new staging site should be created without any issues.
4. There should be no unexpected regressions.
5. If you like, you may also apply the following diffs to see the error messages in the UI:

```diff
diff --git a/client/sites/tools/staging-site/components/staging-site-card/index.js b/client/sites/tools/staging-site/components/staging-site-card/index.js
index f75f61bb989..401ef0d3daf 100644
--- a/client/sites/tools/staging-site/components/staging-site-card/index.js
+++ b/client/sites/tools/staging-site/components/staging-site-card/index.js
@@ -506,7 +506,7 @@ export const StagingSiteCard = ( {
 		);
 	} else if ( showAddStagingSiteCard ) {
 		const getDisabledMessage = () => {
-			if ( isSyncInProgress ) {
+			if ( ! isSyncInProgress ) {
 				return translate(
 					'Unable to create a new staging site. If the issue persists, please contact support.'
 				);
@@ -527,7 +527,7 @@ export const StagingSiteCard = ( {
 				isDevelopmentSite={ isDevelopmentSite }
 				disabledMessage={ disabledMessage }
 				isButtonDisabled={
-					disabled ||
+					! disabled ||
 					isLoadingAddStagingSite ||
 					isLoadingQuotaValidation ||
 					! hasValidQuota ||
```

or:

```diff
diff --git a/client/sites/tools/staging-site/components/staging-site-card/index.js b/client/sites/tools/staging-site/components/staging-site-card/index.js
index f75f61bb989..f81b8e07486 100644
--- a/client/sites/tools/staging-site/components/staging-site-card/index.js
+++ b/client/sites/tools/staging-site/components/staging-site-card/index.js
@@ -511,7 +511,7 @@ export const StagingSiteCard = ( {
 					'Unable to create a new staging site. If the issue persists, please contact support.'
 				);
 			}
-			if ( isPossibleJetpackConnectionProblem ) {
+			if ( ! isPossibleJetpackConnectionProblem ) {
 				return translate(
 					'Unable to create a new staging site. There is a site connection issue. If the issue persists, please contact support.'
 				);
@@ -527,7 +527,7 @@ export const StagingSiteCard = ( {
 				isDevelopmentSite={ isDevelopmentSite }
 				disabledMessage={ disabledMessage }
 				isButtonDisabled={
-					disabled ||
+					! disabled ||
 					isLoadingAddStagingSite ||
 					isLoadingQuotaValidation ||
 					! hasValidQuota ||

```


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
