### PR TITLE
Reader discover - ensure back button is present on all tabs.

### DIFF
--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -112,9 +112,9 @@ const DiscoverStream = ( props ) => {
 	const HeaderAndNavigation = () => {
 		return (
 			<>
+				{ previousRoute && <BackButton onClick={ () => page.back( previousRoute ) } /> }
 				<DiscoverHeader selectedTab={ effectiveTabSelection } width={ props.width } />
 				<DiscoverNavigation selectedTab={ selectedTab } />
-				{ previousRoute && <BackButton onClick={ () => page.back( previousRoute ) } /> }
 
 				{ selectedTab === 'tags' && (
 					<DiscoverTagsNavigation

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -2,6 +2,7 @@ import page from '@automattic/calypso-router';
 import { addLocaleToPathLocaleInFront, useLocale } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import BackButton from 'calypso/components/back-button';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { addQueryArgs } from 'calypso/lib/url';
 import withDimensions from 'calypso/lib/with-dimensions';
@@ -14,6 +15,7 @@ import Stream, { WIDE_DISPLAY_CUTOFF } from 'calypso/reader/stream';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import {
 	getDiscoverStreamTags,
 	DEFAULT_TAB,
@@ -72,6 +74,7 @@ const DiscoverStream = ( props ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const selectedTab = props.selectedTab || DEFAULT_TAB;
 	const selectedTag = props.query?.selectedTag;
+	const previousRoute = useSelector( getPreviousRoute );
 
 	// If the selected tab is tags and no selectedTag is provided, redirect to the tags tab with dailyprompt selected.
 	if ( selectedTab === 'tags' && ! selectedTag ) {
@@ -101,6 +104,7 @@ const DiscoverStream = ( props ) => {
 		...props,
 		streamKey,
 		useCompactCards: true,
+		showBack: false, // We will instead add this through the header section, since not all discover tabs have a stream to render the back button.
 		sidebarTabTitle: isDefaultTab ? translate( 'Sites' ) : translate( 'Related' ),
 		selectedStreamName: selectedTab,
 	};
@@ -110,6 +114,7 @@ const DiscoverStream = ( props ) => {
 			<>
 				<DiscoverHeader selectedTab={ effectiveTabSelection } width={ props.width } />
 				<DiscoverNavigation selectedTab={ selectedTab } />
+				{ previousRoute && <BackButton onClick={ () => page.back( previousRoute ) } /> }
 
 				{ selectedTab === 'tags' && (
 					<DiscoverTagsNavigation

--- a/client/reader/discover/index.web.js
+++ b/client/reader/discover/index.web.js
@@ -17,7 +17,6 @@ import {
 	trackPageLoad,
 	trackUpdatesLoaded,
 	trackScrollPage,
-	userHasHistory,
 } from 'calypso/reader/controller-helper';
 import { recordTrack } from 'calypso/reader/stats';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -79,7 +78,6 @@ const discover = ( context, next ) => {
 				suppressSiteNameLink
 				isDiscoverStream
 				useCompactCards
-				showBack={ userHasHistory( context ) }
 				className="is-discover-stream"
 				selectedTab={ selectedTab }
 				query={ context.query }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/99994

## Proposed Changes

Adds the back button where it is missing in the discover sections "add new" and "reddit" tabs.
* Prevents the stream components from rendering their own back buttons on Discover.
    * Removes `showBack` from the discover-steams props. (this was passed to the stream component).
    * Passes a `false` value for `showBack` from the discover-stream to the stream component (since it has a default true value).
* Adds the back button to the `HeaderAndNavigation` section of the discover-stream for consistency.


BEFORE
![Screenshot 2025-03-03 at 12 18 55 PM](https://github.com/user-attachments/assets/284746e1-edde-4fa9-943b-62fe8b71e487)


AFTER
![Screenshot 2025-03-03 at 12 19 06 PM](https://github.com/user-attachments/assets/2092b7bd-9c1a-4622-b87b-f95fc449845c)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Inconsistent experience, missing back button on some discover tabs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test discover, verify the back button is available on all tabs and doesn't have any style regressions.
* Back button should work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
