### PR TITLE
Replace 100 year thank you page video

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -292,7 +292,7 @@ export default function HundredYearThankYou( {
 						</div>
 						<VideoContainer isMobile={ isMobile }>
 							<video
-								src="https://wpcom.files.wordpress.com/2023/08/century-100-banner.mp4"
+								src="https://wpcom.files.wordpress.com/2025/03/century-100-banner-new.mp4"
 								preload="auto"
 								width="100%"
 								height="auto"


### PR DESCRIPTION
Related to https://github.com/Automattic/nomado-issues/issues/1301

## Proposed Changes
Replace the video showed in 100 year domain/plan purchase thank you page with a new one

## Why are these changes being made?
The previous video showed the old 100 year logo-

## Testing Instructions
Enable store sandbox and purchase an 100 year domain. Verify that the thank you page shows the new video (https://wpcom.files.wordpress.com/2025/03/century-100-banner-new.mp4)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
