### PR TITLE
'Me' section: Add margin-top shim to me > main

### DIFF
--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -56,7 +56,7 @@ body.is-section-me {
 				max-width: none;
 				& > * {
 					max-width: 1040px;
-					margin: 0 auto;
+					margin: 1px auto 0;
 				}
 				& > div.section-nav {
                     margin-bottom: 24px; /* Preserve margin for Purchases mobile nav */


### PR DESCRIPTION
There was a small visual bug introduced when the `me` section of Calypso was overhauled during the A4A sprint. This PR will add a margin-top of 1px to fix the visual bug, but this area should be refactored more elegantly in a future iteration.

| Before | After |
| ----- | ----- |
| <img width="1044" alt="image" src="https://github.com/user-attachments/assets/dcbf0ba8-699c-4e71-94e7-678088e8e04e" /> | <img width="1044" alt="image" src="https://github.com/user-attachments/assets/5d408f32-1917-4e2d-9e41-ff1e1afd25a5" /> |

Related to pfOicC-jx-p2

## Testing Instructions

* Go to Me > Purchases > Billing History > [Add tax details (VAT)](http://calypso.localhost:3000/me/purchases/vat-details), or, the Add/Change payment method form
* Ensure the overlapping upper border of the `main` element no longer overlaps the header cake section