### PR TITLE
Reader all tags page - various improvements: back button, header, max-width

### DIFF
--- a/client/reader/tags/main.tsx
+++ b/client/reader/tags/main.tsx
@@ -20,6 +20,7 @@ export default function TagsPage( { trendingTags, alphabeticTags }: Props ) {
 	const translate = useTranslate();
 	const previousRoute = useSelector( getPreviousRoute );
 	const isLoggedIn = useSelector( isUserLoggedIn );
+
 	return (
 		<ReaderMain className="tags__main">
 			{ isLoggedIn && previousRoute && <BackButton onClick={ () => page.back( previousRoute ) } /> }

--- a/client/reader/tags/main.tsx
+++ b/client/reader/tags/main.tsx
@@ -1,4 +1,11 @@
+import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
+import BackButton from 'calypso/components/back-button';
+import NavigationHeader from 'calypso/components/navigation-header';
+import ReaderMain from 'calypso/reader/components/reader-main';
+import { useSelector } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import AlphabeticTags from './alphabetic-tags';
 import { TagResult, AlphabeticTagsResult } from './controller';
 import TrendingTags from './trending-tags';
@@ -11,8 +18,19 @@ interface Props {
 
 export default function TagsPage( { trendingTags, alphabeticTags }: Props ) {
 	const translate = useTranslate();
+	const previousRoute = useSelector( getPreviousRoute );
+	const isLoggedIn = useSelector( isUserLoggedIn );
 	return (
-		<div className="tags__main">
+		<ReaderMain className="tags__main">
+			{ previousRoute && <BackButton onClick={ () => page.back( previousRoute ) } /> }
+			{ isLoggedIn && (
+				<NavigationHeader
+					title={ translate( 'All the Tags' ) }
+					subtitle={ translate(
+						`For every one of your interests, there's a tag on WordPress.com.`
+					) }
+				/>
+			) }
 			<div className="tags__header">
 				<h4>
 					{
@@ -25,6 +43,6 @@ export default function TagsPage( { trendingTags, alphabeticTags }: Props ) {
 				<TrendingTags trendingTags={ trendingTags } />
 				<AlphabeticTags alphabeticTags={ alphabeticTags } />
 			</div>
-		</div>
+		</ReaderMain>
 	);
 }

--- a/client/reader/tags/main.tsx
+++ b/client/reader/tags/main.tsx
@@ -22,7 +22,7 @@ export default function TagsPage( { trendingTags, alphabeticTags }: Props ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	return (
 		<ReaderMain className="tags__main">
-			{ previousRoute && <BackButton onClick={ () => page.back( previousRoute ) } /> }
+			{ isLoggedIn && previousRoute && <BackButton onClick={ () => page.back( previousRoute ) } /> }
 			{ isLoggedIn && (
 				<NavigationHeader
 					title={ translate( 'All the Tags' ) }

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -70,7 +70,7 @@
 
 	.tags__main {
 		box-sizing: border-box;
-		max-width: none;
+		max-width: 968px; // Max width of dual column reader stream.
 		padding: 24px 0;
 
 		.tags__header h4 {

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -77,6 +77,11 @@
 		max-width: 968px; // Max width of dual column reader stream.
 		padding: 24px 0;
 
+		.navigation-header {
+			// Align the header text with the text in tags page content below.
+			padding-inline: 35px;
+		}
+
 		.tags__header h4 {
 			margin: -4px 0 19px;
 		}

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -68,6 +68,10 @@
 		}
 	}
 
+	&.is-group-reader .layout__content .layout__primary > div {
+		overflow-y: auto;
+	}
+
 	.tags__main {
 		box-sizing: border-box;
 		max-width: 968px; // Max width of dual column reader stream.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # ... other back button and reader consistency issues we are looking at in CANI, this stood out as something we may be able to add a quick improvement of consistency.

## Proposed Changes

A few improvements to logged in all tags page
* Adds back button when able.
* Adds NavigationHeader with the same title and subtitle we use for the logged out all tags page.
* Limits max width to that of other reader streams and pages for consistency.
    * This also allows the back button to play nice with current breakpoint styles. If we wanted a different max width we would need to add more custom back button css handling just for this page. But we probably want the same max width anyways for consistency.
* Wraps the component in the ReaderMain component, carrying over some consistency with styles and adding a `main` element to the tags page both logged in and logged out similar to our other reader pages.
* This also aligns the various text areas of the tags page with each other in the same way they are aligned in the logged out view.

BEFORE
<img width="800" alt="Screenshot 2025-03-05 at 10 56 09 AM" src="https://github.com/user-attachments/assets/248d6d25-6851-4e2d-93cd-8dc2ff52ea74" />

AFTER
<img width="800" alt="Screenshot 2025-03-05 at 10 56 34 AM" src="https://github.com/user-attachments/assets/6760ad21-18b6-4816-9e17-340f950b4907" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Consistency. We recently added the back button to all other reader pages so we should add it here. Similar with the content width, navigation header, alignment, etc. are done for consistency and better UX. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to the /reader
* in the tags section of the sidebar, select "see all tags"
* Verify the new header is shown.
* Verify the back button is shown.
* verify back button works as expected. It should fit the with the header on various breakpoints the same as our other reader page headers.
* verify scrolling works and the sticky-header for the alphabetical short buttons works as expected once scrolling past them.
* load directly the /tags page, verify the back button is not present as there is no history to go back to.
* Verify no regressions for logged-out.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
