### PR TITLE
fix(deps): update `@types/webpack-env` to `^1.18.8`

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
 		"@types/store": "^2.0.2",
 		"@types/uuid": "^9.0.7",
 		"@types/validator": "^13.7.1",
-		"@types/webpack-env": "^1.18.5",
+		"@types/webpack-env": "^1.18.8",
 		"@types/wordpress__block-editor": "^11.5.8",
 		"@wordpress/base-styles": "^5.19.0",
 		"@wordpress/block-editor": "^14.14.0",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -39,7 +39,7 @@
 		"@automattic/webpack-rtl-plugin": "workspace:^",
 		"@babel/compat-data": "^7.26.3",
 		"@babel/core": "^7.26.0",
-		"@types/webpack-env": "^1.18.5",
+		"@types/webpack-env": "^1.18.8",
 		"@wordpress/browserslist-config": "^6.19.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "^6.14.0",
 		"autoprefixer": "^10.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -281,7 +281,7 @@ __metadata:
     "@automattic/webpack-rtl-plugin": "workspace:^"
     "@babel/compat-data": "npm:^7.26.3"
     "@babel/core": "npm:^7.26.0"
-    "@types/webpack-env": "npm:^1.18.5"
+    "@types/webpack-env": "npm:^1.18.8"
     "@wordpress/browserslist-config": "npm:^6.19.0"
     "@wordpress/dependency-extraction-webpack-plugin": "npm:^6.14.0"
     autoprefixer: "npm:^10.2.5"
@@ -9227,10 +9227,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/webpack-env@npm:^1.18.5":
-  version: 1.18.5
-  resolution: "@types/webpack-env@npm:1.18.5"
-  checksum: b9e4876e8c7cae419896249f9ed795db283c008fe1d38efa679cbbf05194fc2eea2a5bfb4ff4393d109e3a9895416dadf5f3ddd5c22931b678062230f860454e
+"@types/webpack-env@npm:^1.18.8":
+  version: 1.18.8
+  resolution: "@types/webpack-env@npm:1.18.8"
+  checksum: 527a5d1eb75c5243e4f3665d956c7c340f899955dd25d16c9fd9750406f32e95a3a17d207640295038e8235c0c2a2daf084f420e088e58b965d82fc74f6012d7
   languageName: node
   linkType: hard
 
@@ -35913,7 +35913,7 @@ __metadata:
     "@types/superagent": "npm:^4.1.24"
     "@types/uuid": "npm:^9.0.7"
     "@types/validator": "npm:^13.7.1"
-    "@types/webpack-env": "npm:^1.18.5"
+    "@types/webpack-env": "npm:^1.18.8"
     "@types/wordpress__block-editor": "npm:^11.5.8"
     "@types/wordpress__blocks": "npm:^12.5.14"
     "@typescript-eslint/eslint-plugin": "npm:^6.21.0"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Extracted from https://github.com/Automattic/wp-calypso/pull/100185

The original PR build was failing without a clear error, so splitting into smaller ones hoping to be able to discern what's failing.

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
