### PR TITLE
Me Section: leave vertical spacing alone in centering override

### DIFF
--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -56,11 +56,9 @@ body.is-section-me {
 				max-width: none;
 				& > * {
 					max-width: 1040px;
-					margin: 0 auto;
+					margin-left: auto;
+					margin-right: auto;
 				}
-				& > div.section-nav {
-                    margin-bottom: 24px; /* Preserve margin for Purchases mobile nav */
-	            }
 			}
 		}
 	}


### PR DESCRIPTION
In #94683 [a wildcard override](https://github.com/Automattic/wp-calypso/pull/94683/files#diff-2f7d286214aa0004543f9ae593b4e74eae4c06bdc75957ecb697f3a70563bd12R46) was added to horizontally center the child components of the `.main` section. The shorthand however set the top and bottom margin for those components to 0. One of the regressions from that rule was addressed in #98637, but another was reported in #100153 and I'm guessing there are more that are harder to spot.

This diff removes the top/bottom override, and leaves the left/right override.

Fixes: #100153

**To test:**
- Navigate to the Me section
- Verify that the vertical spacing around elements is correct, especially section navs and header cakes.
- Compare local environments and production to see if there are any regressions