### PR TITLE
Theme Details page: Improve preview button UX (alternative approach)

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -1,9 +1,15 @@
 @import "@automattic/onboarding/styles/mixins";
 
 $theme-sheet-content-max-width: 1462px;
+$theme-sheet-content-padding-x: 20px;
+$theme-sheet-content-padding-y: 48px;
 $button-border: 4px;
 
 .is-section-theme {
+	$layout-header-height: 68px;
+	$layout-padding-top: 47px;
+	$theme-preview-offset-y: $layout-header-height + $theme-sheet-content-padding-y;
+
 	// overwrite notices z-index so they are visible on top of the theme preview
 	.global-notices {
 		// This should be - z-index: z-index("root", ".is-section-theme .global-notices")
@@ -17,12 +23,13 @@ $button-border: 4px;
 
 	.layout.is-logged-in .layout__content {
 		overflow: clip;
-		padding-top: 47px;
+		padding-top: $layout-padding-top;
 
+		.theme__sheet-screenshot,
 		.theme__sheet-web-preview .theme-preview__frame-wrapper {
 			@include breakpoint-deprecated( ">960px" ) {
-				// Inner padding: 32px.
-				max-height: calc(100vh - var(--content-padding-top) - var(--content-padding-bottom) - var(--masterbar-height) - 32px );
+				$offset-y: $layout-padding-top - $theme-preview-offset-y - 16px;
+				max-height: calc(100vh - var(--content-padding-top, 0px) - var(--content-padding-bottom, 0px) - $offset-y);
 			}
 		}
 	}
@@ -40,10 +47,19 @@ $button-border: 4px;
 	&.is-global-sidebar-visible {
 		background: var(--studio-gray-0);
 
-		.layout__content {
+		&.layout.is-logged-in .layout__content {
 			min-height: 100vh;
+
 			@media screen and (min-width: 782px) {
 				padding: calc(var(--masterbar-height) + var(--content-padding-top)) 16px var(--content-padding-bottom) var(--sidebar-width-max);
+			}
+
+			.theme__sheet-screenshot,
+			.theme__sheet-web-preview .theme-preview__frame-wrapper {
+				@include breakpoint-deprecated( ">960px" ) {
+					$offset-y: $theme-preview-offset-y - 16px;
+					max-height: calc(100vh - var(--content-padding-top, 0px) - var(--content-padding-bottom, 0px) - var(--masterbar-height) - $offset-y);
+				}
 			}
 		}
 
@@ -126,7 +142,7 @@ $button-border: 4px;
 	grid-template-rows: auto 1fr;
 	margin: 0 auto;
 	max-width: $theme-sheet-content-max-width;
-	padding: 48px 20px;
+	padding: $theme-sheet-content-padding-y $theme-sheet-content-padding-x;
 
 	@include breakpoint-deprecated( "<960px" ) {
 		display: flex;
@@ -438,6 +454,7 @@ $button-border: 4px;
 	}
 
 	@include breakpoint-deprecated( ">960px" ) {
+		overflow-y: scroll;
 		pointer-events: all;
 		position: sticky;
 		top: 16px;
@@ -452,14 +469,23 @@ $button-border: 4px;
 }
 
 .theme__sheet-preview-demo-site {
+	$button-height: 40px;
+
+	height: $button-height;
 	opacity: 0;
-	position: absolute;
+	position: sticky;
 	left: 50%;
 	top: 50%;
 	z-index: 1;
 	transform: translate(-50%, 0);
+
 	&.button {
 		border-radius: $button-border;
+	}
+
+	+ .theme__sheet-img,
+	+ .theme-preview__container {
+		margin-top: -$button-height;
 	}
 }
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -28,7 +28,7 @@ $button-border: 4px;
 		.theme__sheet-screenshot,
 		.theme__sheet-web-preview .theme-preview__frame-wrapper {
 			@include breakpoint-deprecated( ">960px" ) {
-				$offset-y: $layout-padding-top - $theme-preview-offset-y + 16px;
+				$offset-y: $layout-padding-top + $theme-preview-offset-y + 16px;
 				max-height: calc(100vh - var(--content-padding-top, 0px) - var(--content-padding-bottom, 0px) - $offset-y);
 			}
 		}

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -28,7 +28,7 @@ $button-border: 4px;
 		.theme__sheet-screenshot,
 		.theme__sheet-web-preview .theme-preview__frame-wrapper {
 			@include breakpoint-deprecated( ">960px" ) {
-				$offset-y: $layout-padding-top - $theme-preview-offset-y - 16px;
+				$offset-y: $layout-padding-top - $theme-preview-offset-y + 16px;
 				max-height: calc(100vh - var(--content-padding-top, 0px) - var(--content-padding-bottom, 0px) - $offset-y);
 			}
 		}
@@ -57,7 +57,7 @@ $button-border: 4px;
 			.theme__sheet-screenshot,
 			.theme__sheet-web-preview .theme-preview__frame-wrapper {
 				@include breakpoint-deprecated( ">960px" ) {
-					$offset-y: $theme-preview-offset-y - 16px;
+					$offset-y: $theme-preview-offset-y + 16px;
 					max-height: calc(100vh - var(--content-padding-top, 0px) - var(--content-padding-bottom, 0px) - var(--masterbar-height) - $offset-y);
 				}
 			}

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -6,10 +6,6 @@ $theme-sheet-content-padding-y: 48px;
 $button-border: 4px;
 
 .is-section-theme {
-	$layout-header-height: 68px;
-	$layout-padding-top: 47px;
-	$theme-preview-offset-y: $layout-header-height + $theme-sheet-content-padding-y;
-
 	// overwrite notices z-index so they are visible on top of the theme preview
 	.global-notices {
 		// This should be - z-index: z-index("root", ".is-section-theme .global-notices")
@@ -23,13 +19,12 @@ $button-border: 4px;
 
 	.layout.is-logged-in .layout__content {
 		overflow: clip;
-		padding-top: $layout-padding-top;
+		padding-top: 47px;
 
 		.theme__sheet-screenshot,
 		.theme__sheet-web-preview .theme-preview__frame-wrapper {
 			@include breakpoint-deprecated( ">960px" ) {
-				$offset-y: $layout-padding-top + $theme-preview-offset-y + 16px;
-				max-height: calc(100vh - var(--content-padding-top, 0px) - var(--content-padding-bottom, 0px) - $offset-y);
+				max-height: calc(100vh - var(--content-padding-top, 0px) - var(--content-padding-bottom, 0px) - 32px);
 			}
 		}
 	}
@@ -52,14 +47,6 @@ $button-border: 4px;
 
 			@media screen and (min-width: 782px) {
 				padding: calc(var(--masterbar-height) + var(--content-padding-top)) 16px var(--content-padding-bottom) var(--sidebar-width-max);
-			}
-
-			.theme__sheet-screenshot,
-			.theme__sheet-web-preview .theme-preview__frame-wrapper {
-				@include breakpoint-deprecated( ">960px" ) {
-					$offset-y: $theme-preview-offset-y + 16px;
-					max-height: calc(100vh - var(--content-padding-top, 0px) - var(--content-padding-bottom, 0px) - var(--masterbar-height) - $offset-y);
-				}
 			}
 		}
 
@@ -418,6 +405,7 @@ $button-border: 4px;
 		0 1px 18px rgba(0, 0, 0, 0.12),
 		0 3px 5px rgba(0, 0, 0, 0.2);
 	display: block;
+	margin-bottom: 16px;
 	margin-top: 0;
 	overflow: hidden;
 	transition: all 200ms ease-in-out;
@@ -457,7 +445,11 @@ $button-border: 4px;
 		overflow-y: scroll;
 		pointer-events: all;
 		position: sticky;
-		top: 16px;
+		top: $theme-sheet-content-padding-y;
+
+		.is-global-sidebar-visible & {
+			top: 16px;
+		}
 
 		&.is-active:hover {
 			cursor: pointer;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/100750

## Proposed Changes

As discussed in https://github.com/Automattic/wp-calypso/pull/100750, this PR explores setting a max-height to the large preview in the Theme Detail page.

![Screenshot 2025-03-05 at 3 26 47 PM](https://github.com/user-attachments/assets/807d1394-05ba-4197-a878-781b4a88d98b)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

WP.com polish. See p1740613422976449-slack-CRWCHQGUB.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Head to the Theme Showcase and test a first-party theme and a partner theme, and ensure that the theme preview has a max-height of the remainder of the viewport height (plus padding).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?