### PR TITLE
Line charts: more left margin

### DIFF
--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -175,7 +175,7 @@ function StatsLineChart( {
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any
 						onPointerDown={ onPointerDown as any }
 						margin={ {
-							left: 15,
+							left: 20,
 							top: 20,
 							bottom: 20,
 							right: Math.max( formatValue( maxValue ).length * 10, 40 ), //TODO: we should support this from the lib.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Increase left margin from 15 to 20

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open stats for a single day `http://calypso.localhost:3000/stats/hour/your-site.com?chartStart=2025-02-16&chartEnd=2025-02-16`
* Ensure the leftmost x-axis label is not cut off

| before | after |
|--------|------|
|<img width="170" alt="Screenshot 2025-03-05 at 2 59 30 PM" src="https://github.com/user-attachments/assets/afdd92fe-556d-4e83-bdab-e6c4568acf87" /> | <img width="144" alt="Screenshot 2025-03-05 at 2 59 49 PM" src="https://github.com/user-attachments/assets/09804c7e-a0f3-494c-8241-29bf552916b7" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
