### PR TITLE
Fix styling of external icon displayed by the staging site address

### DIFF
--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -80,6 +80,11 @@ const ActionButtons = styled.div( {
 	},
 } );
 
+const ExternalIcon = styled( Icon )( {
+	verticalAlign: 'middle',
+	marginLeft: 4,
+} );
+
 type CardContentProps = {
 	stagingSite: StagingSite;
 	siteId: number;
@@ -161,7 +166,7 @@ export const ManageStagingSiteCardContent = ( {
 							>
 								<span>
 									{ stagingSite.url }
-									<Icon icon={ external } size={ 16 } />
+									<ExternalIcon icon={ external } size={ 16 } />
 								</span>
 							</WPButton>
 						</SiteInfo>

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -83,6 +83,7 @@ const ActionButtons = styled.div( {
 const ExternalIcon = styled( Icon )( {
 	verticalAlign: 'middle',
 	marginLeft: 4,
+	marginBottom: 2,
 } );
 
 type CardContentProps = {

--- a/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/sites/tools/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -80,12 +80,6 @@ const ActionButtons = styled.div( {
 	},
 } );
 
-const ExternalIcon = styled( Icon )( {
-	verticalAlign: 'middle',
-	marginLeft: 4,
-	marginBottom: 2,
-} );
-
 type CardContentProps = {
 	stagingSite: StagingSite;
 	siteId: number;
@@ -165,10 +159,8 @@ export const ManageStagingSiteCardContent = ( {
 								target="_blank"
 								className="tools-staging-site__site-url"
 							>
-								<span>
-									{ stagingSite.url }
-									<ExternalIcon icon={ external } size={ 16 } />
-								</span>
+								{ stagingSite.url }
+								<Icon icon={ external } size={ 16 } />
 							</WPButton>
 						</SiteInfo>
 					</SiteRow>

--- a/client/sites/tools/staging-site/components/staging-site-card/index.js
+++ b/client/sites/tools/staging-site/components/staging-site-card/index.js
@@ -39,6 +39,9 @@ import { NewStagingSiteCardContent } from './card-content/new-staging-site-card-
 import { StagingSiteLoadingBarCardContent } from './card-content/staging-site-loading-bar-card-content';
 import { StagingSiteLoadingErrorCardContent } from './card-content/staging-site-loading-error-card-content';
 import { LoadingPlaceholder } from './loading-placeholder';
+
+import './style.scss';
+
 const stagingSiteAddSuccessNoticeId = 'staging-site-add-success';
 const stagingSiteAddFailureNoticeId = 'staging-site-add-failure';
 const stagingSiteDeleteSuccessNoticeId = 'staging-site-remove-success';

--- a/client/sites/tools/staging-site/components/staging-site-card/style.scss
+++ b/client/sites/tools/staging-site/components/staging-site-card/style.scss
@@ -1,0 +1,9 @@
+.tools-staging-site__site-url {
+	word-wrap: break-word;
+	text-decoration: none;
+
+	svg {
+		margin-left: 4px;
+	}
+}
+

--- a/client/sites/tools/staging-site/components/staging-site-card/style.scss
+++ b/client/sites/tools/staging-site/components/staging-site-card/style.scss
@@ -1,9 +1,9 @@
-.tools-staging-site__site-url {
+.tools-staging-site__site-url.is-link {
 	word-wrap: break-word;
 	text-decoration: none;
 
 	svg {
-		margin-left: 4px;
+		margin-left: 3px;
 	}
 }
 

--- a/client/sites/tools/staging-site/components/staging-site-card/style.scss
+++ b/client/sites/tools/staging-site/components/staging-site-card/style.scss
@@ -1,9 +1,10 @@
 .tools-staging-site__site-url.is-link {
 	word-wrap: break-word;
 	text-decoration: none;
+	display: inline-block;
 
 	svg {
-		margin-left: 3px;
+		margin: 0 0 -3px 3px;
 	}
 }
 

--- a/client/sites/tools/staging-site/style.scss
+++ b/client/sites/tools/staging-site/style.scss
@@ -4,15 +4,3 @@
 	align-items: flex-start;
     gap: 16px;
 }
-
-.tools-staging-site__site-url {
-    word-wrap: break-word;
-
-    &.is-link {
-        text-decoration: none;
-    }
-
-    svg {
-        vertical-align: middle;
-    }
-}


### PR DESCRIPTION
Related to #

## Proposed Changes
We don't need extra styles for vertical aligning, since Button by default has it, so we need just to remove useless wrapper.
Also, we already have custom styles for this component, but they are not used. I took a look a bit and maybe they are not used due to having `.js` extension for the imported file or maybe some tree-shaking removed it (also, due to .js file in the middle), but anyway it's not critical to understand the right reason for the issue, since anyway it's more appropriate to keep this CSS as close as possible to the actual component where it's used, instead of the global scss for all components, so I jut moved it close to the actual component and everything works.

Off topic thing: @matt-west AFAIR, about a month ago, I saw some of your "Staging Sites tab" walkthrough and you mentioned that this link should be w/o underline, is it right or it's my hallucinations? 😅 If my memory work well, then I will address it here :) 

<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="933" alt="Screenshot 2025-03-04 at 12 47 40" src="https://github.com/user-attachments/assets/cbafbeed-c5b4-4b88-b263-1b412725d186" />
<td><img width="1004" alt="Screenshot 2025-03-04 at 12 49 56" src="https://github.com/user-attachments/assets/5d37e0c1-35a6-48b5-a33c-857c98e9590c" />
</tr>
</table>