### PR TITLE
Jetpack Checkout Thank you: Update loading component

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/licensing-pending-async-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-pending-async-activation.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
 import { FC, useState, useCallback, useEffect, useMemo } from 'react';
 import QueryProducts from 'calypso/components/data/query-products-list';
-import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import Loading from 'calypso/components/loading';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -235,8 +235,7 @@ function PendingContent( {
 
 	return (
 		<div className="pending-content__wrapper">
-			<div className="pending-content__title">{ headingText }</div>
-			<LoadingEllipsis />
+			<Loading title={ headingText } />
 			<br />
 			<div className="pending-content__info-text-container">
 				{ productName && (

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -952,3 +952,12 @@ main.akismet-checkout-thank-you {
 	background: #fff;
 	height: calc(100vh - 72px);
 }
+
+main.checkout-thank-you__pending {
+	.wpcom__loading {
+		margin: 0 auto;
+	}
+	.wpcom__loading-title {
+		height: auto;
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/wp-calypso/issues/100735

## Proposed Changes

* Update jetpack checkout `licensing-pending-async-activation` loading component

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Unify loading state

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/checkout/jetpack/thank-you/licensing-pending-async-activation/jetpack_premium?fromSiteSlug={SITE_ID}`
* Verify the loading progress bar appears before the thank you component appears

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
