### PR TITLE
Stats: Use a valid date time string for the date object parse

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -153,7 +153,8 @@ class StatModuleChartTabs extends Component {
 		// Align the format with the original chart data parser.
 		const timeformat = chartLabelformats[ this.props.selectedPeriod ];
 
-		return moment.utc( date ).format( timeformat );
+		// Use browser's timezone offset to display the correct datetime.
+		return moment( date ).format( timeformat );
 	};
 
 	render() {

--- a/client/my-sites/stats/stats-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-chart-tabs/utility.js
@@ -96,7 +96,7 @@ export const buildChartData = memoizeLast(
 
 // data validation for line chart
 export const transformChartDataToLineFormat = memoizeLast(
-	( chartData, activeLegend = [], activeTab, primaryColor, secondaryColor, gmtOffset = 0 ) => {
+	( chartData, activeLegend = [], activeTab, primaryColor, secondaryColor ) => {
 		if ( ! Array.isArray( chartData ) || chartData.length === 0 ) {
 			return [];
 		}
@@ -105,7 +105,7 @@ export const transformChartDataToLineFormat = memoizeLast(
 
 		const mainSeries = chartData
 			.map( ( record ) => {
-				const date = parseLocalDate( record.data.period, gmtOffset );
+				const date = parseLocalDate( record.data.period );
 				const value = record.data[ activeTab.attr ];
 				if ( isNaN( date.getTime() ) || typeof value !== 'number' ) {
 					return null;
@@ -129,7 +129,7 @@ export const transformChartDataToLineFormat = memoizeLast(
 		if ( activeLegend.length > 0 ) {
 			const secondarySeries = chartData
 				.map( ( record ) => {
-					const date = parseLocalDate( record.data.period, gmtOffset );
+					const date = parseLocalDate( record.data.period );
 					const value = record.data.visitors;
 					if ( isNaN( date.getTime() ) || typeof value !== 'number' ) {
 						return null;

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -8,7 +8,6 @@ import AsyncLoad from 'calypso/components/async-load';
 import UplotChart from 'calypso/components/chart-uplot';
 import useSubscribersQuery from 'calypso/my-sites/stats/hooks/use-subscribers-query';
 import { useSelector } from 'calypso/state';
-import { getSiteOption } from 'calypso/state/sites/selectors';
 import useCssVariable from '../hooks/use-css-variable';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsPeriodHeader from '../stats-period-header';
@@ -76,13 +75,12 @@ type ChartDataPoint = {
 
 const transformLineChartData = (
 	data: SubscribersData[],
-	hasAddedPaidSubscriptionProduct: boolean,
-	gmtOffset: number = 0
+	hasAddedPaidSubscriptionProduct: boolean
 ): ChartDataPoint[][] => {
 	const subscribersData: ChartDataPoint[] = [];
 	const paidSubscribersData: ChartDataPoint[] = [];
 	data?.map( ( point ) => {
-		const dateObj = parseLocalDate( point.period, gmtOffset );
+		const dateObj = parseLocalDate( point.period );
 		if ( isNaN( dateObj.getTime() ) ) {
 			return null;
 		}
@@ -125,7 +123,6 @@ export default function SubscribersChartSection( {
 	const [ errorMessage, setErrorMessage ] = useState( '' );
 	const legendRef = useRef< HTMLDivElement >( null );
 	const translate = useTranslate();
-	const gmtOffset = useSelector( ( state ) => getSiteOption( state, siteId, 'gmt_offset' ) );
 
 	const formatTimeTick = useCallback(
 		( timestamp: number ) => {
@@ -198,12 +195,7 @@ export default function SubscribersChartSection( {
 		[ data?.data, hasAddedPaidSubscriptionProduct ]
 	);
 	const [ subscribersData, paidSubscribersData ] = useMemo(
-		() =>
-			transformLineChartData(
-				data?.data || [],
-				hasAddedPaidSubscriptionProduct,
-				gmtOffset as number
-			),
+		() => transformLineChartData( data?.data || [], hasAddedPaidSubscriptionProduct ),
 		[ data?.data, hasAddedPaidSubscriptionProduct ]
 	);
 

--- a/client/my-sites/stats/utils.js
+++ b/client/my-sites/stats/utils.js
@@ -63,14 +63,21 @@ export const appendQueryStringForRedirection = ( pathname, query = {} ) => {
 
 /**
  * Parse a date string into a Date object
- *
  * @param {string|number} dateString YYYY-MM-DD format or a timestamp
  * @param {number} gmtOffset GMT offset in minutes
  * @returns
  */
 export const parseLocalDate = ( dateString, gmtOffset = 0 ) => {
+	let validDateString = dateString;
+
+	const dateStringSplits = dateString.split( ' ' );
+	// For date strings like '2025-01-01 01:00:00'.
+	if ( dateStringSplits.length === 2 ) {
+		validDateString = `${ dateStringSplits[ 0 ] }T${ dateStringSplits[ 1 ] }Z`;
+	}
+
 	// Compatible with Date object.
-	const date = new Date( dateString );
+	const date = new Date( validDateString );
 	if ( isNaN( date.getTime() ) ) {
 		return date;
 	}

--- a/client/my-sites/stats/utils.js
+++ b/client/my-sites/stats/utils.js
@@ -62,18 +62,21 @@ export const appendQueryStringForRedirection = ( pathname, query = {} ) => {
 };
 
 /**
- * Parse a date string into a Date object
+ * Parse a date string into a Date object in the timezone of browser.
+ *
  * @param {string|number} dateString YYYY-MM-DD format or a timestamp
- * @param {number} gmtOffset GMT offset in minutes
- * @returns
+ *
+ * @returns {Date} A Date object in the timezone of the browser.
  */
-export const parseLocalDate = ( dateString, gmtOffset = 0 ) => {
+export const parseLocalDate = ( dateString ) => {
 	let validDateString = dateString;
 
 	const dateStringSplits = dateString.split( ' ' );
 	// For date strings like '2025-01-01 01:00:00'.
 	if ( dateStringSplits.length === 2 ) {
 		validDateString = `${ dateStringSplits[ 0 ] }T${ dateStringSplits[ 1 ] }Z`;
+	} else if ( dateStringSplits.length === 1 ) {
+		validDateString = `${ dateStringSplits[ 0 ] }T00:00:00Z`;
 	}
 
 	// Compatible with Date object.
@@ -82,6 +85,8 @@ export const parseLocalDate = ( dateString, gmtOffset = 0 ) => {
 		return date;
 	}
 
-	date.setMinutes( date.getMinutes() - ( gmtOffset - date.getTimezoneOffset() ) );
+	// Adjust the date to the timezone of the browser.
+	date.setMinutes( date.getMinutes() + date.getTimezoneOffset() );
+
 	return date;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1741072714273439-slack-C82FZ5T4G

## Proposed Changes
* Update hourly date string format to `yyyy-mm-ddThh:mm:ssZ` for `Date` object parsing.
* Use browser's timezone for displaying X-axis labels.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The date string with format `yyyy-mm-dd hh:mm:ss` could not be parsed correctly by the `Date` object.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page for a site of `gmtOffset` not `0` with the feature flag: `flags=stats/chart-library`.
* Toggle the line chart type for the Traffic chart.
* Ensure the daily data series are aligned with X-axis labels.

<img width="1268" alt="截圖 2025-03-04 下午5 11 59" src="https://github.com/user-attachments/assets/d6996dc0-a91d-46d0-bf14-d23050f61c22" />

* Ensure the hourly data series start from `00:00` correctly.

<img width="1300" alt="截圖 2025-03-04 下午5 12 11" src="https://github.com/user-attachments/assets/30935d02-5252-4f8d-a878-efb5c540b7a1" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?