### PR TITLE
Update the delete site url to avoid dashboard redirect.

### DIFF
--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -12,6 +12,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useMemo } from 'react';
 import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpts-query';
+import { useRemoveDuplicateViewsExperimentEnabled } from 'calypso/lib/remove-duplicate-views-experiment';
 import useRestoreSiteMutation from 'calypso/sites/hooks/use-restore-site-mutation';
 import {
 	getAdminInterface,
@@ -321,6 +322,8 @@ export function useActions( {
 		Capabilities
 	>( ( state ) => state.currentUser.capabilities );
 
+	const isUntangled = useRemoveDuplicateViewsExperimentEnabled();
+
 	return useMemo(
 		() => [
 			...( viewType !== 'list'
@@ -576,16 +579,31 @@ export function useActions( {
 				label: __( 'Delete site' ),
 				callback: ( sites ) => {
 					const site = sites[ 0 ];
-					page(
-						isStagingSite( site )
-							? `/staging-site/${ site.slug }`
-							: `/sites/settings/site/${ site.slug }/delete-site`
-					);
+					let urlPath;
+
+					if ( isStagingSite( site ) ) {
+						urlPath = `/staging-site/${ site.slug }`;
+					} else if ( isUntangled ) {
+						urlPath = `/sites/settings/site/${ site.slug }/delete-site`;
+					} else {
+						urlPath = `/settings/delete-site/${ site.slug }`;
+					}
+
+					page( urlPath );
 					dispatch( recordTracksEvent( 'calypso_sites_dashboard_site_action_delete_click' ) );
 				},
 				isEligible: isActionEligible( 'delete-site', capabilities ),
 			},
 		],
-		[ __, capabilities, dispatch, openSitePreviewPane, restoreSite, viewType, localizeUrl ]
+		[
+			__,
+			capabilities,
+			dispatch,
+			openSitePreviewPane,
+			restoreSite,
+			viewType,
+			localizeUrl,
+			isUntangled,
+		]
 	);
 }

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -579,7 +579,7 @@ export function useActions( {
 					page(
 						isStagingSite( site )
 							? `/staging-site/${ site.slug }`
-							: `/settings/delete-site/${ site.slug }`
+							: `/sites/settings/site/${ site.slug }/delete-site`
 					);
 					dispatch( recordTracksEvent( 'calypso_sites_dashboard_site_action_delete_click' ) );
 				},


### PR DESCRIPTION
Fixes: #100723

## Proposed Changes

Update the redirect URL when users click "Delete site" from `/sites`.

`/settings/delete-site/${ site.slug }` to `/sites/settings/site/${ site.slug }/delete-site`.

## Why are these changes being made?

Currently, when a user clicks "Delete site" in the item menu, users are redirected to their `wp.com/settings/delete-site/{site}` which is then intercepted by [redirectToolsIfRemoveDuplicateViewsExperimentEnabled ](https://github.com/Automattic/wp-calypso/blob/2d5b6e03837493dad8ae265991e53ff98ad94895/client/my-sites/site-settings/settings-controller.js#L59)introduced in #98875 and redirect back to `/sites/settings/site/${ site.slug }/delete-site`. The user then sees their wp-admin dashboard load for a second.

### Before

https://github.com/user-attachments/assets/68fa0429-eec5-4095-9896-736262717dae

### After

https://github.com/user-attachments/assets/603d0b43-c616-4a1b-befe-305d7c2b9d27


## Considerations/Questions

The function `redirectToolsIfRemoveDuplicateViewsExperimentEnabled` relies on `isRemoveDuplicateViewsExperimentEnabled`to determine whether to redirect, seemingly only redirecting the treatment group. 

I'm not sure if this PR should also verify whether the session is `untangled` or just redirect anyways.

@lsl or @okmttdhr Any thoughts?

## Testing Instructions

With an active site
1. Click on the dropdown menu
2. Select `Delete site`
3. Expect to not see a flash before the Delete site view is loaded.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
