### PR TITLE
Add interactive states for social buttons in login and signup

### DIFF
--- a/client/assets/stylesheets/_p2-extends.scss
+++ b/client/assets/stylesheets/_p2-extends.scss
@@ -82,7 +82,7 @@
 	height: auto;
 	width: 100%;
 
-	&:hover:not(:disabled):not(.disabled) {
+	&:hover:not(.social-buttons__button):not(:disabled):not(.disabled) {
 		background-color: var(--p2-color-button-dark);
 		color: var(--p2-color-text);
 	}

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -65,12 +65,3 @@ form {
     	}
     }
 }
-
-.wp-login__main .login.is-akismet .is-social-first .card.login__form > .social-buttons__button.button {
-	background-color: var(--color-akismet);
-
-	&:hover,
-	&:focus {
-    	background-color: var(--color-akismet);
-	}	
-}

--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -231,4 +231,13 @@
 			padding: 24px;
 		}
 	}
+
+	/**
+	* Akismet Login
+	*/
+	@at-root .is-akismet & {
+		.auth-form__social-buttons .auth-form__social-buttons-container .social-buttons__button {
+			--color-accent: var(--color-akismet);
+		}
+	}
 }

--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -38,45 +38,6 @@
 				display: flex;
 				flex-direction: column;
 				width: 100%;
-
-				@at-root .wp-login__container .is-social-first .login__form ,
-				& {
-					.social-buttons__button.button {
-						align-items: center;
-						background: var(--black-white-white, #fff);
-						border: 1px solid var(--studio-gray-50, #646970);
-						border-radius: 4px;
-						display: flex;
-						height: 44px;
-						justify-content: center;
-						margin-bottom: 0;
-						padding: 4px 16px;
-						border-color: #ccc;
-						text-wrap: balance;
-
-						& > svg.social-icons {
-							border: 0;
-							border-radius: 0;
-							margin-right: auto;
-						}
-
-						span.social-buttons__service-name {
-							flex: 1;
-							font-feature-settings: "clig" off, "liga" off;
-							color: var(--studio-gray-80, #2c3338);
-							font-family: "SF Pro Text", sans-serif;
-							font-size: 0.875rem;
-							font-style: normal;
-							font-weight: 500;
-							letter-spacing: 0.32px;
-							line-height: normal;
-							max-width: 240px;
-							text-align: center;
-							margin-right: auto;
-							margin-left: -10px;
-						}
-					}
-				}
 			}
 		}
 	}
@@ -269,40 +230,6 @@
 				display: flex;
 				flex-direction: column;
 				width: 100%;
-
-				.social-buttons__button {
-					align-items: center;
-					align-self: stretch;
-					background: var(--black-white-white, #fff);
-					border: 1px solid var(--studio-gray-50, #646970);
-					border-radius: 4px;
-					display: flex;
-					height: 40px;
-					justify-content: center;
-					margin-bottom: 0;
-					padding: 4px 16px;
-					border-color: #ccc;
-
-					& > svg {
-						border: 0;
-						border-radius: 0;
-						margin-right: auto;
-					}
-
-					span {
-						font-feature-settings: "clig" off, "liga" off;
-						color: var(--studio-gray-80, #2c3338);
-						font-family: "SF Pro Text", sans-serif;
-						font-size: 0.875rem;
-						font-style: normal;
-						font-weight: 500;
-						letter-spacing: 0.32px;
-						line-height: normal;
-						margin-left: -20px;
-						margin-right: auto;
-						max-width: 240px;
-					}
-				}
 			}
 		}
 	}

--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -36,44 +36,6 @@
 	}
 
 	/**
-	* P2 Login
-	*/
-	@at-root .is-p2-login & .auth-form__social-buttons-container .social-buttons__button {
-		align-items: center;
-		background-color: var(--p2-color-button);
-		border: none;
-		/* stylelint-disable-next-line scales/radii */
-		border-radius: 50px;
-		color: var(--p2-color-text);
-		display: flex;
-		font-family: var(--p2-font-inter);
-		font-size: var(--p2-font-size-form-xs);
-		height: auto;
-		justify-content: center;
-		letter-spacing: -0.01em;
-		line-height: 1.5;
-		padding: 1em 2em;
-		transition: 0.2s ease-in-out;
-		width: 100%;
-
-		> svg {
-			margin-right: 0;
-		}
-
-		span {
-			margin-left: 9px;
-			margin-right: 0;
-			font-family: inherit;
-			font-size: inherit;
-			font-style: inherit;
-			font-weight: inherit;
-			letter-spacing: -0.01em;
-			line-height: 1.5;
-		}
-	}
-
-
-	/**
 	* Jetpack Login
 	*/
 	@at-root .is-jetpack-login & {
@@ -134,44 +96,6 @@
 			}
 		}
 	}
-
-	/**
-	* P2 Login
-	*/
-	@at-root .is-p2-login & .auth-form__social-buttons-container .social-buttons__button {
-		align-items: center;
-		background-color: var(--p2-color-button);
-		border: none;
-		/* stylelint-disable-next-line scales/radii */
-		border-radius: 50px;
-		color: var(--p2-color-text);
-		display: flex;
-		font-family: var(--p2-font-inter);
-		font-size: var(--p2-font-size-form-xs);
-		height: auto;
-		justify-content: center;
-		letter-spacing: -0.01em;
-		line-height: 1.5;
-		padding: 1em 2em;
-		transition: 0.2s ease-in-out;
-		width: 100%;
-
-		> svg {
-			margin-right: 0;
-		}
-
-		span {
-			margin-left: 9px;
-			margin-right: 0;
-			font-family: inherit;
-			font-size: inherit;
-			font-style: inherit;
-			font-weight: inherit;
-			letter-spacing: -0.01em;
-			line-height: 1.5;
-		}
-	}
-
 
 	/**
 	* Jetpack Login

--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -129,33 +129,6 @@
 			padding: 24px;
 		}
 	}
-
-	/**
-	* WooCommerce Login
-	*/
-	@at-root .is-woo-passwordless & {
-		.auth-form__social-buttons .auth-form__social-buttons-container .social-buttons__button {
-			height: 48px;
-			/* stylelint-disable-next-line scales/radii */
-			border-radius: 8px;
-
-			> svg {
-				margin-right: auto;
-			}
-
-			span {
-				color: var(--studio-gray-100);
-				font-family: Inter, -apple-system, system-ui, sans-serif;
-				font-size: 1rem;
-				font-style: normal;
-				font-weight: 500;
-				line-height: 24px;
-				letter-spacing: 0.32px;
-				margin-left: -20px;
-				margin-right: auto;
-			}
-		}
-	}
 }
 
 .auth-form__social {
@@ -300,33 +273,6 @@
 
 		@include break-mobile {
 			padding: 24px;
-		}
-	}
-
-	/**
-	* WooCommerce Login
-	*/
-	@at-root .is-woo-passwordless & {
-		.auth-form__social-buttons .auth-form__social-buttons-container .social-buttons__button {
-			height: 48px;
-			/* stylelint-disable-next-line scales/radii */
-			border-radius: 8px;
-
-			> svg {
-				margin-right: auto;
-			}
-
-			span {
-				color: var(--studio-gray-100);
-				font-family: Inter, -apple-system, system-ui, sans-serif;
-				font-size: 1rem;
-				font-style: normal;
-				font-weight: 500;
-				line-height: 24px;
-				letter-spacing: 0.32px;
-				margin-left: -20px;
-				margin-right: auto;
-			}
 		}
 	}
 }

