### PR TITLE
Stats: Release line chart take 2

### DIFF
--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -160,8 +160,8 @@ function StatsLineChart( {
 		<div className={ clsx( 'stats-line-chart', className ) }>
 			{ isEmpty && (
 				<EmptyState
-					headingText={ translate( 'Real-time views' ) }
-					infoText={ translate( 'Collecting data… auto-refreshing in a minute…' ) }
+					headingText={ translate( 'No data available' ) }
+					infoText={ translate( 'Try selecting a different time frame.' ) }
 				/>
 			) }
 			{ ! isEmpty && (

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -19,7 +19,6 @@ import { getCountRecords, getLoadingTabs } from 'calypso/state/stats/chart-tabs/
 import { chartLabelformats } from 'calypso/state/stats/lists/utils';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useCssVariable from '../hooks/use-css-variable';
-import PageLoading from '../pages/shared/page-loading';
 import StatsEmptyState from '../stats-empty-state';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatTabs from '../stats-tabs';
@@ -239,7 +238,9 @@ class StatModuleChartTabs extends Component {
 						moment={ moment }
 						onClick={ this.props.barClick }
 						formatTimeTick={ this.formatLineChartTimeTick }
-						placeholder={ PageLoading }
+						placeholder={
+							<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />
+						}
 					/>
 				) }
 

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -19,6 +19,7 @@ import { getCountRecords, getLoadingTabs } from 'calypso/state/stats/chart-tabs/
 import { chartLabelformats } from 'calypso/state/stats/lists/utils';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useCssVariable from '../hooks/use-css-variable';
+import PageLoading from '../pages/shared/page-loading';
 import StatsEmptyState from '../stats-empty-state';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatTabs from '../stats-tabs';
@@ -216,7 +217,7 @@ class StatModuleChartTabs extends Component {
 
 				<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />
 
-				{ chartType === 'bar' ? (
+				{ chartType === 'bar' || chartData.length === 0 ? (
 					<Chart barClick={ this.props.barClick } data={ chartData } minBarWidth={ 35 }>
 						<StatsEmptyState
 							headingText={
@@ -238,6 +239,7 @@ class StatModuleChartTabs extends Component {
 						moment={ moment }
 						onClick={ this.props.barClick }
 						formatTimeTick={ this.formatLineChartTimeTick }
+						placeholder={ PageLoading }
 					/>
 				) }
 

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -9,7 +9,6 @@ import UplotChart from 'calypso/components/chart-uplot';
 import useSubscribersQuery from 'calypso/my-sites/stats/hooks/use-subscribers-query';
 import { useSelector } from 'calypso/state';
 import useCssVariable from '../hooks/use-css-variable';
-import PageLoading from '../pages/shared/page-loading';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsPeriodHeader from '../stats-period-header';
 import { parseLocalDate } from '../utils';
@@ -275,7 +274,7 @@ export default function SubscribersChartSection( {
 							EmptyState={ () => null }
 							zeroBaseline={ lineChartData.length > 1 }
 							formatTimeTick={ formatTimeTick }
-							placeholder={ PageLoading }
+							placeholder={ <StatsModulePlaceholder className="is-chart" isLoading /> }
 						/>
 					) : (
 						<UplotChart

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -9,6 +9,7 @@ import UplotChart from 'calypso/components/chart-uplot';
 import useSubscribersQuery from 'calypso/my-sites/stats/hooks/use-subscribers-query';
 import { useSelector } from 'calypso/state';
 import useCssVariable from '../hooks/use-css-variable';
+import PageLoading from '../pages/shared/page-loading';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsPeriodHeader from '../stats-period-header';
 import { parseLocalDate } from '../utils';
@@ -274,6 +275,7 @@ export default function SubscribersChartSection( {
 							EmptyState={ () => null }
 							zeroBaseline={ lineChartData.length > 1 }
 							formatTimeTick={ formatTimeTick }
+							placeholder={ PageLoading }
 						/>
 					) : (
 						<UplotChart

--- a/config/development.json
+++ b/config/development.json
@@ -186,7 +186,7 @@
 		"site-profiler/metrics": true,
 		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": false,
-		"stats/chart-library": false,
+		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"stats/locations": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -119,7 +119,7 @@
 		"site-profiler/metrics": true,
 		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": true,
-		"stats/chart-library": false,
+		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,

--- a/config/production.json
+++ b/config/production.json
@@ -154,7 +154,7 @@
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
-		"stats/chart-library": false,
+		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"stats/locations": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -149,7 +149,7 @@
 		"site-profiler/metrics": false,
 		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": true,
-		"stats/chart-library": false,
+		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"stats/locations": true,

--- a/config/test.json
+++ b/config/test.json
@@ -114,7 +114,7 @@
 		"site-indicator": true,
 		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": true,
-		"stats/chart-library": false,
+		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -157,7 +157,7 @@
 		"site-profiler/metrics": true,
 		"sites/drive-migrations": true,
 		"ssr/prefetch-timebox": true,
-		"stats/chart-library": false,
+		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"stats/locations": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Release line charts
* A couple of small fixes regarding loading and empty states

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Release

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live on the Traffic page
* Ensure you could switch to line chart and back to bar chart
* Ensure clicking behaves the same as bar chart
* Ensure the date/time on the line match the axis
* Ensure date/time on tooltip matches the data piont
* Ensure tooltip looks okay
* Ensure the line chart is responsive
* Check whether there's anything off
* Open the subscribers page
* Repeat above steps

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
