### PR TITLE
Theme Detail page: Improve preview button UX

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -529,18 +529,20 @@ class ThemeSheet extends Component {
 		}
 
 		return (
-			<div className="theme__sheet-web-preview">
+			<>
 				{ this.renderPreviewButton( 'web-preview' ) }
-				<ThemeWebPreview
-					url={ url }
-					inlineCss={ baseStyleVariationInlineCss + selectedStyleVariationInlineCss }
-					iframeScaleRatio={ 0.5 }
-					iframeToken={ iframeToken }
-					isShowFrameBorder={ false }
-					isShowDeviceSwitcher={ false }
-					isFitHeight
-				/>
-			</div>
+				<div className="theme__sheet-web-preview">
+					<ThemeWebPreview
+						url={ url }
+						inlineCss={ baseStyleVariationInlineCss + selectedStyleVariationInlineCss }
+						iframeScaleRatio={ 0.5 }
+						iframeToken={ iframeToken }
+						isShowFrameBorder={ false }
+						isShowDeviceSwitcher={ false }
+						isFitHeight
+					/>
+				</div>
+			</>
 		);
 	};
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -481,40 +481,27 @@ class ThemeSheet extends Component {
 
 		if ( this.isThemeAvailable() && ! this.shouldRenderForStaging() ) {
 			return (
-				<a
-					className="theme__sheet-screenshot is-active"
-					href={ demoUrl }
-					onClick={ ( e ) => {
-						this.previewAction( e, 'screenshot', 'preview' );
-					} }
-					rel="noopener noreferrer"
-				>
-					{ this.shouldRenderPreviewButton() && (
-						<Button className="theme__sheet-preview-demo-site">
-							{ translate( 'Preview demo site' ) }
-							<Icon icon={ external } size={ 16 } />
-						</Button>
-					) }
-					{ img }
-				</a>
+				<>
+					{ this.renderPreviewButton( 'screenshot' ) }
+					<a
+						className="theme__sheet-screenshot is-active"
+						href={ demoUrl }
+						onClick={ ( e ) => {
+							this.previewAction( e, 'screenshot', 'preview' );
+						} }
+						rel="noopener noreferrer"
+					>
+						{ img }
+					</a>
+				</>
 			);
 		}
 
 		return (
-			<div className="theme__sheet-screenshot">
-				{ this.shouldRenderPreviewButton() && (
-					<Button
-						className="theme__sheet-preview-demo-site"
-						onClick={ ( e ) => {
-							this.previewAction( e, 'link', 'preview' );
-						} }
-					>
-						{ translate( 'Preview demo site' ) }
-						<Icon icon={ external } size={ 16 } />
-					</Button>
-				) }
-				{ img }
-			</div>
+			<>
+				{ this.renderPreviewButton( 'screenshot' ) }
+				<div className="theme__sheet-screenshot">{ img }</div>
+			</>
 		);
 	}
 
