### PR TITLE
Stats: Chart switcher memoize chart type selection

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -149,10 +149,6 @@ class StatModuleChartTabs extends Component {
 		this.props.recordTracksEvent( CHART_TYPE_EVENTS[ event_from ][ newType ] );
 	};
 
-	getInitialChartType() {
-		return getChartType( this.props.siteId );
-	}
-
 	formatLineChartTimeTick = ( date ) => {
 		// Align the format with the original chart data parser.
 		const timeformat = chartLabelformats[ this.props.selectedPeriod ];

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { localize, translate } from 'i18n-calypso';
-import { flowRight } from 'lodash';
+import { flowRight, memoize } from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { Component, useRef } from 'react';
@@ -35,6 +35,13 @@ const ChartTabShape = PropTypes.shape( {
 } );
 
 const CHART_TYPE_STORAGE_KEY = ( siteId ) => `jetpack_stats_chart_type_${ siteId }`;
+
+const getChartType = memoize( ( siteId ) => {
+	if ( ! siteId ) {
+		return 'bar';
+	}
+	return localStorage.getItem( CHART_TYPE_STORAGE_KEY( siteId ) ) || 'bar';
+} );
 
 // Define chart type change event names
 const CHART_TYPE_EVENTS = {
@@ -78,7 +85,7 @@ class StatModuleChartTabs extends Component {
 	};
 
 	state = {
-		chartType: this.getInitialChartType(),
+		chartType: getChartType( this.props.siteId ),
 	};
 
 	intervalId = null;
@@ -135,6 +142,7 @@ class StatModuleChartTabs extends Component {
 		this.setState( { chartType: newType } );
 		if ( siteId ) {
 			localStorage.setItem( CHART_TYPE_STORAGE_KEY( siteId ), newType );
+			getChartType.cache.clear(); // Clear memoization cache when type changes
 		}
 
 		// Record the chart type change event
@@ -142,12 +150,7 @@ class StatModuleChartTabs extends Component {
 	};
 
 	getInitialChartType() {
-		const { siteId } = this.props;
-		if ( ! siteId ) {
-			return 'bar';
-		}
-		const savedChartType = localStorage.getItem( CHART_TYPE_STORAGE_KEY( siteId ) );
-		return savedChartType || 'bar';
+		return getChartType( this.props.siteId );
 	}
 
 	formatLineChartTimeTick = ( date ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR memoizes the chart type selection
* Follow up from https://github.com/Automattic/wp-calypso/pull/100746

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `http://calypso.localhost:3000/stats/day/your-site.com?flags=stats/chart-library`
* Switch to line chart. 
* Inspect localStorage in the dev tools browser inspector
* Check that it is adding local storage with the naming `jetpack_stats_chart_type_{site_id}` with the value `line` 
* Switch back to bar chart
* Check that the localStorage item is switching back to `bar`
* Go away, close the window, come back - check if your chart selection persists. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
