### PR TITLE
Help Center DIFM: Show help center if no text is passed

### DIFF
--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -225,7 +225,6 @@ class StepWrapper extends Component {
 						{ customizedActionButtons }
 						{ isHelpCenterLinkEnabled && (
 							<HelpCenterStepButton
-								helpCenterButtonText={ flow?.helpCenterButtonText }
 								hasPremiumSupport={ flow?.enablePremiumSupport }
 								flowName={ flowName }
 							/>

--- a/packages/help-center/src/components/help-center-step-button.tsx
+++ b/packages/help-center/src/components/help-center-step-button.tsx
@@ -8,13 +8,11 @@ import { HELP_CENTER_STORE } from '../stores';
 import type { FC } from 'react';
 
 interface HelpCenterStepButtonProps {
-	helpCenterButtonText?: string;
 	hasPremiumSupport?: boolean;
 	flowName?: string;
 }
 
 const HelpCenterStepButton: FC< HelpCenterStepButtonProps > = ( {
-	helpCenterButtonText,
 	hasPremiumSupport,
 	flowName,
 } ) => {
@@ -26,10 +24,6 @@ const HelpCenterStepButton: FC< HelpCenterStepButtonProps > = ( {
 	);
 	const flowCustomOptions = useFlowCustomOptions( flowName || '' );
 	const { userFieldMessage, userFieldFlowName } = useFlowZendeskUserFields( flowName || '' );
-
-	if ( ! helpCenterButtonText ) {
-		return null;
-	}
 
 	function openHelpCenter() {
 		setShowHelpCenter( ! isShowingHelpCenter, hasPremiumSupport, flowCustomOptions );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Adds a missing removal of an if to https://github.com/Automattic/wp-calypso/pull/100729