### PR TITLE
Domains DataViews: Remove owner field from domains table

### DIFF
--- a/client/my-sites/domains/domain-management/dataviews/use-fields.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/use-fields.tsx
@@ -44,34 +44,6 @@ export function useFields() {
 				render: ( { item }: { item: PartialDomainData } ) => <DomainType item={ item } />,
 			},
 			{
-				id: 'owner',
-				label: translate( 'Owner' ),
-				enableHiding: false,
-				enableSorting: true,
-				getValue: ( { item }: { item: PartialDomainData } ) => {
-					const domain = getFullDomain( item );
-					if ( ! domain ) {
-						return '';
-					}
-					if ( ! domain.owner ) {
-						return '';
-					}
-					// Removes the username that appears in parentheses after the owner's name.
-					// Uses $ and the negative lookahead assertion (?!.*\() to ensure we only match the very last parenthetical.
-					return domain.owner.replace( / \((?!.*\().+\)$/, '' );
-				},
-				render: ( { item }: { item: PartialDomainData } ) => {
-					const domain = getFullDomain( item );
-					if ( ! domain ) {
-						return <LoadingPlaceholder />;
-					}
-					if ( ! domain.owner ) {
-						return '-';
-					}
-					return domain.owner.replace( / \((?!.*\().+\)$/, '' );
-				},
-			},
-			{
 				id: 'site',
 				label: translate( 'Site' ),
 				enableHiding: false,

--- a/client/my-sites/domains/domain-management/dataviews/view.ts
+++ b/client/my-sites/domains/domain-management/dataviews/view.ts
@@ -9,7 +9,7 @@ import {
 
 export function getFieldsByBreakpoint( isDesktop: boolean, sidebarMode?: boolean ) {
 	if ( isDesktop && ! sidebarMode ) {
-		return [ 'owner', 'site', 'ssl_status', 'expiry', 'domain_status' ];
+		return [ 'site', 'ssl_status', 'expiry', 'domain_status' ];
 	}
 
 	return [];
@@ -41,9 +41,6 @@ export function initializeViewState(
 			domain_name: {
 				minWidth: '1fr',
 				maxWidth: '2fr',
-			},
-			owner: {
-				width: '2fr',
 			},
 			blog_name: {},
 			ssl: {


### PR DESCRIPTION
In production, we show only domains that the user owns.

## Proposed Changes

* Remove the owner fields from the DataViews table for domains.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of Domains Management Revamp project.

## Testing Instructions

* Turn on feature flags in your browser's console: `window.sessionStorage.setItem('flags', 'calypso/domains-dataviews'])`
* Go to http://calypso.localhost:3000/domains/manage
* Make sure there is no owner column in the table.
* Check the DataViews settings (the cog) don't have a mention of the owner field.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
