### PR TITLE
Hosting logs: dispatch notice upon clicking copy action for WebServer logs

### DIFF
--- a/client/sites/tools/logs/hooks/use-actions.tsx
+++ b/client/sites/tools/logs/hooks/use-actions.tsx
@@ -64,9 +64,24 @@ const useActions = ( { logType, isLoading }: { logType: LogType; isLoading: bool
 				isPrimary: true,
 				disabled: isLoading,
 				supportsBulk: false,
-				callback: ( items: ( PHPLog | ServerLog )[] ) => {
+				callback: async ( items: ( PHPLog | ServerLog )[] ) => {
 					const url = ( items[ 0 ] as ServerLog ).request_url;
-					navigator.clipboard.writeText( url );
+					try {
+						await navigator.clipboard.writeText( url );
+						dispatch(
+							successNotice(
+								/* translators: notice shown upon copy of request URL */
+								translate( 'Copied' )
+							)
+						);
+					} catch ( error ) {
+						dispatch(
+							errorNotice(
+								/* translators: notice shown upon failed copy of request URL */
+								translate( 'Copy failed' )
+							)
+						);
+					}
 				},
 			},
 			{


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/99056

## What

Dispatches a "Copied" notice upon trigger the copy action for the "Web Server" logs. It follows suit on what we do for the "PHP" logs copy action.

## Testing Instructions

- Go to the Hosting Logs screnn.
- Switch to Web Server logs.
- Click on the copy action.
- Verify that the proper text is copied (paste somewhere) and that a noticed is dispatched in the top-right corner:

<img width="313" alt="Screenshot 2025-03-04 at 11 32 26" src="https://github.com/user-attachments/assets/11403ebd-8498-4810-b629-bded3a072787" />

