### PR TITLE
A4A > WooPayments: Implement site actions

### DIFF
--- a/client/a8c-for-agencies/components/list-item-cards/index.tsx
+++ b/client/a8c-for-agencies/components/list-item-cards/index.tsx
@@ -1,4 +1,17 @@
+import { Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { useCallback, useRef, useState, type ReactNode } from 'react';
+import PopoverMenu from 'calypso/components/popover-menu';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+
 import './style.scss';
+
+export interface Action {
+	id: string;
+	label: string;
+	icon: ReactNode;
+	callback: ( items: any[] ) => void;
+}
 
 export function ListItemCardContent( {
 	title,
@@ -13,6 +26,44 @@ export function ListItemCardContent( {
 				<div className="list-item-card-content__header-title">{ title.toUpperCase() }</div>
 			</div>
 			{ children }
+		</div>
+	);
+}
+
+export function ListItemCardActions( { actions, item }: { actions: Action[]; item: any } ) {
+	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	const showActions = useCallback( () => {
+		setIsOpen( true );
+	}, [] );
+
+	const closeDropdown = useCallback( () => {
+		setIsOpen( false );
+	}, [] );
+
+	return (
+		<div className="list-item-card-actions">
+			<Button onClick={ showActions } ref={ buttonActionRef }>
+				<Gridicon icon="ellipsis" size={ 18 } />
+			</Button>
+			<PopoverMenu
+				context={ buttonActionRef.current }
+				isVisible={ isOpen }
+				onClose={ closeDropdown }
+				position="bottom left"
+			>
+				{ actions.map( ( action ) => (
+					<PopoverMenuItem
+						key={ action.id }
+						onClick={ () => {
+							action.callback( [ item ] );
+						} }
+					>
+						{ action.label }
+					</PopoverMenuItem>
+				) ) }
+			</PopoverMenu>
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/components/list-item-cards/style.scss
+++ b/client/a8c-for-agencies/components/list-item-cards/style.scss
@@ -28,4 +28,7 @@
 	}
 }
 
-
+.list-item-card-actions {
+	display: flex;
+	justify-content: flex-end;
+}

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/mobile-view.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/mobile-view.tsx
@@ -3,6 +3,8 @@ import {
 	ListItemCards,
 	ListItemCard,
 	ListItemCardContent,
+	ListItemCardActions,
+	type Action,
 } from 'calypso/a8c-for-agencies/components/list-item-cards';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import { useWooPaymentsContext } from '../context';
@@ -17,8 +19,10 @@ import type { SitesWithWooPaymentsState } from '../types';
 
 export default function SitesWithWooPaymentsMobileView( {
 	items,
+	actions,
 }: {
 	items: SitesWithWooPaymentsState[];
+	actions: Action[];
 } ) {
 	const translate = useTranslate();
 	const { woopaymentsData, isLoadingWooPaymentsData } = useWooPaymentsContext();
@@ -28,6 +32,7 @@ export default function SitesWithWooPaymentsMobileView( {
 			<ListItemCards>
 				{ items.map( ( item ) => (
 					<ListItemCard key={ item.blogId }>
+						<ListItemCardActions actions={ actions } item={ item } />
 						<ListItemCardContent title={ translate( 'Site' ) }>
 							<div className="sites-with-woopayments-list-mobile-view__column">
 								<SiteColumn site={ item.siteUrl } />


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1871

## Proposed Changes

This PR implements actions for sites with WooPayments 

## Why are these changes being made?

* To add actions to sites with WooPayments

## Testing Instructions

* Open the A4A live link
* Go to WooPayments: Dashboard > Verify that you can see the `...` icon > Click the icon and verify you can see the action `Visit WP-Admin` > Click the `Visit WP-Admin` option and verify you are redirected to `/wp-admin/admin.php?page=wc-admin&path=/payments/connect` if the plugin state is "active" and to `/wp-admin/plugin-install.php?s=woopayments&tab=search&type=term` if not. Also, verify the same on mobile view

active: When the License is purchased from A4A and the WooPayments plugin is activated
other states: When the License is purchased from A4A and the WooPayments plugin is not activated

<img width="1728" alt="Screenshot 2025-03-04 at 12 22 48 PM" src="https://github.com/user-attachments/assets/f0b05a2b-a3f7-4d31-aeef-dc20c70aa94a" />

<img width="374" alt="Screenshot 2025-03-04 at 12 21 43 PM" src="https://github.com/user-attachments/assets/92e2de92-9529-463f-976f-88e7067d68da" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
