### PR TITLE
Stepper: Fix auth with a8c email address

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -13,6 +13,7 @@ import LoggedOutForm from 'calypso/components/logged-out-form';
 import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
 import Notice from 'calypso/components/notice';
 import { recordRegistration } from 'calypso/lib/analytics/signup';
+import { stripHTML } from 'calypso/lib/formatting';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import { isExistingAccountError } from 'calypso/lib/signup/is-existing-account-error';
 import wpcom from 'calypso/lib/wp';
@@ -140,8 +141,13 @@ class PasswordlessSignupForm extends Component {
 
 	createAccountError = async ( error ) => {
 		this.submitTracksEvent( false, { action_message: error.message, error_code: error.error } );
-
-		if ( ! isExistingAccountError( error.error ) ) {
+		// This error only happens when users sign up with an email belongs to a8c.
+		if ( error.error === 'account_unactivated' ) {
+			this.setState( {
+				// No need to translate the error message, it's for a8c users only.
+				errorMessages: [ stripHTML( error.message ) ],
+			} );
+		} else if ( ! isExistingAccountError( error.error ) ) {
 			this.setState( {
 				errorMessages: [
 					this.props.translate(

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -141,7 +141,7 @@ class PasswordlessSignupForm extends Component {
 
 	createAccountError = async ( error ) => {
 		this.submitTracksEvent( false, { action_message: error.message, error_code: error.error } );
-		// This error only happens when users sign up with an email belongs to a8c.
+		// This error only happens when users sign up with an email that belongs to a8c.
 		if ( error.error === 'account_unactivated' ) {
 			this.setState( {
 				// No need to translate the error message, it's for a8c users only.

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -1,6 +1,11 @@
 import { StepperInternal } from '@automattic/data-stores';
 import React from 'react';
 import { STEPPER_TRACKS_EVENTS } from '../../constants';
+import type { STEPS, PRIVATE_STEPS } from './steps';
+
+export type StepperStepSlug =
+	| ( typeof STEPS )[ keyof typeof STEPS ][ 'slug' ]
+	| ( typeof PRIVATE_STEPS )[ keyof typeof PRIVATE_STEPS ][ 'slug' ];
 
 /**
  * This is the return type of useStepNavigation hook
@@ -29,7 +34,7 @@ export type NavigationControls = {
 	 * screen(s) to a new stepper flow and linking directly
 	 * between flows/screens.
 	 */
-	goToStep?: ( step: string ) => void;
+	goToStep?: ( step: StepperStepSlug | `${ StepperStepSlug }?${ string }` ) => void;
 
 	/**
 	 * Submits the answers provided in the flow
@@ -46,7 +51,7 @@ export type DeprecatedStepperStep = {
 	/**
 	 * The step slug is what appears as part of the pathname. Eg the intro in /setup/link-in-bio/intro
 	 */
-	slug: string;
+	slug: StepperStepSlug;
 	/**
 	 * Does the step require a logged-in user?
 	 */
@@ -63,7 +68,7 @@ export type AsyncStepperStep = {
 	/**
 	 * The step slug is what appears as part of the pathname. Eg the intro in /setup/link-in-bio/intro
 	 */
-	slug: Exclude< string, 'user' >;
+	slug: StepperStepSlug;
 	/**
 	 * Does the step require a logged-in user?
 	 */
@@ -85,8 +90,8 @@ export interface AsyncUserStep extends AsyncStepperStep {
 
 export type StepperStep = DeprecatedStepperStep | AsyncStepperStep | AsyncUserStep;
 
-export type Navigate< FlowSteps extends readonly StepperStep[] > = (
-	stepName: FlowSteps[ number ][ 'slug' ] | `${ FlowSteps[ number ][ 'slug' ] }?${ string }`,
+export type Navigate = (
+	stepName: StepperStepSlug | `${ StepperStepSlug }?${ string }`,
 	extraData?: any,
 	/**
 	 * If true, the current step will be replaced in the history stack.
@@ -99,19 +104,14 @@ export type Navigate< FlowSteps extends readonly StepperStep[] > = (
  */
 export type UseStepsHook = () => StepperStep[];
 
-export type UseStepNavigationHook< FlowSteps extends StepperStep[] > = (
-	currentStepSlug: FlowSteps[ number ][ 'slug' ],
-	navigate: Navigate< FlowSteps >
+export type UseStepNavigationHook = (
+	currentStepSlug: StepperStepSlug,
+	navigate: Navigate
 ) => NavigationControls;
 
-export type UseAssertConditionsHook< FlowSteps extends readonly StepperStep[] > = (
-	navigate?: Navigate< FlowSteps >
-) => AssertConditionResult;
+export type UseAssertConditionsHook = ( navigate?: Navigate ) => AssertConditionResult;
 
-export type UseSideEffectHook< FlowSteps extends readonly StepperStep[] > = (
-	currentStepSlug: FlowSteps[ number ][ 'slug' ],
-	navigate: Navigate< FlowSteps >
-) => void;
+export type UseSideEffectHook = ( currentStepSlug: StepperStepSlug, navigate: Navigate ) => void;
 
 /**
  * Used for overriding props recorded by the default Tracks event loggers.
@@ -166,15 +166,15 @@ export type FlowV1 = {
 	 * Use this method to define the steps of the flow and do any actions that need to run before the flow starts.
 	 * This hook is called only once when the flow is mounted. It can be asynchronous if you would like to load an experiment or other data.
 	 */
-	useStepNavigation: UseStepNavigationHook< StepperStep[] >;
+	useStepNavigation: UseStepNavigationHook;
 	/**
 	 * @deprecated Use `initialize` instead. `initialize` will run before the flow is rendered and you can make any decisions there.
 	 */
-	useAssertConditions?: UseAssertConditionsHook< ReturnType< FlowV1[ 'useSteps' ] > >;
+	useAssertConditions?: UseAssertConditionsHook;
 	/**
 	 * A hook that is called in the flow's root at every render. You can use this hook to setup side-effects, call other hooks, etc..
 	 */
-	useSideEffect?: UseSideEffectHook< ReturnType< FlowV1[ 'useSteps' ] > >;
+	useSideEffect?: UseSideEffectHook;
 	useTracksEventProps?: UseTracksEventPropsHook;
 	/**
 	 * Temporary hook to allow gradual migration of flows to the globalised/default event tracking.
@@ -237,11 +237,11 @@ export type FlowV2 = {
 		| Promise< false >
 		| Promise< readonly StepperStep[] >
 		| readonly StepperStep[];
-	useStepNavigation: UseStepNavigationHook< StepperStep[] >;
+	useStepNavigation: UseStepNavigationHook;
 	/**
 	 * A hook that is called in the flow's root at every render. You can use this hook to setup side-effects, call other hooks, etc..
 	 */
-	useSideEffect?: UseSideEffectHook< StepperStep[] >;
+	useSideEffect?: UseSideEffectHook;
 	useTracksEventProps?: UseTracksEventPropsHook;
 	/**
 	 * Temporary hook to allow gradual migration of flows to the globalised/default event tracking.
@@ -251,14 +251,14 @@ export type FlowV2 = {
 	/**
 	 * @deprecated Avoid this. Assert your conditions in `initialize` instead unless you're 100% sure you need this.
 	 */
-	useAssertConditions?: UseAssertConditionsHook< ReturnType< FlowV1[ 'useSteps' ] > >;
+	useAssertConditions?: UseAssertConditionsHook;
 };
 
 export type Flow = FlowV1 | FlowV2;
 
 export type StepProps = {
 	navigation: NavigationControls;
-	stepName: string;
+	stepName: StepperStepSlug;
 	flow: string;
 	/**
 	 * If this is a step of a flow that extends another, pass the variantSlug of the variant flow, it can come handy.


### PR DESCRIPTION
Implements https://github.com/Automattic/wp-calypso/issues/98116#issuecomment-2578706360.

![image](https://github.com/user-attachments/assets/dec26c35-7048-42e5-81cf-d68e67595d1d)


### Testing

1. #175803 PR in wpcom repo.
2. Go to /setup/onboarding and sign up with an a8c email while proxied.