### PR TITLE
i18n: Fix invalid string with percentage in migration-flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -3,7 +3,7 @@ import { BadgeType } from '@automattic/components';
 import { Step, StepContainer } from '@automattic/onboarding';
 import { canInstallPlugins } from '@automattic/sites';
 import { getQueryArg } from '@wordpress/url';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import { useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -32,8 +32,12 @@ const SiteMigrationImportOrMigrate: StepType< {
 	const isUsingStepContainerV2 = shouldUseStepContainerV2MigrationFlow( flow );
 
 	const options = useMemo( () => {
-		const upgradeRequiredLabel = translate( '50% off %(planName)s', {
-			args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+		const upgradeRequiredLabel = translate( '%(discountPercentage)s off %(planName)s', {
+			args: {
+				planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+				discountPercentage: numberFormat( 0.5, { numberFormatOptions: { style: 'percent' } } ),
+			},
+			comment: 'discountPercentage is a number between 0 and 100 followed or preceded by a % sign',
 		} );
 
 		const migrateOptionDescription = translate(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/949
Closes https://github.com/Automattic/i18n-issues/issues/950

## Proposed Changes

- Updates the string `Available on Business with 50% off` to use a placeholder for the percent value and parse it with `numberFormat`
- It fixes the inconsistency/bug with the French locale

## Media

In FR after:

<img width="700" alt="Screenshot 2025-03-06 at 11 39 04 AM" src="https://github.com/user-attachments/assets/e0f8df9a-503f-4987-aa9b-2d9ac78afd62" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fix https://github.com/Automattic/i18n-issues/issues/950

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Attempt to import a site `/setup/site-migration/site-migration-import-or-migrate?siteSlug=SITE_SLUG&ref=calypso-importer` and confirm the media above
- We obviously don't have a translation yet for French, but being this programmatically handled it should add the default/standard localisation
- Once translations are complete, confirm with Arabic/Hebrew for RTL that it renders fine

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
