### PR TITLE
Reader - remove back buttons while logged out

### DIFF
--- a/client/reader/controller-helper.js
+++ b/client/reader/controller-helper.js
@@ -4,6 +4,7 @@ import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
 import { recordTrack } from 'calypso/reader/stats';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
 
 export function trackPageLoad( path, title, readerView ) {
@@ -53,4 +54,10 @@ export function setPageTitle( context, title ) {
 
 export function userHasHistory( context ) {
 	return !! context.lastRoute;
+}
+
+export function shouldShowBackButton( context ) {
+	const state = context.store.getState();
+	const isLoggedIn = isUserLoggedIn( state );
+	return isLoggedIn && userHasHistory( context );
 }

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -23,14 +23,11 @@ import {
 	trackScrollPage,
 	setPageTitle,
 	getStartDate,
+	shouldShowBackButton,
 } from './controller-helper';
 
 const analyticsPageTitle = 'Reader';
 let lastRoute = null;
-
-function userHasHistory( context ) {
-	return !! context.lastRoute;
-}
 
 function renderFeedError( context, next ) {
 	context.primary = createElement( FeedError );
@@ -100,7 +97,7 @@ export function following( context, next ) {
 		streamKey: 'following',
 		startDate,
 		recsStreamKey: 'custom_recs_posts_with_images',
-		showBack: userHasHistory( context ),
+		showBack: shouldShowBackButton( context ),
 		trackScrollPage: trackScrollPage.bind(
 			null,
 			basePath,
@@ -163,7 +160,7 @@ export function feedListing( context, next ) {
 			) }
 			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
 			suppressSiteNameLink
-			showBack={ userHasHistory( context ) }
+			showBack={ shouldShowBackButton( context ) }
 			placeholder={ null }
 		/>
 	);
@@ -197,7 +194,7 @@ export function blogListing( context, next ) {
 			) }
 			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
 			suppressSiteNameLink
-			showBack={ userHasHistory( context ) }
+			showBack={ shouldShowBackButton( context ) }
 			placeholder={ null }
 		/>
 	);

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -112,7 +112,7 @@ const DiscoverStream = ( props ) => {
 	const HeaderAndNavigation = () => {
 		return (
 			<>
-				{ previousRoute && <BackButton onClick={ () => page.back( previousRoute ) } /> }
+				{ props.showBack && <BackButton onClick={ () => page.back( previousRoute ) } /> }
 				<DiscoverHeader selectedTab={ effectiveTabSelection } width={ props.width } />
 				<DiscoverNavigation selectedTab={ selectedTab } />
 

--- a/client/reader/discover/index.web.js
+++ b/client/reader/discover/index.web.js
@@ -17,6 +17,7 @@ import {
 	trackPageLoad,
 	trackUpdatesLoaded,
 	trackScrollPage,
+	shouldShowBackButton,
 } from 'calypso/reader/controller-helper';
 import { recordTrack } from 'calypso/reader/stats';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -80,6 +81,7 @@ const discover = ( context, next ) => {
 				useCompactCards
 				className="is-discover-stream"
 				selectedTab={ selectedTab }
+				showBack={ shouldShowBackButton( context ) }
 				query={ context.query }
 			/>
 		</>

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -5,7 +5,7 @@ import {
 	trackPageLoad,
 	trackUpdatesLoaded,
 	trackScrollPage,
-	userHasHistory,
+	shouldShowBackButton,
 } from 'calypso/reader/controller-helper';
 import { SEARCH_TYPES } from 'calypso/reader/search-stream/search-stream-header';
 import { recordTrack } from 'calypso/reader/stats';
@@ -84,7 +84,7 @@ const exported = {
 								mcKey
 							) }
 							onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-							showBack={ userHasHistory( context ) }
+							showBack={ shouldShowBackButton( context ) }
 							autoFocusInput={ autoFocusInput }
 							onQueryChange={ reportQueryChange }
 							onSortChange={ reportSortChange }

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -13,6 +13,7 @@ import { recordTrack } from 'calypso/reader/stats';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { shouldShowBackButton } from '../controller-helper';
 import renderHeaderSection from '../lib/header-section';
 
 const analyticsPageTitle = 'Reader';
@@ -76,7 +77,7 @@ export const tagListing = ( context, next ) => {
 				) }
 				startDate={ startDate }
 				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) } // eslint-disable-line
-				showBack={ !! context.lastRoute }
+				showBack={ shouldShowBackButton( context ) }
 			/>
 		</>
 	);

--- a/client/reader/user-profile/controller.tsx
+++ b/client/reader/user-profile/controller.tsx
@@ -1,7 +1,11 @@
 import page, { Context } from '@automattic/calypso-router';
 import { ReactElement } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
-import { trackPageLoad, trackScrollPage } from 'calypso/reader/controller-helper';
+import {
+	trackPageLoad,
+	trackScrollPage,
+	shouldShowBackButton,
+} from 'calypso/reader/controller-helper';
 import { getUserProfileBasePath } from 'calypso/reader/user-profile/user-profile.utils';
 
 interface UserPostsContext extends Context {
@@ -25,7 +29,7 @@ export function userPosts( ctx: Context, next: () => void ): void {
 	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
 	function goBack() {
-		page.back( ctx.lastRoute );
+		page.back( context.lastRoute );
 	}
 
 	context.primary = (
@@ -41,7 +45,7 @@ export function userPosts( ctx: Context, next: () => void ): void {
 				analyticsPageTitle,
 				mcKey
 			) }
-			showBack={ !! ctx.lastRoute }
+			showBack={ shouldShowBackButton( context ) }
 			handleBack={ goBack }
 			path={ context.path }
 		/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/100073

## Proposed Changes

Removes the reader back buttons from the logged out context.
* Adds a `shouldShowBackButton` helper function that checks both logged in state and the previous `userHasHistory` helper.
* Consolidates our top level `showBack` props passed to various reader streams to use `shouldShowBackButton` helper. These previously used `useHasHistory` or an adhoc version of the same logic.

BEFORE
![image](https://github.com/user-attachments/assets/25412e83-39d2-44c2-a1a1-b80e5e2706df)


AFTER
![Screenshot 2025-03-04 at 1 15 44 PM](https://github.com/user-attachments/assets/590984de-e2b0-47c3-abeb-d036bd7021a1)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The logged out reader doesn't need back buttons, and they currently appear in a broken layout https://github.com/Automattic/wp-calypso/issues/100073. These don't improve the logged out experience, and the standard browser back buttons continue to work as expected. We did not show the back buttons on these streams previously and they bled over as part of a recent change focused on bringing them to the logged in streams.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the /reader logged out.
* Click around discover tabs, verify no back button appears (was hidden in blue header).
* Click "Seach" in the top right. Verify no back button appears.
* Click "all tags" and select a tag stream, verify no back button appears.
* Go to the /reader logged in.
* Click around the various streams associated to these changes (following, discover, feed/blog, search, tag stream, user profile main tab). Verify the back button is present and works as expected when there is a previous route in state.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
