### PR TITLE
Reader as Default Home: Fire PUT request directly without awaiting the response

### DIFF
--- a/client/signup/steps/set-reader-landing/index.tsx
+++ b/client/signup/steps/set-reader-landing/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
-import { useDispatch } from 'calypso/state';
-import { savePreference } from 'calypso/state/preferences/actions';
+import wpcom from 'calypso/lib/wp';
+import { USER_SETTING_KEY } from 'calypso/state/preferences/constants';
 import { READER_AS_LANDING_PAGE_PREFERENCE } from 'calypso/state/sites/selectors/has-reader-as-landing-page';
 
 interface Props {
@@ -14,24 +14,24 @@ interface Props {
 }
 
 const SetReaderLanding = ( { submitSignupStep, goToNextStep, initialContext }: Props ): null => {
-	const dispatch = useDispatch();
 	const refParam = initialContext?.query?.ref;
-
 	useEffect( () => {
-		// Submit the step immediately to trigger the processing screen.
-		submitSignupStep( { stepName: 'set-reader-landing' } );
-
 		const saveAndProceed = async () => {
-			// Save the preference
 			if ( 'reader-lp' === refParam ) {
-				await dispatch(
-					savePreference( READER_AS_LANDING_PAGE_PREFERENCE, {
-						useReaderAsLandingPage: true,
-						updatedAt: Date.now(),
-					} )
-				);
-			}
+				// Fire PUT request directly without awaiting the response
+				const payload = {
+					[ USER_SETTING_KEY ]: {
+						[ READER_AS_LANDING_PAGE_PREFERENCE ]: {
+							useReaderAsLandingPage: true,
+							updatedAt: Date.now(),
+						},
+					},
+				};
 
+				// Send the request but don't wait for it
+				wpcom.req.put( '/me/preferences', payload );
+			}
+			submitSignupStep( { stepName: 'set-reader-landing' } );
 			goToNextStep();
 		};
 

--- a/client/signup/steps/set-reader-landing/index.tsx
+++ b/client/signup/steps/set-reader-landing/index.tsx
@@ -18,7 +18,6 @@ const SetReaderLanding = ( { submitSignupStep, goToNextStep, initialContext }: P
 	useEffect( () => {
 		const saveAndProceed = async () => {
 			if ( 'reader-lp' === refParam ) {
-				// Fire PUT request directly without awaiting the response
 				const payload = {
 					[ USER_SETTING_KEY ]: {
 						[ READER_AS_LANDING_PAGE_PREFERENCE ]: {
@@ -28,7 +27,7 @@ const SetReaderLanding = ( { submitSignupStep, goToNextStep, initialContext }: P
 					},
 				};
 
-				// Send the request but don't wait for it
+				// Fire PUT request directly without awaiting the response.
 				wpcom.req.put( '/me/preferences', payload );
 			}
 			submitSignupStep( { stepName: 'set-reader-landing' } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/100663

## Proposed Changes

* https://github.com/Automattic/wp-calypso/pull/100663 suffers from a race condition on production.
* Trying this approach of calling wpcom.req.put directly and not waiting on it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix a race condition in production.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On Calypso Live go to /start/reader/user-social?ref=reader-lp
* You should not see a blank white screen and the Reader should be set as the default home page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
