### PR TITLE
Fix usage of apiNamespace param for WP.com proxy requests

### DIFF
--- a/apps/odyssey-stats/src/widget/modules.tsx
+++ b/apps/odyssey-stats/src/widget/modules.tsx
@@ -154,15 +154,7 @@ const ProtectModule: FunctionComponent< ProtectModuleProps > = ( { siteId } ) =>
 
 	const activateModule = ( module: string ) => () => {
 		return wpcom.req
-			.post(
-				{
-					apiNamespace: 'jetpack/v4',
-					path: `/settings`,
-				},
-				{
-					[ module ]: true,
-				}
-			)
+			.post( { path: '/settings', apiNamespace: 'jetpack/v4' }, { [ module ]: true } )
 			.then( refetchProtectData );
 	};
 

--- a/client/a8c-for-agencies/components/a4a-feedback/hooks/use-save-feedback-mutation.ts
+++ b/client/a8c-for-agencies/components/a4a-feedback/hooks/use-save-feedback-mutation.ts
@@ -17,9 +17,9 @@ function mutationSaveFeedback( { params }: MutationSaveFeedbackVariables ): Prom
 	};
 
 	return wpcom.req.post( {
+		path: '/marketing/survey',
 		apiNamespace: 'wpcom/v2',
-		path: `/marketing/survey`,
-		body: { ...prefixedParams },
+		body: prefixedParams,
 	} );
 }
 