--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -130,6 +130,8 @@
 	*/
 	@at-root .crowdsignal & {
 		.auth-form__social-buttons .auth-form__social-buttons-container .social-buttons__button {
+			height: 44px;
+			border-radius: 2px;
 			display: none;
 
 			&.google {

--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -100,35 +100,6 @@
 			padding: 24px;
 		}
 	}
-
-	/**
-	* Jetpack Cloud
-	*/
-	@at-root .jetpack-cloud & {
-		max-width: 375px;
-		width: 100%;
-		padding: 16px;
-		margin-bottom: 0;
-
-		.auth-form__social-buttons .auth-form__social-buttons-container .social-buttons__button {
-			> svg {
-				margin-right: 0;
-			}
-
-			span {
-				font-weight: 400;
-				font-family: inherit;
-				letter-spacing: normal;
-				line-height: 22px;
-				margin-left: 9px;
-				margin-right: 0;
-			}
-		}
-
-		@include break-mobile {
-			padding: 24px;
-		}
-	}
 }
 
 .auth-form__social {
@@ -255,21 +226,6 @@
 		width: 100%;
 		padding: 16px;
 		margin-bottom: 0;
-
-		.auth-form__social-buttons .auth-form__social-buttons-container .social-buttons__button {
-			> svg {
-				margin-right: 0;
-			}
-
-			span {
-				font-weight: 400;
-				font-family: inherit;
-				letter-spacing: normal;
-				line-height: 22px;
-				margin-left: 9px;
-				margin-right: 0;
-			}
-		}
 
 		@include break-mobile {
 			padding: 24px;

--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -16,13 +16,6 @@
 .auth-form__social.is-login {
 	margin-bottom: 0;
 
-	.auth-form__social-buttons-container {
-		width: 100%;
-		gap: 10px;
-		display: flex;
-		flex-direction: column;
-	}
-
 	/**
 	* Social First Logins
 	*/
@@ -105,42 +98,6 @@
 
 		@include break-mobile {
 			padding: 24px;
-		}
-	}
-
-	/**
-	* Crowdsignal Login
-	*/
-	@at-root .crowdsignal & {
-		.auth-form__social-buttons .auth-form__social-buttons-container .social-buttons__button {
-			display: none;
-
-			&.google {
-				display: block;
-				background-color: #fff;
-				margin-bottom: 20px;
-				box-shadow: none;
-				border: solid var(--color-neutral-10);
-				border-width: 1px 1px 2px;
-				border-radius: 2px;
-				box-sizing: border-box;
-				height: 45px;
-				padding: 13px 40px 12px;
-
-				span {
-					margin-left: 15px;
-					font-family: inherit;
-					font-style: inherit;
-					line-height: normal;
-					letter-spacing: normal;
-					font-weight: 600;
-					font-size: 0.875rem;
-				}
-
-				@include break-medium {
-					margin-bottom: 40px;
-				}
-			}
 		}
 	}
 
@@ -308,26 +265,7 @@
 			display: none;
 
 			&.google {
-				display: block;
-				background-color: #fff;
-				margin-bottom: 20px;
-				box-shadow: none;
-				border: solid var(--color-neutral-10);
-				border-width: 1px 1px 2px;
-				border-radius: 2px;
-				box-sizing: border-box;
-				height: 45px;
-				padding: 13px 40px 12px;
-
-				span {
-					margin-left: 15px;
-					font-family: inherit;
-					font-style: inherit;
-					line-height: normal;
-					letter-spacing: normal;
-					font-weight: 600;
-					font-size: 0.875rem;
-				}
+				display: inline-flex;
 
 				@include break-medium {
 					margin-bottom: 40px;

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -458,6 +458,7 @@ $breakpoint-mobile: 782px; //Mobile size.
 		padding: 0;
 		box-shadow: none;
 		margin-bottom: 2em;
+		clip-path: unset;
 	}
 
 	.login__social-tos {
@@ -479,6 +480,10 @@ $breakpoint-mobile: 782px; //Mobile size.
 		&.login__form-change-username:hover:not(:disabled):not(.disabled) {
 			background: none;
 			color: var(--p2-color-link-dark);
+		}
+
+		&.social-buttons__button:not(:focus) {
+			box-shadow: none;
 		}
 	}
 

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -653,17 +653,4 @@ $breakpoint-mobile: 782px; //Mobile size.
 	.login__form-terms {
 		display: block;
 	}
-
-	.auth-form__social {
-		.auth-form__social-buttons-container {
-			width: unset;
-			.social-buttons__button {
-				> svg {
-					border: 1px solid var(--studio-gray-10);
-					border-radius: 24px; /* stylelint-disable-line scales/radii */
-					padding: 12px;
-				}
-			}
-		}
-	}
 }

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -110,6 +110,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	}
 
 	.social-buttons__button {
+		height: 44px;
 		border-radius: 2px;
 	}
 }
@@ -124,8 +125,8 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 }
 
 .crowdsignal .auth-form__social {
-	.auth-form__social-buttons-tos {
-		display: none;
+		.auth-form__social-buttons-tos {
+			display: none;
 	}
 }
 

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -125,8 +125,8 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 }
 
 .crowdsignal .auth-form__social {
-		.auth-form__social-buttons-tos {
-			display: none;
+	.auth-form__social-buttons-tos {
+		display: none;
 	}
 }
 

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -120,25 +120,6 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 }
 
 .crowdsignal .auth-form__social {
-	.button {
-		display: none;
-		margin-bottom: 40px;
-		text-align: center;
-		padding: 13px 40px 12px;
-
-		&:first-child {
-			display: block;
-		}
-
-		@include breakpoint-deprecated( "<660px" ) {
-			margin-bottom: 20px;
-		}
-	}
-
-	.social-buttons__service-name {
-		margin-left: 15px;
-	}
-
 	.auth-form__social-buttons-tos {
 		display: none;
 	}

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -108,6 +108,10 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 			}
 		}
 	}
