### PR TITLE
Recent feed - add specific routes for selected sub items.

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -109,6 +109,7 @@ export function following( context, next ) {
 			mcKey
 		),
 		onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
+		feedId: context.params.feed_id,
 	} );
 	next();
 }

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import BloganuaryHeader from 'calypso/components/bloganuary-header';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -9,6 +10,8 @@ import QuickPost from 'calypso/reader/components/quick-post';
 import ReaderOnboarding from 'calypso/reader/onboarding';
 import SuggestionProvider from 'calypso/reader/search-stream/suggestion-provider';
 import ReaderStream, { WIDE_DISPLAY_CUTOFF } from 'calypso/reader/stream';
+import { useDispatch } from 'calypso/state';
+import { selectSidebarRecentSite } from 'calypso/state/reader-ui/sidebar/actions';
 import Recent from '../recent';
 import { useSiteSubscriptions } from './use-site-subscriptions';
 import { useFollowingView } from './view-preference';
@@ -18,6 +21,13 @@ import './style.scss';
 function FollowingStream( { ...props } ) {
 	const { currentView } = useFollowingView();
 	const { isLoading, hasNonSelfSubscriptions } = useSiteSubscriptions();
+	const dispatch = useDispatch();
+
+	// Set the selected feed based on route param.
+	useEffect( () => {
+		// Note that 'null' specifically sets the all view.
+		dispatch( selectSidebarRecentSite( { feedId: props.feedId || null } ) );
+	}, [ props.feedId, dispatch ] );
 
 	if ( ! isLoading && ! hasNonSelfSubscriptions ) {
 		return (

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -26,7 +26,7 @@ function FollowingStream( { ...props } ) {
 	// Set the selected feed based on route param.
 	useEffect( () => {
 		// Note that 'null' specifically sets the all view.
-		dispatch( selectSidebarRecentSite( { feedId: props.feedId || null } ) );
+		dispatch( selectSidebarRecentSite( { feedId: Number( props.feedId ) || null } ) );
 	}, [ props.feedId, dispatch ] );
 
 	if ( ! isLoading && ! hasNonSelfSubscriptions ) {

--- a/client/reader/index.ts
+++ b/client/reader/index.ts
@@ -53,7 +53,7 @@ export default async function (): Promise< void > {
 
 	if ( config.isEnabled( 'reader' ) ) {
 		page(
-			'/reader',
+			[ '/reader', '/reader/recent/:feed_id' ],
 			redirectLoggedOutToDiscover,
 			updateLastRoute,
 			sidebar,

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -37,7 +37,7 @@ type Props = {
 };
 
 const SITE_DISPLAY_CUTOFF = 8;
-const RECENT_PATH_REGEX = /^\/reader\/?(?:\?|$)/;
+const RECENT_PATH_REGEX = /^\/reader(?:\/recent\/\d+)?\/?(?:\?|$)/;
 
 const ReaderSidebarRecent = ( {
 	translate,
@@ -52,7 +52,7 @@ const ReaderSidebarRecent = ( {
 		( state ) => state.readerUi.sidebar.selectedRecentSite
 	);
 	const recordReaderTracksEvent = useRecordReaderTracksEvent();
-	const isRecentStream = RECENT_PATH_REGEX.test( path ); // likely need to adjust
+	const isRecentStream = RECENT_PATH_REGEX.test( path );
 
 	let sitesToShow = showAllSites ? sites : sites.slice( 0, SITE_DISPLAY_CUTOFF );
 	// const totalUnseenCount = sites.reduce( ( total, site ) => total + site.unseen_count, 0 );

--- a/client/reader/sidebar/reader-sidebar-recent/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-recent/index.tsx
@@ -2,14 +2,13 @@ import page from '@automattic/calypso-router';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import React, { useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import Favicon from 'calypso/reader/components/favicon';
 import ReaderFollowingIcon from 'calypso/reader/components/icons/following-icon';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
 import getReaderFollowedSites from 'calypso/state/reader/follows/selectors/get-reader-followed-sites';
-import { selectSidebarRecentSite } from 'calypso/state/reader-ui/sidebar/actions';
 import { AppState } from 'calypso/types';
 
 import './style.scss';
@@ -53,8 +52,7 @@ const ReaderSidebarRecent = ( {
 		( state ) => state.readerUi.sidebar.selectedRecentSite
 	);
 	const recordReaderTracksEvent = useRecordReaderTracksEvent();
-	const dispatch = useDispatch();
-	const isRecentStream = RECENT_PATH_REGEX.test( path );
+	const isRecentStream = RECENT_PATH_REGEX.test( path ); // likely need to adjust
 
 	let sitesToShow = showAllSites ? sites : sites.slice( 0, SITE_DISPLAY_CUTOFF );
 	// const totalUnseenCount = sites.reduce( ( total, site ) => total + site.unseen_count, 0 );
@@ -75,8 +73,9 @@ const ReaderSidebarRecent = ( {
 	};
 
 	const selectSite = ( feedId: number | null ) => {
-		dispatch( selectSidebarRecentSite( { feedId } ) );
-		if ( ! isRecentStream ) {
+		if ( feedId ) {
+			page( `/reader/recent/${ feedId }` );
+		} else {
 			page( '/reader' );
 		}
 
@@ -97,9 +96,6 @@ const ReaderSidebarRecent = ( {
 			onClick();
 		}
 		selectSite( null );
-		if ( ! isRecentStream ) {
-			page( '/reader' );
-		}
 	};
 
 	return (

--- a/client/state/reader-ui/sidebar/reducer.js
+++ b/client/state/reader-ui/sidebar/reducer.js
@@ -45,14 +45,14 @@ export const openOrganizations = withPersistence( ( state = [], action ) => {
 	return state;
 } );
 
-export const selectedRecentSite = withPersistence( ( state = null, action ) => {
+export const selectedRecentSite = ( state = null, action ) => {
 	switch ( action.type ) {
 		case READER_SIDEBAR_SELECT_RECENT_SITE:
 			return action.feedId;
 	}
 
 	return state;
-} );
+};
 
 export default combineReducers( {
 	isListsOpen,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/100074 and may also resolve https://github.com/Automattic/wp-calypso/issues/99166 

## Proposed Changes

Adds routes for specific site selections in the readers recent stream. This enables the reader and browser "back" buttons to not overlook these selections. This also means when navigating back to the reader at /reader the user will always see the "all" selection by default, and not immediately funneled into a sub-selection based on their previous activity in a different reader session.

* Selecting an individual item in recent will now use the route `reader/recent/:feed_id`, the all selection will continue to use `/reader` as it has for ages.
* Sets the selected feed in state from the following/main component based on the route param feed id.
* No longer sets the selected feed in state from the sidebar, this instead now directs to the new routes.
* Removes persistence from the selected recent feed state, as this is no longer necessary or useful given the new route handling.

Note - at first I wondered if it would make sense to pull out the redux state for the selected recent feed here and handle everything via the routes. However, it seems that the state is still useful for us to connect this information easily in different areas/components that need it. It seems like it would be messier to update all those places to evaluate the route and path than just continue reading this store. The handoff between route and state at the highest level component feels like a good balance.

BEFORE
<img width=350 src="https://github.com/user-attachments/assets/9bbceaa7-7877-46ab-b8a8-0c9426051283" />


AFTER
<img width=400 src="https://github.com/user-attachments/assets/8120fa27-71a5-4044-a1c5-3f7cc3ee7532" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Back buttons were made present in these streams, but this highlighted that these stream selections were overlooked by back navigation. Adding routes creates a more consistent experience.
* The change that visiting /reader will always show the "all" selection and no longer enforce a sub-selection based on previous reader sessions is also seen as a UX improvement and also gets rid of another potential bug as noted here https://github.com/Automattic/wp-calypso/issues/99166

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Visit the /reader
* select a stream outside of Recent, such as "Discover".
* Under the "Recent" submenu, now select into a few different sub options (individual recent feeds).
* Press the "back" button. Verify the individual recent streams are now respected in the back navigation and no longer jump all the way to back to "Discover" (or whichever other feed you were on before them).
* Navigate away from the reader ("W" Icon in top left) and navigate back to the reader via the top toolbar. Verify you are seeing the "all" recent feed and not a sub selection.
* Test around these feed selections and try to find any other regressions.

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
