### PR TITLE
Newsletter importer: Fix progress steps by allowing the content step for Jetpack sites

### DIFF
--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -118,10 +118,9 @@ export default function Summary( {
 				</div>
 				<ImporterActionButtonContainer noSpacing>
 					<ImporterActionButton
-						href={ `/import/newsletter/substack/${ selectedSite.slug }/${
-							// Content step is disabled for Jetpack sites, thus first step would be subscribers
-							steps?.content ? 'content' : 'subscribers'
-						}?from=${ fromSite }` }
+						href={ `/import/newsletter/substack/${
+							selectedSite.slug
+						}/${ 'content' }?from=${ fromSite }` }
 						onClick={ resetImporter }
 						primary
 					>

--- a/client/my-sites/importer/newsletter/utils.tsx
+++ b/client/my-sites/importer/newsletter/utils.tsx
@@ -33,6 +33,18 @@ export function getStepsProgress(
 
 	const result: ClickHandler[] = [
 		{
+			message: __( 'Content' ),
+			onClick: () => {
+				navigate(
+					addQueryArgs( `/import/newsletter/${ engine }/${ selectedSiteSlug }/content`, {
+						from: fromSite,
+					} )
+				);
+			},
+			show: 'onComplete',
+			indicator: getStepProgressIndicator( paidNewsletterData?.steps?.content?.status ),
+		},
+		{
 			message: __( 'Subscribers' ),
 			onClick: () => {
 				navigate(
@@ -58,22 +70,6 @@ export function getStepsProgress(
 		},
 	];
 
-	// Content step as first only when it's available (not available for Jetpack sites)
-	if ( paidNewsletterData?.steps?.content ) {
-		result.unshift( {
-			message: __( 'Content' ),
-			onClick: () => {
-				navigate(
-					addQueryArgs( `/import/newsletter/${ engine }/${ selectedSiteSlug }/content`, {
-						from: fromSite,
-					} )
-				);
-			},
-			show: 'onComplete',
-			indicator: getStepProgressIndicator( paidNewsletterData?.steps?.content?.status ),
-		} );
-	}
-
 	return result;
 }
 
@@ -84,28 +80,27 @@ export function getImporterStatus(
 	contentStepStatus?: StepStatus,
 	subscribersStepStatus?: StepStatus
 ): StepStatus {
-	// When content step is hidden for Jetpack sites, we can rely on subscriber status for entire engine's status
-	if ( ! contentStepStatus ) {
-		return subscribersStepStatus || 'initial';
-	}
+	// Initialize both statuses to 'initial' if undefined.
+	const content = contentStepStatus || 'initial';
+	const subscribers = subscribersStepStatus || 'initial';
 
-	if ( contentStepStatus === 'done' && subscribersStepStatus === 'done' ) {
+	if ( content === 'done' && subscribers === 'done' ) {
 		return 'done';
 	}
 
-	if ( contentStepStatus === 'done' && subscribersStepStatus === 'skipped' ) {
+	if ( content === 'done' && subscribers === 'skipped' ) {
 		return 'done';
 	}
 
-	if ( contentStepStatus === 'skipped' && subscribersStepStatus === 'done' ) {
+	if ( content === 'skipped' && subscribers === 'done' ) {
 		return 'done';
 	}
 
-	if ( contentStepStatus === 'skipped' && subscribersStepStatus === 'skipped' ) {
+	if ( content === 'skipped' && subscribers === 'skipped' ) {
 		return 'skipped';
 	}
 
-	if ( contentStepStatus === 'importing' || subscribersStepStatus === 'importing' ) {
+	if ( content === 'importing' || subscribers === 'importing' ) {
 		return 'importing';
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/493

## Proposed Changes

* Currently we skip the content step in the progress steps for Jetpack sites. But we do show the content step at the beginning of the flow, which leads to the steps being out of sync with the importer. I'm removing the "hide when Jetpack" checks so that we no longer skip the step.

Before | After
---- | -----
<img width="825" alt="Screen Shot 2025-03-04 at 5 35 10 PM" src="https://github.com/user-attachments/assets/93819aa8-c736-4982-b162-b8cea85e5874" /> | <img width="905" alt="Screen Shot 2025-03-04 at 5 35 40 PM" src="https://github.com/user-attachments/assets/df140463-e049-4290-b3cb-dc2c6f74cdc6" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve the newsletter importer flow for Jetpack sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/import/newsletter/substack/{site}` for a Jetpack site where you haven't imported this Substack before, on the Calypso branch.
* Enter a Substack address.
* Check that you see all three steps at the top: Content, Subscribers, Summary.
* Try importing a content zip to verify that the posts get imported.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
