### PR TITLE
Reader User Profile: Fix header flash

### DIFF
--- a/client/reader/user-profile/index.tsx
+++ b/client/reader/user-profile/index.tsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import BackButton from 'calypso/components/back-button';
 import EmptyContent from 'calypso/components/empty-content';
 import { UserData } from 'calypso/lib/user/user';
+import UserProfileHeader from 'calypso/reader/user-profile/components/user-profile-header';
 import { getUserProfileUrl } from 'calypso/reader/user-profile/user-profile.utils';
 import UserLists from 'calypso/reader/user-profile/views/lists';
 import UserPosts from 'calypso/reader/user-profile/views/posts';
@@ -88,7 +89,10 @@ export function UserProfile( props: UserProfileProps ): JSX.Element | null {
 		<div className="user-profile">
 			<div className={ `user-profile__wrapper${ showBack ? ' has-back-button' : '' }` }>
 				{ showBack && <BackButton onClick={ handleBack } /> }
-				<div className="user-profile__wrapper-content">{ renderContent() }</div>
+				<div className="user-profile__wrapper-content">
+					<UserProfileHeader user={ user } />
+					{ renderContent() }
+				</div>
 			</div>
 		</div>
 	);

--- a/client/reader/user-profile/style.scss
+++ b/client/reader/user-profile/style.scss
@@ -26,6 +26,8 @@
 
 			&-content {
 				padding-top: 24px;
+				max-width: 768px;
+				margin: 0 auto;
 
 				@include breakpoint-deprecated( '<660px' ) {
 					padding-top: 0;

--- a/client/reader/user-profile/views/lists.tsx
+++ b/client/reader/user-profile/views/lists.tsx
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
 import { UserData } from 'calypso/lib/user/user';
 import { List } from 'calypso/reader/list-manage/types';
-import UserProfileHeader from 'calypso/reader/user-profile/components/user-profile-header';
 import { requestUserLists } from 'calypso/state/reader/lists/actions';
 
 interface AppState {
@@ -43,7 +42,6 @@ const UserLists = ( { user, requestUserLists, lists, isLoading }: UserListsProps
 	if ( ! lists || lists.length === 0 ) {
 		return (
 			<div className="user-profile__lists">
-				<UserProfileHeader user={ user } />
 				<EmptyContent
 					illustration={ null }
 					icon={ <Icon icon={ formatListBullets } size={ 48 } /> }
@@ -56,7 +54,6 @@ const UserLists = ( { user, requestUserLists, lists, isLoading }: UserListsProps
 
 	return (
 		<div className="user-profile__lists">
-			<UserProfileHeader user={ user } />
 			<div className="user-profile__lists-body">
 				{ lists.map( ( list: List ) => (
 					<a

--- a/client/reader/user-profile/views/posts.tsx
+++ b/client/reader/user-profile/views/posts.tsx
@@ -3,7 +3,6 @@ import { useTranslate } from 'i18n-calypso';
 import EmptyContent from 'calypso/components/empty-content';
 import { UserData } from 'calypso/lib/user/user';
 import Stream from 'calypso/reader/stream';
-import UserProfileHeader from 'calypso/reader/user-profile/components/user-profile-header';
 
 interface UserPostsProps {
 	user: UserData;
@@ -31,9 +30,7 @@ const UserPosts = ( { user }: UserPostsProps ): JSX.Element => {
 				/>
 			) }
 			showBack={ false }
-		>
-			<UserProfileHeader user={ user } />
-		</Stream>
+		/>
 	);
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100161

## Proposed Changes

The flash was happening because the User Profile Header component was being rendered via a function, causing it to reload whenever the route changed.

### Before

https://github.com/user-attachments/assets/409abdcc-d891-4e1e-ad46-13ae6f3ab746

### After

https://github.com/user-attachments/assets/23904a8d-5c99-4e71-9afb-3878088bb380

This PR...
- Moves the header component out of the `renderContent` function
- Updates the styles so the base profile page matches what's on production
  - This also fixes the Lists page styles, which were inconsistent with the base profile page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The flash is jarring and is a bad UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit the profile page
- Navigate between the post page and lists page
- Make sure the flash no longer occurs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
