### PR TITLE
Remove redundant span for Stagin Site link

### DIFF
--- a/client/sites/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/sites/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -159,10 +159,8 @@ export const ManageStagingSiteCardContent = ( {
 								target="_blank"
 								className="tools-staging-site__site-url"
 							>
-								<span>
-									{ stagingSite.url }
-									<Icon icon={ external } size={ 16 } />
-								</span>
+								{ stagingSite.url }
+								<Icon icon={ external } size={ 16 } />
 							</WPButton>
 						</SiteInfo>
 					</SiteRow>

--- a/client/sites/staging-site/components/staging-site-card/style.scss
+++ b/client/sites/staging-site/components/staging-site-card/style.scss
@@ -1,6 +1,7 @@
 .tools-staging-site__site-url.is-link {
 	word-wrap: break-word;
 	text-decoration: none;
+	display: inline;
 
 	svg {
 		vertical-align: middle;


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/100762
Specifically [this comment](https://github.com/Automattic/wp-calypso/pull/100762#issuecomment-2697871685)