### PR TITLE
Help Center - DIFM: Open Help Center from site picker

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -425,7 +425,6 @@ export function generateFlows( {
 			lastModified: '2024-05-16',
 			enableBranchSteps: true,
 			hideProgressIndicator: true,
-			enablePremiumSupport: true,
 			get helpCenterButtonCopy() {
 				return translate( 'Questions?' );
 			},
@@ -452,7 +451,6 @@ export function generateFlows( {
 			lastModified: '2024-05-16',
 			enableBranchSteps: true,
 			hideProgressIndicator: true,
-			enablePremiumSupport: true,
 			get helpCenterButtonCopy() {
 				return translate( 'Questions?' );
 			},
@@ -471,7 +469,6 @@ export function generateFlows( {
 			providesDependenciesInQuery: [ 'siteSlug', 'back_to' ],
 			optionalDependenciesInQuery: [ 'back_to' ],
 			lastModified: '2024-06-14',
-			enablePremiumSupport: true,
 			get helpCenterButtonCopy() {
 				return translate( 'Questions?' );
 			},

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -225,7 +225,6 @@ class StepWrapper extends Component {
 						{ customizedActionButtons }
 						{ isHelpCenterLinkEnabled && (
 							<HelpCenterStepButton
-								hasPremiumSupport={ flow?.enablePremiumSupport }
 								flowName={ flowName }
 								helpCenterButtonCopy={ flow?.helpCenterButtonCopy }
 								helpCenterButtonLink={ flow?.helpCenterButtonLink }

--- a/client/signup/steps/difm-site-picker/index.tsx
+++ b/client/signup/steps/difm-site-picker/index.tsx
@@ -62,11 +62,7 @@ export default function DIFMSitePickerStep( props: Props ) {
 		{
 			components: {
 				SupportLink: (
-					<HelpCenterInlineButton
-						className="subtitle-link"
-						hasPremiumSupport
-						flowName={ props.flowName }
-					/>
+					<HelpCenterInlineButton className="subtitle-link" flowName={ props.flowName } />
 				),
 				NewSiteLink: (
 					<Button variant="link" className="subtitle-link" onClick={ onNewSiteClicked } />

--- a/client/signup/steps/difm-site-picker/index.tsx
+++ b/client/signup/steps/difm-site-picker/index.tsx
@@ -1,4 +1,5 @@
 import { Card } from '@automattic/components';
+import { HelpCenterInlineButton } from '@automattic/help-center';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -60,7 +61,13 @@ export default function DIFMSitePickerStep( props: Props ) {
 		'Please {{SupportLink}}contact support{{/SupportLink}} if your existing WordPress.com site isn’t listed, or create a {{NewSiteLink}}new site{{/NewSiteLink}} instead.',
 		{
 			components: {
-				SupportLink: <a className="subtitle-link" rel="noopener noreferrer" href="/help/contact" />,
+				SupportLink: (
+					<HelpCenterInlineButton
+						className="subtitle-link"
+						hasPremiumSupport
+						flowName={ props.flowName }
+					/>
+				),
 				NewSiteLink: (
 					<Button variant="link" className="subtitle-link" onClick={ onNewSiteClicked } />
 				),

--- a/client/signup/types.ts
+++ b/client/signup/types.ts
@@ -21,7 +21,6 @@ export interface Flow {
 	showRecaptcha?: boolean;
 	enableBranchSteps?: boolean;
 	hideProgressIndicator?: boolean;
-	enablePremiumSupport?: boolean;
 	helpCenterButtonText?: string;
 	enableHotjar?: boolean;
 	onEnterFlow?: ( flowName: string ) => void;

--- a/packages/help-center/src/components/help-center-inline-button.tsx
+++ b/packages/help-center/src/components/help-center-inline-button.tsx
@@ -1,0 +1,51 @@
+import { HelpCenterSelect } from '@automattic/data-stores';
+import { Button } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
+import clsx from 'clsx';
+import { useFlowCustomOptions, useFlowZendeskUserFields } from '../hooks';
+import { HELP_CENTER_STORE } from '../stores';
+import type { FC, ReactNode } from 'react';
+
+interface HelpCenterInlineButtonProps {
+	hasPremiumSupport?: boolean;
+	flowName?: string;
+	children?: ReactNode;
+	className?: string;
+}
+
+const HelpCenterInlineButton: FC< HelpCenterInlineButtonProps > = ( {
+	hasPremiumSupport,
+	flowName,
+	children,
+	className,
+} ) => {
+	const { setShowHelpCenter, setNavigateToRoute } = useDispatch( HELP_CENTER_STORE );
+	const isShowingHelpCenter = useSelect(
+		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).isHelpCenterShown(),
+		[]
+	);
+	const flowCustomOptions = useFlowCustomOptions( flowName || '' );
+	const { userFieldMessage, userFieldFlowName } = useFlowZendeskUserFields( flowName || '' );
+
+	function toggleHelpCenter() {
+		setShowHelpCenter( ! isShowingHelpCenter, hasPremiumSupport, flowCustomOptions );
+		if ( hasPremiumSupport ) {
+			const urlWithQueryArgs = addQueryArgs( '/odie?provider=zendesk', {
+				userFieldMessage,
+				userFieldFlowName,
+			} );
+			setNavigateToRoute( urlWithQueryArgs );
+		} else {
+			setNavigateToRoute( `/odie` );
+		}
+	}
+
+	return (
+		<Button onClick={ toggleHelpCenter } className={ clsx( className, 'is-link' ) }>
+			{ children }
+		</Button>
+	);
+};
+
+export default HelpCenterInlineButton;

--- a/packages/help-center/src/components/help-center-inline-button.tsx
+++ b/packages/help-center/src/components/help-center-inline-button.tsx
@@ -8,14 +8,12 @@ import { HELP_CENTER_STORE } from '../stores';
 import type { FC, ReactNode } from 'react';
 
 interface HelpCenterInlineButtonProps {
-	hasPremiumSupport?: boolean;
 	flowName?: string;
 	children?: ReactNode;
 	className?: string;
 }
 
 const HelpCenterInlineButton: FC< HelpCenterInlineButtonProps > = ( {
-	hasPremiumSupport,
 	flowName,
 	children,
 	className,
@@ -29,8 +27,12 @@ const HelpCenterInlineButton: FC< HelpCenterInlineButtonProps > = ( {
 	const { userFieldMessage, userFieldFlowName } = useFlowZendeskUserFields( flowName || '' );
 
 	function toggleHelpCenter() {
-		setShowHelpCenter( ! isShowingHelpCenter, hasPremiumSupport, flowCustomOptions );
-		if ( hasPremiumSupport ) {
+		setShowHelpCenter(
+			! isShowingHelpCenter,
+			flowCustomOptions?.hasPremiumSupport,
+			flowCustomOptions
+		);
+		if ( flowCustomOptions?.hasPremiumSupport ) {
 			const urlWithQueryArgs = addQueryArgs( '/odie?provider=zendesk', {
 				userFieldMessage,
 				userFieldFlowName,

--- a/packages/help-center/src/components/help-center-step-button.tsx
+++ b/packages/help-center/src/components/help-center-step-button.tsx
@@ -1,56 +1,26 @@
-import { HelpCenterSelect } from '@automattic/data-stores';
-import { Button } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useFlowCustomOptions, useFlowZendeskUserFields } from '../hooks';
-import { HELP_CENTER_STORE } from '../stores';
+import HelpCenterInlineButton from './help-center-inline-button';
 import type { FC } from 'react';
 
 interface HelpCenterStepButtonProps {
-	hasPremiumSupport?: boolean;
 	flowName?: string;
 	helpCenterButtonCopy?: string;
 	helpCenterButtonLink?: string;
 }
 
 const HelpCenterStepButton: FC< HelpCenterStepButtonProps > = ( {
-	hasPremiumSupport,
 	flowName,
 	helpCenterButtonCopy,
 	helpCenterButtonLink,
 } ) => {
 	const translate = useTranslate();
-	const { setShowHelpCenter, setNavigateToRoute } = useDispatch( HELP_CENTER_STORE );
-	const isShowingHelpCenter = useSelect(
-		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).isHelpCenterShown(),
-		[]
-	);
-	const flowCustomOptions = useFlowCustomOptions( flowName || '' );
-	const { userFieldMessage, userFieldFlowName } = useFlowZendeskUserFields( flowName || '' );
-
-	function toggleHelpCenter() {
-		if ( ! isShowingHelpCenter ) {
-			if ( hasPremiumSupport ) {
-				const urlWithQueryArgs = addQueryArgs( '/odie?provider=zendesk', {
-					userFieldMessage,
-					userFieldFlowName,
-				} );
-				setNavigateToRoute( urlWithQueryArgs );
-			} else {
-				setNavigateToRoute( `/odie` );
-			}
-		}
-
-		setShowHelpCenter( ! isShowingHelpCenter, hasPremiumSupport, flowCustomOptions );
-	}
 
 	return (
 		<div className="step-wrapper__help-center-button-container">
-			<label>{ helpCenterButtonCopy ?? translate( 'Need extra help?' ) }</label>
-			<Button className="step-wrapper__help-center-button" onClick={ toggleHelpCenter }>
+			<label>{ helpCenterButtonCopy ?? translate( 'Need extra help?' ) }</label>{ ' ' }
+			<HelpCenterInlineButton flowName={ flowName } className="step-wrapper__help-center-button">
 				{ helpCenterButtonLink ?? translate( 'Visit Help Center' ) }
-			</Button>
+			</HelpCenterInlineButton>
 		</div>
 	);
 };

--- a/packages/help-center/src/hooks/use-flow-custom-options.ts
+++ b/packages/help-center/src/hooks/use-flow-custom-options.ts
@@ -9,6 +9,7 @@ export function useFlowCustomOptions( flowName: string ) {
 	) {
 		return {
 			hideBackButton: true,
+			hasPremiumSupport: true,
 		};
 	}
 

--- a/packages/help-center/src/index.ts
+++ b/packages/help-center/src/index.ts
@@ -5,6 +5,7 @@ export { SuccessScreen } from './components/ticket-success-screen';
 export { BackButton } from './components/back-button';
 export { HelpCenterContactForm } from './components/help-center-contact-form';
 export { default as HelpCenterStepButton } from './components/help-center-step-button';
+export { default as HelpCenterInlineButton } from './components/help-center-inline-button';
 export { default as Mail } from './icons/mail';
 export { default as NewReleases } from './icons/new-releases';
 export * from './support-variations';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Context: https://wp.me/pdh1Xd-31k#comment-3015

## Proposed Changes

- Open the Help Center from a link in a subtitle of a step.
- Extracted the inline link to open the Help Center to a component.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

<img width="693" alt="image" src="https://github.com/user-attachments/assets/0ba78a4a-80d6-4f04-bce5-70aa55b9285c" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `http://calypso.localhost:3000/start/do-it-for-me/difm-site-picker?flags=signup/help-center-link`
