### PR TITLE
fix(deps): update `webpack` to `^5.98.0`

### DIFF
--- a/apps/blaze-dashboard/package.json
+++ b/apps/blaze-dashboard/package.json
@@ -67,7 +67,7 @@
 		"node-fetch": "^2.7.0",
 		"path-browserify": "^1.0.1",
 		"postcss": "^8.5.1",
-		"webpack": "^5.97.1",
+		"webpack": "^5.98.0",
 		"webpack-bundle-analyzer": "^4.10.2"
 	}
 }

--- a/apps/command-palette-wp-admin/package.json
+++ b/apps/command-palette-wp-admin/package.json
@@ -50,7 +50,7 @@
 		"node-fetch": "^2.7.0",
 		"npm-run-all": "^4.1.5",
 		"postcss": "^8.5.1",
-		"webpack": "^5.97.1",
+		"webpack": "^5.98.0",
 		"webpack-bundle-analyzer": "^4.10.2"
 	}
 }

--- a/apps/happy-blocks/package.json
+++ b/apps/happy-blocks/package.json
@@ -56,6 +56,6 @@
 		"copy-webpack-plugin": "^10.2.4",
 		"glob": "^7.1.6",
 		"postcss": "^8.5.1",
-		"webpack": "^5.97.1"
+		"webpack": "^5.98.0"
 	}
 }

--- a/apps/help-center/package.json
+++ b/apps/help-center/package.json
@@ -53,7 +53,7 @@
 		"@wordpress/readable-js-assets-webpack-plugin": "3.14.0",
 		"copy-webpack-plugin": "^10.2.4",
 		"typescript": "^5.3.3",
-		"webpack": "^5.97.1"
+		"webpack": "^5.98.0"
 	},
 	"peerDependencies": {
 		"@automattic/calypso-router": "workspace:^",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -56,6 +56,6 @@
 		"html-webpack-plugin": "^5.6.3",
 		"postcss": "^8.5.1",
 		"postcss-custom-properties": "^11.0.0",
-		"webpack": "^5.97.1"
+		"webpack": "^5.98.0"
 	}
 }

--- a/apps/o2-blocks/package.json
+++ b/apps/o2-blocks/package.json
@@ -49,6 +49,6 @@
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@wordpress/readable-js-assets-webpack-plugin": "^3.14.0",
 		"postcss": "^8.5.1",
-		"webpack": "^5.97.1"
+		"webpack": "^5.98.0"
 	}
 }

--- a/apps/odyssey-stats/package.json
+++ b/apps/odyssey-stats/package.json
@@ -74,7 +74,7 @@
 		"path-browserify": "^1.0.1",
 		"postcss": "^8.5.1",
 		"size-limit": "^8.2.6",
-		"webpack": "^5.97.1",
+		"webpack": "^5.98.0",
 		"webpack-bundle-analyzer": "^4.10.2"
 	}
 }

--- a/apps/whats-new/package.json
+++ b/apps/whats-new/package.json
@@ -53,7 +53,7 @@
 		"node-fetch": "^2.7.0",
 		"npm-run-all": "^4.1.5",
 		"postcss": "^8.5.1",
-		"webpack": "^5.97.1",
+		"webpack": "^5.98.0",
 		"webpack-bundle-analyzer": "^4.10.2"
 	}
 }

--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -60,7 +60,7 @@
 		"@wordpress/dependency-extraction-webpack-plugin": "^6.14.0",
 		"npm-run-all": "^4.1.5",
 		"postcss": "^8.5.1",
-		"webpack": "^5.97.1",
+		"webpack": "^5.98.0",
 		"webpack-bundle-analyzer": "^4.10.2"
 	}
 }

--- a/client/package.json
+++ b/client/package.json
@@ -215,7 +215,7 @@
 		"utility-types": "^3.10.0",
 		"uuid": "^9.0.1",
 		"valid-url": "^1.0.9",
-		"webpack": "^5.97.1",
+		"webpack": "^5.98.0",
 		"webpack-bundle-analyzer": "^4.10.2",
 		"webpack-dev-middleware": "^5.3.4",
 		"webpack-hot-middleware": "^2.26.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -48,7 +48,7 @@
 		"postcss": "^8.5.1",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"webpack": "^5.97.1",
