### PR TITLE
Newsletter importer: Clarify why we're asking for the address

### DIFF
--- a/client/my-sites/importer/newsletter/select-newsletter-form.tsx
+++ b/client/my-sites/importer/newsletter/select-newsletter-form.tsx
@@ -62,9 +62,9 @@ export default function SelectNewsletterForm( {
 			{ ! hasError && (
 				<p className="select-newsletter-form__help">
 					{ i18n.fixMe( {
-						text: 'Enter your Substack URL and we will direct you to the page where you can download your newsletter content.',
+						text: "Enter your Substack URL. We'll create a link where you can download your newsletter content.",
 						newCopy: i18n.translate(
-							'Enter your Substack URL and we will direct you to the page where you can download your newsletter content.'
+							"Enter your Substack URL. We'll create a link where you can download your newsletter content."
 						),
 						oldCopy: i18n.translate(
 							'Enter the URL of the Substack newsletter that you wish to import.'

--- a/client/my-sites/importer/newsletter/select-newsletter-form.tsx
+++ b/client/my-sites/importer/newsletter/select-newsletter-form.tsx
@@ -2,6 +2,7 @@ import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
+import i18n from 'i18n-calypso';
 import { useState } from 'react';
 import FormTextInputWithAction from 'calypso/components/forms/form-text-input-with-action';
 import { isValidUrl, parseUrl } from 'calypso/lib/importer/url-validation';
@@ -60,7 +61,15 @@ export default function SelectNewsletterForm( {
 			) }
 			{ ! hasError && (
 				<p className="select-newsletter-form__help">
-					{ __( 'Enter the URL of the Substack newsletter that you wish to import.' ) }
+					{ i18n.fixMe( {
+						text: 'Enter your Substack URL and we will direct you to the page where you can download your newsletter content.',
+						newCopy: i18n.translate(
+							'Enter your Substack URL and we will direct you to the page where you can download your newsletter content.'
+						),
+						oldCopy: i18n.translate(
+							'Enter the URL of the Substack newsletter that you wish to import.'
+						),
+					} ) }
 				</p>
 			) }
 		</Card>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/492

## Proposed Changes

* Update copy to clarify why we're asking for the URL here. It's to provide the user with the URLs that they can click to download the files that they need to import.

Before | After
---- | -----
<img width="822" alt="Screen Shot 2025-03-04 at 4 48 24 PM" src="https://github.com/user-attachments/assets/f9fe8154-4c70-4834-b6cf-f0f83eb58072" /> | <img width="799" alt="Screen Shot 2025-03-05 at 10 27 57 AM" src="https://github.com/user-attachments/assets/fbc36250-1420-4e88-baaf-6b207347746e" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We noticed this was unclear and potentially confusing during a walkthrough: pg9MHR-p8-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /import/newsletter/substack/{site URL} and check that you see the correct copy. 
* Switch locales and check that you see the fallback translation.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?