--- a/client/a8c-for-agencies/components/site-configurations-modal/use-random-site-name.tsx
+++ b/client/a8c-for-agencies/components/site-configurations-modal/use-random-site-name.tsx
@@ -22,8 +22,8 @@ export const getRandomSiteBaseUrl = async ( title: string ) => {
 const getRandomSiteName = async () => {
 	try {
 		const { suggestions } = await wpcom.req.get( {
+			path: '/site-suggestions',
 			apiNamespace: 'wpcom/v2',
-			path: `/site-suggestions`,
 		} );
 		const { title } = suggestions[ 0 ];
 

--- a/client/blocks/reader-export-button/index.tsx
+++ b/client/blocks/reader-export-button/index.tsx
@@ -79,10 +79,8 @@ const ReaderExportButton = ( {
 		try {
 			const data =
 				exportType === READER_EXPORT_TYPE_LIST
-					? await wp.req.get( `/read/lists/${ listId }/export`, {
-							apiNamespace: 'wpcom/v2',
-					  } )
-					: await wp.req.get( `/read/following/mine/export`, { apiVersion: '1.2' } );
+					? await wp.req.get( `/read/lists/${ listId }/export`, { apiNamespace: 'wpcom/v2' } )
+					: await wp.req.get( '/read/following/mine/export', { apiVersion: '1.2' } );
 			onApiResponse( data );
 		} catch ( error ) {
 			showErrorNotice();

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -148,7 +148,6 @@ class GoogleSocialButton extends Component {
 			const response = await wpcomRequest( {
 				path: '/generate-authorization-nonce',
 				apiNamespace: 'wpcom/v2',
-				apiVersion: '2',
 				method: 'GET',
 			} );
 			const state = response.nonce;

--- a/client/data/domains/glue-records/use-create-glue-record-mutation.ts
+++ b/client/data/domains/glue-records/use-create-glue-record-mutation.ts
@@ -19,7 +19,7 @@ export default function useCreateGlueRecordMutation(
 			wp.req
 				.post(
 					{
-						path: `/domains/glue-records`,
+						path: '/domains/glue-records',
 						apiNamespace: 'wpcom/v2',
 					},
 					{

--- a/client/data/domains/glue-records/use-update-glue-record-mutation.ts
+++ b/client/data/domains/glue-records/use-update-glue-record-mutation.ts
@@ -19,7 +19,7 @@ export default function useUpdateGlueRecordMutation(
 			wp.req
 				.put(
 					{
-						path: `/domains/glue-records`,
+						path: '/domains/glue-records',
 						apiNamespace: 'wpcom/v2',
 						method: 'PUT',
 					},

--- a/client/data/jetpack/use-jetpack-masterbar-data-query.ts
+++ b/client/data/jetpack/use-jetpack-masterbar-data-query.ts
@@ -21,9 +21,9 @@ const useJetpackMasterbarDataQuery = (): UseQueryResult< MasterbarData > => {
 
 	return useQuery( {
 		queryKey,
-		queryFn: async () =>
+		queryFn: () =>
 			wpcom.req.get( {
-				path: `/jetpack-marketing/jetpack-menu`,
+				path: '/jetpack-marketing/jetpack-menu',
 				apiNamespace: 'wpcom/v2',
 			} ),
 		refetchOnWindowFocus: false,

--- a/client/data/newsletter-categories/test/use-categories-query.test.tsx
+++ b/client/data/newsletter-categories/test/use-categories-query.test.tsx
@@ -69,8 +69,7 @@ describe( 'useCategoriesQuery', () => {
 		await waitFor( () => expect( result.current.isFetched ).toBe( true ) );
 
 		expect( request ).toHaveBeenCalledWith( {
-			path: `/sites/123/categories`,
-			apiVersion: '2',
+			path: '/sites/123/categories',
 			apiNamespace: 'wp/v2',
 		} );
 	} );

--- a/client/data/newsletter-categories/test/use-subscribed-newsletter-categories-query.test.tsx
+++ b/client/data/newsletter-categories/test/use-subscribed-newsletter-categories-query.test.tsx
@@ -123,7 +123,7 @@ describe( 'useSubscribedNewsletterCategories', () => {
 		await waitFor( () => expect( mockGet ).toHaveBeenCalled() );
 
 		expect( mockGet ).toHaveBeenCalledWith( {
-			path: `/sites/123/newsletter-categories/subscriptions`,
+			path: '/sites/123/newsletter-categories/subscriptions',
 			apiNamespace: 'wpcom/v2',
 		} );
 	} );
@@ -141,7 +141,7 @@ describe( 'useSubscribedNewsletterCategories', () => {
 		await waitFor( () => expect( mockGet ).toHaveBeenCalled() );
 
 		expect( mockGet ).toHaveBeenCalledWith( {
-			path: `/sites/123/newsletter-categories/subscriptions/456`,
+			path: '/sites/123/newsletter-categories/subscriptions/456',
 			apiNamespace: 'wpcom/v2',
 		} );
 	} );
@@ -159,7 +159,7 @@ describe( 'useSubscribedNewsletterCategories', () => {
 		await waitFor( () => expect( mockGet ).toHaveBeenCalled() );
 
 		expect( mockGet ).toHaveBeenCalledWith( {
-			path: `/sites/123/newsletter-categories/subscriptions/456?type=wpcom`,
+			path: '/sites/123/newsletter-categories/subscriptions/456?type=wpcom',
 			apiNamespace: 'wpcom/v2',
 		} );
 	} );

--- a/client/data/newsletter-categories/use-categories-query.tsx
+++ b/client/data/newsletter-categories/use-categories-query.tsx
@@ -10,7 +10,6 @@ const useCategoriesQuery = ( siteId?: string | number ): UseQueryResult< Categor
 		queryFn: () =>
 			request< Category[] >( {
 				path: `/sites/${ siteId }/categories`,
-				apiVersion: '2',
 				apiNamespace: 'wp/v2',
 			} ),
 		initialData: [],

--- a/client/data/p2/use-p2-guests-query.js
+++ b/client/data/p2/use-p2-guests-query.js
@@ -13,15 +13,7 @@ const useP2GuestsQuery = ( siteId, queryOptions = {} ) => {
 	return useQuery( {
 		queryKey: [ 'p2-guest-users', siteId ],
 		queryFn: () =>
-			wpcom.req.get(
-				{
-					path: `/p2/users/guests/`,
-					apiNamespace: 'wpcom/v2',
-				},
-				{
-					blog_id: siteId,
-				}
-			),
+			wpcom.req.get( { path: '/p2/users/guests/', apiNamespace: 'wpcom/v2' }, { blog_id: siteId } ),
 		...queryOptions,
 		enabled: !! siteId && ! requestUnnecessary,
 		retryDelay: 3000,

--- a/client/data/p2/use-p2-hub-p2s-query.js
+++ b/client/data/p2/use-p2-hub-p2s-query.js
@@ -15,7 +15,7 @@ const useP2HubP2sQuery = ( siteId, fetchOptions = {}, queryOptions = {} ) => {
 		queryFn: () =>
 			wpcom.req.get(
 				{
-					path: `/p2/workspace/sites/all`,
+					path: '/p2/workspace/sites/all',
 					apiNamespace: 'wpcom/v2',
 				},
 				{

--- a/client/data/plugins/use-core-plugins-query.ts
+++ b/client/data/plugins/use-core-plugins-query.ts
@@ -34,7 +34,6 @@ export const useCorePluginsQuery = (
 		queryFn: () => {
 			return wpcomRequest( {
 				path: `/sites/${ siteIdOrSlug }/plugins`,
-				apiVersion: '2',
 				apiNamespace: 'wp/v2',
 			} );
 		},

--- a/client/data/plugins/use-core-sites-plugins-query.ts
+++ b/client/data/plugins/use-core-sites-plugins-query.ts
@@ -6,7 +6,6 @@ import { CorePlugin } from 'calypso/data/plugins/types';
 const fetchPluginsForSite = async ( siteId: number ): Promise< CorePlugin[] > => {
 	return await wpcomRequest( {
 		path: `/sites/${ siteId }/plugins`,
-		apiVersion: '2',
 		apiNamespace: 'wp/v2',
 	} );
 };

--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -110,7 +110,7 @@ export const useMultisiteUpdateScheduleQuery = (
 		queryKey: [ 'multisite-schedules-update' ],
 		queryFn: () =>
 			wpcomRequest< MultisiteSchedulesUpdatesResponse >( {
-				path: `/hosting/update-schedules`,
+				path: '/hosting/update-schedules',
 				apiNamespace: 'wpcom/v2',
 				method: 'GET',
 			} ),

--- a/client/data/segmentaton-survey/mutations/use-link-answers-mutation.ts
+++ b/client/data/segmentaton-survey/mutations/use-link-answers-mutation.ts
@@ -10,7 +10,7 @@ const useLinkAnswersMutation = () => {
 	return useMutation( {
 		mutationFn: async ( { blogId, surveyKey }: LinkAnswersMutationArgs ) => {
 			return wpcom.req.post( {
-				path: `/segmentation-survey/answers/link`,
+				path: '/segmentation-survey/answers/link',
 				apiNamespace: 'wpcom/v2',
 				body: {
 					blog_id: blogId,

--- a/client/data/site-migration/use-migration-enabled.ts
+++ b/client/data/site-migration/use-migration-enabled.ts
@@ -25,8 +25,8 @@ export const useMigrationEnabledInfoQuery = (
 		],
 		queryFn: () =>
 			wpcom.req.get( {
-				apiNamespace: 'wpcom/v2/',
-				path: `sites/${ targetSiteId }/migration-enabled/${ encodeURIComponent( sourceSite ) }`,
+				path: `/sites/${ targetSiteId }/migration-enabled/${ encodeURIComponent( sourceSite ) }`,
+				apiNamespace: 'wpcom/v2',
 			} ),
 		meta: {
 			persist: false,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/hooks/use-migration-ticket-mutation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/hooks/use-migration-ticket-mutation.ts
@@ -17,7 +17,6 @@ const setMigration = (
 	return wpcomRequest( {
 		path: `/sites/${ siteSlug }/automated-migration/wpcom-survey`,
 		apiNamespace: 'wpcom/v2',
-		apiVersion: '2',
 		method: 'POST',
 		body: {
 			intents,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/test/index.tsx
@@ -91,7 +91,6 @@ describe( 'SiteMigrationAlreadyWPCOM', () => {
 		expect( wpcomRequest ).toHaveBeenCalledWith( {
 			path: '/sites/site-url.wordpress.com/automated-migration/wpcom-survey',
 			apiNamespace: 'wpcom/v2',
-			apiVersion: '2',
 			method: 'POST',
 			body: {
 				intents: [

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/hooks/use-store-application-password.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/hooks/use-store-application-password.ts
@@ -17,9 +17,8 @@ const useStoreApplicationPassword = ( siteSlug: string ) => {
 		{
 			mutationFn: ( { password, username, source } ) => {
 				return wpcomRequest( {
-					path: `sites/${ siteSlug }/automated-migration/application-passwords`,
-					apiNamespace: 'wpcom/v2/',
-					apiVersion: '2',
+					path: `/sites/${ siteSlug }/automated-migration/application-passwords`,
+					apiNamespace: 'wpcom/v2',
 					method: 'POST',
 					body: {
 						password,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-request-automated-migration.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-request-automated-migration.tsx
@@ -24,9 +24,8 @@ const requestAutomatedMigration = async (
 	locale: string
 ): Promise< AutomatedMigrationAPIResponse > => {
 	return wpcomRequest( {
-		path: `sites/${ siteSlug }/automated-migration?_locale=${ locale }`,
-		apiNamespace: 'wpcom/v2/',
-		apiVersion: '2',
+		path: `/sites/${ siteSlug }/automated-migration?_locale=${ locale }`,
+		apiNamespace: 'wpcom/v2',
 		method: 'POST',
 		body: payload,
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -79,9 +79,8 @@ const fillNoteField = async () => {
 };
 
 const requestPayload = {
-	path: 'sites/site-url.wordpress.com/automated-migration?_locale=en',
-	apiNamespace: 'wpcom/v2/',
-	apiVersion: '2',
+	path: '/sites/site-url.wordpress.com/automated-migration?_locale=en',
+	apiNamespace: 'wpcom/v2',
 	method: 'POST',
 	body: {
 		migration_type: 'credentials',
@@ -156,9 +155,8 @@ describe( 'SiteMigrationCredentials', () => {
 		await userEvent.click( continueButton() );
 
 		expect( wpcomRequest ).toHaveBeenCalledWith( {
-			path: 'sites/site-url.wordpress.com/automated-migration?_locale=en',
-			apiNamespace: 'wpcom/v2/',
-			apiVersion: '2',
+			path: '/sites/site-url.wordpress.com/automated-migration?_locale=en',
+			apiNamespace: 'wpcom/v2',
 			method: 'POST',
 			body: {
 				migration_type: 'credentials',
@@ -201,9 +199,8 @@ describe( 'SiteMigrationCredentials', () => {
 		await userEvent.click( continueButton() );
 
 		expect( wpcomRequest ).toHaveBeenCalledWith( {
-			path: 'sites/site-url.wordpress.com/automated-migration?_locale=en',
-			apiNamespace: 'wpcom/v2/',
-			apiVersion: '2',
+			path: '/sites/site-url.wordpress.com/automated-migration?_locale=en',
+			apiNamespace: 'wpcom/v2',
 			method: 'POST',
 			body: {
 				migration_type: 'credentials',
@@ -236,9 +233,8 @@ describe( 'SiteMigrationCredentials', () => {
 
 		//TODO: Ideally we should use nock to mock the request, but it is not working with the current implementation due to wpcomRequest usage that is well captured by nock.
 		expect( wpcomRequest ).toHaveBeenCalledWith( {
-			path: 'sites/site-url.wordpress.com/automated-migration?_locale=en',
-			apiNamespace: 'wpcom/v2/',
-			apiVersion: '2',
+			path: '/sites/site-url.wordpress.com/automated-migration?_locale=en',
+			apiNamespace: 'wpcom/v2',
 			method: 'POST',
 			body: {
 				blog_url: 'site-url.wordpress.com',
@@ -650,9 +646,8 @@ describe( 'SiteMigrationCredentials', () => {
 		await userEvent.click( continueButton() );
 
 		expect( wpcomRequest ).toHaveBeenCalledWith( {
-			path: 'help/migration-ticket/new',
-			apiNamespace: 'wpcom/v2/',
-			apiVersion: '2',
+			path: '/help/migration-ticket/new',
+			apiNamespace: 'wpcom/v2',
 			method: 'POST',
 			body: {
 				locale: 'en',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/hooks/use-request-automated-migration.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/hooks/use-request-automated-migration.tsx
@@ -23,9 +23,8 @@ const requestAutomatedMigration = async (
 	locale: string
 ): Promise< AutomatedMigrationAPIResponse > => {
 	return wpcomRequest( {
-		path: `sites/${ siteSlug }/automated-migration?_locale=${ locale }`,
-		apiNamespace: 'wpcom/v2/',
-		apiVersion: '2',
+		path: `/sites/${ siteSlug }/automated-migration?_locale=${ locale }`,
+		apiNamespace: 'wpcom/v2',
 		method: 'POST',
 		body: payload,
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/test/index.tsx
@@ -77,9 +77,8 @@ describe( 'SiteMigrationCredentials', () => {
 		await userEvent.click( continueButton() );
 
 		expect( wpcomRequest ).toHaveBeenCalledWith( {
-			path: 'sites/site-url.wordpress.com/automated-migration?_locale=en',
-			apiNamespace: 'wpcom/v2/',
-			apiVersion: '2',
+			path: '/sites/site-url.wordpress.com/automated-migration?_locale=en',
+			apiNamespace: 'wpcom/v2',
 			method: 'POST',
 			body: {
 				migration_type: 'credentials',

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -247,9 +247,8 @@ const siteSetupFlow: FlowV1 = {
 					pendingActions.push(
 						wpcomRequest( {
 							path: `/sites/${ siteId }/onboarding-customization`,
-							method: 'POST',
 							apiNamespace: 'wpcom/v2',
-							apiVersion: '2',
+							method: 'POST',
 							formData,
 						} )
 					);

--- a/client/landing/stepper/hooks/use-submit-migration-ticket.ts
+++ b/client/landing/stepper/hooks/use-submit-migration-ticket.ts
@@ -29,9 +29,8 @@ export const useSubmitMigrationTicket = <
 	const { mutate, mutateAsync, ...rest } = useMutation( {
 		mutationFn: ( { locale, blog_url, from_url, context } ) =>
 			wpcomRequest( {
-				path: 'help/migration-ticket/new',
-				apiNamespace: 'wpcom/v2/',
-				apiVersion: '2',
+				path: '/help/migration-ticket/new',
+				apiNamespace: 'wpcom/v2',
 				method: 'POST',
 				body: {
 					locale,

--- a/client/lib/get-google-media/index.ts
+++ b/client/lib/get-google-media/index.ts
@@ -2,7 +2,7 @@ import wpcom from 'calypso/lib/wp';
 
 export function getGoogleMediaViaProxy( mediaUrl: string ): Promise< Blob > {
 	const params = {
-		path: `/meta/external-media/proxy/google_photos`,
+		path: '/meta/external-media/proxy/google_photos',
 		apiNamespace: 'wpcom/v2',
 		body: {
 			url: mediaUrl,

--- a/client/lib/guides/trigger-guides-for-step.ts
+++ b/client/lib/guides/trigger-guides-for-step.ts
@@ -15,9 +15,9 @@ export function triggerGuidesForStep( flowName: string, stepName?: string, siteI
 	previousRequests.add( key );
 	wpcom.req
 		.post(
-			'guides/trigger',
+			'/guides/trigger',
 			{
-				apiNamespace: 'wpcom/v2/',
+				apiNamespace: 'wpcom/v2',
 			},
 			{
 				flow: flowName,

--- a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
+++ b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
@@ -22,10 +22,7 @@ import { convertErrorToString, logStashEvent } from '../lib/analytics';
 const debug = debugFactory( 'calypso:paypal-js' );
 
 async function fetchPayPalConfiguration(): Promise< PayPalConfigurationApiResponse > {
-	return await wp.req.get( {
-		path: `/me/paypal-configuration`,
-		method: 'GET',
-	} );
+	return await wp.req.get( '/me/paypal-configuration' );
 }
 
 export function createPayPal(): PaymentMethod {

--- a/client/my-sites/domains/domain-management/dataviews/use-bulk-action-notice.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/use-bulk-action-notice.tsx
@@ -128,7 +128,6 @@ export default function useBulkActionNotice() {
 			await wpcomRequest< void >( {
 				path: '/domains/bulk-actions',
 				apiNamespace: 'wpcom/v2',
-				apiVersion: '2',
 				method: 'DELETE',
 			} );
 		}

--- a/client/my-sites/domains/domain-management/domains-table-fetch-functions.ts
+++ b/client/my-sites/domains/domain-management/domains-table-fetch-functions.ts
@@ -61,7 +61,6 @@ export async function fetchBulkActionStatus(): Promise< BulkDomainUpdateStatusQu
 	return wp.req.get( {
 		path: '/domains/bulk-actions',
 		apiNamespace: 'wpcom/v2',
-		apiVersion: '2',
 	} );
 }
 
@@ -69,7 +68,6 @@ export async function deleteBulkActionStatus(): Promise< void > {
 	return wp.req.post( {
 		path: '/domains/bulk-actions',
 		apiNamespace: 'wpcom/v2',
-		apiVersion: '2',
 		method: 'DELETE',
 	} );
 }

--- a/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
+++ b/client/my-sites/site-settings/settings-p2/preapproved-domains.jsx
@@ -122,7 +122,7 @@ const P2PreapprovedDomainsForm = ( {
 		try {
 			const { success, errors } = await wpcom.req.get(
 				{
-					path: `/p2/preapproved-joining/settings/validate`,
+					path: '/p2/preapproved-joining/settings/validate',
 					apiNamespace: 'wpcom/v2',
 				},
 				{ domains: tokens }

--- a/client/my-sites/stats/hooks/use-jetpack-connection-status.ts
+++ b/client/my-sites/stats/hooks/use-jetpack-connection-status.ts
@@ -13,10 +13,7 @@ interface ConnectionInfo {
 
 function queryJetpackConnectionStatus(): Promise< ConnectionInfo > {
 	// The following code only runs on Jetpack self-hosted sites.
-	return wpcom.req.get( {
-		apiNamespace: 'jetpack/v4',
-		path: `/connection`,
-	} );
+	return wpcom.req.get( { path: '/connection', apiNamespace: 'jetpack/v4' } );
 }
 
 export function useJetpackConnectionStatus( siteId: number | null, isSimpleSites = false ) {

--- a/client/my-sites/subscribers/queries/test/use-subscriber-count-query-test.tsx
+++ b/client/my-sites/subscribers/queries/test/use-subscriber-count-query-test.tsx
@@ -56,8 +56,8 @@ describe( 'useSubscriberCountQuery', () => {
 		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
 
 		expect( wpcom.req.get ).toHaveBeenCalledWith( {
+			path: '/sites/123/subscribers/counts',
 			apiNamespace: 'wpcom/v2',
-			path: `/sites/123/subscribers/counts`,
 		} );
 	} );
 

--- a/client/reader/discover/components/tags-navigation/index.tsx
+++ b/client/reader/discover/components/tags-navigation/index.tsx
@@ -30,18 +30,8 @@ export const useRecommendedTags = (): Tag[] => {
 	const { data: interestTags = [] } = useQuery< InterestResponse, unknown, Tag[] >( {
 		queryKey: [ 'read/interests', locale ],
 		queryFn: () =>
-			wpcom.req.get(
-				{
-					path: `/read/interests`,
-					apiNamespace: 'wpcom/v2',
-				},
-				{
-					_locale: locale,
-				}
-			),
-		select: ( data ) => {
-			return data.interests;
-		},
+			wpcom.req.get( { path: '/read/interests', apiNamespace: 'wpcom/v2' }, { _locale: locale } ),
+		select: ( data ) => data.interests,
 	} );
 
 	const promptSlug = isBloganuary() ? 'bloganuary' : 'dailyprompt';

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -82,7 +82,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		queryFn: () =>
 			wpcom.req.get(
 				{
-					path: `/read/tags/cards`,
+					path: '/read/tags/cards',
 					apiNamespace: 'wpcom/v2',
 				},
 				{

--- a/client/sites/deployments/use-github-installations-query.ts
+++ b/client/sites/deployments/use-github-installations-query.ts
@@ -3,10 +3,7 @@ import wp from 'calypso/lib/wp';
 import { GITHUB_DEPLOYMENTS_QUERY_KEY } from './constants';
 
 const fetchInstallations = (): GitHubInstallationData[] =>
-	wp.req.get( {
-		path: `/hosting/github/installations`,
-		apiNamespace: 'wpcom/v2',
-	} );
+	wp.req.get( { path: '/hosting/github/installations', apiNamespace: 'wpcom/v2' } );
 
 const GITHUB_DEPLOYMENTS_INSTALLATIONS_QUERY_KEY = [
 	GITHUB_DEPLOYMENTS_QUERY_KEY,

--- a/client/state/data-layer/wpcom/all-domains/index.js
+++ b/client/state/data-layer/wpcom/all-domains/index.js
@@ -10,13 +10,7 @@ import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'calypso/state/notices/actions';
 
 export const getAllDomains = ( action ) => {
-	return http(
-		{
-			method: 'GET',
-			path: `/all-domains`,
-		},
-		action
-	);
+	return http( { path: '/all-domains', method: 'GET' }, action );
 };
 
 export const getAllDomainsError = ( action, error ) => {

--- a/client/state/data-layer/wpcom/auth/send-login-email/index.js
+++ b/client/state/data-layer/wpcom/auth/send-login-email/index.js
@@ -57,9 +57,9 @@ export const sendLoginEmail = ( action ) => {
 			: [] ),
 		http(
 			{
-				path: `/auth/send-login-email`,
-				method: 'POST',
+				path: '/auth/send-login-email',
 				apiVersion: '1.3',
+				method: 'POST',
 				body: {
 					client_id: config( 'wpcom_signup_id' ),
 					client_secret: config( 'wpcom_signup_key' ),

--- a/client/state/data-layer/wpcom/cancellation-offers/index.tsx
+++ b/client/state/data-layer/wpcom/cancellation-offers/index.tsx
@@ -16,7 +16,7 @@ const fetchCancellationOffers = ( action: { siteId: number; purchaseId: number }
 	return http(
 		{
 			method: 'GET',
-			path: `/cancellation-offers`,
+			path: '/cancellation-offers',
 			apiNamespace: 'wpcom/v2',
 			query: {
 				site: action.siteId,
@@ -52,7 +52,7 @@ const applyCancellationOffer = ( action: { siteId: number; purchaseId: number } 
 	return http(
 		{
 			method: 'POST',
-			path: `/cancellation-offers/apply`,
+			path: '/cancellation-offers/apply',
 			apiNamespace: 'wpcom/v2',
 			body: {
 				site: action.siteId,

--- a/client/state/data-layer/wpcom/introductory-offers/index.tsx
+++ b/client/state/data-layer/wpcom/introductory-offers/index.tsx
@@ -14,7 +14,7 @@ const fetchIntroOffers = ( action: { siteId: number | 'none'; currency: string |
 	return http(
 		{
 			method: 'GET',
-			path: `/introductory-offers`,
+			path: '/introductory-offers',
 			apiNamespace: 'wpcom/v2',
 			query: {
 				site: typeof action.siteId === 'number' && action.siteId > 0 ? action.siteId : undefined,

--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -87,8 +87,8 @@ const getGlobalStylesInfoForSite = (
 
 	return wpcom.req
 		.get( {
-			path: `sites/${ siteId }/global-styles/status`,
-			apiNamespace: 'wpcom/v2/',
+			path: `/sites/${ siteId }/global-styles/status`,
+			apiNamespace: 'wpcom/v2',
 		} )
 		.then( ( response: GlobalStylesStatus ) => ( {
 			...DEFAULT_GLOBAL_STYLES_INFO,

--- a/packages/data-stores/src/analyzer/actions.ts
+++ b/packages/data-stores/src/analyzer/actions.ts
@@ -24,7 +24,6 @@ export function createActions() {
 			const data: AnalyzeColorsResponse = yield wpcomRequest( {
 				path: '/imports/url-analyzer/colors/?url=' + encodeURIComponent( url ),
 				apiNamespace: 'wpcom/v2',
-				apiVersion: '2',
 			} );
 
 			yield colorsAnalyzeSuccess( url, data );

--- a/packages/data-stores/src/newsletter-categories/index.ts
+++ b/packages/data-stores/src/newsletter-categories/index.ts
@@ -35,7 +35,6 @@ export const useNewsletterCategories = ( {
 			try {
 				const response = await request< NewsletterCategoryResponse >( {
 					path: `/sites/${ siteId }/newsletter-categories`,
-					apiVersion: '2',
 					apiNamespace: 'wpcom/v2',
 				} );
 				return {

--- a/packages/data-stores/src/newsletter-categories/test/index.tsx
+++ b/packages/data-stores/src/newsletter-categories/test/index.tsx
@@ -82,7 +82,6 @@ describe( 'useNewsletterCategories', () => {
 
 		expect( request ).toHaveBeenCalledWith( {
 			path: `/sites/123/newsletter-categories`,
-			apiVersion: '2',
 			apiNamespace: 'wpcom/v2',
 		} );
 	} );

--- a/packages/data-stores/src/queries/use-bulk-domain-update-status-query.ts
+++ b/packages/data-stores/src/queries/use-bulk-domain-update-status-query.ts
@@ -69,7 +69,6 @@ export function useBulkDomainUpdateStatusQuery< TError = unknown >(
 			wpcomRequest< BulkDomainUpdateStatusQueryFnData >( {
 				path: '/domains/bulk-actions',
 				apiNamespace: 'wpcom/v2',
-				apiVersion: '2',
 			} ),
 		select: ( data ): BulkDomainUpdateStatusResult => {
 			// get top-level info about recent jobs

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -79,7 +79,6 @@ export const fetchLaunchpad = (
 		? wpcomRequest( {
 				path: addQueryArgs( `/sites/${ slug }/launchpad`, queryArgs ),
 				apiNamespace: 'wpcom/v2',
-				apiVersion: '2',
 				method: 'GET',
 		  } )
 		: apiFetch( {

--- a/packages/data-stores/src/users/use-send-invites.ts
+++ b/packages/data-stores/src/users/use-send-invites.ts
@@ -12,9 +12,8 @@ export function useSendInvites( siteId: number ) {
 			return wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteId ) }/invites/new`,
 				apiNamespace: 'wpcom/v2',
-				apiVersion: '2',
 				method: 'POST',
-				body: { invitees: invitees },
+				body: { invitees },
 			} );
 		},
 	} );

--- a/packages/domains-table/src/domains-table/domains-table-bulk-update-notice.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-bulk-update-notice.tsx
@@ -20,7 +20,6 @@ export const DomainsTableBulkUpdateNotice = () => {
 			await wpcomRequest< void >( {
 				path: '/domains/bulk-actions',
 				apiNamespace: 'wpcom/v2',
-				apiVersion: '2',
 				method: 'DELETE',
 			} );
 		}

--- a/packages/help-center/src/data/use-jetpack-search-ai.ts
+++ b/packages/help-center/src/data/use-jetpack-search-ai.ts
@@ -34,9 +34,8 @@ export function useJetpackSearchAIQuery( config: JetpackSearchAIConfig ) {
 		queryFn: () =>
 			canAccessWpcomApis()
 				? wpcomRequest( {
-						path: `sites/${ config.siteId }/jetpack-search/ai/search`,
-						apiNamespace: 'wpcom/v2/',
-						apiVersion: '2',
+						path: `/sites/${ config.siteId }/jetpack-search/ai/search`,
+						apiNamespace: 'wpcom/v2',
 						query: `query=${ encodeURIComponent( config.query ) }&stop_at=${ config.stopAt }`,
 				  } )
 				: apiFetch( {

--- a/packages/help-center/src/data/use-submit-forums-topic.ts
+++ b/packages/help-center/src/data/use-submit-forums-topic.ts
@@ -58,9 +58,8 @@ export function useSubmitForumsMutation() {
 
 			return canAccessWpcomApis()
 				? wpcomRequest< ForumResponse >( {
-						path: 'help/forum/new',
-						apiNamespace: 'wpcom/v2/',
-						apiVersion: '2',
+						path: '/help/forum/new',
+						apiNamespace: 'wpcom/v2',
 						method: 'POST',
 						body: requestData,
 				  } )

--- a/packages/help-center/src/data/use-submit-support-ticket.ts
+++ b/packages/help-center/src/data/use-submit-support-ticket.ts
@@ -19,9 +19,8 @@ export function useSubmitTicketMutation() {
 		mutationFn: ( newTicket: Ticket ) =>
 			canAccessWpcomApis()
 				? wpcomRequest( {
-						path: 'help/ticket/new',
-						apiNamespace: 'wpcom/v2/',
-						apiVersion: '2',
+						path: '/help/ticket/new',
+						apiNamespace: 'wpcom/v2',
 						method: 'POST',
 						body: newTicket,
 				  } )

--- a/packages/help-center/src/data/use-support-activity.ts
+++ b/packages/help-center/src/data/use-support-activity.ts
@@ -11,9 +11,8 @@ export function useSupportActivity( enabled = true ) {
 		queryFn: () =>
 			canAccessWpcomApis()
 				? wpcomRequest< SupportActivity[] >( {
-						path: 'support-activity',
-						apiNamespace: 'wpcom/v2/',
-						apiVersion: '2',
+						path: '/support-activity',
+						apiNamespace: 'wpcom/v2',
 				  } )
 				: apiFetch< SupportActivity[] >( {
 						path: 'help-center/support-activity',

--- a/packages/help-center/src/data/use-support-status.ts
+++ b/packages/help-center/src/data/use-support-status.ts
@@ -16,14 +16,8 @@ export function useSupportStatus( enabled = true ) {
 		queryKey: [ 'support-status', VERSION ],
 		queryFn: async () =>
 			canAccessWpcomApis()
-				? await wpcomRequest( {
-						path: `/help/support-status`,
-						apiNamespace: 'wpcom/v2',
-				  } )
-				: await apiFetch( {
-						path: `help-center/support-status`,
-						global: true,
-				  } as APIFetchOptions ),
+				? await wpcomRequest( { path: '/help/support-status', apiNamespace: 'wpcom/v2' } )
+				: await apiFetch( { path: 'help-center/support-status', global: true } as APIFetchOptions ),
 		enabled,
 		refetchOnWindowFocus: false,
 		placeholderData: keepPreviousData,

--- a/packages/help-center/src/data/use-support-status.ts
+++ b/packages/help-center/src/data/use-support-status.ts
@@ -17,9 +17,8 @@ export function useSupportStatus( enabled = true ) {
 		queryFn: async () =>
 			canAccessWpcomApis()
 				? await wpcomRequest( {
-						path: `help/support-status`,
-						apiNamespace: 'wpcom/v2/',
-						apiVersion: '2',
+						path: `/help/support-status`,
+						apiNamespace: 'wpcom/v2',
 				  } )
 				: await apiFetch( {
 						path: `help-center/support-status`,

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -29,9 +29,8 @@ const fetchArticlesAPI = async (
 	const queryString = buildQueryString( { query: search, locale, section: sectionName } );
 	if ( canAccessWpcomApis() ) {
 		searchResultResponse = ( await wpcomRequest( {
-			path: `help/search/wpcom?${ queryString }`,
-			apiNamespace: 'wpcom/v2/',
-			apiVersion: '2',
+			path: `/help/search/wpcom?${ queryString }`,
+			apiNamespace: 'wpcom/v2',
 		} ) ) as SearchResult[];
 	} else {
 		searchResultResponse = ( await apiFetch( {

--- a/packages/help-center/src/hooks/use-post-by-url.ts
+++ b/packages/help-center/src/hooks/use-post-by-url.ts
@@ -15,9 +15,8 @@ export function usePostByUrl( url: string ) {
 		queryFn: () =>
 			canAccessWpcomApis()
 				? wpcomRequest( {
-						path: `help/article?post_url=${ postUrl }`,
-						apiNamespace: 'wpcom/v2/',
-						apiVersion: '2',
+						path: `/help/article?post_url=${ postUrl }`,
+						apiNamespace: 'wpcom/v2',
 				  } )
 				: apiFetch( {
 						path: `/help-center/fetch-post?post_url=${ postUrl }`,

--- a/packages/onboarding/src/setup-tailored-site-after-creation.ts
+++ b/packages/onboarding/src/setup-tailored-site-after-creation.ts
@@ -81,9 +81,8 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 		promises.push(
 			wpcomRequest< { updated: object } >( {
 				path: `/sites/${ siteId }/onboarding-customization`,
-				method: 'POST',
 				apiNamespace: 'wpcom/v2',
-				apiVersion: '2',
+				method: 'POST',
 				formData,
 			} ).then( () => {
 				recordTracksEvent( 'calypso_signup_site_options_submit', {

--- a/packages/zendesk-client/src/use-authenticate-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-authenticate-zendesk-messaging.ts
@@ -30,9 +30,8 @@ export function useAuthenticateZendeskMessaging(
 			const auth = await ( canAccessWpcomApis()
 				? wpcomRequest< MessagingAuth >( {
 						path: '/help/authenticate/chat',
-						query: wpcomParams.toString(),
 						apiNamespace: 'wpcom/v2',
-						apiVersion: '2',
+						query: wpcomParams.toString(),
 						method: 'POST',
 				  } )
 				: apiFetch< MessagingAuth >( {

--- a/packages/zendesk-client/src/use-update-zendesk-user-fields.ts
+++ b/packages/zendesk-client/src/use-update-zendesk-user-fields.ts
@@ -14,9 +14,8 @@ export function useUpdateZendeskUserFields() {
 		mutationFn: ( userFields: UserFields ) => {
 			return canAccessWpcomApis()
 				? wpcomRequest( {
-						path: 'help/zendesk/update-user-fields',
-						apiNamespace: 'wpcom/v2/',
-						apiVersion: '2',
+						path: '/help/zendesk/update-user-fields',
+						apiNamespace: 'wpcom/v2',
 						method: 'POST',
 						body: { fields: userFields },
 				  } )

--- a/packages/zendesk-client/src/use-zendesk-messaging-availability.ts
+++ b/packages/zendesk-client/src/use-zendesk-messaging-availability.ts
@@ -25,9 +25,8 @@ export function useZendeskMessagingAvailability( group: MessagingGroup, enabled 
 			return canAccessWpcomApis()
 				? wpcomRequest< MessagingAvailability >( {
 						path: '/help/support-status/messaging',
-						query: wpcomParams.toString(),
 						apiNamespace: 'wpcom/v2',
-						apiVersion: '2',
+						query: wpcomParams.toString(),
 						method: 'GET',
 				  } )
 				: apiFetch< MessagingAvailability >( {


### PR DESCRIPTION
This PR fixes a somewhat chaotic usage of `path`, `apiNamespace` and `apiVersion` parameters for WP.com proxy requests. I noticed this when debugging an issue with REST API.

The usage conventions are:
1. The `path` should start with `/`
2. The `apiNamespace` shouldn't have a trailing `/`, it's an identifier of a namespace
3. The v2 endpoints don't need the `apiVersion` parameter at all, `apiVersion` is for v1 endpoints (`/rest/v1.x`) and `apiNamespace` is for v2 endpoints (`/wp/v2`). If `apiNamespace` is specified, `apiVersion` won't be used.

My patch refactors many usages I found to this convention. Move the slashes, remove redundant `apiVersion`.

**How to test:**
There should be no behavior change. The proxy client will concanenate `apiNamespace` and `path` together, so it doesn't break things when the slash is in the other string.

I'm testing this on the `help-center` endpoints. Deploy the `help-center` build from this PR to your sandbox, open a Simple site's `wp-admin` and verify that it continues to send a successful `/wpcom/v2/help/support-status` request on initialization.