### PR TITLE
Reader Editor: Focus editor as soon as it's available

### DIFF
--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -58,65 +58,31 @@ function QuickPost( {
 	const hasSites = ( currentUser?.site_count ?? 0 ) > 0;
 	const [ showSuccessMessage, setShowSuccessMessage ] = useState( false );
 
-	// Add effect to focus editor as soon as it's available
+	// Add effect to focus editor as soon as it's available.
 	useEffect( () => {
-		let observer: MutationObserver | null = null;
+		const attemptFocus = () => {
+			const editable = document
+				.querySelector< HTMLIFrameElement >( 'iframe[name="editor-canvas"]' )
+				?.contentDocument?.querySelector< HTMLElement >( '[contenteditable="true"]' );
 
-		// Function to attempt focusing the editor
-		const attemptEditorFocus = () => {
-			// Find the editable area in the block editor iframe
-			const editorIframe = document.querySelector(
-				'iframe[name="editor-canvas"]'
-			) as HTMLIFrameElement;
-			if ( editorIframe?.contentDocument ) {
-				const editableArea = editorIframe.contentDocument.querySelector(
-					'[contenteditable="true"]'
-				);
-				if ( editableArea ) {
-					// We found the editable area - focus it
-					( editableArea as HTMLElement ).focus();
-					const clickEvent = new MouseEvent( 'click', {
-						bubbles: true,
-						cancelable: true,
-						view: editorIframe.contentWindow || window,
-					} );
-					editableArea.dispatchEvent( clickEvent );
-
-					// Disconnect the observer since we've succeeded
-					if ( observer ) {
-						observer.disconnect();
-						observer = null;
-					}
-					return true;
-				}
+			if ( ! editable ) {
+				return false;
 			}
-			return false;
+
+			editable.focus();
+			editable.dispatchEvent( new MouseEvent( 'click' ) );
+
+			return true;
 		};
 
-		// Try immediately first
-		if ( ! attemptEditorFocus() ) {
-			// If immediate attempt fails, set up an observer to watch for DOM changes
-			observer = new MutationObserver( ( mutations, obs ) => {
-				// Try to focus on each DOM mutation
-				if ( attemptEditorFocus() ) {
-					obs.disconnect();
-				}
-			} );
-
-			// Start observing the document with configured parameters
-			observer.observe( document.body, {
-				childList: true,
-				subtree: true,
-			} );
+		// If immediate focus attempt fails, watch for DOM changes until
+		// the editor becomes available, then focus and auto-disconnect.
+		if ( ! attemptFocus() ) {
+			const obs = new MutationObserver( ( _, o ) => attemptFocus() && o.disconnect() );
+			obs.observe( document.body, { childList: true, subtree: true } );
+			return () => obs.disconnect();
 		}
-
-		return () => {
-			// Clean up the observer on component unmount
-			if ( observer ) {
-				observer.disconnect();
-			}
-		};
-	}, [ editorKey ] ); // Re-run when editor is reset
+	}, [ editorKey ] );
 
 	const clearEditor = () => {
 		setEditorKey( ( key ) => key + 1 );

--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -8,7 +8,7 @@ import {
 } from '@automattic/verbum-block-editor';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useSelector, useDispatch, connect } from 'react-redux';
 import SitesDropdown from 'calypso/components/sites-dropdown';
 import { stripHTML } from 'calypso/lib/formatting';
@@ -57,6 +57,66 @@ function QuickPost( {
 	const hasLoaded = useSelector( hasLoadedSites );
 	const hasSites = ( currentUser?.site_count ?? 0 ) > 0;
 	const [ showSuccessMessage, setShowSuccessMessage ] = useState( false );
+
+	// Add effect to focus editor as soon as it's available
+	useEffect( () => {
+		let observer: MutationObserver | null = null;
+
+		// Function to attempt focusing the editor
+		const attemptEditorFocus = () => {
+			// Find the editable area in the block editor iframe
+			const editorIframe = document.querySelector(
+				'iframe[name="editor-canvas"]'
+			) as HTMLIFrameElement;
+			if ( editorIframe?.contentDocument ) {
+				const editableArea = editorIframe.contentDocument.querySelector(
+					'[contenteditable="true"]'
+				);
+				if ( editableArea ) {
+					// We found the editable area - focus it
+					( editableArea as HTMLElement ).focus();
+					const clickEvent = new MouseEvent( 'click', {
+						bubbles: true,
+						cancelable: true,
+						view: editorIframe.contentWindow || window,
+					} );
+					editableArea.dispatchEvent( clickEvent );
+
+					// Disconnect the observer since we've succeeded
+					if ( observer ) {
+						observer.disconnect();
+						observer = null;
+					}
+					return true;
+				}
+			}
+			return false;
+		};
+
+		// Try immediately first
+		if ( ! attemptEditorFocus() ) {
+			// If immediate attempt fails, set up an observer to watch for DOM changes
+			observer = new MutationObserver( ( mutations, obs ) => {
+				// Try to focus on each DOM mutation
+				if ( attemptEditorFocus() ) {
+					obs.disconnect();
+				}
+			} );
+
+			// Start observing the document with configured parameters
+			observer.observe( document.body, {
+				childList: true,
+				subtree: true,
+			} );
+		}
+
+		return () => {
+			// Clean up the observer on component unmount
+			if ( observer ) {
+				observer.disconnect();
+			}
+		};
+	}, [ editorKey ] ); // Re-run when editor is reset
 
 	const clearEditor = () => {
 		setEditorKey( ( key ) => key + 1 );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/514

## Proposed Changes

* Adds effect to focus editor as soon as it's available, thereby making the toolbar visible.

Before | After
--|--
<img width="1246" alt="Screenshot 2025-03-04 at 2 26 07 PM" src="https://github.com/user-attachments/assets/f5803669-8aaa-4a37-8acb-743dcf426551" />  | <img width="1244" alt="Screenshot 2025-03-04 at 2 25 15 PM" src="https://github.com/user-attachments/assets/85c8d35b-bdbb-411b-ac89-8d197da3931d" />




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live and go to /reader
* The Reader Editor should be focused with the cursor, and the editor toolbar should be visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
