### PR TITLE
A4A: Show error message when client referral do not match current user.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useContext, useEffect, useRef, useState } from 'react';
 import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
+import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
@@ -19,6 +20,7 @@ import LayoutHeader, {
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
 import useFetchClientReferral from '../../client/hooks/use-fetch-client-referral';
 import { MarketplaceTypeContext } from '../context';
@@ -48,6 +50,7 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const agency = useSelector( getActiveAgency );
+	const userEmail = useSelector( ( state ) => getCurrentUser( state )?.email );
 
 	const canIssueLicenses = agency?.can_issue_licenses ?? true;
 	const [ showPopover, setShowPopover ] = useState( false );
@@ -63,10 +66,12 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 	const { selectedProductsBySlug } = useProductsBySlug();
 
 	// Fetch client referral items if it's a client referral checkout
-	const { data: clientCheckoutItems } = useFetchClientReferral( getClientReferralQueryArgs() );
+	const { data: referral } = useFetchClientReferral( getClientReferralQueryArgs() );
 
 	// Get referred products for client referral checkout only if it's a client referral checkout
-	const { referredProducts } = useProductsById( clientCheckoutItems?.products ?? [], isClient );
+	const { referredProducts } = useProductsById( referral?.products ?? [], isClient );
+
+	const isDoNotMatchReferralClientEmail = referral?.client?.email !== userEmail;
 
 	// Get sites and selected site
 	const sites = useSelector( getSites );
@@ -210,7 +215,13 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 	}
 
 	if ( isClient ) {
-		actionContent = <SubmitPaymentInfo disableButton={ checkoutItems?.length === 0 } />;
+		actionContent = (
+			<SubmitPaymentInfo
+				disableButton={
+					checkoutItems?.length === 0 || ( isClient && isDoNotMatchReferralClientEmail )
+				}
+			/>
+		);
 	}
 
 	return (
@@ -243,6 +254,21 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 				<div className="checkout__container">
 					<div className="checkout__main">
 						<h1 className="checkout__main-title">{ title }</h1>
+
+						<LayoutBanner level="error" hideCloseButton>
+							{ translate(
+								'This referral is not intended for your account. Please make sure you sign in using {{b}}%(referralEmail)s{{/b}}.',
+								{
+									args: {
+										referralEmail: referral?.client?.email,
+									},
+									components: {
+										b: <b />,
+									},
+									comment: '%(referralEmail)s is the email of the referral client.',
+								}
+							) }
+						</LayoutBanner>
 
 						<div className="checkout__main-list">
 							{ referralBlogId && isLoadingReferralDevSite ? (

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -255,20 +255,22 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 					<div className="checkout__main">
 						<h1 className="checkout__main-title">{ title }</h1>
 
-						<LayoutBanner level="error" hideCloseButton>
-							{ translate(
-								'This referral is not intended for your account. Please make sure you sign in using {{b}}%(referralEmail)s{{/b}}.',
-								{
-									args: {
-										referralEmail: referral?.client?.email,
-									},
-									components: {
-										b: <b />,
-									},
-									comment: '%(referralEmail)s is the email of the referral client.',
-								}
-							) }
-						</LayoutBanner>
+						{ isClient && isDoNotMatchReferralClientEmail && (
+							<LayoutBanner level="error" hideCloseButton>
+								{ translate(
+									'This referral is not intended for your account. Please make sure you sign in using {{b}}%(referralEmail)s{{/b}}.',
+									{
+										args: {
+											referralEmail: referral?.client?.email,
+										},
+										components: {
+											b: <b />,
+										},
+										comment: '%(referralEmail)s is the email of the referral client.',
+									}
+								) }
+							</LayoutBanner>
+						) }
 
 						<div className="checkout__main-list">
 							{ referralBlogId && isLoadingReferralDevSite ? (


### PR DESCRIPTION
To avoid unauthorized users purchasing a referral order not meant for their account, we display an error message and deactivate the purchase button.

<img width="1551" alt="Screenshot 2025-03-04 at 11 40 48 PM" src="https://github.com/user-attachments/assets/2177b7a2-3e95-477d-bda3-2010252331d2" />

NOTE: This needs to be tested with 175744-ghe-Automattic/wpcom

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1872

## Proposed Changes
* We now disable the 'Purchase' button on the client checkout page when the email of the client associated with the current referral order does not match the email of the current user.
* We also display an error message to clarify why the purchase is disabled.

## Why are these changes being made?

* Pressable licenses have critical errors linked to the wrong client user processing the payment for the plan. This PR addresses the issue by ensuring that the checkout process is restricted to the appropriate client.


## Testing Instructions

* Create a referral to a random client and receive the payment link.
* Apply patch 175744-ghe-Automattic/wpcom
* Spin up this branch
* Use incognito on your browser and sign in with a different client user.
* Now access the payment link sent to your email. Make sure you replace the domain pointing to your localhost. 
* Confirm that you see the error message and the purchase button is disabled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?