+		"webpack": "^5.98.0",
 		"webpack-cli": "^4.10.0"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -313,7 +313,7 @@
 		"stylelint": "^16.13.2",
 		"tslib": "^2.3.0",
 		"typescript": "^5.3.3",
-		"webpack": "^5.97.1",
+		"webpack": "^5.98.0",
 		"webpack-bundle-analyzer": "^4.10.2",
 		"webpack-cli": "^4.10.0",
 		"webpack-dev-middleware": "^5.3.4",

--- a/packages/calypso-apps-builder/package.json
+++ b/packages/calypso-apps-builder/package.json
@@ -19,7 +19,7 @@
 		"html-webpack-plugin": "^5.6.3",
 		"npm-run-all": "^4.1.5",
 		"tree-kill": "^1.2.2",
-		"webpack": "^5.97.1",
+		"webpack": "^5.98.0",
 		"yargs": "^17.0.1"
 	},
 	"devDependencies": {

--- a/packages/calypso-storybook/package.json
+++ b/packages/calypso-storybook/package.json
@@ -37,7 +37,7 @@
 		"react-dom": "^18.3.1",
 		"sass-loader": "^13.1.0",
 		"style-loader": "^1.3.0",
-		"webpack": "^5.97.1"
+		"webpack": "^5.98.0"
 	},
 	"peerDependencies": {
 		"@storybook/react": "^7.6.20"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -83,7 +83,7 @@
 		"postcss": "^8.5.1",
 		"resize-observer-polyfill": "^1.5.1",
 		"typescript": "^5.3.3",
-		"webpack": "^5.97.1"
+		"webpack": "^5.98.0"
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",

--- a/packages/design-picker/package.json
+++ b/packages/design-picker/package.json
@@ -58,7 +58,7 @@
 		"react-dom": "^18.3.1",
 		"redux": "^5.0.1",
 		"typescript": "^5.3.3",
-		"webpack": "^5.97.1"
+		"webpack": "^5.98.0"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/domains-table/package.json
+++ b/packages/domains-table/package.json
@@ -55,7 +55,7 @@
 		"react-dom": "^18.3.1",
 		"resize-observer-polyfill": "^1.5.1",
 		"typescript": "^5.3.3",
-		"webpack": "^5.97.1"
+		"webpack": "^5.98.0"
 	},
 	"peerDependencies": {
 		"@automattic/calypso-router": "workspace:^",

--- a/packages/fingerprintjs/package.json
+++ b/packages/fingerprintjs/package.json
@@ -86,7 +86,7 @@
 		"ts-node": "^10.9.1",
 		"typescript": "^5.3.3",
 		"ua-parser-js": "^0.7.32",
-		"webpack": "^5.97.1",
+		"webpack": "^5.98.0",
 		"webpack-cli": "^5.1.4",
 		"webpack-dev-server": "^4.15.2"
 	}

--- a/packages/jetpack-ai-calypso/package.json
+++ b/packages/jetpack-ai-calypso/package.json
@@ -52,7 +52,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"typescript": "^5.3.3",
-		"webpack": "^5.97.1"
+		"webpack": "^5.98.0"
 	},
 	"peerDependencies": {
 		"@babel/runtime": "^7.26.9",

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -40,6 +40,6 @@
 		"react-dom": "^18.3.1",
 		"redux": "^5.0.1",
 		"typescript": "^5.3.3",
-		"webpack": "^5.97.1"
+		"webpack": "^5.98.0"
 	}
 }

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -61,7 +61,7 @@
 		"react-dom": "^18.3.1",
 		"redux": "^5.0.1",
 		"typescript": "^5.3.3",
-		"webpack": "^5.97.1"
+		"webpack": "^5.98.0"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -56,7 +56,7 @@
 		"sass-loader": "^13.1.0",
 		"style-loader": "^1.3.0",
 		"typescript": "^5.3.3",
