### PR TITLE
Launchpad: Update e2e onboarding tests to reflect domains first + Focused Launchpad

### DIFF
--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -200,10 +200,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 		} );
 
 		it( 'Navigated to Home dashboard', async function () {
-			await page.waitForURL(
-				DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.site_slug }` ),
-				{ timeout: 30 * 1000 }
-			);
+			await page.waitForURL( /home/ );
 			const myHomePage = new MyHomePage( page );
 			await new Promise( ( r ) => setTimeout( r, 2000 ) );
 			await page.reload();

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -149,8 +149,6 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 		} );
 	} );
 
-	// wpcalypso is currently using the goals-first onboarding flow, so this is
-	// skipped for now. Check out the "Goals-first Signup" test below.
 	describe( 'Sell', function () {
 		const themeName = 'Attar';
 		let startSiteFlow: StartSiteFlow;
@@ -180,19 +178,21 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 		} );
 	} );
 
-	describe( 'Launch site without Focused Launchpad', function () {
+	describe( 'Check if site is launched', function () {
 		it( 'Verify site is not yet launched', async function () {
 			const tmpPage = await browser.newPage();
 			await tmpPage.goto( newSiteDetails.blog_details.url as string );
 
 			// View site.
-			const comingSoonPage = new ComingSoonPage( tmpPage );
+			const comingSoonPage = new ComingSoonPage( page );
 			await comingSoonPage.validateComingSoonState();
 
 			// Dispose the test page and context.
 			await tmpPage.close();
 		} );
+	} );
 
+	describe( 'Launch site without Focused Launchpad', function () {
 		it( 'Start site launch', async function () {
 			const siteSettingsPage = new SiteSettingsPage( page );
 			await siteSettingsPage.visit( newSiteDetails.blog_details.site_slug );
@@ -206,9 +206,14 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 		} );
 
 		it( 'Navigated to Home dashboard', async function () {
+			await page.waitForURL(
+				DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.site_slug }` ),
+				{ timeout: 30 * 1000 }
+			);
 			const myHomePage = new MyHomePage( page );
-			await myHomePage.visit( newSiteDetails.blog_details.site_slug );
-			await myHomePage.validateTaskHeadingMessage( 'You launched your site!' );
+			await new Promise( ( r ) => setTimeout( r, 2000 ) );
+			await page.reload();
+			return await myHomePage.validateTaskHeadingMessage( 'You launched your site!' );
 		} );
 	} );
 
@@ -265,5 +270,8 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 			username: newUserDetails.body.username,
 			email: testUser.email,
 		} );
+
+		// Close the page to prevent hanging
+		await page.close();
 	} );
 } );

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -49,9 +49,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 		page = await browser.newPage();
 	} );
 
-	// wpcalypso is currently using the goals-first onboarding flow, so this is
-	// skipped for now. Check out the "Goals-first Signup" test below.
-	describe.skip( 'Signup', function () {
+	describe( 'Signup', function () {
 		let cartCheckoutPage: CartCheckoutPage;
 		let signupPickPlanPage: SignupPickPlanPage;
 		let originalAmount: number;
@@ -134,9 +132,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 		} );
 	} );
 
