### PR TITLE
Reader: Fix reddit icon on full post view

### DIFF
--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import TagsList from 'calypso/blocks/reader-post-card/tags-list';
 import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
 import AutoDirection from 'calypso/components/auto-direction';
+import { getPostIcon } from 'calypso/reader/get-helpers';
 import { recordPermalinkClick } from 'calypso/reader/stats';
 import ReaderFullPostHeaderPlaceholder from './placeholders/header';
 
@@ -33,7 +34,7 @@ const ReaderFullPostHeader = ( { post, authorProfile, layout = 'default' } ) => 
 	const { props: { siteName, followCount } = {} } = authorProfile || {};
 
 	const isDefaultLayout = layout === 'default';
-	const iconSrc = post?.site_icon?.img || post?.author?.avatar_URL;
+	const iconSrc = getPostIcon( post );
 
 	/* eslint-disable react/jsx-no-target-blank */
 	return (

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -23,6 +23,15 @@ export const getSiteUrl = ( { feed, site, post } = {} ) => {
 };
 
 /**
+ * Given a feed, site, or post: return the site icon. return false if one could not be found.
+ * @param {Object} post - Post object.
+ * @returns {string|undefined} Url of the site icon or undefined if not found.
+ */
+export function getPostIcon( post ) {
+	return post?.site_icon?.img || post?.site_icon || post?.author?.avatar_URL;
+}
+
+/**
  * Given a feed, site, or post: return the feed url. return false if one could not be found.
  * The feed url is different from the site url in that it is unique per feed. A single siteUrl may
  * be home to many feeds

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -9,7 +9,9 @@ import { ThunkDispatch } from 'redux-thunk';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import AsyncLoad from 'calypso/components/async-load';
 import NavigationHeader from 'calypso/components/navigation-header';
+import { getPostIcon } from 'calypso/reader/get-helpers';
 import FollowingEmptyContent from 'calypso/reader/stream/empty';
+import { getReaderFollowForFeed } from 'calypso/state/reader/follows/selectors';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 import { requestPaginatedStream } from 'calypso/state/reader/streams/actions';
 import { viewStream } from 'calypso/state/reader-ui/actions';
@@ -82,9 +84,17 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 				feedId: item.feedId,
 				postId: item.postId,
 			} );
+
+			// Add site icon to feed object so have icon for external feeds
+			if ( post ) {
+				const feedSubscription = getReaderFollowForFeed( state, item.feedId );
+				post.site_icon = feedSubscription?.site_icon;
+			}
+
 			if ( post ) {
 				acc[ `${ item?.feedId }-${ item?.postId }` ] = post;
 			}
+
 			return acc;
 		}, {} );
 	}, shallowEqual );
@@ -107,7 +117,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 						return <Skeleton height="24px" width="24px" shape="circle" />;
 					}
 					const post = getPostFromItem( item );
-					const iconUrl = post?.site_icon?.img || post?.author?.avatar_URL || '';
+					const iconUrl = getPostIcon( post );
 					return iconUrl ? <ReaderAvatar siteIcon={ iconUrl } iconSize={ 24 } /> : null;
 				},
 				enableHiding: false,

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -80,20 +80,22 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 			if ( isPaddingItem( item ) ) {
 				return acc;
 			}
+
 			const post = getPostByKey( state, {
 				feedId: item.feedId,
 				postId: item.postId,
 			} );
+			if ( ! post ) {
+				return acc;
+			}
 
 			// Add site icon to feed object so have icon for external feeds
-			if ( post ) {
+			if ( ! post.site_icon ) {
 				const feedSubscription = getReaderFollowForFeed( state, item.feedId );
 				post.site_icon = feedSubscription?.site_icon;
 			}
 
-			if ( post ) {
-				acc[ `${ item?.feedId }-${ item?.postId }` ] = post;
-			}
+			acc[ `${ item?.feedId }-${ item?.postId }` ] = post;
 
 			return acc;
 		}, {} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/522

## Proposed Changes

* On Full Post View add site icon on feed object resolving an issue where site icons were not appearing for external feeds such as Reddit.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix the appearance of external feeds icons such as Reddit.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/reader`
* Subscribe to any Reddit feed if not already subscribed.
* Select "Full Post View"
* Verify that Reddit feeds are now correctly displaying their respective icons in both the sidebar and detailed view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
