### PR TITLE
Reader: Enable Quick Edit in dev and preview environments

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -166,7 +166,7 @@
 		"reader": true,
 		"reader/comment-polling": false,
 		"reader/full-errors": true,
-		"reader/quick-post": false,
+		"reader/quick-post": true,
 		"reader/quick-post-v2": false,
 		"readymade-templates/showcase": true,
 		"redirect-fallback-browsers": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -102,6 +102,7 @@
 		"purchases/billing-history-data-view": false,
 		"purchases/new-payment-methods": true,
 		"reader": true,
+		"reader/quick-post": true,
 		"readymade-templates/showcase": false,
 		"redirect-fallback-browsers": true,
 		"safari-idb-mitigation": true,

--- a/config/production.json
+++ b/config/production.json
@@ -133,6 +133,7 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": false,
+		"reader/quick-post": false,
 		"readymade-templates/showcase": false,
 		"redirect-fallback-browsers": true,
 		"rum-tracking/logstash": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -130,6 +130,7 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": false,
+		"reader/quick-post": true,
 		"readymade-templates/showcase": false,
 		"redirect-fallback-browsers": true,
 		"rum-tracking/logstash": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -138,6 +138,7 @@
 		"purchases/new-payment-methods": true,
 		"reader": true,
 		"reader/full-errors": true,
+		"reader/quick-post": true,
 		"readymade-templates/showcase": true,
 		"redirect-fallback-browsers": true,
 		"rum-tracking/logstash": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/457

## Proposed Changes

- Enables the Quick Edit on development, wpcalypso, horizon, and staging environments.
- Adds the flag to the production environment as `false`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of ongoing work to create a Quick Edit mode.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure config flags are spelled correctly and there are no typos

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