@@ -522,7 +509,7 @@ class ThemeSheet extends Component {
 	 * Render web preview for wpcom themes.
 	 */
 	renderWebPreview = () => {
-		const { locale, siteSlug, stylesheet, styleVariations, themeId, translate } = this.props;
+		const { locale, siteSlug, stylesheet, styleVariations, themeId } = this.props;
 		const baseStyleVariation = styleVariations.find( ( style ) =>
 			isDefaultGlobalStylesVariationSlug( style.slug )
 		);
@@ -543,16 +530,7 @@ class ThemeSheet extends Component {
 
 		return (
 			<div className="theme__sheet-web-preview">
-				{ this.shouldRenderPreviewButton() && (
-					<Button
-						className="theme__sheet-preview-demo-site"
-						onClick={ ( e ) => {
-							this.previewAction( e, 'link', 'preview' );
-						} }
-					>
-						{ translate( 'Preview demo site' ) }
-					</Button>
-				) }
+				{ this.renderPreviewButton( 'web-preview' ) }
 				<ThemeWebPreview
 					url={ url }
 					inlineCss={ baseStyleVariationInlineCss + selectedStyleVariationInlineCss }
@@ -1025,9 +1003,20 @@ class ThemeSheet extends Component {
 		);
 	};
 
-	renderPreviewButton = () => {
+	renderPreviewButton = ( context ) => {
 		const { translate, isWpcomTheme, isExternallyManagedTheme } = this.props;
 		const isExternalLink = ! isWpcomTheme || isExternallyManagedTheme;
+
+		let classNames = 'theme__sheet-demo-button';
+		switch ( context ) {
+			case 'web-preview':
+				classNames = 'theme__sheet-preview-demo-site';
+				break;
+
+			case 'screenshot':
+				classNames = 'theme__sheet-preview-demo-site theme__sheet-screenshot-demo-site';
+				break;
+		}
 
 		if ( ! this.shouldRenderPreviewButton() ) {
 			return null;
@@ -1035,12 +1024,10 @@ class ThemeSheet extends Component {
 
 		return (
 			<Button
-				className="theme__sheet-demo-button"
-				onClick={ ( e ) => this.previewAction( e, 'link', 'preview', 'regular' ) }
+				className={ classNames }
+				onClick={ ( e ) => this.previewAction( e, 'link', 'preview' ) }
 			>
-				{ translate( 'Preview', {
-					context: 'Button to preview a theme',
-				} ) }
+				{ translate( 'Preview', { context: 'Button to preview a theme' } ) }
 				{ isExternalLink && <Icon icon={ external } size={ 16 } /> }
 			</Button>
 		);

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1010,11 +1010,8 @@ class ThemeSheet extends Component {
 		let classNames = 'theme__sheet-demo-button';
 		switch ( context ) {
 			case 'web-preview':
-				classNames = 'theme__sheet-preview-demo-site';
-				break;
-
 			case 'screenshot':
-				classNames = 'theme__sheet-preview-demo-site theme__sheet-screenshot-demo-site';
+				classNames = 'theme__sheet-preview-demo-site';
 				break;
 		}
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -288,6 +288,13 @@ $button-border: 4px;
 			opacity: 0.8;
 		}
 	}
+
+	&:has(.theme-preview__container--loading) {
+		.theme__sheet-preview-demo-site {
+			opacity: 0 !important;
+			pointer-events: none;
+		}
+	}
 }
 
 .theme__sheet-primary-button {

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -275,10 +275,17 @@ $button-border: 4px;
 	&:has(.theme__sheet-web-preview:hover),
 	&:has(.theme__sheet-web-preview:focus),
 	&:has(.theme__sheet-screenshot:hover),
-	&:has(.theme__sheet-screenshot:focus) {
+	&:has(.theme__sheet-screenshot:focus),
+	&:has(.theme__sheet-preview-demo-site:hover),
+	&:has(.theme__sheet-preview-demo-site:focus) {
 		.theme__sheet-preview-demo-site {
 			opacity: 1;
 			animation: theme__sheet-preview-demo-site 150ms ease-in-out;
+		}
+
+		.theme__sheet-img,
+		.theme-preview__frame-wrapper {
+			opacity: 0.8;
 		}
 	}
 }
@@ -373,12 +380,6 @@ $button-border: 4px;
 			}
 		}
 	}
-	&:hover,
-	&:focus {
-		.theme-preview__frame-wrapper {
-			opacity: 0.8;
-		}
-	}
 
 	.theme-preview__container {
 		position: relative;
@@ -386,15 +387,6 @@ $button-border: 4px;
 
 	.theme-preview__frame {
 		transform: none !important;
-	}
-}
-
-.theme__sheet-screenshot {
-	&:hover,
-	&:focus {
-		.theme__sheet-img {
-			opacity: 0.8;
-		}
 	}
 }
 
@@ -471,7 +463,6 @@ $button-border: 4px;
 		left: 0;
 		margin-left: 50%;
 		margin-top: -16px;
-		pointer-events: none;
 		top: 50%;
 		transform: translate(-50%, 0);
 	}

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -270,6 +270,17 @@ $button-border: 4px;
 
 .theme__sheet-column-right {
 	grid-area: preview;
+	position: relative;
+
+	&:has(.theme__sheet-web-preview:hover),
+	&:has(.theme__sheet-web-preview:focus),
+	&:has(.theme__sheet-screenshot:hover),
+	&:has(.theme__sheet-screenshot:focus) {
+		.theme__sheet-preview-demo-site {
+			opacity: 1;
+			animation: theme__sheet-preview-demo-site 150ms ease-in-out;
+		}
+	}
 }
 
 .theme__sheet-primary-button {
@@ -408,14 +419,6 @@ $button-border: 4px;
 	width: 98%;
 	z-index: 1;
 
-	&:hover,
-	&:focus {
-		.theme__sheet-preview-demo-site {
-			opacity: 1;
-			animation: theme__sheet-preview-demo-site 150ms ease-in-out;
-		}
-	}
-
 	@include breakpoint-deprecated( "<960px" ) {
 		border-radius: 0;
 		box-shadow: none;
@@ -458,8 +461,23 @@ $button-border: 4px;
 	top: 50%;
 	z-index: 1;
 	transform: translate(-50%, 0);
+
 	&.button {
 		border-radius: $button-border;
+	}
+}
+
+.theme__sheet-screenshot-demo-site {
+	z-index: 2;
+
+	@include breakpoint-deprecated( ">960px" ) {
+		position: sticky;
+		left: 0;
+		margin-left: 50%;
+		margin-top: -16px;
+		pointer-events: none;
+		top: 50%;
+		transform: translate(-50%, 0);
 	}
 }
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -459,16 +459,12 @@ $button-border: 4px;
 	position: absolute;
 	left: 50%;
 	top: 50%;
-	z-index: 1;
+	z-index: 2;
 	transform: translate(-50%, 0);
 
 	&.button {
 		border-radius: $button-border;
 	}
-}
-
-.theme__sheet-screenshot-demo-site {
-	z-index: 2;
 
 	@include breakpoint-deprecated( ">960px" ) {
 		position: sticky;

--- a/packages/calypso-e2e/src/lib/pages/themes-detail-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-detail-page.ts
@@ -4,7 +4,7 @@ import { PreviewComponent } from '../components';
 
 const selectors = {
 	// Preview
-	demoButton: 'button:text("Demo site")',
+	demoButton: 'button:text("Preview")',
 
 	// Main body
 	activateDesignButton: 'button:text("Activate this design")',


### PR DESCRIPTION
## Proposed Changes

This PR updates the theme preview in the Theme Details page so that the preview button is always in the browser viewport. Note that this only applies to viewports with width > 960px.

| Before | After |
| --- | --- | 
| ![Screenshot 2025-03-04 at 11 56 35 AM](https://github.com/user-attachments/assets/c50426c5-2fe2-46c1-b71e-3a795951228a) |  ![Screenshot 2025-03-04 at 11 56 41 AM](https://github.com/user-attachments/assets/5aefd5dc-3580-4823-9f2f-6fa06de143f3) | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

WP.com polish. See p1740613422976449-slack-CRWCHQGUB.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Head to the Theme Showcase and test a first-party theme and a partner theme, and ensure that the Preview button is shown in the viewport.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?