### PR TITLE
A4A: Update texts for Payout settings for referrals

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-migrations-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-migrations-menu-items.tsx
@@ -51,7 +51,7 @@ const useMigrationsMenuItems = ( path: string ) => {
 					icon: cog,
 					path: A4A_MIGRATIONS_LINK,
 					link: A4A_MIGRATIONS_PAYMENT_SETTINGS,
-					title: translate( 'Payment Settings' ),
+					title: translate( 'Payout Settings' ),
 					trackEventProps: {
 						menu_item: 'Automattic for Agencies / Migrations / Payment Settings',
 					},

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-referrals-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-referrals-menu-items.tsx
@@ -40,7 +40,7 @@ const useReferralsMenuItems = ( path: string ) => {
 					icon: cog,
 					path: A4A_REFERRALS_LINK,
 					link: A4A_REFERRALS_PAYMENT_SETTINGS,
-					title: translate( 'Payment Settings' ),
+					title: translate( 'Payout Settings' ),
 					trackEventProps: {
 						menu_item: 'Automattic for Agencies / Referrals / Payment Settings',
 					},

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-woopayments-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-woopayments-menu-items.tsx
@@ -38,7 +38,7 @@ const useWooPaymentsMenuItems = ( path: string ) => {
 					icon: cog,
 					path: A4A_WOOPAYMENTS_LINK,
 					link: A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK,
-					title: translate( 'Payment Settings' ),
+					title: translate( 'Payout Settings' ),
 					trackEventProps: {
 						menu_item: 'Automattic for Agencies / WooPayments / Payment Settings',
 					},

--- a/client/a8c-for-agencies/sections/migrations/controller.tsx
+++ b/client/a8c-for-agencies/sections/migrations/controller.tsx
@@ -54,7 +54,7 @@ export const migrationsPaymentSettingsContext: Callback = ( context, next ) => {
 	context.primary = (
 		<>
 			<PageViewTracker title="Migrations > Payment Settings" path={ context.path } />
-			<ReferralsBankDetails isAutomatedReferral isMigrations />
+			<ReferralsBankDetails type="migrations" />
 		</>
 	);
 	context.secondary = <MigrationsSidebar path={ context.path } />;

--- a/client/a8c-for-agencies/sections/referrals/controller.tsx
+++ b/client/a8c-for-agencies/sections/referrals/controller.tsx
@@ -20,7 +20,7 @@ export const referralsPaymentSettingsContext: Callback = ( context, next ) => {
 	context.primary = (
 		<>
 			<PageViewTracker title="Referrals > Payment Settings" path={ context.path } />
-			<ReferralsBankDetails isAutomatedReferral />
+			<ReferralsBankDetails />
 		</>
 	);
 	context.secondary = <ReferralsSidebar path={ context.path } />;

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/style.scss
@@ -40,18 +40,22 @@ $iframe-background-color: #f7f7f7;
 	color: var(--color-neutral-60);
 }
 
-.bank-details__layout--automated {
-	.hosting-dashboard-layout__top-wrapper {
-		padding-block-start: 24px;
-		padding-block-end: 0;
-	}
-}
-
 .bank-details__status {
 	@include a4a-font-label-button;
 	color: var(--color-accent-80);
 
 	.badge {
 		margin-inline-start: 6px;
+	}
+}
+
+.referrals-overview__link {
+	color: var(--color-accent-100);
+	text-decoration: underline;
+
+	&:hover,
+	&:visited,
+	&:focus {
+		color: var(--color-accent-100);
 	}
 }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -202,17 +202,6 @@ $data-view-border-color: #f1f1f1;
 	}
 }
 
-.referrals-overview__link {
-	color: var(--color-accent-100);
-	text-decoration: underline;
-
-	&:hover,
-	&:visited,
-	&:focus {
-		color: var(--color-accent-100);
-	}
-}
-
 /* FIXME: This is a temporary fix to make the referral
  * layout columns the same height
  */

--- a/client/a8c-for-agencies/sections/woopayments/controller.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/controller.tsx
@@ -20,7 +20,7 @@ export const woopaymentsPaymentSettingsContext: Callback = ( context, next ) => 
 	context.primary = (
 		<>
 			<PageViewTracker title="WooPayments > Payment Settings" path={ context.path } />
-			<ReferralsBankDetails isAutomatedReferral />
+			<ReferralsBankDetails type="woopayments" />
 		</>
 	);
 	context.secondary = <WooPaymentsSidebar path={ context.path } />;


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1853

## Proposed Changes

This PR:

- Updates the sidebar menu label to Payout Settings on Referrals, Migrations, and WooPayments.
- Refactor the component to render texts based on where it is getting rendered.

Note: The WooPayments work is in progress, so please ignore any issues. We are only updating the texts on this PR.

## Why are these changes being made?

* To avoid the confusion of using `Payment Settings`



## Testing Instructions

* Open the A4A live link
* Go to Referrals > Click the `Payout Settings` menu item and verify it looks good on both large & mobile screens

| Large Screen | Mobile |
|--------|--------|
| <img width="1728" alt="Screenshot 2025-03-04 at 11 25 45 AM" src="https://github.com/user-attachments/assets/b9526ee0-8120-4930-b20b-3c30f5d13afe" /> | <img width="376" alt="Screenshot 2025-03-04 at 11 26 50 AM" src="https://github.com/user-attachments/assets/01aaf283-e51a-44cd-a529-601c04c09b90" /> | 

* Go to Migrations > Click the `Payout Settings` menu item and verify it looks good on both large & mobile screens

| Large Screen | Mobile |
|--------|--------|
| <img width="1728" alt="Screenshot 2025-03-04 at 11 27 27 AM" src="https://github.com/user-attachments/assets/3ebf733c-5333-4a09-a4b4-3f97b264535b" /> | <img width="374" alt="Screenshot 2025-03-04 at 11 30 32 AM" src="https://github.com/user-attachments/assets/fb265725-ddd3-41ec-a13c-b17897d6d187" /> | 

* Go to WooPayments > Click the `Payout Settings` menu item and verify it looks good on both large & mobile screens

| Large Screen | Mobile |
|--------|--------|
| <img width="1728" alt="Screenshot 2025-03-04 at 11 27 47 AM" src="https://github.com/user-attachments/assets/2ff6d991-63ba-4028-a1d6-7f05dc704037" /> | <img width="375" alt="Screenshot 2025-03-04 at 11 28 18 AM" src="https://github.com/user-attachments/assets/89090916-b245-402d-9381-46ffe167fadd" /> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