-	// wpcalypso is currently using the goals-first onboarding flow, so this is
-	// skipped for now. Check out the "Goals-first Signup" test below.
-	describe.skip( 'Onboarding', function () {
+	describe( 'Onboarding', function () {
 		let startSiteFlow: StartSiteFlow;
 
 		beforeAll( async function () {
@@ -155,7 +151,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 
 	// wpcalypso is currently using the goals-first onboarding flow, so this is
 	// skipped for now. Check out the "Goals-first Signup" test below.
-	describe.skip( 'Sell', function () {
+	describe( 'Sell', function () {
 		const themeName = 'Attar';
 		let startSiteFlow: StartSiteFlow;
 
@@ -184,126 +180,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 		} );
 	} );
 
-	// The steps in this test don't match what happens on production, because only wpcalypso
-	// is using the goals-first onboarding flow. Check out the "Signup" test above
-	// for the steps that work on production.
-	describe( 'Goals-first Signup', function () {
-		let cartCheckoutPage: CartCheckoutPage;
-		let signupPickPlanPage: SignupPickPlanPage;
-		let startSiteFlow: StartSiteFlow;
-		let originalAmount: number;
-		const themeName = 'Attar';
-
-		beforeAll( async function () {
-			await BrowserManager.setStoreCookie( page, { currency: 'GBP' } );
-		} );
-
-		it( 'Navigate to Signup page', async function () {
-			const loginPage = new LoginPage( page );
-			await loginPage.visit();
-			await loginPage.clickCreateNewAccount();
-		} );
-
-		it( 'Land on goal selection step', async function () {
-			page.waitForURL( /setup\/onboarding\/goals/, { timeout: 30 * 1000 } );
-		} );
-
-		it( 'Select "Sell services or digital goods" goal', async function () {
-			startSiteFlow = new StartSiteFlow( page );
-
-			await startSiteFlow.selectGoal( 'Sell services or digital goods' );
-			await startSiteFlow.clickButton( 'Next' );
-		} );
-
-		it( 'Select theme', async function () {
-			await startSiteFlow.selectTheme( themeName );
-			await startSiteFlow.clickButton( 'Continue' );
-		} );
-
-		it( 'Sign up as new user', async function () {
-			const userSignupPage = new UserSignupPage( page );
-			newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
-		} );
-
-		it( 'Skip domain selection', async function () {
-			const signupDomainPage = new SignupDomainPage( page );
-			await signupDomainPage.searchForFooDomains();
-			await signupDomainPage.skipDomainSelection();
-		} );
-
-		it( `Select WordPress.com ${ planName } plan`, async function () {
-			signupPickPlanPage = new SignupPickPlanPage( page );
-			newSiteDetails = await signupPickPlanPage.selectPlan( planName );
-		} );
-
-		it( 'See secure payment', async function () {
-			cartCheckoutPage = new CartCheckoutPage( page );
-			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
-		} );
-
-		it( 'Prices are shown in GBP', async function () {
-			const cartAmount = ( await cartCheckoutPage.getCheckoutTotalAmount( {
-				rawString: true,
-			} ) ) as string;
-			expect( cartAmount.startsWith( '£' ) ).toBe( true );
-		} );
-
-		it( 'Apply coupon', async function () {
-			originalAmount = ( await cartCheckoutPage.getCheckoutTotalAmount() ) as number;
-			await cartCheckoutPage.enterCouponCode( SecretsManager.secrets.testCouponCode );
-		} );
-
-		it( 'Apply coupon and validate purchase amount', async function () {
-			const newAmount = ( await cartCheckoutPage.getCheckoutTotalAmount() ) as number;
-
-			expect( newAmount ).toBeLessThan( originalAmount );
-			const expectedAmount = originalAmount * 0.99;
-
-			// Some currencies do not typically have decimal places.
-			// eg. USD would commonly have 2 decimal places, e.g. 12.34.
-			// In JPY or TWD there will be no decimal digits.
-			// Drop decimals so that the result won't be affected by the currency variation.
-			expect( newAmount ).toStrictEqual( expectedAmount );
-		} );
-
-		it( 'Enter billing and payment details', async function () {
-			const paymentDetails = DataHelper.getTestPaymentDetails();
-			await cartCheckoutPage.enterBillingDetails( paymentDetails );
-			await cartCheckoutPage.enterPaymentDetails( paymentDetails );
-		} );
-
-		it( 'Make purchase', async function () {
-			await cartCheckoutPage.purchase( { timeout: 90 * 1000 } );
-		} );
-
-		it( 'Skip upsell if present', async function () {
-			const selector = 'button[data-e2e-button="decline"]';
-			const locator = page.locator( selector );
-
-			try {
-				await locator.click( { timeout: 2 * 1000 } );
-			} catch {
-				// noop
-			}
-		} );
-
-		it( 'Land in Home dashboard', async function () {
-			// dirty hack to wait for the launchpad to load.
-			// Stepper has a quirk where it redirects twice. Playwright hooks to the first one and thinks it was aborted.
-			await fixme_retry( () =>
-				page.waitForURL(
-					DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.blogid }` ),
-					{ timeout: 30 * 1000 }
-				)
-			);
-		} );
-
-		it( 'Site slug exists', async function () {
-			expect( newSiteDetails.blog_details.site_slug ).toBeDefined();
-		} );
-	} );
-
-	describe( 'Launch site', function () {
+	describe( 'Launch site using Focused Launchpad', function () {
 		it( 'Verify site is not yet launched', async function () {
 			const tmpPage = await browser.newPage();
 			await tmpPage.goto( newSiteDetails.blog_details.url as string );
@@ -330,6 +207,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 
 		it( 'Navigated to Home dashboard', async function () {
 			const myHomePage = new MyHomePage( page );
+			await myHomePage.visit( newSiteDetails.blog_details.site_slug );
 			await myHomePage.validateTaskHeadingMessage( 'You launched your site!' );
 		} );
 	} );

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -180,7 +180,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 		} );
 	} );
 
-	describe( 'Launch site using Focused Launchpad', function () {
+	describe( 'Launch site without Focused Launchpad', function () {
 		it( 'Verify site is not yet launched', async function () {
 			const tmpPage = await browser.newPage();
 			await tmpPage.goto( newSiteDetails.blog_details.url as string );

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -26,7 +26,7 @@ import {
 	PurchasesPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { apiCloseAccount, fixme_retry } from '../shared';
+import { apiCloseAccount } from '../shared';
 
 declare const browser: Browser;
 
@@ -162,15 +162,9 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 			await startSiteFlow.clickButton( 'Continue' );
 		} );
 
-		it( 'Land in Home dashboard', async function () {
-			// dirty hack to wait for the launchpad to load.
-			// Stepper has a quirk where it redirects twice. Playwright hooks to the first one and thinks it was aborted.
-			await fixme_retry( () =>
-				page.waitForURL(
-					DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.blogid }` ),
-					{ timeout: 30 * 1000 }
-				)
-			);
+		it( 'Focused Launchpad is shown', async function () {
+			const title = await page.getByText( "Let's get started!" );
+			await title.waitFor( { timeout: 30 * 1000 } );
 		} );
 
 		it( 'Site slug exists', async function () {

--- a/test/e2e/specs/onboarding/onboarding__focused-launchpad.ts
+++ b/test/e2e/specs/onboarding/onboarding__focused-launchpad.ts
@@ -1,0 +1,133 @@
+/**
+ * @group calypso-release
+ */
+import {
+	DataHelper,
+	TestAccount,
+	envVariables,
+	getTestAccountByFeature,
+	envToFeatureKey,
+	BrowserManager,
+	SignupDomainPage,
+	SignupPickPlanPage,
+	NewSiteResponse,
+	StartSiteFlow,
+	MyHomePage,
+	EditorPage,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
+	let page: Page;
+	let newSiteDetails: NewSiteResponse;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+		const testUser = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+			{
+				gutenberg: 'stable',
+				siteType: 'simple',
+				accountName: 'defaultUser',
+			},
+		] );
+		const testAccount = new TestAccount( testUser );
+		await testAccount.authenticate( page );
+	} );
+
+	describe( 'Log in, select a goal and theme', function () {
+		const themeName = 'Retrospect';
+		let startSiteFlow: StartSiteFlow;
+
+		beforeAll( async function () {
+			await BrowserManager.setStoreCookie( page, { currency: 'GBP' } );
+			startSiteFlow = new StartSiteFlow( page );
+		} );
+
+		it( 'Visit onboarding page', async function () {
+			await page.goto( DataHelper.getCalypsoURL( `/setup/onboarding` ) );
+		} );
+
+		it( 'Skip domain selection', async function () {
+			const signupDomainPage = new SignupDomainPage( page );
+			await signupDomainPage.searchForFooDomains();
+			await signupDomainPage.skipDomainSelection();
+		} );
+
+		it( `Select WordPress.com Free plan`, async function () {
+			const signupPickPlanPage = new SignupPickPlanPage( page );
+			newSiteDetails = await signupPickPlanPage.selectPlan( 'Free' );
+		} );
+
+		it( 'Select "Publish a blog" goal', async function () {
+			await startSiteFlow.selectGoal( 'Publish a blog' );
+			await startSiteFlow.clickButton( 'Next' );
+		} );
+
+		it( 'Select theme', async function () {
+			await startSiteFlow.selectTheme( themeName );
+			await startSiteFlow.clickButton( 'Continue' );
+		} );
+	} );
+
+	describe( 'Launch the site', function () {
+		let editorPage: EditorPage;
+
+		it( 'Visit Focused Launchpad page', async function () {
+			const title = await page.getByText( "Let's get started!" );
+			await title.waitFor( { timeout: 30 * 1000 } );
+		} );
+
+		it( 'Will add subscribers', async function () {
+			const addSubscribersButton = await page.getByText( 'Add subscribers' );
+			await addSubscribersButton.waitFor();
+			await addSubscribersButton.click();
+
+			await page.goto(
+				DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.site_slug }` )
+			);
+		} );
+
+		it( 'will Write your first post', async function () {
+			const writeFirstPostButton = await page.getByText( 'Write your first post' );
+			await writeFirstPostButton.waitFor();
+			await writeFirstPostButton.click();
+		} );
+
+		it( 'Editor loads', async function () {
+			editorPage = new EditorPage( page );
+			await editorPage.waitUntilLoaded();
+			await editorPage.closeWelcomeGuideIfNeeded();
+		} );
+
+		it( 'Enter blog title', async function () {
+			await editorPage.enterTitle( 'my first post' );
+		} );
+
+		it( 'Publish post', async function () {
+			await editorPage.closeWelcomeGuideIfNeeded();
+			await editorPage.publish();
+			await page.goto(
+				DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.site_slug }` )
+			);
+		} );
+
+		it( 'Should show Launch Site button and update title', async function () {
+			const header = await page.getByText( "You're all set!" );
+			await header.waitFor();
+
+			await page.goto(
+				DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.site_slug }` )
+			);
+			const launchSiteButton = await page.getByText( 'Launch your site' );
+			await launchSiteButton.waitFor();
+			await launchSiteButton.click();
+		} );
+
+		it( 'Make sure launch modal shows', async function () {
+			const myHomePage = new MyHomePage( page );
+			await myHomePage.validateTaskHeadingMessage( 'Congrats, your site is live!' );
+		} );
+	} );
+} );

--- a/test/e2e/specs/onboarding/onboarding__focused-launchpad.ts
+++ b/test/e2e/specs/onboarding/onboarding__focused-launchpad.ts
@@ -98,6 +98,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 		it( 'Editor loads', async function () {
 			editorPage = new EditorPage( page );
 			await editorPage.waitUntilLoaded();
+			await new Promise( ( r ) => setTimeout( r, 2000 ) );
 			await editorPage.closeWelcomeGuideIfNeeded();
 		} );
 
@@ -106,7 +107,6 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 		} );
 
 		it( 'Publish post', async function () {
-			await editorPage.closeWelcomeGuideIfNeeded();
 			await editorPage.publish();
 			await page.goto(
 				DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.site_slug }` )

--- a/test/e2e/specs/onboarding/onboarding__focused-launchpad.ts
+++ b/test/e2e/specs/onboarding/onboarding__focused-launchpad.ts
@@ -79,7 +79,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			await title.waitFor( { timeout: 30 * 1000 } );
 		} );
 
-		it( 'Will add subscribers', async function () {
+		it( 'It will add subscribers', async function () {
 			const addSubscribersButton = await page.getByText( 'Add subscribers' );
 			await addSubscribersButton.waitFor();
 			await addSubscribersButton.click();
@@ -89,7 +89,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 			);
 		} );
 
-		it( 'will Write your first post', async function () {
+		it( "It will write the user's first post", async function () {
 			const writeFirstPostButton = await page.getByText( 'Write your first post' );
 			await writeFirstPostButton.waitFor();
 			await writeFirstPostButton.click();

--- a/test/e2e/specs/onboarding/onboarding__write.ts
+++ b/test/e2e/specs/onboarding/onboarding__write.ts
@@ -19,9 +19,7 @@ import { apiCloseAccount, fixme_retry } from '../shared';
 
 declare const browser: Browser;
 
-// wpcalypso is currently using the goals-first onboarding flow, so this is
-// skipped for now. Check out the "Goals-First Onboarding: Write Focus" test below.
-describe.skip( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () {
+describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () {
 	const blogName = DataHelper.getBlogName();
 	const testUser = DataHelper.getNewTestUser( {
 		usernamePrefix: 'signupfree',
@@ -66,7 +64,7 @@ describe.skip( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), functio
 	} );
 
 	describe( 'Onboarding', function () {
-		const themeName = 'Poema';
+		const themeName = 'Retrospect';
 		let startSiteFlow: StartSiteFlow;
 
 		beforeAll( async function () {
@@ -90,159 +88,6 @@ describe.skip( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), functio
 			await startSiteFlow.clickButton( 'Show all Blog themes' );
 			await startSiteFlow.selectTheme( themeName );
 			await startSiteFlow.clickButton( 'Continue' );
-		} );
-	} );
-
-	describe( 'Write', function () {
-		const postTitle = DataHelper.getRandomPhrase();
-
-		let editorPage: EditorPage;
-
-		it( 'Launchpad is shown', async function () {
-			// dirty hack to wait for the launchpad to load.
-			// Stepper has a quirk where it redirects twice. Playwright hooks to the first one and thinks it was aborted.
-			await fixme_retry( () => page.waitForURL( /launchpad/ ) );
-		} );
-
-		it( 'Write first post', async function () {
-			await page.getByRole( 'link', { name: 'Write your first post' } ).click();
-		} );
-
-		it( 'Editor loads', async function () {
-			editorPage = new EditorPage( page );
-			await editorPage.waitUntilLoaded();
-
-			await page.waitForURL( new RegExp( newSiteDetails.blog_details.site_slug ) );
-		} );
-
-		it( 'Enter blog title', async function () {
-			await editorPage.enterTitle( postTitle );
-		} );
-
-		it( 'Publish post', async function () {
-			await editorPage.publish();
-		} );
-
-		it( 'First post congratulatory message is shown', async function () {
-			const editorParent = await editorPage.getEditorParent();
-			await editorParent
-				.getByRole( 'heading', { name: 'Your first post is published!' } )
-				.waitFor();
-		} );
-
-		it( 'View Next Steps', async function () {
-			const editorParent = await editorPage.getEditorParent();
-			await editorParent.getByRole( 'button', { name: 'Next steps' } ).click();
-		} );
-	} );
-
-	describe( 'Launchpad', function () {
-		it( 'Launchpad is shown', async function () {
-			// dirty hack to wait for the launchpad to load.
-			// Stepper has a quirk where it redirects twice. Playwright hooks to the first one and thinks it was aborted.
-			await fixme_retry( () => page.waitForURL( /launchpad/ ) );
-		} );
-
-		it( 'Launch site', async function () {
-			await page.getByRole( 'button', { name: 'Launch your site' } ).click();
-
-			await page.waitForURL( /setup\/write\/processing/ );
-		} );
-
-		it( 'Post-launch congratulatory message is shown', async function () {
-			// User is redirected to the Home dashboard.
-			await page.waitForURL( /home/ );
-
-			await page.getByRole( 'dialog' ).getByRole( 'heading', { name: 'Congrats' } ).waitFor();
-		} );
-
-		it( 'Close congratulatory message', async function () {
-			await page.getByRole( 'dialog' ).getByRole( 'button', { name: 'Close' } ).click();
-		} );
-	} );
-
-	afterAll( async function () {
-		if ( ! newUserDetails ) {
-			return;
-		}
-
-		const restAPIClient = new RestAPIClient(
-			{ username: testUser.username, password: testUser.password },
-			newUserDetails.body.bearer_token
-		);
-
-		await apiCloseAccount( restAPIClient, {
-			userID: newUserDetails.body.user_id,
-			username: newUserDetails.body.username,
-			email: testUser.email,
-		} );
-	} );
-} );
-
-// The steps in this test don't match what happens on production, because only wpcalypso
-// is using the goals-first onboarding flow. Check out the "Onboarding: Write Focus" test above
-// for the steps that work on production.
-describe( DataHelper.createSuiteTitle( 'Goals-First Onboarding: Write Focus' ), function () {
-	const themeName = 'Poema';
-	const blogName = DataHelper.getBlogName();
-	const testUser = DataHelper.getNewTestUser( {
-		usernamePrefix: 'signupfree',
-	} );
-
-	let newUserDetails: NewUserResponse;
-	let newSiteDetails: NewSiteResponse;
-	let page: Page;
-	let selectedFreeDomain: string;
-	let startSiteFlow: StartSiteFlow;
-
-	beforeAll( async function () {
-		page = await browser.newPage();
-	} );
-
-	describe( 'Register as new user with "Write" goal', function () {
-		let loginPage: LoginPage;
-
-		it( 'Navigate to the Login page', async function () {
-			loginPage = new LoginPage( page );
-			await loginPage.visit();
-		} );
-
-		it( 'Click on button to create a new account', async function () {
-			await loginPage.clickCreateNewAccount();
-		} );
-
-		it( 'Select "Publish a blog" goal', async function () {
-			await page.waitForURL( /setup\/onboarding\/goals/, { timeout: 30 * 1000 } );
-
-			startSiteFlow = new StartSiteFlow( page );
-			await startSiteFlow.selectGoal( 'Publish a blog' );
-			await startSiteFlow.clickButton( 'Next' );
-		} );
-
-		it( 'Choose to proceed with theme', async function () {
-			await startSiteFlow.clickDesignChoice( 'theme' );
-		} );
-
-		it( 'Select theme', async function () {
-			await startSiteFlow.clickButton( 'Show all Blog themes' );
-			await startSiteFlow.selectTheme( themeName );
-			await startSiteFlow.clickButton( 'Continue' );
-		} );
-
-		it( 'Sign up as a new user', async function () {
-			const userSignupPage = new UserSignupPage( page );
-			newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
-		} );
-
-		it( 'Select a .wordpress.com domain name', async function () {
-			const domainSearchComponent = new DomainSearchComponent( page );
-			await domainSearchComponent.search( blogName );
-			selectedFreeDomain = await domainSearchComponent.selectDomain( '.wordpress.com' );
-		} );
-
-		it( `Select WordPress.com Free plan`, async function () {
-			const signupPickPlanPage = new SignupPickPlanPage( page );
-			newSiteDetails = await signupPickPlanPage.selectPlan( 'Free' );
 		} );
 	} );
 
@@ -291,31 +136,9 @@ describe( DataHelper.createSuiteTitle( 'Goals-First Onboarding: Write Focus' ), 
 	} );
 
 	describe( 'Launchpad', function () {
-		it( 'Launchpad is shown', async function () {
-			// dirty hack to wait for the launchpad to load.
-			// Stepper has a quirk where it redirects twice. Playwright hooks to the first one and thinks it was aborted.
-			await fixme_retry( () => page.waitForURL( /launchpad/ ) );
-		} );
-
-		it( 'Launch site', async function () {
-			await page.getByRole( 'button', { name: 'Launch your site' } ).click();
-
-			await page.waitForURL( /setup\/write\/processing/ );
-			//
-			// Additional assertions for the URL.
-			expect( page.url() ).toContain( 'siteSlug' );
-			expect( page.url() ).toContain( selectedFreeDomain );
-		} );
-
-		it( 'Post-launch congratulatory message is shown', async function () {
-			// User is redirected to the Home dashboard.
-			await page.waitForURL( /home/ );
-
-			await page.getByRole( 'dialog' ).getByRole( 'heading', { name: 'Congrats' } ).waitFor();
-		} );
-
-		it( 'Close congratulatory message', async function () {
-			await page.getByRole( 'dialog' ).getByRole( 'button', { name: 'Close' } ).click();
+		it( 'Focused Launchpad is shown', async function () {
+			const title = await page.getByText( "Let's get started!" );
+			await title.waitFor( { timeout: 30 * 1000 } );
 		} );
 	} );
 

--- a/test/e2e/specs/onboarding/onboarding__write.ts
+++ b/test/e2e/specs/onboarding/onboarding__write.ts
@@ -115,7 +115,6 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 		} );
 
 		it( 'Publish post', async function () {
-			await editorPage.closeWelcomeGuideIfNeeded();
 			await editorPage.publish();
 		} );
 

--- a/test/e2e/specs/onboarding/onboarding__write.ts
+++ b/test/e2e/specs/onboarding/onboarding__write.ts
@@ -8,7 +8,6 @@ import {
 	RestAPIClient,
 	DomainSearchComponent,
 	SignupPickPlanPage,
-	NewSiteResponse,
 	NewUserResponse,
 	LoginPage,
 	UserSignupPage,
@@ -26,7 +25,6 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 	} );
 
 	let newUserDetails: NewUserResponse;
-	let newSiteDetails: NewSiteResponse;
 	let page: Page;
 	let selectedFreeDomain: string;
 
@@ -59,7 +57,7 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 
 		it( `Select WordPress.com Free plan`, async function () {
 			const signupPickPlanPage = new SignupPickPlanPage( page );
-			newSiteDetails = await signupPickPlanPage.selectPlan( 'Free' );
+			await signupPickPlanPage.selectPlan( 'Free' );
 		} );
 	} );
 
@@ -99,7 +97,7 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 		it( 'Launchpad is shown', async function () {
 			// dirty hack to wait for the launchpad to load.
 			// Stepper has a quirk where it redirects twice. Playwright hooks to the first one and thinks it was aborted.
-			await fixme_retry( () => page.waitForURL( /launchpad/ ) );
+			await fixme_retry( () => page.waitForURL( /home/ ) );
 		} );
 
 		it( 'Write first post', async function () {
@@ -110,8 +108,6 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 			editorPage = new EditorPage( page );
 			await editorPage.waitUntilLoaded();
 			await editorPage.closeWelcomeGuideIfNeeded();
-
-			await page.waitForURL( new RegExp( newSiteDetails.blog_details.site_slug ) );
 		} );
 
 		it( 'Enter blog title', async function () {
@@ -119,6 +115,7 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 		} );
 
 		it( 'Publish post', async function () {
+			await editorPage.closeWelcomeGuideIfNeeded();
 			await editorPage.publish();
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10558

## Proposed Changes

* We want to make sure all e2e runs and pass as expected after getting back to the domain first experience

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- [Apply this](https://github.com/Automattic/jetpack/pull/42196) to your sandbox
- Run the tests to ensure everything is working as expected:
  - `export CALYPSO_BASE_URL=http://calypso.localhost:3000` to ensure you're testing against your local
  - `yarn workspace wp-e2e-tests test -- test/e2e/specs/onboarding/onboarding__write.ts`
  - `yarn workspace wp-e2e-tests test -- test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts`
  - `yarn workspace wp-e2e-tests test -- test/e2e/specs/onboarding/onboarding__focused-launchpad.ts`

CI will run against `calypso.live`
The post-merge canary tests will run against `wpcalypso`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
