### PR TITLE
Stepper: Move copy-site flow to use the dictionary

### DIFF
--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -1,7 +1,6 @@
 import { COPY_SITE_FLOW } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
-import { translate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
@@ -12,16 +11,12 @@ import {
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
 import { useSiteCopy } from '../hooks/use-site-copy';
-import AutomatedCopySite from './internals/steps-repository/automated-copy-site';
-import CreateSite from './internals/steps-repository/create-site';
-import DomainsStep from './internals/steps-repository/domains';
-import ProcessingStep from './internals/steps-repository/processing-step';
+import { STEPS } from './internals/steps';
 import {
 	AssertConditionResult,
 	AssertConditionState,
 	Flow,
 	ProvidedDependencies,
-	StepProps,
 } from './internals/types';
 import type { SiteSelect } from '@automattic/data-stores';
 
@@ -69,25 +64,13 @@ function useIsValidSite() {
 	};
 }
 
-function ProcessingCopy( props: StepProps ) {
-	return (
-		<ProcessingStep
-			{ ...props }
-			title={ translate( 'We’re copying your site' ) }
-			subtitle={ translate(
-				'Feel free to close this window. We’ll email you when your new site is ready.'
-			) }
-		/>
-	);
-}
-
 const COPY_SITE_STEPS = [
-	{ slug: 'domains', component: DomainsStep },
-	{ slug: 'create-site', component: CreateSite },
-	{ slug: 'processing', component: ProcessingStep },
-	{ slug: 'automated-copy', component: AutomatedCopySite },
-	{ slug: 'processing-copy', component: ProcessingCopy },
-	{ slug: 'resuming', component: ProcessingStep }, // Needs siteSlug param
+	STEPS.DOMAINS,
+	STEPS.SITE_CREATION_STEP,
+	STEPS.PROCESSING,
+	STEPS.AUTOMATED_COPY_SITE,
+	STEPS.PROCESSING_COPY,
+	STEPS.PROCESSING,
 ];
 
 const copySite: Flow = {
@@ -118,7 +101,6 @@ const copySite: Flow = {
 					return navigate( 'processing' );
 				}
 
-				case 'resuming':
 				case 'processing': {
 					const siteSlug = providedDependencies?.siteSlug || urlQueryParams.get( 'siteSlug' );
 					const destination = addQueryArgs( `/setup/${ this.name }/automated-copy`, {

--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -69,8 +69,8 @@ const COPY_SITE_STEPS = [
 	STEPS.SITE_CREATION_STEP,
 	STEPS.PROCESSING,
 	STEPS.AUTOMATED_COPY_SITE,
-	STEPS.PROCESSING_COPY,
-	STEPS.PROCESSING,
+	STEPS.PROCESSING_COPY_SITE_FLOW,
+	{ ...STEPS.PROCESSING, slug: 'resuming' },
 ];
 
 const copySite: Flow = {
@@ -101,6 +101,7 @@ const copySite: Flow = {
 					return navigate( 'processing' );
 				}
 
+				case 'resuming':
 				case 'processing': {
 					const siteSlug = providedDependencies?.siteSlug || urlQueryParams.get( 'siteSlug' );
 					const destination = addQueryArgs( `/setup/${ this.name }/automated-copy`, {
@@ -158,7 +159,7 @@ const copySite: Flow = {
 		const { isValidSite, hasFetchedSiteDetails, isFetchingError } = useIsValidSite();
 
 		if ( ! sourceSlug || isFetchingError || ( ! isValidSite && hasFetchedSiteDetails ) ) {
-			window.location.assign( `/sites` );
+			window.location.assign( '/sites' );
 			result = {
 				state: AssertConditionState.FAILURE,
 				message: isFetchingError

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step-copy-site-flow/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step-copy-site-flow/index.tsx
@@ -1,0 +1,16 @@
+import { useTranslate } from 'i18n-calypso';
+import { StepProps } from '../../types';
+import ProcessingStep from '../processing-step';
+
+export default function ProcessingStepCopySiteFlow( props: StepProps ) {
+	const translate = useTranslate();
+	return (
+		<ProcessingStep
+			{ ...props }
+			title={ translate( 'We’re copying your site' ) }
+			subtitle={ translate(
+				'Feel free to close this window. We’ll email you when your new site is ready.'
+			) }
+		/>
+	);
+}

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -12,7 +12,7 @@ export const STEPS = {
 	},
 
 	AUTOMATED_COPY_SITE: {
-		slug: 'automated-copy-site',
+		slug: 'automated-copy',
 		asyncComponent: () => import( './steps-repository/automated-copy-site' ),
 	},
 

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -11,6 +11,11 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/business-info' ),
 	},
 
+	AUTOMATED_COPY_SITE: {
+		slug: 'automated-copy-site',
+		asyncComponent: () => import( './steps-repository/automated-copy-site' ),
+	},
+
 	CELEBRATION: {
 		slug: 'celebration-step',
 		asyncComponent: () => import( './steps-repository/celebration-step' ),
@@ -185,6 +190,12 @@ export const STEPS = {
 	PROCESSING: {
 		slug: 'processing',
 		asyncComponent: () => import( './steps-repository/processing-step' ),
+	},
+
+	/** Temporary step until we allow passing props to steps */
+	PROCESSING_COPY_SITE_FLOW: {
+		slug: 'processing-copy',
+		asyncComponent: () => import( './steps-repository/processing-step-copy-site-flow' ),
 	},
 
 	SITE_CREATION_STEP: {


### PR DESCRIPTION
## Proposed Changes
Migrate the copy-site migration flow away from the deprecated Stepper API.

## Why are these changes being made?
To keep the API surface area smaller. 

## Testing Instructions


1. Go to /setup/copy-site/domains?sourceSlug=SOME_ATOMIC_SITE_YOU_OWN&plan=business
2. Pick a domain.
3. You should be taken to checkout with a business plan.