### PR TITLE
Stats: add event to Track stats card upsell view

### DIFF
--- a/client/my-sites/stats/stats-card-upsell/index.tsx
+++ b/client/my-sites/stats/stats-card-upsell/index.tsx
@@ -1,5 +1,7 @@
 import { Plans } from '@automattic/data-stores';
 import { translate, TranslateResult } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { trackStatsAnalyticsEvent } from 'calypso/my-sites/stats/utils';
 import { useSelector } from 'calypso/state';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { statTypeToPlan } from '../stat-type-to-plan';
@@ -33,6 +35,12 @@ const StatsCardUpsell: React.FC< Props > = ( { className, statType, siteId, butt
 		UpsellComponent = StatsCardUpsellJetpack;
 		upsellButtonLabel = buttonLabel ?? translate( 'Upgrade plan' );
 	}
+
+	useEffect( () => {
+		trackStatsAnalyticsEvent( 'stats_card_upsell_view', {
+			stat_type: statType,
+		} );
+	}, [ statType ] );
 
 	return (
 		<UpsellComponent


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/99308

## Proposed Changes
- Add a `stats_card_upsell_view` event to track when the upsell card is displayed.
  - **`stats_card_upsell_view`**
    - **Description:** Tracks when the user views the stats upsell card.
    - **Props:**  
      - **`stat_type`** (string): The stats module associated with the upsell (e.g., `StatsModuleLocations/region` `StatsModuleLocations/city`).

![CleanShot 2025-03-03 at 19 05 48@2x](https://github.com/user-attachments/assets/ae83a2c7-ec7d-4168-b790-aa5f1151aad9)

> [!NOTE]  
> If it is triggered in Calypso, it will have the `calypso_` prefix; otherwise, it will have the `jetpack_odyssey_` prefix.

## Why are these changes being made?
We currently track when users **click** on the card upsell and when they see the modal, but we do not track how many users **see** it.  
This event provides better insight into the upsell's visibility and conversion funnel.

## Testing Instructions
> **Note:**  
> For brevity in describing the test steps, when we say "validate that event X was triggered," it means you should see a request to `t.gif` with the described event name.  
>  
> You can also use this extension to make it easier: p7H4VZ-4cf-p2.  

1. Spin up the Calypso Live Branch or test it on Odyssey using option 2: PCYsg-Pp7-p2.
   - For Calypso, you should use a site with a Personal or lower plan (including Free).
   - For Odyssey, you should use a self-hosted site with no Stats Commercial license.
2. Open the **Network** tab in your developer tools.  
3. Navigate to the **Stats** page.  
4. Locate any module that includes an upsell, for example: Locations (regions tab), UTM, or Devices.
   - Validate that the event `*_stats_card_upsell_view` was triggered, passing the `stat_type` prop with the corresponding module value.
5. Click on the upsell button.
   - Validate that the existing `*_stats_card_upsell_clicked` event is still triggered.
