### PR TITLE
Update migration copy on the site overview page

### DIFF
--- a/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
@@ -1,21 +1,13 @@
-import { globe, group, Icon, scheduled } from '@wordpress/icons';
+import { globe, group, Icon, scheduled, envelope } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { Container, Header } from './layout';
-import type { SiteDetails } from '@automattic/data-stores';
 
-export const MigrationStartedDIFM = ( { site }: { site?: SiteDetails } ) => {
+export const MigrationStartedDIFM = () => {
 	const translate = useTranslate();
-	const migrationSourceSiteDomain = site?.options?.migration_source_site_domain
-		? site?.options?.migration_source_site_domain?.replace( /^https?:\/\/|\/+$/g, '' )
-		: translate( 'your site' );
 
-	const title = translate( 'Your migration is underway' );
+	const title = translate( "We've received your migration request" );
 	const subTitle = translate(
-		"Sit back as {{strong}}%(siteName)s{{/strong}} transfers to its new home. Here's what you can expect.",
-		{
-			components: { strong: <strong /> },
-			args: { siteName: migrationSourceSiteDomain },
-		}
+		"Our team has received your details. We will review your site to make sure we have everything we need. Here's what you can expect next:"
 	) as string;
 
 	return (
@@ -24,6 +16,16 @@ export const MigrationStartedDIFM = ( { site }: { site?: SiteDetails } ) => {
 			<div className="migration-started-difm">
 				<h2 className="migration-started-difm__title">{ translate( 'What to expect' ) }</h2>
 				<ul className="migration-started-difm__list">
+					<li className="migration-started-difm__item">
+						<div className="migration-started-difm__icon-wrapper">
+							<Icon icon={ envelope } className="migration-started-difm__icon" size={ 30 } />
+						</div>
+						<span>
+							{ translate(
+								"We'll send you an email with more details on the process and we'll let you know when we start the migration."
+							) }
+						</span>
+					</li>
 					<li className="migration-started-difm__item">
 						<div className="migration-started-difm__icon-wrapper">
 							<Icon icon={ group } className="migration-started-difm__icon" size={ 30 } />

--- a/client/sites/overview/components/migration-overview/index.tsx
+++ b/client/sites/overview/components/migration-overview/index.tsx
@@ -15,7 +15,7 @@ const MigrationOverview = ( { site }: { site: SiteDetails } ) => {
 	}
 
 	if ( migrationType === 'difm' ) {
-		return <MigrationStartedDIFM site={ site } />;
+		return <MigrationStartedDIFM />;
 	}
 
 	if ( migrationType === 'diy' ) {

--- a/client/sites/overview/components/migration-overview/style.scss
+++ b/client/sites/overview/components/migration-overview/style.scss
@@ -61,6 +61,7 @@
 			align-items: center;
 			justify-content: center;
 			background-color: #F7F8FE;
+			flex-shrink: 0;
 		}
 	}
 }

--- a/client/sites/overview/components/migration-overview/test/index.tsx
+++ b/client/sites/overview/components/migration-overview/test/index.tsx
@@ -121,9 +121,14 @@ describe( 'MigrationOverview', () => {
 		it( 'shows the migrating started instructions', () => {
 			const site = buildMigrationSite( { status: 'started', how: 'difm' } );
 
-			render( <MigrationOverview site={ site } /> );
+			const { getByText } = render( <MigrationOverview site={ site } /> );
 
-			expect( screen.queryByText( /Your migration is underway/ ) ).toBeVisible();
+			expect( getByText( /We've received your migration request/ ) ).toBeVisible();
+			expect(
+				getByText(
+					/Our team has received your details. We will review your site to make sure we have everything we need. Here's what you can expect next:/
+				)
+			).toBeVisible();
 		} );
 
 		it( 'does not show the continue migration link', () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #97667

## Proposed Changes

This updates the copy we show on `/sites/overview/:siteSlug` after a user has requested a DIFM migration.

![image](https://github.com/user-attachments/assets/2d195c05-6f6a-432f-bfc4-c7d3351387f2)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We're trying to make it clear to the user that we may need things from them in order to perform the migration. A lot of people were just sitting back thinking the migration was happening and it turned out we were waiting for credentials or something else.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this pr locally or use the calypso.live link.
* Go through `/start`, select the "Import or Migrate" option on the goals page.
* Select a DIFM migration. Purchase a Business plan as needed.
* You should eventually end up on `/sites/overview/:siteSlug` and see the new copy.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
