### PR TITLE
Set Reader landing: Add it back

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -76,7 +76,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'account',
-			steps: [ userSocialStep ],
+			steps: [ userSocialStep, 'set-reader-landing' ],
 			destination: getRedirectDestination,
 			description: 'Create an account without a blog.',
 			lastModified: '2025-02-18',


### PR DESCRIPTION
I accidentaly removed this in https://github.com/Automattic/wp-calypso/pull/100729/files#r1978472228.