### PR TITLE
Fix UI issues on Use my Domain screen

### DIFF
--- a/client/components/domains/use-my-domain/transfer-or-connect/style.scss
+++ b/client/components/domains/use-my-domain/transfer-or-connect/style.scss
@@ -12,6 +12,11 @@
 		flex-direction: column;
 		padding: 0 24px;
 
+		// Specificity increase to override Card background color loaded later in the cascade.
+		&.domain-transfer-or-connect__content {
+			background-color: transparent;
+		}	
+
 		.option-content {
 			+ .option-content {
 				border-top: 1px solid var(--studio-gray-5);
@@ -166,6 +171,7 @@
 				.button {
 					padding: 8px 39px;
 					flex-grow: 1;
+					white-space: nowrap;
 
 					@include break-mobile {
 						flex-grow: 0;

--- a/client/components/domains/use-my-domain/utilities/get-option-info.js
+++ b/client/components/domains/use-my-domain/utilities/get-option-info.js
@@ -249,9 +249,5 @@ export function getOptionInfo( {
 
 	connectContent.primary = ! transferContent?.primary;
 
-	if ( transferContent?.primary ) {
-		return [ transferContent, connectContent ];
-	}
-
-	return [ { ...connectContent, primary: true }, transferContent ];
+	return [ transferContent, connectContent ];
 }

--- a/packages/components/src/badge/style.scss
+++ b/packages/components/src/badge/style.scss
@@ -40,8 +40,8 @@ $badge-padding-y: 2px;
 }
 
 .badge--info-green {
-	color: var(--studio-green-80);
-	background-color: rgba(184, 230, 191, 0.64);
+	color: var(--studio-green-50);
+	background-color: var(--studio-green-0);
 }
 
 .badge--info-purple {

--- a/packages/components/src/badge/style.scss
+++ b/packages/components/src/badge/style.scss
@@ -40,8 +40,8 @@ $badge-padding-y: 2px;
 }
 
 .badge--info-green {
-	color: var(--studio-green-50);
-	background-color: var(--studio-green-0);
+	color: var(--studio-green-80);
+	background-color: rgba(184, 230, 191, 0.64);
 }
 
 .badge--info-purple {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #100237

## Proposed Changes

* Removes background color from `domain-transfer-or-connect__content` card component.
* Changes `badge--info-green` color and background color.
* Prevents "Purchase a plan" button text from wrapping (this should work with whatever length because the text before it is adaptable)

<img width="1446" alt="Screenshot 2025-03-05 at 3 32 04 pm" src="https://github.com/user-attachments/assets/4536bcdd-dcaf-4a16-8b62-798a3ae52574" />

The one thing I'm not 100% is the order of the sections but I've requested clarification in the issue.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a new site and, at the "Choose your domains" step, select "use a domain I own". Make sure to input an existing domain.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
