### PR TITLE
DIFM: fix back button behaviour

### DIFF
--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -251,11 +251,12 @@ const onboarding: Flow = {
 				}
 
 				case 'difmStartingPoint': {
-					const { newOrExistingSiteChoice } = providedDependencies;
-					const difmFlowLink = addQueryArgs( withLocale( '/start/do-it-for-me', locale ), {
-						back_to: window.location.href.replace( window.location.origin, '' ),
-						newOrExistingSiteChoice,
-					} );
+					const difmFlowLink = addQueryArgs(
+						withLocale( '/start/website-design-services', locale ),
+						{
+							back_to: window.location.href.replace( window.location.origin, '' ),
+						}
+					);
 
 					if ( isUserLoggedIn ) {
 						return window.location.assign( difmFlowLink );

--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -286,7 +286,7 @@ const onboarding: Flow = {
 						currentQueryArgs.step = 'domain-input';
 
 						setRedirectedToUseMyDomain( true );
-						let useMyDomainURL = addQueryArgs( `/use-my-domain`, currentQueryArgs );
+						let useMyDomainURL = addQueryArgs( '/use-my-domain', currentQueryArgs );
 
 						const lastQueryParam = ( providedDependencies?.domainForm as { lastQuery?: string } )
 							?.lastQuery;

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -432,8 +432,8 @@ export function generateFlows( {
 			get helpCenterButtonLink() {
 				return translate( 'Contact our site building team' );
 			},
-			providesDependenciesInQuery: [ 'coupon', 'back_to', 'newOrExistingSiteChoice' ],
-			optionalDependenciesInQuery: [ 'coupon', 'back_to', 'newOrExistingSiteChoice' ],
+			providesDependenciesInQuery: [ 'coupon', 'back_to' ],
+			optionalDependenciesInQuery: [ 'coupon', 'back_to' ],
 		},
 		{
 			name: DIFM_FLOW_STORE,

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -469,7 +469,7 @@ export function generateFlows( {
 			description: 'A flow for DIFM onboarding',
 			excludeFromManageSiteFlows: true,
 			providesDependenciesInQuery: [ 'siteSlug', 'back_to' ],
-			optionalDependenciesInQuery: [ 'back_to' ],
+			optionalDependenciesInQuery: [ 'siteSlug', 'back_to' ],
 			lastModified: '2025-03-04',
 			enabledHelpCenterGeos: [ 'US' ],
 			get helpCenterButtonCopy() {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -879,7 +879,8 @@ export function generateSteps( {
 		},
 		'difm-page-picker': {
 			stepName: 'difm-page-picker',
-			providesDependencies: [ 'selectedPageTitles' ],
+			providesDependencies: [ 'selectedPageTitles', 'newOrExistingSiteChoice' ],
+			optionalDependencies: [ 'newOrExistingSiteChoice' ],
 			props: {
 				hideSkip: true,
 			},

--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -28,16 +28,14 @@ export default function NewOrExistingSiteStep( props: Props ) {
 	const dispatch = useDispatch();
 
 	const { stepName, goToNextStep, existingSiteCount, flowName, signupDependencies } = props;
-	const { back_to: backUrl, newOrExistingSiteChoice: preselectedChoice } = signupDependencies;
+	const { back_to: backUrl } = signupDependencies;
 
 	useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );
 		triggerGuidesForStep( flowName, stepName );
 	}, [ dispatch, flowName, stepName ] );
 
-	const branchSteps = useBranchSteps( stepName, () =>
-		preselectedChoice ? [ 'new-or-existing-site', 'difm-site-picker' ] : [ 'difm-site-picker' ]
-	);
+	const branchSteps = useBranchSteps( stepName, () => [ 'difm-site-picker' ] );
 
 	const newOrExistingSiteSelected = ( value: ChoiceType ) => {
 		// If 'new-site' is selected, skip the `difm-site-picker` step.
@@ -58,17 +56,6 @@ export default function NewOrExistingSiteStep( props: Props ) {
 	};
 
 	const showNewOrExistingSiteChoice = existingSiteCount > 0;
-
-	// Support pre-selected choice.
-	useEffect( () => {
-		if ( preselectedChoice ) {
-			newOrExistingSiteSelected( preselectedChoice );
-		}
-	}, [ preselectedChoice ] );
-
-	if ( preselectedChoice ) {
-		return null;
-	}
 
 	return (
 		<StepWrapper

--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -489,7 +489,15 @@ function DIFMPagePicker( props: StepProps ) {
 				return;
 			}
 
-			dispatch( submitSignupStep( { stepName }, { selectedPageTitles: selectedPages } ) );
+			dispatch(
+				submitSignupStep(
+					{ stepName },
+					{
+						selectedPageTitles: selectedPages,
+						newOrExistingSiteChoice: isExistingSite ? 'existing-site' : 'new-site', // Ensure the value of newOrExistingSiteChoice is set if it's not already
+					}
+				)
+			);
 			goToNextStep();
 		}
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/3733

## Proposed Changes

* If the back button was clicked on the `/start/do-it-for-me/difm-site-picker` page, it redirected to `/start/do-it-for-me/new-or-existing-site` correctly, but the following piece of code again redirected to `/start/do-it-for-me/difm-site-picker` since `preselectedChoice` was already chosen. The overall effect was that clicking on the back button did not do anything.

https://github.com/Automattic/wp-calypso/blob/102d6fee12f91c1b708e7172a21e23606e7350ea/client/signup/steps/new-or-existing-site/index.tsx#L62-L71

* This regression was likely introduced in #97749. In that PR, the goals step redirected to `/start/do-it-for-me?newOrExistingSiteChoice=<value>` and introduced the above hook to skip the `new-or-existing-site` step if the query param existed. However, a cleaner way would be to redirect to the `/start/website-design-services` flow which does not contain the `new-or-existing-site` step and was specifically made for a similar purpose.
* The `/start/website-design-services` was meant to handle cases where users wanted to purchase DIFM for a specific site, and expected a `siteSlug` query param. This PR also contains changes so that the flow can also support the `new-site` choice.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Test the vanilla DIFM flow

* Go to `/start/do-it-for-me`.
* Go through the flow steps and confirm the back button works on each page.
* Confirm that you reach checkout for both new and existing site flows.

### Test the DIFM flow from the goals step
* Go to `/setup/onboarding?flags=onboarding/force-goals-first` in a new incognito window.
* Click on `Let us build a custom site for you`.
* Click on the "Get started" button on the DIFM screen.
* Confirm that you see the user login/signup screen.
* Continue with any of the login/signup options.
* Confirm that you are redirected to the DIFM options (site title/tagline) step.
* Go through the flow steps.
* Confirm that you can reach checkout.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
