### PR TITLE
Clean-up: Remove function isBlogOnboardingFlow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { ProductsList } from '@automattic/data-stores';
-import { START_WRITING_FLOW, isBlogOnboardingFlow } from '@automattic/onboarding';
+import { START_WRITING_FLOW, isStartWritingFlow } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
@@ -47,7 +47,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 	};
 
 	const onSkip = async () => {
-		if ( isBlogOnboardingFlow( flow ) ) {
+		if ( isStartWritingFlow( flow ) ) {
 			setDomain( null );
 			setDomainCartItem( undefined );
 			setHideFreePlan( false );
@@ -136,7 +136,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 	};
 
 	const getFormattedHeader = () => {
-		if ( isBlogOnboardingFlow( flow ) ) {
+		if ( isStartWritingFlow( flow ) ) {
 			return (
 				<FormattedHeader
 					id="choose-a-domain-writer-header"
@@ -161,7 +161,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 			<StepContainer
 				stepName="chooseADomain"
 				shouldHideNavButtons={ false }
-				hideSkip={ isBlogOnboardingFlow( flow ) }
+				hideSkip={ isStartWritingFlow( flow ) }
 				goBack={ goBack }
 				goNext={ goNext }
 				isHorizontalLayout={ false }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -8,7 +8,6 @@ import {
 	isCopySiteFlow,
 	isImportFocusedFlow,
 	isMigrationSignupFlow,
-	isStartWritingFlow,
 	isEntrepreneurFlow,
 	isNewHostedSiteCreationFlow,
 	isNewsletterFlow,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -12,8 +12,8 @@ import {
 	isEntrepreneurFlow,
 	isNewHostedSiteCreationFlow,
 	isNewsletterFlow,
-	isBlogOnboardingFlow,
 	isReadymadeFlow,
+	isStartWritingFlow,
 	isOnboardingFlow,
 } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -130,7 +130,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 		isOnboardingFlow( flow ) ||
 		isCopySiteFlow( flow ) ||
 		isImportFocusedFlow( flow ) ||
-		isBlogOnboardingFlow( flow ) ||
+		isStartWritingFlow( flow ) ||
 		isNewHostedSiteCreationFlow( flow ) ||
 		isReadymadeFlow( flow ) ||
 		wooFlows.includes( flow || '' )

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -6,7 +6,7 @@ import {
 	useLaunchpad,
 } from '@automattic/data-stores';
 import { LaunchpadInternal, type Task } from '@automattic/launchpad';
-import { isBlogOnboardingFlow } from '@automattic/onboarding';
+import { isStartWritingFlow } from '@automattic/onboarding';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSelect } from '@wordpress/data';
 import { useRef, useState } from '@wordpress/element';
@@ -90,7 +90,7 @@ const Sidebar = ( {
 	);
 
 	const showDomain =
-		! isBlogOnboardingFlow( flow ) ||
+		! isStartWritingFlow( flow ) ||
 		( checklistStatuses?.domain_upsell_deferred === true && selectedDomain );
 
 	const isEmailVerified = useSelector( isCurrentUserEmailVerified );
@@ -170,7 +170,7 @@ const Sidebar = ( {
 	const showLaunchTitle = launchTask && ! launchTask.disabled;
 
 	function getDomainUpgradeBadgeUrl() {
-		if ( isBlogOnboardingFlow( siteIntentOption ) ) {
+		if ( isStartWritingFlow( siteIntentOption ) ) {
 			return `/setup/${ siteIntentOption }/domains?siteSlug=${ selectedDomain?.domain_name }&domainAndPlanPackage=true`;
 		}
 		return ! site?.plan?.is_free
@@ -179,7 +179,7 @@ const Sidebar = ( {
 	}
 
 	function showDomainUpgradeBadge() {
-		if ( isBlogOnboardingFlow( siteIntentOption ) ) {
+		if ( isStartWritingFlow( siteIntentOption ) ) {
 			return selectedDomain?.is_free;
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
@@ -1,5 +1,5 @@
 import { Task } from '@automattic/launchpad';
-import { isBlogOnboardingFlow, isReadymadeFlow } from '@automattic/onboarding';
+import { isStartWritingFlow, isReadymadeFlow } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { isDomainUpsellCompleted, getSiteIdOrSlug } from '../../task-helper';
@@ -10,7 +10,7 @@ export const getDomainUpSellTask: TaskAction = ( task, flow, context ): Task => 
 	const domainUpsellCompleted = isDomainUpsellCompleted( site, checklistStatuses );
 
 	const getDestionationUrl = () => {
-		if ( isBlogOnboardingFlow( flow ) || isReadymadeFlow( flow ) ) {
+		if ( isStartWritingFlow( flow ) || isReadymadeFlow( flow ) ) {
 			return addQueryArgs( `/setup/${ flow }/domains`, {
 				...getSiteIdOrSlug( flow, site, siteSlug ),
 				flowToReturnTo: flow,
@@ -33,7 +33,7 @@ export const getDomainUpSellTask: TaskAction = ( task, flow, context ): Task => 
 		completed: domainUpsellCompleted,
 		calypso_path: getDestionationUrl(),
 		badge_text:
-			domainUpsellCompleted || isBlogOnboardingFlow( flow ) ? '' : translate( 'Upgrade plan' ),
+			domainUpsellCompleted || isStartWritingFlow( flow ) ? '' : translate( 'Upgrade plan' ),
 		useCalypsoPath: true,
 	};
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/post/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/post/index.tsx
@@ -1,5 +1,5 @@
 import { Task } from '@automattic/launchpad';
-import { isBlogOnboardingFlow, isNewsletterFlow } from '@automattic/onboarding';
+import { isNewsletterFlow, isStartWritingFlow } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { TaskAction } from '../../types';
 
@@ -11,9 +11,9 @@ export const getFirstPostPublished: TaskAction = ( task, flow, context ): Task =
 		...task,
 		disabled:
 			mustVerifyEmailBeforePosting ||
-			( task.completed && isBlogOnboardingFlow( flow || null ) ) ||
+			( task.completed && isStartWritingFlow( flow || null ) ) ||
 			false,
-		calypso_path: ! isBlogOnboardingFlow( flow || null )
+		calypso_path: ! isStartWritingFlow( flow || null )
 			? task.calypso_path
 			: addQueryArgs( task.calypso_path, {
 					origin: window.location.origin,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/setup/index.tsx
@@ -1,5 +1,5 @@
 import { type Task } from '@automattic/launchpad';
-import { isBlogOnboardingFlow } from '@automattic/onboarding';
+import { isStartWritingFlow } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { getSiteIdOrSlug } from '../../task-helper';
 import { type TaskAction } from '../../types';
@@ -22,7 +22,7 @@ export const getSetupBlogTask: TaskAction = ( task, flow, context ): Task => {
 	return {
 		...task,
 		calypso_path: addQueryArgs( task.calypso_path, { ...getSiteIdOrSlug( flow, site, siteSlug ) } ),
-		disabled: task.completed && ! isBlogOnboardingFlow( flow ),
+		disabled: task.completed && ! isStartWritingFlow( flow ),
 		useCalypsoPath: true,
 	};
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/site/index.tsx
@@ -1,10 +1,6 @@
 import { OnboardActions, SiteActions } from '@automattic/data-stores';
 import { Task } from '@automattic/launchpad';
-import {
-	isBlogOnboardingFlow,
-	isStartWritingFlow,
-	replaceProductsInCart,
-} from '@automattic/onboarding';
+import { isStartWritingFlow, replaceProductsInCart } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -56,7 +52,7 @@ const getOnboardingCartItems = ( context: TaskContext ) => {
 const getLaunchSiteTaskTitle = ( task: Task, flow: string, context: TaskContext ) => {
 	const { tasks } = context;
 	const onboardingCartItems = getOnboardingCartItems( context );
-	const isSupportedFlow = isBlogOnboardingFlow( flow );
+	const isSupportedFlow = isStartWritingFlow( flow );
 	const { planCompleted } = getCompletedInfo( tasks, flow );
 	if ( isSupportedFlow && planCompleted && onboardingCartItems.length ) {
 		return translate( 'Checkout and launch' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -1,5 +1,5 @@
 import { type SiteDetails, type ChecklistStatuses } from '@automattic/data-stores';
-import { isBlogOnboardingFlow, isReadymadeFlow } from '@automattic/onboarding';
+import { isStartWritingFlow, isReadymadeFlow } from '@automattic/onboarding';
 import { launchpadFlowTasks } from './tasks';
 import { LaunchpadChecklist, Task } from './types';
 
@@ -15,7 +15,7 @@ export const getSiteIdOrSlug = (
 	site: SiteDetails | null,
 	siteSlug?: string | null
 ) => {
-	return isBlogOnboardingFlow( flow ) || isReadymadeFlow( flow )
+	return isStartWritingFlow( flow ) || isReadymadeFlow( flow )
 		? { siteId: site?.ID }
 		: { siteSlug };
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
@@ -6,7 +6,7 @@ import {
 	HUNDRED_YEAR_DOMAIN_FLOW,
 	HUNDRED_YEAR_PLAN_FLOW,
 	StepContainer,
-	isBlogOnboardingFlow,
+	isStartWritingFlow,
 	START_WRITING_FLOW,
 	READYMADE_TEMPLATE_FLOW,
 } from '@automattic/onboarding';
@@ -96,7 +96,7 @@ const NewOrExistingSiteStep: Step = function NewOrExistingSiteStep( { navigation
 	};
 
 	const getHeaderText = () => {
-		if ( isBlogOnboardingFlow( flow ) ) {
+		if ( isStartWritingFlow( flow ) ) {
 			return translate( 'New or existing site' );
 		}
 		switch ( flow ) {
@@ -127,7 +127,7 @@ const NewOrExistingSiteStep: Step = function NewOrExistingSiteStep( { navigation
 			stepName="new-or-existing-site"
 			flowName={ flow }
 			recordTracksEvent={ recordTracksEvent }
-			hideBack={ isBlogOnboardingFlow( flow ) }
+			hideBack={ isStartWritingFlow( flow ) }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -1,7 +1,7 @@
 import {
-	isBlogOnboardingFlow,
 	isDomainUpsellFlow,
 	isNewHostedSiteCreationFlow,
+	isStartWritingFlow,
 	StepContainer,
 } from '@automattic/onboarding';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -20,7 +20,7 @@ const plans: Step = function Plans( { navigation, flow } ) {
 			plan,
 		};
 
-		if ( isDomainUpsellFlow( flow ) || isBlogOnboardingFlow( flow ) ) {
+		if ( isDomainUpsellFlow( flow ) || isStartWritingFlow( flow ) ) {
 			providedDependencies.goToCheckout = true;
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -220,7 +220,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		);
 
 		if (
-			isBlogOnboardingFlow( flowName ) ||
+			isStartWritingFlow( flowName ) ||
 			isNewsletterFlow( flowName ) ||
 			isDomainUpsellFlow( flowName )
 		) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -8,7 +8,7 @@ import {
 	NEW_HOSTED_SITE_FLOW,
 	isNewHostedSiteCreationFlow,
 	isDomainUpsellFlow,
-	isBlogOnboardingFlow,
+	isStartWritingFlow,
 } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
@@ -203,7 +203,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			return __( 'Choose your flavor of WordPress' );
 		}
 
-		if ( isNewsletterFlow( flowName ) || isBlogOnboardingFlow( flowName ) ) {
+		if ( isNewsletterFlow( flowName ) || isStartWritingFlow( flowName ) ) {
 			return __( `There's a plan for you.` );
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sites-checker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sites-checker/index.tsx
@@ -1,5 +1,5 @@
 import { SiteDetails } from '@automattic/data-stores';
-import { StepContainer, isBlogOnboardingFlow } from '@automattic/onboarding';
+import { StepContainer, isStartWritingFlow } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
@@ -28,7 +28,7 @@ const SitesChecker: Step = function SitePicker( { navigation, flow } ) {
 
 	useEffect( () => {
 		if ( hasAllSitesFetched ) {
-			const filteredSites = isBlogOnboardingFlow( flow )
+			const filteredSites = isStartWritingFlow( flow )
 				? allSites?.filter(
 						( site: SiteDetails | null | undefined ) => site?.launch_status === 'unlaunched'
 				  )

--- a/client/my-sites/checkout/src/lib/get-flow-plan-features.ts
+++ b/client/my-sites/checkout/src/lib/get-flow-plan-features.ts
@@ -9,7 +9,7 @@ import {
 	NEWSLETTER_FLOW,
 	isAnyHostingFlow,
 	isNewsletterFlow,
-	isBlogOnboardingFlow,
+	isStartWritingFlow,
 } from '@automattic/onboarding';
 import { ResponseCartProduct } from '@automattic/shopping-cart';
 
@@ -22,7 +22,7 @@ const hostingFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
 };
 
 const blogOnboardingFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
-	return isBlogOnboardingFlow( flowName ) && plan.getBlogOnboardingSignupFeatures;
+	return isStartWritingFlow( flowName ) && plan.getBlogOnboardingSignupFeatures;
 };
 
 const senseiFeatures = ( plan: IncompleteWPcomPlan ) => plan.getSenseiFeatures?.( plan.term );
@@ -58,7 +58,7 @@ const newsletterHighlightedFeatures = ( flowName: string, plan: IncompleteWPcomP
 };
 
 const blogOnboardingHighlightedFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
-	return isBlogOnboardingFlow( flowName ) && plan.getBlogOnboardingHighlightedFeatures;
+	return isStartWritingFlow( flowName ) && plan.getBlogOnboardingHighlightedFeatures;
 };
 
 const senseiHighlightedFeatures = ( plan: IncompleteWPcomPlan ) =>

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -111,10 +111,6 @@ export const isStartWritingFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ START_WRITING_FLOW ].includes( flowName ) );
 };
 
-export const isBlogOnboardingFlow = ( flowName: string | null ) => {
-	return Boolean( flowName && [ START_WRITING_FLOW ].includes( flowName ) );
-};
-
 export const isOnboardingFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ ONBOARDING_FLOW ].includes( flowName ) );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10553

## Proposed Changes

As a follow-up of https://github.com/Automattic/dotcom-forge/issues/10553, now the helper functions `isStartWritingFlow` and `isBlogOnboardingFlow` are the same. This PR removes the latter since it's redundant.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Clean-up.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Smoke test general onboarding.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