-		"webpack": "^5.97.1"
+		"webpack": "^5.98.0"
 	},
 	"peerDependencies": {
 		"@wordpress/i18n": "^5.19.0",

--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -75,7 +75,7 @@
 		"msw-storybook-addon": "^2.0.2",
 		"resize-observer-polyfill": "^1.5.1",
 		"typescript": "^5.3.3",
-		"webpack": "^5.97.1"
+		"webpack": "^5.98.0"
 	},
 	"msw": {
 		"workerDirectory": "static"

--- a/packages/privacy-toolset/package.json
+++ b/packages/privacy-toolset/package.json
@@ -53,6 +53,6 @@
 		"postcss": "^8.5.1",
 		"require-from-string": "^2.0.2",
 		"typescript": "^5.3.3",
-		"webpack": "^5.97.1"
+		"webpack": "^5.98.0"
 	}
 }

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -60,7 +60,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"typescript": "^5.3.3",
-		"webpack": "^5.97.1"
+		"webpack": "^5.98.0"
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",

--- a/packages/site-admin/package.json
+++ b/packages/site-admin/package.json
@@ -54,7 +54,7 @@
 		"copyfiles": "^2.4.1",
 		"postcss": "^8.4.5",
 		"typescript": "^5.3.3",
-		"webpack": "^5.97.1"
+		"webpack": "^5.98.0"
 	},
 	"dependencies": {
 		"@wordpress/base-styles": "^5.19.0",

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -59,7 +59,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"typescript": "^5.3.3",
-		"webpack": "^5.97.1"
+		"webpack": "^5.98.0"
 	},
 	"peerDependencies": {
 		"@babel/runtime": "^7.26.9",

--- a/packages/webpack-inline-constant-exports-plugin/package.json
+++ b/packages/webpack-inline-constant-exports-plugin/package.json
@@ -24,7 +24,7 @@
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"rimraf": "^3.0.2",
-		"webpack": "^5.97.1"
+		"webpack": "^5.98.0"
 	},
 	"files": [
 		"index.js"

--- a/packages/webpack-rtl-plugin/package.json
+++ b/packages/webpack-rtl-plugin/package.json
@@ -27,7 +27,7 @@
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"css-loader": "^6.11.0",
 		"mini-css-extract-plugin": "^1.6.2",
-		"webpack": "^5.97.1"
+		"webpack": "^5.98.0"
 	},
 	"peerDependencies": {
 		"webpack": "^5.97.1"

--- a/packages/wpcom-proxy-request/package.json
+++ b/packages/wpcom-proxy-request/package.json
@@ -48,6 +48,6 @@
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"postcss": "^8.5.1",
-		"webpack": "^5.97.1"
+		"webpack": "^5.98.0"
 	}
 }

--- a/packages/wpcom.js/package.json
+++ b/packages/wpcom.js/package.json
@@ -52,7 +52,7 @@
 		"@babel/core": "^7.26.9",
 		"babel-loader": "^8.2.3",
 		"npm-run-all": "^4.1.5",