+
+	.social-buttons__button {
+		border-radius: 2px;
+	}
 }
 
 .button.is-primary.signup-form__crowdsignal-submit {

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -366,26 +366,7 @@ body.is-section-accept-invite {
 			display: none;
 
 			&.google {
-				display: block;
-				background-color: #fff;
-				margin-bottom: 20px;
-				box-shadow: none;
-				border: solid var(--color-neutral-10);
-				border-width: 1px 1px 2px;
-				border-radius: 2px;
-				box-sizing: border-box;
-				height: 45px;
-				padding: 13px 40px 12px;
-
-				span {
-					margin-left: 15px;
-					font-family: inherit;
-					font-style: inherit;
-					line-height: normal;
-					letter-spacing: normal;
-					font-weight: 600;
-					font-size: 0.875rem;
-				}
+				display: inline-flex;
 
 				@include break-medium {
 					margin-bottom: 40px;

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -296,39 +296,10 @@ body.is-section-accept-invite {
 	* P2 Signup
 	*/
 	@at-root .is-p2-login & .auth-form__social-buttons-container .social-buttons__button {
-		align-items: center;
-		background-color: var(--p2-color-button);
-		border: none;
-		/* stylelint-disable-next-line scales/radii */
-		border-radius: 50px;
-		color: var(--p2-color-text);
-		display: flex;
-		font-family: var(--p2-font-inter);
-		font-size: var(--p2-font-size-form-xs);
-		height: auto;
-		justify-content: center;
-		letter-spacing: -0.01em;
-		line-height: 1.5;
-		padding: 1em 2em;
-		transition: 0.2s ease-in-out;
-		width: 100%;
-
-		> svg {
-			margin-right: 0;
-		}
-
-		span {
-			margin-left: 9px;
-			margin-right: 0;
-			font-family: inherit;
-			font-size: inherit;
-			font-style: inherit;
-			font-weight: inherit;
-			letter-spacing: -0.01em;
-			line-height: 1.5;
+		&:not(:focus) {
+			box-shadow: none;
 		}
 	}
-
 
 	/**
 	* Jetpack Signup

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -52,15 +52,8 @@
 	}
 }
 
-.auth-form__social-buttons {
-	button {
-		display: block;
-		margin: 0 auto 15px;
-		box-shadow:
-			0 1px 1px 0 rgba(0, 0, 0, 0.14),
-			0 2px 1px -1px rgba(0, 0, 0, 0.12),
-			0 1px 3px 0 rgba(0, 0, 0, 0.2);
-	}
+.auth-form__social-buttons .social-buttons__button {
+	border-radius: 4px;
 }
 
 .auth-form__social-buttons-tos a {
@@ -295,41 +288,6 @@ body.is-section-accept-invite {
 				display: flex;
 				flex-direction: column;
 				width: 100%;
-
-				.social-buttons__button {
-					display: flex;
-					align-items: center;
-					justify-content: center;
-					align-self: stretch;
-					background: var(--black-white-white, #fff);
-					border: 1px solid #ccc;
-					border-radius: 4px;
-					box-shadow: none;
-					height: 40px;
-					margin-bottom: 0;
-					padding: 4px 16px;
-
-					& > svg {
-						border: 0;
-						border-radius: 0;
-						margin-right: auto;
-					}
-
-					span {
-						font-feature-settings: "clig" off, "liga" off;
-						color: var(--studio-gray-80, #2c3338);
-						font-family: "SF Pro Text", sans-serif;
-						font-size: 0.875rem;
-						font-style: normal;
-						font-weight: 500;
-						letter-spacing: 0.32px;
-						line-height: normal;
-						margin-left: -20px;
-						margin-right: auto;
-						max-width: 240px;
-						text-align: center;
-					}
-				}
 			}
 		}
 	}

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -384,21 +384,6 @@ body.is-section-accept-invite {
 		padding: 16px;
 		margin-bottom: 0;
 
-		.auth-form__social-buttons .auth-form__social-buttons-container .social-buttons__button {
-			> svg {
-				margin-right: 0;
-			}
-
-			span {
-				font-weight: 400;
-				font-family: inherit;
-				letter-spacing: normal;
-				line-height: 22px;
-				margin-left: 9px;
-				margin-right: 0;
-			}
-		}
-
 		@include break-mobile {
 			padding: 24px;
 		}

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -403,33 +403,6 @@ body.is-section-accept-invite {
 			padding: 24px;
 		}
 	}
-
-	/**
-	* WooCommerce Signup
-	*/
-	@at-root .is-woo-passwordless & {
-		.auth-form__social-buttons .auth-form__social-buttons-container .social-buttons__button {
-			height: 48px;
-			/* stylelint-disable-next-line scales/radii */
-			border-radius: 8px;
-
-			> svg {
-				margin-right: auto;
-			}
-
-			span {
-				color: var(--studio-gray-100);
-				font-family: Inter, -apple-system, system-ui, sans-serif;
-				font-size: 1rem;
-				font-style: normal;
-				font-weight: 500;
-				line-height: 24px;
-				letter-spacing: 0.32px;
-				margin-left: -20px;
-				margin-right: auto;
-			}
-		}
-	}
 }
 
 .is-woo-passwordless .signup-form .auth-form__separator {

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -388,6 +388,15 @@ body.is-section-accept-invite {
 			padding: 24px;
 		}
 	}
+
+	/**
+	* Akismet Signup
+	*/
+	@at-root .is-akismet & {
+		.auth-form__social-buttons .auth-form__social-buttons-container .social-buttons__button {
+			--color-accent: var(--color-akismet);
+		}
+	}
 }
 
 .is-woo-passwordless .signup-form .auth-form__separator {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -337,16 +337,15 @@
 	max-width: 100%;
 }
 
-body.is-section-stepper:not(:has(.step-container-v2)),
-body.is-section-signup:not(:has(.step-container-v2)) {
-	svg:not(.jetpack-logo) {
-		padding-top: 0;
-		margin-right: 0;
-	}
-}
-
 body.is-section-stepper,
 body.is-section-signup {
+	&:not(:has(.step-container-v2)) {
+		svg:not(.jetpack-logo, .social-buttons__button svg) {
+			padding-top: 0;
+			margin-right: 0;
+		}
+	}
+
 	.domain-registration-suggestion__badges {
 		margin-left: 0;
 		margin-bottom: 4px;

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -152,6 +152,7 @@ class AppleLoginButton extends Component {
 						data-social-service="apple"
 						onClick={ this.handleClick }
 						variant="secondary"
+						__next40pxDefaultSize
 					>
 						<AppleIcon isDisabled={ isDisabled } width={ 17 } height={ 17 } />
 

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { loadScript } from '@automattic/load-script';
 import requestExternalAccess from '@automattic/request-external-access';
+import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -9,7 +10,6 @@ import { connect } from 'react-redux';
 import AppleIcon from 'calypso/components/social-icons/apple';
 import { isFormDisabled } from 'calypso/state/login/selectors';
 import { getUxMode, getRedirectUri } from './utils';
-
 import './style.scss';
 
 const appleClientUrl =
@@ -147,10 +147,11 @@ class AppleLoginButton extends Component {
 				{ customButton ? (
 					customButton
 				) : (
-					<button
-						className={ clsx( 'social-buttons__button button apple', { disabled: isDisabled } ) }
+					<Button
+						className={ clsx( 'social-buttons__button apple', { disabled: isDisabled } ) }
 						data-social-service="apple"
 						onClick={ this.handleClick }
+						variant="secondary"
 					>
 						<AppleIcon isDisabled={ isDisabled } width={ 17 } height={ 17 } />
 
@@ -161,7 +162,7 @@ class AppleLoginButton extends Component {
 									'%(service)s is the name of a third-party authentication provider, e.g. "Google", "Facebook", "Apple" ...',
 							} ) }
 						</span>
-					</button>
+					</Button>
 				) }
 			</Fragment>
 		);

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -10,6 +10,8 @@ import { connect } from 'react-redux';
 import AppleIcon from 'calypso/components/social-icons/apple';
 import { isFormDisabled } from 'calypso/state/login/selectors';
 import { getUxMode, getRedirectUri } from './utils';
+
+import '@automattic/components/styles/wp-button-override.scss';
 import './style.scss';
 
 const appleClientUrl =
@@ -148,7 +150,9 @@ class AppleLoginButton extends Component {
 					customButton
 				) : (
 					<Button
-						className={ clsx( 'social-buttons__button apple', { disabled: isDisabled } ) }
+						className={ clsx( 'a8c-components-wp-button social-buttons__button apple', {
+							disabled: isDisabled,
+						} ) }
 						data-social-service="apple"
 						onClick={ this.handleClick }
 						variant="secondary"

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import {
@@ -18,7 +19,6 @@ import { getErrorFromHTTPError, postLoginRequest } from 'calypso/state/login/uti
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getRedirectUri } from './utils';
 import type { AppState } from 'calypso/types';
-
 import './style.scss';
 
 type GithubLoginButtonProps = {
@@ -175,10 +175,11 @@ const GitHubLoginButton = ( {
 			{ customButton ? (
 				customButton
 			) : (
-				<button
-					className={ clsx( 'social-buttons__button button github', { disabled: isDisabled } ) }
+				<Button
+					className={ clsx( 'social-buttons__button github', { disabled: isDisabled } ) }
 					data-social-service="github"
 					{ ...eventHandlers }
+					variant="secondary"
 				>
 					<GitHubIcon isDisabled={ isDisabled } />
 
@@ -189,7 +190,7 @@ const GitHubLoginButton = ( {
 								'%(service)s is the name of a third-party authentication provider, e.g. "Google", "Facebook", "Apple" ...',
 						} ) }
 					</span>
-				</button>
+				</Button>
 			) }
 		</>
 	);

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -19,6 +19,8 @@ import { getErrorFromHTTPError, postLoginRequest } from 'calypso/state/login/uti
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getRedirectUri } from './utils';
 import type { AppState } from 'calypso/types';
+
+import '@automattic/components/styles/wp-button-override.scss';
 import './style.scss';
 
 type GithubLoginButtonProps = {
@@ -176,7 +178,9 @@ const GitHubLoginButton = ( {
 				customButton
 			) : (
 				<Button
-					className={ clsx( 'social-buttons__button github', { disabled: isDisabled } ) }
+					className={ clsx( 'a8c-components-wp-button social-buttons__button github', {
+						disabled: isDisabled,
+					} ) }
 					data-social-service="github"
 					{ ...eventHandlers }
 					variant="secondary"

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -180,6 +180,7 @@ const GitHubLoginButton = ( {
 					data-social-service="github"
 					{ ...eventHandlers }
 					variant="secondary"
+					__next40pxDefaultSize
 				>
 					<GitHubIcon isDisabled={ isDisabled } />
 

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -201,6 +201,7 @@ class GoogleSocialButton extends Component {
 						data-social-service="google"
 						disabled={ isDisabled }
 						variant="secondary"
+						__next40pxDefaultSize
 					>
 						<GoogleIcon isDisabled={ isDisabled } width={ 19 } height={ 19 } />
 

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { loadScript } from '@automattic/load-script';
+import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -13,7 +14,6 @@ import { getErrorFromHTTPError, postLoginRequest } from 'calypso/state/login/uti
 import { errorNotice } from 'calypso/state/notices/actions';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import { getUxMode, getRedirectUri } from './utils';
-
 import './style.scss';
 
 const noop = () => {};
@@ -195,11 +195,12 @@ class GoogleSocialButton extends Component {
 				{ customButton ? (
 					customButton
 				) : (
-					<button
-						className={ clsx( 'social-buttons__button button google', { disabled: isDisabled } ) }
+					<Button
+						className={ clsx( 'social-buttons__button google', { disabled: isDisabled } ) }
 						onClick={ this.handleClick }
 						data-social-service="google"
 						disabled={ isDisabled }
+						variant="secondary"
 					>
 						<GoogleIcon isDisabled={ isDisabled } width={ 19 } height={ 19 } />
 
@@ -210,7 +211,7 @@ class GoogleSocialButton extends Component {
 									'%(service)s is the name of a third-party authentication provider, e.g. "Google", "Facebook", "Apple" ...',
 							} ) }
 						</span>
-					</button>
+					</Button>
 				) }
 			</Fragment>
 		);

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -14,6 +14,8 @@ import { getErrorFromHTTPError, postLoginRequest } from 'calypso/state/login/uti
 import { errorNotice } from 'calypso/state/notices/actions';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import { getUxMode, getRedirectUri } from './utils';
+
+import '@automattic/components/styles/wp-button-override.scss';
 import './style.scss';
 
 const noop = () => {};
@@ -196,7 +198,9 @@ class GoogleSocialButton extends Component {
 					customButton
 				) : (
 					<Button
-						className={ clsx( 'social-buttons__button google', { disabled: isDisabled } ) }
+						className={ clsx( 'a8c-components-wp-button social-buttons__button google', {
+							disabled: isDisabled,
+						} ) }
 						onClick={ this.handleClick }
 						data-social-service="google"
 						disabled={ isDisabled }

--- a/client/components/social-buttons/magic-login.tsx
+++ b/client/components/social-buttons/magic-login.tsx
@@ -26,13 +26,14 @@ const MagicLoginButton = ( { loginUrl }: MagicLoginButtonProps ) => {
 
 	return (
 		<Button
-			className={ clsx( 'social-buttons__button button magic-login-link', {
+			className={ clsx( 'social-buttons__button magic-login-link', {
 				disabled: isDisabled,
 			} ) }
 			href={ loginUrl }
 			onClick={ handleClick }
 			data-e2e-link="magic-login-link"
 			key="magic-login-link"
+			variant="secondary"
 		>
 			<MailIcon width="20" height="20" isDisabled={ isDisabled } />
 			<span className="social-buttons__service-name">{ translate( 'Email me a login link' ) }</span>

--- a/client/components/social-buttons/magic-login.tsx
+++ b/client/components/social-buttons/magic-login.tsx
@@ -7,6 +7,9 @@ import { useSelector, useDispatch } from 'calypso/state';
 import { resetMagicLoginRequestForm } from 'calypso/state/login/magic-login/actions';
 import { isFormDisabled } from 'calypso/state/login/selectors';
 
+import '@automattic/components/styles/wp-button-override.scss';
+import './style.scss';
+
 type MagicLoginButtonProps = {
 	loginUrl: string;
 };
@@ -26,7 +29,7 @@ const MagicLoginButton = ( { loginUrl }: MagicLoginButtonProps ) => {
 
 	return (
 		<Button
-			className={ clsx( 'social-buttons__button magic-login-link', {
+			className={ clsx( 'a8c-components-wp-button social-buttons__button magic-login-link', {
 				disabled: isDisabled,
 			} ) }
 			href={ loginUrl }

--- a/client/components/social-buttons/magic-login.tsx
+++ b/client/components/social-buttons/magic-login.tsx
@@ -34,6 +34,7 @@ const MagicLoginButton = ( { loginUrl }: MagicLoginButtonProps ) => {
 			data-e2e-link="magic-login-link"
 			key="magic-login-link"
 			variant="secondary"
+			__next40pxDefaultSize
 		>
 			<MailIcon width="20" height="20" isDisabled={ isDisabled } />
 			<span className="social-buttons__service-name">{ translate( 'Email me a login link' ) }</span>

--- a/client/components/social-buttons/qr-code.tsx
+++ b/client/components/social-buttons/qr-code.tsx
@@ -42,11 +42,12 @@ const QrCodeLoginButton = ( { loginUrl }: QrCodeLoginButtonProps ) => {
 
 	return (
 		<Button
-			className={ clsx( 'social-buttons__button button', { disabled: isDisabled } ) }
+			className={ clsx( 'social-buttons__button', { disabled: isDisabled } ) }
 			href={ loginUrl }
 			onClick={ handleClick }
 			data-e2e-link="magic-login-link"
 			key="lost-password-link"
+			variant="secondary"
 		>
 			<JetpackLogo monochrome={ isDisabled } size={ 20 } className="social-icons" />
 			<span className="social-buttons__service-name">

--- a/client/components/social-buttons/qr-code.tsx
+++ b/client/components/social-buttons/qr-code.tsx
@@ -10,6 +10,9 @@ import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selector
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 
+import '@automattic/components/styles/wp-button-override.scss';
+import './style.scss';
+
 type QrCodeLoginButtonProps = {
 	loginUrl: string;
 };
@@ -42,7 +45,9 @@ const QrCodeLoginButton = ( { loginUrl }: QrCodeLoginButtonProps ) => {
 
 	return (
 		<Button
-			className={ clsx( 'social-buttons__button', { disabled: isDisabled } ) }
+			className={ clsx( 'a8c-components-wp-button social-buttons__button', {
+				disabled: isDisabled,
+			} ) }
 			href={ loginUrl }
 			onClick={ handleClick }
 			data-e2e-link="magic-login-link"

--- a/client/components/social-buttons/qr-code.tsx
+++ b/client/components/social-buttons/qr-code.tsx
@@ -48,6 +48,7 @@ const QrCodeLoginButton = ( { loginUrl }: QrCodeLoginButtonProps ) => {
 			data-e2e-link="magic-login-link"
 			key="lost-password-link"
 			variant="secondary"
+			__next40pxDefaultSize
 		>
 			<JetpackLogo monochrome={ isDisabled } size={ 20 } className="social-icons" />
 			<span className="social-buttons__service-name">

--- a/client/components/social-buttons/style.scss
+++ b/client/components/social-buttons/style.scss
@@ -2,13 +2,32 @@
 
 .social-buttons__button {
 	width: 100%;
+	height: 44px;
+	padding-inline: 18px;
+	font-size: $font-body-small;
 
-	svg {
+	> svg {
 		margin-top: -2px;
+		border: 0;
+		border-radius: 0;
+		margin-right: auto;
 
 		&.disabled {
 			display: none;
 		}
+	}
+
+	> span {
+		font-feature-settings: "clig" off, "liga" off;
+		color: var(--studio-gray-80, #2c3338);
+		font-family: "SF Pro Text", sans-serif;
+		font-style: normal;
+		font-weight: 500;
+		letter-spacing: 0.32px;
+		line-height: normal;
+		margin-left: -20px;
+		margin-right: auto;
+		max-width: 240px;
 	}
 }
 

--- a/client/components/social-buttons/style.scss
+++ b/client/components/social-buttons/style.scss
@@ -5,7 +5,6 @@
 	align-items: center;
 	justify-content: center;
 	width: 100%;
-	height: 44px;
 	padding-inline: 18px;
 	font-size: $font-body-small;
 

--- a/client/components/social-buttons/style.scss
+++ b/client/components/social-buttons/style.scss
@@ -1,6 +1,9 @@
 /*rtl:ignore*/
 
 .social-buttons__button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
 	width: 100%;
 	height: 44px;
 	padding-inline: 18px;

--- a/client/components/social-buttons/style.scss
+++ b/client/components/social-buttons/style.scss
@@ -1,10 +1,6 @@
 /*rtl:ignore*/
 
 .social-buttons__button {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	width: 100%;
 	padding-inline: 18px;
 	font-size: $font-body-small;
 
@@ -13,6 +9,7 @@
 		border: 0;
 		border-radius: 0;
 		margin-right: auto;
+		fill: inherit;
 
 		&.disabled {
 			display: none;

--- a/client/components/social-buttons/style.scss
+++ b/client/components/social-buttons/style.scss
@@ -18,20 +18,9 @@
 
 	> span {
 		font-feature-settings: "clig" off, "liga" off;
-		color: var(--studio-gray-80, #2c3338);
-		font-family: "SF Pro Text", sans-serif;
-		font-style: normal;
-		font-weight: 500;
-		letter-spacing: 0.32px;
-		line-height: normal;
-		margin-left: -20px;
-		margin-right: auto;
+		margin-inline: -20px auto;
 		max-width: 240px;
 	}
-}
-
-.social-buttons__service-name {
-	margin-left: 9px;
 }
 
 .social-buttons__error {

--- a/client/components/social-buttons/username-or-email.tsx
+++ b/client/components/social-buttons/username-or-email.tsx
@@ -15,9 +15,10 @@ const UsernameOrEmailButton = ( { onClick }: UsernameOrEmailButtonProps ) => {
 
 	return (
 		<Button
-			className={ clsx( 'social-buttons__button button', { disabled: isDisabled } ) }
+			className={ clsx( 'social-buttons__button', { disabled: isDisabled } ) }
 			onClick={ onClick }
 			disabled={ isDisabled }
+			variant="secondary"
 		>
 			<WordPressLogo
 				className={ clsx( 'social-icons', {

--- a/client/components/social-buttons/username-or-email.tsx
+++ b/client/components/social-buttons/username-or-email.tsx
@@ -19,6 +19,7 @@ const UsernameOrEmailButton = ( { onClick }: UsernameOrEmailButtonProps ) => {
 			onClick={ onClick }
 			disabled={ isDisabled }
 			variant="secondary"
+			__next40pxDefaultSize
 		>
 			<WordPressLogo
 				className={ clsx( 'social-icons', {

--- a/client/components/social-buttons/username-or-email.tsx
+++ b/client/components/social-buttons/username-or-email.tsx
@@ -5,6 +5,9 @@ import clsx from 'clsx';
 import { useSelector } from 'calypso/state';
 import { isFormDisabled } from 'calypso/state/login/selectors';
 
+import '@automattic/components/styles/wp-button-override.scss';
+import './style.scss';
+
 type UsernameOrEmailButtonProps = {
 	onClick: () => void;
 };
@@ -15,7 +18,9 @@ const UsernameOrEmailButton = ( { onClick }: UsernameOrEmailButtonProps ) => {
 
 	return (
 		<Button
-			className={ clsx( 'social-buttons__button', { disabled: isDisabled } ) }
+			className={ clsx( 'a8c-components-wp-button social-buttons__button', {
+				disabled: isDisabled,
+			} ) }
 			onClick={ onClick }
 			disabled={ isDisabled }
 			variant="secondary"

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -325,10 +325,14 @@ body.is-section-signup {
 		margin-bottom: 24px;
 
 		.social-buttons__button {
-			font-family: $inter;
-			font-size: rem(13px);
-			font-weight: 600;
-			line-height: 14px;
+			--color-accent: var(--color-orange);
+
+			> span {
+				font-family: $inter;
+				font-size: rem(13px);
+				font-weight: 600;
+			}
+
 		}
 	}
 

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -608,10 +608,6 @@
 
 	.auth-form__social-buttons {
 		margin-top: 16px;
-
-		.social-buttons__button {
-			box-shadow: 0 2px 0 #afbbc6;
-		}
 	}
 
 	.card.two-factor-authentication__verification-code-form,
@@ -690,6 +686,10 @@
 		&:focus {
 			color: var(--studio-jetpack-green-60);
 		}
+	}
+
+	.social-buttons__button {
+		--color-accent: var(--studio-jetpack-green-40);
 	}
 }
 

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -763,6 +763,10 @@
 			color: var(--color-primary-60);
 		}
 	}
+
+	.social-buttons__button {
+		--color-accent: var(--color-primary-40);
+	}
 }
 
 // Adding some CSS to cover the --color-primary

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -121,6 +121,7 @@
 
 	.card {
 		--color-link-hover: #4ccee4;
+		clip-path: unset;
 	}
 
 	&.is-section-login {
@@ -170,22 +171,6 @@
 		}
 
 		.auth-form__social-buttons {
-			.button {
-				display: none;
-				margin-bottom: 40px;
-
-				&:first-child {
-					display: block;
-				}
-
-				@include breakpoint-deprecated("<660px") {
-					margin-bottom: 20px;
-				}
-			}
-
-			.social-buttons__service-name {
-				margin-left: 15px;
-			}
 
 			.login__social-tos {
 				display: none;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1563,14 +1563,15 @@ $breakpoint-mobile: 660px;
 
 					height: 48px;
 					padding: 8px 16px;
-					align-self: stretch;
 					border-radius: 8px; // stylelint-disable-line scales/radii
-					box-shadow: inset 0 0 0 2px var(--wp-components-color-accent), 0 0 0 currentColor;
-					width: 100%;
 					margin: 0;
 
-					&:hover:not(:focus) {
-						box-shadow: inset 0 0 0 2px var(--wp-components-color-accent-darker-20), 0 0 0 currentColor;
+					&:not(:focus) {
+						box-shadow: inset 0 0 0 2px $gray-300, 0 0 0 currentColor;
+					}
+
+					&:focus {
+						box-shadow: 0 0 0 currentColor inset, 0 0 0 2px var(--wp-components-color-accent);
 					}
 
 					> span {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1573,31 +1573,13 @@ $breakpoint-mobile: 660px;
 						box-shadow: inset 0 0 0 2px var(--wp-components-color-accent-darker-20), 0 0 0 currentColor;
 					}
 
-					> svg {
-						margin-right: auto;
-					}
-
 					> span {
 						color: var(--studio-gray-100);
-						font-family: Inter, -apple-system, system-ui, sans-serif;
+						font-family: $woo-inter-font;
 						font-size: 1rem;
-						font-style: normal;
-						font-weight: 500;
-						line-height: 24px;
-						letter-spacing: 0.32px;
 						margin-left: -20px;
 						margin-right: auto;
 					}
-				}
-
-
-				.social-buttons__service-name {
-					font-size: 1rem;
-					font-style: normal;
-					font-weight: 500;
-					line-height: 24px;
-					color: var(--studio-gray-100);
-					font-family: $woo-inter-font;
 				}
 
 				.social-icons {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -153,7 +153,7 @@ $breakpoint-mobile: 660px;
 		letter-spacing: 0;
 	}
 
-	a,
+	a:not(.social-buttons__button),
 	.wp-login__links a,
 	.wp-login__links button,
 	.button:not(.social-buttons__button),
@@ -243,7 +243,7 @@ $breakpoint-mobile: 660px;
 
 
 			a,
-			a:visited, {
+			a:visited {
 				color: var(--woo-purple-60);
 				font-size: rem(14px);
 				font-style: normal;
@@ -1555,22 +1555,38 @@ $breakpoint-mobile: 660px;
 
 				.auth-form__social-buttons-container {
 					gap: 16px;
+					width: 100%;
 				}
 
-				.social-buttons__button.button {
-					display: flex;
+				.social-buttons__button {
+					--color-accent: var(--woo-purple-40);
+
 					height: 48px;
 					padding: 8px 16px;
-					align-items: center;
 					align-self: stretch;
 					border-radius: 8px; // stylelint-disable-line scales/radii
-					border: 2px solid var(--studio-gray-10) !important;
+					box-shadow: inset 0 0 0 2px var(--wp-components-color-accent), 0 0 0 currentColor;
 					width: 100%;
 					margin: 0;
-					text-decoration: none;
 
-					&:hover {
-						background: var(--studio-gray-0, #f6f7f7);
+					&:hover:not(:focus) {
+						box-shadow: inset 0 0 0 2px var(--wp-components-color-accent-darker-20), 0 0 0 currentColor;
+					}
+
+					> svg {
+						margin-right: auto;
+					}
+
+					> span {
+						color: var(--studio-gray-100);
+						font-family: Inter, -apple-system, system-ui, sans-serif;
+						font-size: 1rem;
+						font-style: normal;
+						font-weight: 500;
+						line-height: 24px;
+						letter-spacing: 0.32px;
+						margin-left: -20px;
+						margin-right: auto;
 					}
 				}
 
@@ -2216,22 +2232,6 @@ $breakpoint-mobile: 660px;
 				padding-right: 0;
 				margin: 0 auto 0 auto;
 				align-items: baseline;
-			}
-		}
-
-		.auth-form__social {
-			.auth-form__social-buttons-container {
-				width: 100%;
-			}
-
-			.auth-form__social-buttons .social-buttons__button.button {
-				border-radius: 2px;
-				border: 1px solid var(--Gray-Gray-20, #a7aaad) !important;
-				background: var(--black-white-white, #fff);
-				span {
-					font-size: 0.875rem;
-					letter-spacing: 0.32px;
-				}
 			}
 		}
 	}

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -349,7 +349,7 @@ $image-height: 47px;
 		// input instances would come from `@wordpress/components` and the
 		// following overrides could be safely deleted.
 		input:not(.components-text-control__input),
-		button {
+		button:not(.social-buttons__button) {
 			/* Note: Same as `button.signup-form__submit, .signup-form__input.form-text-input` */
 			height: 44px;
 			border-radius: 4px;
@@ -363,6 +363,10 @@ $image-height: 47px;
 			}
 		}
 
+		.social-buttons__button {
+			border-radius: 4px;
+		}
+
 		.login__form-userdata input {
 			margin: 0 0 20px;
 		}
@@ -372,20 +376,12 @@ $image-height: 47px;
 			margin: 0 0 10px;
 		}
 
-		.login__form-userdata,
-		.auth-form__social-buttons {
-
-			button {
-				border: 0;
-				height: unset;
-				text-align: start;
-			}
-		}
-
 		.login__form-userdata {
 			button {
 				min-width: 194px;
 				height: unset;
+				border: 0;
+				text-align: start;
 			}
 		}
 	}
@@ -530,15 +526,6 @@ $image-height: 47px;
 	.form-password-input .form-password-input__toggle-visibility {
 		top: calc((44px - 24px) / 2);
 		/* height of input - height of toggle */
-	}
-
-	.social-buttons__button {
-		text-align: left;
-		border: 0;
-		padding-bottom: 0;
-		padding-left: 0;
-		padding-right: 0;
-		box-shadow: none;
 	}
 
 	.two-factor-authentication__verification-code-form > p,

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -2,7 +2,9 @@
 @import "@automattic/onboarding/styles/mixins";
 @import "@automattic/typography/styles/fonts";
 @import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/colors";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 $image-height: 47px;
 
@@ -814,11 +816,10 @@ $image-height: 47px;
 
 		box-shadow: none;
 		padding: unset;
-		border-radius: unset;
 		height: auto;
 
 		> svg {
-			border: 1px solid var(--studio-gray-10);
+			box-shadow: inset 0 0 0 $border-width $gray-300;
 			border-radius: 50%;
 			margin: 0;
 			width: 20px;
@@ -833,6 +834,7 @@ $image-height: 47px;
 
 		&:hover {
 			background: unset;
+			box-shadow: none;
 
 			> svg {
 				/* Matches hover state of .components-button */
@@ -844,7 +846,6 @@ $image-height: 47px;
 			box-shadow: none;
 
 			> svg {
-				border-color: transparent;
 				/* Matches focus state of .components-button */
 				box-shadow: 0 0 0 currentColor inset, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent);
 			}

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -587,7 +587,7 @@ $image-height: 47px;
 
 		.login a,
 		.login__form-change-username {
-			color: #2404eb;
+			color: var(--color-wp-job-manager);
 		}
 
 		.login {
@@ -597,13 +597,17 @@ $image-height: 47px;
 		.form-button.is-primary {
 			&,
 			&:disabled {
-				background-color: #2404eb;
+				background-color: var(--color-wp-job-manager);
 			}
 
 			&:hover:not(&:disabled),
 			&:focus {
 				background-color: darken(#2404eb, 10%);
 			}
+		}
+
+		.social-buttons__button {
+			--color-accent: var(--color-wp-job-manager);
 		}
 	}
 
@@ -633,7 +637,7 @@ $image-height: 47px;
 		line-height: 1.5;
 
 		a:not(.notice.is-error a) {
-			color: #1d4fc4;
+			color: var(--color-gravatar);
 		}
 
 		button {
@@ -691,7 +695,7 @@ $image-height: 47px;
 	}
 
 	.login__form-change-username {
-		color: #1d4fc4;
+		color: var(--color-gravatar);
 	}
 
 	.login__form-password {
@@ -747,7 +751,7 @@ $image-height: 47px;
 
 		&,
 		&:disabled {
-			background-color: #1d4fc4;
+			background-color: var(--color-gravatar);
 		}
 
 		&:hover:not(&:disabled),
@@ -769,7 +773,7 @@ $image-height: 47px;
 		}
 
 		.button {
-			color: #1d4fc4;
+			color: var(--color-gravatar);
 			border: 1px solid #1d4fc44d;
 			box-shadow: none;
 
@@ -802,26 +806,48 @@ $image-height: 47px;
 		margin: 24px 0 0;
 		padding: 0;
 		width: fit-content;
-	}
-
-	.auth-form__social-buttons-container {
-		padding: 2px 0;
+		clip-path: unset;
 	}
 
 	.social-buttons__button {
-		display: flex;
-		align-items: center;
-		padding: 0;
+		--color-accent: var(--color-gravatar);
 
-		&:focus {
-			outline: dotted;
-		}
+		box-shadow: none;
+		padding: unset;
+		border-radius: unset;
+		height: auto;
 
 		> svg {
 			border: 1px solid var(--studio-gray-10);
-			border-radius: 24px;
+			border-radius: 50%;
 			margin: 0;
+			width: 20px;
+			height: 20px;
+			margin-right: 12px;
 			padding: 12px;
+		}
+
+		> span {
+			margin-left: unset;
+		}
+
+		&:hover {
+			background: unset;
+
+			> svg {
+				/* Matches hover state of .components-button */
+				background: color-mix(in srgb, var(--wp-components-color-accent) 4%, transparent);
+			}
+		}
+
+		&:focus {
+			box-shadow: none;
+
+			> svg {
+				border-color: transparent;
+				/* Matches focus state of .components-button */
+				box-shadow: 0 0 0 currentColor inset, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent);
+			}
 		}
 	}
 
@@ -856,7 +882,7 @@ $image-height: 47px;
 
 		a,
 		button {
-			color: #1d4fc4;
+			color: var(--color-gravatar);
 			font-weight: normal;
 			text-decoration: underline;
 			padding: 0;

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -294,11 +294,13 @@
 	/* Brand Color Properties */
 	--color-akismet: #357b49;
 	--color-automattic: var(--studio-blue-40);
+	--color-gravatar: #1d4fc4;
 	--color-jetpack: var(--studio-jetpack-green);
 	--color-simplenote: var(--studio-simplenote-blue);
 	--color-woocommerce: var(--studio-woocommerce-purple);
 	--color-wordpress-com: var(--studio-wordpress-blue);
 	--color-wordpress-org: #585c60;
+	--color-wp-job-manager: #2404eb;
 
 	--color-blogger: #ff5722;
 	--color-bluesky: #0085ff;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #100217 and addresses the social buttons aspect of https://github.com/Automattic/wp-calypso/issues/99615

## Proposed Changes

Implements consistent interactive states for the social buttons as used across all our products that use Wordpress.com authentication:

* Updates the social button components used on the login and signup screens to use `@wordpress/components` Buttons, which include hover and focus styles
* Centralizes styles and removes a lot of duplicate or redundant styles
* Applies theming to the buttons per product, by using the product accent color for the hover background color and focus ring color

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Interactive elements must have styles for states like focus and hover for accessibility
* Applying theming to these states also reinforces brand identity and raises the perceived quality of the product

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the login page for each product (see links below)
2. Check the interactive states for each social button (particularly hover and focus) - hover background should use a lower opacity product accent color, and the focus ring color should use the accent color
3. Tab through the form to ensure the buttons are focusable
4. Activate the buttons to ensure the actions still fire
5. If applicable do the same on the signup page (see screenshots below - some products do not have social buttons for signup, and maybe this is an inconsistency we should clean up?)
6. Check for responsiveness - mobile and ipad size

#### Login links

[WordPress.com](http://calypso.localhost:3000/log-in)
[Crowdsignal](http://calypso.localhost:3000/log-in?client_id=978&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3Df5da55616562ed1b1ef36c8e88328853efcc0167150831e59437c3330ec11509%26redirect_uri%3Dhttps%253A%252F%252Fapp.crowdsignal.com%252Fconnect%253Fsource%253Dlogin%2526action%253Drequest_access_token%26wpcom_connect%3D1%26from-calypso%3D1)
[Jetpack Cloud](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud.jetpack.com%252Fconnect%252Foauth%252Ftoken%253Fnext%253D%25252F%26scope%3Dglobal%26blog_id%3D0%26from-calypso%3D1&client_id=69040&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D69040%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fresponse_type%253Dtoken%2526client_id%253D69040%2526redirect_uri%253Dhttps%25253A%25252F%25252Fcloud.jetpack.com%25252Fconnect%25252Foauth%25252Ftoken%25253Fnext%25253D%2525252F%2526scope%253Dglobal%2526blog_id%253D0%2526from-calypso%253D1)
[Woo](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Db30d4e6a81f72b803c873f517f4189601c46a1bc8b9bfdb9ed27cf3d17ad5601%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1&client_id=50916&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D50916%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%252F%253Fresponse_type%253Dcode%2526client_id%253D50916%2526state%253Db30d4e6a81f72b803c873f517f4189601c46a1bc8b9bfdb9ed27cf3d17ad5601%2526redirect_uri%253Dhttps%25253A%25252F%25252Fwoocommerce.com%25252Fwc-api%25252Fwpcom-signin%25253Fnext%25253D%2525252F%2526blog_id%253D0%2526wpcom_connect%253D1%2526wccom-from%2526calypso_env%253Dproduction%2526from-calypso%253D1)
[Blaze Pro](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D0f0d1f16975b65cf8e9e924461b7c892f78eabeeb190dc03654cef0465786da0%26redirect_uri%3Dhttps%253A%252F%252Fblazepro.tumblr.com%252Fauth%252Fconnected%26blog_id%3D0%26wpcom_connect%3D1%26calypso_env%3Dproduction%26scope%3Dglobal%26from-calypso%3D1&client_id=99370&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D99370%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fresponse_type%253Dcode%2526client_id%253D99370%2526state%253D0f0d1f16975b65cf8e9e924461b7c892f78eabeeb190dc03654cef0465786da0%2526redirect_uri%253Dhttps%25253A%25252F%25252Fblazepro.tumblr.com%25252Fauth%25252Fconnected%2526blog_id%253D0%2526wpcom_connect%253D1%2526calypso_env%253Dproduction%2526scope%253Dglobal%2526from-calypso%253D1)
[Akismet](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fr-login.wordpress.com%2Fremote-login.php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet.com%252Faccount%252F&signup_url=%2Fstart%2Faccount%2Fuser-social%3Fredirect_to%3Dhttps%253A%252F%252Fr-login.wordpress.com%252Fremote-login.php%253Faction%253Dlink%2526back%253Dhttps%25253A%25252F%25252Fakismet.com%25252Faccount%25252F)
A4A - Can't link due to GitHub OSS scan rules: go to the A4A site and click login. Edit the URL and change the host to calypso.localhost:3000
[Gravatar](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D4a5153e30a28e2ef24ca7e599abd80f3969340cd1f88327c1f5d2fbc88593fa1%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&client_id=1854)
[WP Job Manager](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fclient_id%3D90057%26response_type%3Dcode%26state%3DeyJyZWRpcmVjdF90byI6Imh0dHBzOlwvXC93cGpvYm1hbmFnZXIuY29tXC9teS1hY2NvdW50In0%26redirect_uri%3Dhttps%253A%252F%252Fwpjobmanager.com%252Fwp-json%252Fwpjmcom-auth%252Fv1%252Fcallback%26blog_id%3D0%26from-calypso%3D1&client_id=90057)
[VIP](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fstate%3Dd01a004590fc4017316cef309b1e213de0cf6c1fd4b68d3152d9f9acbf9c%26scope%3Dauth%26response_type%3Dcode%26approval_prompt%3Dauto%26redirect_uri%3Dhttps%253A%252F%252Fid.wpvip.com%252Fwp-json%252Foauth%252Fv1%252Fcallback%252Fwpcom%26client_id%3D76596%26from-calypso%3D1&client_id=76596&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D76596%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fstate%253Dd01a004590fc4017316cef309b1e213de0cf6c1fd4b68d3152d9f9acbf9c%2526scope%253Dauth%2526response_type%253Dcode%2526approval_prompt%253Dauto%2526redirect_uri%253Dhttps%25253A%25252F%25252Fid.wpvip.com%25252Fwp-json%25252Foauth%25252Fv1%25252Fcallback%25252Fwpcom%2526client_id%253D76596%2526from-calypso%253D1)
[P2](http://calypso.localhost:3000/log-in?from=p2)

### Screenshots

In all screenshots the Google button is hovered and the Apple button is focused.

#### WordPress.com

| Login | Signup |
|-|-|
| ![calypso localhost_3000_log-in(Desktop)](https://github.com/user-attachments/assets/24dd4a99-24a0-4f4c-a6cb-6a0dd46c1a45) | ![calypso localhost_3000_setup_onboarding_start_ref=http%3A%2F%2Fcalypso localhost%3A3000%2F(Desktop)](https://github.com/user-attachments/assets/3efa225b-73f6-4733-b81f-4fd89dd6282b) |

#### Crowdsignal

| Login - hover | Login - focus | Signup - hover | Signup - focus |
|-|-|-|-|
| ![calypso localhost_3000_log-in_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3D4d11c652d720c922e2eab1ea0c27e15b6bbe585a1f2610a20176a84394cca2ef%26re (1)](https://github.com/user-attachments/assets/4ac57b1d-cf5f-4e31-aa3a-5f9539ea4fd9) | ![calypso localhost_3000_log-in_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3D4d11c652d720c922e2eab1ea0c27e15b6bbe585a1f2610a20176a84394cca2ef%26re (2)](https://github.com/user-attachments/assets/2f9de9c1-344d-4ce6-8b20-435d988b7682) | ![calypso localhost_3000_start_crowdsignal_oauth2-name_oauth2_client_id=978 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3D4d11c652d720c922e2eab (3)](https://github.com/user-attachments/assets/464870a5-c0f2-4184-a05f-27da913e24f1) | ![calypso localhost_3000_start_crowdsignal_oauth2-name_oauth2_client_id=978 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3D4d11c652d720c922e2eab (4)](https://github.com/user-attachments/assets/51d8486a-16bc-484b-9a74-dc2afa50de5e) |

#### Jetpack Cloud

| Login | Signup |
|-|-|
| ![calypso localhost_3000_log-in_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud jetpack com%252Fconnect%252Foauth%252Ftoken%253 (1)](https://github.com/user-attachments/assets/53733e67-271a-493f-b377-f50164773d4b) | N/A - No social buttons |

#### Woo

| Login | Signup |
|-|-|
| ![calypso localhost_3000_log-in_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Db30d4e6a81f72b803c873f517f4189601c46a1bc8b9bfdb9ed27cf3d17ad5601%26redirect_ur (1)](https://github.com/user-attachments/assets/60deb9cd-fc4c-44f0-bc18-8e168ae51a65) | ![calypso localhost_3000_start_wpcc_oauth2-user_oauth2_client_id=50916 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Db30d4e6a81f72b803c873f517f4189601c4 (2)](https://github.com/user-attachments/assets/80788486-3332-4606-8217-bf1644e524a7) |

#### Blaze Pro

| Login | Signup |
|-|-|
| ![calypso localhost_3000_log-in_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D0f0d1f16975b65cf8e9e924461b7c892f78eabeeb190dc03654cef0465786da0%26redirect_uri%3 (2)](https://github.com/user-attachments/assets/056c11ad-b362-4818-9e70-206a2156a52e) | N/A - No social buttons |

#### Akismet

| Login | Signup |
|-|-|
| ![calypso localhost_3000_log-in_redirect_to=https%3A%2F%2Fr-login wordpress com%2Fremote-login php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet com%252Faccount%252F signup_url=%2Fstart%2Faccount%2Fuser-social%3Fredirect_to%3Dhttps (3)](https://github.com/user-attachments/assets/c5c9ae68-6479-4444-891a-d169e229ccc3) | ![calypso localhost_3000_start_account_user-social_redirect_to=https%3A%2F%2Fr-login wordpress com%2Fremote-login php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet com%252Faccount%252F(Desktop) (1)](https://github.com/user-attachments/assets/5a68e0b0-b24b-41fd-9011-014ec54f19ed) |

#### A4A

| Login | Signup |
|-|-|
| ![calypso localhost_3000_log-in_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D95931%26redirect_uri%3Dhttps%253A%252F%252Fagencies automattic com%252Fconnect%252Foauth%252Ftok (1)](https://github.com/user-attachments/assets/b13b9a6a-c261-4c0f-9bf9-3361c8407ef5) | N/A - No social buttons |

#### Gravatar

| Login | Signup |
|-|-|
| ![calypso localhost_3000_log-in_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D4a5153e30a28e2ef24ca7e599abd80f3969340cd1f88327c1f5d2fbc88593fa1%26r (3)](https://github.com/user-attachments/assets/302380ed-3e29-49c2-9564-f6085439c159) | N/A - No social buttons |

#### WP Job Manager

| Login | Signup |
|-|-|
| ![calypso localhost_3000_log-in_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fclient_id%3D90057%26response_type%3Dcode%26state%3DeyJyZWRpcmVjdF90byI6Imh0dHBzOlwvXC93cGpvYm1hbmFnZXIuY29tXC9teS1hY2NvdW50In0%26 (3)](https://github.com/user-attachments/assets/f11476c3-fb0a-4641-ba7a-1bf491262a3f) | N/A - No social buttons |

#### VIP

| Login | Signup |
|-|-|
| ![calypso localhost_3000_log-in_client_id=76596 redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fstate%3Dd01a004590fc4017316cef309b1e213de0cf6c1fd4b68d3152d9f9acbf9c%26scope%3Dauth%26response_type%3Dcode%26approval_pr](https://github.com/user-attachments/assets/cb4e8fcf-6694-4906-9c07-a12ae5ce160e) | N/A - No social buttons |

#### P2

| Login | Signup |
|-|-|
| ![calypso localhost_3000_log-in_from=p2(Desktop)](https://github.com/user-attachments/assets/ed2e8efc-6203-44f3-9f62-bbe6f8ca0dcb) | N/A - Signup disabled |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
