### PR TITLE
Stats: Align the X-axis label format with the original Traffic chart label parser

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -17,6 +17,7 @@ import { getSiteOption } from 'calypso/state/sites/selectors';
 import { requestChartCounts } from 'calypso/state/stats/chart-tabs/actions';
 import { QUERY_FIELDS } from 'calypso/state/stats/chart-tabs/constants';
 import { getCountRecords, getLoadingTabs } from 'calypso/state/stats/chart-tabs/selectors';
+import { chartLabelformats } from 'calypso/state/stats/lists/utils';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useCssVariable from '../hooks/use-css-variable';
 import StatsEmptyState from '../stats-empty-state';
@@ -162,6 +163,13 @@ class StatModuleChartTabs extends Component {
 		this.setState( { chartType: newType } );
 	};
 
+	formatLineChartTimeTick = ( date ) => {
+		// Align the format with the original chart data parser.
+		const timeformat = chartLabelformats[ this.props.selectedPeriod ];
+
+		return moment.utc( date ).format( timeformat );
+	};
+
 	render() {
 		const {
 			siteId,
@@ -230,6 +238,7 @@ class StatModuleChartTabs extends Component {
 						height={ 200 }
 						moment={ moment }
 						onClick={ this.props.barClick }
+						formatTimeTick={ this.formatLineChartTimeTick }
 					/>
 				) }
 

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -152,6 +152,23 @@ export function parseOrderDeltas( payload ) {
 	} );
 }
 
+export const chartLabelformats = {
+	hour: translate( 'HH:mm', {
+		context: 'momentjs format string (hour)',
+		comment: 'This specifies an hour for the stats x-axis label.',
+	} ),
+	day: translate( 'MMM D', {
+		context: 'momentjs format string (day)',
+		comment: 'This specifies a day for the stats x-axis label.',
+	} ),
+	week: translate( 'MMM D', {
+		context: 'momentjs format string (week)',
+		comment: 'This specifies a week for the stats x-axis label.',
+	} ),
+	month: 'MMM',
+	year: 'YYYY',
+};
+
 /**
  * Create the correct property and value for a label to be used in a chart
  * @param {string} unit - day, week, month, year
@@ -167,24 +184,8 @@ export function getChartLabels( unit, date, localizedDate ) {
 		const dayOfWeek = date.toDate().getDay();
 		const isWeekend = 'day' === unit && ( 6 === dayOfWeek || 0 === dayOfWeek );
 		const labelName = `label${ unit.charAt( 0 ).toUpperCase() + unit.slice( 1 ) }`;
-		const formats = {
-			hour: translate( 'HH:mm', {
-				context: 'momentjs format string (hour)',
-				comment: 'This specifies an hour for the stats x-axis label.',
-			} ),
-			day: translate( 'MMM D', {
-				context: 'momentjs format string (day)',
-				comment: 'This specifies a day for the stats x-axis label.',
-			} ),
-			week: translate( 'MMM D', {
-				context: 'momentjs format string (week)',
-				comment: 'This specifies a week for the stats x-axis label.',
-			} ),
-			month: 'MMM',
-			year: 'YYYY',
-		};
 		return {
-			[ labelName ]: localizedDate.format( formats[ unit ] ),
+			[ labelName ]: localizedDate.format( chartLabelformats[ unit ] ),
 			classNames: isWeekend ? [ 'is-weekend' ] : [],
 		};
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Align the datetime format with the original `Traffic` chart data parser, especially for hourly views.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The date object passed back from the chart library needs to be formatted in line with the original bar chart labels.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic with the line chart feature flag: `flags=stats/chart-library`.
* Toggle the main chart to the line chart type.
* Ensure the X-axis labels are aligned with the bar chart for every period.

> Note: The tooltip date label fix on the screenshot is handled in another PR https://github.com/Automattic/wp-calypso/pull/100726.

<img width="1316" alt="截圖 2025-03-04 凌晨2 36 09" src="https://github.com/user-attachments/assets/7723b975-9d3f-43fc-8314-838d309b1188" />

<img width="1353" alt="截圖 2025-03-04 凌晨3 04 47" src="https://github.com/user-attachments/assets/baba6843-6f40-420b-8829-89f7972d7be4" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
