### PR TITLE
Staging Sites: Fix staging site address external link icon alignment

### DIFF
--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -80,12 +80,6 @@ const ActionButtons = styled.div( {
 	},
 } );
 
-const ExternalIcon = styled( Icon )( {
-	verticalAlign: 'middle',
-	marginLeft: 4,
-	marginBottom: 2,
-} );
-
 type CardContentProps = {
 	stagingSite: StagingSite;
 	siteId: number;
@@ -167,7 +161,7 @@ export const ManageStagingSiteCardContent = ( {
 							>
 								<span>
 									{ stagingSite.url }
-									<ExternalIcon icon={ external } size={ 16 } />
+									<Icon icon={ external } size={ 16 } />
 								</span>
 							</WPButton>
 						</SiteInfo>

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -80,6 +80,11 @@ const ActionButtons = styled.div( {
 	},
 } );
 
+const ExternalIcon = styled( Icon )( {
+	verticalAlign: 'middle',
+	marginLeft: 4,
+} );
+
 type CardContentProps = {
 	stagingSite: StagingSite;
 	siteId: number;
@@ -161,7 +166,7 @@ export const ManageStagingSiteCardContent = ( {
 							>
 								<span>
 									{ stagingSite.url }
-									<Icon icon={ external } size={ 16 } />
+									<ExternalIcon icon={ external } size={ 16 } />
 								</span>
 							</WPButton>
 						</SiteInfo>

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -83,6 +83,7 @@ const ActionButtons = styled.div( {
 const ExternalIcon = styled( Icon )( {
 	verticalAlign: 'middle',
 	marginLeft: 4,
+	marginBottom: 2,
 } );
 
 type CardContentProps = {

--- a/client/sites/tools/staging-site/components/staging-site-card/index.js
+++ b/client/sites/tools/staging-site/components/staging-site-card/index.js
@@ -39,6 +39,7 @@ import { NewStagingSiteCardContent } from './card-content/new-staging-site-card-
 import { StagingSiteLoadingBarCardContent } from './card-content/staging-site-loading-bar-card-content';
 import { StagingSiteLoadingErrorCardContent } from './card-content/staging-site-loading-error-card-content';
 import { LoadingPlaceholder } from './loading-placeholder';
+import './style.scss';
 const stagingSiteAddSuccessNoticeId = 'staging-site-add-success';
 const stagingSiteAddFailureNoticeId = 'staging-site-add-failure';
 const stagingSiteDeleteSuccessNoticeId = 'staging-site-remove-success';

--- a/client/sites/tools/staging-site/components/staging-site-card/style.scss
+++ b/client/sites/tools/staging-site/components/staging-site-card/style.scss
@@ -1,0 +1,14 @@
+.tools-staging-site__site-url {
+	word-wrap: break-word;
+	text-decoration: none;
+
+	&.is-link {
+		text-decoration: none;
+	}
+
+	svg {
+		vertical-align: middle;
+		margin-left: 4px;
+		margin-bottom: 2px;
+	}
+}

--- a/client/sites/tools/staging-site/components/staging-site-card/style.scss
+++ b/client/sites/tools/staging-site/components/staging-site-card/style.scss
@@ -1,10 +1,6 @@
-.tools-staging-site__site-url {
+.tools-staging-site__site-url.is-link {
 	word-wrap: break-word;
 	text-decoration: none;
-
-	&.is-link {
-		text-decoration: none;
-	}
 
 	svg {
 		vertical-align: middle;

--- a/client/sites/tools/staging-site/style.scss
+++ b/client/sites/tools/staging-site/style.scss
@@ -1,18 +1,6 @@
 .tools-staging-site {
 	display: flex;
-    flex-direction: column;
+	flex-direction: column;
 	align-items: flex-start;
-    gap: 16px;
-}
-
-.tools-staging-site__site-url {
-    word-wrap: break-word;
-
-    &.is-link {
-        text-decoration: none;
-    }
-
-    svg {
-        vertical-align: middle;
-    }
+	gap: 16px;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/99326.

## Proposed Changes

* fix external link icon styling

| Before | After |
|--------|--------|
| ![Markup on 2025-03-04 at 10:52:37](https://github.com/user-attachments/assets/b9fc206b-c85d-4c04-8c34-b70cb5e60ed2) | ![Markup on 2025-03-04 at 10:51:42](https://github.com/user-attachments/assets/ecd3ebf2-5ee3-4699-af79-f2dde48a3d78) | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

These changes are made to fix the https://github.com/Automattic/wp-calypso/issues/99326 issue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start`.
2. Head over to `http://calypso.localhost:3000/staging-site/{atomic-site-slug}` on an existing Atomic site and create a new staging site (if the site doesn't have any yet).
3. Review the external link icon. It should be formatted correctly. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
