### PR TITLE
Design Picker: Show correct theme tier badge in onboarding

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/index.js
+++ b/client/components/theme-tier/theme-tier-badge/index.js
@@ -5,7 +5,6 @@ import { useSelector } from 'calypso/state';
 import { useIsThemeAllowedOnSite } from 'calypso/state/themes/hooks/use-is-theme-allowed-on-site';
 import { useThemeTierForTheme } from 'calypso/state/themes/hooks/use-theme-tier-for-theme';
 import { getThemeType } from 'calypso/state/themes/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { ThemeTierBadgeContextProvider } from './theme-tier-badge-context';
 import ThemeTierBundledBadge from './theme-tier-bundled-badge';
 import ThemeTierCommunityBadge from './theme-tier-community-badge';
@@ -22,11 +21,12 @@ export default function ThemeTierBadge( {
 	className = '',
 	isLockedStyleVariation,
 	showUpgradeBadge = true,
+	siteId,
+	siteSlug,
 	themeId,
 	showPartnerPrice = false,
 	isThemeList = false,
 } ) {
-	const siteId = useSelector( getSelectedSiteId );
 	const themeType = useSelector( ( state ) => getThemeType( state, themeId ) );
 	const themeTier = useThemeTierForTheme( themeId );
 	const isThemeAllowed = useIsThemeAllowedOnSite( siteId, themeId );
@@ -110,6 +110,8 @@ export default function ThemeTierBadge( {
 				canGoToCheckout={ canGoToCheckout }
 				showUpgradeBadge={ showUpgradeBadge }
 				themeId={ themeId }
+				siteId={ siteId }
+				siteSlug={ siteSlug }
 			>
 				{ badge }
 			</ThemeTierBadgeContextProvider>

--- a/client/components/theme-tier/theme-tier-badge/index.js
+++ b/client/components/theme-tier/theme-tier-badge/index.js
@@ -28,11 +28,16 @@ export default function ThemeTierBadge( {
 	isThemeList = false,
 } ) {
 	const themeType = useSelector( ( state ) => getThemeType( state, themeId ) );
-	const themeTier = useThemeTierForTheme( themeId );
+	const { slug: themeTierSlug } = useThemeTierForTheme( themeId );
 	const isThemeAllowed = useIsThemeAllowedOnSite( siteId, themeId );
 
 	const badge = useMemo( () => {
-		if ( themeTier?.slug === 'free' ) {
+		// We're still loading the theme tier, so don't render anything.
+		if ( ! themeTierSlug ) {
+			return null;
+		}
+
+		if ( themeTierSlug === 'free' ) {
 			return <ThemeTierFreeBadge />;
 		}
 
@@ -66,7 +71,7 @@ export default function ThemeTierBadge( {
 			);
 		}
 
-		if ( themeTier?.slug === 'partner' || themeType === MARKETPLACE_THEME ) {
+		if ( themeTierSlug === 'partner' || themeType === MARKETPLACE_THEME ) {
 			return (
 				<ThemeTierPartnerBadge
 					showPartnerPrice={ showPartnerPrice }
@@ -88,7 +93,7 @@ export default function ThemeTierBadge( {
 
 		return null;
 	}, [
-		themeTier,
+		themeTierSlug,
 		siteId,
 		isThemeAllowed,
 		themeType,
@@ -104,7 +109,7 @@ export default function ThemeTierBadge( {
 
 	return (
 		<div
-			className={ clsx( 'theme-tier-badge', `theme-tier-badge--${ themeTier.slug }`, className ) }
+			className={ clsx( 'theme-tier-badge', `theme-tier-badge--${ themeTierSlug }`, className ) }
 		>
 			<ThemeTierBadgeContextProvider
 				canGoToCheckout={ canGoToCheckout }

--- a/client/components/theme-tier/theme-tier-badge/test/theme-tier-style-variation-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/test/theme-tier-style-variation-badge.js
@@ -3,7 +3,7 @@ import { getPlan } from '@automattic/calypso-products';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useSelector } from 'calypso/state';
+import { ThemeTierBadgeContextProvider } from '../theme-tier-badge-context';
 import ThemeTierStyleVariationBadge from '../theme-tier-style-variation-badge';
 
 jest.mock( 'calypso/state' );
@@ -11,6 +11,7 @@ jest.mock( '@automattic/calypso-products' );
 
 describe( 'ThemeTierStyleVariationBadge', () => {
 	const siteSlug = 'example.wordpress.com';
+	const siteId = 1;
 	let originalWindowLocation;
 
 	// Create a QueryClient instance
@@ -27,7 +28,11 @@ describe( 'ThemeTierStyleVariationBadge', () => {
 	// Utility to wrap component with QueryClientProvider
 	const renderWithQueryClient = ( ui ) => {
 		const queryClient = createTestQueryClient();
-		return render( <QueryClientProvider client={ queryClient }>{ ui }</QueryClientProvider> );
+		return render(
+			<ThemeTierBadgeContextProvider canGoToCheckout siteId={ siteId } siteSlug={ siteSlug }>
+				<QueryClientProvider client={ queryClient }>{ ui }</QueryClientProvider>
+			</ThemeTierBadgeContextProvider>
+		);
 	};
 
 	beforeEach( () => {
@@ -39,8 +44,6 @@ describe( 'ThemeTierStyleVariationBadge', () => {
 			href: 'http://wwww.example.com',
 			origin: 'http://www.example.com',
 		};
-
-		useSelector.mockImplementation( () => siteSlug );
 	} );
 
 	afterEach( () => {

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-badge-checkout-link.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-badge-checkout-link.js
@@ -1,12 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
-import { useSelector } from 'calypso/state';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { useThemeTierBadgeContext } from './theme-tier-badge-context';
 
 export default function ThemeTierBadgeCheckoutLink( { children, plan } ) {
-	const siteSlug = useSelector( getSelectedSiteSlug );
-	const { canGoToCheckout } = useThemeTierBadgeContext();
+	const { canGoToCheckout, siteSlug } = useThemeTierBadgeContext();
 
 	if ( ! canGoToCheckout || ! siteSlug ) {
 		return <>{ children }</>;

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-badge-context.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-badge-context.js
@@ -4,6 +4,8 @@ const ThemeTierBadgeContext = createContext( {
 	canGoToCheckout: true,
 	showUpgradeBadge: true,
 	themeId: '',
+	siteId: null,
+	siteSlug: null,
 } );
 
 export const useThemeTierBadgeContext = () => useContext( ThemeTierBadgeContext );
@@ -13,11 +15,15 @@ export function ThemeTierBadgeContextProvider( {
 	children,
 	showUpgradeBadge = true,
 	themeId,
+	siteId,
+	siteSlug,
 } ) {
 	const value = {
 		canGoToCheckout,
 		showUpgradeBadge,
 		themeId,
+		siteId,
+		siteSlug,
 	};
 
 	return (

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
@@ -3,14 +3,12 @@ import useIsUpdatedBadgeDesign from 'calypso/landing/stepper/declarative-flow/in
 import { useBundleSettingsByTheme } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
 import { useSelector } from 'calypso/state';
 import { canUseTheme } from 'calypso/state/themes/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useThemeTierBadgeContext } from './theme-tier-badge-context';
 import ThemeTierIncludedBadge from './theme-tier-included-badge';
 import ThemeTierUpgradeBadge from './theme-tier-upgrade-badge';
 
 export default function ThemeTierBundledBadge( { hideBackgroundOnUpgrade, hideBundledBadge } ) {
-	const siteId = useSelector( getSelectedSiteId );
-	const { showUpgradeBadge, themeId } = useThemeTierBadgeContext();
+	const { showUpgradeBadge, themeId, siteId } = useThemeTierBadgeContext();
 
 	const bundleSettings = useBundleSettingsByTheme( themeId );
 	const isThemeIncluded = useSelector(

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
@@ -2,15 +2,13 @@ import { PremiumBadge } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { canUseTheme } from 'calypso/state/themes/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useThemeTierBadgeContext } from './theme-tier-badge-context';
 import ThemeTierIncludedBadge from './theme-tier-included-badge';
 import ThemeTierPlanUpgradeBadge from './theme-tier-upgrade-badge';
 
 export default function ThemeTierCommunityBadge( { hideBackgroundOnUpgrade, hideCommunityBadge } ) {
 	const translate = useTranslate();
-	const siteId = useSelector( getSelectedSiteId );
-	const { showUpgradeBadge, themeId } = useThemeTierBadgeContext();
+	const { showUpgradeBadge, themeId, siteId } = useThemeTierBadgeContext();
 
 	const isThemeIncluded = useSelector(
 		( state ) => siteId && canUseTheme( state, siteId, themeId )

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
@@ -8,7 +8,6 @@ import {
 	isMarketplaceThemeSubscribed,
 	getMarketplaceThemeSubscriptionPrices,
 } from 'calypso/state/themes/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useThemeTierBadgeContext } from './theme-tier-badge-context';
 import ThemeTierPlanUpgradeBadge from './theme-tier-upgrade-badge';
 
@@ -26,8 +25,7 @@ export default function ThemeTierPartnerBadge( {
 	hidePartnerBadge,
 } ) {
 	const translate = useTranslate();
-	const siteId = useSelector( getSelectedSiteId );
-	const { themeId } = useThemeTierBadgeContext();
+	const { themeId, siteId } = useThemeTierBadgeContext();
 
 	const isPartnerThemePurchased = useSelector( ( state ) =>
 		siteId ? isMarketplaceThemeSubscribed( state, themeId, siteId ) : false
@@ -77,6 +75,7 @@ export default function ThemeTierPartnerBadge( {
 		subscriptionPrices.month,
 		showPartnerPrice,
 		hideBackgroundOnUpgrade,
+		isLongLabel,
 		translate,
 	] );
 

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-style-variation-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-style-variation-badge.js
@@ -4,13 +4,15 @@ import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useSiteGlobalStylesOnPersonal } from 'calypso/state/sites/hooks/use-site-global-styles-on-personal';
 import ThemeTierBadgeCheckoutLink from './theme-tier-badge-checkout-link';
+import { useThemeTierBadgeContext } from './theme-tier-badge-context';
 import ThemeTierTooltipTracker from './theme-tier-tooltip-tracker';
 
 export default function ThemeTierStyleVariationBadge() {
 	const translate = useTranslate();
+	const { siteId } = useThemeTierBadgeContext();
 
 	// @TODO Cleanup once the test phase is over.
-	const upgradeToPlan = useSiteGlobalStylesOnPersonal()
+	const upgradeToPlan = useSiteGlobalStylesOnPersonal( siteId )
 		? getPlan( PLAN_PERSONAL )
 		: getPlan( PLAN_PREMIUM );
 

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
@@ -12,14 +12,13 @@ import { useSelector } from 'calypso/state';
 import { getSitePlanSlug } from 'calypso/state/sites/selectors';
 import { useThemeTierForTheme } from 'calypso/state/themes/hooks/use-theme-tier-for-theme';
 import { getMarketplaceThemeSubscriptionPrices } from 'calypso/state/themes/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { THEME_TIERS } from '../constants';
 import { useThemeTierBadgeContext } from './theme-tier-badge-context';
 
 const MAX_LABEL_LENGTH = 45;
 
 const useUpgradeLabel = ( showPartnerPrice, planName, subscriptionPrices, translate ) => {
-	const siteId = useSelector( getSelectedSiteId );
+	const { siteId } = useThemeTierBadgeContext();
 	const planSlug = useSelector( ( state ) => getSitePlanSlug( state, siteId ) ?? '' );
 	const isEcommerceTrialMonthly = planSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -325,7 +325,7 @@ export class Theme extends Component {
 	};
 
 	renderBadge = () => {
-		const { selectedStyleVariation, shouldLimitGlobalStyles, theme } = this.props;
+		const { selectedStyleVariation, shouldLimitGlobalStyles, theme, siteId, siteSlug } = this.props;
 
 		const isPremiumTheme = theme.theme_tier?.slug === PREMIUM_THEME;
 
@@ -335,7 +335,15 @@ export class Theme extends Component {
 			shouldLimitGlobalStyles,
 		} );
 
-		return <ThemeTierBadge themeId={ theme.id } isLockedStyleVariation={ isLocked } isThemeList />;
+		return (
+			<ThemeTierBadge
+				siteId={ siteId }
+				siteSlug={ siteSlug }
+				themeId={ theme.id }
+				isLockedStyleVariation={ isLocked }
+				isThemeList
+			/>
+		);
 	};
 
 	render() {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
@@ -7,9 +7,16 @@ import './design-picker-design-title.scss';
 type Props = {
 	designTitle: string;
 	selectedDesign: Design;
+	siteId: number | null;
+	siteSlug: string | null;
 };
 
-const DesignPickerDesignTitle: FC< Props > = ( { designTitle, selectedDesign } ) => (
+const DesignPickerDesignTitle: FC< Props > = ( {
+	designTitle,
+	selectedDesign,
+	siteId,
+	siteSlug,
+} ) => (
 	<div className="design-picker-design-title__container">
 		{ designTitle }
 		<ThemeTierBadge
@@ -17,6 +24,8 @@ const DesignPickerDesignTitle: FC< Props > = ( { designTitle, selectedDesign } )
 			isLockedStyleVariation={ false }
 			themeId={ selectedDesign.slug }
 			showPartnerPrice
+			siteId={ siteId }
+			siteSlug={ siteSlug }
 		/>
 	</div>
 );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -120,7 +120,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		};
 	}, [] );
 
-	const { site, siteSlug, siteSlugOrId } = useSiteData();
+	const { site, siteSlug, siteId, siteSlugOrId } = useSiteData();
 	const siteTitle = site?.name;
 	const siteDescription = site?.description;
 	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( site?.ID );
@@ -383,6 +383,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			canGoToCheckout={ false }
 			isThemeList
 			isLockedStyleVariation={ isLockedStyleVariation }
+			siteId={ siteId }
+			siteSlug={ siteSlug }
 			themeId={ themeId }
 		/>
 	);
@@ -712,7 +714,12 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	if ( selectedDesign && isPreviewingDesign ) {
 		const designTitle = selectedDesign.design_type !== 'vertical' ? selectedDesign.title : '';
 		const headerDesignTitle = (
-			<DesignPickerDesignTitle designTitle={ designTitle } selectedDesign={ selectedDesign } />
+			<DesignPickerDesignTitle
+				designTitle={ designTitle }
+				selectedDesign={ selectedDesign }
+				siteId={ siteId }
+				siteSlug={ siteSlug }
+			/>
 		);
 
 		// If the user fills out the site title and/or tagline with write or sell intent, we show it on the design preview

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -590,8 +590,17 @@ class ThemeSheet extends Component {
 	};
 
 	renderHeader = () => {
-		const { author, isWPForTeamsSite, name, retired, softLaunched, translate, themeId } =
-			this.props;
+		const {
+			author,
+			isWPForTeamsSite,
+			name,
+			retired,
+			softLaunched,
+			translate,
+			themeId,
+			siteId,
+			siteSlug,
+		} = this.props;
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = name || placeholder;
 		const tag = author ? translate( 'by %(author)s', { args: { author: author } } ) : placeholder;
@@ -607,6 +616,8 @@ class ThemeSheet extends Component {
 								showUpgradeBadge
 								showPartnerPrice
 								themeId={ themeId }
+								siteId={ siteId }
+								siteSlug={ siteSlug }
 							/>
 
 							{ title }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/100650.

## Proposed Changes

Provide `siteSlug` and `siteId` props for the `ThemeTierBadge` component. This fixes the bug where, during onboarding, we were displaying the wrong badges. For example, if the site is on the Business plan, we still show "Available on Business."

That was happening because, on Stepper, there is no selected site, so the Redux selectors were returning `null`. We are still in the context of a site (that's why the `siteSlug` query parameter is passed), so passing them as props to the badge component fixes the problem.

I'll add tests to this component as soon as @fditrapani approves it.

### Before

![image](https://github.com/user-attachments/assets/3b8c7f71-c459-4faa-8263-e09501f2d08e) 

### After

![image](https://github.com/user-attachments/assets/dc975ded-df52-4c22-9544-8802055d1a59)

## Testing Instructions

Enter `/setup/site-setup/design-setup?siteSlug=%s`, with `%s` being the slug of a Business site. Verify free themes are labeled as "Free" and all other themes, excluding partner ones, are labeled as "Included with a plan." Partner themes should show the star and the additional price. Clicking the partner plan should show, at the top, the extra cost.

Enter `/setup/site-setup/design-setup?siteSlug=%s`, with `%s` being a Premium or Personal site slug. Verify free themes are labeled as "Free," and the corresponding paid themes are badged as "Available on %(plan)." Partner themes should show the star and the corresponding plan. Clicking the partner plan should show, at the top, the required plan and the additional price.

Enter `/themes/%s` and verify the same things happen in the contextual themes list (i.e., within a site.)