-		"webpack": "^5.97.1",
+		"webpack": "^5.98.0",
 		"webpack-cli": "^4.10.0",
 		"wpcom-oauth-cors": "^1.0.2-beta",
 		"wpcom-proxy-request": "workspace:^"

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -28,7 +28,7 @@
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@babel/core": "^7.16.0",
-		"webpack": "^5.63.0"
+		"webpack": "^5.98.0"
 	},
 	"dependencies": {
 		"@automattic/calypso-babel-config": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -31423,7 +31423,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"schema-utils@npm:^3.0.0, schema-utils@npm:^3.1.1, schema-utils@npm:^3.2.0":
+"schema-utils@npm:^3.0.0, schema-utils@npm:^3.1.1":
   version: 3.3.0
   resolution: "schema-utils@npm:3.3.0"
   dependencies:
@@ -33379,7 +33379,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terser-webpack-plugin@npm:^5.3.1, terser-webpack-plugin@npm:^5.3.10, terser-webpack-plugin@npm:^5.3.11":
+"terser-webpack-plugin@npm:^5.3.1, terser-webpack-plugin@npm:^5.3.11":
   version: 5.3.11
   resolution: "terser-webpack-plugin@npm:5.3.11"
   dependencies:
@@ -35555,43 +35555,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:5":
-  version: 5.97.1
-  resolution: "webpack@npm:5.97.1"
-  dependencies:
-    "@types/eslint-scope": "npm:^3.7.7"
-    "@types/estree": "npm:^1.0.6"
-    "@webassemblyjs/ast": "npm:^1.14.1"
-    "@webassemblyjs/wasm-edit": "npm:^1.14.1"
-    "@webassemblyjs/wasm-parser": "npm:^1.14.1"
-    acorn: "npm:^8.14.0"
-    browserslist: "npm:^4.24.0"
-    chrome-trace-event: "npm:^1.0.2"
-    enhanced-resolve: "npm:^5.17.1"
-    es-module-lexer: "npm:^1.2.1"
-    eslint-scope: "npm:5.1.1"
-    events: "npm:^3.2.0"
-    glob-to-regexp: "npm:^0.4.1"
-    graceful-fs: "npm:^4.2.11"
-    json-parse-even-better-errors: "npm:^2.3.1"
-    loader-runner: "npm:^4.2.0"
-    mime-types: "npm:^2.1.27"
-    neo-async: "npm:^2.6.2"
-    schema-utils: "npm:^3.2.0"
-    tapable: "npm:^2.1.1"
-    terser-webpack-plugin: "npm:^5.3.10"
-    watchpack: "npm:^2.4.1"
-    webpack-sources: "npm:^3.2.3"
-  peerDependenciesMeta:
-    webpack-cli:
-      optional: true
-  bin:
-    webpack: bin/webpack.js
-  checksum: a12d3dc882ca582075f2c4bd88840be8307427245c90a8a0e0b372d73560df13fcf25a61625c9e7edc964981d16b5a8323640562eb48347cf9dd2f8bd1b39d35
-  languageName: node
-  linkType: hard
-
-"webpack@npm:^5.98.0":
+"webpack@npm:5, webpack@npm:^5.98.0":
   version: 5.98.0
   resolution: "webpack@npm:5.98.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -170,7 +170,7 @@ __metadata:
     react-redux: "npm:^9.2.0"
     redux: "npm:^5.0.1"
     redux-thunk: "npm:^3.1.0"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
     webpack-bundle-analyzer: "npm:^4.10.2"
     wpcom: "workspace:^"
     wpcom-proxy-request: "workspace:^"
@@ -238,7 +238,7 @@ __metadata:
     html-webpack-plugin: "npm:^5.6.3"
     npm-run-all: "npm:^4.1.5"
     tree-kill: "npm:^1.2.2"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
     yargs: "npm:^17.0.1"
   bin:
     calypso-apps-builder: ./index.js
@@ -529,7 +529,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     sass-loader: "npm:^13.1.0"
     style-loader: "npm:^1.3.0"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
   peerDependencies:
     "@storybook/react": ^7.6.20
   languageName: unknown
@@ -627,7 +627,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     redux: "npm:^5.0.1"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
     webpack-bundle-analyzer: "npm:^4.10.2"
   languageName: unknown
   linkType: soft
@@ -717,7 +717,7 @@ __metadata:
     typescript: "npm:^5.3.3"
     utility-types: "npm:^3.10.0"
     uuid: "npm:^9.0.1"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     react: ^18.3.1
@@ -843,7 +843,7 @@ __metadata:
     tslib: "npm:^2.3.0"
     typescript: "npm:^5.3.3"
     utility-types: "npm:^3.10.0"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     "@wordpress/element": ^6.19.0
@@ -952,7 +952,7 @@ __metadata:
     react-intersection-observer: "npm:^9.4.3"
     resize-observer-polyfill: "npm:^1.5.1"
     typescript: "npm:^5.3.3"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
   peerDependencies:
     "@automattic/calypso-router": "workspace:^"
     "@wordpress/data": ^10.19.0
@@ -1061,7 +1061,7 @@ __metadata:
     tslib: "npm:^2.4.1"
     typescript: "npm:^5.3.3"
     ua-parser-js: "npm:^0.7.32"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
     webpack-cli: "npm:^5.1.4"
     webpack-dev-server: "npm:^4.15.2"
   languageName: unknown
@@ -1146,7 +1146,7 @@ __metadata:
     copy-webpack-plugin: "npm:^10.2.4"
     postcss-prefix-selector: "npm:^1.16.1"
     typescript: "npm:^5.3.3"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
   peerDependencies:
     "@automattic/calypso-router": "workspace:^"
     "@wordpress/data": ^10.19.0
@@ -1263,7 +1263,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     typescript: "npm:^5.3.3"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
   peerDependencies:
     "@babel/runtime": ^7.26.9
     "@wordpress/data": ^10.19.0
@@ -1319,7 +1319,7 @@ __metadata:
     redux: "npm:^5.0.1"
     tslib: "npm:^2.3.0"
     typescript: "npm:^5.3.3"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
   languageName: unknown
   linkType: soft
 
@@ -1365,7 +1365,7 @@ __metadata:
     tslib: "npm:^2.3.0"
     typescript: "npm:^5.3.3"
     utility-types: "npm:^3.10.0"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
     "@wordpress/data": ^10.19.0
@@ -1453,7 +1453,7 @@ __metadata:
     react-redux: "npm:^9.2.0"
     redux: "npm:^5.0.1"
     redux-thunk: "npm:^3.1.0"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
     webpack-bundle-analyzer: "npm:^4.10.2"
     wpcom: "workspace:^"
     wpcom-proxy-request: "workspace:^"
@@ -1489,7 +1489,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     redux: "npm:^5.0.1"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
   languageName: unknown
   linkType: soft
 
@@ -1579,7 +1579,7 @@ __metadata:
     redux: "npm:^5.0.1"
     redux-thunk: "npm:^3.1.0"
     size-limit: "npm:^8.2.6"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
     webpack-bundle-analyzer: "npm:^4.10.2"
     wpcom: "workspace:^"
   languageName: unknown
@@ -1613,7 +1613,7 @@ __metadata:
     style-loader: "npm:^1.3.0"
     tslib: "npm:^2.5.0"
     typescript: "npm:^5.3.3"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
     "@wordpress/i18n": ^5.19.0
@@ -1688,7 +1688,7 @@ __metadata:
     react-transition-group: "npm:^4.3.0"
     resize-observer-polyfill: "npm:^1.5.1"
     typescript: "npm:^5.3.3"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
   peerDependencies:
     "@wordpress/i18n": ^5.19.0
     postcss: ^8.5.1
@@ -1724,7 +1724,7 @@ __metadata:
     postcss: "npm:^8.5.1"
     require-from-string: "npm:^2.0.2"
     typescript: "npm:^5.3.3"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
   peerDependencies:
     react: ^18.3.1
     react-dom: ^18.3.1
@@ -1786,7 +1786,7 @@ __metadata:
     redux: "npm:^5.0.1"
     tslib: "npm:^2.3.0"
     typescript: "npm:^5.3.3"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
   peerDependencies:
     react: ^18.3.1
     react-dom: ^18.3.1
@@ -1827,7 +1827,7 @@ __metadata:
     copyfiles: "npm:^2.4.1"
     postcss: "npm:^8.4.5"
     typescript: "npm:^5.3.3"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     react: ^18.3.1
@@ -1874,7 +1874,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     tslib: "npm:^2.3.0"
     typescript: "npm:^5.3.3"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
   peerDependencies:
     "@babel/runtime": ^7.26.9
     react: ^18.3.1
@@ -2058,7 +2058,7 @@ __metadata:
     "@automattic/calypso-eslint-overrides": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     rimraf: "npm:^3.0.2"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
   peerDependencies:
     webpack: ^5.97.1
   languageName: unknown
@@ -2072,7 +2072,7 @@ __metadata:
     css-loader: "npm:^6.11.0"
     mini-css-extract-plugin: "npm:^1.6.2"
     rtlcss: "npm:^3.1.2"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
   peerDependencies:
     webpack: ^5.97.1
   languageName: unknown
@@ -2108,7 +2108,7 @@ __metadata:
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     redux: "npm:^5.0.1"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
     webpack-bundle-analyzer: "npm:^4.10.2"
   languageName: unknown
   linkType: soft
@@ -2207,7 +2207,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     redux: "npm:^5.0.1"
     tinymce: "npm:^5.0.0"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
     webpack-bundle-analyzer: "npm:^4.10.2"
   languageName: unknown
   linkType: soft
@@ -11632,7 +11632,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     semver: "npm:^7.3.2"
     superagent: "npm:^3.8.3"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
     webpack-cli: "npm:^4.10.0"
     winston: "npm:^3.3.3"
     wpcom-xhr-request: "workspace:^"
@@ -13894,7 +13894,7 @@ __metadata:
     utility-types: "npm:^3.10.0"
     uuid: "npm:^9.0.1"
     valid-url: "npm:^1.0.9"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
     webpack-bundle-analyzer: "npm:^4.10.2"
     webpack-dev-middleware: "npm:^5.3.4"
     webpack-hot-middleware: "npm:^2.26.1"
@@ -20533,7 +20533,7 @@ __metadata:
     postcss: "npm:^8.5.1"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
   languageName: unknown
   linkType: soft
 
@@ -35555,7 +35555,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:5, webpack@npm:^5.63.0, webpack@npm:^5.97.1":
+"webpack@npm:5":
   version: 5.97.1
   resolution: "webpack@npm:5.97.1"
   dependencies:
@@ -35588,6 +35588,42 @@ __metadata:
   bin:
     webpack: bin/webpack.js
   checksum: a12d3dc882ca582075f2c4bd88840be8307427245c90a8a0e0b372d73560df13fcf25a61625c9e7edc964981d16b5a8323640562eb48347cf9dd2f8bd1b39d35
+  languageName: node
+  linkType: hard
+
+"webpack@npm:^5.98.0":
+  version: 5.98.0
+  resolution: "webpack@npm:5.98.0"
+  dependencies:
+    "@types/eslint-scope": "npm:^3.7.7"
+    "@types/estree": "npm:^1.0.6"
+    "@webassemblyjs/ast": "npm:^1.14.1"
+    "@webassemblyjs/wasm-edit": "npm:^1.14.1"
+    "@webassemblyjs/wasm-parser": "npm:^1.14.1"
+    acorn: "npm:^8.14.0"
+    browserslist: "npm:^4.24.0"
+    chrome-trace-event: "npm:^1.0.2"
+    enhanced-resolve: "npm:^5.17.1"
+    es-module-lexer: "npm:^1.2.1"
+    eslint-scope: "npm:5.1.1"
+    events: "npm:^3.2.0"
+    glob-to-regexp: "npm:^0.4.1"
+    graceful-fs: "npm:^4.2.11"
+    json-parse-even-better-errors: "npm:^2.3.1"
+    loader-runner: "npm:^4.2.0"
+    mime-types: "npm:^2.1.27"
+    neo-async: "npm:^2.6.2"
+    schema-utils: "npm:^4.3.0"
+    tapable: "npm:^2.1.1"
+    terser-webpack-plugin: "npm:^5.3.11"
+    watchpack: "npm:^2.4.1"
+    webpack-sources: "npm:^3.2.3"
+  peerDependenciesMeta:
+    webpack-cli:
+      optional: true
+  bin:
+    webpack: bin/webpack.js
+  checksum: bee4fa77f444802f0beafb2ff30eb5454a606163ad7d3cc9a5dcc9d24033c62407bed04601b25dea49ea3969b352c1b530a86c753246f42560a4a084eefb094e
   languageName: node
   linkType: hard
 
@@ -36030,7 +36066,7 @@ __metadata:
     swiper: "npm:^10.1.0"
     tslib: "npm:^2.3.0"
     typescript: "npm:^5.3.3"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
     webpack-bundle-analyzer: "npm:^4.10.2"
     webpack-cli: "npm:^4.10.0"
     webpack-dev-middleware: "npm:^5.3.4"
@@ -36079,7 +36115,7 @@ __metadata:
     node-fetch: "npm:^2.7.0"
     playwright: "npm:1.48.2"
     postcss: "npm:^8.3.11"
-    webpack: "npm:^5.63.0"
+    webpack: "npm:^5.98.0"
   languageName: unknown
   linkType: soft
 
@@ -36112,7 +36148,7 @@ __metadata:
     debug: "npm:^4.3.3"
     postcss: "npm:^8.5.1"
     uuid: "npm:^9.0.1"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
     wp-error: "npm:^1.3.0"
   languageName: unknown
   linkType: soft
@@ -36141,7 +36177,7 @@ __metadata:
     npm-run-all: "npm:^4.1.5"
     qs: "npm:^6.5.2"
     tus-js-client: "npm:2.3.0"
-    webpack: "npm:^5.97.1"
+    webpack: "npm:^5.98.0"
     webpack-cli: "npm:^4.10.0"
     wpcom-oauth-cors: "npm:^1.0.2-beta"
     wpcom-proxy-request: "workspace:^"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Extracted from https://github.com/Automattic/wp-calypso/pull/100185

## Proposed Changes

* The original PR build was failing without a clear error, so splitting into smaller ones hoping to be able to discern what's failing.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
