### PR TITLE
Hosting Logs: iterate over "open details" action + update PHPLogs fields

### DIFF
--- a/client/sites/logs/components/details-modal-php.tsx
+++ b/client/sites/logs/components/details-modal-php.tsx
@@ -40,8 +40,6 @@ const DetailsModalPHP = ( { item }: DetailsModalPHPProps ) => {
 			<div>
 				<Badge className={ `badge--${ item.severity }` }>{ item.severity }</Badge>
 			</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'Message' ) }</div>
-			<div>{ item.message }</div>
 			<div className="site-logs-details-modal__field-title">{ translate( 'Kind' ) }</div>
 			<div>{ item.kind }</div>
 			<div className="site-logs-details-modal__field-title">{ translate( 'Name' ) }</div>
@@ -50,6 +48,8 @@ const DetailsModalPHP = ( { item }: DetailsModalPHPProps ) => {
 			<div>{ item.file }</div>
 			<div className="site-logs-details-modal__field-title">{ translate( 'Line' ) }</div>
 			<div>{ numberFormat( item.line ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Message' ) }</div>
+			<div>{ item.message }</div>
 		</div>
 	);
 };

--- a/client/sites/logs/components/details-modal-php.tsx
+++ b/client/sites/logs/components/details-modal-php.tsx
@@ -27,14 +27,6 @@ const DetailsModalPHP = ( { item }: DetailsModalPHPProps ) => {
 
 	return (
 		<div className="site-logs-details-modal">
-			<div className="site-logs-details-modal__field-title">{ translate( 'Kind' ) }</div>
-			<div>{ item.kind !== '' ? item.kind : translate( 'core' ) }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'Source' ) }</div>
-			<div>{ item.name !== '' ? item.name : translate( 'core' ) }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'Severity' ) }</div>
-			<div>
-				<Badge className={ `badge--${ item.severity }` }>{ item.severity }</Badge>
-			</div>
 			<div className="site-logs-details-modal__field-title">
 				{
 					// translators: %(siteGsmOffsetDisplay)s will be replaced with the timezone offset of the site, e.g. GMT, GMT +1, GMT -1.
@@ -44,6 +36,14 @@ const DetailsModalPHP = ( { item }: DetailsModalPHPProps ) => {
 				}
 			</div>
 			<div>{ getFormattedDate( item.timestamp ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Group' ) }</div>
+			<div>{ item.kind }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Source' ) }</div>
+			<div>{ item.name }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Severity' ) }</div>
+			<div>
+				<Badge className={ `badge--${ item.severity }` }>{ item.severity }</Badge>
+			</div>
 			<div className="site-logs-details-modal__field-title">{ translate( 'File' ) }</div>
 			<div>{ item.file }</div>
 			<div className="site-logs-details-modal__field-title">{ translate( 'Line' ) }</div>

--- a/client/sites/logs/components/details-modal-php.tsx
+++ b/client/sites/logs/components/details-modal-php.tsx
@@ -40,9 +40,9 @@ const DetailsModalPHP = ( { item }: DetailsModalPHPProps ) => {
 			<div>
 				<Badge className={ `badge--${ item.severity }` }>{ item.severity }</Badge>
 			</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'Kind' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Type' ) }</div>
 			<div>{ item.kind }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'Name' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Source' ) }</div>
 			<div>{ item.name }</div>
 			<div className="site-logs-details-modal__field-title">{ translate( 'File' ) }</div>
 			<div>{ item.file }</div>

--- a/client/sites/logs/components/details-modal-php.tsx
+++ b/client/sites/logs/components/details-modal-php.tsx
@@ -27,6 +27,14 @@ const DetailsModalPHP = ( { item }: DetailsModalPHPProps ) => {
 
 	return (
 		<div className="site-logs-details-modal">
+			<div className="site-logs-details-modal__field-title">{ translate( 'Kind' ) }</div>
+			<div>{ item.kind !== '' ? item.kind : translate( 'core' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Source' ) }</div>
+			<div>{ item.name !== '' ? item.name : translate( 'core' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Severity' ) }</div>
+			<div>
+				<Badge className={ `badge--${ item.severity }` }>{ item.severity }</Badge>
+			</div>
 			<div className="site-logs-details-modal__field-title">
 				{
 					// translators: %(siteGsmOffsetDisplay)s will be replaced with the timezone offset of the site, e.g. GMT, GMT +1, GMT -1.
@@ -36,14 +44,6 @@ const DetailsModalPHP = ( { item }: DetailsModalPHPProps ) => {
 				}
 			</div>
 			<div>{ getFormattedDate( item.timestamp ) }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'Severity' ) }</div>
-			<div>
-				<Badge className={ `badge--${ item.severity }` }>{ item.severity }</Badge>
-			</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'Type' ) }</div>
-			<div>{ item.kind }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'Source' ) }</div>
-			<div>{ item.name }</div>
 			<div className="site-logs-details-modal__field-title">{ translate( 'File' ) }</div>
 			<div>{ item.file }</div>
 			<div className="site-logs-details-modal__field-title">{ translate( 'Line' ) }</div>

--- a/client/sites/logs/components/site-logs.tsx
+++ b/client/sites/logs/components/site-logs.tsx
@@ -34,7 +34,6 @@ import {
 	default as useView,
 	toFilterParams,
 	getSortField,
-	getTitleField,
 	getVisibleFields,
 	getFilterValue,
 } from '../hooks/use-view';
@@ -280,7 +279,7 @@ export const SiteLogsDataViews = ( {
 									field: getSortField( value ),
 									direction: view?.sort?.direction || 'desc',
 								},
-								titleField: getTitleField( value ),
+								titleField: getSortField( value ),
 								fields: getVisibleFields( value ),
 							} ) );
 						}

--- a/client/sites/logs/components/site-logs.tsx
+++ b/client/sites/logs/components/site-logs.tsx
@@ -43,136 +43,136 @@ import type { View, Action, Filter } from '@wordpress/dataviews';
 import type { Moment } from 'moment';
 import './style.scss';
 
-export const SiteLogsDataViews = ({
+export const SiteLogsDataViews = ( {
 	logType,
 	query,
 }: {
 	logType: LogType;
 	query: LogQueryParams;
-}) => {
+} ) => {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
-	const siteId = useSelector(getSelectedSiteId);
+	const siteId = useSelector( getSelectedSiteId );
 	const dispatch = useDispatch();
 
 	const getMomentFromTimestamp = useCallback(
-		(value: string, fallback?: string) => {
-			const fromValue = parseInt(value || '', 10);
-			if (!isNaN(fromValue)) {
-				return moment.unix(fromValue);
+		( value: string, fallback?: string ) => {
+			const fromValue = parseInt( value || '', 10 );
+			if ( ! isNaN( fromValue ) ) {
+				return moment.unix( fromValue );
 			}
 
-			if (fallback === '7-days-ago') {
-				return moment().subtract(7, 'd');
+			if ( fallback === '7-days-ago' ) {
+				return moment().subtract( 7, 'd' );
 			}
 
 			return moment();
 		},
-		[moment]
+		[ moment ]
 	);
 
 	const getTimestampFor7DaysAgo = useCallback(
-		() => moment().subtract(7, 'd').unix().toString(10),
-		[moment]
+		() => moment().subtract( 7, 'd' ).unix().toString( 10 ),
+		[ moment ]
 	);
-	const getTimestampForNow = useCallback(() => moment().unix().toString(10), [moment]);
+	const getTimestampForNow = useCallback( () => moment().unix().toString( 10 ), [ moment ] );
 
 	const startTime = useMemo(
-		() => getMomentFromTimestamp(query.from, '7-days-ago'),
-		[query.from, getMomentFromTimestamp]
+		() => getMomentFromTimestamp( query.from, '7-days-ago' ),
+		[ query.from, getMomentFromTimestamp ]
 	);
 	const endTime = useMemo(
-		() => getMomentFromTimestamp(query.to),
-		[query.to, getMomentFromTimestamp]
+		() => getMomentFromTimestamp( query.to ),
+		[ query.to, getMomentFromTimestamp ]
 	);
-	const dateRange = useMemo(() => {
-		const daysInRange = endTime.diff(startTime, 'days');
+	const dateRange = useMemo( () => {
+		const daysInRange = endTime.diff( startTime, 'days' );
 		return {
-			chartStart: startTime.format('YYYY-MM-DD'),
-			chartEnd: endTime.format('YYYY-MM-DD'),
+			chartStart: startTime.format( 'YYYY-MM-DD' ),
+			chartEnd: endTime.format( 'YYYY-MM-DD' ),
 			daysInRange,
 		};
-	}, [startTime, endTime]);
+	}, [ startTime, endTime ] );
 
-	const { supportedShortcutList } = useSelector((state) =>
-		getShortcuts(state, dateRange, translate)
+	const { supportedShortcutList } = useSelector( ( state ) =>
+		getShortcuts( state, dateRange, translate )
 	);
 
-	const [autoRefresh, setAutoRefresh] = useState(false);
-	const autoRefreshCallback = useCallback(() => {
-		const url = new URL(window.location.href);
-		url.searchParams.set('from', getTimestampFor7DaysAgo());
-		url.searchParams.set('to', getTimestampForNow());
-		page.replace(url.pathname + url.search);
-	}, [getTimestampFor7DaysAgo, getTimestampForNow]);
-	useInterval(autoRefreshCallback, autoRefresh && 10 * 1000);
-	const handleAutoRefreshClick = (isChecked: boolean) => {
-		if (isChecked) {
-			const url = new URL(window.location.href);
-			url.searchParams.delete('from');
-			url.searchParams.delete('to');
-			page.replace(url.pathname + url.search);
+	const [ autoRefresh, setAutoRefresh ] = useState( false );
+	const autoRefreshCallback = useCallback( () => {
+		const url = new URL( window.location.href );
+		url.searchParams.set( 'from', getTimestampFor7DaysAgo() );
+		url.searchParams.set( 'to', getTimestampForNow() );
+		page.replace( url.pathname + url.search );
+	}, [ getTimestampFor7DaysAgo, getTimestampForNow ] );
+	useInterval( autoRefreshCallback, autoRefresh && 10 * 1000 );
+	const handleAutoRefreshClick = ( isChecked: boolean ) => {
+		if ( isChecked ) {
+			const url = new URL( window.location.href );
+			url.searchParams.delete( 'from' );
+			url.searchParams.delete( 'to' );
+			page.replace( url.pathname + url.search );
 		} else {
-			const url = new URL(window.location.href);
-			url.searchParams.set('from', getTimestampFor7DaysAgo());
-			url.searchParams.set('to', getTimestampForNow());
-			page.replace(url.pathname + url.search);
+			const url = new URL( window.location.href );
+			url.searchParams.set( 'from', getTimestampFor7DaysAgo() );
+			url.searchParams.set( 'to', getTimestampForNow() );
+			page.replace( url.pathname + url.search );
 		}
 
-		dispatch(recordTracksEvent('calypso_site_logs_auto_refresh', { enabled: isChecked }));
-		setAutoRefresh(isChecked);
+		dispatch( recordTracksEvent( 'calypso_site_logs_auto_refresh', { enabled: isChecked } ) );
+		setAutoRefresh( isChecked );
 	};
 
-	const handleTimeChange = useCallback((updatedStartTime: Moment, updatedEndTime: Moment) => {
-		setAutoRefresh(false);
+	const handleTimeChange = useCallback( ( updatedStartTime: Moment, updatedEndTime: Moment ) => {
+		setAutoRefresh( false );
 
-		const url = new URL(window.location.href);
+		const url = new URL( window.location.href );
 
-		if (!updatedStartTime.isValid()) {
-			url.searchParams.delete('from');
+		if ( ! updatedStartTime.isValid() ) {
+			url.searchParams.delete( 'from' );
 		} else {
-			url.searchParams.set('from', updatedStartTime.unix().toString(10));
+			url.searchParams.set( 'from', updatedStartTime.unix().toString( 10 ) );
 		}
 
-		if (!updatedEndTime.isValid()) {
-			url.searchParams.delete('to');
+		if ( ! updatedEndTime.isValid() ) {
+			url.searchParams.delete( 'to' );
 		} else {
-			url.searchParams.set('to', updatedEndTime.unix().toString(10));
+			url.searchParams.set( 'to', updatedEndTime.unix().toString( 10 ) );
 		}
 
-		page.replace(url.pathname + url.search);
-	}, []);
+		page.replace( url.pathname + url.search );
+	}, [] );
 
-	const [view, setView] = useView({ logType, query });
-	const oldSeverity = getFilterValue(view, 'severity')?.sort().toString() || '';
+	const [ view, setView ] = useView( { logType, query } );
+	const oldSeverity = getFilterValue( view, 'severity' )?.sort().toString() || '';
 	const setViewWithSideEffects = useCallback(
-		(newView: View) => {
-			const severity = getFilterValue(newView, 'severity')?.sort().toString() || '';
-			if (severity !== oldSeverity) {
+		( newView: View ) => {
+			const severity = getFilterValue( newView, 'severity' )?.sort().toString() || '';
+			if ( severity !== oldSeverity ) {
 				dispatch(
-					recordTracksEvent('calypso_site_logs_severity_filter', {
+					recordTracksEvent( 'calypso_site_logs_severity_filter', {
 						severity,
-						severity_user: severity.includes('User'),
-						severity_warning: severity.includes('Warning'),
-						severity_deprecated: severity.includes('Deprecated'),
-						severity_fatal: severity.includes('Fatal'),
-					})
+						severity_user: severity.includes( 'User' ),
+						severity_warning: severity.includes( 'Warning' ),
+						severity_deprecated: severity.includes( 'Deprecated' ),
+						severity_fatal: severity.includes( 'Fatal' ),
+					} )
 				);
 			}
 
 			// Disable auto-refresh if the user navigates to a different page.
-			if (autoRefresh === true && newView.page !== view.page) {
-				setAutoRefresh(false);
+			if ( autoRefresh === true && newView.page !== view.page ) {
+				setAutoRefresh( false );
 			}
 
-			setView(newView);
+			setView( newView );
 
 			// Handle URL changes.
-			const url = new URL(window.location.href);
-			const isEmpty = (filter: Filter | undefined) =>
-				!filter || !filter?.value || filter?.value.length === 0;
-			['severity', 'request_type', 'status', 'renderer', 'cached'].forEach((filterField) => {
-				const filter = newView.filters?.find((f) => f.field === filterField);
+			const url = new URL( window.location.href );
+			const isEmpty = ( filter: Filter | undefined ) =>
+				! filter || ! filter?.value || filter?.value.length === 0;
+			[ 'severity', 'request_type', 'status', 'renderer', 'cached' ].forEach( ( filterField ) => {
+				const filter = newView.filters?.find( ( f ) => f.field === filterField );
 
 				// Use cases to cover:
 				//
@@ -182,158 +182,164 @@ export const SiteLogsDataViews = ({
 				// 4. URL has the filter and the filter is different from before. Update URL param.
 				// 5. URL has the filter and the filter is empty. Remove URL param.
 
-				if (!url.searchParams.has(filterField) && isEmpty(filter)) {
+				if ( ! url.searchParams.has( filterField ) && isEmpty( filter ) ) {
 					return;
 				}
 
-				if (!url.searchParams.has(filterField) && !isEmpty(filter)) {
-					url.searchParams.set(filterField, filter?.value.sort().toString());
+				if ( ! url.searchParams.has( filterField ) && ! isEmpty( filter ) ) {
+					url.searchParams.set( filterField, filter?.value.sort().toString() );
 				}
 
 				if (
-					url.searchParams.has(filterField) &&
-					url.searchParams.get(filterField) === filter?.value.sort().toString()
+					url.searchParams.has( filterField ) &&
+					url.searchParams.get( filterField ) === filter?.value.sort().toString()
 				) {
 					return;
 				}
 
 				if (
-					url.searchParams.has(filterField) &&
-					url.searchParams.get(filterField) !== filter?.value.sort().toString()
+					url.searchParams.has( filterField ) &&
+					url.searchParams.get( filterField ) !== filter?.value.sort().toString()
 				) {
-					url.searchParams.set(filterField, filter?.value.sort().toString());
+					url.searchParams.set( filterField, filter?.value.sort().toString() );
 				}
 
-				if (url.searchParams.has(filterField) && isEmpty(filter)) {
-					url.searchParams.delete(filterField);
+				if ( url.searchParams.has( filterField ) && isEmpty( filter ) ) {
+					url.searchParams.delete( filterField );
 				}
-			});
+			} );
 
-			page.replace(url.pathname + url.search);
+			page.replace( url.pathname + url.search );
 		},
-		[autoRefresh, setAutoRefresh, oldSeverity, view.page, setView, dispatch]
+		[ autoRefresh, setAutoRefresh, oldSeverity, view.page, setView, dispatch ]
 	);
 
-	const fields = useFields({ logType });
-	const { data, paginationInfo, isLoading } = useData({
+	const fields = useFields( { logType } );
+	const { data, paginationInfo, isLoading } = useData( {
 		view,
 		logType,
 		startTime,
 		endTime,
-	});
-	const actions: Action<PHPLog | ServerLog>[] = useActions({ logType, isLoading });
+	} );
+	const actions: Action< PHPLog | ServerLog >[] = useActions( { logType, isLoading } );
 
-	const { downloadLogs, state } = useSiteLogsDownloader({ roundDateRangeToWholeDays: false });
+	const { downloadLogs, state } = useSiteLogsDownloader( { roundDateRangeToWholeDays: false } );
 	const isDownloading = state.status === 'downloading';
-	const onDownloadLogs = useCallback(() => {
-		downloadLogs({
+	const onDownloadLogs = useCallback( () => {
+		downloadLogs( {
 			logType,
 			startDateTime: startTime,
 			endDateTime: endTime,
-			filter: toFilterParams({ view, logType }),
-		});
-	}, [downloadLogs, logType, startTime, endTime, view]);
+			filter: toFilterParams( { view, logType } ),
+		} );
+	}, [ downloadLogs, logType, startTime, endTime, view ] );
 
-	const [itemDetailsModal, setItemDetailsModal] = useState<PHPLog | ServerLog | null>(null);
-	const onOpenDetailsModal = useCallback((item: PHPLog | ServerLog) => {
-		setItemDetailsModal(item);
-	}, []);
-	const onCloseDetailsModal = useCallback(() => {
-		setItemDetailsModal(null);
-	}, []);
+	const [ itemDetailsModal, setItemDetailsModal ] = useState< PHPLog | ServerLog | null >( null );
+	const onOpenDetailsModal = useCallback( ( item: PHPLog | ServerLog ) => {
+		setItemDetailsModal( item );
+	}, [] );
+	const onCloseDetailsModal = useCallback( () => {
+		setItemDetailsModal( null );
+	}, [] );
 
 	return (
 		<>
-			{siteId && <QuerySiteSettings siteId={siteId} />}
-			{!!itemDetailsModal && (
-				<DetailsModal item={itemDetailsModal} logType={logType} onClose={onCloseDetailsModal} />
-			)}
+			{ siteId && <QuerySiteSettings siteId={ siteId } /> }
+			{ !! itemDetailsModal && (
+				<DetailsModal
+					item={ itemDetailsModal }
+					logType={ logType }
+					onClose={ onCloseDetailsModal }
+				/>
+			) }
 			<div className="site-logs-header">
 				<NavigationHeader
-					title={translate('Logs')}
-					subtitle={translate(
+					title={ translate( 'Logs' ) }
+					subtitle={ translate(
 						'View and download various server logs. {{link}}Learn more{{/link}}',
 						{
 							components: {
-								link: <InlineSupportLink supportContext="site-monitoring-logs" showIcon={false} />,
+								link: (
+									<InlineSupportLink supportContext="site-monitoring-logs" showIcon={ false } />
+								),
 							},
 						}
-					)}
+					) }
 				/>
 				<ToggleGroupControl
 					className="site-logs-toolbar__toggle"
 					hideLabelFromVision
 					label=""
-					onChange={(value) => {
-						if (value === LogType.PHP || value === LogType.WEB) {
-							navigate(window.location.pathname.replace(/\/[^/]+$/, '/' + value));
-							setView((view: View) => ({
+					onChange={ ( value ) => {
+						if ( value === LogType.PHP || value === LogType.WEB ) {
+							navigate( window.location.pathname.replace( /\/[^/]+$/, '/' + value ) );
+							setView( ( view: View ) => ( {
 								...view,
 								filters: [],
 								sort: {
-									field: getSortField(value),
+									field: getSortField( value ),
 									direction: view?.sort?.direction || 'desc',
 								},
-								titleField: getTitleField(value),
-								fields: getVisibleFields(value),
-							}));
+								titleField: getTitleField( value ),
+								fields: getVisibleFields( value ),
+							} ) );
 						}
-					}}
-					value={logType}
+					} }
+					value={ logType }
 					__nextHasNoMarginBottom
 				>
 					<ToggleGroupControlOption
 						className="site-logs-toolbar__toggle-option"
-						label={translate('PHP error', {
+						label={ translate( 'PHP error', {
 							textOnly: true,
-						})}
+						} ) }
 						value="php"
 					/>
 					<ToggleGroupControlOption
 						className="site-logs-toolbar__toggle-option"
-						label={translate('Web server', {
+						label={ translate( 'Web server', {
 							textOnly: true,
-						})}
+						} ) }
 						value="web"
 					/>
 				</ToggleGroupControl>
 				<DateControl
-					dateRange={dateRange}
-					onApplyButtonClick={handleTimeChange}
-					shortcutList={supportedShortcutList}
-					onShortcutClick={(shortcut, closePopoverAndCommit) => {
+					dateRange={ dateRange }
+					onApplyButtonClick={ handleTimeChange }
+					shortcutList={ supportedShortcutList }
+					onShortcutClick={ ( shortcut, closePopoverAndCommit ) => {
 						/* Time change is handled by onApplyButtonClick */
 						closePopoverAndCommit();
-					}}
-					tooltip={translate('Select a date range')}
+					} }
+					tooltip={ translate( 'Select a date range' ) }
 				/>
 			</div>
-			<DataViews<PHPLog | ServerLog>
-				data={data}
-				isLoading={isLoading}
-				paginationInfo={paginationInfo}
-				fields={fields}
-				view={view}
-				onChangeView={setViewWithSideEffects}
-				onClickItem={onOpenDetailsModal}
-				actions={actions}
-				search={false}
-				defaultLayouts={{ table: {} }}
+			<DataViews< PHPLog | ServerLog >
+				data={ data }
+				isLoading={ isLoading }
+				paginationInfo={ paginationInfo }
+				fields={ fields }
+				view={ view }
+				onChangeView={ setViewWithSideEffects }
+				onClickItem={ onOpenDetailsModal }
+				actions={ actions }
+				search={ false }
+				defaultLayouts={ { table: {} } }
 				header={
 					<>
 						<Button
 							size="compact"
-							icon={download}
+							icon={ download }
 							label="Download logs"
-							onClick={onDownloadLogs}
-							isBusy={isDownloading}
+							onClick={ onDownloadLogs }
+							isBusy={ isDownloading }
 						/>
 						<ToggleControl
 							__nextHasNoMarginBottom
 							className="site-logs__auto-refresh site-logs__auto-refresh_desktop"
-							label={translate('Auto-refresh', { textOnly: true })}
-							checked={autoRefresh}
-							onChange={handleAutoRefreshClick}
+							label={ translate( 'Auto-refresh', { textOnly: true } ) }
+							checked={ autoRefresh }
+							onChange={ handleAutoRefreshClick }
 						/>
 					</>
 				}

--- a/client/sites/logs/components/site-logs.tsx
+++ b/client/sites/logs/components/site-logs.tsx
@@ -34,6 +34,7 @@ import {
 	default as useView,
 	toFilterParams,
 	getSortField,
+	getTitleField,
 	getVisibleFields,
 	getFilterValue,
 } from '../hooks/use-view';
@@ -42,136 +43,136 @@ import type { View, Action, Filter } from '@wordpress/dataviews';
 import type { Moment } from 'moment';
 import './style.scss';
 
-export const SiteLogsDataViews = ( {
+export const SiteLogsDataViews = ({
 	logType,
 	query,
 }: {
 	logType: LogType;
 	query: LogQueryParams;
-} ) => {
+}) => {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
-	const siteId = useSelector( getSelectedSiteId );
+	const siteId = useSelector(getSelectedSiteId);
 	const dispatch = useDispatch();
 
 	const getMomentFromTimestamp = useCallback(
-		( value: string, fallback?: string ) => {
-			const fromValue = parseInt( value || '', 10 );
-			if ( ! isNaN( fromValue ) ) {
-				return moment.unix( fromValue );
+		(value: string, fallback?: string) => {
+			const fromValue = parseInt(value || '', 10);
+			if (!isNaN(fromValue)) {
+				return moment.unix(fromValue);
 			}
 
-			if ( fallback === '7-days-ago' ) {
-				return moment().subtract( 7, 'd' );
+			if (fallback === '7-days-ago') {
+				return moment().subtract(7, 'd');
 			}
 
 			return moment();
 		},
-		[ moment ]
+		[moment]
 	);
 
 	const getTimestampFor7DaysAgo = useCallback(
-		() => moment().subtract( 7, 'd' ).unix().toString( 10 ),
-		[ moment ]
+		() => moment().subtract(7, 'd').unix().toString(10),
+		[moment]
 	);
-	const getTimestampForNow = useCallback( () => moment().unix().toString( 10 ), [ moment ] );
+	const getTimestampForNow = useCallback(() => moment().unix().toString(10), [moment]);
 
 	const startTime = useMemo(
-		() => getMomentFromTimestamp( query.from, '7-days-ago' ),
-		[ query.from, getMomentFromTimestamp ]
+		() => getMomentFromTimestamp(query.from, '7-days-ago'),
+		[query.from, getMomentFromTimestamp]
 	);
 	const endTime = useMemo(
-		() => getMomentFromTimestamp( query.to ),
-		[ query.to, getMomentFromTimestamp ]
+		() => getMomentFromTimestamp(query.to),
+		[query.to, getMomentFromTimestamp]
 	);
-	const dateRange = useMemo( () => {
-		const daysInRange = endTime.diff( startTime, 'days' );
+	const dateRange = useMemo(() => {
+		const daysInRange = endTime.diff(startTime, 'days');
 		return {
-			chartStart: startTime.format( 'YYYY-MM-DD' ),
-			chartEnd: endTime.format( 'YYYY-MM-DD' ),
+			chartStart: startTime.format('YYYY-MM-DD'),
+			chartEnd: endTime.format('YYYY-MM-DD'),
 			daysInRange,
 		};
-	}, [ startTime, endTime ] );
+	}, [startTime, endTime]);
 
-	const { supportedShortcutList } = useSelector( ( state ) =>
-		getShortcuts( state, dateRange, translate )
+	const { supportedShortcutList } = useSelector((state) =>
+		getShortcuts(state, dateRange, translate)
 	);
 
-	const [ autoRefresh, setAutoRefresh ] = useState( false );
-	const autoRefreshCallback = useCallback( () => {
-		const url = new URL( window.location.href );
-		url.searchParams.set( 'from', getTimestampFor7DaysAgo() );
-		url.searchParams.set( 'to', getTimestampForNow() );
-		page.replace( url.pathname + url.search );
-	}, [ getTimestampFor7DaysAgo, getTimestampForNow ] );
-	useInterval( autoRefreshCallback, autoRefresh && 10 * 1000 );
-	const handleAutoRefreshClick = ( isChecked: boolean ) => {
-		if ( isChecked ) {
-			const url = new URL( window.location.href );
-			url.searchParams.delete( 'from' );
-			url.searchParams.delete( 'to' );
-			page.replace( url.pathname + url.search );
+	const [autoRefresh, setAutoRefresh] = useState(false);
+	const autoRefreshCallback = useCallback(() => {
+		const url = new URL(window.location.href);
+		url.searchParams.set('from', getTimestampFor7DaysAgo());
+		url.searchParams.set('to', getTimestampForNow());
+		page.replace(url.pathname + url.search);
+	}, [getTimestampFor7DaysAgo, getTimestampForNow]);
+	useInterval(autoRefreshCallback, autoRefresh && 10 * 1000);
+	const handleAutoRefreshClick = (isChecked: boolean) => {
+		if (isChecked) {
+			const url = new URL(window.location.href);
+			url.searchParams.delete('from');
+			url.searchParams.delete('to');
+			page.replace(url.pathname + url.search);
 		} else {
-			const url = new URL( window.location.href );
-			url.searchParams.set( 'from', getTimestampFor7DaysAgo() );
-			url.searchParams.set( 'to', getTimestampForNow() );
-			page.replace( url.pathname + url.search );
+			const url = new URL(window.location.href);
+			url.searchParams.set('from', getTimestampFor7DaysAgo());
+			url.searchParams.set('to', getTimestampForNow());
+			page.replace(url.pathname + url.search);
 		}
 
-		dispatch( recordTracksEvent( 'calypso_site_logs_auto_refresh', { enabled: isChecked } ) );
-		setAutoRefresh( isChecked );
+		dispatch(recordTracksEvent('calypso_site_logs_auto_refresh', { enabled: isChecked }));
+		setAutoRefresh(isChecked);
 	};
 
-	const handleTimeChange = useCallback( ( updatedStartTime: Moment, updatedEndTime: Moment ) => {
-		setAutoRefresh( false );
+	const handleTimeChange = useCallback((updatedStartTime: Moment, updatedEndTime: Moment) => {
+		setAutoRefresh(false);
 
-		const url = new URL( window.location.href );
+		const url = new URL(window.location.href);
 
-		if ( ! updatedStartTime.isValid() ) {
-			url.searchParams.delete( 'from' );
+		if (!updatedStartTime.isValid()) {
+			url.searchParams.delete('from');
 		} else {
-			url.searchParams.set( 'from', updatedStartTime.unix().toString( 10 ) );
+			url.searchParams.set('from', updatedStartTime.unix().toString(10));
 		}
 
-		if ( ! updatedEndTime.isValid() ) {
-			url.searchParams.delete( 'to' );
+		if (!updatedEndTime.isValid()) {
+			url.searchParams.delete('to');
 		} else {
-			url.searchParams.set( 'to', updatedEndTime.unix().toString( 10 ) );
+			url.searchParams.set('to', updatedEndTime.unix().toString(10));
 		}
 
-		page.replace( url.pathname + url.search );
-	}, [] );
+		page.replace(url.pathname + url.search);
+	}, []);
 
-	const [ view, setView ] = useView( { logType, query } );
-	const oldSeverity = getFilterValue( view, 'severity' )?.sort().toString() || '';
+	const [view, setView] = useView({ logType, query });
+	const oldSeverity = getFilterValue(view, 'severity')?.sort().toString() || '';
 	const setViewWithSideEffects = useCallback(
-		( newView: View ) => {
-			const severity = getFilterValue( newView, 'severity' )?.sort().toString() || '';
-			if ( severity !== oldSeverity ) {
+		(newView: View) => {
+			const severity = getFilterValue(newView, 'severity')?.sort().toString() || '';
+			if (severity !== oldSeverity) {
 				dispatch(
-					recordTracksEvent( 'calypso_site_logs_severity_filter', {
+					recordTracksEvent('calypso_site_logs_severity_filter', {
 						severity,
-						severity_user: severity.includes( 'User' ),
-						severity_warning: severity.includes( 'Warning' ),
-						severity_deprecated: severity.includes( 'Deprecated' ),
-						severity_fatal: severity.includes( 'Fatal' ),
-					} )
+						severity_user: severity.includes('User'),
+						severity_warning: severity.includes('Warning'),
+						severity_deprecated: severity.includes('Deprecated'),
+						severity_fatal: severity.includes('Fatal'),
+					})
 				);
 			}
 
 			// Disable auto-refresh if the user navigates to a different page.
-			if ( autoRefresh === true && newView.page !== view.page ) {
-				setAutoRefresh( false );
+			if (autoRefresh === true && newView.page !== view.page) {
+				setAutoRefresh(false);
 			}
 
-			setView( newView );
+			setView(newView);
 
 			// Handle URL changes.
-			const url = new URL( window.location.href );
-			const isEmpty = ( filter: Filter | undefined ) =>
-				! filter || ! filter?.value || filter?.value.length === 0;
-			[ 'severity', 'request_type', 'status', 'renderer', 'cached' ].forEach( ( filterField ) => {
-				const filter = newView.filters?.find( ( f ) => f.field === filterField );
+			const url = new URL(window.location.href);
+			const isEmpty = (filter: Filter | undefined) =>
+				!filter || !filter?.value || filter?.value.length === 0;
+			['severity', 'request_type', 'status', 'renderer', 'cached'].forEach((filterField) => {
+				const filter = newView.filters?.find((f) => f.field === filterField);
 
 				// Use cases to cover:
 				//
@@ -181,164 +182,158 @@ export const SiteLogsDataViews = ( {
 				// 4. URL has the filter and the filter is different from before. Update URL param.
 				// 5. URL has the filter and the filter is empty. Remove URL param.
 
-				if ( ! url.searchParams.has( filterField ) && isEmpty( filter ) ) {
+				if (!url.searchParams.has(filterField) && isEmpty(filter)) {
 					return;
 				}
 
-				if ( ! url.searchParams.has( filterField ) && ! isEmpty( filter ) ) {
-					url.searchParams.set( filterField, filter?.value.sort().toString() );
+				if (!url.searchParams.has(filterField) && !isEmpty(filter)) {
+					url.searchParams.set(filterField, filter?.value.sort().toString());
 				}
 
 				if (
-					url.searchParams.has( filterField ) &&
-					url.searchParams.get( filterField ) === filter?.value.sort().toString()
+					url.searchParams.has(filterField) &&
+					url.searchParams.get(filterField) === filter?.value.sort().toString()
 				) {
 					return;
 				}
 
 				if (
-					url.searchParams.has( filterField ) &&
-					url.searchParams.get( filterField ) !== filter?.value.sort().toString()
+					url.searchParams.has(filterField) &&
+					url.searchParams.get(filterField) !== filter?.value.sort().toString()
 				) {
-					url.searchParams.set( filterField, filter?.value.sort().toString() );
+					url.searchParams.set(filterField, filter?.value.sort().toString());
 				}
 
-				if ( url.searchParams.has( filterField ) && isEmpty( filter ) ) {
-					url.searchParams.delete( filterField );
+				if (url.searchParams.has(filterField) && isEmpty(filter)) {
+					url.searchParams.delete(filterField);
 				}
-			} );
+			});
 
-			page.replace( url.pathname + url.search );
+			page.replace(url.pathname + url.search);
 		},
-		[ autoRefresh, setAutoRefresh, oldSeverity, view.page, setView, dispatch ]
+		[autoRefresh, setAutoRefresh, oldSeverity, view.page, setView, dispatch]
 	);
 
-	const fields = useFields( { logType } );
-	const { data, paginationInfo, isLoading } = useData( {
+	const fields = useFields({ logType });
+	const { data, paginationInfo, isLoading } = useData({
 		view,
 		logType,
 		startTime,
 		endTime,
-	} );
-	const actions: Action< PHPLog | ServerLog >[] = useActions( { logType, isLoading } );
+	});
+	const actions: Action<PHPLog | ServerLog>[] = useActions({ logType, isLoading });
 
-	const { downloadLogs, state } = useSiteLogsDownloader( { roundDateRangeToWholeDays: false } );
+	const { downloadLogs, state } = useSiteLogsDownloader({ roundDateRangeToWholeDays: false });
 	const isDownloading = state.status === 'downloading';
-	const onDownloadLogs = useCallback( () => {
-		downloadLogs( {
+	const onDownloadLogs = useCallback(() => {
+		downloadLogs({
 			logType,
 			startDateTime: startTime,
 			endDateTime: endTime,
-			filter: toFilterParams( { view, logType } ),
-		} );
-	}, [ downloadLogs, logType, startTime, endTime, view ] );
+			filter: toFilterParams({ view, logType }),
+		});
+	}, [downloadLogs, logType, startTime, endTime, view]);
 
-	const [ itemDetailsModal, setItemDetailsModal ] = useState< PHPLog | ServerLog | null >( null );
-	const onOpenDetailsModal = useCallback( ( item: PHPLog | ServerLog ) => {
-		setItemDetailsModal( item );
-	}, [] );
-	const onCloseDetailsModal = useCallback( () => {
-		setItemDetailsModal( null );
-	}, [] );
+	const [itemDetailsModal, setItemDetailsModal] = useState<PHPLog | ServerLog | null>(null);
+	const onOpenDetailsModal = useCallback((item: PHPLog | ServerLog) => {
+		setItemDetailsModal(item);
+	}, []);
+	const onCloseDetailsModal = useCallback(() => {
+		setItemDetailsModal(null);
+	}, []);
 
 	return (
 		<>
-			{ siteId && <QuerySiteSettings siteId={ siteId } /> }
-			{ !! itemDetailsModal && (
-				<DetailsModal
-					item={ itemDetailsModal }
-					logType={ logType }
-					onClose={ onCloseDetailsModal }
-				/>
-			) }
+			{siteId && <QuerySiteSettings siteId={siteId} />}
+			{!!itemDetailsModal && (
+				<DetailsModal item={itemDetailsModal} logType={logType} onClose={onCloseDetailsModal} />
+			)}
 			<div className="site-logs-header">
 				<NavigationHeader
-					title={ translate( 'Logs' ) }
-					subtitle={ translate(
+					title={translate('Logs')}
+					subtitle={translate(
 						'View and download various server logs. {{link}}Learn more{{/link}}',
 						{
 							components: {
-								link: (
-									<InlineSupportLink supportContext="site-monitoring-logs" showIcon={ false } />
-								),
+								link: <InlineSupportLink supportContext="site-monitoring-logs" showIcon={false} />,
 							},
 						}
-					) }
+					)}
 				/>
 				<ToggleGroupControl
 					className="site-logs-toolbar__toggle"
 					hideLabelFromVision
 					label=""
-					onChange={ ( value ) => {
-						if ( value === LogType.PHP || value === LogType.WEB ) {
-							navigate( window.location.pathname.replace( /\/[^/]+$/, '/' + value ) );
-							setView( ( view: View ) => ( {
+					onChange={(value) => {
+						if (value === LogType.PHP || value === LogType.WEB) {
+							navigate(window.location.pathname.replace(/\/[^/]+$/, '/' + value));
+							setView((view: View) => ({
 								...view,
 								filters: [],
 								sort: {
-									field: getSortField( value ),
+									field: getSortField(value),
 									direction: view?.sort?.direction || 'desc',
 								},
-								titleField: getSortField( value ),
-								fields: getVisibleFields( value ),
-							} ) );
+								titleField: getTitleField(value),
+								fields: getVisibleFields(value),
+							}));
 						}
-					} }
-					value={ logType }
+					}}
+					value={logType}
 					__nextHasNoMarginBottom
 				>
 					<ToggleGroupControlOption
 						className="site-logs-toolbar__toggle-option"
-						label={ translate( 'PHP error', {
+						label={translate('PHP error', {
 							textOnly: true,
-						} ) }
+						})}
 						value="php"
 					/>
 					<ToggleGroupControlOption
 						className="site-logs-toolbar__toggle-option"
-						label={ translate( 'Web server', {
+						label={translate('Web server', {
 							textOnly: true,
-						} ) }
+						})}
 						value="web"
 					/>
 				</ToggleGroupControl>
 				<DateControl
-					dateRange={ dateRange }
-					onApplyButtonClick={ handleTimeChange }
-					shortcutList={ supportedShortcutList }
-					onShortcutClick={ ( shortcut, closePopoverAndCommit ) => {
+					dateRange={dateRange}
+					onApplyButtonClick={handleTimeChange}
+					shortcutList={supportedShortcutList}
+					onShortcutClick={(shortcut, closePopoverAndCommit) => {
 						/* Time change is handled by onApplyButtonClick */
 						closePopoverAndCommit();
-					} }
-					tooltip={ translate( 'Select a date range' ) }
+					}}
+					tooltip={translate('Select a date range')}
 				/>
 			</div>
-			<DataViews< PHPLog | ServerLog >
-				data={ data }
-				isLoading={ isLoading }
-				paginationInfo={ paginationInfo }
-				fields={ fields }
-				view={ view }
-				onChangeView={ setViewWithSideEffects }
-				onClickItem={ onOpenDetailsModal }
-				actions={ actions }
-				search={ false }
-				defaultLayouts={ { table: {} } }
+			<DataViews<PHPLog | ServerLog>
+				data={data}
+				isLoading={isLoading}
+				paginationInfo={paginationInfo}
+				fields={fields}
+				view={view}
+				onChangeView={setViewWithSideEffects}
+				onClickItem={onOpenDetailsModal}
+				actions={actions}
+				search={false}
+				defaultLayouts={{ table: {} }}
 				header={
 					<>
 						<Button
 							size="compact"
-							icon={ download }
+							icon={download}
 							label="Download logs"
-							onClick={ onDownloadLogs }
-							isBusy={ isDownloading }
+							onClick={onDownloadLogs}
+							isBusy={isDownloading}
 						/>
 						<ToggleControl
 							__nextHasNoMarginBottom
 							className="site-logs__auto-refresh site-logs__auto-refresh_desktop"
-							label={ translate( 'Auto-refresh', { textOnly: true } ) }
-							checked={ autoRefresh }
-							onChange={ handleAutoRefreshClick }
+							label={translate('Auto-refresh', { textOnly: true })}
+							checked={autoRefresh}
+							onChange={handleAutoRefreshClick}
 						/>
 					</>
 				}

--- a/client/sites/logs/components/style.scss
+++ b/client/sites/logs/components/style.scss
@@ -53,7 +53,6 @@
 }
 
 // Long fields in PHP Errors.
-.site-logs-table__message,
 .site-logs-table__file,
 // Long fields in Web Errors.
 .site-logs-table__request-url,
@@ -61,6 +60,12 @@
 	overflow: visible;
 	white-space: normal;
 	word-break: break-word;
+}
+// Long field in PHP Errors that we want to truncate.
+.site-logs-table__message {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
 }
 
 // Badges

--- a/client/sites/logs/components/style.scss
+++ b/client/sites/logs/components/style.scss
@@ -10,14 +10,14 @@
 	}
 
 	.site-logs-toolbar__toggle {
-		border-color: var(--color-neutral-10);
+		border-color: var( --color-neutral-10 );
 	}
 	.site-logs-toolbar__toggle-option {
 		white-space: nowrap;
 	}
 }
 
-@media (max-width: 600px) {
+@media ( max-width: 600px ) {
 	.site-logs-header {
 		align-items: flex-start;
 		flex-direction: column;
@@ -81,20 +81,20 @@
 
 	.badge.badge--POST,
 	.badge.badge--Deprecated {
-		background-color: rgba(187, 224, 250, 1);
-		color: rgba(2, 57, 92, 1);
+		background-color: rgba( 187, 224, 250, 1 );
+		color: rgba( 2, 57, 92, 1 );
 	}
 
 	.badge.badge--GET {
-		background-color: rgba(184, 230, 191, 1);
-		color: rgba(0, 69, 12, 1);
+		background-color: rgba( 184, 230, 191, 1 );
+		color: rgba( 0, 69, 12, 1 );
 	}
 
 	.badge.badge--DELETE,
 	.badge.badge--Error,
 	.badge.badge--Fatal.error {
-		background-color: rgba(250, 207, 210, 1);
-		color: rgba(105, 28, 28, 1);
+		background-color: rgba( 250, 207, 210, 1 );
+		color: rgba( 105, 28, 28, 1 );
 	}
 
 	.badge.badge--Fatal.error {
@@ -102,13 +102,13 @@
 	}
 
 	.badge.badge--Warning {
-		background-color: rgba(245, 230, 179, 1);
-		color: rgba(79, 53, 0, 1);
+		background-color: rgba( 245, 230, 179, 1 );
+		color: rgba( 79, 53, 0, 1 );
 	}
 
 	.badge.badge--User {
-		background-color: rgba(220, 220, 222, 1);
-		color: rgba(44, 51, 56, 1);
+		background-color: rgba( 220, 220, 222, 1 );
+		color: rgba( 44, 51, 56, 1 );
 	}
 }
 
@@ -125,12 +125,12 @@
 		font-size: 0.75rem;
 		text-transform: uppercase;
 	}
-	:not(.site-logs-details-modal__field-title) {
+	:not( .site-logs-details-modal__field-title ) {
 		word-wrap: break-word;
 		min-width: 0;
 		font-size: 0.875rem;
 	}
-	:not(.site-logs-details-modal__field-title) .badge {
+	:not( .site-logs-details-modal__field-title ) .badge {
 		font-size: 0.75rem;
 	}
 }

--- a/client/sites/logs/components/style.scss
+++ b/client/sites/logs/components/style.scss
@@ -10,14 +10,14 @@
 	}
 
 	.site-logs-toolbar__toggle {
-		border-color: var( --color-neutral-10 );
+		border-color: var(--color-neutral-10);
 	}
 	.site-logs-toolbar__toggle-option {
 		white-space: nowrap;
 	}
 }
 
-@media ( max-width: 600px ) {
+@media (max-width: 600px) {
 	.site-logs-header {
 		align-items: flex-start;
 		flex-direction: column;
@@ -81,20 +81,20 @@
 
 	.badge.badge--POST,
 	.badge.badge--Deprecated {
-		background-color: rgba( 187, 224, 250, 1 );
-		color: rgba( 2, 57, 92, 1 );
+		background-color: rgba(187, 224, 250, 1);
+		color: rgba(2, 57, 92, 1);
 	}
 
 	.badge.badge--GET {
-		background-color: rgba( 184, 230, 191, 1 );
-		color: rgba( 0, 69, 12, 1 );
+		background-color: rgba(184, 230, 191, 1);
+		color: rgba(0, 69, 12, 1);
 	}
 
 	.badge.badge--DELETE,
 	.badge.badge--Error,
 	.badge.badge--Fatal.error {
-		background-color: rgba( 250, 207, 210, 1 );
-		color: rgba( 105, 28, 28, 1 );
+		background-color: rgba(250, 207, 210, 1);
+		color: rgba(105, 28, 28, 1);
 	}
 
 	.badge.badge--Fatal.error {
@@ -102,13 +102,13 @@
 	}
 
 	.badge.badge--Warning {
-		background-color: rgba( 245, 230, 179, 1 );
-		color: rgba( 79, 53, 0, 1 );
+		background-color: rgba(245, 230, 179, 1);
+		color: rgba(79, 53, 0, 1);
 	}
 
 	.badge.badge--User {
-		background-color: rgba( 220, 220, 222, 1 );
-		color: rgba( 44, 51, 56, 1 );
+		background-color: rgba(220, 220, 222, 1);
+		color: rgba(44, 51, 56, 1);
 	}
 }
 
@@ -125,12 +125,12 @@
 		font-size: 0.75rem;
 		text-transform: uppercase;
 	}
-	:not( .site-logs-details-modal__field-title ) {
+	:not(.site-logs-details-modal__field-title) {
 		word-wrap: break-word;
 		min-width: 0;
 		font-size: 0.875rem;
 	}
-	:not( .site-logs-details-modal__field-title ) .badge {
+	:not(.site-logs-details-modal__field-title) .badge {
 		font-size: 0.75rem;
 	}
 }

--- a/client/sites/logs/hooks/use-actions.tsx
+++ b/client/sites/logs/hooks/use-actions.tsx
@@ -1,4 +1,4 @@
-import { copy } from '@wordpress/icons';
+import { details, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { LogType, ServerLog, PHPLog } from 'calypso/data/hosting/use-site-logs-query';
@@ -15,10 +15,21 @@ const useActions = ( { logType, isLoading }: { logType: LogType; isLoading: bool
 		if ( logType === LogType.PHP ) {
 			return [
 				{
+					id: 'details-modal',
+					label: translate( 'View log details' ),
+					modalHeader: translate( 'Log details' ),
+					isPrimary: true,
+					icon: details,
+					disabled: isLoading,
+					supportsBulk: false,
+					RenderModal: ( { items }: { items: ( PHPLog | ServerLog )[] } ) => {
+						const item = items[ 0 ] as PHPLog;
+						return <DetailsModalPHP item={ item } />;
+					},
+				},
+				{
 					id: 'copy-msg',
 					label: translate( 'Copy message' ),
-					icon: copy,
-					isPrimary: true,
 					disabled: isLoading,
 					supportsBulk: false,
 					callback: async ( items: ( PHPLog | ServerLog )[] ) => {
@@ -41,27 +52,26 @@ const useActions = ( { logType, isLoading }: { logType: LogType; isLoading: bool
 						}
 					},
 				},
-				{
-					id: 'details-modal',
-					label: translate( 'View log details' ),
-					modalHeader: translate( 'Log details' ),
-					isPrimary: false,
-					disabled: isLoading,
-					supportsBulk: false,
-					RenderModal: ( { items }: { items: ( PHPLog | ServerLog )[] } ) => {
-						const item = items[ 0 ] as PHPLog;
-						return <DetailsModalPHP item={ item } />;
-					},
-				},
 			];
 		}
 
 		return [
 			{
+				id: 'details-modal',
+				label: translate( 'View log details' ),
+				modalHeader: translate( 'Log details' ),
+				isPrimary: true,
+				icon: info,
+				disabled: isLoading,
+				supportsBulk: false,
+				RenderModal: ( { items }: { items: ( PHPLog | ServerLog )[] } ) => {
+					const item = items[ 0 ] as ServerLog;
+					return <DetailsModalServer item={ item } />;
+				},
+			},
+			{
 				id: 'copy-url',
 				label: translate( 'Copy request URL' ),
-				icon: copy,
-				isPrimary: true,
 				disabled: isLoading,
 				supportsBulk: false,
 				callback: async ( items: ( PHPLog | ServerLog )[] ) => {
@@ -82,18 +92,6 @@ const useActions = ( { logType, isLoading }: { logType: LogType; isLoading: bool
 							)
 						);
 					}
-				},
-			},
-			{
-				id: 'details-modal',
-				label: translate( 'View log details' ),
-				modalHeader: translate( 'Log details' ),
-				isPrimary: false,
-				disabled: isLoading,
-				supportsBulk: false,
-				RenderModal: ( { items }: { items: ( PHPLog | ServerLog )[] } ) => {
-					const item = items[ 0 ] as ServerLog;
-					return <DetailsModalServer item={ item } />;
 				},
 			},
 		];

--- a/client/sites/logs/hooks/use-actions.tsx
+++ b/client/sites/logs/hooks/use-actions.tsx
@@ -1,4 +1,4 @@
-import { details, info } from '@wordpress/icons';
+import { details } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { LogType, ServerLog, PHPLog } from 'calypso/data/hosting/use-site-logs-query';
@@ -61,7 +61,7 @@ const useActions = ({ logType, isLoading }: { logType: LogType; isLoading: boole
 				label: translate('View log details'),
 				modalHeader: translate('Log details'),
 				isPrimary: true,
-				icon: info,
+				icon: details,
 				disabled: isLoading,
 				supportsBulk: false,
 				RenderModal: ({ items }: { items: (PHPLog | ServerLog)[] }) => {

--- a/client/sites/logs/hooks/use-actions.tsx
+++ b/client/sites/logs/hooks/use-actions.tsx
@@ -7,46 +7,46 @@ import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import DetailsModalPHP from '../components/details-modal-php';
 import DetailsModalServer from '../components/details-modal-server';
 
-const useActions = ({ logType, isLoading }: { logType: LogType; isLoading: boolean }) => {
+const useActions = ( { logType, isLoading }: { logType: LogType; isLoading: boolean } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const actions = useMemo(() => {
-		if (logType === LogType.PHP) {
+	const actions = useMemo( () => {
+		if ( logType === LogType.PHP ) {
 			return [
 				{
 					id: 'details-modal',
-					label: translate('View log details'),
-					modalHeader: translate('Log details'),
+					label: translate( 'View log details' ),
+					modalHeader: translate( 'Log details' ),
 					isPrimary: true,
 					icon: details,
 					disabled: isLoading,
 					supportsBulk: false,
-					RenderModal: ({ items }: { items: (PHPLog | ServerLog)[] }) => {
-						const item = items[0] as PHPLog;
-						return <DetailsModalPHP item={item} />;
+					RenderModal: ( { items }: { items: ( PHPLog | ServerLog )[] } ) => {
+						const item = items[ 0 ] as PHPLog;
+						return <DetailsModalPHP item={ item } />;
 					},
 				},
 				{
 					id: 'copy-msg',
-					label: translate('Copy message'),
+					label: translate( 'Copy message' ),
 					disabled: isLoading,
 					supportsBulk: false,
-					callback: async (items: (PHPLog | ServerLog)[]) => {
-						const message = (items[0] as PHPLog).message;
+					callback: async ( items: ( PHPLog | ServerLog )[] ) => {
+						const message = ( items[ 0 ] as PHPLog ).message;
 						try {
-							await navigator.clipboard.writeText(message);
+							await navigator.clipboard.writeText( message );
 							dispatch(
 								successNotice(
 									/* translators: notice shown upon copy of Logs entry */
-									translate('Copied message')
+									translate( 'Copied message' )
 								)
 							);
-						} catch (error) {
+						} catch ( error ) {
 							dispatch(
 								errorNotice(
 									/* translators: notice shown upon failed copy of Logs entry */
-									translate('Message could not be copied')
+									translate( 'Message could not be copied' )
 								)
 							);
 						}
@@ -58,44 +58,44 @@ const useActions = ({ logType, isLoading }: { logType: LogType; isLoading: boole
 		return [
 			{
 				id: 'details-modal',
-				label: translate('View log details'),
-				modalHeader: translate('Log details'),
+				label: translate( 'View log details' ),
+				modalHeader: translate( 'Log details' ),
 				isPrimary: true,
 				icon: details,
 				disabled: isLoading,
 				supportsBulk: false,
-				RenderModal: ({ items }: { items: (PHPLog | ServerLog)[] }) => {
-					const item = items[0] as ServerLog;
-					return <DetailsModalServer item={item} />;
+				RenderModal: ( { items }: { items: ( PHPLog | ServerLog )[] } ) => {
+					const item = items[ 0 ] as ServerLog;
+					return <DetailsModalServer item={ item } />;
 				},
 			},
 			{
 				id: 'copy-url',
-				label: translate('Copy request URL'),
+				label: translate( 'Copy request URL' ),
 				disabled: isLoading,
 				supportsBulk: false,
-				callback: async (items: (PHPLog | ServerLog)[]) => {
-					const url = (items[0] as ServerLog).request_url;
+				callback: async ( items: ( PHPLog | ServerLog )[] ) => {
+					const url = ( items[ 0 ] as ServerLog ).request_url;
 					try {
-						await navigator.clipboard.writeText(url);
+						await navigator.clipboard.writeText( url );
 						dispatch(
 							successNotice(
 								/* translators: notice shown upon copy of request URL */
-								translate('Copied request URL')
+								translate( 'Copied request URL' )
 							)
 						);
-					} catch (error) {
+					} catch ( error ) {
 						dispatch(
 							errorNotice(
 								/* translators: notice shown upon failed copy of request URL */
-								translate('Request URL could not be copied')
+								translate( 'Request URL could not be copied' )
 							)
 						);
 					}
 				},
 			},
 		];
-	}, [logType, translate, isLoading, dispatch]);
+	}, [ logType, translate, isLoading, dispatch ] );
 
 	return actions;
 };

--- a/client/sites/logs/hooks/use-actions.tsx
+++ b/client/sites/logs/hooks/use-actions.tsx
@@ -7,46 +7,46 @@ import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import DetailsModalPHP from '../components/details-modal-php';
 import DetailsModalServer from '../components/details-modal-server';
 
-const useActions = ( { logType, isLoading }: { logType: LogType; isLoading: boolean } ) => {
+const useActions = ({ logType, isLoading }: { logType: LogType; isLoading: boolean }) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const actions = useMemo( () => {
-		if ( logType === LogType.PHP ) {
+	const actions = useMemo(() => {
+		if (logType === LogType.PHP) {
 			return [
 				{
 					id: 'details-modal',
-					label: translate( 'View log details' ),
-					modalHeader: translate( 'Log details' ),
+					label: translate('View log details'),
+					modalHeader: translate('Log details'),
 					isPrimary: true,
 					icon: details,
 					disabled: isLoading,
 					supportsBulk: false,
-					RenderModal: ( { items }: { items: ( PHPLog | ServerLog )[] } ) => {
-						const item = items[ 0 ] as PHPLog;
-						return <DetailsModalPHP item={ item } />;
+					RenderModal: ({ items }: { items: (PHPLog | ServerLog)[] }) => {
+						const item = items[0] as PHPLog;
+						return <DetailsModalPHP item={item} />;
 					},
 				},
 				{
 					id: 'copy-msg',
-					label: translate( 'Copy message' ),
+					label: translate('Copy message'),
 					disabled: isLoading,
 					supportsBulk: false,
-					callback: async ( items: ( PHPLog | ServerLog )[] ) => {
-						const message = ( items[ 0 ] as PHPLog ).message;
+					callback: async (items: (PHPLog | ServerLog)[]) => {
+						const message = (items[0] as PHPLog).message;
 						try {
-							await navigator.clipboard.writeText( message );
+							await navigator.clipboard.writeText(message);
 							dispatch(
 								successNotice(
 									/* translators: notice shown upon copy of Logs entry */
-									translate( 'Copied message' )
+									translate('Copied message')
 								)
 							);
-						} catch ( error ) {
+						} catch (error) {
 							dispatch(
 								errorNotice(
 									/* translators: notice shown upon failed copy of Logs entry */
-									translate( 'Message could not be copied' )
+									translate('Message could not be copied')
 								)
 							);
 						}
@@ -58,44 +58,44 @@ const useActions = ( { logType, isLoading }: { logType: LogType; isLoading: bool
 		return [
 			{
 				id: 'details-modal',
-				label: translate( 'View log details' ),
-				modalHeader: translate( 'Log details' ),
+				label: translate('View log details'),
+				modalHeader: translate('Log details'),
 				isPrimary: true,
 				icon: info,
 				disabled: isLoading,
 				supportsBulk: false,
-				RenderModal: ( { items }: { items: ( PHPLog | ServerLog )[] } ) => {
-					const item = items[ 0 ] as ServerLog;
-					return <DetailsModalServer item={ item } />;
+				RenderModal: ({ items }: { items: (PHPLog | ServerLog)[] }) => {
+					const item = items[0] as ServerLog;
+					return <DetailsModalServer item={item} />;
 				},
 			},
 			{
 				id: 'copy-url',
-				label: translate( 'Copy request URL' ),
+				label: translate('Copy request URL'),
 				disabled: isLoading,
 				supportsBulk: false,
-				callback: async ( items: ( PHPLog | ServerLog )[] ) => {
-					const url = ( items[ 0 ] as ServerLog ).request_url;
+				callback: async (items: (PHPLog | ServerLog)[]) => {
+					const url = (items[0] as ServerLog).request_url;
 					try {
-						await navigator.clipboard.writeText( url );
+						await navigator.clipboard.writeText(url);
 						dispatch(
 							successNotice(
 								/* translators: notice shown upon copy of request URL */
-								translate( 'Copied request URL' )
+								translate('Copied request URL')
 							)
 						);
-					} catch ( error ) {
+					} catch (error) {
 						dispatch(
 							errorNotice(
 								/* translators: notice shown upon failed copy of request URL */
-								translate( 'Request URL could not be copied' )
+								translate('Request URL could not be copied')
 							)
 						);
 					}
 				},
 			},
 		];
-	}, [ logType, translate, isLoading, dispatch ] );
+	}, [logType, translate, isLoading, dispatch]);
 
 	return actions;
 };

--- a/client/sites/logs/hooks/use-fields.tsx
+++ b/client/sites/logs/hooks/use-fields.tsx
@@ -91,15 +91,17 @@ const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPL
 				{
 					id: 'kind',
 					type: 'text',
-					label: translate( 'Type' ),
-					render: ( { item }: { item: PHPLog } ) => item.kind ?? translate( 'Core' ),
+					label: translate( 'Kind' ),
+					render: ( { item }: { item: PHPLog } ) =>
+						item.kind !== '' ? item.kind : translate( 'core' ),
 					enableSorting: false,
 				},
 				{
 					id: 'name',
 					type: 'text',
 					label: translate( 'Source' ),
-					render: ( { item }: { item: PHPLog } ) => item.name ?? translate( 'Core' ),
+					render: ( { item }: { item: PHPLog } ) =>
+						item.name !== '' ? item.name : translate( 'core' ),
 					enableSorting: false,
 				},
 				{

--- a/client/sites/logs/hooks/use-fields.tsx
+++ b/client/sites/logs/hooks/use-fields.tsx
@@ -88,8 +88,20 @@ const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPL
 					},
 					enableSorting: false,
 				},
-				{ id: 'kind', type: 'text', label: translate( 'Kind' ), enableSorting: false },
-				{ id: 'name', type: 'text', label: translate( 'Name' ), enableSorting: false },
+				{
+					id: 'kind',
+					type: 'text',
+					label: translate( 'Type' ),
+					render: ( { item }: { item: PHPLog } ) => item.kind ?? translate( 'Core' ),
+					enableSorting: false,
+				},
+				{
+					id: 'name',
+					type: 'text',
+					label: translate( 'Source' ),
+					render: ( { item }: { item: PHPLog } ) => item.name ?? translate( 'Core' ),
+					enableSorting: false,
+				},
 				{
 					id: 'file',
 					type: 'text',

--- a/client/sites/logs/hooks/use-fields.tsx
+++ b/client/sites/logs/hooks/use-fields.tsx
@@ -91,17 +91,13 @@ const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPL
 				{
 					id: 'kind',
 					type: 'text',
-					label: translate( 'Kind' ),
-					render: ( { item }: { item: PHPLog } ) =>
-						item.kind !== '' ? item.kind : translate( 'core' ),
+					label: translate( 'Group' ),
 					enableSorting: false,
 				},
 				{
 					id: 'name',
 					type: 'text',
 					label: translate( 'Source' ),
-					render: ( { item }: { item: PHPLog } ) =>
-						item.name !== '' ? item.name : translate( 'core' ),
 					enableSorting: false,
 				},
 				{

--- a/client/sites/logs/hooks/use-view.ts
+++ b/client/sites/logs/hooks/use-view.ts
@@ -95,7 +95,7 @@ const useView = ( { logType, query }: { logType: LogType; query: LogQueryParams 
 						maxWidth: '150px',
 					},
 					message: {
-						minWidth: '300px',
+						maxWidth: '42vw',
 					},
 					file: {
 						minWidth: '300px',

--- a/client/sites/logs/hooks/use-view.ts
+++ b/client/sites/logs/hooks/use-view.ts
@@ -9,11 +9,10 @@ import {
 } from './use-fields';
 import type { View, Filter } from '@wordpress/dataviews';
 
-const getTitleField = ( logType: LogType ) => ( logType === LogType.PHP ? 'name' : 'date' );
 const getSortField = ( logType: LogType ) => ( logType === LogType.PHP ? 'timestamp' : 'date' );
 const getVisibleFields = ( logType: LogType ) => {
 	if ( logType === LogType.PHP ) {
-		return [ 'severity', 'timestamp', 'message' ];
+		return [ 'severity', 'name', 'message' ];
 	}
 	return [ 'request_type', 'status', 'request_url' ];
 };
@@ -84,18 +83,18 @@ const useView = ( { logType, query }: { logType: LogType; query: LogQueryParams 
 				direction: 'desc',
 			},
 			filters: fromFilterParams( query ),
-			titleField: getTitleField( logType ),
+			titleField: getSortField( logType ),
 			fields: getVisibleFields( logType ),
 			layout: {
 				styles: {
 					// PHP errors
-					name: {
+					timestamp: {
 						maxWidth: '150px',
 					},
 					severity: {
 						maxWidth: '150px',
 					},
-					timestamp: {
+					name: {
 						maxWidth: '150px',
 					},
 					message: {
@@ -121,4 +120,4 @@ const useView = ( { logType, query }: { logType: LogType; query: LogQueryParams 
 };
 
 export default useView;
-export { toFilterParams, getSortField, getTitleField, getVisibleFields, getFilterValue };
+export { toFilterParams, getSortField, getVisibleFields, getFilterValue };

--- a/client/sites/logs/hooks/use-view.ts
+++ b/client/sites/logs/hooks/use-view.ts
@@ -9,80 +9,83 @@ import {
 } from './use-fields';
 import type { View, Filter } from '@wordpress/dataviews';
 
-const getTitleField = (logType: LogType) => (logType === LogType.PHP ? 'name' : 'date');
-const getSortField = (logType: LogType) => (logType === LogType.PHP ? 'timestamp' : 'date');
-const getVisibleFields = (logType: LogType) => {
-	if (logType === LogType.PHP) {
-		return ['severity', 'timestamp', 'message'];
+const getTitleField = ( logType: LogType ) => ( logType === LogType.PHP ? 'name' : 'date' );
+const getSortField = ( logType: LogType ) => ( logType === LogType.PHP ? 'timestamp' : 'date' );
+const getVisibleFields = ( logType: LogType ) => {
+	if ( logType === LogType.PHP ) {
+		return [ 'severity', 'timestamp', 'message' ];
 	}
-	return ['request_type', 'status', 'request_url'];
+	return [ 'request_type', 'status', 'request_url' ];
 };
-const getFilterValue = (view: View, fieldName: string) =>
-	view.filters?.filter((filter) => filter.field === fieldName)?.[0]?.value;
+const getFilterValue = ( view: View, fieldName: string ) =>
+	view.filters?.filter( ( filter ) => filter.field === fieldName )?.[ 0 ]?.value;
 
-const getFilterParamsFromView = (view: View, fieldNames: string[]): FilterType => {
-	return (view.filters || [])
-		.filter((filter) => fieldNames.includes(filter.field))
-		.reduce((acc: FilterType, filter) => {
-			if (filter.value) {
-				acc[filter.field] = filter.value;
+const getFilterParamsFromView = ( view: View, fieldNames: string[] ): FilterType => {
+	return ( view.filters || [] )
+		.filter( ( filter ) => fieldNames.includes( filter.field ) )
+		.reduce( ( acc: FilterType, filter ) => {
+			if ( filter.value ) {
+				acc[ filter.field ] = filter.value;
 			}
 			return acc;
-		}, {} as FilterType);
+		}, {} as FilterType );
 };
 
-function toFilterParams({ view, logType }: { view: View; logType: LogType }): FilterType {
-	if (logType === LogType.PHP) {
-		return getFilterParamsFromView(view, ['severity']);
+function toFilterParams( { view, logType }: { view: View; logType: LogType } ): FilterType {
+	if ( logType === LogType.PHP ) {
+		return getFilterParamsFromView( view, [ 'severity' ] );
 	}
 
-	return getFilterParamsFromView(view, ['cached', 'request_type', 'status', 'renderer']);
+	return getFilterParamsFromView( view, [ 'cached', 'request_type', 'status', 'renderer' ] );
 }
 
-function fromFilterParams(query: LogQueryParams): Filter[] {
+function fromFilterParams( query: LogQueryParams ): Filter[] {
 	const filters = [];
 
-	const severity = query.severity?.split(',') || [];
-	if (severity.length > 0 && severity.every((s) => VALUES_SEVERITY.includes(s))) {
-		filters.push({ field: 'severity', operator: 'isAny' as const, value: severity });
+	const severity = query.severity?.split( ',' ) || [];
+	if ( severity.length > 0 && severity.every( ( s ) => VALUES_SEVERITY.includes( s ) ) ) {
+		filters.push( { field: 'severity', operator: 'isAny' as const, value: severity } );
 	}
 
-	const request_type = query.request_type?.split(',') || [];
-	if (request_type.length > 0 && request_type.every((r) => VALUES_REQUEST_TYPE.includes(r))) {
-		filters.push({ field: 'request_type', operator: 'isAny' as const, value: request_type });
+	const request_type = query.request_type?.split( ',' ) || [];
+	if (
+		request_type.length > 0 &&
+		request_type.every( ( r ) => VALUES_REQUEST_TYPE.includes( r ) )
+	) {
+		filters.push( { field: 'request_type', operator: 'isAny' as const, value: request_type } );
 	}
 
-	const status = query.status?.split(',') || [];
-	if (status.length > 0 && status.every((s) => VALUES_STATUS.includes(s))) {
-		filters.push({ field: 'status', operator: 'isAny' as const, value: status });
+	const status = query.status?.split( ',' ) || [];
+	if ( status.length > 0 && status.every( ( s ) => VALUES_STATUS.includes( s ) ) ) {
+		filters.push( { field: 'status', operator: 'isAny' as const, value: status } );
 	}
 
-	const renderer = query.renderer?.split(',') || [];
-	if (renderer.length > 0 && renderer.every((r) => VALUES_RENDERER.includes(r))) {
-		filters.push({ field: 'renderer', operator: 'isAny' as const, value: renderer });
+	const renderer = query.renderer?.split( ',' ) || [];
+	if ( renderer.length > 0 && renderer.every( ( r ) => VALUES_RENDERER.includes( r ) ) ) {
+		filters.push( { field: 'renderer', operator: 'isAny' as const, value: renderer } );
 	}
 
-	const cached = query.cached?.split(',') || [];
-	if (cached.length > 0 && cached.every((c) => VALUES_CACHED.includes(c))) {
-		filters.push({ field: 'cached', operator: 'isAny' as const, value: cached });
+	const cached = query.cached?.split( ',' ) || [];
+	if ( cached.length > 0 && cached.every( ( c ) => VALUES_CACHED.includes( c ) ) ) {
+		filters.push( { field: 'cached', operator: 'isAny' as const, value: cached } );
 	}
 
 	return filters;
 }
 
-const useView = ({ logType, query }: { logType: LogType; query: LogQueryParams }) => {
-	return useState<View>(() => {
+const useView = ( { logType, query }: { logType: LogType; query: LogQueryParams } ) => {
+	return useState< View >( () => {
 		return {
 			type: 'table' as const,
 			page: 1,
 			perPage: 50,
 			sort: {
-				field: getSortField(logType),
+				field: getSortField( logType ),
 				direction: 'desc',
 			},
-			filters: fromFilterParams(query),
-			titleField: getTitleField(logType),
-			fields: getVisibleFields(logType),
+			filters: fromFilterParams( query ),
+			titleField: getTitleField( logType ),
+			fields: getVisibleFields( logType ),
 			layout: {
 				styles: {
 					// PHP errors
@@ -114,7 +117,7 @@ const useView = ({ logType, query }: { logType: LogType; query: LogQueryParams }
 				},
 			},
 		};
-	});
+	} );
 };
 
 export default useView;

--- a/client/sites/logs/hooks/use-view.ts
+++ b/client/sites/logs/hooks/use-view.ts
@@ -9,82 +9,79 @@ import {
 } from './use-fields';
 import type { View, Filter } from '@wordpress/dataviews';
 
-const getSortField = ( logType: LogType ) => ( logType === LogType.PHP ? 'timestamp' : 'date' );
-const getVisibleFields = ( logType: LogType ) => {
-	if ( logType === LogType.PHP ) {
-		return [ 'severity', 'name', 'message' ];
+const getSortField = (logType: LogType) => (logType === LogType.PHP ? 'timestamp' : 'date');
+const getVisibleFields = (logType: LogType) => {
+	if (logType === LogType.PHP) {
+		return ['severity', 'name', 'message'];
 	}
-	return [ 'request_type', 'status', 'request_url' ];
+	return ['request_type', 'status', 'request_url'];
 };
-const getFilterValue = ( view: View, fieldName: string ) =>
-	view.filters?.filter( ( filter ) => filter.field === fieldName )?.[ 0 ]?.value;
+const getFilterValue = (view: View, fieldName: string) =>
+	view.filters?.filter((filter) => filter.field === fieldName)?.[0]?.value;
 
-const getFilterParamsFromView = ( view: View, fieldNames: string[] ): FilterType => {
-	return ( view.filters || [] )
-		.filter( ( filter ) => fieldNames.includes( filter.field ) )
-		.reduce( ( acc: FilterType, filter ) => {
-			if ( filter.value ) {
-				acc[ filter.field ] = filter.value;
+const getFilterParamsFromView = (view: View, fieldNames: string[]): FilterType => {
+	return (view.filters || [])
+		.filter((filter) => fieldNames.includes(filter.field))
+		.reduce((acc: FilterType, filter) => {
+			if (filter.value) {
+				acc[filter.field] = filter.value;
 			}
 			return acc;
-		}, {} as FilterType );
+		}, {} as FilterType);
 };
 
-function toFilterParams( { view, logType }: { view: View; logType: LogType } ): FilterType {
-	if ( logType === LogType.PHP ) {
-		return getFilterParamsFromView( view, [ 'severity' ] );
+function toFilterParams({ view, logType }: { view: View; logType: LogType }): FilterType {
+	if (logType === LogType.PHP) {
+		return getFilterParamsFromView(view, ['severity']);
 	}
 
-	return getFilterParamsFromView( view, [ 'cached', 'request_type', 'status', 'renderer' ] );
+	return getFilterParamsFromView(view, ['cached', 'request_type', 'status', 'renderer']);
 }
 
-function fromFilterParams( query: LogQueryParams ): Filter[] {
+function fromFilterParams(query: LogQueryParams): Filter[] {
 	const filters = [];
 
-	const severity = query.severity?.split( ',' ) || [];
-	if ( severity.length > 0 && severity.every( ( s ) => VALUES_SEVERITY.includes( s ) ) ) {
-		filters.push( { field: 'severity', operator: 'isAny' as const, value: severity } );
+	const severity = query.severity?.split(',') || [];
+	if (severity.length > 0 && severity.every((s) => VALUES_SEVERITY.includes(s))) {
+		filters.push({ field: 'severity', operator: 'isAny' as const, value: severity });
 	}
 
-	const request_type = query.request_type?.split( ',' ) || [];
-	if (
-		request_type.length > 0 &&
-		request_type.every( ( r ) => VALUES_REQUEST_TYPE.includes( r ) )
-	) {
-		filters.push( { field: 'request_type', operator: 'isAny' as const, value: request_type } );
+	const request_type = query.request_type?.split(',') || [];
+	if (request_type.length > 0 && request_type.every((r) => VALUES_REQUEST_TYPE.includes(r))) {
+		filters.push({ field: 'request_type', operator: 'isAny' as const, value: request_type });
 	}
 
-	const status = query.status?.split( ',' ) || [];
-	if ( status.length > 0 && status.every( ( s ) => VALUES_STATUS.includes( s ) ) ) {
-		filters.push( { field: 'status', operator: 'isAny' as const, value: status } );
+	const status = query.status?.split(',') || [];
+	if (status.length > 0 && status.every((s) => VALUES_STATUS.includes(s))) {
+		filters.push({ field: 'status', operator: 'isAny' as const, value: status });
 	}
 
-	const renderer = query.renderer?.split( ',' ) || [];
-	if ( renderer.length > 0 && renderer.every( ( r ) => VALUES_RENDERER.includes( r ) ) ) {
-		filters.push( { field: 'renderer', operator: 'isAny' as const, value: renderer } );
+	const renderer = query.renderer?.split(',') || [];
+	if (renderer.length > 0 && renderer.every((r) => VALUES_RENDERER.includes(r))) {
+		filters.push({ field: 'renderer', operator: 'isAny' as const, value: renderer });
 	}
 
-	const cached = query.cached?.split( ',' ) || [];
-	if ( cached.length > 0 && cached.every( ( c ) => VALUES_CACHED.includes( c ) ) ) {
-		filters.push( { field: 'cached', operator: 'isAny' as const, value: cached } );
+	const cached = query.cached?.split(',') || [];
+	if (cached.length > 0 && cached.every((c) => VALUES_CACHED.includes(c))) {
+		filters.push({ field: 'cached', operator: 'isAny' as const, value: cached });
 	}
 
 	return filters;
 }
 
-const useView = ( { logType, query }: { logType: LogType; query: LogQueryParams } ) => {
-	return useState< View >( () => {
+const useView = ({ logType, query }: { logType: LogType; query: LogQueryParams }) => {
+	return useState<View>(() => {
 		return {
 			type: 'table' as const,
 			page: 1,
 			perPage: 50,
 			sort: {
-				field: getSortField( logType ),
+				field: getSortField(logType),
 				direction: 'desc',
 			},
-			filters: fromFilterParams( query ),
-			titleField: getSortField( logType ),
-			fields: getVisibleFields( logType ),
+			filters: fromFilterParams(query),
+			titleField: getSortField(logType),
+			fields: getVisibleFields(logType),
 			layout: {
 				styles: {
 					// PHP errors
@@ -113,7 +110,7 @@ const useView = ( { logType, query }: { logType: LogType; query: LogQueryParams 
 				},
 			},
 		};
-	} );
+	});
 };
 
 export default useView;

--- a/client/sites/logs/hooks/use-view.ts
+++ b/client/sites/logs/hooks/use-view.ts
@@ -9,10 +9,11 @@ import {
 } from './use-fields';
 import type { View, Filter } from '@wordpress/dataviews';
 
+const getTitleField = (logType: LogType) => (logType === LogType.PHP ? 'name' : 'date');
 const getSortField = (logType: LogType) => (logType === LogType.PHP ? 'timestamp' : 'date');
 const getVisibleFields = (logType: LogType) => {
 	if (logType === LogType.PHP) {
-		return ['severity', 'name', 'message'];
+		return ['severity', 'timestamp', 'message'];
 	}
 	return ['request_type', 'status', 'request_url'];
 };
@@ -80,19 +81,22 @@ const useView = ({ logType, query }: { logType: LogType; query: LogQueryParams }
 				direction: 'desc',
 			},
 			filters: fromFilterParams(query),
-			titleField: getSortField(logType),
+			titleField: getTitleField(logType),
 			fields: getVisibleFields(logType),
 			layout: {
 				styles: {
 					// PHP errors
-					timestamp: {
+					name: {
 						maxWidth: '150px',
 					},
 					severity: {
 						maxWidth: '150px',
 					},
+					timestamp: {
+						maxWidth: '150px',
+					},
 					message: {
-						maxWidth: '42vw',
+						maxWidth: '30vw',
 					},
 					file: {
 						minWidth: '300px',
@@ -114,4 +118,4 @@ const useView = ({ logType, query }: { logType: LogType; query: LogQueryParams }
 };
 
 export default useView;
-export { toFilterParams, getSortField, getVisibleFields, getFilterValue };
+export { toFilterParams, getSortField, getTitleField, getVisibleFields, getFilterValue };

--- a/client/sites/logs/hooks/use-view.ts
+++ b/client/sites/logs/hooks/use-view.ts
@@ -12,7 +12,7 @@ import type { View, Filter } from '@wordpress/dataviews';
 const getSortField = ( logType: LogType ) => ( logType === LogType.PHP ? 'timestamp' : 'date' );
 const getVisibleFields = ( logType: LogType ) => {
 	if ( logType === LogType.PHP ) {
-		return [ 'severity', 'message' ];
+		return [ 'severity', 'name', 'message' ];
 	}
 	return [ 'request_type', 'status', 'request_url' ];
 };


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/99056
Addressed feedback provided at p5j4vm-51h-p2#comment-7710

## Proposed Changes

- Make "open details" action primary (details icon) for both PHPLogs and WebServer.
- Iterate over data in PHP Logs:
  - Make `name` the title field for the table. Use "Source" as title for the field instead of "Name".
  - If the value of `name` or `kind` is empty, render `core`.
  - Truncated `message`.
  - Update modal to position `message` at the bottom, and `kind` & `name` at the top.

## Why are these changes being made?

To better highlight the important information to users and give more prominence to the "open details" action.

## Testing Instructions

- Navigate to Hosting Logs screen and verify the changes look good.

## Screenshots & videos

| Table | Modal | 
| --- | --- | 
| <img width="1038" alt="Screenshot 2025-03-05 at 19 04 47" src="https://github.com/user-attachments/assets/1c52ab8e-07bf-4908-ab1c-6494b0e3c73b" /> | <img width="1005" alt="Screenshot 2025-03-05 at 18 59 32" src="https://github.com/user-attachments/assets/db4e556a-b988-48f8-9110-05a527a65828" /> |

Video:

https://github.com/user-attachments/assets/b93920ba-54d0-44f9-8ac8-b610ae891f53

