### PR TITLE
Reader Editor: Disable keyboard shortcuts when Editor is focused

### DIFF
--- a/client/reader/components/quick-post/utils.tsx
+++ b/client/reader/components/quick-post/utils.tsx
@@ -1,0 +1,12 @@
+/**
+ * Check if the Editor iframe is focused.
+ * @returns {boolean} Whether the editor iframe has focus
+ */
+export const isEditorIframeFocused = (): boolean => {
+	const editorIframe = document.querySelector< HTMLIFrameElement >(
+		'iframe[name="editor-canvas"]'
+	);
+	const iframeFocused =
+		editorIframe?.contentDocument?.activeElement?.getAttribute( 'contenteditable' ) === 'true';
+	return !! iframeFocused;
+};

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -17,6 +17,7 @@ import NavTabs from 'calypso/components/section-nav/tabs';
 import { Interval, EVERY_MINUTE } from 'calypso/lib/interval';
 import scrollTo from 'calypso/lib/scroll-to';
 import withDimensions from 'calypso/lib/with-dimensions';
+import { isEditorIframeFocused } from 'calypso/reader/components/quick-post/utils';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { shouldShowLikes } from 'calypso/reader/like-helper';
 import { keysAreEqual, keyToString } from 'calypso/reader/post-key';
@@ -284,7 +285,11 @@ class ReaderStream extends Component {
 		}
 
 		const tagName = ( event.target || event.srcElement ).tagName;
-		if ( inputTags.includes( tagName ) || event.target.isContentEditable ) {
+		if (
+			inputTags.includes( tagName ) ||
+			event.target.isContentEditable ||
+			isEditorIframeFocused()
+		) {
 			return;
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/521

## Proposed Changes

* Introduce `isEditorIframeFocused` to determine if the Editor iframe is focused.
* Disable keyboard shortcuts in the Reader stream if `isEditorIframeFocused` is true.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To allow the user to type letters such as `j` and `k` in the quick post box.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live and go to /reader
* Try typing `j` and `k` in the post editor. It should work.
* Click outside of the Editor so it loses focus and try pressing `j` and `k`. They should act as keyboard shortcuts.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
