### PR TITLE
Help Center - 100year: Add flow_name for Zendesk

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
@@ -12,6 +12,7 @@ import {
 	useDispatch as useDataStoreDispatch,
 	useSelect as useDataStoreSelect,
 } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
@@ -71,7 +72,7 @@ export function DefaultMasterbarContact() {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 
-	const { hasPremiumSupport, initialMessage } = useProductsWithPremiumSupport(
+	const { hasPremiumSupport, userFieldMessage, userFieldFlowName } = useProductsWithPremiumSupport(
 		responseCart.products,
 		'checkout'
 	);
@@ -92,9 +93,13 @@ export function DefaultMasterbarContact() {
 
 		if ( hasPremiumSupport ) {
 			setShowHelpCenter( ! isShowingHelpCenter, hasPremiumSupport, helpCenterOptions );
-			setNavigateToRoute(
-				`/odie?provider=zendesk&userFieldMessage=${ initialMessage }&siteUrl=${ siteSlug }&siteId=${ siteId }`
-			);
+			const urlWithQueryArgs = addQueryArgs( '/odie?provider=zendesk', {
+				userFieldMessage,
+				userFieldFlowName,
+				siteUrl: siteSlug,
+				siteId,
+			} );
+			setNavigateToRoute( urlWithQueryArgs );
 		} else {
 			setShowHelpCenter( ! isShowingHelpCenter, hasPremiumSupport );
 		}

--- a/packages/help-center/src/constants.ts
+++ b/packages/help-center/src/constants.ts
@@ -1,5 +1,11 @@
 export const SUPPORT_BLOG_ID = 9619154;
-
+import {
+	DIFM_FLOW,
+	DIFM_FLOW_STORE,
+	HUNDRED_YEAR_DOMAIN_FLOW,
+	HUNDRED_YEAR_PLAN_FLOW,
+	WEBSITE_DESIGN_SERVICES,
+} from '@automattic/onboarding';
 /**
  * Customizer: Mapping from Calypso panel slug to tuple of focus key and value.
  */
@@ -42,3 +48,19 @@ export const EMAIL_SUPPORT_LOCALES = [
 	'sv-fi',
 	'sv-se',
 ];
+
+export const FLOWS_ZENDESK_INITIAL_MESSAGES = {
+	[ DIFM_FLOW ]: 'User is purchasing DIFM plan.',
+	[ DIFM_FLOW_STORE ]: 'User is purchasing DIFM store plan.',
+	[ WEBSITE_DESIGN_SERVICES ]: 'User is purchasing DIFM website design services.',
+	[ HUNDRED_YEAR_PLAN_FLOW ]: 'User is purchasing 100 year plan.',
+	[ HUNDRED_YEAR_DOMAIN_FLOW ]: 'User is purchasing 100 year domain.',
+};
+
+export const FLOWS_ZENDESK_FLOWNAME = {
+	[ DIFM_FLOW ]: 'messaging_flow_dotcom_difm',
+	[ DIFM_FLOW_STORE ]: 'messaging_flow_dotcom_difm',
+	[ WEBSITE_DESIGN_SERVICES ]: 'messaging_flow_dotcom_difm',
+	[ HUNDRED_YEAR_PLAN_FLOW ]: 'messaging_flow_dotcom_100_year_plan',
+	[ HUNDRED_YEAR_DOMAIN_FLOW ]: 'messaging_flow_dotcom_100_year_domain',
+};

--- a/packages/help-center/src/hooks/use-flow-zendesk-user-fields.ts
+++ b/packages/help-center/src/hooks/use-flow-zendesk-user-fields.ts
@@ -1,24 +1,4 @@
-import {
-	DIFM_FLOW,
-	DIFM_FLOW_STORE,
-	HUNDRED_YEAR_DOMAIN_FLOW,
-	HUNDRED_YEAR_PLAN_FLOW,
-	WEBSITE_DESIGN_SERVICES,
-} from '@automattic/onboarding';
-
-const FLOWS_INITIAL_MESSAGES = {
-	[ DIFM_FLOW ]: 'User is purchasing DIFM plan.',
-	[ DIFM_FLOW_STORE ]: 'User is purchasing DIFM store plan.',
-	[ WEBSITE_DESIGN_SERVICES ]: 'User is purchasing DIFM website design services.',
-	[ HUNDRED_YEAR_PLAN_FLOW ]: 'User is purchasing 100 year plan.',
-	[ HUNDRED_YEAR_DOMAIN_FLOW ]: 'User is purchasing 100 year domain.',
-};
-
-const FLOWS_FLOWNAME = {
-	[ DIFM_FLOW ]: 'messaging_flow_dotcom_difm',
-	[ DIFM_FLOW_STORE ]: 'messaging_flow_dotcom_difm',
-	[ WEBSITE_DESIGN_SERVICES ]: 'messaging_flow_dotcom_difm',
-};
+import { FLOWS_ZENDESK_FLOWNAME, FLOWS_ZENDESK_INITIAL_MESSAGES } from '../constants';
 
 // We want to give the Help Center custom options based on the flow in which the user is in
 export function useFlowZendeskUserFields( flowName: string ) {
@@ -26,14 +6,14 @@ export function useFlowZendeskUserFields( flowName: string ) {
 	let userFieldFlowName = null;
 	let userFieldMessage = null;
 
-	if ( Object.keys( FLOWS_INITIAL_MESSAGES ).includes( flowName ) ) {
+	if ( Object.keys( FLOWS_ZENDESK_INITIAL_MESSAGES ).includes( flowName ) ) {
 		userFieldMessage = `${
-			FLOWS_INITIAL_MESSAGES[ flowName as keyof typeof FLOWS_INITIAL_MESSAGES ]
+			FLOWS_ZENDESK_INITIAL_MESSAGES[ flowName as keyof typeof FLOWS_ZENDESK_INITIAL_MESSAGES ]
 		} URL: ${ url }`;
 	}
 
-	if ( Object.keys( FLOWS_FLOWNAME ).includes( flowName ) ) {
-		userFieldFlowName = FLOWS_FLOWNAME[ flowName as keyof typeof FLOWS_FLOWNAME ];
+	if ( Object.keys( FLOWS_ZENDESK_FLOWNAME ).includes( flowName ) ) {
+		userFieldFlowName = FLOWS_ZENDESK_FLOWNAME[ flowName as keyof typeof FLOWS_ZENDESK_FLOWNAME ];
 	}
 
 	return {

--- a/packages/help-center/src/hooks/use-products-with-premium-support.ts
+++ b/packages/help-center/src/hooks/use-products-with-premium-support.ts
@@ -1,27 +1,48 @@
 import { isDIFMProduct, PLAN_100_YEARS } from '@automattic/calypso-products';
+import {
+	DIFM_FLOW,
+	HUNDRED_YEAR_DOMAIN_FLOW,
+	HUNDRED_YEAR_PLAN_FLOW,
+} from '@automattic/onboarding';
 import { ResponseCartProduct } from '@automattic/shopping-cart';
+import { FLOWS_ZENDESK_INITIAL_MESSAGES, FLOWS_ZENDESK_FLOWNAME } from '../constants';
+
+const getUserFieldMessage = ( flowName: string, url?: string ) => {
+	return `${
+		FLOWS_ZENDESK_INITIAL_MESSAGES[ flowName as keyof typeof FLOWS_ZENDESK_INITIAL_MESSAGES ]
+	}. URL: ${ url }`;
+};
 
 export function useProductsWithPremiumSupport( products: ResponseCartProduct[], url?: string ) {
-	let hasDIFMProduct = false;
-	let has100YPlan = false;
-
 	for ( const product of products ) {
 		if ( isDIFMProduct( product ) ) {
-			hasDIFMProduct = true;
+			return {
+				userFieldMessage: getUserFieldMessage( DIFM_FLOW, url ),
+				userFieldFlowName:
+					FLOWS_ZENDESK_FLOWNAME[ DIFM_FLOW as keyof typeof FLOWS_ZENDESK_FLOWNAME ],
+				hasPremiumSupport: true,
+			};
 		}
-		if ( product?.product_slug === PLAN_100_YEARS || product?.extra?.is_hundred_year_domain ) {
-			has100YPlan = true;
+		if ( product?.product_slug === PLAN_100_YEARS ) {
+			return {
+				userFieldMessage: getUserFieldMessage( HUNDRED_YEAR_PLAN_FLOW, url ),
+				userFieldFlowName:
+					FLOWS_ZENDESK_FLOWNAME[ HUNDRED_YEAR_PLAN_FLOW as keyof typeof FLOWS_ZENDESK_FLOWNAME ],
+				hasPremiumSupport: true,
+			};
+		}
+		if ( product?.extra?.is_hundred_year_domain ) {
+			return {
+				userFieldMessage: getUserFieldMessage( HUNDRED_YEAR_DOMAIN_FLOW, url ),
+				userFieldFlowName:
+					FLOWS_ZENDESK_FLOWNAME[ HUNDRED_YEAR_DOMAIN_FLOW as keyof typeof FLOWS_ZENDESK_FLOWNAME ],
+				hasPremiumSupport: true,
+			};
 		}
 	}
 
-	const initialMessage = hasDIFMProduct
-		? `User is purchasing DIFM plan.${ url ? ` URL: ${ url }` : '' }`
-		: `User is purchasing 100 year plan.`;
-
-	const hasPremiumSupport = hasDIFMProduct || has100YPlan;
-
 	return {
-		initialMessage,
-		hasPremiumSupport,
+		hasPremiumSupport: false,
+		userFieldMessage: null,
 	};
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1741113629911259-slack-C07D72S1135

## Proposed Changes

We have two hooks, `useProductsWithPremiumSupport` and `useFlowZendeskUserFields`, used to determine if the Help Center should be opened with premium support (HEs) in checkout and during a flow. Also which Zendesk fields to pass to the Help Center.

This PR:

- Moves things in the shared constant files.
- Renames arrays to best tell this is for Zendesk.
- Handle the 100 year plan and domain flows.
- On Checkout, passes the values of the flow name to Zendesk.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the 100 year plan.
* Open Help Center.
* You should have the premium experience.
* Check that in `update-user-fields` call we send the flow name prop.