### PR TITLE
Gift Thank you: Update loading component

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/gift/gift-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/gift/gift-thank-you.tsx
@@ -4,7 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import successImage from 'calypso/assets/images/marketplace/check-circle.svg';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
-import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import Loading from 'calypso/components/loading';
 import Main from 'calypso/components/main';
 import { ThankYou } from 'calypso/components/thank-you';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -79,7 +79,7 @@ export default function GiftThankYou( { site }: { site: number | string } ) {
 			<PageViewTracker path="/checkout/gift/thank-you/:site" title="Checkout > Thank You" />
 			{ isLoading && (
 				<div className="gift-thank-you__loader">
-					<LoadingEllipsis />
+					<Loading />
 				</div>
 			) }
 			{ ! isLoading && (

--- a/client/my-sites/checkout/checkout-thank-you/gift/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/gift/style.scss
@@ -23,7 +23,6 @@
 	.gift-thank-you__loader {
 		display: flex;
 		justify-content: center;
-		margin-top: 160px;
 	}
 
 	// Thankyou component overrides


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/wp-calypso/issues/100736

## Proposed Changes

* Update loading component and margin

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Unify loading state

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `checkout/gift/thank-you/{SITE_SLUG}`
* Verify the loading progress bar appears before the thank you component appears

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
