### PR TITLE
DIFM/Help Center: refactor to move eligibility checks outside Help Center

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
@@ -1,13 +1,11 @@
-import { isEnabled } from '@automattic/calypso-config';
-import { HelpCenterStepButton } from '@automattic/help-center';
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
-import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import DIFMLanding from 'calypso/my-sites/marketing/do-it-for-me/difm-landing';
+import HelpCenterStepButton from 'calypso/signup/help-center-step-button';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import type { Step } from '../../types';
 import type { AppState } from 'calypso/types';
@@ -20,10 +18,9 @@ const DIFMStartingPoint: Step = function ( { navigation, flow } ) {
 	const siteId = useSite()?.ID;
 	const showNewOrExistingSiteChoice = ! siteId && !! existingSiteCount && existingSiteCount > 0;
 
-	const { data: geoData } = useGeoLocationQuery();
-
-	const isHelpCenterLinkEnabled =
-		geoData?.country_short === 'US' && isEnabled( 'signup/help-center-link' );
+	const queryParams = new URLSearchParams( window?.location.search );
+	const flags = queryParams.get( 'flags' )?.split( ',' );
+	const isHelpCenterLinkEnabled = flags?.includes( 'signup/help-center-link' );
 
 	const onSubmit = ( value: string ) => {
 		submit?.( {
@@ -46,6 +43,7 @@ const DIFMStartingPoint: Step = function ( { navigation, flow } ) {
 					isHelpCenterLinkEnabled ? (
 						<HelpCenterStepButton
 							flowName={ flow }
+							enabledGeos={ [ 'US' ] }
 							helpCenterButtonCopy={ translate( 'Questions?' ) }
 							helpCenterButtonLink={ translate( 'Contact our site building team' ) }
 						/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
@@ -1,7 +1,10 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { HelpCenterStepButton } from '@automattic/help-center';
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
+import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import DIFMLanding from 'calypso/my-sites/marketing/do-it-for-me/difm-landing';
@@ -10,12 +13,17 @@ import type { Step } from '../../types';
 import type { AppState } from 'calypso/types';
 
 const STEP_NAME = 'difmStartingPoint';
-const DIFMStartingPoint: Step = function ( { navigation } ) {
+const DIFMStartingPoint: Step = function ( { navigation, flow } ) {
 	const { goNext, goBack, submit } = navigation;
 	const translate = useTranslate();
 	const existingSiteCount = useSelector( ( state: AppState ) => getCurrentUserSiteCount( state ) );
 	const siteId = useSite()?.ID;
 	const showNewOrExistingSiteChoice = ! siteId && !! existingSiteCount && existingSiteCount > 0;
+
+	const { data: geoData } = useGeoLocationQuery();
+
+	const isHelpCenterLinkEnabled =
+		geoData?.country_short === 'US' && isEnabled( 'signup/help-center-link' );
 
 	const onSubmit = ( value: string ) => {
 		submit?.( {
@@ -34,6 +42,15 @@ const DIFMStartingPoint: Step = function ( { navigation } ) {
 				isWideLayout
 				isLargeSkipLayout={ false }
 				skipLabelText={ translate( 'No Thanks, I’ll Build It' ) }
+				customizedActionButtons={
+					isHelpCenterLinkEnabled ? (
+						<HelpCenterStepButton
+							flowName={ flow }
+							helpCenterButtonCopy={ translate( 'Questions?' ) }
+							helpCenterButtonLink={ translate( 'Contact our site building team' ) }
+						/>
+					) : undefined
+				}
 				stepContent={
 					<DIFMLanding
 						onPrimarySubmit={ () =>

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -422,9 +422,10 @@ export function generateFlows( {
 			destination: getDIFMSignupDestination,
 			description: 'A flow for DIFM Lite leads',
 			excludeFromManageSiteFlows: true,
-			lastModified: '2024-05-16',
+			lastModified: '2025-03-04',
 			enableBranchSteps: true,
 			hideProgressIndicator: true,
+			enabledHelpCenterGeos: [ 'US' ],
 			get helpCenterButtonCopy() {
 				return translate( 'Questions?' );
 			},
@@ -446,11 +447,12 @@ export function generateFlows( {
 				'difm-page-picker',
 			],
 			destination: getDIFMSignupDestination,
-			description: 'The BBE store flow',
+			description: 'The DIFM store flow',
 			excludeFromManageSiteFlows: true,
-			lastModified: '2024-05-16',
+			lastModified: '2025-03-04',
 			enableBranchSteps: true,
 			hideProgressIndicator: true,
+			enabledHelpCenterGeos: [ 'US' ],
 			get helpCenterButtonCopy() {
 				return translate( 'Questions?' );
 			},
@@ -468,7 +470,8 @@ export function generateFlows( {
 			excludeFromManageSiteFlows: true,
 			providesDependenciesInQuery: [ 'siteSlug', 'back_to' ],
 			optionalDependenciesInQuery: [ 'back_to' ],
-			lastModified: '2024-06-14',
+			lastModified: '2025-03-04',
+			enabledHelpCenterGeos: [ 'US' ],
 			get helpCenterButtonCopy() {
 				return translate( 'Questions?' );
 			},

--- a/client/signup/help-center-step-button/index.tsx
+++ b/client/signup/help-center-step-button/index.tsx
@@ -1,20 +1,28 @@
-/* eslint-disable no-restricted-imports */
+import { HelpCenterInlineButton } from '@automattic/help-center';
 import { useTranslate } from 'i18n-calypso';
-import HelpCenterInlineButton from './help-center-inline-button';
+import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import type { FC } from 'react';
 
 interface HelpCenterStepButtonProps {
 	flowName?: string;
+	enabledGeos?: string[];
 	helpCenterButtonCopy?: string;
 	helpCenterButtonLink?: string;
 }
 
 const HelpCenterStepButton: FC< HelpCenterStepButtonProps > = ( {
 	flowName,
+	enabledGeos,
 	helpCenterButtonCopy,
 	helpCenterButtonLink,
 } ) => {
 	const translate = useTranslate();
+
+	const { data: geoData } = useGeoLocationQuery();
+
+	if ( ! geoData?.country_short || ! enabledGeos?.includes( geoData.country_short ) ) {
+		return null;
+	}
 
 	return (
 		<div className="step-wrapper__help-center-button-container">

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { HelpCenterStepButton } from '@automattic/help-center';
 import { ActionButtons } from '@automattic/onboarding';
 import clsx from 'clsx';
@@ -214,11 +215,9 @@ class StepWrapper extends Component {
 			sticky = isSticky;
 		}
 
-		const queryParams = new URLSearchParams( window?.location.search );
-		const flags = queryParams.get( 'flags' );
 		const isHelpCenterLinkEnabled =
 			flow?.enabledHelpCenterGeos.includes( geo?.country_short ) &&
-			flags === 'signup/help-center-link';
+			isEnabled( 'signup/help-center-link' );
 
 		return (
 			<>

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { withGeoLocation } from 'calypso/data/geo/with-geolocation';
 import flows from 'calypso/signup/config/flows';
 import NavigationLink from 'calypso/signup/navigation-link';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -39,6 +40,7 @@ class StepWrapper extends Component {
 		queryParams: PropTypes.object,
 		customizedActionButtons: PropTypes.element,
 		userLoggedIn: PropTypes.bool,
+		geo: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -186,6 +188,7 @@ class StepWrapper extends Component {
 			customizedActionButtons,
 			isExtraWideLayout,
 			isSticky,
+			geo,
 		} = this.props;
 
 		const backButton = ! hideBack && this.renderBack();
@@ -213,7 +216,9 @@ class StepWrapper extends Component {
 
 		const queryParams = new URLSearchParams( window?.location.search );
 		const flags = queryParams.get( 'flags' );
-		const isHelpCenterLinkEnabled = flags === 'signup/help-center-link';
+		const isHelpCenterLinkEnabled =
+			flow?.enabledHelpCenterGeos.includes( geo?.country_short ) &&
+			flags === 'signup/help-center-link';
 
 		return (
 			<>
@@ -280,4 +285,4 @@ export default connect( ( state, ownProps ) => {
 		backUrl,
 		userLoggedIn: isUserLoggedIn( state ),
 	};
-} )( localize( StepWrapper ) );
+} )( localize( withGeoLocation( StepWrapper ) ) );

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -1,5 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
-import { HelpCenterStepButton } from '@automattic/help-center';
 import { ActionButtons } from '@automattic/onboarding';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
@@ -7,11 +5,11 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { withGeoLocation } from 'calypso/data/geo/with-geolocation';
 import flows from 'calypso/signup/config/flows';
 import NavigationLink from 'calypso/signup/navigation-link';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import HelpCenterStepButton from '../help-center-step-button';
 import './style.scss';
 
 class StepWrapper extends Component {
@@ -41,7 +39,6 @@ class StepWrapper extends Component {
 		queryParams: PropTypes.object,
 		customizedActionButtons: PropTypes.element,
 		userLoggedIn: PropTypes.bool,
-		geo: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -189,7 +186,6 @@ class StepWrapper extends Component {
 			customizedActionButtons,
 			isExtraWideLayout,
 			isSticky,
-			geo,
 		} = this.props;
 
 		const backButton = ! hideBack && this.renderBack();
@@ -215,9 +211,10 @@ class StepWrapper extends Component {
 			sticky = isSticky;
 		}
 
+		const queryParams = new URLSearchParams( window?.location.search );
+		const flags = queryParams.get( 'flags' )?.split( ',' );
 		const isHelpCenterLinkEnabled =
-			flow?.enabledHelpCenterGeos.includes( geo?.country_short ) &&
-			isEnabled( 'signup/help-center-link' );
+			flags?.includes( 'signup/help-center-link' ) && flow?.enabledHelpCenterGeos;
 
 		return (
 			<>
@@ -230,6 +227,7 @@ class StepWrapper extends Component {
 						{ isHelpCenterLinkEnabled && (
 							<HelpCenterStepButton
 								flowName={ flowName }
+								enabledGeos={ flow?.enabledHelpCenterGeos }
 								helpCenterButtonCopy={ flow?.helpCenterButtonCopy }
 								helpCenterButtonLink={ flow?.helpCenterButtonLink }
 							/>
@@ -284,4 +282,4 @@ export default connect( ( state, ownProps ) => {
 		backUrl,
 		userLoggedIn: isUserLoggedIn( state ),
 	};
-} )( localize( withGeoLocation( StepWrapper ) ) );
+} )( localize( StepWrapper ) );

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -190,11 +190,11 @@
 }
 
 .step-wrapper__help-center-button-container {
-	font-size: rem(14px);
 	font-weight: 500;
 	margin-left: auto;
-
+	
 	.components-button.step-wrapper__help-center-button {
+		font-size: rem(14px);
 		color: var( --studio-wordpress-blue );
 		text-decoration: underline;
 

--- a/client/signup/steps/difm-site-picker/index.tsx
+++ b/client/signup/steps/difm-site-picker/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { HelpCenterInlineButton } from '@automattic/help-center';
 import { Button } from '@wordpress/components';
@@ -61,8 +60,10 @@ export default function DIFMSitePickerStep( props: Props ) {
 
 	const { data: geoData } = useGeoLocationQuery();
 
+	const queryParams = new URLSearchParams( window?.location.search );
+	const flags = queryParams.get( 'flags' )?.split( ',' );
 	const isHelpCenterLinkEnabled =
-		geoData?.country_short === 'US' && isEnabled( 'signup/help-center-link' );
+		flags?.includes( 'signup/help-center-link' ) && geoData?.country_short === 'US';
 
 	const subHeaderText = translate(
 		'Please {{SupportLink}}contact support{{/SupportLink}} if your existing WordPress.com site isn’t listed, or create a {{NewSiteLink}}new site{{/NewSiteLink}} instead.',

--- a/client/signup/steps/difm-site-picker/index.tsx
+++ b/client/signup/steps/difm-site-picker/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { HelpCenterInlineButton } from '@automattic/help-center';
 import { Button } from '@wordpress/components';
@@ -60,10 +61,8 @@ export default function DIFMSitePickerStep( props: Props ) {
 
 	const { data: geoData } = useGeoLocationQuery();
 
-	const queryParams = new URLSearchParams( window?.location.search );
-	const flags = queryParams.get( 'flags' );
 	const isHelpCenterLinkEnabled =
-		geoData?.country_short === 'US' && flags === 'signup/help-center-link';
+		geoData?.country_short === 'US' && isEnabled( 'signup/help-center-link' );
 
 	const subHeaderText = translate(
 		'Please {{SupportLink}}contact support{{/SupportLink}} if your existing WordPress.com site isn’t listed, or create a {{NewSiteLink}}new site{{/NewSiteLink}} instead.',

--- a/client/signup/steps/difm-site-picker/index.tsx
+++ b/client/signup/steps/difm-site-picker/index.tsx
@@ -4,6 +4,7 @@ import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import SiteSelector from 'calypso/components/site-selector';
+import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { useDispatch, useStore } from 'calypso/state';
@@ -57,12 +58,21 @@ export default function DIFMSitePickerStep( props: Props ) {
 		goToNextStep();
 	};
 
+	const { data: geoData } = useGeoLocationQuery();
+
+	const queryParams = new URLSearchParams( window?.location.search );
+	const flags = queryParams.get( 'flags' );
+	const isHelpCenterLinkEnabled =
+		geoData?.country_short === 'US' && flags === 'signup/help-center-link';
+
 	const subHeaderText = translate(
 		'Please {{SupportLink}}contact support{{/SupportLink}} if your existing WordPress.com site isn’t listed, or create a {{NewSiteLink}}new site{{/NewSiteLink}} instead.',
 		{
 			components: {
-				SupportLink: (
+				SupportLink: isHelpCenterLinkEnabled ? (
 					<HelpCenterInlineButton className="subtitle-link" flowName={ props.flowName } />
+				) : (
+					<a className="subtitle-link" rel="noopener noreferrer" href="/help/contact" />
 				),
 				NewSiteLink: (
 					<Button variant="link" className="subtitle-link" onClick={ onNewSiteClicked } />

--- a/client/signup/types.ts
+++ b/client/signup/types.ts
@@ -23,6 +23,7 @@ export interface Flow {
 	hideProgressIndicator?: boolean;
 	helpCenterButtonText?: string;
 	enableHotjar?: boolean;
+	enabledHelpCenterGeos?: string[];
 	onEnterFlow?: ( flowName: string ) => void;
 }
 

--- a/packages/help-center/src/components/help-center-step-button.tsx
+++ b/packages/help-center/src/components/help-center-step-button.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-restricted-imports */
 import { useTranslate } from 'i18n-calypso';
-import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import HelpCenterInlineButton from './help-center-inline-button';
 import type { FC } from 'react';
 
@@ -16,11 +15,6 @@ const HelpCenterStepButton: FC< HelpCenterStepButtonProps > = ( {
 	helpCenterButtonLink,
 } ) => {
 	const translate = useTranslate();
-	const { data: geoData } = useGeoLocationQuery();
-
-	if ( geoData?.country_short === 'US' ) {
-		return null;
-	}
 
 	return (
 		<div className="step-wrapper__help-center-button-container">

--- a/packages/help-center/src/index.ts
+++ b/packages/help-center/src/index.ts
@@ -4,7 +4,6 @@ export { SuccessIcon } from './components/success-icon';
 export { SuccessScreen } from './components/ticket-success-screen';
 export { BackButton } from './components/back-button';
 export { HelpCenterContactForm } from './components/help-center-contact-form';
-export { default as HelpCenterStepButton } from './components/help-center-step-button';
 export { default as HelpCenterInlineButton } from './components/help-center-inline-button';
 export { default as Mail } from './icons/mail';
 export { default as NewReleases } from './icons/new-releases';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* The Help Center button in the DIFM flow should appear if the flag is active and the current geo is US. This PR consolidates these checks and moves them outside the help center since each flow can have its own set of rules for enabling/disabling the help center link.
* The help center should also be opened by clicking on the "contact support" link on the DIFM site picker page. This PR also duplicates the same checks to control whether the help center should be opened when clicking that link.
<img width="927" alt="image" src="https://github.com/user-attachments/assets/363c755e-55b4-44c4-b13b-277508960074" />

* This PR also adds the Help Center button to the `difmStartingPoint` step.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Explained above.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Test that the help center is shown in these scenarios
* Be in the US locale. (If you are an a11n, connect to the DFW proxy)
* Go to `/start/do-it-for-me?flags=signup/help-center-link`
* Confirm that you can see the help center link in the top right.
<img width="319" alt="image" src="https://github.com/user-attachments/assets/4e2a8988-cc85-47c2-ba83-773351a49922" />

### Test that the help center is NOT shown in these scenarios
* Switch to a US locale and go to `/start/do-it-for-me`.
* Switch to a non-US locale (If you are an a11n, connect to the CDG proxy). Go to `/start/do-it-for-me?flags=signup/help-center-link`.
* Switch to a non-US locale and go to `/start/do-it-for-me`.

### Testing the DIFM starting point step
* Go to `/setup/onboarding?flags=onboarding/force-goals-first,signup/help-center-link`.
* Click on "Let us build a custom site for you"
* Confirm that the help center button is shown in the top right.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
