### PR TITLE
Help Center - DIFM: Show only if US

### DIFF
--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -1,7 +1,8 @@
 import { HelpCenterStepButton } from '@automattic/help-center';
+import { englishLocales } from '@automattic/i18n-utils';
 import { ActionButtons } from '@automattic/onboarding';
 import clsx from 'clsx';
-import { localize } from 'i18n-calypso';
+import { localize, getLocaleSlug } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -213,7 +214,8 @@ class StepWrapper extends Component {
 
 		const queryParams = new URLSearchParams( window?.location.search );
 		const flags = queryParams.get( 'flags' );
-		const isHelpCenterLinkEnabled = flags === 'signup/help-center-link';
+		const isHelpCenterLinkEnabled =
+			flags === 'signup/help-center-link' && englishLocales.includes( getLocaleSlug() );
 
 		return (
 			<>

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -1,8 +1,7 @@
 import { HelpCenterStepButton } from '@automattic/help-center';
-import { englishLocales } from '@automattic/i18n-utils';
 import { ActionButtons } from '@automattic/onboarding';
 import clsx from 'clsx';
-import { localize, getLocaleSlug } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -214,8 +213,7 @@ class StepWrapper extends Component {
 
 		const queryParams = new URLSearchParams( window?.location.search );
 		const flags = queryParams.get( 'flags' );
-		const isHelpCenterLinkEnabled =
-			flags === 'signup/help-center-link' && englishLocales.includes( getLocaleSlug() );
+		const isHelpCenterLinkEnabled = flags === 'signup/help-center-link';
 
 		return (
 			<>

--- a/packages/help-center/src/components/help-center-step-button.tsx
+++ b/packages/help-center/src/components/help-center-step-button.tsx
@@ -1,4 +1,6 @@
+/* eslint-disable no-restricted-imports */
 import { useTranslate } from 'i18n-calypso';
+import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import HelpCenterInlineButton from './help-center-inline-button';
 import type { FC } from 'react';
 
@@ -14,7 +16,10 @@ const HelpCenterStepButton: FC< HelpCenterStepButtonProps > = ( {
 	helpCenterButtonLink,
 } ) => {
 	const translate = useTranslate();
-
+	const { data: geoData } = useGeoLocationQuery();
+	if ( geoData?.country_short === 'US' ) {
+		return null;
+	}
 	return (
 		<div className="step-wrapper__help-center-button-container">
 			<label>{ helpCenterButtonCopy ?? translate( 'Need extra help?' ) }</label>{ ' ' }

--- a/packages/help-center/src/components/help-center-step-button.tsx
+++ b/packages/help-center/src/components/help-center-step-button.tsx
@@ -17,9 +17,11 @@ const HelpCenterStepButton: FC< HelpCenterStepButtonProps > = ( {
 } ) => {
 	const translate = useTranslate();
 	const { data: geoData } = useGeoLocationQuery();
+
 	if ( geoData?.country_short === 'US' ) {
 		return null;
 	}
+
 	return (
 		<div className="step-wrapper__help-center-button-container">
 			<label>{ helpCenterButtonCopy ?? translate( 'Need extra help?' ) }</label>{ ' ' }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Context: https://wp.me/pdh1Xd-31k#comment-3026

## Proposed Changes

* We want to show the link to premium support, during the DIFM flow, only to US users.

## Testing

- live link
- Be in the US
- `/start/do-it-for-me/difm-site-picker?flags=signup/help-center-link`