### PR TITLE
Enable Domains DataViews in all environments

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -39,7 +39,7 @@
 		"calypso/ai-blogging-prompts": true,
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
-		"calypso/domains-dataviews": false,
+		"calypso/domains-dataviews": true,
 		"cancellation-offers": true,
 		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -17,6 +17,7 @@
 		"calypso/ai-blogging-prompts": false,
 		"calypso/all-domain-management": false,
 		"calypso/big-sky": true,
+		"calypso/domains-dataviews": true,
 		"cancellation-offers": true,
 		"catch-js-errors": true,
 		"checkout/ebanx-pix": true,

--- a/config/production.json
+++ b/config/production.json
@@ -29,7 +29,7 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"bilmur-script": true,
-		"calypso/domains-dataviews": false,
+		"calypso/domains-dataviews": true,
 		"cancellation-offers": true,
 		"catch-js-errors": true,
 		"checkout/ebanx-pix": true,

--- a/config/test.json
+++ b/config/test.json
@@ -28,7 +28,7 @@
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/application-password": true,
 		"calypso/all-domain-management": true,
-		"calypso/domains-dataviews": false,
+		"calypso/domains-dataviews": true,
 		"cancellation-offers": true,
 		"catch-js-errors": false,
 		"checkout/ebanx-pix": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -26,7 +26,7 @@
 		"calypso/ai-blogging-prompts": true,
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
-		"calypso/domains-dataviews": false,
+		"calypso/domains-dataviews": true,
 		"cancellation-offers": true,
 		"catch-js-errors": false,
 		"checkout/ebanx-pix": true,


### PR DESCRIPTION
Related to #96675 

## Proposed Changes

* Enable DataViews for Domains in all envs.

## Why are these changes being made?

* Part of Domains Management revamp project, releasing to public.

## Testing Instructions

* Check it is enabled in all WP.com envs now.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
