### PR TITLE
Enable Billing History DataViews Component via Feature Flag

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -99,7 +99,7 @@
 		"post-list/qr-code-link": false,
 		"press-this": true,
 		"publicize-preview": true,
-		"purchases/billing-history-data-view": false,
+		"purchases/billing-history-data-view": true,
 		"purchases/new-payment-methods": true,
 		"reader": true,
 		"reader/quick-post": true,

--- a/config/production.json
+++ b/config/production.json
@@ -128,7 +128,7 @@
 		"post-list/qr-code-link": false,
 		"press-this": true,
 		"publicize-preview": true,
-		"purchases/billing-history-data-view": false,
+		"purchases/billing-history-data-view": true,
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,
 		"reader": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -125,7 +125,7 @@
 		"post-list/qr-code-link": true,
 		"press-this": true,
 		"publicize-preview": true,
-		"purchases/billing-history-data-view": false,
+		"purchases/billing-history-data-view": true,
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,
 		"reader": true,

--- a/config/test.json
+++ b/config/test.json
@@ -99,6 +99,7 @@
 		"post-list/qr-code-link": false,
 		"press-this": true,
 		"publicize-preview": true,
+		"purchases/billing-history-data-view": true,
 		"purchases/new-payment-methods": true,
 		"reader": true,
 		"reader/full-errors": true,


### PR DESCRIPTION
Related to https://github.com/Automattic/payments-florin/issues/772

## Proposed Changes

Set the `purchases/billing-history-data-view` feature flag to `true` for staging, horizon, and production so that the `BillingHistoryListDataView` component is enabled for all users.

## Why are these changes being made?
This component has been complete for some time now, and it would be good to go on and roll it out as we move to using DataViews more and more.  The Billing History section is already visually different from the purchases list so we don't have to worry about disrupting continuity between them.

## Testing Instructions

The component is already live at https://wpcalypso.wordpress.com/me/purchases/billing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
