### PR TITLE
Theme Details page: Consolidate theme activation button label

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -866,28 +866,8 @@ class ThemeSheet extends Component {
 	};
 
 	getDefaultOptionLabel = () => {
-		const {
-			siteId,
-			defaultOption,
-			canInstallPlugins,
-			isActive,
-			isLoggedIn,
-			isPremium,
-			isThemePurchased,
-			translate,
-			isBundledSoftwareSet,
-			isExternallyManagedTheme,
-			isSiteEligibleForManagedExternalThemes,
-			isMarketplaceThemeSubscribed,
-			isThemeActivationSyncStarted,
-			isThemeAllowed,
-			isThemeInstalled,
-			isSiteWooExpressFreeTrial,
-			isThemeBundleWooCommerce,
-		} = this.props;
-		const { isAtomicTransferCompleted } = this.state;
+		const { defaultOption, isActive, isLoggedIn, siteId, translate } = this.props;
 		if ( isActive ) {
-			// Customize site
 			return (
 				<span className="theme__sheet-customize-button">
 					<Gridicon icon="external" />
@@ -895,41 +875,7 @@ class ThemeSheet extends Component {
 				</span>
 			);
 		} else if ( isLoggedIn && siteId ) {
-			if (
-				( ( ! isThemeAllowed || isPremium ) && ! isThemePurchased && ! isExternallyManagedTheme ) ||
-				( isBundledSoftwareSet &&
-					! canInstallPlugins &&
-					! ( isSiteWooExpressFreeTrial && isThemeBundleWooCommerce ) )
-			) {
-				// upgrade plan
-				return translate( 'Upgrade to activate', {
-					comment:
-						'label prompting user to upgrade the WordPress.com plan to activate a certain theme',
-				} );
-			} else if (
-				isExternallyManagedTheme &&
-				! isMarketplaceThemeSubscribed &&
-				! isSiteEligibleForManagedExternalThemes
-			) {
-				return translate( 'Upgrade to subscribe' );
-			} else if (
-				isExternallyManagedTheme &&
-				! isMarketplaceThemeSubscribed &&
-				isSiteEligibleForManagedExternalThemes &&
-				! isThemeInstalled
-			) {
-				return translate( 'Subscribe to activate' );
-			} else if ( isThemeActivationSyncStarted && ! isAtomicTransferCompleted ) {
-				return (
-					<span className="theme__sheet-customize-button spin">
-						<Gridicon icon="sync" />
-						{ translate( 'Activate this design' ) }
-					</span>
-				);
-			} else if ( defaultOption.label === translate( 'Activate' ) ) {
-				return translate( 'Activate' );
-			}
-			// else: fall back to default label
+			return translate( 'Activate' );
 		}
 		return defaultOption.label;
 	};

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -17,8 +17,8 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { THEME_TIERS } from 'calypso/components/theme-tier/constants';
 import withIsFSEActive from 'calypso/data/themes/with-is-fse-active';
-import { localizeThemesPath } from 'calypso/my-sites/themes/helpers';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { localizeThemesPath, shouldSelectSite } from 'calypso/my-sites/themes/helpers';
+import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getCustomizeUrl from 'calypso/state/selectors/get-customize-url';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
@@ -57,6 +57,7 @@ import {
 	isWporgTheme,
 } from 'calypso/state/themes/selectors';
 import { isMarketplaceThemeSubscribed } from 'calypso/state/themes/selectors/is-marketplace-theme-subscribed';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 /**
  * Get the checkout path slug for the given site and minimum plan.
@@ -384,9 +385,18 @@ function getAllThemeOptions( { translate, isFSEActive, isGlobalStylesOnPersonal 
 		},
 	};
 
+	const signupLabel = ( state ) =>
+		shouldSelectSite( {
+			isLoggedIn: isUserLoggedIn( state ),
+			siteCount: getCurrentUserSiteCount( state ),
+			siteId: getSelectedSiteId( state ),
+		} )
+			? translate( 'Activate' )
+			: translate( 'Get started' );
+
 	const signup = {
-		label: translate( 'Activate' ),
-		extendedLabel: translate( 'Activate' ),
+		label: signupLabel,
+		extendedLabel: signupLabel,
 		getUrl: ( state, themeId, siteId, options ) => getThemeSignupUrl( state, themeId, options ),
 		hideForTheme: ( state, themeId, siteId ) => isUserLoggedIn( state ) && siteId,
 	};

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -17,8 +17,8 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { THEME_TIERS } from 'calypso/components/theme-tier/constants';
 import withIsFSEActive from 'calypso/data/themes/with-is-fse-active';
-import { localizeThemesPath, shouldSelectSite } from 'calypso/my-sites/themes/helpers';
-import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { localizeThemesPath } from 'calypso/my-sites/themes/helpers';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getCustomizeUrl from 'calypso/state/selectors/get-customize-url';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
@@ -57,7 +57,6 @@ import {
 	isWporgTheme,
 } from 'calypso/state/themes/selectors';
 import { isMarketplaceThemeSubscribed } from 'calypso/state/themes/selectors/is-marketplace-theme-subscribed';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 /**
  * Get the checkout path slug for the given site and minimum plan.
@@ -385,23 +384,9 @@ function getAllThemeOptions( { translate, isFSEActive, isGlobalStylesOnPersonal 
 		},
 	};
 
-	const signupLabel = ( state ) =>
-		shouldSelectSite( {
-			isLoggedIn: isUserLoggedIn( state ),
-			siteCount: getCurrentUserSiteCount( state ),
-			siteId: getSelectedSiteId( state ),
-		} )
-			? translate( 'Select a site', {
-					comment:
-						'On the theme details page, button text shown so the user selects one of their sites before activating the selected theme',
-			  } )
-			: translate( 'Pick this design', {
-					comment: 'when signing up for a WordPress.com account with a selected theme',
-			  } );
-
 	const signup = {
-		label: signupLabel,
-		extendedLabel: signupLabel,
+		label: translate( 'Activate' ),
+		extendedLabel: translate( 'Activate' ),
 		getUrl: ( state, themeId, siteId, options ) => getThemeSignupUrl( state, themeId, options ),
 		hideForTheme: ( state, themeId, siteId ) => isUserLoggedIn( state ) && siteId,
 	};

--- a/packages/calypso-e2e/src/lib/pages/themes-detail-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-detail-page.ts
@@ -63,10 +63,10 @@ export class ThemesDetailPage {
 	}
 
 	/**
-	 * Click on the Pick this design button displayed in Logged out theme details.
+	 * Click on the Activate button displayed in Logged out theme details.
 	 */
 	async pickThisDesign(): Promise< void > {
-		await this.page.getByRole( 'link', { name: 'Pick this design' } ).click();
+		await this.page.getByRole( 'link', { name: 'Activate' } ).click();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/themes-detail-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-detail-page.ts
@@ -66,7 +66,7 @@ export class ThemesDetailPage {
 	 * Click on the Activate button displayed in Logged out theme details.
 	 */
 	async pickThisDesign(): Promise< void > {
-		await this.page.getByRole( 'link', { name: 'Activate' } ).click();
+		await this.page.getByRole( 'link', { name: 'Get started' } ).click();
 	}
 
 	/**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR consolidates theme activation button labels to just "Activate" as recommended in https://github.com/Automattic/wp-calypso/issues/100216.

| Context | Before | After |
| --- | --- | --- |
| Logged-out | ![Screenshot 2025-03-05 at 5 00 49 PM](https://github.com/user-attachments/assets/991ef6b9-c713-45e6-90fc-420e10061f00) | ![Screenshot 2025-03-05 at 5 01 21 PM](https://github.com/user-attachments/assets/9e3a63df-7411-4b75-aecb-6c617e0c4646) |
| Global | ![Screenshot 2025-03-05 at 5 05 28 PM](https://github.com/user-attachments/assets/adefcee0-d156-4594-9089-5b300d9f02c3) | ![Screenshot 2025-03-05 at 5 05 34 PM](https://github.com/user-attachments/assets/078147e9-95b4-4418-b3ad-9b090c5bab50) |
|First-party paid theme | ![Screenshot 2025-03-05 at 5 02 08 PM](https://github.com/user-attachments/assets/8e333405-9103-4419-b1cb-0a47734933ac) | ![Screenshot 2025-03-05 at 5 02 14 PM](https://github.com/user-attachments/assets/02e86c3b-0f21-4de6-8eb6-a5c5114bb51a) |
| Partner theme | ![Screenshot 2025-03-05 at 5 03 16 PM](https://github.com/user-attachments/assets/d253f2b0-011b-4887-8968-876184e942f9) | ![Screenshot 2025-03-05 at 5 03 21 PM](https://github.com/user-attachments/assets/d0ab9b2a-3113-43b6-a6b9-e29127f528f0) |
| Partner theme (WoA) | ![Screenshot 2025-03-05 at 5 08 23 PM](https://github.com/user-attachments/assets/dd20f79e-fdbb-49a3-9953-4d99423b6f47) | ![Screenshot 2025-03-05 at 5 08 28 PM](https://github.com/user-attachments/assets/484adec6-d6d3-4449-9b63-424eb3bdad32) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Overall WP.com polish.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the scenarios as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
